### PR TITLE
[Minor] Dependency upgrades (env_logger, rustyline)

### DIFF
--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -36,7 +36,7 @@ async-trait = "0.1.36"
 ballista-core = { path = "../core", version = "0.6.0" }
 configure_me = "0.4.0"
 datafusion = { path = "../../../datafusion", version = "5.1.0" }
-env_logger = "0.8"
+env_logger = "0.9"
 futures = "0.3"
 log = "0.4"
 snmalloc-rs = {version = "0.2", features= ["cache-friendly"], optional = true}

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -36,7 +36,7 @@ ballista-core = { path = "../core", version = "0.6.0" }
 clap = "2"
 configure_me = "0.4.0"
 datafusion = { path = "../../../datafusion", version = "5.1.0" }
-env_logger = "0.8"
+env_logger = "0.9"
 etcd-client = { version = "0.7", optional = true }
 futures = "0.3"
 http = "0.2"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -36,7 +36,7 @@ ballista = { path = "../ballista/rust/client" }
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "^1.0", features = ["macros", "rt", "rt-multi-thread"] }
 futures = "0.3"
-env_logger = "^0.8"
+env_logger = "0.9"
 mimalloc = { version = "0.1", optional = true, default-features = false }
 snmalloc-rs = {version = "0.2", optional = true, features= ["cache-friendly"] }
 

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/apache/arrow-datafusion"
 
 [dependencies]
 clap = "2.33"
-rustyline = "8.0"
+rustyline = "9.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 datafusion = { path = "../datafusion", version = "5.1.0" }
 arrow = { version = "6.0.0"  }


### PR DESCRIPTION
# Which issue does this PR close?
 # Rationale for this change
Output of `cargo upgrades`:
```
datafusion-cli: /home/danielheres/Code/gdd/arrow-datafusion/datafusion-cli/Cargo.toml
  rustyline >=8.0.0, <9.0.0 matches 8.2.0; latest is 9.0.0

ballista-core: /home/danielheres/Code/gdd/arrow-datafusion/ballista/rust/core/Cargo.toml
  prost >=0.8.0, <0.9.0 matches 0.8.0; latest is 0.9.0

ballista-executor: /home/danielheres/Code/gdd/arrow-datafusion/ballista/rust/executor/Cargo.toml
  env_logger >=0.8.0, <0.9.0 matches 0.8.4; latest is 0.9.0

ballista-scheduler: /home/danielheres/Code/gdd/arrow-datafusion/ballista/rust/scheduler/Cargo.toml
  env_logger >=0.8.0, <0.9.0 matches 0.8.4; latest is 0.9.0
  prost >=0.8.0, <0.9.0 matches 0.8.0; latest is 0.9.0

datafusion-examples: /home/danielheres/Code/gdd/arrow-datafusion/datafusion-examples/Cargo.toml
  prost >=0.8.0, <0.9.0 matches 0.8.0; latest is 0.9.0

arrow-benchmarks: /home/danielheres/Code/gdd/arrow-datafusion/benchmarks/Cargo.toml
  env_logger >=0.8.0, <0.9.0 matches 0.8.4; latest is 0.9.0

ballista-examples: /home/danielheres/Code/gdd/arrow-datafusion/ballista-examples/Cargo.toml
  prost >=0.8.0, <0.9.0 matches 0.8.0; latest is 0.9.0
```

# What changes are included in this PR?
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
