### PR TITLE
Expose a static object store registry

### DIFF
--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -674,7 +674,6 @@ impl TryFrom<&protobuf::PhysicalExprNode> for Arc<dyn PhysicalExpr> {
                     aggregate_functions: Default::default(),
                     config: ExecutionConfig::new(),
                     execution_props: ExecutionProps::new(),
-                    object_store_registry: Arc::new(ObjectStoreRegistry::new()),
                 };
 
                 let fun_expr = functions::create_physical_fun(

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -40,7 +40,7 @@ path = "src/lib.rs"
 default = ["crypto_expressions", "regex_expressions", "unicode_expressions"]
 simd = ["arrow/simd"]
 crypto_expressions = ["md-5", "sha2"]
-regex_expressions = ["regex", "lazy_static"]
+regex_expressions = ["regex"]
 unicode_expressions = ["unicode-segmentation"]
 # Used for testing ONLY: causes all values to hash to the same value (test for collisions)
 force_hash_collisions = []
@@ -67,7 +67,7 @@ sha2 = { version = "^0.9.1", optional = true }
 ordered-float = "2.0"
 unicode-segmentation = { version = "^1.7.1", optional = true }
 regex = { version = "^1.4.3", optional = true }
-lazy_static = { version = "^1.4.0", optional = true }
+lazy_static = "^1.4.0"
 smallvec = { version = "1.6", features = ["union"] }
 rand = "0.8"
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }


### PR DESCRIPTION
# Which issue does this PR close?

This is linked to #1010 #1062 

 # Rationale for this change
Currently, we don't have a good way to make the `ObjectStoreRegistry` available in various places of the code. Indeed, to setup its object stores, the registry needs to have access to the implementation code (which might be in an other crate) at compile time and needs to have access to the proper configurations (such as credentials) when initialized. In particular in Ballista, we need to have the right registry configuration on the Executors _and_ the Scheduler.

Creating a singleton static object store registry is not ideal (it comes with with the usual curses that go with static), but solves (at least temporarily) some of the issues:
- To add a new object store, we now have a single point of configuration, the `OBJECT_STORES` initialization, that will propagate the configuration to all the places where the registry is required (local, scheduler, executor)
- `OBJECT_STORES` can be accessed in any place of the code: logical plan or physical plan deserialization, provider creation...

# What changes are included in this PR?
- removing the registry from the `ExecutionContextState`
- exposing a static `ObjectStoreRegistry` called `OBJECT_STORES`

# Are there any user-facing changes?
- removing the registry from the `ExecutionContextState` changes the config API but that part was likely not used yet
