### PR TITLE
DRAFT: Resolve function calls by name during planning 

### DIFF
--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -19,11 +19,11 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::execution::FunctionRegistry;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TreeNode};
-use datafusion_common::{plan_err, DataFusionError, Result, ScalarValue, internal_err};
+use datafusion_common::{internal_err, plan_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::{
     AggregateUDF, Between, Expr, Filter, LogicalPlan, ScalarUDF, TableSource, WindowUDF,
 };
-use datafusion_optimizer::analyzer::{Analyzer, AnalyzerRule, AnalyzerConfig};
+use datafusion_optimizer::analyzer::{Analyzer, AnalyzerConfig, AnalyzerRule};
 use datafusion_optimizer::optimizer::Optimizer;
 use datafusion_optimizer::{utils, OptimizerConfig, OptimizerContext, OptimizerRule};
 use datafusion_sql::planner::{ContextProvider, SqlToRel};
@@ -33,11 +33,11 @@ use datafusion_sql::TableReference;
 use std::any::Any;
 use std::sync::Arc;
 
-struct ExamplesAnalyzerConfig<'a>{
-    config_options:&'a ConfigOptions
+struct ExamplesAnalyzerConfig<'a> {
+    config_options: &'a ConfigOptions,
 }
 
-impl <'a> FunctionRegistry for ExamplesAnalyzerConfig<'a>{
+impl<'a> FunctionRegistry for ExamplesAnalyzerConfig<'a> {
     fn udfs(&self) -> std::collections::HashSet<String> {
         std::collections::HashSet::new()
     }
@@ -55,7 +55,7 @@ impl <'a> FunctionRegistry for ExamplesAnalyzerConfig<'a>{
     }
 }
 
-impl <'a> AnalyzerConfig for ExamplesAnalyzerConfig<'a>{
+impl<'a> AnalyzerConfig for ExamplesAnalyzerConfig<'a> {
     fn function_registry(&self) -> &dyn FunctionRegistry {
         self
     }
@@ -83,7 +83,9 @@ pub fn main() -> Result<()> {
     // run the analyzer with our custom rule
     let config = OptimizerContext::default().with_skip_failing_rules(false);
     let analyzer = Analyzer::with_rules(vec![Arc::new(MyAnalyzerRule {})]);
-    let analyzer_config = ExamplesAnalyzerConfig{config_options: config.options()};
+    let analyzer_config = ExamplesAnalyzerConfig {
+        config_options: config.options(),
+    };
     let analyzed_plan =
         analyzer.execute_and_check(&logical_plan, &analyzer_config, |_, _| {})?;
     println!(
@@ -114,7 +116,11 @@ fn observe(plan: &LogicalPlan, rule: &dyn OptimizerRule) {
 struct MyAnalyzerRule {}
 
 impl AnalyzerRule for MyAnalyzerRule {
-    fn analyze(&self, plan: LogicalPlan, _config: &dyn AnalyzerConfig) -> Result<LogicalPlan> {
+    fn analyze(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn AnalyzerConfig,
+    ) -> Result<LogicalPlan> {
         Self::analyze_plan(plan)
     }
 

--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -83,7 +83,7 @@ pub fn main() -> Result<()> {
     // run the analyzer with our custom rule
     let config = OptimizerContext::default().with_skip_failing_rules(false);
     let analyzer = Analyzer::with_rules(vec![Arc::new(MyAnalyzerRule {})]);
-    let analyzer_config = ExamplesAnalyzerConfig{config_options: config.options()}
+    let analyzer_config = ExamplesAnalyzerConfig{config_options: config.options()};
     let analyzed_plan =
         analyzer.execute_and_check(&logical_plan, &analyzer_config, |_, _| {})?;
     println!(

--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -114,7 +114,7 @@ fn observe(plan: &LogicalPlan, rule: &dyn OptimizerRule) {
 struct MyAnalyzerRule {}
 
 impl AnalyzerRule for MyAnalyzerRule {
-    fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
+    fn analyze(&self, plan: LogicalPlan, _config: &dyn AnalyzerConfig) -> Result<LogicalPlan> {
         Self::analyze_plan(plan)
     }
 

--- a/datafusion-examples/examples/rewrite_expr.rs
+++ b/datafusion-examples/examples/rewrite_expr.rs
@@ -42,15 +42,15 @@ impl <'a> FunctionRegistry for ExamplesAnalyzerConfig<'a>{
         std::collections::HashSet::new()
     }
 
-    fn udf(&self, name: &str) -> Result<Arc<ScalarUDF>> {
+    fn udf(&self, _name: &str) -> Result<Arc<ScalarUDF>> {
         internal_err!("Mock Function Registry")
     }
 
-    fn udaf(&self, name: &str) -> Result<Arc<AggregateUDF>> {
+    fn udaf(&self, _name: &str) -> Result<Arc<AggregateUDF>> {
         internal_err!("Mock Function Registry")
     }
 
-    fn udwf(&self, name: &str) -> Result<Arc<WindowUDF>> {
+    fn udwf(&self, _name: &str) -> Result<Arc<WindowUDF>> {
         internal_err!("Mock Function Registry")
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -351,8 +351,8 @@ mod tests {
     use arrow::datatypes::{DataType, Field};
     use datafusion_common::internal_err;
     use datafusion_common::{config::ConfigOptions, TableReference, ToDFSchema};
-    use datafusion_execution::FunctionRegistry;
     use datafusion_common::{DataFusionError, Result};
+    use datafusion_execution::FunctionRegistry;
     use datafusion_expr::{
         builder::LogicalTableSource, cast, col, lit, AggregateUDF, Expr, ScalarUDF,
         TableSource, WindowUDF,
@@ -374,7 +374,7 @@ mod tests {
     use std::sync::Arc;
 
     struct TestAnalyzerConfig<'a> {
-        config_options: &'a ConfigOptions
+        config_options: &'a ConfigOptions,
     }
 
     impl<'a> FunctionRegistry for TestAnalyzerConfig<'a> {
@@ -397,7 +397,7 @@ mod tests {
 
     impl<'a> AnalyzerConfig for TestAnalyzerConfig<'a> {
         fn function_registry(&self) -> &dyn datafusion_execution::FunctionRegistry {
-            self        
+            self
         }
 
         fn options(&self) -> &ConfigOptions {
@@ -1349,8 +1349,8 @@ mod tests {
         let analyzer = Analyzer::new();
         let optimizer = Optimizer::new();
         // analyze and optimize the logical plan
-        let analyzer_config = TestAnalyzerConfig{
-            config_options:config.options()
+        let analyzer_config = TestAnalyzerConfig {
+            config_options: config.options(),
         };
         let plan = analyzer.execute_and_check(&plan, &analyzer_config, |_, _| {})?;
         let plan = optimizer.optimize(&plan, &config, |_, _| {})?;

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -1202,7 +1202,7 @@ mod tests {
 
         // hard code the return value of now()
         let config = OptimizerContext::new().with_skip_failing_rules(false);
-        let analyzer = Analyzer::new();
+        let analyzer = Analyzer::new(panic);
         let optimizer = Optimizer::new();
         // analyze and optimize the logical plan
         let plan = analyzer.execute_and_check(&plan, config.options(), |_, _| {})?;

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -1345,7 +1345,7 @@ impl SessionState {
 
         SessionState {
             session_id,
-            analyzer: Analyzer::new(),
+            analyzer: Analyzer::new(panic!("circular deps")),
             optimizer: Optimizer::new(),
             physical_optimizers: PhysicalOptimizer::new(),
             query_planner: Arc::new(DefaultQueryPlanner {}),

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -27,7 +27,8 @@ use crate::{
     aggregate_function, built_in_function, conditional_expressions::CaseBuilder,
     logical_plan::Subquery, AccumulatorFactoryFunction, AggregateUDF,
     BuiltinScalarFunction, Expr, LogicalPlan, Operator, ReturnTypeFunction,
-    ScalarFunctionImplementation, ScalarUDF, Signature, StateTypeFunction, Volatility,
+    ScalarFunctionDefinition, ScalarFunctionImplementation, ScalarUDF, Signature,
+    StateTypeFunction, Volatility,
 };
 use arrow::datatypes::DataType;
 use datafusion_common::{Column, Result};
@@ -999,7 +1000,7 @@ pub fn create_udwf(
     )
 }
 
-/// Calls a named built in function
+/// Calls a named function
 /// ```
 /// use datafusion_expr::{col, lit, call_fn};
 ///
@@ -1007,10 +1008,10 @@ pub fn create_udwf(
 /// let expr = call_fn("sin", vec![col("x")]).unwrap().lt(lit(0.2));
 /// ```
 pub fn call_fn(name: impl AsRef<str>, args: Vec<Expr>) -> Result<Expr> {
-    match name.as_ref().parse::<BuiltinScalarFunction>() {
-        Ok(fun) => Ok(Expr::ScalarFunction(ScalarFunction::new(fun, args))),
-        Err(e) => Err(e),
-    }
+    Ok(Expr::ScalarFunction(ScalarFunction {
+        func_def: ScalarFunctionDefinition::Name(Arc::from(name.as_ref())),
+        args,
+    }))
 }
 
 #[cfg(test)]

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -43,6 +43,7 @@ arrow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 datafusion-common = { workspace = true }
+datafusion-execution = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-physical-expr = { path = "../physical-expr", version = "33.0.0", default-features = false }
 hashbrown = { version = "0.14", features = ["raw"] }

--- a/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::analyzer::AnalyzerRule;
-use datafusion_common::config::ConfigOptions;
+
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
 use datafusion_common::Result;
 use datafusion_expr::expr::{AggregateFunction, AggregateFunctionDefinition, InSubquery};
@@ -28,6 +28,8 @@ use datafusion_expr::{
     LogicalPlanBuilder, Projection, Sort, Subquery,
 };
 use std::sync::Arc;
+
+use super::AnalyzerConfig;
 
 /// Rewrite `Count(Expr:Wildcard)` to `Count(Expr:Literal)`.
 ///
@@ -42,7 +44,7 @@ impl CountWildcardRule {
 }
 
 impl AnalyzerRule for CountWildcardRule {
-    fn analyze(&self, plan: LogicalPlan, _: &ConfigOptions) -> Result<LogicalPlan> {
+    fn analyze(&self, plan: LogicalPlan, _: &dyn AnalyzerConfig) -> Result<LogicalPlan> {
         plan.transform_down(&analyze_internal)
     }
 

--- a/datafusion/optimizer/src/analyzer/function_name_resolver.rs
+++ b/datafusion/optimizer/src/analyzer/function_name_resolver.rs
@@ -191,6 +191,6 @@ mod tests {
             args: vec![],
         };
         let result = rewrite(function);
-        assert!(matches!(result, Err(_)));
+        assert!(result.is_err());
     }
 }

--- a/datafusion/optimizer/src/analyzer/function_name_resolver.rs
+++ b/datafusion/optimizer/src/analyzer/function_name_resolver.rs
@@ -1,0 +1,185 @@
+use std::sync::Arc;
+
+use crate::analyzer::AnalyzerRule;
+use datafusion_common::config::ConfigOptions;
+use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
+use datafusion_common::DataFusionError;
+use datafusion_common::{internal_err, Result};
+use datafusion_expr::expr::ScalarFunction;
+use datafusion_expr::expr_rewriter::rewrite_preserving_name;
+use datafusion_expr::{BuiltinScalarFunction, ScalarFunctionDefinition};
+
+use datafusion_execution::FunctionRegistry;
+use datafusion_expr::{logical_plan::LogicalPlan, Expr};
+use std::str::FromStr;
+
+/// Resolves `ScalarFunctionDefinition::Name` at execution time.
+///
+
+pub struct ResolveFunctionByName<T: FunctionRegistry> {
+    registry: T,
+}
+
+impl<T: FunctionRegistry> ResolveFunctionByName<T> {
+    pub fn new(registry: T) -> Self {
+        ResolveFunctionByName { registry }
+    }
+}
+
+impl<T: FunctionRegistry> AnalyzerRule for ResolveFunctionByName<T> {
+    fn analyze(&self, plan: LogicalPlan, _: &ConfigOptions) -> Result<LogicalPlan> {
+        analyze_internal(&plan, self.registry)
+    }
+
+    fn name(&self) -> &str {
+        "resolve_function_by_name"
+    }
+}
+
+fn analyze_internal(
+    plan: &LogicalPlan,
+    registry: impl FunctionRegistry,
+) -> Result<LogicalPlan> {
+    // optimize child plans first
+    let new_inputs = plan
+        .inputs()
+        .iter()
+        .map(|p| analyze_internal(p, registry))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut expr_rewrite = FunctionResolverRewriter { registry };
+
+    let new_expr = plan
+        .expressions()
+        .into_iter()
+        .map(|expr| rewrite_preserving_name(expr, &mut expr_rewrite))
+        .collect::<Result<Vec<_>>>()?;
+    plan.with_new_exprs(new_expr, &new_inputs)
+}
+
+struct FunctionResolverRewriter<T: FunctionRegistry> {
+    registry: T,
+}
+
+impl<T: FunctionRegistry> TreeNodeRewriter for FunctionResolverRewriter<T> {
+    type N = Expr;
+
+    fn mutate(&mut self, old_expr: Expr) -> Result<Expr> {
+        match old_expr.clone() {
+            Expr::ScalarFunction(ScalarFunction {
+                func_def: ScalarFunctionDefinition::Name(name),
+                args,
+            }) => {
+                // user-defined function (UDF) should have precedence in case it has the same name as a scalar built-in function
+                if let Ok(fm) = self.registry.udf(&name) {
+                    return Ok(Expr::ScalarFunction(ScalarFunction::new_udf(fm, args)));
+                }
+
+                // next, scalar built-in
+                if let Ok(fun) = BuiltinScalarFunction::from_str(&name) {
+                    return Ok(Expr::ScalarFunction(ScalarFunction::new(fun, args)));
+                }
+                internal_err!("Unknown scalar function")
+            }
+            _ => Ok(old_expr),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::datatypes::DataType;
+    use datafusion_common::ScalarValue;
+    use datafusion_expr::{
+        ColumnarValue, ReturnTypeFunction, ScalarFunctionImplementation, ScalarUDF,
+        Signature, Volatility,
+    };
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct MockRegistry {}
+
+    impl FunctionRegistry for MockRegistry {
+        fn udfs(&self) -> std::collections::HashSet<String> {
+            todo!()
+        }
+
+        fn udf(&self, name: &str) -> Result<Arc<datafusion_expr::ScalarUDF>> {
+            if name == "my-udf" {
+                let return_type: ReturnTypeFunction =
+                    Arc::new(move |_| Ok(Arc::new(DataType::Utf8)));
+                let fun: ScalarFunctionImplementation = Arc::new(move |_| {
+                    Ok(ColumnarValue::Scalar(ScalarValue::new_utf8("a")))
+                });
+                return Ok(Arc::new(datafusion_expr::ScalarUDF::new(
+                    "my-udf",
+                    &Signature::uniform(1, vec![DataType::Float32], Volatility::Stable),
+                    &return_type,
+                    &fun,
+                )));
+            }
+            internal_err!("function not found")
+        }
+
+        fn udaf(&self, _name: &str) -> Result<Arc<datafusion_expr::AggregateUDF>> {
+            todo!()
+        }
+
+        fn udwf(&self, _name: &str) -> Result<Arc<datafusion_expr::WindowUDF>> {
+            todo!()
+        }
+    }
+
+    fn rewrite(function: ScalarFunction) -> Result<Expr, DataFusionError> {
+        let registry = MockRegistry {};
+        let mut rewriter = FunctionResolverRewriter { registry };
+        rewriter.mutate(Expr::ScalarFunction(function))
+    }
+
+    #[test]
+    fn rewriter_rewrites_builtin_correctly() {
+        let function = datafusion_expr::expr::ScalarFunction {
+            func_def: ScalarFunctionDefinition::Name(Arc::from("log10")),
+            args: vec![],
+        };
+        let result = rewrite(function);
+        assert!(matches!(
+            result,
+            Ok(Expr::ScalarFunction(
+                datafusion_expr::expr::ScalarFunction {
+                    func_def: ScalarFunctionDefinition::BuiltIn(
+                        BuiltinScalarFunction::Log
+                    ),
+                    ..
+                }
+            ))
+        ));
+    }
+    #[test]
+    fn rewriter_rewrites_udf_correctly() {
+        let function = datafusion_expr::expr::ScalarFunction {
+            func_def: ScalarFunctionDefinition::Name(Arc::from("my-udf")),
+            args: vec![],
+        };
+        let result = rewrite(function);
+        if let Ok(Expr::ScalarFunction(datafusion_expr::expr::ScalarFunction {
+            func_def: ScalarFunctionDefinition::UDF(udf),
+            ..
+        })) = result
+        {
+            assert_eq!(udf.name(), "my-udf");
+        } else {
+            panic!("Pattern did not match");
+        }
+    }
+    #[test]
+    fn rewriter_fails_unknown_function() {
+        let function = datafusion_expr::expr::ScalarFunction {
+            func_def: ScalarFunctionDefinition::Name(Arc::from("my-udf-invalid")),
+            args: vec![],
+        };
+        let result = rewrite(function);
+        assert!(matches!(result, Err(_)));
+    }
+}

--- a/datafusion/optimizer/src/analyzer/function_name_resolver.rs
+++ b/datafusion/optimizer/src/analyzer/function_name_resolver.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use crate::analyzer::AnalyzerRule;
 
 use datafusion_common::tree_node::TreeNodeRewriter;

--- a/datafusion/optimizer/src/analyzer/function_name_resolver.rs
+++ b/datafusion/optimizer/src/analyzer/function_name_resolver.rs
@@ -1,8 +1,6 @@
-
-
 use crate::analyzer::AnalyzerRule;
 
-use datafusion_common::tree_node::{TreeNodeRewriter};
+use datafusion_common::tree_node::TreeNodeRewriter;
 use datafusion_common::DataFusionError;
 use datafusion_common::{internal_err, Result};
 use datafusion_expr::expr::ScalarFunction;
@@ -100,11 +98,11 @@ impl<'a> TreeNodeRewriter for FunctionResolverRewriter<'a> {
 mod tests {
     use arrow::datatypes::DataType;
     use datafusion_common::ScalarValue;
-    use std::sync::Arc;
     use datafusion_expr::{
-        ColumnarValue, ReturnTypeFunction, ScalarFunctionImplementation,
-        Signature, Volatility,
+        ColumnarValue, ReturnTypeFunction, ScalarFunctionImplementation, Signature,
+        Volatility,
     };
+    use std::sync::Arc;
 
     use super::*;
 
@@ -144,7 +142,9 @@ mod tests {
 
     fn rewrite(function: ScalarFunction) -> Result<Expr, DataFusionError> {
         let registry = MockRegistry {};
-        let mut rewriter = FunctionResolverRewriter { registry: &registry };
+        let mut rewriter = FunctionResolverRewriter {
+            registry: &registry,
+        };
         rewriter.mutate(Expr::ScalarFunction(function))
     }
 

--- a/datafusion/optimizer/src/analyzer/inline_table_scan.rs
+++ b/datafusion/optimizer/src/analyzer/inline_table_scan.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 
 use crate::analyzer::AnalyzerRule;
-use datafusion_common::config::ConfigOptions;
+
 use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::Result;
 use datafusion_expr::expr::Exists;
@@ -28,6 +28,8 @@ use datafusion_expr::expr::InSubquery;
 use datafusion_expr::{
     logical_plan::LogicalPlan, Expr, Filter, LogicalPlanBuilder, TableScan,
 };
+
+use crate::analyzer::AnalyzerConfig;
 
 /// Analyzed rule that inlines TableScan that provide a [`LogicalPlan`]
 /// (DataFrame / ViewTable)
@@ -41,7 +43,7 @@ impl InlineTableScan {
 }
 
 impl AnalyzerRule for InlineTableScan {
-    fn analyze(&self, plan: LogicalPlan, _: &ConfigOptions) -> Result<LogicalPlan> {
+    fn analyze(&self, plan: LogicalPlan, _: &dyn AnalyzerConfig) -> Result<LogicalPlan> {
         plan.transform_up(&analyze_internal)
     }
 

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, IntervalUnit};
 
-use datafusion_common::config::ConfigOptions;
+
 use datafusion_common::tree_node::{RewriteRecursion, TreeNodeRewriter};
 use datafusion_common::{
     exec_err, internal_err, plan_datafusion_err, plan_err, DFSchema, DFSchemaRef,
@@ -52,6 +52,8 @@ use datafusion_expr::{
 
 use crate::analyzer::AnalyzerRule;
 
+use crate::analyzer::AnalyzerConfig;
+
 #[derive(Default)]
 pub struct TypeCoercion {}
 
@@ -66,7 +68,7 @@ impl AnalyzerRule for TypeCoercion {
         "type_coercion"
     }
 
-    fn analyze(&self, plan: LogicalPlan, _: &ConfigOptions) -> Result<LogicalPlan> {
+    fn analyze(&self, plan: LogicalPlan, _: &dyn AnalyzerConfig) -> Result<LogicalPlan> {
         analyze_internal(&DFSchema::empty(), &plan)
     }
 }

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, IntervalUnit};
 
-
 use datafusion_common::tree_node::{RewriteRecursion, TreeNodeRewriter};
 use datafusion_common::{
     exec_err, internal_err, plan_datafusion_err, plan_err, DFSchema, DFSchemaRef,

--- a/datafusion/optimizer/src/test/mod.rs
+++ b/datafusion/optimizer/src/test/mod.rs
@@ -111,7 +111,18 @@ pub fn get_tpch_table_schema(table: &str) -> Schema {
     }
 }
 
-struct EmptyRegistryAnalyzerConfig { }
+struct EmptyRegistryAnalyzerConfig { 
+    options:ConfigOptions
+}
+
+
+impl EmptyRegistryAnalyzerConfig {
+    fn new() -> Self {
+        let options = ConfigOptions::default();
+        EmptyRegistryAnalyzerConfig{options}
+    }
+}
+
     
 
 impl FunctionRegistry for EmptyRegistryAnalyzerConfig {
@@ -138,8 +149,7 @@ impl AnalyzerConfig for EmptyRegistryAnalyzerConfig {
     }
 
     fn options(&self) -> &ConfigOptions {
-        let options = ConfigOptions::default();
-        &options
+       &self.options   
     }
 }
 
@@ -148,7 +158,7 @@ pub fn assert_analyzed_plan_eq(
     plan: &LogicalPlan,
     expected: &str,
 ) -> Result<()> {
-    let analyzer_config = EmptyRegistryAnalyzerConfig{};
+    let analyzer_config = EmptyRegistryAnalyzerConfig::new();
     let analyzed_plan =
         Analyzer::with_rules(vec![rule]).execute_and_check(plan, &analyzer_config, |_, _| {})?;
     let formatted_plan = format!("{analyzed_plan:?}");
@@ -161,7 +171,7 @@ pub fn assert_analyzed_plan_eq_display_indent(
     plan: &LogicalPlan,
     expected: &str,
 ) -> Result<()> {
-    let analyzer_config = EmptyRegistryAnalyzerConfig{};
+    let analyzer_config = EmptyRegistryAnalyzerConfig::new();
     let analyzed_plan =
         Analyzer::with_rules(vec![rule]).execute_and_check(plan, &analyzer_config, |_, _| {})?;
     let formatted_plan = analyzed_plan.display_indent_schema().to_string();
@@ -175,7 +185,7 @@ pub fn assert_analyzer_check_err(
     plan: &LogicalPlan,
     expected: &str,
 ) {
-    let analyzer_config = EmptyRegistryAnalyzerConfig{};
+    let analyzer_config = EmptyRegistryAnalyzerConfig::new();
     let analyzed_plan =
         Analyzer::with_rules(rules).execute_and_check(plan, &analyzer_config, |_, _| {});
     match analyzed_plan {

--- a/datafusion/optimizer/src/test/mod.rs
+++ b/datafusion/optimizer/src/test/mod.rs
@@ -127,7 +127,7 @@ impl FunctionRegistry for EmptyRegistryAnalyzerConfig {
         std::collections::HashSet::new()
     }
 
-    fn udf(&self, name: &str) -> Result<Arc<datafusion_expr::ScalarUDF>> {
+    fn udf(&self, _name: &str) -> Result<Arc<datafusion_expr::ScalarUDF>> {
         internal_err!("empty registry")
     }
 

--- a/datafusion/optimizer/src/test/mod.rs
+++ b/datafusion/optimizer/src/test/mod.rs
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::analyzer::{Analyzer, AnalyzerRule, AnalyzerConfig};
+use crate::analyzer::{Analyzer, AnalyzerConfig, AnalyzerRule};
 use crate::optimizer::{assert_schema_is_the_same, Optimizer};
 use crate::{OptimizerContext, OptimizerRule};
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{assert_contains, Result, internal_err};
+use datafusion_common::{assert_contains, internal_err, Result};
 use datafusion_execution::FunctionRegistry;
 use datafusion_expr::{col, logical_plan::table_scan, LogicalPlan, LogicalPlanBuilder};
 
@@ -111,19 +111,16 @@ pub fn get_tpch_table_schema(table: &str) -> Schema {
     }
 }
 
-struct EmptyRegistryAnalyzerConfig { 
-    options:ConfigOptions
+struct EmptyRegistryAnalyzerConfig {
+    options: ConfigOptions,
 }
-
 
 impl EmptyRegistryAnalyzerConfig {
     fn new() -> Self {
         let options = ConfigOptions::default();
-        EmptyRegistryAnalyzerConfig{options}
+        EmptyRegistryAnalyzerConfig { options }
     }
 }
-
-    
 
 impl FunctionRegistry for EmptyRegistryAnalyzerConfig {
     fn udfs(&self) -> std::collections::HashSet<String> {
@@ -149,7 +146,7 @@ impl AnalyzerConfig for EmptyRegistryAnalyzerConfig {
     }
 
     fn options(&self) -> &ConfigOptions {
-       &self.options   
+        &self.options
     }
 }
 
@@ -159,8 +156,11 @@ pub fn assert_analyzed_plan_eq(
     expected: &str,
 ) -> Result<()> {
     let analyzer_config = EmptyRegistryAnalyzerConfig::new();
-    let analyzed_plan =
-        Analyzer::with_rules(vec![rule]).execute_and_check(plan, &analyzer_config, |_, _| {})?;
+    let analyzed_plan = Analyzer::with_rules(vec![rule]).execute_and_check(
+        plan,
+        &analyzer_config,
+        |_, _| {},
+    )?;
     let formatted_plan = format!("{analyzed_plan:?}");
     assert_eq!(formatted_plan, expected);
 
@@ -172,8 +172,11 @@ pub fn assert_analyzed_plan_eq_display_indent(
     expected: &str,
 ) -> Result<()> {
     let analyzer_config = EmptyRegistryAnalyzerConfig::new();
-    let analyzed_plan =
-        Analyzer::with_rules(vec![rule]).execute_and_check(plan, &analyzer_config, |_, _| {})?;
+    let analyzed_plan = Analyzer::with_rules(vec![rule]).execute_and_check(
+        plan,
+        &analyzer_config,
+        |_, _| {},
+    )?;
     let formatted_plan = analyzed_plan.display_indent_schema().to_string();
     assert_eq!(formatted_plan, expected);
 

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -16,12 +16,12 @@
 // under the License.
 
 use std::any::Any;
-use std::collections::{HashMap,HashSet};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{plan_err, DataFusionError, Result, internal_err};
+use datafusion_common::{internal_err, plan_err, DataFusionError, Result};
 use datafusion_execution::FunctionRegistry;
 use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource, WindowUDF};
 use datafusion_optimizer::analyzer::{Analyzer, AnalyzerConfig};
@@ -34,7 +34,6 @@ use datafusion_sql::sqlparser::parser::Parser;
 use datafusion_sql::TableReference;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
-
 
 #[cfg(test)]
 #[ctor::ctor]
@@ -337,13 +336,11 @@ fn test_same_name_but_not_ambiguous() {
     assert_eq!(expected, format!("{plan:?}"));
 }
 
-
-struct EmptyRegistryAnalyzerConfig<'a> { 
-    config_options:& 'a ConfigOptions
+struct EmptyRegistryAnalyzerConfig<'a> {
+    config_options: &'a ConfigOptions,
 }
 
-
-impl <'a> FunctionRegistry for EmptyRegistryAnalyzerConfig<'a>{
+impl<'a> FunctionRegistry for EmptyRegistryAnalyzerConfig<'a> {
     fn udfs(&self) -> std::collections::HashSet<String> {
         HashSet::new()
     }
@@ -361,7 +358,7 @@ impl <'a> FunctionRegistry for EmptyRegistryAnalyzerConfig<'a>{
     }
 }
 
-impl <'a> AnalyzerConfig for EmptyRegistryAnalyzerConfig<'a>{
+impl<'a> AnalyzerConfig for EmptyRegistryAnalyzerConfig<'a> {
     fn function_registry(&self) -> &dyn FunctionRegistry {
         self
     }
@@ -390,7 +387,9 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
         .with_query_execution_start_time(now_time);
     let analyzer = Analyzer::new();
     let optimizer = Optimizer::new();
-    let analyzer_config = EmptyRegistryAnalyzerConfig{config_options: config.options()};
+    let analyzer_config = EmptyRegistryAnalyzerConfig {
+        config_options: config.options(),
+    };
     // analyze and optimize the logical plan
     let plan = analyzer.execute_and_check(&plan, &analyzer_config, |_, _| {})?;
     optimizer.optimize(&plan, &config, |_, _| {})

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -364,7 +364,7 @@ impl<'a> AnalyzerConfig for EmptyRegistryAnalyzerConfig<'a> {
     }
 
     fn options(&self) -> &ConfigOptions {
-        &self.config_options
+        self.config_options
     }
 }
 


### PR DESCRIPTION
Addresses #8157 


Implement an AnalyzerRules that rewrites Expr::ScalarFunction replacing `ScalarFunctionDefinition::Name` into `ScalarFunctionDefinition::BuiltIn` or `ScalarFunctionDefinition:ScalarUDF` at plan time.

Introduces a new `AnalyzerConfig` to wrap a `FunctionRegistry` and `ConfigOptions`

# Ignore from here, left for reference
Unclear how to pass the FunctionRegistry down to the analyzer rule.

### Option 1:  When creating the analyzer
Using this approach means giving up the Default implementation, as well as doing some refactoring in https://github.com/apache/arrow-datafusion/blob/c8e1c84e6b4f1292afa6f5517bc6978b55758723/datafusion/core/src/execution/context/mod.rs#L1348, since the analyzer needs a FunctionRegistry and the SessionState implements that trait

### Option 2: When invoking the analyzer 

Using this approach means changing the `pub trait Analyzer` adding a fourth parameter.

```rust
pub trait AnalyzerRule {
    /// Rewrite `plan`
    fn analyze(&self, plan: LogicalPlan, config: &ConfigOptions, registry: impl FunctionRegistry + Send + Sync) -> Result<LogicalPlan>;

    /// A human readable name for this analyzer rule
    fn name(&self) -> &str;
}
```

However this creates on its own a problem 
```
the trait `AnalyzerRule` cannot be made into an object
consider moving `analyze` to another traitrustc[Click for full compiler diagnostic](rust-analyzer-diagnostics-view:/diagnostic%20message%20%5B2%5D?2#file%3A%2F%2F%2Fworkspace%2Farrow-datafusion%2Fdatafusion%2Foptimizer%2Fsrc%2Fanalyzer%2Fmod.rs)
mod.rs(55, 8): for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
the trait `analyzer::AnalyzerRule` cannot be made into an object
consider moving `analyze` to another traitrustc[Click for full compiler diagnostic](rust-analyzer-diagnostics-view:/diagnostic%20message%20%5B5%5D?5#file%3A%2F%2F%2Fworkspace%2Farrow-datafusion%2Fdatafusion%2Foptimizer%2Fsrc%2Fanalyzer%2Fmod.rs)
mod.rs(55, 8): for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
No quick fixes available
```

Maybe the best solution is to create an intermediate struct that contains the various HashMaps of SessionState, an pass that struct to the Analyzer, as well as the SessionState constructor? Suggestions are welcome :)
