### PR TITLE
fix: match boolean null for substrait

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -1080,9 +1080,14 @@ fn to_substrait_literal(value: &ScalarValue) -> Result<Expression> {
 }
 
 fn try_to_substrait_null(v: &ScalarValue) -> Result<LiteralType> {
-    // let default_type_ref = 0;
     let default_nullability = r#type::Nullability::Nullable as i32;
     match v {
+        ScalarValue::Boolean(None) => Ok(LiteralType::Null(substrait::proto::Type {
+            kind: Some(r#type::Kind::Bool(r#type::Boolean {
+                type_variation_reference: DEFAULT_TYPE_REF,
+                nullability: default_nullability,
+            })),
+        })),
         ScalarValue::Int8(None) => Ok(LiteralType::Null(substrait::proto::Type {
             kind: Some(r#type::Kind::I8(r#type::I8 {
                 type_variation_reference: DEFAULT_TYPE_REF,
@@ -1330,9 +1335,7 @@ mod test {
     fn round_trip_literal(scalar: ScalarValue) -> Result<()> {
         println!("Checking round trip of {:?}", scalar);
 
-        let scalar = ScalarValue::Int32(Some(i32::MAX));
         let substrait = to_substrait_literal(&scalar)?;
-
         let Expression { rex_type: Some(RexType::Literal(substrait_literal)) } = substrait else {
             panic!("Expected Literal expression, got {:?}", substrait);
         };


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Forget to match boolean null in #5775. And fix a test from #5946 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- support boolean null literal
- fix test runner `round_trip_literal`

# Are these changes tested?

yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No