### PR TITLE
WIP: directly pass Vec<Expr> instead of &[Expr] to avoid clone

### DIFF
--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -716,9 +716,7 @@ impl TreeNodeRewriter for CommonSubexprRewriter<'_> {
             Some((_, counter, _, symbol)) => {
                 // if has a commonly used (a.k.a. 1+ use) expr
                 if *counter > 1 {
-                    if !self.affected_id.contains(curr_id) {
-                        self.affected_id.insert(curr_id.clone());
-                    }
+                    self.affected_id.insert(curr_id.clone());
 
                     let expr_name = expr.display_name()?;
                     // Alias this `Column` expr to it original "expr name",


### PR DESCRIPTION
## Which issue does this PR close?
change performance of eliminate_subexpr. Still in progress, this is just for benchmark test
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

part of #9873 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
