### PR TITLE
RFC: Make it easier to call window functions via expression API (and add example)

### DIFF
--- a/datafusion-examples/examples/simple_udwf.rs
+++ b/datafusion-examples/examples/simple_udwf.rs
@@ -112,12 +112,14 @@ async fn main() -> Result<()> {
     df.show().await?;
 
     // Now, run the function using the DataFrame API:
-    let window_expr = smooth_it().call(
-        vec![col("speed")],                 // smooth_it(speed)
-        vec![col("car")],                   // PARTITION BY car
-        vec![col("time").sort(true, true)], // ORDER BY time ASC
-        WindowFrame::new(false),
-    );
+    let window_expr = smooth_it()
+        // smooth_it(speed)
+        .call(vec![col("speed")])
+        .with_partition_by(vec![col("car")])
+        // ORDER BY time ASC
+        .with_order_by(vec![col("time").sort(true, true)])
+        .build();
+
     let df = ctx.table("cars").await?.window(vec![window_expr])?;
 
     // print the results

--- a/datafusion/core/src/dataframe.rs
+++ b/datafusion/core/src/dataframe.rs
@@ -219,6 +219,23 @@ impl DataFrame {
     }
 
     /// Apply one or more window functions ([`Expr::WindowFunction`]) to extend the schema
+    ///
+    /// ```
+    /// # use datafusion::prelude::*;
+    /// # use datafusion::error::Result;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    /// let ctx = SessionContext::new();
+    /// let df = ctx.read_csv("tests/data/example.csv", CsvReadOptions::new()).await?;
+    ///
+    /// // The following is the equivalent of "SELECT FIRST_VALUE(b) OVER(PARTITION BY a)"
+    /// let first_value = first_value(col("b"))
+    ///    .with_partition_by(vec![col("a")])
+    ///    .build();
+    /// let _ = df.window(vec![first_value]);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn window(self, window_exprs: Vec<Expr>) -> Result<DataFrame> {
         let plan = LogicalPlanBuilder::from(self.plan)
             .window(window_exprs)?

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -18,17 +18,17 @@
 //! Functions for creating logical expressions
 
 use crate::expr::{
-    AggregateFunction, BinaryExpr, Cast, Exists, GroupingSet, InList, InSubquery,
+    self, AggregateFunction, BinaryExpr, Cast, Exists, GroupingSet, InList, InSubquery,
     ScalarFunction, TryCast,
 };
 use crate::function::PartitionEvaluatorFactory;
-use crate::WindowUDF;
 use crate::{
     aggregate_function, built_in_function, conditional_expressions::CaseBuilder,
     logical_plan::Subquery, AccumulatorFactoryFunction, AggregateUDF,
     BuiltinScalarFunction, Expr, LogicalPlan, Operator, ReturnTypeFunction,
     ScalarFunctionImplementation, ScalarUDF, Signature, StateTypeFunction, Volatility,
 };
+use crate::{BuiltInWindowFunction, WindowUDF};
 use arrow::datatypes::DataType;
 use datafusion_common::{Column, Result};
 use std::sync::Arc;
@@ -156,6 +156,83 @@ pub fn count(expr: Expr) -> Expr {
         None,
         None,
     ))
+}
+
+/// Create an expression to represent the `row_number` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn row_number() -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::RowNumber, vec![])
+}
+
+/// Create an expression to represent the `rank` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn rank() -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::Rank, vec![])
+}
+
+/// Create an expression to represent the `dense_rank` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn dense_rank() -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::DenseRank, vec![])
+}
+
+/// Create an expression to represent the `percent_rank` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn percent_rank() -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::PercentRank, vec![])
+}
+
+/// Create an expression to represent the `cume_dist` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn cume_dist(arg: Expr) -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::CumeDist, vec![arg])
+}
+
+/// Create an expression to represent the `ntile` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn ntile(arg: Expr) -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::Ntile, vec![arg])
+}
+
+/// Create an expression to represent the `lag` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn lag(arg: Expr) -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::Lag, vec![arg])
+}
+
+/// Create an expression to represent the `lead` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn lead(arg: Expr) -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::Lead, vec![arg])
+}
+
+/// Create an expression to represent the `first_value` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn first_value(arg: Expr) -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::FirstValue, vec![arg])
+}
+
+/// Create an expression to represent the `last_value` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn last_value(arg: Expr) -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::LastValue, vec![arg])
+}
+
+/// Create an expression to represent the `nth_value` window function
+///
+/// Note: call [`expr::WindowFunction::build]` to create an [`Expr`]
+pub fn nth_value(arg: Expr) -> expr::WindowFunction {
+    expr::WindowFunction::new(BuiltInWindowFunction::NthValue, vec![arg])
 }
 
 /// Return a new expression with bitwise AND
