### PR TITLE
[Minor] Remove deprecated  feature flag from snmalloc

### DIFF
--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -39,7 +39,7 @@ datafusion = { path = "../../../datafusion", version = "7.0.0" }
 env_logger = "0.9"
 futures = "0.3"
 log = "0.4"
-snmalloc-rs = {version = "0.2", features= ["cache-friendly"], optional = true}
+snmalloc-rs = {version = "0.2", optional = true}
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "^1.0", features = ["macros", "rt", "rt-multi-thread", "park
 futures = "0.3"
 env_logger = "0.9"
 mimalloc = { version = "0.1", optional = true, default-features = false }
-snmalloc-rs = {version = "0.2", optional = true, features= ["cache-friendly"] }
+snmalloc-rs = {version = "0.2", optional = true }
 rand = "0.8.4"
 serde = "1.0.136"
 serde_json = "1.0.78"


### PR DESCRIPTION
 # Rationale for this change
According to the warning message: 
"cache-friendly feature flag is deprecated and no longer has any effect. it may be removed in a future release"

# Are there any user-facing changes?

No.
