### PR TITLE
Fix Select Into with Order By and Limit

### DIFF
--- a/datafusion/core/tests/sqllogictests/test_files/ddl.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/ddl.slt
@@ -346,6 +346,22 @@ SELECT * FROM new_table;
 1 2 hello
 
 statement ok
+DROP TABLE new_table
+
+# create_table_with_schema_as_multiple_values
+statement ok
+CREATE TABLE test_table(c1 int, c2 float, c3 varchar) AS VALUES(1, 2, 'hello'),(2, 1, 'there'),(3, 0, '!');
+
+statement ok
+SELECT * INTO new_table FROM test_table ORDER BY c1 DESC LIMIT 2
+
+query IRT
+SELECT * FROM new_table
+----
+3 0 !
+2 1 there
+
+statement ok
 DROP TABLE my_table;
 
 statement ok

--- a/datafusion/sql/src/query.rs
+++ b/datafusion/sql/src/query.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use crate::select;
 
 use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::{

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -31,8 +31,7 @@ use datafusion_expr::utils::{
 };
 use datafusion_expr::Expr::Alias;
 use datafusion_expr::{
-    CreateMemoryTable, DdlStatement, Expr, Filter, GroupingSet, LogicalPlan,
-    LogicalPlanBuilder, Partitioning,
+    Expr, Filter, GroupingSet, LogicalPlan, LogicalPlanBuilder, Partitioning,
 };
 
 use sqlparser::ast::{Distinct, Expr as SQLExpr, WildcardAdditionalOptions, WindowType};
@@ -240,21 +239,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             plan
         };
 
-        if let Some(select_into) = select.into {
-            Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
-                CreateMemoryTable {
-                    name: self.object_name_to_table_reference(select_into.name)?,
-                    // SELECT INTO statement does not copy constraints such as primary key
-                    primary_key: Vec::new(),
-                    input: Arc::new(plan),
-                    // These are not applicable with SELECT INTO
-                    if_not_exists: false,
-                    or_replace: false,
-                },
-            )))
-        } else {
-            Ok(plan)
-        }
+        Ok(plan)
     }
 
     fn plan_selection(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6440.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Select Into queries with `order by` or `limit` statements give an error while creating an initial physical plan. 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

In SELECT INTO queries, CreateMemoryTable plan was built before order by and limit planning. However, in CREATE TABLE AS queries, CreateMemoryTable is built with the finalized logical plan (after order by and limit statements are included the plan). Select Into follows the same planning order now. 

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->