### PR TITLE
[WIP] Add timeseries / observability benchmarks

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,6 +33,7 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 arrow = { workspace = true }
+async-trait = "0.1"
 datafusion = { path = "../datafusion/core", version = "35.0.0" }
 datafusion-common = { path = "../datafusion/common", version = "35.0.0" }
 env_logger = { workspace = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,7 +33,6 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 arrow = { workspace = true }
-async-trait = "0.1"
 datafusion = { path = "../datafusion/core", version = "35.0.0" }
 datafusion-common = { path = "../datafusion/common", version = "35.0.0" }
 env_logger = { workspace = true }

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -259,7 +259,7 @@ SUBCOMMANDS:
 
 # Benchmarks
 
-The output of `dfbench` help includes a descripion of each benchmark, which is reproducedd here for convenience
+The output of `dfbench` help includes a description of each benchmark, which is reproduced here for convenience
 
 ## ClickBench
 

--- a/benchmarks/src/access_log_gen.rs
+++ b/benchmarks/src/access_log_gen.rs
@@ -60,8 +60,8 @@ pub struct RunOpt {
     #[structopt(long = "scale-factor", default_value = "0.01")]
     scale_factor: f32,
 
-    /// How many files are created. Defaults to 10
-    #[structopt(default_value = "10", short = "n", long = "num-files")]
+    /// How many files are created. Defaults to 25
+    #[structopt(default_value = "25", short = "n", long = "num-files")]
     num_files: NonZeroUsize,
 
     /// Should the files be sorted or not? Defaults to false. If true, the files will be sorted by XX, YY, and timestamp.

--- a/benchmarks/src/access_log_gen.rs
+++ b/benchmarks/src/access_log_gen.rs
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::AccessLogOpt;
+use crate::{BenchmarkRun, CommonOpt};
+use arrow::util::pretty;
+use datafusion::common::Result;
+use datafusion::datasource::function::TableFunctionImpl;
+use datafusion::datasource::TableProvider;
+use datafusion::logical_expr::utils::disjunction;
+use datafusion::logical_expr::{lit, or, Expr};
+use datafusion::physical_plan::collect;
+use datafusion::prelude::{col, SessionConfig, SessionContext};
+use datafusion::test_util::parquet::{ParquetScanOptions, TestParquetFile};
+use parquet::file::properties::WriterProperties;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+use structopt::StructOpt;
+use test_utils::AccessLogGenerator;
+
+/// Creates synthetic data that mimic's a web server access log
+/// dataset
+///
+/// Example
+///
+/// dfbench access-log-gen   --path ./data/access_logs --scale-factor 1.0
+///
+///
+/// Generates synthetic dataset in `./data/access_logs`. The size
+/// of the dataset can be controlled through the `size_factor`
+/// (with the default value of `1.0` generating a ~1GB parquet file).
+///
+#[derive(Debug, StructOpt, Clone)]
+#[structopt(verbatim_doc_comment)]
+pub struct RunOpt {
+    /// Path to folder where access log files will be generated
+    #[structopt(parse(from_os_str), required = true, short = "p", long = "path")]
+    path: PathBuf,
+
+    /// Total size of each file in dataset. The default scale factor of 1.0 will generate roughly 1GB parquet files
+    //#[structopt(long = "scale-factor", default_value = "1.0")]
+    #[structopt(long = "scale-factor", default_value = "0.1")]
+    scale_factor: f32,
+
+    /// How many files should be created? 10 by default
+    #[structopt(default_value = "10", short = "n", long = "num-files")]
+    num_files: NonZeroUsize,
+
+    /// Should the files be sorted or not? Defaults to false. If true, the files will be sorted by XX, YY, and timestamp.
+    #[structopt(short = "s", long = "sorted")]
+    sort: bool,
+}
+
+impl RunOpt {
+    pub async fn run(self) -> Result<()> {
+        let Self {
+            path,
+            scale_factor,
+            num_files,
+            sort,
+        } = self;
+
+        std::fs::create_dir_all(&path)?;
+
+        let mut ctx = SessionContext::new();
+        ctx.register_udtf("access_log_gen", Arc::new(AccessLogTable::new()));
+
+        // use the COPY command to write data to the file
+        let output_file = path.join("1.parquet");
+        let output_filename = output_file.to_str().expect("non utf8 path name");
+        let seed = 1;
+        let sql = format!(
+            "COPY (SELECT * from access_log_gen({scale_factor}, {seed})) INTO '{output_filename}')",
+        );
+        println!("Running sql: {}", sql);
+        ctx.sql(&sql).await?.show().await
+    }
+}
+
+/// User defined table function that generates access logs for a given seed
+///
+/// Usage:
+/// access_log_gen(scale_factor, seed)
+struct AccessLogTable {}
+
+impl AccessLogTable {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TableFunctionImpl for AccessLogTable {
+    fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+        todo!();
+
+        //let generator = AccessLogGenerator::new();
+        //let num_batches = 100_f32 * self.scale_factor;
+    }
+}

--- a/benchmarks/src/access_log_gen.rs
+++ b/benchmarks/src/access_log_gen.rs
@@ -15,24 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::AccessLogOpt;
-use crate::{BenchmarkRun, CommonOpt};
-use arrow::util::pretty;
 use datafusion::common::Result;
 use datafusion::datasource::function::TableFunctionImpl;
 use datafusion::datasource::TableProvider;
-use datafusion::logical_expr::utils::disjunction;
-use datafusion::logical_expr::{lit, or, Expr};
-use datafusion::physical_plan::collect;
-use datafusion::prelude::{col, SessionConfig, SessionContext};
-use datafusion::test_util::parquet::{ParquetScanOptions, TestParquetFile};
-use parquet::file::properties::WriterProperties;
+use datafusion::logical_expr::Expr;
+use datafusion::prelude::SessionContext;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
 use structopt::StructOpt;
-use test_utils::AccessLogGenerator;
 
 /// Creates synthetic data that mimic's a web server access log
 /// dataset
@@ -86,7 +77,7 @@ impl RunOpt {
         let output_filename = output_file.to_str().expect("non utf8 path name");
         let seed = 1;
         let sql = format!(
-            "COPY (SELECT * from access_log_gen({scale_factor}, {seed})) INTO '{output_filename}')",
+            "COPY (SELECT * from access_log_gen({scale_factor}, {seed})) TO '{output_filename}'",
         );
         println!("Running sql: {}", sql);
         ctx.sql(&sql).await?.show().await

--- a/benchmarks/src/bin/dfbench.rs
+++ b/benchmarks/src/bin/dfbench.rs
@@ -28,7 +28,7 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use datafusion_benchmarks::{clickbench, parquet_filter, sort, tpch};
+use datafusion_benchmarks::{access_log_gen, clickbench, parquet_filter, sort, tpch};
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "benchmark command")]
@@ -37,6 +37,7 @@ enum Options {
     TpchConvert(tpch::ConvertOpt),
     Clickbench(clickbench::RunOpt),
     ParquetFilter(parquet_filter::RunOpt),
+    AccessLogGen(access_log_gen::RunOpt),
     Sort(sort::RunOpt),
 }
 
@@ -50,6 +51,7 @@ pub async fn main() -> Result<()> {
         Options::TpchConvert(opt) => opt.run().await,
         Options::Clickbench(opt) => opt.run().await,
         Options::ParquetFilter(opt) => opt.run().await,
+        Options::AccessLogGen(opt) => opt.run().await,
         Options::Sort(opt) => opt.run().await,
     }
 }

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -16,9 +16,11 @@
 // under the License.
 
 //! DataFusion benchmark runner
