### PR TITLE
Avoid copies in `TypeCoercion` via TreeNode API

### DIFF
--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -625,6 +625,12 @@ impl<T> Transformed<T> {
         Self::new(data, false, TreeNodeRecursion::Continue)
     }
 
+    /// If not already, sets `self.transformed` to true if `transformed` is true.
+    pub fn update_transformed(mut self, transformed: bool) -> Self {
+        self.transformed |= transformed;
+        self
+    }
+
     /// Applies the given `f` to the data of this [`Transformed`] object.
     pub fn update_data<U, F: FnOnce(T) -> U>(self, f: F) -> Transformed<U> {
         Transformed::new(f(self.data), self.transformed, self.tnr)

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -815,6 +815,7 @@ impl LogicalPlan {
             }
         }
     }
+
     /// Replaces placeholder param values (like `$1`, `$2`) in [`LogicalPlan`]
     /// with the specified `param_values`.
     ///

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -84,6 +84,10 @@ fn analyze_internal(
         ..
     } = plan.map_children(|plan| analyze_internal(external_schema, plan))?;
 
+    // if any of the expressions were rewritten, we need to recreate the plan to
+    // recalculate the schema. At the moment this requires a copy
+    let plan = plan.recalculate_schema()?;
+
     // get schema representing all available input fields. This is used for data type
     // resolution only, so order does not matter here
     let mut schema = merge_schema(plan.inputs());
@@ -106,30 +110,21 @@ fn analyze_internal(
     };
 
     let preserver = NamePreserver::new(&plan);
-    let transformed_plan = plan.map_expressions(|expr| {
+    plan.map_expressions(|expr| {
         // ensure aggregate names don't change:
         // https://github.com/apache/datafusion/issues/3555
         let original_name = preserver.save(&expr)?;
         expr.rewrite(&mut expr_rewrite)?
             .map_data(|expr| original_name.restore(expr))
-    })?;
+    })?
+        .transform_data(|plan| {
+            // recalculate the schema after the rewrites
+            plan.recalculate_schema().map(Transformed::yes)
+        })
 
-    // if any of the expressions were rewritten, we need to recreate the plan to
-    // recalculate the schema. At the moment this requires a copy
-    if transformed_plan.transformed || children_transformed {
-        // TODO avoid this copy
-        let plan = transformed_plan.data;
-        let new_inputs = plan
-            .inputs()
-            .into_iter()
-            .map(|input| input.clone())
-            .collect::<Vec<_>>();
-
-        plan.with_new_exprs(plan.expressions(), new_inputs)
-            .map(Transformed::yes)
-    } else {
-        Ok(transformed_plan)
-    }
+    //} else {
+    //    Ok(transformed_plan)
+    //}
 }
 
 pub(crate) struct TypeCoercionRewriter {


### PR DESCRIPTION
Draft as it has a failure in tpchds planning for some reason

## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/10210

Part of https://github.com/apache/arrow-datafusion/issues/9637 -- let's make DataFusion planning faster by not copying so much



## Rationale for this change
Now that we have the nice TreeNode API thanks to #8913 and @peter-toth  let's use it to both simplify the code and avoid copies


## What changes are included in this PR?
1. Avoid copies in `TypeCoercion` via TreeNode API


## Are these changes tested?
Existing CI

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
