### PR TITLE
Add ScalarValue::Struct variant

### DIFF
--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -1281,10 +1281,7 @@ impl From<Vec<(&str, ScalarValue)>> for ScalarValue {
         let (fields, scalars): (Vec<_>, Vec<_>) = value
             .into_iter()
             .map(|(name, scalar)| {
-                (
-                    Field::new(name, scalar.get_datatype(), false),
-                    scalar.clone(),
-                )
+                (Field::new(name, scalar.get_datatype(), false), scalar)
             })
             .unzip();
 
@@ -2237,14 +2234,14 @@ mod tests {
                 Arc::new(StringArray::from(vec!["Hello", "World", "!!!!!"])) as ArrayRef,
             ),
             (
-                field_d.clone(),
+                field_d,
                 Arc::new(StructArray::from(vec![
                     (
-                        field_e.clone(),
+                        field_e,
                         Arc::new(Int16Array::from(vec![2, 4, 6])) as ArrayRef,
                     ),
                     (
-                        field_f.clone(),
+                        field_f,
                         Arc::new(Int64Array::from(vec![3, 5, 7])) as ArrayRef,
                     ),
                 ])) as ArrayRef,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #602

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

DataFusion already works well, in many cases, with Arrow `StructArray` columns.  This PR adds a corresponding `ScalarValue` variant that can be used to represent a single element of a `StructArray`.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This is currently a fairly minimal PR that adds a new `ScalarValue::Struct` variant, largely following the existing pattern for the `ScalarValue::List` variant.  The `Struct` variant should support the same feature set as `ScalarValue::List`.

Let me know if there are uses of `ScalarValue` throughout the rest of DataFusion that should be updated to include struct support before these changes are merged.  Thanks!

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes, a new `ScalarValue` enumeration variant

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