+pub mod access_log_gen;
 pub mod clickbench;
 pub mod parquet_filter;
 pub mod sort;
 pub mod tpch;
 mod util;
+
 pub use util::*;

--- a/test-utils/src/data_gen.rs
+++ b/test-utils/src/data_gen.rs
@@ -33,6 +33,7 @@ struct GeneratorOptions {
     pods_per_host: Range<usize>,
     containers_per_pod: Range<usize>,
     entries_per_container: Range<usize>,
+    service_names: Vec<String>,
 }
 
 impl Default for GeneratorOptions {
@@ -42,6 +43,12 @@ impl Default for GeneratorOptions {
             pods_per_host: 1..15,
             containers_per_pod: 1..3,
             entries_per_container: 1024..8192,
+            service_names: vec![
+                String::from("frontend"),
+                String::from("backend"),
+                String::from("database"),
+                String::from("cache"),
+            ],
         }
     }
 }
@@ -265,9 +272,9 @@ impl Default for AccessLogGenerator {
     }
 }
 
-const  DEFAULT_SEED: [u8; 32] =  [
-1, 0, 0, 0, 23, 0, 3, 0, 200, 1, 0, 0, 210, 30, 8, 0, 1, 0, 21, 0, 6, 0, 0,
-0, 0, 0, 5, 0, 0, 0, 0, 0,
+const DEFAULT_SEED: [u8; 32] = [
+    1, 0, 0, 0, 23, 0, 3, 0, 200, 1, 0, 0, 210, 30, 8, 0, 1, 0, 21, 0, 6, 0, 0, 0, 0, 0,
+    5, 0, 0, 0, 0, 0,
 ];
 
 impl AccessLogGenerator {
@@ -322,6 +329,12 @@ impl AccessLogGenerator {
         self.options.entries_per_container = range;
         self
     }
+
+    /// set the possible service names that are used
+    pub fn with_service_names(mut self, service_names: Vec<String>) -> Self {
+        self.options.service_names = service_names;
+        self
+    }
 }
 
 impl Iterator for AccessLogGenerator {
@@ -350,7 +363,7 @@ impl Iterator for AccessLogGenerator {
         );
         self.host_idx += 1;
 
-        for service in &["frontend", "backend", "database", "cache"] {
+        for service in &self.options.service_names {
             if self.rng.gen_bool(0.5) {
                 continue;
             }

--- a/test-utils/src/data_gen.rs
+++ b/test-utils/src/data_gen.rs
@@ -265,17 +265,17 @@ impl Default for AccessLogGenerator {
     }
 }
 
+const  DEFAULT_SEED: [u8; 32] =  [
+1, 0, 0, 0, 23, 0, 3, 0, 200, 1, 0, 0, 210, 30, 8, 0, 1, 0, 21, 0, 6, 0, 0,
+0, 0, 0, 5, 0, 0, 0, 0, 0,
+];
+
 impl AccessLogGenerator {
     pub fn new() -> Self {
-        let seed = [
-            1, 0, 0, 0, 23, 0, 3, 0, 200, 1, 0, 0, 210, 30, 8, 0, 1, 0, 21, 0, 6, 0, 0,
-            0, 0, 0, 5, 0, 0, 0, 0, 0,
-        ];
-
         Self {
             schema: BatchBuilder::schema(),
             host_idx: 0,
-            rng: StdRng::from_seed(seed),
+            rng: StdRng::from_seed(DEFAULT_SEED),
             max_batch_size: usize::MAX,
             row_count: 0,
             options: Default::default(),
@@ -285,6 +285,12 @@ impl AccessLogGenerator {
     /// Return the schema of the [`RecordBatch`]es  created
     pub fn schema(&self) -> SchemaRef {
         self.schema.clone()
+    }
+
+    /// Reset the random number generator with the specified seed
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.rng = StdRng::seed_from_u64(seed);
+        self
     }
 
     /// Limit the maximum batch size


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/8791


## Rationale for this change

There are usecases for several DataFusion users (like IOx) that store observability data, that is often characterized by low cardinality string data encoded as dictionaries. While the current parquet_filter pushdown benchmarks (TODO LINK) cover this example, we don't have an end to end test that does. 

This has caused problems when have made changes such as https://github.com/apache/arrow-datafusion/issues/7647  that should improve the performance of these queries but we had no reproducible way to measure the impact, and couldn't evaluate if the change was beneficial enough to warrant additional code complexity

There in systems such as IOx the data is very often sorted and the sort order is quite important for performance. However, DataFusion's existing benchmark coverage does not have any pre-sorted data

## What changes are included in this PR?
1. Add  a datafusion specific data set to to model common patterns in timeseries data -- http access logs / metrics and tracing data specifically. This uses the same generator as used in several other parts of DataFusion
2. Add a XXX benchmark to dfbench, runnable by `bench.sh` along with several queries


## Are these changes tested?

All tests

## Are there any user-facing changes?
No

## TODO
- [ ] add ticket / extend to model logging data as well
