### PR TITLE
WIP: Consolidate statistics aggregation

### DIFF
--- a/datafusion/common/src/stats/aggregator.rs
+++ b/datafusion/common/src/stats/aggregator.rs
@@ -1,0 +1,807 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`StatisticsAggregator`] for aggregating multiple statistics together
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use crate::error::_internal_err;
+use crate::stats::Precision;
+use crate::ColumnStatistics;
+use crate::{DataFusionError, Result};
+use crate::{ScalarValue, Statistics};
+use arrow::datatypes::Schema;
+
+/// Aggregates one or more [`Statistics`] together, representing the result of
+/// combining multiple inputs (such as individual parquet files) together.
+///
+/// `StatisticsAggregator` also handles "Schema Evolution", by merging
+/// statistics from different schemas, where each may have a different subset of
+/// columns and/or different types.
+///
+/// # Example Merging Different Columns
+///
+/// Some statistics may not be present for certain columns or fields, for
+/// example if some file does not have statistics for Column B, the overall
+/// statistics take this into account.
+//
+//
+/// ```text
+/// ┌─────────────────────────┐         ┌────────────┐          ┌─────────────────────────┐
+/// │ ┌────────┐   ┌────────┐ │         │ ┌────────┐ │          │ ┌────────┐   ┌────────┐ │
+/// │ │ max: 5 │   │ max: 9 │ │         │ │ max: 7 │ │          │ │ max: 7 │   │max: 9* │ │
+/// │ │        │   │        │ │   ┃     │ │        │ │   ━━━━━  │ │        │   │        │ │
+/// │ │ min: 3 │   │ min: 5 │ │ ━━╋━━   │ │ min: 1 │ │          │ │ min: 1 │   │min: 5* │ │
+/// │ │        │   │        │ │   ┃     │ │        │ │   ━━━━━  │ │        │   │        │ │
+/// │ └────────┘   └────────┘ │         │ └────────┘ │          │ └────────┘   └────────┘ │
+/// │                         │         │            │          │                         │
+/// │  Column A     Column B  │         │  Column A  │          │  Column A     Column B  │
+/// └─────────────────────────┘         └────────────┘          └─────────────────────────┘
+///
+///        Statistics                     Statistics                    Statistics
+/// ```
+///
+/// # Example Merging Different Types
+///
+/// In some cases the types of statistics may not match exactly. For example, if
+/// the file schema specifies Column A is a `u64` but the statistics for one of
+/// the files has a `u32` for Column A, the `u32` values will be cast to u64
+/// prior to aggregation
+///
+/// ```text
+/// ┌─────────────┐        ┌────────────┐       ┌──────────────┐
+/// │┌───────────┐│        │┌──────────┐│       │ ┌────────┐   │
+/// ││ max: 5u64 ││        ││max: 7u32 ││       │ │ max: 7 │   │
+/// ││           ││    ┃   ││          ││  ━━━━━│ │        │   │
+/// ││ min: 3u64 ││  ━━╋━━ ││min: 1u32 ││       │ │ min: 1 │   │
+/// ││           ││    ┃   ││          ││  ━━━━━│ │        │   │
+/// │└───────────┘│        │└──────────┘│       │ └────────┘   │
+/// │             │        │            │       │              │
+/// │  Column A   │        │  Column A  │       │  Column A    │
+/// └─────────────┘        └────────────┘       └──────────────┘
+///
+///   Statistics            Statistics             Statistics
+/// ```
+///
+/// Things to test:
+/// Aggregating statistics from different types (e.g. when the table column is a float but the column is an int)
+#[derive(Debug)]
+pub struct StatisticsAggregator<'a> {
+    num_rows: PrecisionAggregator<usize>,
+    total_byte_size: PrecisionAggregator<usize>,
+    column_statistics: Vec<ColumnStatisticsAggregator>,
+    // Maps column name to index in column_statistics for all columns we are
+    // aggregating
+    col_idx_map: HashMap<&'a str, usize>,
+}
+
+impl<'a> StatisticsAggregator<'a> {
+    /// Creates new aggregator the the given schema.
+    ///
+    /// This will start with:
+    ///
+    /// - 0 rows
+    /// - 0 bytes
+    /// - for each column:
+    ///   - 0 null values
+    ///   - unknown min value
+    ///   - unknown max value
+    /// - exact representation
+    pub fn new(schema: &'a Schema) -> Self {
+        let col_idx_map = schema
+            .fields()
+            .iter()
+            .enumerate()
+            .map(|(idx, f)| (f.name().as_str(), idx))
+            .collect::<HashMap<_, _>>();
+
+        let column_statistics: Vec<_> = (0..col_idx_map.len())
+            .map(|_| ColumnStatisticsAggregator::new())
+            .collect();
+
+        Self {
+            num_rows: PrecisionAggregator::new(),
+            total_byte_size: PrecisionAggregator::new(),
+            column_statistics,
+            col_idx_map,
+        }
+    }
+
+    /// Update the StatisticsAggregator with statistics from a new file with the
+    /// given schema
+    ///
+    /// Updates are meant to be "additive", i.e. they only add data/rows. There
+    /// is NO way to remove/substract data from the accumulator.
+    ///
+    /// If statistics are not provided for a column, that column is assumed be
+    /// entirely null (as is the result when merging schemas)
+    ///
+    /// Returns an error if the number of columns in the statistics and the
+    /// schema are different.
+    pub fn update(
+        &mut self,
+        update_stats: &Statistics,
+        update_schema: &Schema,
+    ) -> Result<()> {
+        // decompose structs so we don't forget new fields added to Statistics
+        let Statistics {
+            num_rows: update_num_rows,
+            total_byte_size: update_total_byte_size,
+            column_statistics: update_column_statistics,
+        } = update_stats;
+
+        self.num_rows.update_sum(update_num_rows);
+        self.total_byte_size.update_sum(update_total_byte_size);
+
+        if update_column_statistics.len() != update_schema.fields().len() {
+            return _internal_err!(
+                "update_stats ({}) and schema ({}) have different column count",
+                update_column_statistics.len(),
+                update_schema.fields().len()
+            );
+        }
+
+        let mut seen_cols = vec![false; self.col_idx_map.len()];
+
+        for (update_field, update_col) in update_schema
+            .fields()
+            .iter()
+            .zip(update_column_statistics.iter())
+        {
+            // Skip if this is some column that we are not aggregating statistics for
+            let Some(idx) = self.col_idx_map.get(update_field.name().as_str()) else {
+                continue;
+            };
+            let base_col = &mut self.column_statistics[*idx];
+            seen_cols[*idx] = true;
+
+            // decompose structs so we don't forget new fields
+            let ColumnStatisticsAggregator {
+                null_count: base_null_count,
+                min_value: base_min_value,
+                max_value: base_max_value,
+            } = base_col;
+            let ColumnStatistics {
+                null_count: update_null_count,
+                min_value: update_min_value,
+                max_value: update_max_value,
+                distinct_count: _update_distinct_count,
+            } = update_col;
+
+            base_null_count.update_sum(update_null_count);
+            base_min_value.update_min(update_min_value);
+            base_max_value.update_max(update_max_value);
+        }
+
+        // for any columns that did not appear in the update, they are all null
+        // they were all-NULL and hence we can update  the null counters
+        for (used, base_col) in seen_cols.into_iter().zip(&mut self.column_statistics) {
+            if !used {
+                base_col.null_count.update_sum(update_num_rows);
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the currently known number of rows, if any
+    pub fn num_rows(&self) -> Precision<usize> {
+        self.num_rows.clone().into_precision()
+    }
+
+    /// Build aggregated statistics.
+    pub fn build(self) -> Statistics {
+        let Self {
+            num_rows,
+            total_byte_size,
+            column_statistics,
+            col_idx_map: _,
+        } = self;
+
+        Statistics {
+            num_rows: num_rows.into_precision(),
+            total_byte_size: total_byte_size.into_precision(),
+            column_statistics: column_statistics
+                .into_iter()
+                .map(|col_agg| col_agg.into_column_statistics())
+                .collect(),
+        }
+    }
+}
+
+/// Tracks the difference between "never seen" and "initialized to zero"
+///
+/// 1. "uninitialized" (`None`)
+/// 1. "initialized" (`Some(Precision::Exact(...))`)
+/// 2. "initialized but invalid" (`Some(Precision::Absent)`).
+#[derive(Debug, Clone)]
+struct PrecisionAggregator<T: Debug + Clone + PartialEq + Eq + PartialOrd> {
+    inner: Option<Precision<T>>,
+}
+
+impl<T: Debug + Clone + PartialEq + Eq + PartialOrd> PrecisionAggregator<T> {
+    fn new() -> Self {
+        Default::default()
+    }
+
+    fn into_precision(self) -> Precision<T> {
+        self.inner.unwrap_or(Precision::Absent)
+    }
+}
+
+impl PrecisionAggregator<usize> {
+    /// Adds the `other` precision, distinguishing between "never seen a value"
+    /// (None) vs "we didn't know the value" (Some(Absent))
+    fn update_sum(&mut self, other: &Precision<usize>) {
+        self.inner = Some(
+            self.inner
+                .take()
+                .map(|value| value.add(other))
+                .unwrap_or_else(|| other.clone()),
+        );
+    }
+}
+
+impl PrecisionAggregator<ScalarValue> {
+    /// Returns the min of self and `other`, distinguishing between "never seen
+    /// a value" (None) vs "we didn't know the value" (Some(Absent))
+    fn update_min(&mut self, other: &Precision<ScalarValue>) {
+        self.inner = Some(
+            self.inner
+                .take()
+                .map(|inner| inner.min(other))
+                .unwrap_or_else(|| other.clone()),
+        );
+    }
+
+    /// Returns the max of self and `other`, distinguishing between "never seen
+    /// a value" (None) vs "we didn't know the value" (Some(Absent))
+    fn update_max(&mut self, other: &Precision<ScalarValue>) {
+        self.inner = Some(
+            self.inner
+                .take()
+                .map(|inner| inner.max(other))
+                .unwrap_or_else(|| other.clone()),
+        );
+    }
+}
+
+impl<T: Debug + Clone + PartialEq + Eq + PartialOrd> Default for PrecisionAggregator<T> {
+    fn default() -> Self {
+        Self { inner: None }
+    }
+}
+
+/// Aggregates multiple [`ColumnStatistics`]
+///
+/// Note this does does NOT contain a distinct count because we cannot aggregate
+/// these.
+#[derive(Debug, Default)]
+struct ColumnStatisticsAggregator {
+    null_count: PrecisionAggregator<usize>,
+    min_value: PrecisionAggregator<ScalarValue>,
+    max_value: PrecisionAggregator<ScalarValue>,
+}
+impl ColumnStatisticsAggregator {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn into_column_statistics(self) -> ColumnStatistics {
+        let Self {
+            null_count,
+            min_value,
+            max_value,
+        } = self;
+
+        ColumnStatistics {
+            null_count: null_count.into_precision(),
+            min_value: min_value.into_precision(),
+            max_value: max_value.into_precision(),
+            distinct_count: Precision::Absent,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use arrow::datatypes::{DataType, Field};
+
+    #[test]
+    fn test_no_cols_no_updates() {
+        let schema = Schema::new(Vec::<Field>::new());
+        let agg = StatisticsAggregator::new(&schema);
+
+        let actual = agg.build();
+        let expected = Statistics {
+            num_rows: Precision::Absent,
+            total_byte_size: Precision::Absent,
+            column_statistics: Statistics::unknown_column(&schema),
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_no_updates() {
+        let schema = Schema::new(vec![
+            Field::new("col1", DataType::UInt64, true),
+            Field::new("col2", DataType::Utf8, false),
+        ]);
+        let agg = StatisticsAggregator::new(&schema);
+
+        let actual = agg.build();
+        let expected = Statistics {
+            num_rows: Precision::Absent,
+            total_byte_size: Precision::Absent,
+            column_statistics: vec![
+                // col1
+                ColumnStatistics {
+                    null_count: Precision::Absent,
+                    min_value: Precision::Absent,
+                    max_value: Precision::Absent,
+                    distinct_count: Precision::Absent,
+                },
+                // col2
+                ColumnStatistics {
+                    null_count: Precision::Absent,
+                    min_value: Precision::Absent,
+                    max_value: Precision::Absent,
+                    distinct_count: Precision::Absent,
+                },
+            ],
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_valid_update_partial() {
+        let schema = Schema::new(vec![
+            Field::new("col1", DataType::UInt64, true),
+            Field::new("col2", DataType::Utf8, false),
+        ]);
+        let mut agg = StatisticsAggregator::new(&schema);
+
+        let update_schema = Schema::new(vec![
+            Field::new("col1", DataType::UInt64, true),
+            Field::new("col2", DataType::Utf8, false),
+        ]);
+        let update_stats = Statistics {
+            num_rows: Precision::Exact(1),
+            total_byte_size: Precision::Exact(10),
+            column_statistics: vec![
+                // col1
+                ColumnStatistics {
+                    null_count: Precision::Exact(100),
+                    min_value: Precision::Exact(ScalarValue::UInt64(Some(50))),
+                    max_value: Precision::Exact(ScalarValue::UInt64(Some(100))),
+                    distinct_count: Precision::Exact(42),
+                },
+                // col2
+                ColumnStatistics {
+                    null_count: Precision::Exact(1_000),
+                    min_value: Precision::Exact(ScalarValue::Utf8(Some("b".to_owned()))),
+                    max_value: Precision::Exact(ScalarValue::Utf8(Some("e".to_owned()))),
+                    distinct_count: Precision::Exact(42),
+                },
+            ],
+        };
+        agg.update(&update_stats, &update_schema).unwrap();
+
+        let update_schema = Schema::new(vec![Field::new("col2", DataType::Utf8, false)]);
+        let update_stats = Statistics {
+            num_rows: Precision::Exact(10_000),
+            total_byte_size: Precision::Exact(100_000),
+            column_statistics: vec![
+                // col2
+                ColumnStatistics {
+                    null_count: Precision::Exact(1_000_000),
+                    min_value: Precision::Exact(ScalarValue::Utf8(Some("c".to_owned()))),
+                    max_value: Precision::Exact(ScalarValue::Utf8(Some("g".to_owned()))),
+                    distinct_count: Precision::Exact(42),
+                },
+            ],
+        };
+        agg.update(&update_stats, &update_schema).unwrap();
+
+        let actual = agg.build();
+        let expected = Statistics {
+            num_rows: Precision::Exact(10_001),
+            total_byte_size: Precision::Exact(100_010),
+            column_statistics: vec![
+                // col1
+                ColumnStatistics {
+                    null_count: Precision::Exact(10100),
+                    min_value: Precision::Exact(ScalarValue::UInt64(Some(50))),
+                    max_value: Precision::Exact(ScalarValue::UInt64(Some(100))),
+                    distinct_count: Precision::Absent,
+                },
+                // col2
+                ColumnStatistics {
+                    null_count: Precision::Exact(1_001_000),
+                    min_value: Precision::Exact(ScalarValue::Utf8(Some("b".to_owned()))),
+                    max_value: Precision::Exact(ScalarValue::Utf8(Some("g".to_owned()))),
+                    distinct_count: Precision::Absent,
+                },
+            ],
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_valid_update_col_reorder() {
+        let schema = Schema::new(vec![
+            Field::new("col1", DataType::UInt64, true),
+            Field::new("col2", DataType::Utf8, false),
+        ]);
+        let mut agg = StatisticsAggregator::new(&schema);
+
+        let update_schema = Schema::new(vec![
+            Field::new("col1", DataType::UInt64, true),
+            Field::new("col2", DataType::Utf8, false),
+        ]);
+        let update_stats = Statistics {
+            num_rows: Precision::Exact(1),
+            total_byte_size: Precision::Exact(10),
+            column_statistics: vec![
+                ColumnStatistics {
+                    null_count: Precision::Exact(100),
+                    min_value: Precision::Exact(ScalarValue::UInt64(Some(50))),
+                    max_value: Precision::Exact(ScalarValue::UInt64(Some(100))),
+                    distinct_count: Precision::Exact(42),
+                },
+                ColumnStatistics {
+                    null_count: Precision::Exact(1_000),
+                    min_value: Precision::Exact(ScalarValue::Utf8(Some("b".to_owned()))),
+                    max_value: Precision::Exact(ScalarValue::Utf8(Some("e".to_owned()))),
+                    distinct_count: Precision::Exact(42),
+                },
+            ],
+        };
+        agg.update(&update_stats, &update_schema).unwrap();
+
+        let update_schema = Schema::new(vec![
+            Field::new("col2", DataType::Utf8, false),
+            Field::new("col1", DataType::UInt64, true),
+        ]);
+        let update_stats = Statistics {
+            num_rows: Precision::Exact(10_000),
+            total_byte_size: Precision::Exact(100_000),
+            column_statistics: vec![
+                ColumnStatistics {
+                    null_count: Precision::Exact(1_000_000),
+                    min_value: Precision::Exact(ScalarValue::Utf8(Some("c".to_owned()))),
+                    max_value: Precision::Exact(ScalarValue::Utf8(Some("g".to_owned()))),
+                    distinct_count: Precision::Exact(42),
+                },
+                ColumnStatistics {
+                    null_count: Precision::Exact(10_000_000),
+                    min_value: Precision::Exact(ScalarValue::UInt64(Some(40))),
+                    max_value: Precision::Exact(ScalarValue::UInt64(Some(99))),
+                    distinct_count: Precision::Exact(42),
+                },
+            ],
+        };
+        agg.update(&update_stats, &update_schema).unwrap();
+
+        let actual = agg.build();
+        let expected = Statistics {
+            num_rows: Precision::Exact(10_001),
+            total_byte_size: Precision::Exact(100_010),
+            column_statistics: vec![
+                ColumnStatistics {
+                    null_count: Precision::Exact(10_000_100),
+                    min_value: Precision::Exact(ScalarValue::UInt64(Some(40))),
+                    max_value: Precision::Exact(ScalarValue::UInt64(Some(100))),
+                    distinct_count: Precision::Absent,
+                },
+                ColumnStatistics {
+                    null_count: Precision::Exact(1_001_000),
+                    min_value: Precision::Exact(ScalarValue::Utf8(Some("b".to_owned()))),
+                    max_value: Precision::Exact(ScalarValue::Utf8(Some("g".to_owned()))),
+                    distinct_count: Precision::Absent,
+                },
+            ],
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_ignores_unknown_cols() {
+        let schema = Schema::new(vec![
+            Field::new("col1", DataType::UInt64, true),
+            Field::new("col2", DataType::Utf8, false),
+        ]);
+        let mut agg = StatisticsAggregator::new(&schema);
+
+        let update_schema = Schema::new(vec![
+            Field::new("col1", DataType::UInt64, true),
+            Field::new("col3", DataType::Utf8, false),
+        ]);
+        let update_stats = Statistics {
+            num_rows: Precision::Exact(1),
+            total_byte_size: Precision::Exact(10),
+            column_statistics: vec![
+                // col1
+                ColumnStatistics {
+                    null_count: Precision::Exact(100),
+                    min_value: Precision::Exact(ScalarValue::UInt64(Some(50))),
+                    max_value: Precision::Exact(ScalarValue::UInt64(Some(100))),
+                    distinct_count: Precision::Exact(42),
+                },
+                // col3
+                ColumnStatistics {
+                    null_count: Precision::Exact(1_000),
+                    min_value: Precision::Exact(ScalarValue::Utf8(Some("b".to_owned()))),
+                    max_value: Precision::Exact(ScalarValue::Utf8(Some("e".to_owned()))),
+                    distinct_count: Precision::Exact(42),
+                },
+            ],
+        };
+        agg.update(&update_stats, &update_schema).unwrap();
+
+        let actual = agg.build();
+        let expected = Statistics {
+            num_rows: Precision::Exact(1),
+            total_byte_size: Precision::Exact(10),
+            column_statistics: vec![
+                // col1
+                ColumnStatistics {
+                    null_count: Precision::Exact(100),
+                    min_value: Precision::Exact(ScalarValue::UInt64(Some(50))),
+                    max_value: Precision::Exact(ScalarValue::UInt64(Some(100))),
+                    distinct_count: Precision::Absent,
+                },
+                // col2
+                ColumnStatistics {
+                    null_count: Precision::Exact(1),
+                    min_value: Precision::Absent,
+                    max_value: Precision::Absent,
+                    distinct_count: Precision::Absent,
+                },
+            ],
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_num_rows_exact() {
+        let (schema, update_stats) = num_rows_schema_and_stats();
+        let mut agg = StatisticsAggregator::new(&schema);
+        assert_eq!(agg.num_rows(), Precision::Absent);
+        agg.update(&update_stats, &schema).unwrap();
+        assert_eq!(agg.num_rows(), Precision::Exact(1));
+        agg.update(&update_stats, &schema).unwrap();
+        assert_eq!(agg.num_rows(), Precision::Exact(2));
+    }
+
+    #[test]
+    fn test_num_rows_inexact() {
+        let (schema, mut update_stats) = num_rows_schema_and_stats();
+        let mut agg = StatisticsAggregator::new(&schema);
+        agg.update(&update_stats, &schema).unwrap();
+        // add inexact stats
+        update_stats.num_rows = Precision::Inexact(1);
+        agg.update(&update_stats, &schema).unwrap();
+        assert_eq!(agg.num_rows(), Precision::Inexact(2));
+    }
+
+    #[test]
+    fn test_num_rows_absent() {
+        let (schema, mut update_stats) = num_rows_schema_and_stats();
+        let mut agg = StatisticsAggregator::new(&schema);
+        agg.update(&update_stats, &schema).unwrap();
+        // add absent stats
+        update_stats.num_rows = Precision::Absent;
+        agg.update(&update_stats, &schema).unwrap();
+        assert_eq!(agg.num_rows(), Precision::Inexact(1));
+    }
+
+    /// Returns a schema and stats with `Precision::Exact(1)` rows for testing num_rows
+    fn num_rows_schema_and_stats() -> (Schema, Statistics) {
+        let schema = Schema::new(vec![Field::new("col1", DataType::UInt64, true)]);
+
+        let stats = Statistics {
+            num_rows: Precision::Exact(1),
+            total_byte_size: Precision::Absent,
+            column_statistics: vec![ColumnStatistics::new_unknown()],
+        };
+        (schema, stats)
+    }
+
+    #[test]
+    fn test_invalidation_base() {
+        let test = AggTest::new();
+        test.run()
+    }
+
+    #[test]
+    fn test_invalidation_num_rows() {
+        let mut test = AggTest::new();
+        // absent stats makes inexact precision
+        test.stats1.num_rows = Precision::Absent;
+        test.expected.num_rows = Precision::Inexact(2); // value of first stats
+        test.run()
+    }
+
+    #[test]
+    fn test_invalidation_num_rows_on_update() {
+        let mut test = AggTest::new();
+        // absent stats makes inexact precision
+        test.stats2.num_rows = Precision::Absent;
+        test.expected.num_rows = Precision::Inexact(1); // value in second stats
+        test.run()
+    }
+
+    #[test]
+    fn test_inexact_num_rows_on_update() {
+        let mut test = AggTest::new();
+        // absent stats makes inexact precision
+        test.stats2.num_rows = Precision::Inexact(78);
+        test.expected.num_rows = Precision::Inexact(79); // value in second stats + 78
+        test.run()
+    }
+
+    #[test]
+    fn test_invalidation_total_byte_size_on_update() {
+        let mut test = AggTest::new();
+        // absent stats on update makes inexact precision
+        test.stats2.total_byte_size = Precision::Absent;
+        test.expected.total_byte_size = Precision::Inexact(10); // value in first stats
+        test.run()
+    }
+
+    #[test]
+    fn test_invalidation_column_null_count_on_update() {
+        let mut test = AggTest::new();
+        // absent stats on update makes inexact precision
+        test.stats2.column_statistics[0].null_count = Precision::Absent;
+        test.expected.column_statistics[0].null_count = Precision::Inexact(100); // value in first stats
+        test.run()
+    }
+
+    #[test]
+    fn test_invalidation_column_min_on_update() {
+        let mut test = AggTest::new();
+        // absent stats on update makes inexact precision
+        test.stats2.column_statistics[0].min_value = Precision::Absent;
+        test.expected.column_statistics[0].min_value = inexact_u64(7); // value in first stats
+        test.run()
+    }
+
+    #[test]
+    fn test_inexact_column_min_on_update() {
+        let mut test = AggTest::new();
+        // absent stats on update makes inexact precision
+        test.stats2.column_statistics[0].min_value = inexact_u64(3);
+        test.expected.column_statistics[0].min_value = inexact_u64(3); // inexact value
+        test.run()
+    }
+
+    #[test]
+    fn test_invalidation_column_max_on_update() {
+        let mut test = AggTest::new();
+        // absent stats on update makes inexact precision
+        test.stats2.column_statistics[0].max_value = Precision::Absent;
+        test.expected.column_statistics[0].max_value = inexact_u64(11); // value in first stats
+        test.run()
+    }
+
+    #[test]
+    fn test_inexact_column_max_on_update() {
+        let mut test = AggTest::new();
+        // absent stats on update makes inexact precision
+        test.stats2.column_statistics[0].max_value = inexact_u64(3000);
+        test.expected.column_statistics[0].max_value = inexact_u64(3000); // inexact value
+        test.run()
+    }
+
+    fn exact_u64(value: u64) -> Precision<ScalarValue> {
+        Precision::Exact(ScalarValue::UInt64(Some(value)))
+    }
+
+    fn inexact_u64(value: u64) -> Precision<ScalarValue> {
+        Precision::Inexact(ScalarValue::UInt64(Some(value)))
+    }
+
+    /// Aggregates stats1 and stats2 and compares the result with the expected statistics.
+    /// #[derive(Debug, Clone)]
+    struct AggTest {
+        schema: Schema,
+        stats1: Statistics,
+        stats2: Statistics,
+        expected: Statistics,
+    }
+
+    impl AggTest {
+        fn run(self) {
+            let Self {
+                schema,
+                stats1,
+                stats2,
+                expected,
+            } = self;
+            let mut stats_agg = StatisticsAggregator::new(&schema);
+            stats_agg.update(&stats1, &schema).unwrap();
+            stats_agg.update(&stats2, &schema).unwrap();
+            let result = stats_agg.build();
+            assert_eq!(result, expected);
+        }
+
+        /// Creates an `AggTest` that aggregates two single column statistics together
+        fn new() -> Self {
+            Self {
+                schema: Schema::new(vec![Field::new("col1", DataType::UInt64, true)]),
+                stats1: Statistics {
+                    num_rows: Precision::Exact(1),
+                    total_byte_size: Precision::Exact(10),
+                    column_statistics: vec![
+                        // col1
+                        ColumnStatistics {
+                            null_count: Precision::Exact(100),
+                            min_value: exact_u64(7),
+                            max_value: exact_u64(11),
+                            distinct_count: Precision::Exact(3),
+                        },
+                    ],
+                },
+                stats2: Statistics {
+                    num_rows: Precision::Exact(2),
+                    total_byte_size: Precision::Exact(20),
+                    column_statistics: vec![
+                        // col1
+                        ColumnStatistics {
+                            null_count: Precision::Exact(200),
+                            min_value: exact_u64(15),
+                            max_value: exact_u64(19),
+                            distinct_count: Precision::Exact(5),
+                        },
+                    ],
+                },
+
+                expected: Statistics {
+                    num_rows: Precision::Exact(3),
+                    total_byte_size: Precision::Exact(30),
+                    column_statistics: vec![
+                        // col1
+                        ColumnStatistics {
+                            null_count: Precision::Exact(300),
+                            min_value: exact_u64(7),
+                            max_value: exact_u64(19),
+                            distinct_count: Precision::Absent,
+                        },
+                    ],
+                },
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "stats (0) and schema (1) have different column count")]
+    fn test_asserts_schema_stats_match() {
+        let schema = Schema::new(vec![Field::new("col1", DataType::UInt64, true)]);
+        let mut agg = StatisticsAggregator::new(&schema);
+
+        let update_schema = Schema::new(vec![Field::new("col1", DataType::UInt64, true)]);
+        let update_stats = Statistics {
+            num_rows: Precision::Exact(1),
+            total_byte_size: Precision::Exact(10),
+            column_statistics: vec![],
+        };
+        agg.update(&update_stats, &update_schema).unwrap();
+    }
+}

--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -74,8 +74,6 @@ pub trait FileFormat: Send + Sync + fmt::Debug {
     ///
     /// `table_schema` is the (combined) schema of the overall table
     /// and may be a superset of the schema contained in this file.
-    ///
-    /// TODO: should the file source return statistics for only columns referred to in the table schema?
     async fn infer_stats(
         &self,
         state: &SessionState,

--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -279,19 +279,6 @@ impl SchemaAdapter {
         Self { table_schema }
     }
 
-    /// Map a column index in the table schema to a column index in a particular
-    /// file schema
-    ///
-    /// Panics if index is not in range for the table schema
-    pub(crate) fn map_column_index(
-        &self,
-        index: usize,
-        file_schema: &Schema,
-    ) -> Option<usize> {
-        let field = self.table_schema.field(index);
-        Some(file_schema.fields.find(field.name())?.0)
-    }
-
     /// Creates a `SchemaMapping` that can be used to cast or map the columns from the file schema to the table schema.
     ///
     /// If the provided `file_schema` contains columns of a different type to the expected

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -66,6 +66,7 @@ mod metrics;
 pub mod page_filter;
 mod row_filter;
 mod row_groups;
+mod statistics;
 
 pub use metrics::ParquetFileMetrics;
 
@@ -716,28 +717,6 @@ pub async fn plan_to_parquet(
     }
 
     Ok(())
-}
-
-// Copy from the arrow-rs
-// https://github.com/apache/arrow-rs/blob/733b7e7fd1e8c43a404c3ce40ecf741d493c21b4/parquet/src/arrow/buffer/bit_util.rs#L55
-// Convert the byte slice to fixed length byte array with the length of 16
-fn sign_extend_be(b: &[u8]) -> [u8; 16] {
-    assert!(b.len() <= 16, "Array too large, expected less than 16");
-    let is_negative = (b[0] & 128u8) == 128u8;
-    let mut result = if is_negative { [255u8; 16] } else { [0u8; 16] };
-    for (d, s) in result.iter_mut().skip(16 - b.len()).zip(b) {
-        *d = *s;
-    }
-    result
-}
-
-// Convert the bytes array to i128.
-// The endian of the input bytes array must be big-endian.
-pub(crate) fn from_bytes_to_i128(b: &[u8]) -> i128 {
-    // The bytes array are from parquet file and must be the big-endian.
-    // The endian is defined by parquet format, and the reference document
-    // https://github.com/apache/parquet-format/blob/54e53e5d7794d383529dd30746378f19a12afd58/src/main/thrift/parquet.thrift#L66
-    i128::from_be_bytes(sign_extend_be(b))
 }
 
 // Convert parquet column schema to arrow data type, and just consider the

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -66,7 +66,7 @@ mod metrics;
 pub mod page_filter;
 mod row_filter;
 mod row_groups;
-mod statistics;
+pub(crate) mod statistics;
 
 pub use metrics::ParquetFileMetrics;
 

--- a/datafusion/core/src/datasource/physical_plan/parquet/page_filter.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/page_filter.rs
@@ -39,9 +39,8 @@ use parquet::{
 };
 use std::sync::Arc;
 
-use crate::datasource::physical_plan::parquet::{
-    from_bytes_to_i128, parquet_to_arrow_decimal_type,
-};
+use crate::datasource::physical_plan::parquet::parquet_to_arrow_decimal_type;
+use crate::datasource::physical_plan::parquet::statistics::from_bytes_to_i128;
 use crate::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
 
 use super::metrics::ParquetFileMetrics;

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -1,0 +1,807 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`RowGroupStatisticsConverter`] tp converts parquet RowGroup statistics to arrow [`ArrayRef`].
+
+use arrow::{array::ArrayRef, datatypes::DataType};
+use arrow_array::new_empty_array;
+use arrow_schema::Field;
+use datafusion_common::{Result, ScalarValue};
+use parquet::file::{
+    metadata::RowGroupMetaData, statistics::Statistics as ParquetStatistics,
+};
+
+// Convert the bytes array to i128.
+// The endian of the input bytes array must be big-endian.
+pub(crate) fn from_bytes_to_i128(b: &[u8]) -> i128 {
+    // The bytes array are from parquet file and must be the big-endian.
+    // The endian is defined by parquet format, and the reference document
+    // https://github.com/apache/parquet-format/blob/54e53e5d7794d383529dd30746378f19a12afd58/src/main/thrift/parquet.thrift#L66
+    i128::from_be_bytes(sign_extend_be(b))
+}
+
+// Copy from arrow-rs
+// https://github.com/apache/arrow-rs/blob/733b7e7fd1e8c43a404c3ce40ecf741d493c21b4/parquet/src/arrow/buffer/bit_util.rs#L55
+// Convert the byte slice to fixed length byte array with the length of 16
+fn sign_extend_be(b: &[u8]) -> [u8; 16] {
+    assert!(b.len() <= 16, "Array too large, expected less than 16");
+    let is_negative = (b[0] & 128u8) == 128u8;
+    let mut result = if is_negative { [255u8; 16] } else { [0u8; 16] };
+    for (d, s) in result.iter_mut().skip(16 - b.len()).zip(b) {
+        *d = *s;
+    }
+    result
+}
+
+/// Converts parquet RowGroup statistics (stored in
+/// [`RowGroupMetaData`]) into an arrow [`ArrayRef`]
+///
+/// For example, given a parquet file with 3 Row Groups, when asked for
+/// statistics for column "A" it will return a single array with 3 elements,
+///
+pub(crate) struct RowGroupStatisticsConverter<'a> {
+    field: &'a Field,
+}
+
+/// Extract a single min/max statistics from a [`ParquetStatistics`] object
+///
+/// * `$column_statistics` is the `ParquetStatistics` object
+/// * `$func is the function` (`min`/`max`) to call to get the value
+/// * `$bytes_func` is the function (`min_bytes`/`max_bytes`) to call to get the value as bytes
+/// * `$target_arrow_type` is the [`DataType`] of the target statistics
+macro_rules! get_statistic {
+    ($column_statistics:expr, $func:ident, $bytes_func:ident, $target_arrow_type:expr) => {{
+        if !$column_statistics.has_min_max_set() {
+            return None;
+        }
+        match $column_statistics {
+            ParquetStatistics::Boolean(s) => Some(ScalarValue::Boolean(Some(*s.$func()))),
+            ParquetStatistics::Int32(s) => {
+                match $target_arrow_type {
+                    // int32 to decimal with the precision and scale
+                    Some(DataType::Decimal128(precision, scale)) => {
+                        Some(ScalarValue::Decimal128(
+                            Some(*s.$func() as i128),
+                            precision,
+                            scale,
+                        ))
+                    }
+                    _ => Some(ScalarValue::Int32(Some(*s.$func()))),
+                }
+            }
+            ParquetStatistics::Int64(s) => {
+                match $target_arrow_type {
+                    // int64 to decimal with the precision and scale
+                    Some(DataType::Decimal128(precision, scale)) => {
+                        Some(ScalarValue::Decimal128(
+                            Some(*s.$func() as i128),
+                            precision,
+                            scale,
+                        ))
+                    }
+                    _ => Some(ScalarValue::Int64(Some(*s.$func()))),
+                }
+            }
+            // 96 bit ints not supported
+            ParquetStatistics::Int96(_) => None,
+            ParquetStatistics::Float(s) => Some(ScalarValue::Float32(Some(*s.$func()))),
+            ParquetStatistics::Double(s) => Some(ScalarValue::Float64(Some(*s.$func()))),
+            ParquetStatistics::ByteArray(s) => {
+                match $target_arrow_type {
+                    // decimal data type
+                    Some(DataType::Decimal128(precision, scale)) => {
+                        Some(ScalarValue::Decimal128(
+                            Some(from_bytes_to_i128(s.$bytes_func())),
+                            precision,
+                            scale,
+                        ))
+                    }
+                    _ => {
+                        let s = std::str::from_utf8(s.$bytes_func())
+                            .map(|s| s.to_string())
+                            .ok();
+                        Some(ScalarValue::Utf8(s))
+                    }
+                }
+            }
+            // type not supported yet
+            ParquetStatistics::FixedLenByteArray(s) => {
+                match $target_arrow_type {
+                    // just support the decimal data type
+                    Some(DataType::Decimal128(precision, scale)) => {
+                        Some(ScalarValue::Decimal128(
+                            Some(from_bytes_to_i128(s.$bytes_func())),
+                            precision,
+                            scale,
+                        ))
+                    }
+                    _ => None,
+                }
+            }
+        }
+    }};
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MinMax {
+    Min,
+    Max,
+}
+
+impl<'a> RowGroupStatisticsConverter<'a> {
+    /// Create a new RowGoupStatisticsConverter suitable that can extract
+    /// statistics for the specified field
+    pub fn new(field: &'a Field) -> Self {
+        Self { field }
+    }
+
+    /// Returns the min value for the column into an array ref.
+    pub fn min<'b>(
+        &self,
+        row_group_meta_data: impl IntoIterator<Item = &'b RowGroupMetaData>,
+    ) -> Result<ArrayRef> {
+        self.min_max_impl(MinMax::Min, row_group_meta_data)
+    }
+
+    /// Returns the max value for the column into an array ref.
+    pub fn max<'b>(
+        &self,
+        row_group_meta_data: impl IntoIterator<Item = &'b RowGroupMetaData>,
+    ) -> Result<ArrayRef> {
+        self.min_max_impl(MinMax::Max, row_group_meta_data)
+    }
+
+    /// Extracts all min/max values for the column into an array ref.
+    fn min_max_impl<'b>(
+        &self,
+        mm: MinMax,
+        row_group_meta_data: impl IntoIterator<Item = &'b RowGroupMetaData>,
+    ) -> Result<ArrayRef> {
+        let mut row_group_meta_data = row_group_meta_data.into_iter().peekable();
+
+        // if it is empty, return empty array
+        if row_group_meta_data.peek().is_none() {
+            return Ok(new_empty_array(self.field.data_type()));
+        }
+
+        let maybe_index = row_group_meta_data.peek().and_then(|rg_meta| {
+            rg_meta
+                .columns()
+                .iter()
+                .enumerate()
+                .find(|(_idx, c)| c.column_descr().name() == self.field.name())
+                .map(|(idx, _c)| idx)
+        });
+
+        // don't have this column, return an array of all NULLs
+        let Some(column_index) = maybe_index else {
+            let num_row_groups = row_group_meta_data.count();
+            let sv = ScalarValue::try_from(self.field.data_type())?;
+            return sv.to_array_of_size(num_row_groups);
+        };
+
+        let stats_iter = row_group_meta_data.map(move |row_group_meta_data| {
+            row_group_meta_data.column(column_index).statistics()
+        });
+
+        // this is the value to use when the statistics are not set
+        let null_value = ScalarValue::try_from(self.field.data_type())?;
+        match mm {
+            MinMax::Min => {
+                let values = stats_iter.map(|column_statistics| {
+                    column_statistics
+                        .and_then(|column_statistics| {
+                            get_statistic!(
+                                column_statistics,
+                                min,
+                                min_bytes,
+                                Some(self.field.data_type().clone())
+                            )
+                        })
+                        .unwrap_or_else(|| null_value.clone())
+                });
+                ScalarValue::iter_to_array(values)
+            }
+            MinMax::Max => {
+                let values = stats_iter.map(|column_statistics| {
+                    column_statistics
+                        .and_then(|column_statistics| {
+                            get_statistic!(
+                                column_statistics,
+                                max,
+                                max_bytes,
+                                Some(self.field.data_type().clone())
+                            )
+                        })
+                        .unwrap_or_else(|| null_value.clone())
+                });
+                ScalarValue::iter_to_array(values)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use arrow_array::{
+        BinaryArray, BooleanArray, Decimal128Array, Float32Array, Float64Array,
+        Int32Array, Int64Array, RecordBatch, StringArray, TimestampNanosecondArray,
+    };
+    use arrow_schema::SchemaRef;
+    use bytes::Bytes;
+    use datafusion_common::test_util::parquet_test_data;
+    use parquet::arrow::arrow_reader::ArrowReaderBuilder;
+    use parquet::arrow::arrow_writer::ArrowWriter;
+    use parquet::file::metadata::ParquetMetaData;
+    use parquet::file::properties::{EnabledStatistics, WriterProperties};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    // TODO error cases (with parquet statistics that are mismatched in expected type)
+
+    #[test]
+    fn roundtrip_empty() {
+        let empty_bool_array = new_empty_array(&DataType::Boolean);
+        Test {
+            input: empty_bool_array.clone(),
+            expected_min: empty_bool_array.clone(),
+            expected_max: empty_bool_array.clone(),
+        }
+        .run()
+    }
+
+    #[test]
+    fn roundtrip_bool() {
+        Test {
+            input: Arc::new(BooleanArray::from(vec![
+                // row group 1
+                Some(true),
+                None,
+                Some(true),
+                // row group 2
+                Some(true),
+                Some(false),
+                None,
+                // row group 3
+                None,
+                None,
+                None,
+            ])),
+            expected_min: Arc::new(BooleanArray::from(vec![
+                Some(true),
+                Some(false),
+                None,
+            ])),
+            expected_max: Arc::new(BooleanArray::from(vec![
+                Some(true),
+                Some(true),
+                None,
+            ])),
+        }
+        .run()
+    }
+
+    #[test]
+    fn roundtrip_int32() {
+        Test {
+            input: Arc::new(Int32Array::from(vec![
+                // row group 1
+                Some(1),
+                None,
+                Some(3),
+                // row group 2
+                Some(0),
+                Some(5),
+                None,
+                // row group 3
+                None,
+                None,
+                None,
+            ])),
+            expected_min: Arc::new(Int32Array::from(vec![Some(1), Some(0), None])),
+            expected_max: Arc::new(Int32Array::from(vec![Some(3), Some(5), None])),
+        }
+        .run()
+    }
+
+    #[test]
+    fn roundtrip_int64() {
+        Test {
+            input: Arc::new(Int64Array::from(vec![
+                // row group 1
+                Some(1),
+                None,
+                Some(3),
+                // row group 2
+                Some(0),
+                Some(5),
+                None,
+                // row group 3
+                None,
+                None,
+                None,
+            ])),
+            expected_min: Arc::new(Int64Array::from(vec![Some(1), Some(0), None])),
+            expected_max: Arc::new(Int64Array::from(vec![Some(3), Some(5), None])),
+        }
+        .run()
+    }
+
+    #[test]
+    fn roundtrip_f32() {
+        Test {
+            input: Arc::new(Float32Array::from(vec![
+                // row group 1
+                Some(1.0),
+                None,
+                Some(3.0),
+                // row group 2
+                Some(-1.0),
+                Some(5.0),
+                None,
+                // row group 3
+                None,
+                None,
+                None,
+            ])),
+            expected_min: Arc::new(Float32Array::from(vec![Some(1.0), Some(-1.0), None])),
+            expected_max: Arc::new(Float32Array::from(vec![Some(3.0), Some(5.0), None])),
+        }
+        .run()
+    }
+
+    #[test]
+    fn roundtrip_f64() {
+        Test {
+            input: Arc::new(Float64Array::from(vec![
+                // row group 1
+                Some(1.0),
+                None,
+                Some(3.0),
+                // row group 2
+                Some(-1.0),
+                Some(5.0),
+                None,
+                // row group 3
+                None,
+                None,
+                None,
+            ])),
+            expected_min: Arc::new(Float64Array::from(vec![Some(1.0), Some(-1.0), None])),
+            expected_max: Arc::new(Float64Array::from(vec![Some(3.0), Some(5.0), None])),
+        }
+        .run()
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Inconsistent types in ScalarValue::iter_to_array. Expected Int64, got TimestampNanosecond(NULL, None)"
+    )]
+    fn roundtrip_timestamp() {
+        Test {
+            input: Arc::new(TimestampNanosecondArray::from(vec![
+                // row group 1
+                Some(1),
+                None,
+                Some(3),
+                // row group 2
+                Some(9),
+                Some(5),
+                None,
+                // row group 3
+                None,
+                None,
+                None,
+            ])),
+            expected_min: Arc::new(TimestampNanosecondArray::from(vec![
+                Some(1),
+                Some(5),
+                None,
+            ])),
+            expected_max: Arc::new(TimestampNanosecondArray::from(vec![
+                Some(3),
+                Some(9),
+                None,
+            ])),
+        }
+        .run()
+    }
+
+    #[test]
+    fn roundtrip_decimal() {
+        Test {
+            input: Arc::new(
+                Decimal128Array::from(vec![
+                    // row group 1
+                    Some(100),
+                    None,
+                    Some(22000),
+                    // row group 2
+                    Some(500000),
+                    Some(330000),
+                    None,
+                    // row group 3
+                    None,
+                    None,
+                    None,
+                ])
+                .with_precision_and_scale(9, 2)
+                .unwrap(),
+            ),
+            expected_min: Arc::new(
+                Decimal128Array::from(vec![Some(100), Some(330000), None])
+                    .with_precision_and_scale(9, 2)
+                    .unwrap(),
+            ),
+            expected_max: Arc::new(
+                Decimal128Array::from(vec![Some(22000), Some(500000), None])
+                    .with_precision_and_scale(9, 2)
+                    .unwrap(),
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn roundtrip_utf8() {
+        Test {
+            input: Arc::new(StringArray::from(vec![
+                // row group 1
+                Some("A"),
+                None,
+                Some("Q"),
+                // row group 2
+                Some("ZZ"),
+                Some("AA"),
+                None,
+                // row group 3
+                None,
+                None,
+                None,
+            ])),
+            expected_min: Arc::new(StringArray::from(vec![Some("A"), Some("AA"), None])),
+            expected_max: Arc::new(StringArray::from(vec![Some("Q"), Some("ZZ"), None])),
+        }
+        .run()
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Inconsistent types in ScalarValue::iter_to_array. Expected Utf8, got Binary(NULL)"
+    )]
+    fn roundtrip_binary() {
+        Test {
+            input: Arc::new(BinaryArray::from_opt_vec(vec![
+                // row group 1
+                Some(b"A"),
+                None,
+                Some(b"Q"),
+                // row group 2
+                Some(b"ZZ"),
+                Some(b"AA"),
+                None,
+                // row group 3
+                None,
+                None,
+                None,
+            ])),
+            expected_min: Arc::new(BinaryArray::from_opt_vec(vec![
+                Some(b"A"),
+                Some(b"AA"),
+                None,
+            ])),
+            expected_max: Arc::new(BinaryArray::from_opt_vec(vec![
+                Some(b"Q"),
+                Some(b"ZZ"),
+                None,
+            ])),
+        }
+        .run()
+    }
+
+    const ROWS_PER_ROW_GROUP: usize = 3;
+
+    /// Writes the input batch into a parquet file, with every every three rows as
+    /// their own row group, and compares the min/maxes to the expected values
+    struct Test {
+        input: ArrayRef,
+        expected_min: ArrayRef,
+        expected_max: ArrayRef,
+    }
+
+    impl Test {
+        fn run(self) {
+            let Self {
+                input,
+                expected_min,
+                expected_max,
+            } = self;
+
+            let input_batch = RecordBatch::try_from_iter([("c1", input)]).unwrap();
+
+            let schema = input_batch.schema();
+
+            let metadata = parquet_metadata(schema.clone(), input_batch);
+
+            for field in schema.fields() {
+                let converter = RowGroupStatisticsConverter::new(field);
+                let row_groups = metadata.row_groups();
+                let min = converter.min(row_groups).unwrap();
+                assert_eq!(
+                    &min,
+                    &expected_min,
+                    "Min. Statistics\n\n{}\n\n",
+                    DisplayStats(row_groups)
+                );
+
+                let max = converter.max(row_groups).unwrap();
+                assert_eq!(
+                    &max,
+                    &expected_max,
+                    "Max. Statistics\n\n{}\n\n",
+                    DisplayStats(row_groups)
+                );
+            }
+        }
+    }
+
+    /// Write the specified batches out as parquet and return the metadata
+    fn parquet_metadata(schema: SchemaRef, batch: RecordBatch) -> Arc<ParquetMetaData> {
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::Chunk)
+            .set_max_row_group_size(ROWS_PER_ROW_GROUP)
+            .build();
+
+        let mut buffer = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buffer, schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let reader = ArrowReaderBuilder::try_new(Bytes::from(buffer)).unwrap();
+        reader.metadata().clone()
+    }
+
+    /// Formats the statistics nicely for display
+    struct DisplayStats<'a>(&'a [RowGroupMetaData]);
+    impl<'a> std::fmt::Display for DisplayStats<'a> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let row_groups = self.0;
+            writeln!(f, "  row_groups: {}", row_groups.len())?;
+            for rg in row_groups {
+                for col in rg.columns() {
+                    if let Some(statistics) = col.statistics() {
+                        writeln!(f, "   {}: {:?}", col.column_path(), statistics)?;
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    struct ExpectedColumn {
+        name: &'static str,
+        expected_min: ArrayRef,
+        expected_max: ArrayRef,
+    }
+
+    /// Reads statistics out of the specified, and compares them to the expected values
+    struct TestFile {
+        file_name: &'static str,
+        expected_columns: Vec<ExpectedColumn>,
+    }
+
+    impl TestFile {
+        fn new(file_name: &'static str) -> Self {
+            Self {
+                file_name,
+                expected_columns: Vec::new(),
+            }
+        }
+
+        fn with_column(mut self, column: ExpectedColumn) -> Self {
+            self.expected_columns.push(column);
+            self
+        }
+
+        /// Reads the specified parquet file and validates that the exepcted min/max
+        /// values for the specified columns are as expected.
+        fn run(self) {
+            let path = PathBuf::from(parquet_test_data()).join(self.file_name);
+            let file = std::fs::File::open(path).unwrap();
+            let reader = ArrowReaderBuilder::try_new(file).unwrap();
+            let arrow_schema = reader.schema();
+            let metadata = reader.metadata();
+
+            for rg in metadata.row_groups() {
+                println!(
+                    "Columns: {}",
+                    rg.columns()
+                        .iter()
+                        .map(|c| c.column_descr().name())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+            println!("  row groups: {}", metadata.row_groups().len());
+
+            for expected_column in self.expected_columns {
+                let ExpectedColumn {
+                    name,
+                    expected_min,
+                    expected_max,
+                } = expected_column;
+
+                let field = arrow_schema
+                    .field_with_name(name)
+                    .expect("can't find field in schema");
+
+                let converter = RowGroupStatisticsConverter::new(field);
+                let actual_min = converter.min(metadata.row_groups()).unwrap();
+                assert_eq!(&expected_min, &actual_min, "column {name}");
+
+                let actual_max = converter.max(metadata.row_groups()).unwrap();
+                assert_eq!(&expected_max, &actual_max, "column {name}");
+            }
+        }
+    }
+
+    #[test]
+    fn alltypes_plain() {
+        // /parquet-testing/data/datapage_v1-snappy-compressed-checksum.parquet
+        // row_groups: 1
+        // (has no statistics)
+        TestFile::new("alltypes_plain.parquet")
+            // No column statistics should be read as NULL, but with the right type
+            .with_column(ExpectedColumn {
+                name: "id",
+                expected_min: Arc::new(Int32Array::from(vec![None])),
+                expected_max: Arc::new(Int32Array::from(vec![None])),
+            })
+            .with_column(ExpectedColumn {
+                name: "bool_col",
+                expected_min: Arc::new(BooleanArray::from(vec![None])),
+                expected_max: Arc::new(BooleanArray::from(vec![None])),
+            })
+            .run();
+    }
+
+    #[test]
+    fn alltypes_tiny_pages() {
+        // /parquet-testing/data/alltypes_tiny_pages.parquet
+        // row_groups: 1
+        // "id": Int32({min: Some(0), max: Some(7299), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "bool_col": Boolean({min: Some(false), max: Some(true), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "tinyint_col": Int32({min: Some(0), max: Some(9), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "smallint_col": Int32({min: Some(0), max: Some(9), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "int_col": Int32({min: Some(0), max: Some(9), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "bigint_col": Int64({min: Some(0), max: Some(90), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "float_col": Float({min: Some(0.0), max: Some(9.9), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "double_col": Double({min: Some(0.0), max: Some(90.89999999999999), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "date_string_col": ByteArray({min: Some(ByteArray { data: "01/01/09" }), max: Some(ByteArray { data: "12/31/10" }), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "string_col": ByteArray({min: Some(ByteArray { data: "0" }), max: Some(ByteArray { data: "9" }), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "timestamp_col": Int96({min: None, max: None, distinct_count: None, null_count: 0, min_max_deprecated: true, min_max_backwards_compatible: true})
+        // "year": Int32({min: Some(2009), max: Some(2010), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        // "month": Int32({min: Some(1), max: Some(12), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+        TestFile::new("alltypes_tiny_pages.parquet")
+            .with_column(ExpectedColumn {
+                name: "id",
+                expected_min: Arc::new(Int32Array::from(vec![Some(0)])),
+                expected_max: Arc::new(Int32Array::from(vec![Some(7299)])),
+            })
+            .with_column(ExpectedColumn {
+                name: "bool_col",
+                expected_min: Arc::new(BooleanArray::from(vec![Some(false)])),
+                expected_max: Arc::new(BooleanArray::from(vec![Some(true)])),
+            })
+            .with_column(ExpectedColumn {
+                name: "tinyint_col",
+                expected_min: Arc::new(Int32Array::from(vec![Some(0)])),
+                expected_max: Arc::new(Int32Array::from(vec![Some(9)])),
+            })
+            .with_column(ExpectedColumn {
+                name: "smallint_col",
+                expected_min: Arc::new(Int32Array::from(vec![Some(0)])),
+                expected_max: Arc::new(Int32Array::from(vec![Some(9)])),
+            })
+            .with_column(ExpectedColumn {
+                name: "int_col",
+                expected_min: Arc::new(Int32Array::from(vec![Some(0)])),
+                expected_max: Arc::new(Int32Array::from(vec![Some(9)])),
+            })
+            .with_column(ExpectedColumn {
+                name: "bigint_col",
+                expected_min: Arc::new(Int64Array::from(vec![Some(0)])),
+                expected_max: Arc::new(Int64Array::from(vec![Some(90)])),
+            })
+            .with_column(ExpectedColumn {
+                name: "float_col",
+                expected_min: Arc::new(Float32Array::from(vec![Some(0.0)])),
+                expected_max: Arc::new(Float32Array::from(vec![Some(9.9)])),
+            })
+            .with_column(ExpectedColumn {
+                name: "double_col",
+                expected_min: Arc::new(Float64Array::from(vec![Some(0.0)])),
+                expected_max: Arc::new(Float64Array::from(vec![Some(90.89999999999999)])),
+            })
+            .with_column(ExpectedColumn {
+                name: "date_string_col",
+                expected_min: Arc::new(StringArray::from(vec![Some("01/01/09")])),
+                expected_max: Arc::new(StringArray::from(vec![Some("12/31/10")])),
+            })
+            .with_column(ExpectedColumn {
+                name: "string_col",
+                expected_min: Arc::new(StringArray::from(vec![Some("0")])),
+                expected_max: Arc::new(StringArray::from(vec![Some("9")])),
+            })
+            // File has no min/max for timestamp_col
+            .with_column(ExpectedColumn {
+                name: "timestamp_col",
+                expected_min: Arc::new(TimestampNanosecondArray::from(vec![None])),
+                expected_max: Arc::new(TimestampNanosecondArray::from(vec![None])),
+            })
+            .with_column(ExpectedColumn {
+                name: "year",
+                expected_min: Arc::new(Int32Array::from(vec![Some(2009)])),
+                expected_max: Arc::new(Int32Array::from(vec![Some(2010)])),
+            })
+            .with_column(ExpectedColumn {
+                name: "month",
+                expected_min: Arc::new(Int32Array::from(vec![Some(1)])),
+                expected_max: Arc::new(Int32Array::from(vec![Some(12)])),
+            })
+            .run();
+    }
+
+    #[test]
+    fn fixed_length_decimal_legacy() {
+        // /parquet-testing/data/fixed_length_decimal_legacy.parquet
+        // row_groups: 1
+        // "value": FixedLenByteArray({min: Some(FixedLenByteArray(ByteArray { data: Some(ByteBufferPtr { data: b"\0\0\0\0\0\xc8" }) })), max: Some(FixedLenByteArray(ByteArray { data: "\0\0\0\0\t`" })), distinct_count: None, null_count: 0, min_max_deprecated: true, min_max_backwards_compatible: true})
+
+        TestFile::new("fixed_length_decimal_legacy.parquet")
+            .with_column(ExpectedColumn {
+                name: "value",
+                expected_min: Arc::new(
+                    Decimal128Array::from(vec![Some(200)])
+                        .with_precision_and_scale(13, 2)
+                        .unwrap(),
+                ),
+                expected_max: Arc::new(
+                    Decimal128Array::from(vec![Some(2400)])
+                        .with_precision_and_scale(13, 2)
+                        .unwrap(),
+                ),
+            })
+            .run();
+    }
+
+    #[test]
+    fn nan_in_stats() {
+        // /parquet-testing/data/nan_in_stats.parquet
+        // row_groups: 1
+        // "x": Double({min: Some(1.0), max: Some(NaN), distinct_count: None, null_count: 0, min_max_deprecated: false, min_max_backwards_compatible: false})
+
+        TestFile::new("nan_in_stats.parquet")
+            .with_column(ExpectedColumn {
+                name: "x",
+                expected_min: Arc::new(Float64Array::from(vec![Some(1.0)])),
+                expected_max: Arc::new(Float64Array::from(vec![Some(f64::NAN)])),
+            })
+            .run();
+    }
+}

--- a/datafusion/core/src/datasource/statistics.rs
+++ b/datafusion/core/src/datasource/statistics.rs
@@ -16,39 +16,26 @@
 // under the License.
 
 use super::listing::PartitionedFile;
-use crate::arrow::datatypes::{Schema, SchemaRef};
+use crate::arrow::datatypes::SchemaRef;
 use crate::error::Result;
-use crate::physical_plan::expressions::{MaxAccumulator, MinAccumulator};
-use crate::physical_plan::{Accumulator, ColumnStatistics, Statistics};
+use crate::physical_plan::Statistics;
 
-use datafusion_common::stats::Precision;
-use datafusion_common::ScalarValue;
+use datafusion_common::stats::{Precision, StatisticsAggregator};
 
 use futures::{Stream, StreamExt};
-use itertools::izip;
-use itertools::multiunzip;
 
-/// Get all files as well as the file level summary statistics (no statistic for partition columns).
-/// If the optional `limit` is provided, includes only sufficient files.
-/// Needed to read up to `limit` number of rows.
+/// Get all files as well as the file level summary statistics (no statistic for
+/// partition columns). If the optional `limit` is provided, includes only
+/// sufficient files needed to read up to `limit` number of rows.
 pub async fn get_statistics_with_limit(
     all_files: impl Stream<Item = Result<(PartitionedFile, Statistics)>>,
     file_schema: SchemaRef,
     limit: Option<usize>,
 ) -> Result<(Vec<PartitionedFile>, Statistics)> {
+    let limit = limit.unwrap_or(usize::MAX);
+
     let mut result_files = vec![];
-    // These statistics can be calculated as long as at least one file provides
-    // useful information. If none of the files provides any information, then
-    // they will end up having `Precision::Absent` values. Throughout calculations,
-    // missing values will be imputed as:
-    // - zero for summations, and
-    // - neutral element for extreme points.
-    let size = file_schema.fields().len();
-    let mut null_counts: Vec<Precision<usize>> = vec![Precision::Absent; size];
-    let mut max_values: Vec<Precision<ScalarValue>> = vec![Precision::Absent; size];
-    let mut min_values: Vec<Precision<ScalarValue>> = vec![Precision::Absent; size];
-    let mut num_rows = Precision::<usize>::Absent;
-    let mut total_byte_size = Precision::<usize>::Absent;
+    let mut stats_agg = StatisticsAggregator::new(&file_schema);
 
     // Fusing the stream allows us to call next safely even once it is finished.
     let mut all_files = Box::pin(all_files.fuse());
@@ -57,83 +44,36 @@ pub async fn get_statistics_with_limit(
         let (file, file_stats) = first_file?;
         result_files.push(file);
 
-        // First file, we set them directly from the file statistics.
-        num_rows = file_stats.num_rows;
-        total_byte_size = file_stats.total_byte_size;
-        for (index, file_column) in file_stats.column_statistics.into_iter().enumerate() {
-            null_counts[index] = file_column.null_count;
-            max_values[index] = file_column.max_value;
-            min_values[index] = file_column.min_value;
-        }
+        stats_agg.update(&file_stats, &file_schema)?;
 
         // If the number of rows exceeds the limit, we can stop processing
         // files. This only applies when we know the number of rows. It also
         // currently ignores tables that have no statistics regarding the
         // number of rows.
-        let conservative_num_rows = match num_rows {
-            Precision::Exact(nr) => nr,
+        let conservative_num_rows = match stats_agg.num_rows() {
+            Precision::Exact(nr) => *nr,
             _ => usize::MIN,
         };
-        if conservative_num_rows <= limit.unwrap_or(usize::MAX) {
+
+        if conservative_num_rows <= limit {
             while let Some(current) = all_files.next().await {
                 let (file, file_stats) = current?;
                 result_files.push(file);
-
-                // We accumulate the number of rows, total byte size and null
-                // counts across all the files in question. If any file does not
-                // provide any information or provides an inexact value, we demote
-                // the statistic precision to inexact.
-                num_rows = add_row_stats(file_stats.num_rows, num_rows);
-
-                total_byte_size =
-                    add_row_stats(file_stats.total_byte_size, total_byte_size);
-
-                (null_counts, max_values, min_values) = multiunzip(
-                    izip!(
-                        file_stats.column_statistics.into_iter(),
-                        null_counts.into_iter(),
-                        max_values.into_iter(),
-                        min_values.into_iter()
-                    )
-                    .map(
-                        |(
-                            ColumnStatistics {
-                                null_count: file_nc,
-                                max_value: file_max,
-                                min_value: file_min,
-                                distinct_count: _,
-                            },
-                            null_count,
-                            max_value,
-                            min_value,
-                        )| {
-                            (
-                                add_row_stats(file_nc, null_count),
-                                set_max_if_greater(file_max, max_value),
-                                set_min_if_lesser(file_min, min_value),
-                            )
-                        },
-                    ),
-                );
+                stats_agg.update(&file_stats, &file_schema)?;
 
                 // If the number of rows exceeds the limit, we can stop processing
-                // files. This only applies when we know the number of rows. It also
-                // currently ignores tables that have no statistics regarding the
-                // number of rows.
-                if num_rows.get_value().unwrap_or(&usize::MIN)
-                    > &limit.unwrap_or(usize::MAX)
-                {
-                    break;
+                // files.
+                if let Precision::Exact(num_rows) = stats_agg.num_rows() {
+                    if *num_rows > limit {
+                        break;
+                    }
                 }
             }
         }
     };
 
-    let mut statistics = Statistics {
-        num_rows,
-        total_byte_size,
-        column_statistics: get_col_stats_vec(null_counts, max_values, min_values),
-    };
+    let mut statistics = stats_agg.build();
+
     if all_files.next().await.is_some() {
         // If we still have files in the stream, it means that the limit kicked
         // in, and the statistic could have been different had we processed the
@@ -142,118 +82,4 @@ pub async fn get_statistics_with_limit(
     }
 
     Ok((result_files, statistics))
-}
-
-pub(crate) fn create_max_min_accs(
-    schema: &Schema,
-) -> (Vec<Option<MaxAccumulator>>, Vec<Option<MinAccumulator>>) {
-    let max_values: Vec<Option<MaxAccumulator>> = schema
-        .fields()
-        .iter()
-        .map(|field| MaxAccumulator::try_new(field.data_type()).ok())
-        .collect();
-    let min_values: Vec<Option<MinAccumulator>> = schema
-        .fields()
-        .iter()
-        .map(|field| MinAccumulator::try_new(field.data_type()).ok())
-        .collect();
-    (max_values, min_values)
-}
-
-fn add_row_stats(
-    file_num_rows: Precision<usize>,
-    num_rows: Precision<usize>,
-) -> Precision<usize> {
-    match (file_num_rows, &num_rows) {
-        (Precision::Absent, _) => num_rows.to_inexact(),
-        (lhs, Precision::Absent) => lhs.to_inexact(),
-        (lhs, rhs) => lhs.add(rhs),
-    }
-}
-
-pub(crate) fn get_col_stats_vec(
-    null_counts: Vec<Precision<usize>>,
-    max_values: Vec<Precision<ScalarValue>>,
-    min_values: Vec<Precision<ScalarValue>>,
-) -> Vec<ColumnStatistics> {
-    izip!(null_counts, max_values, min_values)
-        .map(|(null_count, max_value, min_value)| ColumnStatistics {
-            null_count,
-            max_value,
-            min_value,
-            distinct_count: Precision::Absent,
-        })
-        .collect()
-}
-
-pub(crate) fn get_col_stats(
-    schema: &Schema,
-    null_counts: Vec<Precision<usize>>,
-    max_values: &mut [Option<MaxAccumulator>],
-    min_values: &mut [Option<MinAccumulator>],
-) -> Vec<ColumnStatistics> {
-    (0..schema.fields().len())
-        .map(|i| {
-            let max_value = match &max_values[i] {
-                Some(max_value) => max_value.evaluate().ok(),
-                None => None,
-            };
-            let min_value = match &min_values[i] {
-                Some(min_value) => min_value.evaluate().ok(),
-                None => None,
-            };
-            ColumnStatistics {
-                null_count: null_counts[i].clone(),
-                max_value: max_value.map(Precision::Exact).unwrap_or(Precision::Absent),
-                min_value: min_value.map(Precision::Exact).unwrap_or(Precision::Absent),
-                distinct_count: Precision::Absent,
-            }
-        })
-        .collect()
-}
-
-/// If the given value is numerically greater than the original maximum value,
-/// return the new maximum value with appropriate exactness information.
-fn set_max_if_greater(
-    max_nominee: Precision<ScalarValue>,
-    max_values: Precision<ScalarValue>,
-) -> Precision<ScalarValue> {
-    match (&max_values, &max_nominee) {
-        (Precision::Exact(val1), Precision::Exact(val2)) if val1 < val2 => max_nominee,
-        (Precision::Exact(val1), Precision::Inexact(val2))
-        | (Precision::Inexact(val1), Precision::Inexact(val2))
-        | (Precision::Inexact(val1), Precision::Exact(val2))
-            if val1 < val2 =>
-        {
-            max_nominee.to_inexact()
-        }
-        (Precision::Exact(_), Precision::Absent) => max_values.to_inexact(),
-        (Precision::Absent, Precision::Exact(_)) => max_nominee.to_inexact(),
-        (Precision::Absent, Precision::Inexact(_)) => max_nominee,
-        (Precision::Absent, Precision::Absent) => Precision::Absent,
-        _ => max_values,
-    }
-}
-
-/// If the given value is numerically lesser than the original minimum value,
-/// return the new minimum value with appropriate exactness information.
-fn set_min_if_lesser(
-    min_nominee: Precision<ScalarValue>,
-    min_values: Precision<ScalarValue>,
-) -> Precision<ScalarValue> {
-    match (&min_values, &min_nominee) {
-        (Precision::Exact(val1), Precision::Exact(val2)) if val1 > val2 => min_nominee,
-        (Precision::Exact(val1), Precision::Inexact(val2))
-        | (Precision::Inexact(val1), Precision::Inexact(val2))
-        | (Precision::Inexact(val1), Precision::Exact(val2))
-            if val1 > val2 =>
-        {
-            min_nominee.to_inexact()
-        }
-        (Precision::Exact(_), Precision::Absent) => min_values.to_inexact(),
-        (Precision::Absent, Precision::Exact(_)) => min_nominee.to_inexact(),
-        (Precision::Absent, Precision::Inexact(_)) => min_nominee,
-        (Precision::Absent, Precision::Absent) => Precision::Absent,
-        _ => min_values,
-    }
 }

--- a/datafusion/core/src/datasource/statistics.rs
+++ b/datafusion/core/src/datasource/statistics.rs
@@ -51,7 +51,7 @@ pub async fn get_statistics_with_limit(
         // currently ignores tables that have no statistics regarding the
         // number of rows.
         let conservative_num_rows = match stats_agg.num_rows() {
-            Precision::Exact(nr) => *nr,
+            Precision::Exact(nr) => nr,
             _ => usize::MIN,
         };
 
@@ -64,7 +64,7 @@ pub async fn get_statistics_with_limit(
                 // If the number of rows exceeds the limit, we can stop processing
                 // files.
                 if let Precision::Exact(num_rows) = stats_agg.num_rows() {
-                    if *num_rows > limit {
+                    if num_rows > limit {
                         break;
                     }
                 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/8229

## Rationale for this change

There were multiple, confusing, and inconsistent paths for aggregating statistics. This both makes it hard to change how Statistics work (e.g. https://github.com/apache/arrow-datafusion/issues/8078) it also makes for subtle bugs

## What changes are included in this PR?

1. Introduce `StatisticsAggregator` that handles aggregating statistics from multiple sources, and is well documented and tested
3. Rewrite existing statistics aggregation to use the new aggregator

Note that this code is based on some authored by @crepererum  for InfluxDB IOx. 

## Are these changes tested?
Yes, substantial new test coverage is added 

## Are there any user-facing changes?

No user facing change intended