### PR TITLE
[draft] Add `LogicalType`, try to support user-defined types

### DIFF
--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -17,6 +17,7 @@
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion_common::config::ConfigOptions;
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::{plan_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::{
@@ -212,7 +213,7 @@ impl ContextProvider for MyContextProvider {
         None
     }
 
-    fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
+    fn get_variable_type(&self, _variable_names: &[String]) -> Option<LogicalType> {
         None
     }
 

--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -357,7 +357,6 @@ impl fmt::Display for Column {
 mod tests {
     use super::*;
     use crate::DFField;
-    use arrow::datatypes::DataType;
     use std::collections::HashMap;
 
     fn create_schema(names: &[(Option<&str>, &str)]) -> Result<DFSchema> {
@@ -367,7 +366,7 @@ mod tests {
                 DFField::new(
                     qualifier.to_owned().map(|s| s.to_string()),
                     name,
-                    DataType::Boolean,
+                    LogicalType::Boolean,
                     true,
                 )
             })

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -33,6 +33,7 @@ pub mod display;
 pub mod file_options;
 pub mod format;
 pub mod hash_utils;
+pub mod logical_type;
 pub mod parsers;
 pub mod scalar;
 pub mod stats;

--- a/datafusion/common/src/logical_type.rs
+++ b/datafusion/common/src/logical_type.rs
@@ -1,0 +1,411 @@
+use std::{borrow::Cow, fmt::Display, sync::Arc};
+
+use crate::error::Result;
+use arrow_schema::{DataType, Field, IntervalUnit, TimeUnit};
+
+#[derive(Clone, Debug)]
+pub enum LogicalType {
+    Null,
+    Boolean,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Float16,
+    Float32,
+    Float64,
+    String,
+    LargeString,
+    Date32,
+    Date64,
+    Time32(TimeUnit),
+    Time64(TimeUnit),
+    Timestamp(TimeUnit, Option<Arc<str>>),
+    Duration(TimeUnit),
+    Interval(IntervalUnit),
+    Binary,
+    FixedSizeBinary(i32),
+    LargeBinary,
+    Utf8,
+    LargeUtf8,
+    List(Box<LogicalType>),
+    FixedSizeList(Box<LogicalType>, i32),
+    LargeList(Box<LogicalType>),
+    Struct(Fields),
+    Map(NamedLogicalTypeRef, bool),
+    // union
+    Decimal128(u8, i8),
+    Decimal256(u8, i8),
+    Extension(ExtensionTypeRef),
+}
+
+impl PartialEq for LogicalType {
+    fn eq(&self, other: &Self) -> bool {
+        self.type_signature() == other.type_signature()
+    }
+}
+
+impl Eq for LogicalType {}
+
+impl std::hash::Hash for LogicalType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.type_signature().hash(state)
+    }
+}
+
+impl Display for LogicalType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.display_name())
+    }
+}
+
+pub type Fields = Arc<[NamedLogicalTypeRef]>;
+pub type NamedLogicalTypeRef = Arc<NamedLogicalType>;
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct NamedLogicalType {
+    name: String,
+    data_type: LogicalType,
+}
+
+impl NamedLogicalType {
+    pub fn new(name: impl Into<String>, data_type: LogicalType) -> Self {
+        Self {
+            name: name.into(),
+            data_type,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn data_type(&self) -> &LogicalType {
+        &self.data_type
+    }
+}
+
+pub type OwnedTypeSignature = TypeSignature<'static>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TypeSignature<'a> {
+    // **func_name**(p1, p2)
+    name: Cow<'a, str>,
+    // func_name(**p1**, **p2**)
+    params: Vec<Cow<'a, str>>,
+}
+
+impl<'a> TypeSignature<'a> {
+    pub fn new(name: impl Into<Cow<'a, str>>) -> Self {
+        Self::new_with_params(name, vec![])
+    }
+
+    pub fn new_with_params(
+        name: impl Into<Cow<'a, str>>,
+        params: Vec<Cow<'a, str>>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            params,
+        }
+    }
+
+    pub fn to_owned_type_signature(&self) -> OwnedTypeSignature {
+        OwnedTypeSignature {
+            name: self.name.to_string().into(),
+            params: self.params.iter().map(|p| p.to_string().into()).collect(),
+        }
+    }
+}
+
+pub type ExtensionTypeRef = Arc<dyn ExtensionType + Send + Sync>;
+
+pub trait ExtensionType: std::fmt::Debug {
+    fn display_name(&self) -> &str;
+    fn type_signature(&self) -> TypeSignature;
+    fn physical_type(&self) -> DataType;
+
+    fn is_comparable(&self) -> bool;
+    fn is_orderable(&self) -> bool;
+    fn is_numeric(&self) -> bool;
+}
+
+pub trait TypeManager {
+    fn register_data_type(
+        &mut self,
+        signature: impl Into<TypeSignature<'static>>,
+        extension_type: ExtensionTypeRef,
+    ) -> Result<()>;
+
+    fn data_type(&self, signature: &TypeSignature) -> Result<Option<ExtensionTypeRef>>;
+}
+
+impl ExtensionType for LogicalType {
+    fn display_name(&self) -> &str {
+        match self {
+            Self::Null => "NULL",
+            Self::Boolean => "BOOLEAN",
+            Self::Int8 => "INT8",
+            Self::Int16 => "INT16",
+            Self::Int32 => "INT32",
+            Self::Int64 => "INT64",
+            Self::UInt8 => "UINT8",
+            Self::UInt16 => "UINT16",
+            Self::UInt32 => "UINT32",
+            Self::UInt64 => "UINT64",
+            Self::Float16 => "FLOAT16",
+            Self::Float32 => "Float16",
+            Self::Float64 => "Float64",
+            Self::String => "String",
+            Self::LargeString => "LargeString",
+            Self::Date32 => "Date32",
+            Self::Date64 => "Date64",
+            Self::Time32(_) => "Time32",
+            Self::Time64(_) => "Time64",
+            Self::Timestamp(_, _) => "Timestamp",
+            Self::Duration(_) => "Duration",
+            Self::Interval(_) => "Interval",
+            Self::Binary => "Binary",
+            Self::FixedSizeBinary(_) => "FixedSizeBinary",
+            Self::LargeBinary => "LargeBinary",
+            Self::Utf8 => "Utf8",
+            Self::LargeUtf8 => "LargeUtf8",
+            Self::List(_) => "List",
+            Self::FixedSizeList(_, _) => "FixedSizeList",
+            Self::LargeList(_) => "LargeList",
+            Self::Struct(_) => "Struct",
+            Self::Map(_, _) => "Map",
+            Self::Decimal128(_, _) => "Decimal128",
+            Self::Decimal256(_, _) => "Decimal256",
+            Self::Extension(ext) => ext.display_name(),
+        }
+    }
+
+    fn type_signature(&self) -> TypeSignature {
+        match self {
+            Self::Boolean => TypeSignature::new("boolean"),
+            Self::Int32 => TypeSignature::new("int32"),
+            Self::Int64 => TypeSignature::new("int64"),
+            Self::UInt64 => TypeSignature::new("uint64"),
+            Self::Float32 => TypeSignature::new("float32"),
+            Self::Float64 => TypeSignature::new("float64"),
+            Self::String => TypeSignature::new("string"),
+            Self::Timestamp(tu, zone) => {
+                let tu = match tu {
+                    TimeUnit::Second => "second",
+                    TimeUnit::Millisecond => "millisecond",
+                    TimeUnit::Microsecond => "microsecond",
+                    TimeUnit::Nanosecond => "nanosecond",
+                };
+
+                let params = if let Some(zone) = zone {
+                    vec![tu.into(), zone.as_ref().into()]
+                } else {
+                    vec![tu.into()]
+                };
+
+                TypeSignature::new_with_params("timestamp", params)
+            }
+            Self::Binary => TypeSignature::new("binary"),
+            Self::Utf8 => TypeSignature::new("string"),
+            Self::Extension(ext) => ext.type_signature(),
+            Self::Struct(fields) => {
+                let params = fields.iter().map(|f| f.name().into()).collect();
+                TypeSignature::new_with_params("struct", params)
+            }
+            other => panic!("not implemented: {other:?}"),
+        }
+    }
+
+    fn physical_type(&self) -> DataType {
+        match self {
+            Self::Boolean => DataType::Boolean,
+            Self::Int32 => DataType::Int32,
+            Self::Int64 => DataType::Int64,
+            Self::UInt64 => DataType::UInt64,
+            Self::Float32 => DataType::Float32,
+            Self::Float64 => DataType::Float64,
+            Self::String => DataType::Utf8,
+            Self::Timestamp(tu, zone) => DataType::Timestamp(tu.clone(), zone.clone()),
+            Self::Binary => DataType::Binary,
+            Self::Utf8 => DataType::Utf8,
+            Self::Extension(ext) => ext.physical_type(),
+            Self::Struct(fields) => {
+                let fields = fields
+                    .iter()
+                    .map(|f| {
+                        let name = f.name();
+                        let data_type = f.physical_type();
+                        Arc::new(Field::new(name, data_type, true))
+                    })
+                    .collect::<Vec<_>>();
+                DataType::Struct(fields.into())
+            }
+            other => panic!("not implemented {other:?}"),
+        }
+    }
+
+    fn is_comparable(&self) -> bool {
+        match self {
+            Self::Null
+            | Self::Boolean
+            | Self::Int8
+            | Self::Int16
+            | Self::Int32
+            | Self::Int64
+            | Self::UInt8
+            | Self::UInt16
+            | Self::UInt32
+            | Self::UInt64
+            | Self::Float16
+            | Self::Float32
+            | Self::Float64
+            | Self::String
+            | Self::LargeString
+            | Self::Date32
+            | Self::Date64
+            | Self::Time32(_)
+            | Self::Time64(_)
+            | Self::Timestamp(_, _)
+            | Self::Duration(_)
+            | Self::Interval(_)
+            | Self::Binary
+            | Self::FixedSizeBinary(_)
+            | Self::LargeBinary
+            | Self::Utf8
+            | Self::LargeUtf8
+            | Self::Decimal128(_, _)
+            | Self::Decimal256(_, _) => true,
+            Self::List(_) => false,
+            Self::FixedSizeList(_, _) => false,
+            Self::LargeList(_) => false,
+            Self::Struct(_) => false,
+            Self::Map(_, _) => false,
+            Self::Extension(ext) => ext.is_comparable(),
+        }
+    }
+
+    fn is_orderable(&self) -> bool {
+        todo!()
+    }
+
+    /// Returns true if this type is numeric: (UInt*, Int*, Float*, Decimal*).
+    #[inline]
+    fn is_numeric(&self) -> bool {
+        use LogicalType::*;
+        match self {
+            UInt8
+            | UInt16
+            | UInt32
+            | UInt64
+            | Int8
+            | Int16
+            | Int32
+            | Int64
+            | Float16
+            | Float32
+            | Float64
+            | Decimal128(_, _)
+            | Decimal256(_, _) => true,
+            Extension(t) => t.is_numeric(),
+            _ => false,
+        }
+    }
+}
+
+impl From<&DataType> for LogicalType {
+    fn from(value: &DataType) -> Self {
+        // TODO
+        value.clone().into()
+    }
+}
+
+impl From<DataType> for LogicalType {
+    fn from(value: DataType) -> Self {
+        match value {
+            DataType::Null => LogicalType::Null,
+            DataType::Boolean => LogicalType::Boolean,
+            DataType::Int8 => LogicalType::Int8,
+            DataType::Int16 => LogicalType::Int16,
+            DataType::Int32 => LogicalType::Int32,
+            DataType::Int64 => LogicalType::Int64,
+            DataType::UInt8 => LogicalType::UInt8,
+            DataType::UInt16 => LogicalType::UInt16,
+            DataType::UInt32 => LogicalType::UInt32,
+            DataType::UInt64 => LogicalType::UInt64,
+            DataType::Float16 => LogicalType::Float16,
+            DataType::Float32 => LogicalType::Float32,
+            DataType::Float64 => LogicalType::Float64,
+            DataType::Timestamp(tu, z) => LogicalType::Timestamp(tu, z),
+            DataType::Date32 => LogicalType::Date32,
+            DataType::Date64 => LogicalType::Date64,
+            DataType::Time32(tu) => LogicalType::Time32(tu),
+            DataType::Time64(tu) => LogicalType::Time64(tu),
+            DataType::Duration(tu) => LogicalType::Duration(tu),
+            DataType::Interval(iu) => LogicalType::Interval(iu),
+            DataType::Binary => LogicalType::Binary,
+            DataType::FixedSizeBinary(len) => LogicalType::FixedSizeBinary(len),
+            DataType::LargeBinary => LogicalType::LargeBinary,
+            DataType::Utf8 => LogicalType::Utf8,
+            DataType::LargeUtf8 => LogicalType::LargeUtf8,
+            DataType::List(f) => LogicalType::List(Box::new(f.data_type().into())),
+            DataType::FixedSizeList(f, len) => {
+                LogicalType::FixedSizeList(Box::new(f.data_type().into()), len)
+            }
+            DataType::LargeList(f) => {
+                LogicalType::LargeList(Box::new(f.data_type().into()))
+            }
+            DataType::Struct(fields) => {
+                let fields = fields
+                    .into_iter()
+                    .map(|f| {
+                        let name = f.name();
+                        let logical_type = f.data_type().into();
+                        Arc::new(NamedLogicalType::new(name, logical_type))
+                    })
+                    .collect::<Vec<_>>();
+                LogicalType::Struct(fields.into())
+            }
+            DataType::Union(_, _) => unimplemented!(),
+            DataType::Dictionary(_, dt) => dt.as_ref().into(),
+            DataType::Decimal128(p, s) => LogicalType::Decimal128(p, s),
+            DataType::Decimal256(p, s) => LogicalType::Decimal256(p, s),
+            DataType::Map(data, sorted) => {
+                let field =
+                    Arc::new(NamedLogicalType::new(data.name(), data.data_type().into()));
+                LogicalType::Map(field, sorted)
+            }
+            DataType::RunEndEncoded(_, f) => f.data_type().into(),
+        }
+    }
+}
+
+impl ExtensionType for NamedLogicalType {
+    fn display_name(&self) -> &str {
+        &self.name
+    }
+
+    fn type_signature(&self) -> TypeSignature {
+        TypeSignature::new(self.name())
+    }
+
+    fn physical_type(&self) -> DataType {
+        self.data_type.physical_type()
+    }
+
+    fn is_comparable(&self) -> bool {
+        self.data_type.is_comparable()
+    }
+
+    fn is_orderable(&self) -> bool {
+        self.data_type.is_orderable()
+    }
+
+    fn is_numeric(&self) -> bool {
+        self.data_type.is_numeric()
+    }
+}

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -263,7 +263,7 @@ async fn prune_partitions(
     let df_schema = DFSchema::new_with_metadata(
         partition_cols
             .iter()
-            .map(|(n, d)| DFField::new_unqualified(n, d.clone(), true))
+            .map(|(n, d)| DFField::new_unqualified(n, d.into(), true))
             .collect(),
         Default::default(),
     )?;

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -253,6 +253,7 @@ pub struct ListingOptions {
     pub format: Arc<dyn FileFormat>,
     /// The expected partition column names in the folder structure.
     /// See [Self::with_table_partition_cols] for details
+    /// TODO this maybe LogicalType
     pub table_partition_cols: Vec<(String, DataType)>,
     /// Set true to try to guess statistics from the files.
     /// This can add a lot of overhead as it will usually require files
@@ -2012,7 +2013,7 @@ mod tests {
         let scan_plan = LogicalPlanBuilder::scan("source", source, None)?.build()?;
         // Create an insert plan to insert the source data into the initial table
         let insert_into_table =
-            LogicalPlanBuilder::insert_into(scan_plan, "t", &schema, false)?.build()?;
+            LogicalPlanBuilder::insert_into(scan_plan, "t", &schema.into(), false)?.build()?;
         // Create a physical plan from the insert plan
         let plan = session_ctx
             .state()
@@ -2227,7 +2228,7 @@ mod tests {
         // Therefore, we will have 8 partitions in the final plan.
         // Create an insert plan to insert the source data into the initial table
         let insert_into_table =
-            LogicalPlanBuilder::insert_into(scan_plan, "t", &schema, false)?.build()?;
+            LogicalPlanBuilder::insert_into(scan_plan, "t", &schema.into(), false)?.build()?;
         // Create a physical plan from the insert plan
         let plan = session_ctx
             .state()

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -561,7 +561,7 @@ mod tests {
         let scan_plan = LogicalPlanBuilder::scan("source", source, None)?.build()?;
         // Create an insert plan to insert the source data into the initial table
         let insert_into_table =
-            LogicalPlanBuilder::insert_into(scan_plan, "t", &schema, false)?.build()?;
+            LogicalPlanBuilder::insert_into(scan_plan, "t", &schema.into(), false)?.build()?;
         // Create a physical plan from the insert plan
         let plan = session_ctx
             .state()

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -1348,7 +1348,7 @@ mod tests {
             None
         }
 
-        fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
+        fn get_variable_type(&self, _variable_names: &[String]) -> Option<LogicalType> {
             None
         }
 

--- a/datafusion/core/src/test/variable.rs
+++ b/datafusion/core/src/test/variable.rs
@@ -21,6 +21,7 @@ use crate::error::Result;
 use crate::scalar::ScalarValue;
 use crate::variable::VarProvider;
 use arrow::datatypes::DataType;
+use datafusion_common::logical_type::LogicalType;
 
 /// System variable
 #[derive(Default, Debug)]
@@ -41,7 +42,7 @@ impl VarProvider for SystemVar {
     }
 
     fn get_type(&self, _: &[String]) -> Option<DataType> {
-        Some(DataType::Utf8)
+        Some(LogicalType::Utf8)
     }
 }
 
@@ -69,9 +70,9 @@ impl VarProvider for UserDefinedVar {
 
     fn get_type(&self, var_names: &[String]) -> Option<DataType> {
         if var_names[0] != "@integer" {
-            Some(DataType::Utf8)
+            Some(LogicalType::Utf8)
         } else {
-            Some(DataType::Int32)
+            Some(LogicalType::Int32)
         }
     }
 }

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -29,6 +29,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use arrow_schema::ArrowError;
+use datafusion_common::logical_type::LogicalType;
 use std::sync::Arc;
 
 use datafusion::dataframe::DataFrame;
@@ -1551,7 +1552,7 @@ impl VarProvider for HardcodedIntProvider {
     }
 
     fn get_type(&self, _: &[String]) -> Option<DataType> {
-        Some(DataType::Int64)
+        Some(LogicalType::Int64)
     }
 }
 

--- a/datafusion/core/tests/simplification.rs
+++ b/datafusion/core/tests/simplification.rs
@@ -20,6 +20,7 @@
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::DFSchema;
 use datafusion::{error::Result, execution::context::ExecutionProps, prelude::*};
+use datafusion_common::logical_type::LogicalType;
 use datafusion_expr::{Expr, ExprSchemable};
 use datafusion_optimizer::simplify_expressions::{ExprSimplifier, SimplifyInfo};
 
@@ -39,7 +40,7 @@ struct MyInfo {
 
 impl SimplifyInfo for MyInfo {
     fn is_boolean_type(&self, expr: &Expr) -> Result<bool> {
-        Ok(matches!(expr.get_type(&self.schema)?, DataType::Boolean))
+        Ok(matches!(expr.get_type(&self.schema)?, LogicalType::Boolean))
     }
 
     fn nullable(&self, expr: &Expr) -> Result<bool> {
@@ -50,7 +51,7 @@ impl SimplifyInfo for MyInfo {
         &self.execution_props
     }
 
-    fn get_data_type(&self, expr: &Expr) -> Result<DataType> {
+    fn get_data_type(&self, expr: &Expr) -> Result<LogicalType> {
         expr.get_type(&self.schema)
     }
 }

--- a/datafusion/expr/src/conditional_expressions.rs
+++ b/datafusion/expr/src/conditional_expressions.rs
@@ -19,6 +19,7 @@
 use crate::expr::Case;
 use crate::{expr_schema::ExprSchemable, Expr};
 use arrow::datatypes::DataType;
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::{plan_err, DFSchema, DataFusionError, Result};
 use std::collections::HashSet;
 
@@ -89,18 +90,18 @@ impl CaseBuilder {
             then_expr.push(e.as_ref().to_owned());
         }
 
-        let then_types: Vec<DataType> = then_expr
+        let then_types: Vec<LogicalType> = then_expr
             .iter()
             .map(|e| match e {
                 Expr::Literal(_) => e.get_type(&DFSchema::empty()),
-                _ => Ok(DataType::Null),
+                _ => Ok(LogicalType::Null),
             })
             .collect::<Result<Vec<_>>>()?;
 
-        if then_types.contains(&DataType::Null) {
+        if then_types.contains(&LogicalType::Null) {
             // cannot verify types until execution type
         } else {
-            let unique_types: HashSet<&DataType> = then_types.iter().collect();
+            let unique_types: HashSet<&LogicalType> = then_types.iter().collect();
             if unique_types.len() != 1 {
                 return plan_err!(
                     "CASE expression 'then' values had multiple data types: {unique_types:?}"

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -30,6 +30,7 @@ use crate::{
     ScalarFunctionImplementation, ScalarUDF, Signature, StateTypeFunction, Volatility,
 };
 use arrow::datatypes::DataType;
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::{Column, Result};
 use std::ops::Not;
 use std::sync::Arc;
@@ -55,7 +56,7 @@ pub fn col(ident: impl Into<Column>) -> Expr {
 
 /// Create an out reference column which hold a reference that has been resolved to a field
 /// outside of the current plan.
-pub fn out_ref_col(dt: DataType, ident: impl Into<Column>) -> Expr {
+pub fn out_ref_col(dt: LogicalType, ident: impl Into<Column>) -> Expr {
     Expr::OuterReferenceColumn(dt, ident.into())
 }
 
@@ -435,12 +436,12 @@ pub fn rollup(exprs: Vec<Expr>) -> Expr {
 }
 
 /// Create a cast expression
-pub fn cast(expr: Expr, data_type: DataType) -> Expr {
+pub fn cast(expr: Expr, data_type: LogicalType) -> Expr {
     Expr::Cast(Cast::new(Box::new(expr), data_type))
 }
 
 /// Create a try cast expression
-pub fn try_cast(expr: Expr, data_type: DataType) -> Expr {
+pub fn try_cast(expr: Expr, data_type: LogicalType) -> Expr {
     Expr::TryCast(TryCast::new(Box::new(expr), data_type))
 }
 

--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -262,7 +262,7 @@ mod test {
     use super::*;
     use crate::expr::Sort;
     use crate::{col, lit, Cast};
-    use arrow::datatypes::DataType;
+    use datafusion_common::logical_type::LogicalType;
     use datafusion_common::tree_node::{RewriteRecursion, TreeNode, TreeNodeRewriter};
     use datafusion_common::{DFField, DFSchema, ScalarValue};
     use std::ops::Add;
@@ -393,7 +393,7 @@ mod test {
     }
 
     fn make_field(relation: &str, column: &str) -> DFField {
-        DFField::new(Some(relation.to_string()), column, DataType::Int8, false)
+        DFField::new(Some(relation.to_string()), column, LogicalType::Int8, false)
     }
 
     #[test]
@@ -423,7 +423,7 @@ mod test {
         // cast data types
         test_rewrite(
             col("a"),
-            Expr::Cast(Cast::new(Box::new(col("a")), DataType::Int32)),
+            Expr::Cast(Cast::new(Box::new(col("a")), LogicalType::Int32)),
         );
 
         // change literal type from i32 to i64

--- a/datafusion/expr/src/expr_rewriter/order_by.rs
+++ b/datafusion/expr/src/expr_rewriter/order_by.rs
@@ -152,6 +152,7 @@ mod test {
     use std::sync::Arc;
 
     use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::logical_type::LogicalType;
 
     use crate::{
         avg, cast, col, lit, logical_plan::builder::LogicalTableSource, min, try_cast,
@@ -268,13 +269,13 @@ mod test {
         let cases = vec![
             TestCase {
                 desc: "Cast is preserved by rewrite_sort_cols_by_aggs",
-                input: sort(cast(col("c2"), DataType::Int64)),
-                expected: sort(cast(col("c2").alias("c2"), DataType::Int64)),
+                input: sort(cast(col("c2"), LogicalType::Int64)),
+                expected: sort(cast(col("c2").alias("c2"), LogicalType::Int64)),
             },
             TestCase {
                 desc: "TryCast is preserved by rewrite_sort_cols_by_aggs",
-                input: sort(try_cast(col("c2"), DataType::Int64)),
-                expected: sort(try_cast(col("c2").alias("c2"), DataType::Int64)),
+                input: sort(try_cast(col("c2"), LogicalType::Int64)),
+                expected: sort(try_cast(col("c2").alias("c2"), LogicalType::Int64)),
             },
         ];
 

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -29,7 +29,7 @@ pub use builder::{
 };
 pub use ddl::{
     CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateMemoryTable,
-    CreateView, DdlStatement, DropCatalogSchema, DropTable, DropView,
+    CreateType, CreateView, DdlStatement, DropCatalogSchema, DropTable, DropView,
 };
 pub use dml::{DmlStatement, WriteOp};
 pub use plan::{

--- a/datafusion/expr/src/type_coercion/mod.rs
+++ b/datafusion/expr/src/type_coercion/mod.rs
@@ -37,6 +37,7 @@ pub mod functions;
 pub mod other;
 
 use arrow::datatypes::DataType;
+use datafusion_common::logical_type::LogicalType;
 /// Determine whether the given data type `dt` represents signed numeric values.
 pub fn is_signed_numeric(dt: &DataType) -> bool {
     matches!(
@@ -69,19 +70,22 @@ pub fn is_interval(dt: &DataType) -> bool {
 }
 
 /// Determine whether the given data type `dt` is a `Date` or `Timestamp`.
-pub fn is_datetime(dt: &DataType) -> bool {
+pub fn is_datetime(dt: &LogicalType) -> bool {
     matches!(
         dt,
-        DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, _)
+        LogicalType::Date32 | LogicalType::Date64 | LogicalType::Timestamp(_, _)
     )
 }
 
 /// Determine whether the given data type `dt` is a `Utf8` or `LargeUtf8`.
-pub fn is_utf8_or_large_utf8(dt: &DataType) -> bool {
-    matches!(dt, DataType::Utf8 | DataType::LargeUtf8)
+pub fn is_utf8_or_large_utf8(dt: &LogicalType) -> bool {
+    matches!(dt, LogicalType::Utf8 | LogicalType::LargeUtf8)
 }
 
 /// Determine whether the given data type `dt` is a `Decimal`.
-pub fn is_decimal(dt: &DataType) -> bool {
-    matches!(dt, DataType::Decimal128(_, _) | DataType::Decimal256(_, _))
+pub fn is_decimal(dt: &LogicalType) -> bool {
+    matches!(
+        dt,
+        LogicalType::Decimal128(_, _) | LogicalType::Decimal256(_, _)
+    )
 }

--- a/datafusion/expr/src/type_coercion/other.rs
+++ b/datafusion/expr/src/type_coercion/other.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use arrow::datatypes::DataType;
+use datafusion_common::logical_type::{ExtensionType, LogicalType};
 
 use super::binary::comparison_coercion;
 
@@ -37,18 +38,22 @@ pub fn get_coerce_type_for_list(
 /// and the `case_or_else_type`, if specified.
 /// Returns the common data type for `when_or_then_types` and `case_or_else_type`
 pub fn get_coerce_type_for_case_expression(
-    when_or_then_types: &[DataType],
-    case_or_else_type: Option<&DataType>,
-) -> Option<DataType> {
+    when_or_then_types: &[LogicalType],
+    case_or_else_type: Option<&LogicalType>,
+) -> Option<LogicalType> {
     let case_or_else_type = match case_or_else_type {
         None => when_or_then_types[0].clone(),
         Some(data_type) => data_type.clone(),
-    };
+    }
+    .physical_type();
+    // FIXME comparison_coercion use LogicalType
     when_or_then_types
         .iter()
+        .map(|e| e.physical_type())
         .try_fold(case_or_else_type, |left_type, right_type| {
             // TODO: now just use the `equal` coercion rule for case when. If find the issue, and
             // refactor again.
-            comparison_coercion(&left_type, right_type)
+            comparison_coercion(&left_type, &right_type)
         })
+        .map(Into::into)
 }

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -22,6 +22,7 @@ use crate::logical_plan::Aggregate;
 use crate::signature::{Signature, TypeSignature};
 use crate::{Cast, Expr, ExprSchemable, GroupingSet, LogicalPlan, TryCast};
 use arrow::datatypes::{DataType, TimeUnit};
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::tree_node::{TreeNode, VisitRecursion};
 use datafusion_common::{
     internal_err, plan_datafusion_err, plan_err, Column, DFField, DFSchema, DFSchemaRef,
@@ -886,39 +887,34 @@ pub(crate) fn find_column_indexes_referenced_by_expr(
 /// can this data type be used in hash join equal conditions??
 /// data types here come from function 'equal_rows', if more data types are supported
 /// in equal_rows(hash join), add those data types here to generate join logical plan.
-pub fn can_hash(data_type: &DataType) -> bool {
+pub fn can_hash(data_type: &LogicalType) -> bool {
     match data_type {
-        DataType::Null => true,
-        DataType::Boolean => true,
-        DataType::Int8 => true,
-        DataType::Int16 => true,
-        DataType::Int32 => true,
-        DataType::Int64 => true,
-        DataType::UInt8 => true,
-        DataType::UInt16 => true,
-        DataType::UInt32 => true,
-        DataType::UInt64 => true,
-        DataType::Float32 => true,
-        DataType::Float64 => true,
-        DataType::Timestamp(time_unit, None) => match time_unit {
+        LogicalType::Null => true,
+        LogicalType::Boolean => true,
+        LogicalType::Int8 => true,
+        LogicalType::Int16 => true,
+        LogicalType::Int32 => true,
+        LogicalType::Int64 => true,
+        LogicalType::UInt8 => true,
+        LogicalType::UInt16 => true,
+        LogicalType::UInt32 => true,
+        LogicalType::UInt64 => true,
+        LogicalType::Float32 => true,
+        LogicalType::Float64 => true,
+        LogicalType::Timestamp(time_unit, None) => match time_unit {
             TimeUnit::Second => true,
             TimeUnit::Millisecond => true,
             TimeUnit::Microsecond => true,
             TimeUnit::Nanosecond => true,
         },
-        DataType::Utf8 => true,
-        DataType::LargeUtf8 => true,
-        DataType::Decimal128(_, _) => true,
-        DataType::Date32 => true,
-        DataType::Date64 => true,
-        DataType::FixedSizeBinary(_) => true,
-        DataType::Dictionary(key_type, value_type)
-            if *value_type.as_ref() == DataType::Utf8 =>
-        {
-            DataType::is_dictionary_key_type(key_type)
-        }
-        DataType::List(_) => true,
-        DataType::LargeList(_) => true,
+        LogicalType::Utf8 => true,
+        LogicalType::LargeUtf8 => true,
+        LogicalType::Decimal128(_, _) => true,
+        LogicalType::Date32 => true,
+        LogicalType::Date64 => true,
+        LogicalType::FixedSizeBinary(_) => true,
+        LogicalType::List(_) => true,
+        LogicalType::LargeList(_) => true,
         _ => false,
     }
 }

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use crate::{utils, OptimizerConfig, OptimizerRule};
 
-use arrow::datatypes::DataType;
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::tree_node::{
     RewriteRecursion, TreeNode, TreeNodeRewriter, TreeNodeVisitor, VisitRecursion,
 };
@@ -39,7 +39,7 @@ use datafusion_expr::{col, Expr, ExprSchemable};
 /// - the expression itself (cloned)
 /// - counter
 /// - DataType of this expression.
-type ExprSet = HashMap<Identifier, (Expr, usize, DataType)>;
+type ExprSet = HashMap<Identifier, (Expr, usize, LogicalType)>;
 
 /// Identifier type. Current implementation use describe of a expression (type String) as
 /// Identifier.
@@ -794,8 +794,8 @@ mod test {
 
         let schema = Arc::new(DFSchema::new_with_metadata(
             vec![
-                DFField::new_unqualified("a", DataType::Int64, false),
-                DFField::new_unqualified("c", DataType::Int64, false),
+                DFField::new_unqualified("a", LogicalType::Int64, false),
+                DFField::new_unqualified("c", LogicalType::Int64, false),
             ],
             Default::default(),
         )?);
@@ -1287,7 +1287,7 @@ mod test {
     fn test_extract_expressions_from_col() -> Result<()> {
         let mut result = Vec::with_capacity(1);
         let schema = DFSchema::new_with_metadata(
-            vec![DFField::new_unqualified("a", DataType::Int32, false)],
+            vec![DFField::new_unqualified("a", LogicalType::Int32, false)],
             HashMap::default(),
         )?;
         extract_expressions(&col("a"), &schema, &mut result)?;

--- a/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
+++ b/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
@@ -322,8 +322,7 @@ impl SubqueryInfo {
 mod tests {
     use super::*;
     use crate::test::*;
-    use arrow::datatypes::DataType;
-    use datafusion_common::Result;
+    use datafusion_common::{logical_type::LogicalType, Result};
     use datafusion_expr::{
         and, binary_expr, col, exists, in_subquery, lit,
         logical_plan::LogicalPlanBuilder, not_exists, not_in_subquery, or, out_ref_col,
@@ -523,7 +522,7 @@ mod tests {
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
                     col("orders.o_custkey")
-                        .eq(out_ref_col(DataType::Int64, "customer.c_custkey")),
+                        .eq(out_ref_col(LogicalType::Int64, "customer.c_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
                 .build()?,
@@ -564,7 +563,7 @@ mod tests {
             LogicalPlanBuilder::from(scan_tpch_table("lineitem"))
                 .filter(
                     col("lineitem.l_orderkey")
-                        .eq(out_ref_col(DataType::Int64, "orders.o_orderkey")),
+                        .eq(out_ref_col(LogicalType::Int64, "orders.o_orderkey")),
                 )?
                 .project(vec![col("lineitem.l_orderkey")])?
                 .build()?,
@@ -575,7 +574,7 @@ mod tests {
                 .filter(
                     in_subquery(col("orders.o_orderkey"), lineitem).and(
                         col("orders.o_custkey")
-                            .eq(out_ref_col(DataType::Int64, "customer.c_custkey")),
+                            .eq(out_ref_col(LogicalType::Int64, "customer.c_custkey")),
                     ),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -612,7 +611,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey"))
                         .and(col("o_orderkey").eq(lit(1))),
                 )?
@@ -647,8 +646,8 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
-                        .eq(out_ref_col(DataType::Int64, "customer.c_custkey")),
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
+                        .eq(out_ref_col(LogicalType::Int64, "customer.c_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
                 .build()?,
@@ -711,7 +710,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .not_eq(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -744,7 +743,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .lt(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -777,7 +776,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey"))
                         .or(col("o_orderkey").eq(lit(1))),
                 )?
@@ -835,7 +834,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -868,7 +867,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey").add(lit(1))])?
@@ -901,7 +900,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey"), col("orders.o_orderkey")])?
@@ -930,7 +929,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -967,7 +966,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -1004,7 +1003,7 @@ mod tests {
     fn in_subquery_correlated() -> Result<()> {
         let sq = Arc::new(
             LogicalPlanBuilder::from(test_table_scan_with_name("sq")?)
-                .filter(out_ref_col(DataType::UInt32, "test.a").eq(col("sq.a")))?
+                .filter(out_ref_col(LogicalType::UInt32, "test.a").eq(col("sq.a")))?
                 .project(vec![col("c")])?
                 .build()?,
         );
@@ -1113,7 +1112,7 @@ mod tests {
 
         let subquery = LogicalPlanBuilder::from(subquery_scan)
             .filter(
-                out_ref_col(DataType::UInt32, "test.a")
+                out_ref_col(LogicalType::UInt32, "test.a")
                     .eq(col("sq.a"))
                     .and(col("sq.a").add(lit(1u32)).eq(col("sq.b"))),
             )?
@@ -1148,8 +1147,8 @@ mod tests {
 
         let subquery = LogicalPlanBuilder::from(subquery_scan)
             .filter(
-                out_ref_col(DataType::UInt32, "test.a")
-                    .add(out_ref_col(DataType::UInt32, "test.b"))
+                out_ref_col(LogicalType::UInt32, "test.a")
+                    .add(out_ref_col(LogicalType::UInt32, "test.b"))
                     .eq(col("sq.a").add(col("sq.b")))
                     .and(col("sq.a").add(lit(1u32)).eq(col("sq.b"))),
             )?
@@ -1184,12 +1183,12 @@ mod tests {
         let subquery_scan2 = test_table_scan_with_name("sq2")?;
 
         let subquery1 = LogicalPlanBuilder::from(subquery_scan1)
-            .filter(out_ref_col(DataType::UInt32, "test.a").gt(col("sq1.a")))?
+            .filter(out_ref_col(LogicalType::UInt32, "test.a").gt(col("sq1.a")))?
             .project(vec![col("c") * lit(2u32)])?
             .build()?;
 
         let subquery2 = LogicalPlanBuilder::from(subquery_scan2)
-            .filter(out_ref_col(DataType::UInt32, "test.a").gt(col("sq2.a")))?
+            .filter(out_ref_col(LogicalType::UInt32, "test.a").gt(col("sq2.a")))?
             .project(vec![col("c") * lit(2u32)])?
             .build()?;
 
@@ -1261,7 +1260,7 @@ mod tests {
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
                     col("orders.o_custkey")
-                        .eq(out_ref_col(DataType::Int64, "customer.c_custkey")),
+                        .eq(out_ref_col(LogicalType::Int64, "customer.c_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
                 .build()?,
@@ -1292,7 +1291,7 @@ mod tests {
             LogicalPlanBuilder::from(scan_tpch_table("lineitem"))
                 .filter(
                     col("lineitem.l_orderkey")
-                        .eq(out_ref_col(DataType::Int64, "orders.o_orderkey")),
+                        .eq(out_ref_col(LogicalType::Int64, "orders.o_orderkey")),
                 )?
                 .project(vec![col("lineitem.l_orderkey")])?
                 .build()?,
@@ -1303,7 +1302,7 @@ mod tests {
                 .filter(
                     exists(lineitem).and(
                         col("orders.o_custkey")
-                            .eq(out_ref_col(DataType::Int64, "customer.c_custkey")),
+                            .eq(out_ref_col(LogicalType::Int64, "customer.c_custkey")),
                     ),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -1334,7 +1333,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey"))
                         .and(col("o_orderkey").eq(lit(1))),
                 )?
@@ -1362,7 +1361,9 @@ mod tests {
     fn exists_subquery_no_cols() -> Result<()> {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
-                .filter(out_ref_col(DataType::Int64, "customer.c_custkey").eq(lit(1u32)))?
+                .filter(
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey").eq(lit(1u32)),
+                )?
                 .project(vec![col("orders.o_custkey")])?
                 .build()?,
         );
@@ -1407,7 +1408,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .not_eq(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -1435,7 +1436,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .lt(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -1463,7 +1464,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey"))
                         .or(col("o_orderkey").eq(lit(1))),
                 )?
@@ -1492,7 +1493,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey")),
                 )?
                 .build()?,
@@ -1518,7 +1519,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey").add(lit(1))])?
@@ -1546,7 +1547,7 @@ mod tests {
         let sq = Arc::new(
             LogicalPlanBuilder::from(scan_tpch_table("orders"))
                 .filter(
-                    out_ref_col(DataType::Int64, "customer.c_custkey")
+                    out_ref_col(LogicalType::Int64, "customer.c_custkey")
                         .eq(col("orders.o_custkey")),
                 )?
                 .project(vec![col("orders.o_custkey")])?
@@ -1600,7 +1601,7 @@ mod tests {
     fn exists_subquery_correlated() -> Result<()> {
         let sq = Arc::new(
             LogicalPlanBuilder::from(test_table_scan_with_name("sq")?)
-                .filter(out_ref_col(DataType::UInt32, "test.a").eq(col("sq.a")))?
+                .filter(out_ref_col(LogicalType::UInt32, "test.a").eq(col("sq.a")))?
                 .project(vec![col("c")])?
                 .build()?,
         );
@@ -1651,12 +1652,12 @@ mod tests {
         let subquery_scan2 = test_table_scan_with_name("sq2")?;
 
         let subquery1 = LogicalPlanBuilder::from(subquery_scan1)
-            .filter(out_ref_col(DataType::UInt32, "test.a").eq(col("sq1.a")))?
+            .filter(out_ref_col(LogicalType::UInt32, "test.a").eq(col("sq1.a")))?
             .project(vec![col("c")])?
             .build()?;
 
         let subquery2 = LogicalPlanBuilder::from(subquery_scan2)
-            .filter(out_ref_col(DataType::UInt32, "test.a").eq(col("sq2.a")))?
+            .filter(out_ref_col(LogicalType::UInt32, "test.a").eq(col("sq2.a")))?
             .project(vec![col("c")])?
             .build()?;
 
@@ -1690,7 +1691,7 @@ mod tests {
         let subquery = LogicalPlanBuilder::from(subquery_scan)
             .filter(
                 (lit(1u32) + col("sq.a"))
-                    .gt(out_ref_col(DataType::UInt32, "test.a") * lit(2u32)),
+                    .gt(out_ref_col(LogicalType::UInt32, "test.a") * lit(2u32)),
             )?
             .project(vec![lit(1u32)])?
             .build()?;
@@ -1742,7 +1743,7 @@ mod tests {
         let subquery = LogicalPlanBuilder::from(subquery_scan)
             .filter(
                 (lit(1u32) + col("sq.a"))
-                    .gt(out_ref_col(DataType::UInt32, "test.a") * lit(2u32)),
+                    .gt(out_ref_col(LogicalType::UInt32, "test.a") * lit(2u32)),
             )?
             .project(vec![col("sq.c")])?
             .distinct()?
@@ -1770,7 +1771,7 @@ mod tests {
         let subquery = LogicalPlanBuilder::from(subquery_scan)
             .filter(
                 (lit(1u32) + col("sq.a"))
-                    .gt(out_ref_col(DataType::UInt32, "test.a") * lit(2u32)),
+                    .gt(out_ref_col(LogicalType::UInt32, "test.a") * lit(2u32)),
             )?
             .project(vec![col("sq.b") + col("sq.c")])?
             .distinct()?
@@ -1798,7 +1799,7 @@ mod tests {
         let subquery = LogicalPlanBuilder::from(subquery_scan)
             .filter(
                 (lit(1u32) + col("sq.a"))
-                    .gt(out_ref_col(DataType::UInt32, "test.a") * lit(2u32)),
+                    .gt(out_ref_col(LogicalType::UInt32, "test.a") * lit(2u32)),
             )?
             .project(vec![lit(1u32), col("sq.c")])?
             .distinct()?

--- a/datafusion/optimizer/src/eliminate_outer_join.rs
+++ b/datafusion/optimizer/src/eliminate_outer_join.rs
@@ -298,7 +298,6 @@ fn extract_non_nullable_columns(
 mod tests {
     use super::*;
     use crate::test::*;
-    use arrow::datatypes::DataType;
     use datafusion_expr::{
         binary_expr, cast, col, lit,
         logical_plan::builder::LogicalPlanBuilder,
@@ -424,9 +423,9 @@ mod tests {
                 None,
             )?
             .filter(binary_expr(
-                cast(col("t1.b"), DataType::Int64).gt(lit(10u32)),
+                cast(col("t1.b"), LogicalType::Int64).gt(lit(10u32)),
                 And,
-                try_cast(col("t2.c"), DataType::Int64).lt(lit(20u32)),
+                try_cast(col("t2.c"), LogicalType::Int64).lt(lit(20u32)),
             ))?
             .build()?;
         let expected = "\

--- a/datafusion/optimizer/src/push_down_projection.rs
+++ b/datafusion/optimizer/src/push_down_projection.rs
@@ -704,9 +704,9 @@ mod tests {
             **optimized_join.schema(),
             DFSchema::new_with_metadata(
                 vec![
-                    DFField::new(Some("test"), "a", DataType::UInt32, false),
-                    DFField::new(Some("test"), "b", DataType::UInt32, false),
-                    DFField::new(Some("test2"), "c1", DataType::UInt32, true),
+                    DFField::new(Some("test"), "a", LogicalType::UInt32, false),
+                    DFField::new(Some("test"), "b", LogicalType::UInt32, false),
+                    DFField::new(Some("test2"), "c1", LogicalType::UInt32, true),
                 ],
                 HashMap::new(),
             )?,
@@ -747,9 +747,9 @@ mod tests {
             **optimized_join.schema(),
             DFSchema::new_with_metadata(
                 vec![
-                    DFField::new(Some("test"), "a", DataType::UInt32, false),
-                    DFField::new(Some("test"), "b", DataType::UInt32, false),
-                    DFField::new(Some("test2"), "c1", DataType::UInt32, true),
+                    DFField::new(Some("test"), "a", LogicalType::UInt32, false),
+                    DFField::new(Some("test"), "b", LogicalType::UInt32, false),
+                    DFField::new(Some("test2"), "c1", LogicalType::UInt32, true),
                 ],
                 HashMap::new(),
             )?,
@@ -788,9 +788,9 @@ mod tests {
             **optimized_join.schema(),
             DFSchema::new_with_metadata(
                 vec![
-                    DFField::new(Some("test"), "a", DataType::UInt32, false),
-                    DFField::new(Some("test"), "b", DataType::UInt32, false),
-                    DFField::new(Some("test2"), "a", DataType::UInt32, true),
+                    DFField::new(Some("test"), "a", LogicalType::UInt32, false),
+                    DFField::new(Some("test"), "b", LogicalType::UInt32, false),
+                    DFField::new(Some("test2"), "a", LogicalType::UInt32, true),
                 ],
                 HashMap::new(),
             )?,
@@ -806,7 +806,7 @@ mod tests {
         let projection = LogicalPlanBuilder::from(table_scan)
             .project(vec![Expr::Cast(Cast::new(
                 Box::new(col("c")),
-                DataType::Float64,
+                LogicalType::Float64,
             ))])?
             .build()?;
 

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -372,8 +372,7 @@ fn build_join(
 mod tests {
     use super::*;
     use crate::test::*;
-    use arrow::datatypes::DataType;
-    use datafusion_common::Result;
+    use datafusion_common::{logical_type::LogicalType as DataType, Result};
     use datafusion_expr::{
         col, lit, logical_plan::LogicalPlanBuilder, max, min, out_ref_col,
         scalar_subquery, sum, Between,

--- a/datafusion/optimizer/src/simplify_expressions/context.rs
+++ b/datafusion/optimizer/src/simplify_expressions/context.rs
@@ -17,8 +17,9 @@
 
 //! Structs and traits to provide the information needed for expression simplification.
 
-use arrow::datatypes::DataType;
-use datafusion_common::{DFSchemaRef, DataFusionError, Result};
+use datafusion_common::{
+    logical_type::LogicalType, DFSchemaRef, DataFusionError, Result,
+};
 use datafusion_expr::{Expr, ExprSchemable};
 use datafusion_physical_expr::execution_props::ExecutionProps;
 
@@ -40,7 +41,7 @@ pub trait SimplifyInfo {
     fn execution_props(&self) -> &ExecutionProps;
 
     /// Returns data type of this expr needed for determining optimized int type of a value
-    fn get_data_type(&self, expr: &Expr) -> Result<DataType>;
+    fn get_data_type(&self, expr: &Expr) -> Result<LogicalType>;
 }
 
 /// Provides simplification information based on DFSchema and
@@ -100,7 +101,7 @@ impl<'a> SimplifyInfo for SimplifyContext<'a> {
     /// returns true if this Expr has boolean type
     fn is_boolean_type(&self, expr: &Expr) -> Result<bool> {
         for schema in &self.schema {
-            if let Ok(DataType::Boolean) = expr.get_type(schema) {
+            if let Ok(LogicalType::Boolean) = expr.get_type(schema) {
                 return Ok(true);
             }
         }
@@ -119,7 +120,7 @@ impl<'a> SimplifyInfo for SimplifyContext<'a> {
     }
 
     /// Returns data type of this expr needed for determining optimized int type of a value
-    fn get_data_type(&self, expr: &Expr) -> Result<DataType> {
+    fn get_data_type(&self, expr: &Expr) -> Result<LogicalType> {
         let schema = self.schema.as_ref().ok_or_else(|| {
             DataFusionError::Internal(
                 "attempt to get data type without schema".to_string(),

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -18,6 +18,7 @@
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use datafusion_common::config::ConfigOptions;
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::{plan_err, DataFusionError, Result};
 use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource, WindowUDF};
 use datafusion_optimizer::analyzer::Analyzer;
@@ -404,7 +405,7 @@ impl ContextProvider for MyContextProvider {
         None
     }
 
-    fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
+    fn get_variable_type(&self, _variable_names: &[String]) -> Option<LogicalType> {
         None
     }
 

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -25,6 +25,7 @@ use crate::{
     PhysicalExpr,
 };
 use arrow::datatypes::Schema;
+use datafusion_common::logical_type::ExtensionType;
 use datafusion_common::{
     exec_err, internal_err, not_impl_err, plan_err, DFSchema, DataFusionError, Result,
     ScalarValue,
@@ -278,12 +279,12 @@ pub fn create_physical_expr(
         Expr::Cast(Cast { expr, data_type }) => expressions::cast(
             create_physical_expr(expr, input_dfschema, input_schema, execution_props)?,
             input_schema,
-            data_type.clone(),
+            data_type.physical_type(),
         ),
         Expr::TryCast(TryCast { expr, data_type }) => expressions::try_cast(
             create_physical_expr(expr, input_dfschema, input_schema, execution_props)?,
             input_schema,
-            data_type.clone(),
+            data_type.physical_type(),
         ),
         Expr::Not(expr) => expressions::not(create_physical_expr(
             expr,

--- a/datafusion/physical-expr/src/var_provider.rs
+++ b/datafusion/physical-expr/src/var_provider.rs
@@ -17,8 +17,7 @@
 
 //! Variable provider
 
-use arrow::datatypes::DataType;
-use datafusion_common::{Result, ScalarValue};
+use datafusion_common::{logical_type::LogicalType, Result, ScalarValue};
 
 /// Variable type, system/user defined
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -35,7 +34,7 @@ pub trait VarProvider: std::fmt::Debug {
     fn get_value(&self, var_names: Vec<String>) -> Result<ScalarValue>;
 
     /// Return the type of the given variable
-    fn get_type(&self, var_names: &[String]) -> Option<DataType>;
+    fn get_type(&self, var_names: &[String]) -> Option<LogicalType>;
 }
 
 pub fn is_system_variables(variable_names: &[String]) -> bool {

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -43,6 +43,7 @@ use datafusion::{
     datasource::{provider_as_source, source_as_provider},
     prelude::SessionContext,
 };
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::plan_datafusion_err;
 use datafusion_common::{
     context, internal_err, not_impl_err, parsers::CompressionTypeVariant,
@@ -771,10 +772,12 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlanType::Prepare(prepare) => {
                 let input: LogicalPlan =
                     into_logical_plan!(prepare.input, ctx, extension_codec)?;
-                let data_types: Vec<DataType> = prepare
+                // FIXME Use LogicalType in proto
+                let data_types: Vec<LogicalType> = prepare
                     .data_types
                     .iter()
                     .map(DataType::try_from)
+                    .map(Into::into)
                     .collect::<Result<_, _>>()?;
                 LogicalPlanBuilder::from(input)
                     .prepare(prepare.name.clone(), data_types)?

--- a/datafusion/sql/examples/sql.rs
+++ b/datafusion/sql/examples/sql.rs
@@ -17,6 +17,7 @@
 
 use arrow_schema::{DataType, Field, Schema};
 use datafusion_common::config::ConfigOptions;
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::{plan_err, DataFusionError, Result};
 use datafusion_expr::WindowUDF;
 use datafusion_expr::{
@@ -120,7 +121,7 @@ impl ContextProvider for MyContextProvider {
         None
     }
 
-    fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
+    fn get_variable_type(&self, _variable_names: &[String]) -> Option<LogicalType> {
         None
     }
 

--- a/datafusion/sql/src/expr/arrow_cast.rs
+++ b/datafusion/sql/src/expr/arrow_cast.rs
@@ -69,7 +69,7 @@ pub fn create_arrow_cast(mut args: Vec<Expr>, schema: &DFSchema) -> Result<Expr>
     };
 
     // do the actual lookup to the appropriate data type
-    let data_type = parse_data_type(&data_type_string)?;
+    let data_type = parse_data_type(&data_type_string)?.into();
 
     arg0.cast_to(&data_type, schema)
 }

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -28,7 +28,7 @@ mod unary_op;
 mod value;
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use arrow_schema::DataType;
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::{
     internal_err, not_impl_err, plan_err, Column, DFSchema, DataFusionError, Result,
     ScalarValue,
@@ -584,7 +584,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     ) -> Result<Expr> {
         let pattern = self.sql_expr_to_logical_expr(pattern, schema, planner_context)?;
         let pattern_type = pattern.get_type(schema)?;
-        if pattern_type != DataType::Utf8 && pattern_type != DataType::Null {
+        if pattern_type != LogicalType::Utf8 && pattern_type != LogicalType::Null {
             return plan_err!("Invalid pattern in LIKE expression");
         }
         Ok(Expr::Like(Like::new(
@@ -607,7 +607,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     ) -> Result<Expr> {
         let pattern = self.sql_expr_to_logical_expr(pattern, schema, planner_context)?;
         let pattern_type = pattern.get_type(schema)?;
-        if pattern_type != DataType::Utf8 && pattern_type != DataType::Null {
+        if pattern_type != LogicalType::Utf8 && pattern_type != LogicalType::Null {
             return plan_err!("Invalid pattern in SIMILAR TO expression");
         }
         Ok(Expr::SimilarTo(Like::new(
@@ -750,6 +750,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::logical_type::LogicalType;
     use sqlparser::dialect::GenericDialect;
     use sqlparser::parser::Parser;
 
@@ -799,7 +800,7 @@ mod tests {
             None
         }
 
-        fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
+        fn get_variable_type(&self, _variable_names: &[String]) -> Option<LogicalType> {
             None
         }
 

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -20,6 +20,7 @@ use arrow::array::new_null_array;
 use arrow::compute::kernels::cast_utils::parse_interval_month_day_nano;
 use arrow::datatypes::DECIMAL128_MAX_PRECISION;
 use arrow_schema::DataType;
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::{
     not_impl_err, plan_err, DFSchema, DataFusionError, Result, ScalarValue,
 };
@@ -35,7 +36,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     pub(crate) fn parse_value(
         &self,
         value: Value,
-        param_data_types: &[DataType],
+        param_data_types: &[LogicalType],
     ) -> Result<Expr> {
         match value {
             Value::Number(n, _) => self.parse_sql_number(&n, false),
@@ -96,7 +97,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// number 1, 2, ... etc. For example, `$1` is the first placeholder; $2 is the second one and so on.
     fn create_placeholder_expr(
         param: String,
-        param_data_types: &[DataType],
+        param_data_types: &[LogicalType],
     ) -> Result<Expr> {
         // Parse the placeholder as a number because it is the only support from sqlparser and postgres
         let index = param[1..].parse::<usize>();

--- a/datafusion/sql/src/relation/join.rs
+++ b/datafusion/sql/src/relation/join.rs
@@ -145,17 +145,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     .build()
             }
             JoinConstraint::Natural => {
-                let left_cols: HashSet<&String> = left
-                    .schema()
-                    .fields()
-                    .iter()
-                    .map(|f| f.field().name())
-                    .collect();
+                let left_cols: HashSet<&String> =
+                    left.schema().fields().iter().map(|f| f.name()).collect();
                 let keys: Vec<Column> = right
                     .schema()
                     .fields()
                     .iter()
-                    .map(|f| f.field().name())
+                    .map(|f| f.name())
                     .filter(|f| left_cols.contains(f))
                     .map(Column::from_name)
                     .collect();

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -18,8 +18,9 @@
 //! SQL Utility Functions
 
 use arrow_schema::{
-    DataType, DECIMAL128_MAX_PRECISION, DECIMAL256_MAX_PRECISION, DECIMAL_DEFAULT_SCALE,
+    DECIMAL128_MAX_PRECISION, DECIMAL256_MAX_PRECISION, DECIMAL_DEFAULT_SCALE,
 };
+use datafusion_common::logical_type::LogicalType;
 use datafusion_common::tree_node::{Transformed, TreeNode};
 use sqlparser::ast::Ident;
 
@@ -212,7 +213,7 @@ pub fn window_expr_common_partition_keys(window_exprs: &[Expr]) -> Result<&[Expr
 pub(crate) fn make_decimal_type(
     precision: Option<u64>,
     scale: Option<u64>,
-) -> Result<DataType> {
+) -> Result<LogicalType> {
     // postgres like behavior
     let (precision, scale) = match (precision, scale) {
         (Some(p), Some(s)) => (p as u8, s as i8),
@@ -233,9 +234,9 @@ pub(crate) fn make_decimal_type(
     } else if precision > DECIMAL128_MAX_PRECISION
         && precision <= DECIMAL256_MAX_PRECISION
     {
-        Ok(DataType::Decimal256(precision, scale))
+        Ok(LogicalType::Decimal256(precision, scale))
     } else {
-        Ok(DataType::Decimal128(precision, scale))
+        Ok(LogicalType::Decimal128(precision, scale))
     }
 }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::{sync::Arc, vec};
 
 use arrow_schema::*;
+use datafusion_common::logical_type::LogicalType;
 use sqlparser::dialect::{Dialect, GenericDialect, HiveDialect, MySqlDialect};
 
 use datafusion_common::plan_err;
@@ -2813,7 +2814,7 @@ impl ContextProvider for MockContextProvider {
         self.udafs.get(name).map(Arc::clone)
     }
 
-    fn get_variable_type(&self, _: &[String]) -> Option<DataType> {
+    fn get_variable_type(&self, _: &[String]) -> Option<LogicalType> {
         unimplemented!()
     }
 
@@ -3685,8 +3686,8 @@ fn test_prepare_statement_should_infer_types() {
     let plan = logical_plan(sql).unwrap();
     let actual_types = plan.get_parameter_types().unwrap();
     let expected_types = HashMap::from([
-        ("$1".to_string(), Some(DataType::Int32)),
-        ("$2".to_string(), Some(DataType::Int64)),
+        ("$1".to_string(), Some(LogicalType::Int32)),
+        ("$2".to_string(), Some(LogicalType::Int64)),
     ]);
     assert_eq!(actual_types, expected_types);
 }
@@ -3699,7 +3700,7 @@ fn test_non_prepare_statement_should_infer_types() {
     let actual_types = plan.get_parameter_types().unwrap();
     let expected_types = HashMap::from([
         // constant 1 is inferred to be int64
-        ("$1".to_string(), Some(DataType::Int64)),
+        ("$1".to_string(), Some(LogicalType::Int64)),
     ]);
     assert_eq!(actual_types, expected_types);
 }
@@ -3874,7 +3875,7 @@ Projection: person.id, orders.order_id
     let plan = prepare_stmt_quick_test(sql, expected_plan, expected_dt);
 
     let actual_types = plan.get_parameter_types().unwrap();
-    let expected_types = HashMap::from([("$1".to_string(), Some(DataType::Int32))]);
+    let expected_types = HashMap::from([("$1".to_string(), Some(LogicalType::Int32))]);
     assert_eq!(actual_types, expected_types);
 
     // replace params with values
@@ -3906,7 +3907,7 @@ Projection: person.id, person.age
     let plan = prepare_stmt_quick_test(sql, expected_plan, expected_dt);
 
     let actual_types = plan.get_parameter_types().unwrap();
-    let expected_types = HashMap::from([("$1".to_string(), Some(DataType::Int32))]);
+    let expected_types = HashMap::from([("$1".to_string(), Some(LogicalType::Int32))]);
     assert_eq!(actual_types, expected_types);
 
     // replace params with values
@@ -3938,8 +3939,8 @@ Projection: person.id, person.age
 
     let actual_types = plan.get_parameter_types().unwrap();
     let expected_types = HashMap::from([
-        ("$1".to_string(), Some(DataType::Int32)),
-        ("$2".to_string(), Some(DataType::Int32)),
+        ("$1".to_string(), Some(LogicalType::Int32)),
+        ("$2".to_string(), Some(LogicalType::Int32)),
     ]);
     assert_eq!(actual_types, expected_types);
 
@@ -3976,7 +3977,7 @@ Projection: person.id, person.age
     let plan = prepare_stmt_quick_test(sql, expected_plan, expected_dt);
 
     let actual_types = plan.get_parameter_types().unwrap();
-    let expected_types = HashMap::from([("$1".to_string(), Some(DataType::UInt32))]);
+    let expected_types = HashMap::from([("$1".to_string(), Some(LogicalType::UInt32))]);
     assert_eq!(actual_types, expected_types);
 
     // replace params with values
@@ -4014,8 +4015,8 @@ Dml: op=[Update] table=[person]
 
     let actual_types = plan.get_parameter_types().unwrap();
     let expected_types = HashMap::from([
-        ("$1".to_string(), Some(DataType::Int32)),
-        ("$2".to_string(), Some(DataType::UInt32)),
+        ("$1".to_string(), Some(LogicalType::Int32)),
+        ("$2".to_string(), Some(LogicalType::UInt32)),
     ]);
     assert_eq!(actual_types, expected_types);
 
@@ -4049,9 +4050,9 @@ Dml: op=[Insert Into] table=[person]
 
     let actual_types = plan.get_parameter_types().unwrap();
     let expected_types = HashMap::from([
-        ("$1".to_string(), Some(DataType::UInt32)),
-        ("$2".to_string(), Some(DataType::Utf8)),
-        ("$3".to_string(), Some(DataType::Utf8)),
+        ("$1".to_string(), Some(LogicalType::UInt32)),
+        ("$2".to_string(), Some(LogicalType::Utf8)),
+        ("$3".to_string(), Some(LogicalType::Utf8)),
     ]);
     assert_eq!(actual_types, expected_types);
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7923 .

Current Pull Request is an Experimental Demo for Validating the Feasibility of Logical Types

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


## Features
- Create User-Defined Types (UDTs) through SQL, specifying the field types as UDTs during table creation.
- Support the use of `UDT` as a function signature in `udf/udaf`.
- Register extension types through the `register_data_type` function in the `SessionContext`.

## New Additions
- `LogicalType` struct.
- `ExtensionType` trait. Abstraction for extension types.
- `TypeSignature` struct. Uniquely identifies a data type.

## Major Changes
- Added `get_data_type(&self, _name: &TypeSignature) -> Option<LogicalType>` function to the `ContextProvider` trait.
- In `DFSchema`, `DFField` now uses `LogicalType`, removing arrow `Field` and retaining only `data_type`, `nullable`, `metadata` since `dict_id`, `dict_is_ordered` are not necessary at the logical stage.
- `ExprSchemable` and `ExprSchema` now use `LogicalType`.
- `ast` to logical plan conversion now uses `LogicalType`.

## To Be Implemented
- `TypeCoercionRewriter` in the analyze stage uses logical types. For example, functions like `comparison_coercion`, `get_input_types`, `get_valid_types`, etc.
- Functions signatures for `udf/udaf` use `TypeSignature` instead of the existing `DataType` for ease of use in `udf/udaf`.

## To Be Determined
- Should `ScalarValue` use `LogicalType` or arrow `DataType`?
  - [ ] `LogicalType`.
  - [ ] `DataType`
- Should `TableSource` return `DFSchema` or arrow `Schema`?
  - [ ] `Schema`.
  - [ ] `DFSchema`
- Conversion between physical types and logical types (in Datafusion, type conversion is achieved through the conversion of `DFSchema` to `Schema`; logical plans use `DFSchema`, physical plans use `Schema`).
- Conversion between `Schema` and `DFSchema`
  * When to convert `Schema` to `DFSchema`? 
    - [ ] During the construction of the logical `TableScan` node, obtain arrow `Schema` through `TableSource/TableProvider` and then convert it to `DFSchema`.
    - [ ] `TableSource/TableProvider` returns `DFSchema` instead of `Schema`.
  * When to convert `DFSchema` to `Schema`? 
    - [ ] Directly obtain arrow `Schema` from `TableSource` in physical planner, no need for conversion.
    - [ ] Convert the `DFSchema` returned by `TableSource` to `Schema` in the physical planner stage.

## Some Thoughts
- In [this comment](https://github.com/apache/arrow-rs/issues/4472#issuecomment-1749805039), the use case of converting from `dyn Array` to `LineStringArray` or `MultiPointArray` was raised. In my perspective, assuming there is a function specifically designed for handling `LineString` data, the function signature can be defined as `LineString`, ensuring that the input data must be of a type acceptable by `LineStringArray`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
