### PR TITLE
feat(7181): provide slicing of CursorValues

### DIFF
--- a/datafusion/physical-plan/src/sorts/cursor.rs
+++ b/datafusion/physical-plan/src/sorts/cursor.rs
@@ -140,7 +140,7 @@ pub struct RowValues {
 
     /// Lower bound of windowed RowValues.
     offset: usize,
-    /// Upper bound of windowed RowValues.
+    /// Upper bound of windowed RowValues (not inclusive).
     limit: usize,
 
     /// Tracks for the memory used by in the `Rows` of this
@@ -189,7 +189,7 @@ impl CursorValues for RowValues {
 
     fn slice(&self, offset: usize, length: usize) -> Self {
         assert!(
-            offset >= self.offset && self.offset + offset <= self.limit,
+            offset >= self.offset && self.offset + offset < self.limit,
             "slice offset is out of bounds"
         );
         assert!(
@@ -683,7 +683,9 @@ mod tests {
         let buffer = ScalarBuffer::from(vec![0, 1, 2]);
         let cursor = new_primitive_cursor(options, buffer, 0);
 
-        cursor.cursor_values().slice(42, 1);
+        cursor
+            .cursor_values()
+            .slice(cursor.cursor_values().len(), 1);
     }
 
     fn new_row_cursor(cols: &[Arc<dyn Array>; 2]) -> Cursor<RowValues> {
@@ -744,7 +746,9 @@ mod tests {
 
         let cursor = new_row_cursor(&cols);
 
-        cursor.cursor_values().slice(42, 1);
+        cursor
+            .cursor_values()
+            .slice(cursor.cursor_values().len(), 1);
     }
 
     fn new_bytearray_cursor(
@@ -770,7 +774,7 @@ mod tests {
     }
 
     #[test]
-    fn test_slice_bytes() {
+    fn test_slice_bytearray() {
         let mut a = new_bytearray_cursor("hellorainbowworld", vec![0, 5, 12, 17]);
         let mut b = new_bytearray_cursor("hellorainbowworld", vec![0, 5, 12, 17]);
 
@@ -802,8 +806,10 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "slice offset is out of bounds")]
-    fn test_slice_bytes_should_panic() {
+    fn test_slice_bytearray_should_panic() {
         let cursor = new_bytearray_cursor("hellorainbowworld", vec![0, 5, 12, 17]);
-        cursor.cursor_values().slice(42, 1);
+        cursor
+            .cursor_values()
+            .slice(cursor.cursor_values().len(), 1);
     }
 }

--- a/datafusion/physical-plan/src/sorts/cursor.rs
+++ b/datafusion/physical-plan/src/sorts/cursor.rs
@@ -42,11 +42,11 @@ pub trait CursorValues {
     /// Returns comparison of `l[l_idx]` and `r[r_idx]`
     fn compare(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> Ordering;
 
-    /// Slice at a given row index, returning a new Self
+    /// Returns a zero-copy slice of this [`CursorValues`] with the indicated offset and length.
     ///
     /// # Panics
     ///
-    /// Panics if the slice is out of bounds, or memory is insufficient
+    /// Panics if the slice is out of bounds
     fn slice(&self, offset: usize, length: usize) -> Self;
 }
 
@@ -138,9 +138,9 @@ impl<T: CursorValues> Ord for Cursor<T> {
 pub struct RowValues {
     rows: Arc<Rows>,
 
-    /// Lower bound of windowed RowValues.
+    /// Lower bound within `rows`.
     offset: usize,
-    /// Upper bound of windowed RowValues (not inclusive).
+    /// Upper bound within `rows` (not inclusive).
     limit: usize,
 
     /// Tracks for the memory used by in the `Rows` of this
@@ -150,7 +150,7 @@ pub struct RowValues {
 }
 
 impl RowValues {
-    /// Create a new [`RowValues`] from `Arc<Rows>`.
+    /// Create a new [`RowValues`] from [`Rows`].
     ///
     /// Panics if `rows` is empty.
     pub fn new(rows: Rows, reservation: MemoryReservation) -> Self {

--- a/datafusion/physical-plan/src/sorts/stream.rs
+++ b/datafusion/physical-plan/src/sorts/stream.rs
@@ -127,7 +127,7 @@ impl RowCursorStream {
         // track the memory in the newly created Rows.
         let mut rows_reservation = self.reservation.new_empty();
         rows_reservation.try_grow(rows.size())?;
-        Ok(RowValues::new(rows, rows_reservation))
+        Ok(RowValues::new(Arc::new(rows)))
     }
 }
 

--- a/datafusion/physical-plan/src/sorts/stream.rs
+++ b/datafusion/physical-plan/src/sorts/stream.rs
@@ -127,7 +127,7 @@ impl RowCursorStream {
         // track the memory in the newly created Rows.
         let mut rows_reservation = self.reservation.new_empty();
         rows_reservation.try_grow(rows.size())?;
-        Ok(RowValues::new(Arc::new(rows)))
+        Ok(RowValues::new(rows, rows_reservation))
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #7181  .

## Rationale for this change
In the cascaded merge tree, partially sorted record batches are yielded per merge node. 
Therefore, we need the ability to yield a partial of these representative values (a.k.a. the `CursorValues`).

## What changes are included in this PR?
Slicing the `CursorValues`.
Add tests to demonstrate use with `Cursor::new(sliced_cursor_values)`.
Have test coverage include different data types.

## Are these changes tested?
Yes, tests are added.

## Are there any user-facing changes?
No. `CursorValues` are currently an internal construct.