### PR TITLE
Add baseline metrics to `SortPreservingMergeExec`

### DIFF
--- a/datafusion/src/physical_plan/sort_preserving_merge.rs
+++ b/datafusion/src/physical_plan/sort_preserving_merge.rs
@@ -1243,7 +1243,7 @@ mod tests {
         // Now, validate metrics
         let metrics = merge.metrics().unwrap();
 
-        assert!(metrics.output_rows().unwrap() > 0);
+        assert_eq!(metrics.output_rows().unwrap(), 4);
         assert!(metrics.elapsed_compute().unwrap() > 0);
 
         let mut saw_start = false;


### PR DESCRIPTION
# Which issue does this PR close?


Next part https://github.com/apache/arrow-datafusion/issues/866

Builds on https://github.com/apache/arrow-datafusion/pull/938 so review that first




# Rationale for this change
We want basic understanding of where a plan's time is spent and in what operators. See https://github.com/apache/arrow-datafusion/issues/866 for more details

# What changes are included in this PR?
1. Instrument `SortPreservingMergeExec` using the API from https://github.com/apache/arrow-datafusion/pull/909


# Are there any user-facing changes?
More fields in `EXPLAIN ANALYZE` are now filled out
