### PR TITLE
Add ScalarValue support for arbitrary list elements

### DIFF
--- a/datafusion/src/scalar.rs
+++ b/datafusion/src/scalar.rs
@@ -854,8 +854,7 @@ impl ScalarValue {
             if let ScalarValue::List(values, _) = scalar {
                 match values {
                     Some(values) => {
-                        let element_array =
-                            ScalarValue::iter_to_array(values.as_ref().clone())?;
+                        let element_array = ScalarValue::iter_to_array(*values)?;
 
                         // Add new offset index
                         flat_len += element_array.len() as i32;
@@ -902,7 +901,7 @@ impl ScalarValue {
             .add_buffer(offsets_array.data().buffers()[0].clone())
             .add_child_data(flat_array.data().clone());
 
-        let list_array = ListArray::from(array_data.build());
+        let list_array = ListArray::from(array_data.build()?);
         Ok(list_array)
     }
 


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-datafusion/issues/1092

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
See https://github.com/apache/arrow-datafusion/issues/1092.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The `ScalarValue::iter_to_array` and `ScalarValue::to_array_of_size` associated functions have been updated to support `ScalarValue::List` variants that contain arbitrary `ScalarValue` elements.  Previously, only lists of primitive elements were supported.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Previously, an error was returned when calling `iter_to_array` or `to_array_of_size` with lists containing non-primitive values. Now these calls complete successfully.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No