### PR TITLE
Support array aggregate sum function

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -167,3 +167,7 @@ name = "sort"
 [[bench]]
 harness = false
 name = "topk_aggregate"
+
+[[bench]]
+harness = false
+name = "aggregate_sum"

--- a/datafusion/core/benches/aggregate_sum.rs
+++ b/datafusion/core/benches/aggregate_sum.rs
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+extern crate arrow;
+extern crate datafusion;
+
+mod data_utils;
+use crate::criterion::Criterion;
+use arrow_array::{RecordBatch, ArrayRef, Float64Array, PrimitiveArray};
+use arrow_schema::{Schema, Field};
+use data_utils::create_table_provider;
+use datafusion::error::Result;
+use datafusion::execution::context::SessionContext;
+use datafusion_common::ScalarValue;
+use datafusion_expr::AggregateFunction;
+use datafusion_expr::type_coercion::aggregates::coerce_types;
+use datafusion_physical_expr::{expressions::{create_aggregate_expr, try_cast, col}, AggregateExpr};
+use parking_lot::Mutex;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+pub fn aggregate(
+    batch: &RecordBatch,
+    agg: Arc<dyn AggregateExpr>,
+) -> Result<ScalarValue> {
+    let mut accum = agg.create_accumulator()?;
+    let expr = agg.expressions();
+    let values = expr
+        .iter()
+        .map(|e| {
+            e.evaluate(batch)
+                .and_then(|v| v.into_array(batch.num_rows()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    accum.update_batch(&values)?;
+    accum.evaluate()
+}
+
+pub fn assert_aggregate(
+    array: ArrayRef,
+    function: AggregateFunction,
+    distinct: bool,
+    expected: ScalarValue,
+) {
+    let data_type = array.data_type();
+    let sig = function.signature();
+    let coerced = coerce_types(&function, &[data_type.clone()], &sig).unwrap();
+
+    let input_schema = Schema::new(vec![Field::new("a", data_type.clone(), true)]);
+    let batch =
+        RecordBatch::try_new(Arc::new(input_schema.clone()), vec![array]).unwrap();
+
+    let input = try_cast(
+        col("a", &input_schema).unwrap(),
+        &input_schema,
+        coerced[0].clone(),
+    )
+    .unwrap();
+
+    let schema = Schema::new(vec![Field::new("a", coerced[0].clone(), true)]);
+    let agg =
+        create_aggregate_expr(&function, distinct, &[input], &[], &schema, "agg")
+            .unwrap();
+
+    let result = aggregate(&batch, agg).unwrap();
+    assert_eq!(expected, result);
+}
+
+fn query(ctx: Arc<Mutex<SessionContext>>, sql: &str) {
+    let rt = Runtime::new().unwrap();
+    let df = rt.block_on(ctx.lock().sql(sql)).unwrap();
+    criterion::black_box(rt.block_on(df.collect()).unwrap());
+}
+
+fn create_context(
+    partitions_len: usize,
+    array_len: usize,
+    batch_size: usize,
+) -> Result<Arc<Mutex<SessionContext>>> {
+    let ctx = SessionContext::new();
+    let provider = create_table_provider(partitions_len, array_len, batch_size)?;
+    ctx.register_table("t", provider)?;
+    Ok(Arc::new(Mutex::new(ctx)))
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // let partitions_len = 8;
+    // let array_len = 32768 * 2; // 2^16
+    // let batch_size = 2048; // 2^11
+    // let ctx = create_context(partitions_len, array_len, batch_size).unwrap();
+
+    let n = 1000000000; 
+    let vec_of_f64: Vec<f64> = (0..=n as usize).map(|x| 1 as f64).collect();
+    let a: ArrayRef = Arc::new(Float64Array::from(vec_of_f64));
+    // c.bench_function("sum 1e9", |b| b.iter(|| assert_aggregate(a.clone(), AggregateFunction::Sum, false, criterion::black_box(ScalarValue::List(Arc::new(Float64Array::from(vec![1000000001_f64])))))));
+    c.bench_function("sum 1e9", |b| b.iter(|| assert_aggregate(a.clone(), AggregateFunction::Sum, false, criterion::black_box(ScalarValue::from(1000000001_f64)))));
+
+    // c.bench_function("aggregate_query_no_group_by 15 12", |b| {
+    //     b.iter(|| {
+    //         query(
+    //             ctx.clone(),
+    //             "SELECT MIN(f64), AVG(f64), COUNT(f64) \
+    //              FROM t",
+    //         )
+    //     })
+    // });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -886,7 +886,8 @@ impl BuiltinScalarFunction {
 
         // for now, the list is small, as we do not have many built-in functions.
         match self {
-            BuiltinScalarFunction::ArrayAppend => Signature::any(2, self.volatility()),
+            BuiltinScalarFunction::ArrayAggregate
+            | BuiltinScalarFunction::ArrayAppend => Signature::any(2, self.volatility()),
             BuiltinScalarFunction::ArrayPopFront => Signature::any(1, self.volatility()),
             BuiltinScalarFunction::ArrayPopBack => Signature::any(1, self.volatility()),
             BuiltinScalarFunction::ArrayConcat => {
@@ -897,24 +898,23 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::ArrayElement => Signature::any(2, self.volatility()),
             BuiltinScalarFunction::ArrayExcept => Signature::any(2, self.volatility()),
             BuiltinScalarFunction::Flatten => Signature::any(1, self.volatility()),
-
-            BuiltinScalarFunction::ArrayAggregate
-            | BuiltinScalarFunction::ArrayHasAll
+            BuiltinScalarFunction::ArrayHasAll
             | BuiltinScalarFunction::ArrayHasAny
-            | BuiltinScalarFunction::ArrayHas
-            | BuiltinScalarFunction::ArrayPositions
-            | BuiltinScalarFunction::ArrayPrepend
-            | BuiltinScalarFunction::ArrayRepeat
-            | BuiltinScalarFunction::ArrayRemove
-            | BuiltinScalarFunction::ArrayRemoveAll => {
-                Signature::any(2, self.volatility())
+            | BuiltinScalarFunction::ArrayHas => Signature::any(2, self.volatility()),
+            BuiltinScalarFunction::ArrayLength => {
+                Signature::variadic_any(self.volatility())
             }
-
-            BuiltinScalarFunction::ArrayRemoveN
-            | BuiltinScalarFunction::ArrayReplace
-            | BuiltinScalarFunction::ArrayReplaceAll
-            | BuiltinScalarFunction::ArraySlice => Signature::any(3, self.volatility()),
-
+            BuiltinScalarFunction::ArrayNdims => Signature::any(1, self.volatility()),
+            BuiltinScalarFunction::ArrayPosition => {
+                Signature::variadic_any(self.volatility())
+            }
+            BuiltinScalarFunction::ArrayPositions => Signature::any(2, self.volatility()),
+            BuiltinScalarFunction::ArrayPrepend => Signature::any(2, self.volatility()),
+            BuiltinScalarFunction::ArrayRepeat => Signature::any(2, self.volatility()),
+            BuiltinScalarFunction::ArrayRemove => Signature::any(2, self.volatility()),
+            BuiltinScalarFunction::ArrayRemoveN => Signature::any(3, self.volatility()),
+            BuiltinScalarFunction::ArrayRemoveAll => Signature::any(2, self.volatility()),
+            BuiltinScalarFunction::ArrayReplace => Signature::any(3, self.volatility()),
             BuiltinScalarFunction::ArrayReplaceN => Signature::any(4, self.volatility()),
             BuiltinScalarFunction::ArrayReplaceAll => {
                 Signature::any(3, self.volatility())

--- a/datafusion/expr/src/built_in_function.rs
+++ b/datafusion/expr/src/built_in_function.rs
@@ -128,6 +128,8 @@ pub enum BuiltinScalarFunction {
     Cot,
 
     // array functions
+    /// array_aggregate
+    ArrayAggregate,
     /// array_append
     ArrayAppend,
     /// array_concat
@@ -389,6 +391,7 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::Tanh => Volatility::Immutable,
             BuiltinScalarFunction::Trunc => Volatility::Immutable,
             BuiltinScalarFunction::ArrayAppend => Volatility::Immutable,
+            BuiltinScalarFunction::ArrayAggregate => Volatility::Immutable,
             BuiltinScalarFunction::ArrayConcat => Volatility::Immutable,
             BuiltinScalarFunction::ArrayEmpty => Volatility::Immutable,
             BuiltinScalarFunction::ArrayHasAll => Volatility::Immutable,
@@ -534,6 +537,7 @@ impl BuiltinScalarFunction {
                 Ok(data_type)
             }
             BuiltinScalarFunction::ArrayAppend => Ok(input_expr_types[0].clone()),
+            BuiltinScalarFunction::ArrayAggregate => unimplemented!("ArrayAggregate is based on Aggreation function, so no return value for it."),
             BuiltinScalarFunction::ArrayConcat => {
                 let mut expr_type = Null;
                 let mut max_dims = 0;
@@ -893,23 +897,24 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::ArrayElement => Signature::any(2, self.volatility()),
             BuiltinScalarFunction::ArrayExcept => Signature::any(2, self.volatility()),
             BuiltinScalarFunction::Flatten => Signature::any(1, self.volatility()),
-            BuiltinScalarFunction::ArrayHasAll
+
+            BuiltinScalarFunction::ArrayAggregate
+            | BuiltinScalarFunction::ArrayHasAll
             | BuiltinScalarFunction::ArrayHasAny
-            | BuiltinScalarFunction::ArrayHas => Signature::any(2, self.volatility()),
-            BuiltinScalarFunction::ArrayLength => {
-                Signature::variadic_any(self.volatility())
+            | BuiltinScalarFunction::ArrayHas
+            | BuiltinScalarFunction::ArrayPositions
+            | BuiltinScalarFunction::ArrayPrepend
+            | BuiltinScalarFunction::ArrayRepeat
+            | BuiltinScalarFunction::ArrayRemove
+            | BuiltinScalarFunction::ArrayRemoveAll => {
+                Signature::any(2, self.volatility())
             }
-            BuiltinScalarFunction::ArrayNdims => Signature::any(1, self.volatility()),
-            BuiltinScalarFunction::ArrayPosition => {
-                Signature::variadic_any(self.volatility())
-            }
-            BuiltinScalarFunction::ArrayPositions => Signature::any(2, self.volatility()),
-            BuiltinScalarFunction::ArrayPrepend => Signature::any(2, self.volatility()),
-            BuiltinScalarFunction::ArrayRepeat => Signature::any(2, self.volatility()),
-            BuiltinScalarFunction::ArrayRemove => Signature::any(2, self.volatility()),
-            BuiltinScalarFunction::ArrayRemoveN => Signature::any(3, self.volatility()),
-            BuiltinScalarFunction::ArrayRemoveAll => Signature::any(2, self.volatility()),
-            BuiltinScalarFunction::ArrayReplace => Signature::any(3, self.volatility()),
+
+            BuiltinScalarFunction::ArrayRemoveN
+            | BuiltinScalarFunction::ArrayReplace
+            | BuiltinScalarFunction::ArrayReplaceAll
+            | BuiltinScalarFunction::ArraySlice => Signature::any(3, self.volatility()),
+
             BuiltinScalarFunction::ArrayReplaceN => Signature::any(4, self.volatility()),
             BuiltinScalarFunction::ArrayReplaceAll => {
                 Signature::any(3, self.volatility())
@@ -1509,6 +1514,12 @@ fn aliases(func: &BuiltinScalarFunction) -> &'static [&'static str] {
         BuiltinScalarFunction::ArrowTypeof => &["arrow_typeof"],
 
         // array functions
+        BuiltinScalarFunction::ArrayAggregate => &[
+            "array_aggregate",
+            "list_aggregate",
+            "array_aggr",
+            "list_aggr",
+        ],
         BuiltinScalarFunction::ArrayAppend => &[
             "array_append",
             "list_append",

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -597,6 +597,13 @@ scalar_expr!(
     "returns the array without the first element."
 );
 
+scalar_expr!(
+    ArrayAggregate,
+    array_aggregate,
+    array name,
+    "allows the execution of arbitrary existing aggregate functions `name` on the elements of a list"
+);
+
 nary_scalar_expr!(ArrayConcat, array_concat, "concatenates arrays.");
 scalar_expr!(
     ArrayHas,

--- a/datafusion/expr/src/type_coercion/aggregates.rs
+++ b/datafusion/expr/src/type_coercion/aggregates.rs
@@ -119,9 +119,9 @@ pub fn coerce_types(
                     return coerce_types(agg_fun, &[v.as_ref().clone()], signature)
                 }
                 List(field) => {
-                    let coerce_types =
+                    let coerced_types =
                         coerce_types(agg_fun, &[field.data_type().clone()], signature)?;
-                    let data_type = coerce_types[0].clone();
+                    let data_type = coerced_types[0].clone();
                     List(Arc::new(Field::new(
                         field.name(),
                         data_type,

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -326,6 +326,9 @@ pub fn create_physical_fun(
         }
 
         // array functions
+        BuiltinScalarFunction::ArrayAggregate => {
+            unimplemented!("ArrayAggregate reused the same function as AggregateExpr")
+        }
         BuiltinScalarFunction::ArrayAppend => {
             Arc::new(|args| make_scalar_function(array_expressions::array_append)(args))
         }

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -641,6 +641,7 @@ enum ScalarFunction {
   ArrayExcept = 123;
   ArrayPopFront = 124;
   Levenshtein = 125;
+  ArrayAggregate = 126;
 }
 
 message ScalarFunctionNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -20849,6 +20849,7 @@ impl serde::Serialize for ScalarFunction {
             Self::ArrayExcept => "ArrayExcept",
             Self::ArrayPopFront => "ArrayPopFront",
             Self::Levenshtein => "Levenshtein",
+            Self::ArrayAggregate => "ArrayAggregate",
         };
         serializer.serialize_str(variant)
     }
@@ -20986,6 +20987,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
             "ArrayExcept",
             "ArrayPopFront",
             "Levenshtein",
+            "ArrayAggregate",
         ];
 
         struct GeneratedVisitor;
@@ -21152,6 +21154,7 @@ impl<'de> serde::Deserialize<'de> for ScalarFunction {
                     "ArrayExcept" => Ok(ScalarFunction::ArrayExcept),
                     "ArrayPopFront" => Ok(ScalarFunction::ArrayPopFront),
                     "Levenshtein" => Ok(ScalarFunction::Levenshtein),
+                    "ArrayAggregate" => Ok(ScalarFunction::ArrayAggregate),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -2572,6 +2572,7 @@ pub enum ScalarFunction {
     ArrayExcept = 123,
     ArrayPopFront = 124,
     Levenshtein = 125,
+    ArrayAggregate = 126,
 }
 impl ScalarFunction {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2706,6 +2707,7 @@ impl ScalarFunction {
             ScalarFunction::ArrayExcept => "ArrayExcept",
             ScalarFunction::ArrayPopFront => "ArrayPopFront",
             ScalarFunction::Levenshtein => "Levenshtein",
+            ScalarFunction::ArrayAggregate => "ArrayAggregate",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2837,6 +2839,7 @@ impl ScalarFunction {
             "ArrayExcept" => Some(Self::ArrayExcept),
             "ArrayPopFront" => Some(Self::ArrayPopFront),
             "Levenshtein" => Some(Self::Levenshtein),
+            "ArrayAggregate" => Some(Self::ArrayAggregate),
             _ => None,
         }
     }

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -462,6 +462,7 @@ impl From<&protobuf::ScalarFunction> for BuiltinScalarFunction {
             ScalarFunction::Ltrim => Self::Ltrim,
             ScalarFunction::Rtrim => Self::Rtrim,
             ScalarFunction::ToTimestamp => Self::ToTimestamp,
+            ScalarFunction::ArrayAggregate => Self::ArrayAggregate,
             ScalarFunction::ArrayAppend => Self::ArrayAppend,
             ScalarFunction::ArrayConcat => Self::ArrayConcat,
             ScalarFunction::ArrayEmpty => Self::ArrayEmpty,

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -1335,6 +1335,7 @@ pub fn parse_expr(
                         .map(|expr| parse_expr(expr, registry))
                         .collect::<Result<Vec<_>, _>>()?,
                 )),
+                ScalarFunction::ArrayAggregate => unimplemented!("ArrayAggregate"),
                 ScalarFunction::ArrayAppend => Ok(array_append(
                     parse_expr(&args[0], registry)?,
                     parse_expr(&args[1], registry)?,

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -1477,6 +1477,7 @@ impl TryFrom<&BuiltinScalarFunction> for protobuf::ScalarFunction {
             BuiltinScalarFunction::Ltrim => Self::Ltrim,
             BuiltinScalarFunction::Rtrim => Self::Rtrim,
             BuiltinScalarFunction::ToTimestamp => Self::ToTimestamp,
+            BuiltinScalarFunction::ArrayAggregate => Self::ArrayAggregate,
             BuiltinScalarFunction::ArrayAppend => Self::ArrayAppend,
             BuiltinScalarFunction::ArrayConcat => Self::ArrayConcat,
             BuiltinScalarFunction::ArrayEmpty => Self::ArrayEmpty,

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -72,8 +72,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         // next, scalar built-in
         if let Ok(fun) = BuiltinScalarFunction::from_str(&name) {
-            let args =
-                self.function_args_to_expr(args, schema, planner_context)?;
+            let args = self.function_args_to_expr(args, schema, planner_context)?;
 
             // Translate array_aggregate to aggregate function with array argument.
             if fun == BuiltinScalarFunction::ArrayAggregate {

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -234,10 +234,10 @@ AS VALUES
 statement ok
 CREATE TABLE arrays_values_without_nulls
 AS VALUES
-  (make_array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 1, 1, ',', [2,3]),
-  (make_array(11, 12, 13, 14, 15, 16, 17, 18, 19, 20), 12, 2, '.', [4,5]),
-  (make_array(21, 22, 23, 24, 25, 26, 27, 28, 29, 30), 23, 3, '-', [6,7]),
-  (make_array(31, 32, 33, 34, 35, 26, 37, 38, 39, 40), 34, 4, 'ok', [8,9])
+  (make_array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 1, 1, ',', [2,3], make_array(1.1, 2.2)),
+  (make_array(11, 12, 13, 14, 15, 16, 17, 18, 19, 20), 12, 2, '.', [4,5], make_array(3.1, -3.1)),
+  (make_array(21, 22, 23, 24, 25, 26, 27, 28, 29, 30), 23, 3, '-', [6,7], make_array(3.1, -1.1)),
+  (make_array(31, 32, 33, 34, 35, 26, 37, 38, 39, 40), 34, 4, 'ok', [8,9], make_array(-1.2, -1.3))
 ;
 
 statement ok
@@ -3076,6 +3076,44 @@ select string_to_list(e, 'm') from values;
 [consectetur]
 [adipiscing]
 NULL
+
+# array aggregate function
+## array aggregate
+
+### sum
+statement ok
+set datafusion.execution.target_partitions = 1;
+
+query IRI
+select 
+array_aggregate([1, 3, 5, 7], 'sum'),
+array_aggregate([1.1, 2.2, 3.3], 'sum'),
+array_aggregate([1, -1, 0, 23], 'sum');
+----
+16 6.6 23
+
+# TODO: Support nulls in array.
+# query error DataFusion error: This feature is not implemented: Arrays with different types are not supported: \{Null, Int64\}
+# select array_aggregate([1, null, 3, null], 'sum');
+
+query ??
+select column1, column6 from arrays_values_without_nulls;
+----
+[1, 2, 3, 4, 5, 6, 7, 8, 9, 10] [1.1, 2.2]
+[11, 12, 13, 14, 15, 16, 17, 18, 19, 20] [3.1, -3.1]
+[21, 22, 23, 24, 25, 26, 27, 28, 29, 30] [3.1, -1.1]
+[31, 32, 33, 34, 35, 26, 37, 38, 39, 40] [-1.2, -1.3]
+
+# I need to set target partition to 1, otherwise the we will get NullArray for some of partition executions.
+query IR
+select array_aggregate(column1, 'sum'),
+       array_aggregate(column6, 'sum')
+from arrays_values_without_nulls;
+----
+55 3.3
+155 0
+255 2
+345 -2.5
 
 ### Delete tables
 

--- a/docs/source/user-guide/expressions.md
+++ b/docs/source/user-guide/expressions.md
@@ -209,6 +209,7 @@ Unlike to some databases the math functions in Datafusion works the same way as 
 
 | Syntax                                | Description                                                                                                                                                              |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| array_aggregate(array, name)          | Allows the execution of arbitrary existing aggregate functions on the elements of a list. `array_aggregate([1, 2, 3], 'sum') -> 6`                                       |
 | array_append(array, element)          | Appends an element to the end of an array. `array_append([1, 2, 3], 4) -> [1, 2, 3, 4]`                                                                                  |
 | array_concat(array[, ..., array_n])   | Concatenates arrays. `array_concat([1, 2, 3], [4, 5, 6]) -> [1, 2, 3, 4, 5, 6]`                                                                                          |
 | array_has(array, element)             | Returns true if the array contains the element `array_has([1,2,3], 1) -> true`                                                                                           |

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1518,6 +1518,7 @@ from_unixtime(expression)
 
 ## Array Functions
 
+- [array_aggregate](#array_aggregate)
 - [array_append](#array_append)
 - [array_cat](#array_cat)
 - [array_concat](#array_concat)
@@ -1577,6 +1578,26 @@ from_unixtime(expression)
 - [string_to_list](#string_to_list)
 - [trim_array](#trim_array)
 - [range](#range)
+
+### `array_aggregate`
+
+Allows the execution of arbitrary existing aggregate function `name` on the elements of a list.
+
+```
+array_aggregate(array, name)
+```
+
+#### Arguments
+
+- **array**: Array expression.
+  Can be a constant, column, or function, and any combination of array operators.
+- **name**: Aggregate function name.
+
+#### Aliases
+
+- list_aggregate
+- array_aggr
+- list_aggr
 
 ### `array_append`
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Ref #7213 .
Ref #7214 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

## Note
* array_aggregate not support somethings like `SELECT list_aggregate([2, 4, 8, 42], 'string_agg', '|')`, so I don't close #7213 .

* `array_sum` is not included in this PR