### PR TITLE
Minor: add doc examples for RawTableAllocExt

### DIFF
--- a/datafusion/execution/src/memory_pool/proxy.rs
+++ b/datafusion/execution/src/memory_pool/proxy.rs
@@ -69,6 +69,23 @@ pub trait RawTableAllocExt {
     /// `accounting` by any newly allocated bytes.
     ///
     /// Returns the bucket where the element was inserted.
+    /// Note that allocation counts  capacity, not size.
+    ///
+    /// # Example:
+    /// ```
+    /// # use datafusion_execution::memory_pool::proxy::RawTableAllocExt;
+    /// # use hashbrown::raw::RawTable;
+    /// let mut table = RawTable::new();
+    /// let mut allocated = 0;
+    /// let hash_fn = |x: &u32| (*x as u64) % 1000;
+    /// // pretend 0x3117 is the hash value for 1
+    /// table.insert_accounted(1, hash_fn, &mut allocated);
+    /// assert_eq!(allocated, 64);
+    ///
+    /// // insert more values
+    /// for i in 0..100 { table.insert_accounted(i, hash_fn, &mut allocated); }
+    /// assert_eq!(allocated, 400);
+    /// ```
     fn insert_accounted(
         &mut self,
         x: Self::T,


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change
As suggested by @crepererum  on https://github.com/apache/arrow-datafusion/pull/9025#discussion_r1469361209 it would be nice to have an example of how to use this API

## What changes are included in this PR?
Add doc example

## Are these changes tested?
By doctest CI

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
