### PR TITLE
feat: track memory consumers for GreedyMemoryPoolState

### DIFF
--- a/datafusion/execution/src/memory_pool/pool.rs
+++ b/datafusion/execution/src/memory_pool/pool.rs
@@ -490,4 +490,38 @@ mod tests {
         r1.try_grow(10).unwrap();
         assert_eq!(pool.reserved(), 20);
     }
+
+    #[test]
+    fn test_greedy_pool_display() {
+        let greedy_pool = Arc::new(GreedyMemoryPool::new(1000));
+        let pool: Arc<dyn MemoryPool> = greedy_pool.clone();
+
+        let mut r1 = MemoryConsumer::new("r1").register(&pool);
+        let mut r2 = MemoryConsumer::new("r2").register(&pool);
+
+        r1.grow(100);
+        r2.grow(321);
+
+        assert_eq!(
+            format!("{}", greedy_pool),
+            "GreedyPool 2 allocations, 421 used, 579 free, 1000 capacity.\nConsumers:\n321: r2\n100: r1\n"
+        );
+    }
+
+    #[test]
+    fn test_fair_pool_display() {
+        let fair_pool = Arc::new(FairSpillPool::new(1000));
+        let pool: Arc<dyn MemoryPool> = fair_pool.clone();
+
+        let mut r1 = MemoryConsumer::new("r1").register(&pool);
+        let mut r2 = MemoryConsumer::new("r2").register(&pool);
+
+        r1.grow(100);
+        r2.grow(321);
+
+        assert_eq!(
+        format!("{}", fair_pool),
+        "FairSpillPool 2 allocations, 0 spillable used, 0 total spillable, 421 unspillable used, 579 free, 1000 capacity.\nConsumers:\n321: r2\n100: r1\n"
+        );
+    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6934

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Modified GreedyMemoryPool and FairMemoryPool to keep track of all it's consumer such that they can be dumped for debugging.

The output for the debug looks as follows:

<img width="416" alt="Screenshot 2024-01-29 at 12 16 14 AM" src="https://github.com/apache/arrow-datafusion/assets/38435962/1d8db0be-dacf-4462-b6d3-9fce67b2367f">
<img width="758" alt="Screenshot 2024-01-29 at 12 24 33 AM" src="https://github.com/apache/arrow-datafusion/assets/38435962/654ac2d9-269c-40ab-bd6b-3301bf57693c">





## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