@@ -750,6 +827,11 @@ pub fn case(expr: Expr) -> CaseBuilder {
 pub fn when(when: Expr, then: Expr) -> CaseBuilder {
     CaseBuilder::new(None, vec![when], vec![then], None)
 }
+
+// /// Create a window expr from
+// pub fn window_expr(window_function: impl Into<crate::expr::WindowFunction>) -> Expr {
+// e    Expr::WindowFunction(expr.into())
+// }
 
 /// Creates a new UDF with a specific signature and specific return type.
 /// This is a helper function to create a new UDF.

--- a/datafusion/expr/src/tree_node/expr.rs
+++ b/datafusion/expr/src/tree_node/expr.rs
@@ -283,13 +283,13 @@ impl TreeNode for Expr {
                 partition_by,
                 order_by,
                 window_frame,
-            }) => Expr::WindowFunction(WindowFunction::new(
+            }) => Expr::WindowFunction(WindowFunction {
                 fun,
-                transform_vec(args, &mut transform)?,
-                transform_vec(partition_by, &mut transform)?,
-                transform_vec(order_by, &mut transform)?,
+                args: transform_vec(args, &mut transform)?,
+                partition_by: transform_vec(partition_by, &mut transform)?,
+                order_by: transform_vec(order_by, &mut transform)?,
                 window_frame,
-            )),
+            }),
             Expr::AggregateFunction(AggregateFunction {
                 args,
                 fun,

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -22,9 +22,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{
-    Expr, PartitionEvaluatorFactory, ReturnTypeFunction, Signature, WindowFrame,
-};
+use crate::{expr, Expr, PartitionEvaluatorFactory, ReturnTypeFunction, Signature};
 
 /// Logical representation of a user-defined window function (UDWF)
 /// A UDWF is different from a UDF in that it is stateful across batches.
@@ -93,26 +91,15 @@ impl WindowUDF {
         }
     }
 
-    /// creates a [`Expr`] that calls the window function given
-    /// the `partition_by`, `order_by`, and `window_frame` definition
+    /// creates a [`expr::WindowFunction`] builder for calling the
+    /// window function given.
+    ///
+    /// Use the methods on the builder to set the `partition_by`,
+    /// `order_by`, and `window_frame` definitions
     ///
     /// This utility allows using the UDWF without requiring access to
     /// the registry, such as with the DataFrame API.
-    pub fn call(
-        &self,
-        args: Vec<Expr>,
-        partition_by: Vec<Expr>,
-        order_by: Vec<Expr>,
-        window_frame: WindowFrame,
-    ) -> Expr {
-        let fun = crate::WindowFunction::WindowUDF(Arc::new(self.clone()));
-
-        Expr::WindowFunction(crate::expr::WindowFunction {
-            fun,
-            args,
-            partition_by,
-            order_by,
-            window_frame,
-        })
+    pub fn call(&self, args: Vec<Expr>) -> expr::WindowFunction {
+        expr::WindowFunction::new(Arc::new(self.clone()), args)
     }
 }

--- a/datafusion/expr/src/window_function.rs
+++ b/datafusion/expr/src/window_function.rs
@@ -61,6 +61,30 @@ pub fn find_df_window_func(name: &str) -> Option<WindowFunction> {
     }
 }
 
