### PR TITLE
Add tests for coercion of timestamps to strings

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/timestamps.slt
@@ -16,7 +16,7 @@
 # under the License.
 
 ##########
-## DDL Tests
+## Timestamp Handling Tests
 ##########
 
 statement ok


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-datafusion/issues/4311

# Rationale for this change
Add end to end SQL test coverage for the feature added by @andre-cc-natzka  in https://github.com/apache/arrow-datafusion/pull/4312

# What changes are included in this PR?

`timestamp.slt` test

# Are these changes tested?
It is entirely tests

# Are there any user-facing changes?

No