### PR TITLE
fix: duplicate output for HashJoinExec in CollectLeft mode

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -19,6 +19,7 @@
 
 use std::fmt;
 use std::mem::size_of;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::Poll;
 use std::{any::Any, usize, vec};
@@ -72,6 +73,9 @@ use datafusion_physical_expr::{PhysicalExpr, PhysicalExprRef};
 
 use ahash::RandomState;
 use futures::{ready, Stream, StreamExt, TryStreamExt};
+use parking_lot::Mutex;
+
+type SharedBitmapBuilder = Mutex<BooleanBufferBuilder>;
 
 /// HashTable and input data for the left (build side) of a join
 struct JoinLeftData {
@@ -79,6 +83,11 @@ struct JoinLeftData {
     hash_map: JoinHashMap,
     /// The input rows for the build side
     batch: RecordBatch,
+    /// Shared bitmap builder for visited left indices
+    visited_indices_bitmap: Mutex<BooleanBufferBuilder>,
+    /// Counter of running probe-threads, potentially
+    /// able to update `visited_indices_bitmap`
+    running_threads_counter: AtomicUsize,
     /// Memory reservation that tracks memory used by `hash_map` hash table
     /// `batch`. Cleared on drop.
     #[allow(dead_code)]
@@ -90,18 +99,17 @@ impl JoinLeftData {
     fn new(
         hash_map: JoinHashMap,
         batch: RecordBatch,
+        visited_indices_bitmap: SharedBitmapBuilder,
+        running_threads_counter: AtomicUsize,
         reservation: MemoryReservation,
     ) -> Self {
         Self {
             hash_map,
             batch,
+            visited_indices_bitmap,
+            running_threads_counter,
             reservation,
         }
-    }
-
-    /// Returns the number of rows in the build side
-    fn num_rows(&self) -> usize {
-        self.batch.num_rows()
     }
 
     /// return a reference to the hash map
@@ -112,6 +120,17 @@ impl JoinLeftData {
     /// returns a reference to the build side batch
     fn batch(&self) -> &RecordBatch {
         &self.batch
+    }
+
+    /// returns a reference to the visited indices bitmap
+    fn visited_indices_bitmap(&self) -> &SharedBitmapBuilder {
+        &self.visited_indices_bitmap
+    }
+
+    /// Decrements the counter of running threads, and returns `true`
+    /// if caller is the last running thread
+    fn report_probe_completed(&self) -> bool {
+        self.running_threads_counter.fetch_sub(1, Ordering::Relaxed) == 1
     }
 }
 
@@ -715,6 +734,8 @@ impl ExecutionPlan for HashJoinExec {
                     context.clone(),
                     join_metrics.clone(),
                     reservation,
+                    need_produce_result_in_final(self.join_type),
+                    self.right().output_partitioning().partition_count(),
                 )
             }),
             PartitionMode::Partitioned => {
@@ -730,6 +751,8 @@ impl ExecutionPlan for HashJoinExec {
                     context.clone(),
                     join_metrics.clone(),
                     reservation,
+                    need_produce_result_in_final(self.join_type),
+                    1,
                 ))
             }
             PartitionMode::Auto => {
@@ -741,9 +764,6 @@ impl ExecutionPlan for HashJoinExec {
         };
 
         let batch_size = context.session_config().batch_size();
-
-        let reservation = MemoryConsumer::new(format!("HashJoinStream[{partition}]"))
-            .register(context.memory_pool());
 
         // we have the batches and the hash map with their keys. We can how create a stream
         // over the right that uses this information to issue new batches.
@@ -769,7 +789,6 @@ impl ExecutionPlan for HashJoinExec {
             random_state: self.random_state.clone(),
             join_metrics,
             null_equals_null: self.null_equals_null,
-            reservation,
             state: HashJoinStreamState::WaitBuildSide,
             build_side: BuildSide::Initial(BuildSideInitialState { left_fut }),
             batch_size,
@@ -808,6 +827,7 @@ impl ExecutionPlan for HashJoinExec {
 
 /// Reads the left (build) side of the input, buffering it in memory, to build a
 /// hash table (`LeftJoinData`)
+#[allow(clippy::too_many_arguments)]
 async fn collect_left_input(
     partition: Option<usize>,
     random_state: RandomState,
@@ -816,6 +836,8 @@ async fn collect_left_input(
     context: Arc<TaskContext>,
     metrics: BuildProbeJoinMetrics,
     reservation: MemoryReservation,
+    with_visited_indices_bitmap: bool,
+    right_input_partitions: usize,
 ) -> Result<JoinLeftData> {
     let schema = left.schema();
 
@@ -892,10 +914,29 @@ async fn collect_left_input(
         )?;
         offset += batch.num_rows();
     }
-    // Merge all batches into a single batch, so we
-    // can directly index into the arrays
+    // Merge all batches into a single batch, so we can directly index into the arrays
     let single_batch = concat_batches(&schema, batches_iter)?;
-    let data = JoinLeftData::new(hashmap, single_batch, reservation);
+
+    // Reserve additional memory for visited indices bitmap and create shared builder
+    let visited_indices_bitmap = if with_visited_indices_bitmap {
+        let bitmap_size = bit_util::ceil(single_batch.num_rows(), 8);
+        reservation.try_grow(bitmap_size)?;
+        metrics.build_mem_used.add(bitmap_size);
+
+        let mut bitmap_buffer = BooleanBufferBuilder::new(single_batch.num_rows());
+        bitmap_buffer.append_n(num_rows, false);
+        bitmap_buffer
+    } else {
+        BooleanBufferBuilder::new(0)
+    };
+
+    let data = JoinLeftData::new(
+        hashmap,
+        single_batch,
+        Mutex::new(visited_indices_bitmap),
+        AtomicUsize::new(right_input_partitions),
+        reservation,
+    );
 
     Ok(data)
 }
@@ -965,10 +1006,6 @@ struct BuildSideInitialState {
 struct BuildSideReadyState {
     /// Collected build-side data
     left_data: Arc<JoinLeftData>,
-    /// Which build-side rows have been matched while creating output.
-    /// For some OUTER joins, we need to know which rows have not been matched
-    /// to produce the correct output.
-    visited_left_side: BooleanBufferBuilder,
 }
 
 impl BuildSide {
@@ -1087,8 +1124,6 @@ struct HashJoinStream {
     column_indices: Vec<ColumnIndex>,
     /// If null_equals_null is true, null == null else null != null
     null_equals_null: bool,
-    /// Memory reservation
-    reservation: MemoryReservation,
     /// State of the stream
     state: HashJoinStreamState,
     /// Build side
@@ -1250,6 +1285,14 @@ pub fn equal_rows_arr(
     ))
 }
 
+fn get_final_indices_from_shared_bitmap(
+    shared_bitmap: &SharedBitmapBuilder,
+    join_type: JoinType,
+) -> (UInt64Array, UInt32Array) {
+    let bitmap = shared_bitmap.lock();
+    get_final_indices_from_bit_map(&bitmap, join_type)
+}
+
 impl HashJoinStream {
     /// Separate implementation function that unpins the [`HashJoinStream`] so
     /// that partial borrows work correctly
@@ -1292,35 +1335,8 @@ impl HashJoinStream {
             .get_shared(cx))?;
         build_timer.done();
 
-        // Reserving memory for visited_left_side bitmap in case it hasn't been initialized yet
-        // and join_type requires to store it
-        if need_produce_result_in_final(self.join_type) {
-            // TODO: Replace `ceil` wrapper with stable `div_cell` after
-            // https://github.com/rust-lang/rust/issues/88581
-            let visited_bitmap_size = bit_util::ceil(left_data.num_rows(), 8);
-            self.reservation.try_grow(visited_bitmap_size)?;
-            self.join_metrics.build_mem_used.add(visited_bitmap_size);
-        }
-
-        let visited_left_side = if need_produce_result_in_final(self.join_type) {
-            let num_rows = left_data.num_rows();
-            // Some join types need to track which row has be matched or unmatched:
-            // `left semi` join:  need to use the bitmap to produce the matched row in the left side
-            // `left` join:       need to use the bitmap to produce the unmatched row in the left side with null
-            // `left anti` join:  need to use the bitmap to produce the unmatched row in the left side
-            // `full` join:       need to use the bitmap to produce the unmatched row in the left side with null
-            let mut buffer = BooleanBufferBuilder::new(num_rows);
-            buffer.append_n(num_rows, false);
-            buffer
-        } else {
-            BooleanBufferBuilder::new(0)
-        };
-
         self.state = HashJoinStreamState::FetchProbeBatch;
-        self.build_side = BuildSide::Ready(BuildSideReadyState {
-            left_data,
-            visited_left_side,
-        });
+        self.build_side = BuildSide::Ready(BuildSideReadyState { left_data });
 
         Poll::Ready(Ok(StatefulStreamResult::Continue))
     }
@@ -1405,8 +1421,9 @@ impl HashJoinStream {
 
         // mark joined left-side indices as visited, if required by join type
         if need_produce_result_in_final(self.join_type) {
+            let mut bitmap = build_side.left_data.visited_indices_bitmap().lock();
             left_indices.iter().flatten().for_each(|x| {
-                build_side.visited_left_side.set_bit(x as usize, true);
+                bitmap.set_bit(x as usize, true);
             });
         }
 
@@ -1485,15 +1502,20 @@ impl HashJoinStream {
 
         if !need_produce_result_in_final(self.join_type) {
             self.state = HashJoinStreamState::Completed;
-
             return Ok(StatefulStreamResult::Continue);
         }
 
         let build_side = self.build_side.try_as_ready()?;
+        if !build_side.left_data.report_probe_completed() {
+            self.state = HashJoinStreamState::Completed;
+            return Ok(StatefulStreamResult::Continue);
+        }
 
         // use the global left bitmap to produce the left indices and right indices
-        let (left_side, right_side) =
-            get_final_indices_from_bit_map(&build_side.visited_left_side, self.join_type);
+        let (left_side, right_side) = get_final_indices_from_shared_bitmap(
+            build_side.left_data.visited_indices_bitmap(),
+            self.join_type,
+        );
         let empty_right_batch = RecordBatch::new_empty(self.right.schema());
         // use the left and right indices to produce the batch result
         let result = build_batch_from_indices(
@@ -1645,25 +1667,72 @@ mod tests {
         null_equals_null: bool,
         context: Arc<TaskContext>,
     ) -> Result<(Vec<String>, Vec<RecordBatch>)> {
+        join_collect_with_partition_mode(
+            left,
+            right,
+            on,
+            join_type,
+            PartitionMode::Partitioned,
+            null_equals_null,
+            context,
+        )
+        .await
+    }
+
+    async fn join_collect_with_partition_mode(
+        left: Arc<dyn ExecutionPlan>,
+        right: Arc<dyn ExecutionPlan>,
+        on: JoinOn,
+        join_type: &JoinType,
+        partition_mode: PartitionMode,
+        null_equals_null: bool,
+        context: Arc<TaskContext>,
+    ) -> Result<(Vec<String>, Vec<RecordBatch>)> {
         let partition_count = 4;
 
         let (left_expr, right_expr) =
             on.iter().map(|(l, r)| (l.clone(), r.clone())).unzip();
 
-        let join = HashJoinExec::try_new(
-            Arc::new(RepartitionExec::try_new(
+        let left_repartitioned: Arc<dyn ExecutionPlan> = match partition_mode {
+            PartitionMode::CollectLeft => Arc::new(CoalescePartitionsExec::new(left)),
+            PartitionMode::Partitioned => Arc::new(RepartitionExec::try_new(
                 left,
                 Partitioning::Hash(left_expr, partition_count),
             )?),
-            Arc::new(RepartitionExec::try_new(
+            PartitionMode::Auto => {
+                return internal_err!("Unexpected PartitionMode::Auto in join tests")
+            }
+        };
+
+        let right_repartitioned: Arc<dyn ExecutionPlan> = match partition_mode {
+            PartitionMode::CollectLeft => {
+                let partition_column_name = right.schema().field(0).name().clone();
+                let partition_expr = vec![Arc::new(Column::new_with_schema(
+                    &partition_column_name,
+                    &right.schema(),
+                )?) as _];
+                Arc::new(RepartitionExec::try_new(
+                    right,
+                    Partitioning::Hash(partition_expr, partition_count),
+                )?) as _
+            }
+            PartitionMode::Partitioned => Arc::new(RepartitionExec::try_new(
                 right,
                 Partitioning::Hash(right_expr, partition_count),
             )?),
+            PartitionMode::Auto => {
+                return internal_err!("Unexpected PartitionMode::Auto in join tests")
+            }
+        };
+
+        let join = HashJoinExec::try_new(
+            left_repartitioned,
+            right_repartitioned,
             on,
             None,
             join_type,
             None,
-            PartitionMode::Partitioned,
+            partition_mode,
             null_equals_null,
         )?;
 
@@ -3312,6 +3381,120 @@ mod tests {
             "+---+---+---+----+---+---+",
         ];
         assert_batches_sorted_eq!(expected, &batches);
+
+        Ok(())
+    }
+
+    /// Test for parallelised HashJoinExec with PartitionMode::CollectLeft
+    #[tokio::test]
+    async fn test_collect_left_multiple_partitions_join() -> Result<()> {
+        let task_ctx = Arc::new(TaskContext::default());
+        let left = build_table(
+            ("a1", &vec![1, 2, 3]),
+            ("b1", &vec![4, 5, 7]),
+            ("c1", &vec![7, 8, 9]),
+        );
+        let right = build_table(
+            ("a2", &vec![10, 20, 30]),
+            ("b2", &vec![4, 5, 6]),
+            ("c2", &vec![70, 80, 90]),
+        );
+        let on = vec![(
+            Arc::new(Column::new_with_schema("b1", &left.schema()).unwrap()) as _,
+            Arc::new(Column::new_with_schema("b2", &right.schema()).unwrap()) as _,
+        )];
+
+        let expected_inner = vec![
+            "+----+----+----+----+----+----+",
+            "| a1 | b1 | c1 | a2 | b2 | c2 |",
+            "+----+----+----+----+----+----+",
+            "| 1  | 4  | 7  | 10 | 4  | 70 |",
+            "| 2  | 5  | 8  | 20 | 5  | 80 |",
+            "+----+----+----+----+----+----+",
+        ];
+        let expected_left = vec![
+            "+----+----+----+----+----+----+",
+            "| a1 | b1 | c1 | a2 | b2 | c2 |",
+            "+----+----+----+----+----+----+",
+            "| 1  | 4  | 7  | 10 | 4  | 70 |",
+            "| 2  | 5  | 8  | 20 | 5  | 80 |",
+            "| 3  | 7  | 9  |    |    |    |",
+            "+----+----+----+----+----+----+",
+        ];
+        let expected_right = vec![
+            "+----+----+----+----+----+----+",
+            "| a1 | b1 | c1 | a2 | b2 | c2 |",
+            "+----+----+----+----+----+----+",
+            "|    |    |    | 30 | 6  | 90 |",
+            "| 1  | 4  | 7  | 10 | 4  | 70 |",
+            "| 2  | 5  | 8  | 20 | 5  | 80 |",
+            "+----+----+----+----+----+----+",
+        ];
+        let expected_full = vec![
+            "+----+----+----+----+----+----+",
+            "| a1 | b1 | c1 | a2 | b2 | c2 |",
+            "+----+----+----+----+----+----+",
+            "|    |    |    | 30 | 6  | 90 |",
+            "| 1  | 4  | 7  | 10 | 4  | 70 |",
+            "| 2  | 5  | 8  | 20 | 5  | 80 |",
+            "| 3  | 7  | 9  |    |    |    |",
+            "+----+----+----+----+----+----+",
+        ];
+        let expected_left_semi = vec![
+            "+----+----+----+",
+            "| a1 | b1 | c1 |",
+            "+----+----+----+",
+            "| 1  | 4  | 7  |",
+            "| 2  | 5  | 8  |",
+            "+----+----+----+",
+        ];
+        let expected_left_anti = vec![
+            "+----+----+----+",
+            "| a1 | b1 | c1 |",
+            "+----+----+----+",
+            "| 3  | 7  | 9  |",
+            "+----+----+----+",
+        ];
+        let expected_right_semi = vec![
+            "+----+----+----+",
+            "| a2 | b2 | c2 |",
+            "+----+----+----+",
+            "| 10 | 4  | 70 |",
+            "| 20 | 5  | 80 |",
+            "+----+----+----+",
+        ];
+        let expected_right_anti = vec![
+            "+----+----+----+",
+            "| a2 | b2 | c2 |",
+            "+----+----+----+",
+            "| 30 | 6  | 90 |",
+            "+----+----+----+",
+        ];
+
+        let test_cases = vec![
+            (JoinType::Inner, expected_inner),
+            (JoinType::Left, expected_left),
+            (JoinType::Right, expected_right),
+            (JoinType::Full, expected_full),
+            (JoinType::LeftSemi, expected_left_semi),
+            (JoinType::LeftAnti, expected_left_anti),
+            (JoinType::RightSemi, expected_right_semi),
+            (JoinType::RightAnti, expected_right_anti),
+        ];
+
+        for (join_type, expected) in test_cases {
+            let (_, batches) = join_collect_with_partition_mode(
+                left.clone(),
+                right.clone(),
+                on.clone(),
+                &join_type,
+                PartitionMode::CollectLeft,
+                false,
+                task_ctx.clone(),
+            )
+            .await?;
+            assert_batches_sorted_eq!(expected, &batches);
+        }
 
         Ok(())
     }

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3662,18 +3662,16 @@ logical_plan
 physical_plan
 01)ProjectionExec: expr=[c@2 as c, d@3 as d, e@0 as e, f@1 as f]
 02)--CoalesceBatchesExec: target_batch_size=2
-03)----HashJoinExec: mode=Partitioned, join_type=Full, on=[(e@0, c@0)]
+03)----HashJoinExec: mode=CollectLeft, join_type=Full, on=[(e@0, c@0)]
 04)------ProjectionExec: expr=[1 as e, 3 as f]
 05)--------PlaceholderRowExec
-06)------CoalesceBatchesExec: target_batch_size=2
-07)--------RepartitionExec: partitioning=Hash([c@0], 1), input_partitions=2
-08)----------UnionExec
-09)------------ProjectionExec: expr=[1 as c, 2 as d]
-10)--------------PlaceholderRowExec
-11)------------ProjectionExec: expr=[1 as c, 3 as d]
-12)--------------PlaceholderRowExec
+06)------UnionExec
+07)--------ProjectionExec: expr=[1 as c, 2 as d]
+08)----------PlaceholderRowExec
+09)--------ProjectionExec: expr=[1 as c, 3 as d]
+10)----------PlaceholderRowExec
 
-query IIII
+query IIII rowsort
 SELECT * FROM (
     SELECT 1 as c, 2 as d
     UNION ALL


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

While #9676, found that at this moment `HashJoinExec` works incorrect in case of LEFT / FULL types. Currently, construction of these joins is prevented by physical optimizer join_selection rule. This PR adds support for all join types in CollectLeft mode.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- `JoinLeftData` now contains bitmap with visited left indices and atomic counter of total right-side threads (streams), updating this particular `JoinLeftData` object (initial value will always be 1 for partitioned joins, and "number of right-side partitions" for CollectLeft)
- In the beginning of `process_unmatched_build_batch`, when it's guaranteed that there won't be any further updates of visited indices bitmap, each `HashJoinStream` decrements the counter of running partitions by calling `report_probe_completed`, and only the last caller-thread (determined by counter value) will return unmatched left-side data
- Conditional logic for join types removed from `try_collect_left` in join_selection rule 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, by adding test case for parallel (multiple right-side partitions) hash join execution with CollectLeft partition mode 

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
