### PR TITLE
Add additional docstring comments to `from_plan`

### DIFF
--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -111,7 +111,25 @@ pub fn optimize_children(
     from_plan(plan, &new_exprs, &new_inputs)
 }
 
-/// Returns a new logical plan based on the original one with inputs and expressions replaced
+/// Returns a new logical plan based on the original one with inputs
+/// and expressions replaced.
+///
+/// The exprs correspond to the same order of expressions returned by
+/// `LogicalPlan::expressions`. This function is used in optimizers in
+/// the following way:
+///
+/// ```text
+/// let new_inputs = optimize_children(..., plan, props);
+///
+/// // get the plans expressions to optimize
+/// let exprs = plan.expressions();
+///
+/// // potentially rewrite plan expressions
+/// let rewritten_exprs = rewrite_exprs(exprs);
+///
+/// // create new plan using rewritten_exprs in same position
+/// let new_plan = from_plan(&plan, rewritten_exprs, new_inputs);
+/// ```
 pub fn from_plan(
     plan: &LogicalPlan,
     expr: &[Expr],


### PR DESCRIPTION
# Which issue does this PR close?

While reviewing https://github.com/apache/arrow-datafusion/pull/1165 I realized that some of the assumptions made by `from_plan` were implicit rather than explicit. So I figured I would add some doc comments

 # Rationale for this change
Avoid potential future bugs

# What changes are included in this PR?
Doc comments

# Are there any user-facing changes?
no