### PR TITLE
Draft: Optimize to_timestamp

### DIFF
--- a/datafusion/functions/src/datetime/common.rs
+++ b/datafusion/functions/src/datetime/common.rs
@@ -17,13 +17,16 @@
 
 use std::sync::Arc;
 
+use arrow::array::timezone::Tz;
+use arrow::array::types::ArrowTimestampType;
 use arrow::array::{
     Array, ArrowPrimitiveType, GenericStringArray, OffsetSizeTrait, PrimitiveArray,
 };
-use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
 use arrow::datatypes::DataType;
+use arrow::datatypes::TimeUnit::{Microsecond, Millisecond, Nanosecond, Second};
+use arrow::error::ArrowError;
 use chrono::LocalResult::Single;
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use itertools::Either;
 
 use datafusion_common::cast::as_generic_string_array;
@@ -33,10 +36,262 @@ use datafusion_expr::ColumnarValue;
 /// Error message if nanosecond conversion request beyond supported interval
 const ERR_NANOSECONDS_NOT_SUPPORTED: &str = "The dates that can be represented as nanoseconds have to be between 1677-09-21T00:12:44.0 and 2262-04-11T23:47:16.854775804";
 
-/// Calls string_to_timestamp_nanos and converts the error type
-pub(crate) fn string_to_timestamp_nanos_shim(s: &str) -> Result<i64> {
-    string_to_timestamp_nanos(s).map_err(|e| e.into())
+#[inline]
+pub(crate) fn string_to_timestamp<T: ArrowTimestampType>(s: &str) -> Result<i64> {
+    match T::UNIT {
+        Second => Ok(x_string_to_datetime(&Utc, s)?.naive_utc().timestamp()),
+        Millisecond => Ok(x_string_to_datetime(&Utc, s)?
+            .naive_utc()
+            .timestamp_millis()),
+        Microsecond => Ok(x_string_to_datetime(&Utc, s)?
+            .naive_utc()
+            .timestamp_micros()),
+        Nanosecond => {
+            // Calls string_to_timestamp_nanos and converts the error type
+            x_string_to_timestamp_nanos(s).map_err(|e| e.into())
+        }
+    }
 }
+
+/// Accepts a string with a `chrono` format and converts it to a
+/// timestamp with precision corresponding to the specified timestamp type.
+///
+/// See [`chrono::format::strftime`] for the full set of supported formats.
+///
+/// Implements the `to_timestamp` function to convert a string to a
+/// timestamp, following the model of spark SQL’s to_`timestamp`.
+///
+/// Internally, this function uses the `chrono` library for the
+/// datetime parsing
+///
+/// ## Timestamp Precision
+///
+/// Function uses the maximum precision timestamps supported by
+/// Arrow (nanoseconds stored as a 64-bit integer) timestamps. This
+/// means the range of dates that (nanoseconds-precision) timestamps
+/// can represent is ~1677 AD to 2262 AM
+///
+/// ## Timezone / Offset Handling
+///
+/// Numerical values of timestamps are stored compared to offset UTC.
+///
+/// Any timestamp in the formatting string is handled according to the rules
+/// defined by `chrono`.
+///
+/// [`chrono::format::strftime`]: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
+///
+#[inline]
+pub(crate) fn string_to_timestamp_formatted<T: ArrowTimestampType>(
+    s: &str,
+    format: &str,
+) -> Result<i64, DataFusionError> {
+    let shim = match T::UNIT {
+        Second => |dt: &DateTime<_>| Ok(dt.timestamp()),
+        Millisecond => |dt: &DateTime<_>| Ok(dt.timestamp_millis()),
+        Microsecond => |dt: &DateTime<_>| Ok(dt.timestamp_micros()),
+        Nanosecond => |dt: &DateTime<_>| {
+            dt.timestamp_nanos_opt().ok_or_else(|| {
+                DataFusionError::Execution(ERR_NANOSECONDS_NOT_SUPPORTED.to_string())
+            })
+        },
+    };
+    let dt = string_to_datetime_formatted(&Utc, s, format)?
+        .naive_utc()
+        .and_utc();
+    shim(&dt)
+}
+
+/// TODO VT: the following should go to parse.rs
+
+#[inline]
+pub fn x_string_to_timestamp_nanos(s: &str) -> Result<i64, ArrowError> {
+    x_to_timestamp_nanos(x_string_to_datetime(&Utc, s)?.naive_utc())
+}
+
+/// Fallible conversion of [`NaiveDateTime`] to `i64` nanoseconds
+#[inline]
+fn x_to_timestamp_nanos(dt: NaiveDateTime) -> Result<i64, ArrowError> {
+    dt.timestamp_nanos_opt()
+        .ok_or_else(|| ArrowError::ParseError(ERR_NANOSECONDS_NOT_SUPPORTED.to_string()))
+}
+
+fn x_string_to_datetime<T: TimeZone>(
+    timezone: &T,
+    s: &str,
+) -> Result<DateTime<T>, ArrowError> {
+    #[allow(deprecated)]
+    const ZERO_TIME: NaiveTime = NaiveTime::from_hms(0, 0, 0);
+
+    let err = |ctx: &str| {
+        ArrowError::ParseError(format!("Error parsing timestamp from '{s}': {ctx}"))
+    };
+
+    let bytes = s.as_bytes();
+    if bytes.len() < 10 {
+        return Err(err("timestamp must contain at least 10 characters"));
+    }
+
+    let parser = XTimestampParser::new(bytes);
+    let date = parser.date().ok_or_else(|| err("error parsing date"))?;
+    if bytes.len() == 10 {
+        let datetime = date.and_time(ZERO_TIME);
+        return timezone
+            .from_local_datetime(&datetime)
+            .single()
+            .ok_or_else(|| err("error computing timezone offset"));
+    }
+
+    let sep = bytes[10];
+    if sep != b'T' && sep != b't' && sep != b' ' {
+        return Err(err("invalid timestamp separator"));
+    }
+
+    let (time, mut tz_offset) = parser.time().ok_or_else(|| err("error parsing time"))?;
+    let datetime = date.and_time(time);
+
+    if tz_offset == 32 {
+        // Decimal overrun
+        while tz_offset < bytes.len() && bytes[tz_offset].is_ascii_digit() {
+            tz_offset += 1;
+        }
+    }
+
+    if bytes.len() <= tz_offset {
+        return timezone
+            .from_local_datetime(&datetime)
+            .single()
+            .ok_or_else(|| err("error computing timezone offset"));
+    }
+
+    let sep = bytes[tz_offset];
+    if (sep == b'z' || sep == b'Z') && tz_offset == bytes.len() - 1 {
+        return Ok(timezone.from_utc_datetime(&datetime));
+    }
+
+    // Parse remainder of string as timezone
+    let parsed_tz: Tz = s[tz_offset..].trim_start().parse()?;
+
+    let parsed = parsed_tz
+        .from_local_datetime(&datetime)
+        .single()
+        .ok_or_else(|| err("error computing timezone offset"))?;
+
+    Ok(parsed.with_timezone(timezone))
+}
+
+struct XTimestampParser {
+    /// The timestamp bytes to parse minus `b'0'`
+    ///
+    /// This makes interpretation as an integer inexpensive
+    digits: [u8; 32],
+    /// A mask containing a `1` bit where the corresponding byte is a valid ASCII digit
+    mask: u32,
+}
+
+impl XTimestampParser {
+    fn new(bytes: &[u8]) -> Self {
+        let mut digits = [0; 32];
+        let mut mask = 0;
+
+        // Treating all bytes the same way, helps LLVM vectorise this correctly
+        for (idx, (o, i)) in digits.iter_mut().zip(bytes).enumerate() {
+            *o = i.wrapping_sub(b'0');
+            mask |= ((*o < 10) as u32) << idx
+        }
+
+        Self { digits, mask }
+    }
+
+    /// Parses a date of the form `1997-01-31`
+    fn date(&self) -> Option<NaiveDate> {
+        const DASH: u8 = b'-'.wrapping_sub(b'0');
+        if self.mask & 0b1111111111 != 0b1101101111
+            || self.digits[4] != DASH
+            || self.digits[7] != DASH
+        {
+            return None;
+        }
+
+        let year = self.digits[0] as u16 * 1000
+            + self.digits[1] as u16 * 100
+            + self.digits[2] as u16 * 10
+            + self.digits[3] as u16;
+
+        let month = self.digits[5] * 10 + self.digits[6];
+        let day = self.digits[8] * 10 + self.digits[9];
+
+        NaiveDate::from_ymd_opt(year as _, month as _, day as _)
+    }
+
+    /// Parses a time of any of forms
+    /// - `09:26:56`
+    /// - `09:26:56.123`
+    /// - `09:26:56.123456`
+    /// - `09:26:56.123456789`
+    /// - `092656`
+    ///
+    /// Returning the end byte offset
+    fn time(&self) -> Option<(NaiveTime, usize)> {
+        const PERIOD: u8 = b'.'.wrapping_sub(b'0');
+        const COLON: u8 = b':'.wrapping_sub(b'0');
+
+        // Make a NaiveTime handling leap seconds
+        let time = |hour, min, sec, nano| match sec {
+            60 => {
+                let nano = 1_000_000_000 + nano;
+                NaiveTime::from_hms_nano_opt(hour as _, min as _, 59, nano)
+            }
+            _ => NaiveTime::from_hms_nano_opt(hour as _, min as _, sec as _, nano),
+        };
+
+        match (self.mask >> 11) & 0b11111111 {
+            // 09:26:56
+            0b11011011 if self.digits[13] == COLON && self.digits[16] == COLON => {
+                let hour = self.digits[11] * 10 + self.digits[12];
+                let minute = self.digits[14] * 10 + self.digits[15];
+                let second = self.digits[17] * 10 + self.digits[18];
+
+                if self.digits[19] == PERIOD {
+                    let digits = (self.mask >> 20).trailing_ones();
+                    let nanos = match digits {
+                        0 => return None,
+                        1 => x_parse_nanos::<1>(&self.digits[20..21]),
+                        2 => x_parse_nanos::<2>(&self.digits[20..22]),
+                        3 => x_parse_nanos::<3>(&self.digits[20..23]),
+                        4 => x_parse_nanos::<4>(&self.digits[20..24]),
+                        5 => x_parse_nanos::<5>(&self.digits[20..25]),
+                        6 => x_parse_nanos::<6>(&self.digits[20..26]),
+                        7 => x_parse_nanos::<7>(&self.digits[20..27]),
+                        8 => x_parse_nanos::<8>(&self.digits[20..28]),
+                        _ => x_parse_nanos::<9>(&self.digits[20..29]),
+                    };
+                    Some((time(hour, minute, second, nanos)?, 20 + digits as usize))
+                } else {
+                    Some((time(hour, minute, second, 0)?, 19))
+                }
+            }
+            // 092656
+            0b111111 => {
+                let hour = self.digits[11] * 10 + self.digits[12];
+                let minute = self.digits[13] * 10 + self.digits[14];
+                let second = self.digits[15] * 10 + self.digits[16];
+                let time = time(hour, minute, second, 0)?;
+                Some((time, 17))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[inline]
+fn x_parse_nanos<const N: usize>(digits: &[u8]) -> u32 {
+    digits[..N]
+        .iter()
+        .fold(0_u32, |acc, v| acc * 10 + *v as u32)
+        * 10_u32.pow((9 - N) as _)
+}
+
+/////////////////////
 
 /// Checks that all the arguments from the second are of type [Utf8] or [LargeUtf8]
 ///
@@ -104,47 +359,6 @@ pub(crate) fn string_to_datetime_formatted<T: TimeZone>(
     }
 }
 
-/// Accepts a string with a `chrono` format and converts it to a
-/// nanosecond precision timestamp.
-///
-/// See [`chrono::format::strftime`] for the full set of supported formats.
-///
-/// Implements the `to_timestamp` function to convert a string to a
-/// timestamp, following the model of spark SQL’s to_`timestamp`.
-///
-/// Internally, this function uses the `chrono` library for the
-/// datetime parsing
-///
-/// ## Timestamp Precision
-///
-/// Function uses the maximum precision timestamps supported by
-/// Arrow (nanoseconds stored as a 64-bit integer) timestamps. This
-/// means the range of dates that timestamps can represent is ~1677 AD
-/// to 2262 AM
-///
-/// ## Timezone / Offset Handling
-///
-/// Numerical values of timestamps are stored compared to offset UTC.
-///
-/// Any timestamp in the formatting string is handled according to the rules
-/// defined by `chrono`.
-///
-/// [`chrono::format::strftime`]: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
-///
-#[inline]
-pub(crate) fn string_to_timestamp_nanos_formatted(
-    s: &str,
-    format: &str,
-) -> Result<i64, DataFusionError> {
-    string_to_datetime_formatted(&Utc, s, format)?
-        .naive_utc()
-        .and_utc()
-        .timestamp_nanos_opt()
-        .ok_or_else(|| {
-            DataFusionError::Execution(ERR_NANOSECONDS_NOT_SUPPORTED.to_string())
-        })
-}
-
 pub(crate) fn handle<'a, O, F, S>(
     args: &'a [ColumnarValue],
     op: F,
@@ -175,17 +389,15 @@ where
 // given an function that maps a `&str`, `&str` to an arrow native type,
 // returns a `ColumnarValue` where the function is applied to either a `ArrayRef` or `ScalarValue`
 // depending on the `args`'s variant.
-pub(crate) fn handle_multiple<'a, O, F, S, M>(
+pub(crate) fn handle_multiple<'a, O, F, S>(
     args: &'a [ColumnarValue],
     op: F,
-    op2: M,
     name: &str,
 ) -> Result<ColumnarValue>
 where
     O: ArrowPrimitiveType,
     S: ScalarType<O::Native>,
     F: Fn(&'a str, &'a str) -> Result<O::Native>,
-    M: Fn(O::Native) -> O::Native,
 {
     match &args[0] {
         ColumnarValue::Array(a) => match a.data_type() {
@@ -211,7 +423,7 @@ where
                 }
 
                 Ok(ColumnarValue::Array(Arc::new(
-                    strings_to_primitive_function::<i32, O, _, _>(args, op, op2, name)?,
+                    strings_to_primitive_function::<i32, O, _>(args, op, name)?,
                 )))
             }
             other => {
@@ -236,7 +448,7 @@ where
                                         match op(a.as_str(), s.as_str()) {
                                             Ok(r) => {
                                                 val = Some(Ok(ColumnarValue::Scalar(
-                                                    S::scalar(Some(op2(r))),
+                                                    S::scalar(Some(r)),
                                                 )));
                                                 break;
                                             }
@@ -271,8 +483,7 @@ where
 
 /// given a function `op` that maps `&str`, `&str` to the first successful Result
 /// of an arrow native type, returns a `PrimitiveArray` after the application of the
-/// function to `args` and the subsequence application of the `op2` function to any
-/// successful result. This function calls the `op` function with the first and second
+/// function to `args`. This function calls the `op` function with the first and second
 /// argument and if not successful continues with first and third, first and fourth,
 /// etc until the result was successful or no more arguments are present.
 /// # Errors
@@ -280,17 +491,15 @@ where
 /// * the number of arguments is not > 1 or
 /// * the array arguments are not castable to a `GenericStringArray` or
 /// * the function `op` errors for all input
-pub(crate) fn strings_to_primitive_function<'a, T, O, F, F2>(
+pub(crate) fn strings_to_primitive_function<'a, T, O, F>(
     args: &'a [ColumnarValue],
     op: F,
-    op2: F2,
     name: &str,
 ) -> Result<PrimitiveArray<O>>
 where
     O: ArrowPrimitiveType,
     T: OffsetSizeTrait,
     F: Fn(&'a str, &'a str) -> Result<O::Native>,
-    F2: Fn(O::Native) -> O::Native,
 {
     if args.len() < 2 {
         return exec_err!(
@@ -345,7 +554,7 @@ where
                     };
 
                     if r.is_ok() {
-                        val = Some(Ok(op2(r.unwrap())));
+                        val = Some(r);
                         break;
                     } else {
                         val = Some(r);

--- a/datafusion/functions/src/datetime/to_date.rs
+++ b/datafusion/functions/src/datetime/to_date.rs
@@ -17,7 +17,7 @@
 
 use std::any::Any;
 
-use arrow::array::types::Date32Type;
+use arrow::array::types::{Date32Type, TimestampNanosecondType};
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::Date32;
 
@@ -42,7 +42,7 @@ impl ToDateFunc {
             1 => handle::<Date32Type, _, Date32Type>(
                 args,
                 |s| {
-                    string_to_timestamp_nanos_shim(s)
+                    string_to_timestamp::<TimestampNanosecondType>(s)
                         .map(|n| n / (1_000_000 * 24 * 60 * 60 * 1_000))
                         .and_then(|v| {
                             v.try_into().map_err(|_| {
@@ -52,10 +52,10 @@ impl ToDateFunc {
                 },
                 "to_date",
             ),
-            n if n >= 2 => handle_multiple::<Date32Type, _, Date32Type, _>(
+            n if n >= 2 => handle_multiple::<Date32Type, _, Date32Type>(
                 args,
                 |s, format| {
-                    string_to_timestamp_nanos_formatted(s, format)
+                    string_to_timestamp_formatted::<TimestampNanosecondType>(s, format)
                         .map(|n| n / (1_000_000 * 24 * 60 * 60 * 1_000))
                         .and_then(|v| {
                             v.try_into().map_err(|_| {
@@ -63,7 +63,6 @@ impl ToDateFunc {
                             })
                         })
                 },
-                |n| n,
                 "to_date",
             ),
             _ => exec_err!("Unsupported 0 argument count for function to_date"),


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion/issues/9090.

## What changes are included in this PR?

**This is still work in progress.** The PR introduces a few simple optimizations to `to_timestamp` (without format). On my local machine, the performance improvement in the benchmarks is about 15%.

## Are these changes tested?

Yes, existing unit tests and benchmarks.

## Are there any user-facing changes?

No.