+impl From<AggregateFunction> for WindowFunction {
+    fn from(value: AggregateFunction) -> Self {
+        Self::AggregateFunction(value)
+    }
+}
+
+impl From<BuiltInWindowFunction> for WindowFunction {
+    fn from(value: BuiltInWindowFunction) -> Self {
+        Self::BuiltInWindowFunction(value)
+    }
+}
+
+impl From<Arc<AggregateUDF>> for WindowFunction {
+    fn from(value: Arc<AggregateUDF>) -> Self {
+        Self::AggregateUDF(value)
+    }
+}
+
+impl From<Arc<WindowUDF>> for WindowFunction {
+    fn from(value: Arc<WindowUDF>) -> Self {
+        Self::WindowUDF(value)
+    }
+}
+
 impl fmt::Display for BuiltInWindowFunction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.name())

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -433,13 +433,13 @@ impl TreeNodeRewriter for TypeCoercionRewriter {
             }) => {
                 let window_frame =
                     coerce_window_frame(window_frame, &self.schema, &order_by)?;
-                let expr = Expr::WindowFunction(WindowFunction::new(
+                let expr = Expr::WindowFunction(WindowFunction {
                     fun,
                     args,
                     partition_by,
                     order_by,
                     window_frame,
-                ));
+                });
                 Ok(expr)
             }
             expr => Ok(expr),

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -101,17 +101,17 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             planner_context,
                         )?;
 
-                        Expr::WindowFunction(expr::WindowFunction::new(
-                            WindowFunction::AggregateFunction(aggregate_fun),
+                        Expr::WindowFunction(expr::WindowFunction {
+                            fun: WindowFunction::AggregateFunction(aggregate_fun),
                             args,
                             partition_by,
                             order_by,
                             window_frame,
-                        ))
+                        })
                     }
-                    _ => Expr::WindowFunction(expr::WindowFunction::new(
+                    _ => Expr::WindowFunction(expr::WindowFunction {
                         fun,
-                        self.function_args_to_expr(
+                        args: self.function_args_to_expr(
                             function.args,
                             schema,
                             planner_context,
@@ -119,7 +119,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         partition_by,
                         order_by,
                         window_frame,
-                    )),
+                    }),
                 };
                 return Ok(expr);
             }

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -182,21 +182,22 @@ where
                 partition_by,
                 order_by,
                 window_frame,
-            }) => Ok(Expr::WindowFunction(WindowFunction::new(
-                fun.clone(),
-                args.iter()
-                    .map(|e| clone_with_replacement(e, replacement_fn))
-                    .collect::<Result<Vec<_>>>()?,
-                partition_by
+            }) => Ok(Expr::WindowFunction(WindowFunction {
+                fun: fun.clone(),
+                args: args
                     .iter()
                     .map(|e| clone_with_replacement(e, replacement_fn))
                     .collect::<Result<Vec<_>>>()?,
-                order_by
+                partition_by: partition_by
                     .iter()
                     .map(|e| clone_with_replacement(e, replacement_fn))
                     .collect::<Result<Vec<_>>>()?,
-                window_frame.clone(),
-            ))),
+                order_by: order_by
+                    .iter()
+                    .map(|e| clone_with_replacement(e, replacement_fn))
+                    .collect::<Result<Vec<_>>>()?,
+                window_frame: window_frame.clone(),
+            })),
             Expr::AggregateUDF(AggregateUDF {
                 fun,
                 args,


### PR DESCRIPTION
before polishing this PR up I wanted to get some feedback on the approach

# Which issue does this PR close?
Related to https://github.com/apache/arrow-datafusion/issues/5781
Closes: https://github.com/apache/arrow-datafusion/issues/6747

# Rationale for this change
@mustafasrepo  suggested adding an example for `DataFrame::window` here: https://github.com/apache/arrow-datafusion/pull/6703#discussion_r1238403292

When I tried to do so it turns out that creating an `Expr::Window` is quite challenging, so I took a step back and tried to clean up the API a little

# What changes are included in this PR?

1. Change `WindowExpr` to be a builder style interface and thus making it easier to construct `Expr::WindowFunction` variants. This is modeled after the `CaseBuilder`
2. Add the `lead`, `lag`, etc. in `expr_fns` to follow the model of the other types of functions

# Are these changes tested?
Yes

TOOD: I need to write tests for all the code in `expr_fns` which I will add to https://github.com/apache/arrow-datafusion/blob/main/datafusion/core/tests/dataframe/dataframe_functions.rs if people like this basic approach

# Are there any user-facing changes?
yes, the APIs to create window functions are improved