### PR TITLE
Transform with payload

### DIFF
--- a/datafusion/core/src/physical_optimizer/join_selection.rs
+++ b/datafusion/core/src/physical_optimizer/join_selection.rs
@@ -27,9 +27,6 @@ use std::sync::Arc;
 
 use crate::config::ConfigOptions;
 use crate::error::Result;
-use crate::physical_optimizer::pipeline_checker::{
-    children_unbounded, PipelineStatePropagator,
-};
 use crate::physical_optimizer::PhysicalOptimizerRule;
 use crate::physical_plan::joins::utils::{ColumnIndex, JoinFilter};
 use crate::physical_plan::joins::{
@@ -231,7 +228,6 @@ impl PhysicalOptimizerRule for JoinSelection {
         plan: Arc<dyn ExecutionPlan>,
         config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let pipeline = PipelineStatePropagator::new_default(plan);
         // First, we make pipeline-fixing modifications to joins so as to accommodate
         // unbounded inputs. Each pipeline-fixing subrule, which is a function
         // of type `PipelineFixerSubrule`, takes a single [`PipelineStatePropagator`]
@@ -241,7 +237,10 @@ impl PhysicalOptimizerRule for JoinSelection {
             Box::new(hash_join_convert_symmetric_subrule),
             Box::new(hash_join_swap_subrule),
         ];
-        let state = pipeline.transform_up(&|p| apply_subrules(p, &subrules, config))?;
+        let (plan, _) =
+            plan.transform_up_with_payload(&mut |p, children_unbounded| {
+                apply_subrules(p, children_unbounded, &subrules, config)
+            })?;
         // Next, we apply another subrule that tries to optimize joins using any
         // statistics their inputs might have.
         // - For a hash join with partition mode [`PartitionMode::Auto`], we will
@@ -256,7 +255,7 @@ impl PhysicalOptimizerRule for JoinSelection {
         let config = &config.optimizer;
         let collect_threshold_byte_size = config.hash_join_single_partition_threshold;
         let collect_threshold_num_rows = config.hash_join_single_partition_threshold_rows;
-        state.plan.transform_up(&|plan| {
+        plan.transform_up(&|plan| {
             statistical_join_selection_subrule(
                 plan,
                 collect_threshold_byte_size,
@@ -445,8 +444,11 @@ fn statistical_join_selection_subrule(
 }
 
 /// Pipeline-fixing join selection subrule.
-pub type PipelineFixerSubrule =
-    dyn Fn(PipelineStatePropagator, &ConfigOptions) -> Result<PipelineStatePropagator>;
+pub type PipelineFixerSubrule = dyn Fn(
+    Arc<dyn ExecutionPlan>,
+    &[bool],
+    &ConfigOptions,
+) -> Result<(Arc<dyn ExecutionPlan>, bool)>;
 
 /// Converts a hash join to a symmetric hash join in the case of infinite inputs on both sides.
 ///
@@ -464,16 +466,18 @@ pub type PipelineFixerSubrule =
 /// it returns `None`. If applicable, it returns `Some(Ok(...))` with the modified pipeline state,
 /// or `Some(Err(...))` if an error occurs during the transformation.
 fn hash_join_convert_symmetric_subrule(
-    mut input: PipelineStatePropagator,
+    plan: Arc<dyn ExecutionPlan>,
+    children_unbounded: &[bool],
     config_options: &ConfigOptions,
-) -> Result<PipelineStatePropagator> {
+) -> Result<(Arc<dyn ExecutionPlan>, bool)> {
+    let mut unbounded = false;
     // Check if the current plan node is a HashJoinExec.
-    if let Some(hash_join) = input.plan.as_any().downcast_ref::<HashJoinExec>() {
+    if let Some(hash_join) = plan.as_any().downcast_ref::<HashJoinExec>() {
         // Determine if left and right children are unbounded.
-        let ub_flags = children_unbounded(&input);
-        let (left_unbounded, right_unbounded) = (ub_flags[0], ub_flags[1]);
+        let (left_unbounded, right_unbounded) =
+            (children_unbounded[0], children_unbounded[1]);
         // Update the unbounded flag of the input.
-        input.data = left_unbounded || right_unbounded;
+        unbounded = left_unbounded || right_unbounded;
         // Process only if both left and right sides are unbounded.
         if left_unbounded && right_unbounded {
             // Determine the partition mode based on configuration.
@@ -515,11 +519,10 @@ fn hash_join_convert_symmetric_subrule(
                                         hash_join.right().schema(),
                                     ),
                                 };
-
                                 let name = schema.field(*index).name();
                                 let col = Arc::new(Column::new(name, *index)) as _;
                                 // Check if the column is ordered.
-                                equivalence.get_expr_ordering(col).data
+                                equivalence.get_expr_ordering(col).1
                                     != SortProperties::Unordered
                             },
                         )
@@ -534,7 +537,6 @@ fn hash_join_convert_symmetric_subrule(
                     })
                     .flatten()
             };
-
             // Determine the sort order for both left and right sides.
             let left_order = determine_order(JoinSide::Left);
             let right_order = determine_order(JoinSide::Right);
@@ -550,15 +552,11 @@ fn hash_join_convert_symmetric_subrule(
                 right_order,
                 mode,
             )
-            .map(|exec| {
-                input.plan = Arc::new(exec) as _;
-                input
-            });
+            .map(|exec| (Arc::new(exec) as _, unbounded));
         }
     }
-    Ok(input)
+    Ok((plan, unbounded))
 }
-
 /// This subrule will swap build/probe sides of a hash join depending on whether
 /// one of its inputs may produce an infinite stream of records. The rule ensures
 /// that the left (build) side of the hash join always operates on an input stream
@@ -601,13 +599,15 @@ fn hash_join_convert_symmetric_subrule(
 ///
 /// ```
 fn hash_join_swap_subrule(
-    mut input: PipelineStatePropagator,
+    mut plan: Arc<dyn ExecutionPlan>,
+    children_unbounded: &[bool],
     _config_options: &ConfigOptions,
-) -> Result<PipelineStatePropagator> {
-    if let Some(hash_join) = input.plan.as_any().downcast_ref::<HashJoinExec>() {
-        let ub_flags = children_unbounded(&input);
-        let (left_unbounded, right_unbounded) = (ub_flags[0], ub_flags[1]);
-        input.data = left_unbounded || right_unbounded;
+) -> Result<(Arc<dyn ExecutionPlan>, bool)> {
+    let mut unbounded = false;
+    if let Some(hash_join) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        let (left_unbounded, right_unbounded) =
+            (children_unbounded[0], children_unbounded[1]);
+        unbounded = left_unbounded || right_unbounded;
         if left_unbounded
             && !right_unbounded
             && matches!(
@@ -618,10 +618,10 @@ fn hash_join_swap_subrule(
                     | JoinType::LeftAnti
             )
         {
-            input.plan = swap_join_according_to_unboundedness(hash_join)?;
+            plan = swap_join_according_to_unboundedness(hash_join)?;
         }
     }
-    Ok(input)
+    Ok((plan, unbounded))
 }
 
 /// This function swaps sides of a hash join to make it runnable even if one of
@@ -654,16 +654,16 @@ fn swap_join_according_to_unboundedness(
 /// Apply given `PipelineFixerSubrule`s to a given plan. This plan, along with
 /// auxiliary boundedness information, is in the `PipelineStatePropagator` object.
 fn apply_subrules(
-    mut input: PipelineStatePropagator,
+    mut plan: Arc<dyn ExecutionPlan>,
+    children_unbounded: Vec<bool>,
     subrules: &Vec<Box<PipelineFixerSubrule>>,
     config_options: &ConfigOptions,
-) -> Result<Transformed<PipelineStatePropagator>> {
+) -> Result<(Transformed<Arc<dyn ExecutionPlan>>, bool)> {
     for subrule in subrules {
-        input = subrule(input, config_options)?;
+        (plan, _) = subrule(plan, children_unbounded.as_slice(), config_options)?;
     }
-    input.data = input
-        .plan
-        .unbounded_output(&children_unbounded(&input))
+    let is_unbounded = plan
+        .unbounded_output(children_unbounded.as_slice())
         // Treat the case where an operator can not run on unbounded data as
         // if it can and it outputs unbounded data. Do not raise an error yet.
         // Such operators may be fixed, adjusted or replaced later on during
@@ -671,7 +671,7 @@ fn apply_subrules(
         // etc. If this doesn't happen, the final `PipelineChecker` rule will
         // catch this and raise an error anyway.
         .unwrap_or(true);
-    Ok(Transformed::Yes(input))
+    Ok((Transformed::Yes(plan), is_unbounded))
 }
 
 #[cfg(test)]
@@ -680,7 +680,6 @@ mod tests_statistical {
 
     use super::*;
     use crate::{
-        physical_optimizer::test_utils::check_integrity,
         physical_plan::{
             displayable, joins::PartitionMode, ColumnStatistics, Statistics,
         },
@@ -829,19 +828,18 @@ mod tests_statistical {
     }
 
     pub(crate) fn crosscheck_plans(plan: Arc<dyn ExecutionPlan>) -> Result<()> {
-        let pipeline = PipelineStatePropagator::new_default(plan);
         let subrules: Vec<Box<PipelineFixerSubrule>> = vec![
             Box::new(hash_join_convert_symmetric_subrule),
             Box::new(hash_join_swap_subrule),
         ];
-        let state = pipeline
-            .transform_up(&|p| apply_subrules(p, &subrules, &ConfigOptions::new()))
-            .and_then(check_integrity)?;
-        // TODO: End state payloads will be checked here.
+        let (plan, _) =
+            plan.transform_up_with_payload(&mut |p, children_unbounded| {
+                apply_subrules(p, children_unbounded, &subrules, &ConfigOptions::new())
+            })?;
         let config = ConfigOptions::new().optimizer;
         let collect_left_threshold = config.hash_join_single_partition_threshold;
         let collect_threshold_num_rows = config.hash_join_single_partition_threshold_rows;
-        let _ = state.plan.transform_up(&|plan| {
+        let _ = plan.transform_up(&|plan| {
             statistical_join_selection_subrule(
                 plan,
                 collect_left_threshold,
@@ -1404,7 +1402,6 @@ mod hash_join_tests {
     use arrow::record_batch::RecordBatch;
     use datafusion_common::utils::DataPtr;
     use datafusion_common::JoinType;
-    use datafusion_physical_plan::empty::EmptyExec;
     use std::sync::Arc;
 
     struct TestCase {
@@ -1772,18 +1769,13 @@ mod hash_join_tests {
             false,
         )?);
 
-        let left_child = Arc::new(EmptyExec::new(Arc::new(Schema::empty())));
-        let right_child = Arc::new(EmptyExec::new(Arc::new(Schema::empty())));
-        let children = vec![
-            PipelineStatePropagator::new(left_child, left_unbounded, vec![]),
-            PipelineStatePropagator::new(right_child, right_unbounded, vec![]),
-        ];
-        let initial_hash_join_state =
-            PipelineStatePropagator::new(join.clone(), false, children);
+        let children_unbounded = vec![left_unbounded, right_unbounded];
 
-        let optimized_hash_join =
-            hash_join_swap_subrule(initial_hash_join_state, &ConfigOptions::new())?;
-        let optimized_join_plan = optimized_hash_join.plan;
+        let (optimized_join_plan, _) = hash_join_swap_subrule(
+            join,
+            children_unbounded.as_slice(),
+            &ConfigOptions::new(),
+        )?;
 
         // If swap did happen
         let projection_added = optimized_join_plan.as_any().is::<ProjectionExec>();

--- a/datafusion/core/src/physical_optimizer/replace_with_order_preserving_variants.rs
+++ b/datafusion/core/src/physical_optimizer/replace_with_order_preserving_variants.rs
@@ -21,211 +21,84 @@
 
 use std::sync::Arc;
 
-use super::utils::{is_repartition, is_sort_preserving_merge};
+use super::utils::is_repartition;
 use crate::error::Result;
 use crate::physical_optimizer::utils::{is_coalesce_partitions, is_sort};
 use crate::physical_plan::repartition::RepartitionExec;
 use crate::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+use crate::physical_plan::ExecutionPlan;
 
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::Transformed;
-use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
-use datafusion_physical_plan::tree_node::PlanContext;
 use datafusion_physical_plan::unbounded_output;
 
-use itertools::izip;
-
-/// For a given `plan`, this object carries the information one needs from its
-/// descendants to decide whether it is beneficial to replace order-losing (but
-/// somewhat faster) variants of certain operators with their order-preserving
-/// (but somewhat slower) cousins.
-pub type OrderPreservationContext = PlanContext<bool>;
-
-/// Updates order-preservation data for all children of the given node.
-pub fn update_children(opc: &mut OrderPreservationContext) {
-    for PlanContext {
-        plan,
-        children,
-        data,
-    } in opc.children.iter_mut()
-    {
-        let maintains_input_order = plan.maintains_input_order();
-        let inspect_child = |idx| {
-            maintains_input_order[idx]
-                || is_coalesce_partitions(plan)
-                || is_repartition(plan)
-        };
-
-        // We cut the path towards nodes that do not maintain ordering.
-        for (idx, c) in children.iter_mut().enumerate() {
-            c.data &= inspect_child(idx);
-        }
-
-        let plan_children = plan.children();
-        *data = if plan_children.is_empty() {
-            false
-        } else if !children[0].data
-            && ((is_repartition(plan) && !maintains_input_order[0])
-                || (is_coalesce_partitions(plan)
-                    && plan_children[0].output_ordering().is_some()))
-        {
-            // We either have a RepartitionExec or a CoalescePartitionsExec
-            // and they lose their input ordering, so initiate connection:
-            true
-        } else {
-            // Maintain connection if there is a child with a connection,
-            // and operator can possibly maintain that connection (either
-            // in its current form or when we replace it with the corresponding
-            // order preserving operator).
-            children
-                .iter()
-                .enumerate()
-                .any(|(idx, c)| c.data && inspect_child(idx))
-        }
-    }
-    opc.data = false;
-}
-
-/// Calculates the updated plan by replacing operators that lose ordering
-/// inside `sort_input` with their order-preserving variants. This will
-/// generate an alternative plan, which will be accepted or rejected later on
-/// depending on whether it helps us remove a `SortExec`.
-fn plan_with_order_preserving_variants(
-    mut sort_input: OrderPreservationContext,
-    // Flag indicating that it is desirable to replace `RepartitionExec`s with
-    // `SortPreservingRepartitionExec`s:
-    is_spr_better: bool,
-    // Flag indicating that it is desirable to replace `CoalescePartitionsExec`s
-    // with `SortPreservingMergeExec`s:
-    is_spm_better: bool,
-) -> Result<OrderPreservationContext> {
-    sort_input.children = sort_input
-        .children
-        .into_iter()
-        .map(|node| {
-            // Update descendants in the given tree if there is a connection:
-            if node.data {
-                plan_with_order_preserving_variants(node, is_spr_better, is_spm_better)
-            } else {
-                Ok(node)
-            }
-        })
-        .collect::<Result<_>>()?;
-    sort_input.data = false;
-
-    if is_repartition(&sort_input.plan)
-        && !sort_input.plan.maintains_input_order()[0]
-        && is_spr_better
-    {
-        // When a `RepartitionExec` doesn't preserve ordering, replace it with
-        // a sort-preserving variant if appropriate:
-        let child = sort_input.children[0].plan.clone();
-        let partitioning = sort_input.plan.output_partitioning();
-        sort_input.plan = Arc::new(
-            RepartitionExec::try_new(child, partitioning)?.with_preserve_order(),
-        ) as _;
-        sort_input.children[0].data = true;
-        return Ok(sort_input);
-    } else if is_coalesce_partitions(&sort_input.plan) && is_spm_better {
-        let child = &sort_input.children[0].plan;
-        if let Some(ordering) = child.output_ordering().map(Vec::from) {
-            // When the input of a `CoalescePartitionsExec` has an ordering,
-            // replace it with a `SortPreservingMergeExec` if appropriate:
-            let spm = SortPreservingMergeExec::new(ordering, child.clone());
-            sort_input.plan = Arc::new(spm) as _;
-            sort_input.children[0].data = true;
-            return Ok(sort_input);
-        }
-    }
-
-    sort_input.update_plan_from_children()
-}
-
-/// Calculates the updated plan by replacing operators that preserve ordering
-/// inside `sort_input` with their order-breaking variants. This will restore
-/// the original plan modified by [`plan_with_order_preserving_variants`].
-fn plan_with_order_breaking_variants(
-    mut sort_input: OrderPreservationContext,
-) -> Result<OrderPreservationContext> {
-    let plan = &sort_input.plan;
-    sort_input.children = izip!(
-        sort_input.children,
-        plan.maintains_input_order(),
-        plan.required_input_ordering()
-    )
-    .map(|(node, maintains, required_ordering)| {
-        // Replace with non-order preserving variants as long as ordering is
-        // not required by intermediate operators:
-        if maintains
-            && (is_sort_preserving_merge(plan)
-                || !required_ordering.map_or(false, |required_ordering| {
-                    node.plan
-                        .equivalence_properties()
-                        .ordering_satisfy_requirement(&required_ordering)
-                }))
-        {
-            plan_with_order_breaking_variants(node)
-        } else {
-            Ok(node)
-        }
-    })
-    .collect::<Result<_>>()?;
-    sort_input.data = false;
-
-    if is_repartition(plan) && plan.maintains_input_order()[0] {
-        // When a `RepartitionExec` preserves ordering, replace it with a
-        // non-sort-preserving variant:
-        let child = sort_input.children[0].plan.clone();
-        let partitioning = plan.output_partitioning();
-        sort_input.plan = Arc::new(RepartitionExec::try_new(child, partitioning)?) as _;
-    } else if is_sort_preserving_merge(plan) {
-        // Replace `SortPreservingMergeExec` with a `CoalescePartitionsExec`:
-        let child = sort_input.children[0].plan.clone();
-        let coalesce = CoalescePartitionsExec::new(child);
-        sort_input.plan = Arc::new(coalesce) as _;
-    } else {
-        return sort_input.update_plan_from_children();
-    }
-
-    sort_input.children[0].data = false;
-    Ok(sort_input)
-}
-
-/// The `replace_with_order_preserving_variants` optimizer sub-rule tries to
-/// remove `SortExec`s from the physical plan by replacing operators that do
-/// not preserve ordering with their order-preserving variants; i.e. by replacing
-/// ordinary `RepartitionExec`s with their sort-preserving variants or by replacing
-/// `CoalescePartitionsExec`s with `SortPreservingMergeExec`s.
+/// For a given `plan`, `propagate_order_maintaining_connections_down` and
+/// `replace_with_order_preserving_variants_up` can be used with
+/// `TreeNode.transform_with_payload()` to propagate down/up the information one needs to
+/// decide whether it is beneficial to replace order-losing (but somewhat faster) variants
+/// of certain operators with their order-preserving  (but somewhat slower) cousins.
 ///
-/// If this replacement is helpful for removing a `SortExec`, it updates the plan.
-/// Otherwise, it leaves the plan unchanged.
+/// The `replace_with_order_preserving_variants_up` optimizer sub-rule tries to remove
+/// `SortExec`s from the physical plan by replacing operators that do not preserve
+/// ordering with their order-preserving variants; i.e. by replacing `RepartitionExec`s
+/// with `SortPreservingRepartitionExec`s or by replacing `CoalescePartitionsExec`s with
+/// `SortPreservingMergeExec`s.
 ///
-/// NOTE: This optimizer sub-rule will only produce sort-preserving `RepartitionExec`s
-/// if the query is bounded or if the config option `prefer_existing_sort` is
-/// set to `true`.
+/// Note: this optimizer sub-rule will only produce `SortPreservingRepartitionExec`s
+/// if the query is bounded or if the config option `bounded_order_preserving_variants`
+/// is set to `true`.
 ///
 /// The algorithm flow is simply like this:
-/// 1. Visit nodes of the physical plan bottom-up and look for `SortExec` nodes.
-///    During the traversal, keep track of operators that maintain ordering (or
-///    can maintain ordering when replaced by an order-preserving variant) until
-///    a `SortExec` is found.
-/// 2. When a `SortExec` is found, update the child of the `SortExec` by replacing
-///    operators that do not preserve ordering in the tree with their order
-///    preserving variants.
-/// 3. Check if the `SortExec` is still necessary in the updated plan by comparing
-///    its input ordering with the output ordering it imposes. We do this because
-///    replacing operators that lose ordering with their order-preserving variants
-///    enables us to preserve the previously lost ordering at the input of `SortExec`.
-/// 4. If the `SortExec` in question turns out to be unnecessary, remove it and
-///    use updated plan. Otherwise, use the original plan.
-/// 5. Continue the bottom-up traversal until another `SortExec` is seen, or the
-///    traversal is complete.
-pub(crate) fn replace_with_order_preserving_variants(
-    mut requirements: OrderPreservationContext,
-    // A flag indicating that replacing `RepartitionExec`s with sort-preserving
-    // variants is desirable when it helps to remove a `SortExec` from the plan.
-    // If this flag is `false`, this replacement should only be made to fix the
-    // pipeline (streaming).
+/// 1. During the top-down traversal, keep track of operators that maintain ordering (or
+///    can maintain ordering when replaced by an order-preserving variant) starting from a
+///    `SortExec` node down the tree.
+/// 2. During the bottom-up traversal, we use the order maintaining information from the
+///    top-down traversal and propagate up order maintaining alternative of the current
+///    plan.
+///    - If the node is `SortExec` then check if `SortExec` is still necessary. If the
+///      propagated up alternative plan satisfies the ordering needs then `SortExec` can
+///      be dropped and the alternative plan can be accepted. If it doesn't satisfy then
+///      the alternative can be dropped.
+///    - If a node can be reached from its parent via an order maintaining connection and
+///      the node is an operator that can be replaced to its order maintaining variant
+///      then start propagating up or extend the already propagated up alternative plan
+///      with the order maintaining operator variant of the current node.
+///    - If the node can't be replaced but we got order maintaining alternative from its
+///      children then extend the alternative plan with the current node.
+#[allow(clippy::type_complexity)]
+pub(crate) fn propagate_order_maintaining_connections_down(
+    plan: Arc<dyn ExecutionPlan>,
+    ordering_connection: bool,
+) -> Result<(Transformed<Arc<dyn ExecutionPlan>>, Vec<bool>, bool)> {
+    let children_ordering_connections = if is_sort(&plan) {
+        // Start an order maintaining connection from the sort node down the tree.
+        vec![true]
+    } else {
+        // Keep the connection towards a child if a node maintains ordering to the child
+        // by default or the node can be replaced to an order maintaining alternative.
+        let possible_ordering_connection =
+            is_repartition(&plan) || is_coalesce_partitions(&plan);
+        plan.maintains_input_order()
+            .into_iter()
+            .map(|mio| ordering_connection && (mio || possible_ordering_connection))
+            .collect()
+    };
+    Ok((
+        Transformed::No(plan),
+        children_ordering_connections,
+        ordering_connection,
+    ))
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn replace_with_order_preserving_variants_up(
+    plan: Arc<dyn ExecutionPlan>,
+    ordering_connection: bool,
+    mut order_preserving_children: Vec<Option<Arc<dyn ExecutionPlan>>>,
+    // A flag indicating that replacing `RepartitionExec`s with
+    // `SortPreservingRepartitionExec`s is desirable when it helps
+    // to remove a `SortExec` from the plan. If this flag is `false`,
+    // this replacement should only be made to fix the pipeline (streaming).
     is_spr_better: bool,
     // A flag indicating that replacing `CoalescePartitionsExec`s with
     // `SortPreservingMergeExec`s is desirable when it helps to remove a
@@ -233,40 +106,83 @@ pub(crate) fn replace_with_order_preserving_variants(
     // should only be made to fix the pipeline (streaming).
     is_spm_better: bool,
     config: &ConfigOptions,
-) -> Result<Transformed<OrderPreservationContext>> {
-    update_children(&mut requirements);
-    if !(is_sort(&requirements.plan) && requirements.children[0].data) {
-        return Ok(Transformed::No(requirements));
-    }
-
-    // For unbounded cases, we replace with the order-preserving variant in any
-    // case, as doing so helps fix the pipeline. Also replace if config allows.
+) -> Result<(
+    Transformed<Arc<dyn ExecutionPlan>>,
+    Option<Arc<dyn ExecutionPlan>>,
+)> {
+    // For unbounded cases, replace with the order-preserving variant in
+    // any case, as doing so helps fix the pipeline.
+    // Also do the replacement if opted-in via config options.
     let use_order_preserving_variant =
-        config.optimizer.prefer_existing_sort || unbounded_output(&requirements.plan);
+        config.optimizer.prefer_existing_sort || unbounded_output(&plan);
 
-    // Create an alternate plan with order-preserving variants:
-    let mut alternate_plan = plan_with_order_preserving_variants(
-        requirements.children.swap_remove(0),
-        is_spr_better || use_order_preserving_variant,
-        is_spm_better || use_order_preserving_variant,
-    )?;
-
-    // If the alternate plan makes this sort unnecessary, accept the alternate:
-    if alternate_plan
-        .plan
-        .equivalence_properties()
-        .ordering_satisfy(requirements.plan.output_ordering().unwrap_or(&[]))
-    {
-        for child in alternate_plan.children.iter_mut() {
-            child.data = false;
+    if is_sort(&plan) {
+        if let Some(order_preserving_plan) = order_preserving_children.swap_remove(0) {
+            // If there is an order preserving alternative available we need to check if
+            // it satisfies ordering of the original sort operator
+            if order_preserving_plan
+                .equivalence_properties()
+                .ordering_satisfy(plan.output_ordering().unwrap_or(&[]))
+            {
+                // If the sort is unnecessary, we should remove it:
+                Ok((Transformed::Yes(order_preserving_plan), None))
+            } else {
+                Ok((Transformed::No(plan), None))
+            }
+        } else {
+            Ok((Transformed::No(plan), None))
         }
-        Ok(Transformed::Yes(alternate_plan))
+    } else if ordering_connection
+        && is_repartition(&plan)
+        && !plan.maintains_input_order()[0]
+        && (is_spr_better || use_order_preserving_variant)
+    {
+        // Replace repartition to its order maintaining variant in the alternative plan.
+        // If the alternative subplan already propagated up then extend that, if not then
+        // start a new from the actual plan.
+        let child = order_preserving_children
+            .swap_remove(0)
+            .unwrap_or_else(|| plan.children().swap_remove(0));
+        let order_preserving_plan = Arc::new(
+            RepartitionExec::try_new(child, plan.output_partitioning())?
+                .with_preserve_order(),
+        );
+        Ok((Transformed::No(plan), Some(order_preserving_plan)))
+    } else if ordering_connection
+        && is_coalesce_partitions(&plan)
+        && (is_spm_better || use_order_preserving_variant)
+    {
+        // Replace coalesce to its order maintaining variant in the alternative plan.
+        // If the alternative subplan already propagated up then extend that, if not then
+        // start a new from the actual plan.
+        let child = order_preserving_children
+            .swap_remove(0)
+            .unwrap_or_else(|| plan.children().swap_remove(0));
+
+        // When the input of a `CoalescePartitionsExec` has an ordering, replace it
+        // with a `SortPreservingMergeExec` if appropriate:
+        let order_preserving_plan = child.output_ordering().map(|o| {
+            Arc::new(SortPreservingMergeExec::new(o.to_vec(), child.clone())) as _
+        });
+        Ok((Transformed::No(plan), order_preserving_plan))
     } else {
-        // The alternate plan does not help, use faster order-breaking variants:
-        alternate_plan = plan_with_order_breaking_variants(alternate_plan)?;
-        alternate_plan.data = false;
-        requirements.children = vec![alternate_plan];
-        Ok(Transformed::Yes(requirements))
+        // If any of the children propagated up an alternative plan then keep propagating
+        // up the alternative plan with the current node.
+        let order_preserving_plan =
+            if order_preserving_children.iter().any(|opc| opc.is_some()) {
+                Some(
+                    plan.clone().with_new_children(
+                        order_preserving_children
+                            .into_iter()
+                            .zip(plan.children().into_iter())
+                            .map(|(opc, c)| opc.unwrap_or(c))
+                            .collect(),
+                    )?,
+                )
+            } else {
+                None
+            };
+        Ok((Transformed::No(plan), order_preserving_plan))
     }
 }
 
@@ -277,9 +193,7 @@ mod tests {
     use crate::datasource::file_format::file_compression_type::FileCompressionType;
     use crate::datasource::listing::PartitionedFile;
     use crate::datasource::physical_plan::{CsvExec, FileScanConfig};
-    use crate::physical_optimizer::test_utils::check_integrity;
     use crate::physical_plan::coalesce_batches::CoalesceBatchesExec;
-    use crate::physical_plan::coalesce_partitions::CoalescePartitionsExec;
     use crate::physical_plan::filter::FilterExec;
     use crate::physical_plan::joins::{HashJoinExec, PartitionMode};
     use crate::physical_plan::repartition::RepartitionExec;
@@ -301,6 +215,7 @@ mod tests {
     use datafusion_physical_expr::PhysicalSortExpr;
     use datafusion_physical_plan::streaming::StreamingTableExec;
 
+    use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
     use rstest::rstest;
 
     /// Runs the `replace_with_order_preserving_variants` sub-rule and asserts
@@ -394,9 +309,10 @@ mod tests {
 
             // Run the rule top-down
             let config = SessionConfig::new().with_prefer_existing_sort($PREFER_EXISTING_SORT);
-            let plan_with_pipeline_fixer = OrderPreservationContext::new_default(physical_plan);
-            let parallel = plan_with_pipeline_fixer.transform_up(&|plan_with_pipeline_fixer| replace_with_order_preserving_variants(plan_with_pipeline_fixer, false, false, config.options())).and_then(check_integrity)?;
-            let optimized_physical_plan = parallel.plan;
+            let (optimized_physical_plan, _) = physical_plan.transform_with_payload(
+                &mut |plan, ordering_connection| propagate_order_maintaining_connections_down(plan, ordering_connection),
+                false,
+                &mut |plan, ordering_connection, order_preserving_children| replace_with_order_preserving_variants_up(plan, ordering_connection, order_preserving_children, false, false, config.options()))?;
 
             // Get string representation of the plan
             let actual = get_plan_string(&optimized_physical_plan);

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -25,7 +25,7 @@ use super::utils::{
     convert_duration_type_to_interval, convert_interval_type_to_duration, get_inverse_op,
 };
 use crate::expressions::Literal;
-use crate::utils::{build_dag, ExprTreeNode};
+use crate::utils::build_dag;
 use crate::PhysicalExpr;
 
 use arrow_schema::{DataType, Schema};
@@ -176,11 +176,11 @@ impl ExprIntervalGraphNode {
         &self.interval
     }
 
-    /// This function creates a DAEG node from Datafusion's [`ExprTreeNode`]
+    /// This function creates a DAEG node from Datafusion's [`PhysicalExpr`]
     /// object. Literals are created with definite, singleton intervals while
     /// any other expression starts with an indefinite interval ([-∞, ∞]).
-    pub fn make_node(node: &ExprTreeNode<NodeIndex>, schema: &Schema) -> Result<Self> {
-        let expr = node.expr.clone();
+    pub fn make_node(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<Self> {
+        let expr = expr.clone();
         if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
             let value = literal.value();
             Interval::try_new(value.clone(), value.clone())

--- a/datafusion/physical-expr/src/sort_properties.rs
+++ b/datafusion/physical-expr/src/sort_properties.rs
@@ -15,11 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::ops::Neg;
-
-use crate::tree_node::ExprContext;
-
 use arrow_schema::SortOptions;
+use std::ops::Neg;
 
 /// To propagate [`SortOptions`] across the `PhysicalExpr`, it is insufficient
 /// to simply use `Option<SortOptions>`: There must be a differentiation between
@@ -134,15 +131,3 @@ impl Neg for SortProperties {
         }
     }
 }
-
-/// The `ExprOrdering` struct is designed to aid in the determination of ordering (represented
-/// by [`SortProperties`]) for a given `PhysicalExpr`. When analyzing the orderings
-/// of a `PhysicalExpr`, the process begins by assigning the ordering of its leaf nodes.
-/// By propagating these leaf node orderings upwards in the expression tree, the overall
-/// ordering of the entire `PhysicalExpr` can be derived.
-///
-/// This struct holds the necessary state information for each expression in the `PhysicalExpr`.
-/// It encapsulates the orderings (`data`) associated with the expression (`expr`), and
-/// orderings of the children expressions (`children`). The [`ExprOrdering`] of a parent
-/// expression is determined based on the [`ExprOrdering`] states of its children expressions.
-pub type ExprOrdering = ExprContext<SortProperties>;

--- a/datafusion/physical-expr/src/tree_node.rs
+++ b/datafusion/physical-expr/src/tree_node.rs
@@ -17,12 +17,11 @@
 
 //! This module provides common traits for visiting or rewriting tree nodes easily.
 
-use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
 
 use crate::physical_expr::{with_new_children_if_necessary, PhysicalExpr};
 
-use datafusion_common::tree_node::{ConcreteTreeNode, DynTreeNode};
+use datafusion_common::tree_node::DynTreeNode;
 use datafusion_common::Result;
 
 impl DynTreeNode for dyn PhysicalExpr {
@@ -36,65 +35,5 @@ impl DynTreeNode for dyn PhysicalExpr {
         new_children: Vec<Arc<Self>>,
     ) -> Result<Arc<Self>> {
         with_new_children_if_necessary(arc_self, new_children)
-    }
-}
-
-/// A node object encapsulating a [`PhysicalExpr`] node with a payload. Since there are
-/// two ways to access child plans—directly from the plan  and through child nodes—it's
-/// recommended to perform mutable operations via [`Self::update_expr_from_children`].
-#[derive(Debug)]
-pub struct ExprContext<T: Sized> {
-    /// The physical expression associated with this context.
-    pub expr: Arc<dyn PhysicalExpr>,
-    /// Custom data payload of the node.
-    pub data: T,
-    /// Child contexts of this node.
-    pub children: Vec<Self>,
-}
-
-impl<T> ExprContext<T> {
-    pub fn new(expr: Arc<dyn PhysicalExpr>, data: T, children: Vec<Self>) -> Self {
-        Self {
-            expr,
-            data,
-            children,
-        }
-    }
-
-    pub fn update_expr_from_children(mut self) -> Result<Self> {
-        let children_expr = self.children.iter().map(|c| c.expr.clone()).collect();
-        self.expr = with_new_children_if_necessary(self.expr, children_expr)?;
-        Ok(self)
-    }
-}
-
-impl<T: Default> ExprContext<T> {
-    pub fn new_default(plan: Arc<dyn PhysicalExpr>) -> Self {
-        let children = plan.children().into_iter().map(Self::new_default).collect();
-        Self::new(plan, Default::default(), children)
-    }
-}
-
-impl<T: Display> Display for ExprContext<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "expr: {:?}", self.expr)?;
-        write!(f, "data:{}", self.data)?;
-        write!(f, "")
-    }
-}
-
-impl<T> ConcreteTreeNode for ExprContext<T> {
-    fn children(&self) -> Vec<&Self> {
-        self.children.iter().collect()
-    }
-
-    fn take_children(mut self) -> (Self, Vec<Self>) {
-        let children = std::mem::take(&mut self.children);
-        (self, children)
-    }
-
-    fn with_new_children(mut self, children: Vec<Self>) -> Result<Self> {
-        self.children = children;
-        self.update_expr_from_children()
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?
Part of #8913, #8663.

## Rationale for this change
After https://github.com/apache/arrow-datafusion/pull/8817 the derived `TreeNode` trees got unified into 2 generic trees: `PlanContext` and `ExprContext`. These generic trees still have the drawback that they contain derived nodes (contains some data and a link to a node of the original tree) for each of the original tree nodes to store some additional information / state of the node, which means transformations needs to keep the 2 trees in sync. While this is done automaticaly, it comes with additional costs and make tranformation algorightms less readable as the generic derived nodes has only a `data` field that encodes different information in different trees.

This PR proposes an alternative approach to many of the transformations that uses derived trees currently. The new API that PR adds to `TreeNode` looks like the following:
```rust
    /// Transforms the tree using `f_down` and `f_up` closures. `f_down` is applied on a
    /// node while traversing the tree top-down (pre-order, before the node's children are
    /// visited) while `f_up` is applied on a node while traversing the tree bottom-up
    /// (post-order, after the the node's children are visited).
    ///
    /// The `f_down` closure takes
    /// - a `PD` type payload from its parent
    /// and returns a tuple made of:
    /// - a possibly modified node,
    /// - a `PC` type payload to pass to `f_up`,
    /// - a `Vec<PD>` type payload to propagate down to the node's children
    ///    (one `PD` element is propagated down to each child).
    ///
    /// The `f_up` closure takes
    /// - a `PC` type payload from `f_down` and
    /// - a `Vec<PU>` type payload collected from the node's children
    /// and returns a tuple made of:
    /// - a possibly modified node,
    /// - a `PU` type payload to propagate up to the node's parent.
    fn transform_with_payload<FD, PD, PC, FU, PU>(
        self,
        f_down: &mut FD,
        payload_down: PD,
        f_up: &mut FU,
    ) -> Result<(Self, PU)>
    where
        FD: FnMut(Self, PD) -> Result<(Transformed<Self>, Vec<PD>, PC)>,
        FU: FnMut(Self, PC, Vec<PU>) -> Result<(Transformed<Self>, PU)>,
```
as well as the `TreeNode.transform_down_with_payload()` and `TreeNode.transform_up_with_payload()` variants that do one direction transformations.

With the help of above new API this PR refactors 9 of the 11 derived trees and makes `ExprContext` obsolete.

Besides the cleaner state transition functions, the new API is capable to describe some transformations that currently require 2 pass with 1 pass. With the new API, the example given in https://github.com/apache/arrow-datafusion/pull/8817 with `RequiringExec` that requires a top-down transformation to store minimum sort requirement in derived nodes and then a bottom-up transformation to insert `SortExecs`s can be done in 1 pass without creating any additional trees.

There are 2 examples for this advanced usecase in this PR:
- `PlanWithCorrespondingCoalescePartitions`:
   Currently `parallelize_sorts` is a bottom-up transformation while at some nodes it kicks off `remove_corresponding_coalesce_in_sub_plan` to do a top-down transformation of the subtree.
  After this PR `propagate_unnecessary_coalesce_connections_down` top-down and `parallelize_sorts_up` bottom-up transformations are incorporated into one pass using `transform_down_with_payload`.
- `OrderPreservationContext`:
  Currently `replace_with_order_preserving_variants` is a bottom-up transformation while at some nodes it starts a top-down `plan_with_order_preserving_variants` transformation.
  After this PR `propagate_order_maintaining_connections_down` top-down and `replace_with_order_preserving_variants_up` bottom-up transformations are incorporated into one pass using `transform_down_with_payload`.

Please note that the new API can't replace or non-trivially can replace derived trees in some cases like:
- Node level states needs to be stored between 2 consecutive "same direction" transformations, but in this case the 2 transformations could be unified into 1 one.
- Node level states needs to be stored between a bottom-up and a consecutive top-down transformation (the other order,  a top-down followed by a bottom-up transformation can be trivially rewritten), but in this case there might be better algorightms that need only 1 pass traversal. Please find 2 advanced examples above.

This PR doesn't necessary want to remove `PlanContext` and `ExprContext` as there might be downstream usescases of those. The purpose of this PR is to offer better API (more effective and readable transformations) for usescases where it make sense to use.
  
This PR implements idea 4. from https://github.com/apache/arrow-datafusion/pull/7942.

## What changes are included in this PR?
This PR:
- Adds `TreeNode.transform_with_payload()`, `TreeNode.transform_down_with_payload()` and `TreeNode.transform_up_with_payload()`,
- Refactors `SortPushDown` and `PlanWithRequitements` using `TreeNode.transform_down_with_payload()`,
- Refactors `ExprOrdering`, `ExprTreeNode` and `PipelineStatePropagator` using `TreeNode.transform_up_with_payload()`,
- Refactors `OrderPreservationContext` and `PlanWithCorrespondingCoalescePartitions ` using `TreeNode.transform_with_payload()`.

The remaining 2 derived trees can be refactored in follow-up PRs if possible and needed.

## Are these changes tested?
Using exinsting tests.

## Are there any user-facing changes?
No.
