### PR TITLE
Optimization: make the most of Hint::AcceptsSingular when call make_scalar_function to Improve performance

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -63,6 +63,7 @@ path = "src/lib.rs"
 
 [dependencies]
 arrow = { workspace = true }
+bitflags = "2.5.0"
 base64 = { version = "0.22", optional = true }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }

--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -133,3 +133,8 @@ required-features = ["string_expressions"]
 harness = false
 name = "upper"
 required-features = ["string_expressions"]
+
+[[bench]]
+harness = false
+name = "overlay"
+required-features = ["string_expressions"]

--- a/datafusion/functions/benches/overlay.rs
+++ b/datafusion/functions/benches/overlay.rs
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::StringArray;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use datafusion_common::ScalarValue;
+use datafusion_expr::ColumnarValue;
+use datafusion_functions::string;
+use std::sync::Arc;
+
+fn create_4args(size: usize) -> Vec<ColumnarValue> {
+    let array: StringArray = std::iter::repeat(Some("Txxxxas")).take(size).collect();
+    let characters = ScalarValue::Utf8(Some("hom".to_string()));
+    let pos = ScalarValue::Int64(Some(2));
+    let len = ScalarValue::Int64(Some(4));
+    vec![
+        ColumnarValue::Array(Arc::new(array)),
+        ColumnarValue::Scalar(characters),
+        ColumnarValue::Scalar(pos),
+        ColumnarValue::Scalar(len),
+    ]
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let overlay = string::overlay();
+    for size in [1024, 4096, 8192] {
+        let args = create_4args(size);
+        let mut group = c.benchmark_group("overlay_with_4args");
+        group.bench_function(BenchmarkId::new("overlay", size), |b| {
+            b.iter(|| criterion::black_box(overlay.invoke(&args).unwrap()))
+        });
+        group.finish();
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -396,3 +396,237 @@ macro_rules! make_function_inputs2 {
             .collect::<$ARRAY_TYPE1>()
     }};
 }
+
+macro_rules! array_iter {
+    ($ARRAY:expr) => {{
+        $ARRAY.iter()
+    }};
+}
+
+macro_rules! scalar_iter {
+    ($ARRAY:expr) => {{
+        let value = if $ARRAY.is_null(0) {
+            None
+        } else {
+            Some($ARRAY.value(0))
+        };
+        std::iter::repeat(value)
+    }};
+}
+
+macro_rules! make_function_3args {
+    (ScalarFlags::None, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr) => {
+        $FUNC(array_iter!($ARG0), array_iter!($ARG1), array_iter!($ARG2))
+    };
+    (ScalarFlags::A, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr) => {
+        $FUNC(scalar_iter!($ARG0), array_iter!($ARG1), array_iter!($ARG2))
+    };
+    (ScalarFlags::B, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr) => {
+        $FUNC(array_iter!($ARG0), scalar_iter!($ARG1), array_iter!($ARG2))
+    };
+    (ScalarFlags::C, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr) => {
+        $FUNC(array_iter!($ARG0), array_iter!($ARG1), scalar_iter!($ARG2))
+    };
+    (ScalarFlags::AB, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr) => {
+        $FUNC(scalar_iter!($ARG0), scalar_iter!($ARG1), array_iter!($ARG2))
+    };
+    (ScalarFlags::AC, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr) => {
+        $FUNC(scalar_iter!($ARG0), array_iter!($ARG1), scalar_iter!($ARG2))
+    };
+    (ScalarFlags::BC, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr) => {
+        $FUNC(array_iter!($ARG0), scalar_iter!($ARG1), scalar_iter!($ARG2))
+    };
+    (ScalarFlags::ABC, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr) => {
+        $FUNC(array_iter!($ARG0), array_iter!($ARG1), array_iter!($ARG2))
+    };
+}
+
+macro_rules! make_function_4args {
+    (ScalarFlags::None, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            array_iter!($ARG0),
+            array_iter!($ARG1),
+            array_iter!($ARG2),
+            array_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::A, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            scalar_iter!($ARG0),
+            array_iter!($ARG1),
+            array_iter!($ARG2),
+            array_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::B, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            array_iter!($ARG0),
+            scalar_iter!($ARG1),
+            array_iter!($ARG2),
+            array_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::C, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            array_iter!($ARG0),
+            array_iter!($ARG1),
+            scalar_iter!($ARG2),
+            array_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::D, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            array_iter!($ARG0),
+            array_iter!($ARG1),
+            array_iter!($ARG2),
+            scalar_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::AB, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            scalar_iter!($ARG0),
+            scalar_iter!($ARG1),
+            array_iter!($ARG2),
+            array_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::AC, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            scalar_iter!($ARG0),
+            array_iter!($ARG1),
+            scalar_iter!($ARG2),
+            array_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::AD, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            scalar_iter!($ARG0),
+            array_iter!($ARG1),
+            array_iter!($ARG2),
+            scalar_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::BC, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            array_iter!($ARG0),
+            scalar_iter!($ARG1),
+            scalar_iter!($ARG2),
+            array_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::BD, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            array_iter!($ARG0),
+            scalar_iter!($ARG1),
+            array_iter!($ARG2),
+            scalar_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::CD, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            array_iter!($ARG0),
+            array_iter!($ARG1),
+            scalar_iter!($ARG2),
+            scalar_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::ABC, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            scalar_iter!($ARG0),
+            scalar_iter!($ARG1),
+            scalar_iter!($ARG2),
+            array_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::ABD, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            scalar_iter!($ARG0),
+            scalar_iter!($ARG1),
+            array_iter!($ARG2),
+            scalar_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::ACD, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            scalar_iter!($ARG0),
+            array_iter!($ARG1),
+            scalar_iter!($ARG2),
+            scalar_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::BCD, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        $FUNC(
+            array_iter!($ARG0),
+            scalar_iter!($ARG1),
+            scalar_iter!($ARG2),
+            scalar_iter!($ARG3),
+        )
+    };
+    (ScalarFlags::ABCD, $FUNC:ident, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        // all args use array_iter
+        $FUNC(
+            array_iter!($ARG0),
+            array_iter!($ARG1),
+            array_iter!($ARG2),
+            array_iter!($ARG3),
+        )
+    };
+}
+
+macro_rules! invoke_function_impl {
+    ($FLAG:expr, $FUNC:expr, $ARG0:expr, $ARG1:expr, $ARG2:expr, [$($FLAG_ITEM:tt),+]) => {
+        match $FLAG {
+            $(ScalarFlags::$FLAG_ITEM => {
+                let func = $FUNC;
+                make_function_3args!(
+                    ScalarFlags::$FLAG_ITEM,
+                    func,
+                    $ARG0,
+                    $ARG1,
+                    $ARG2
+                )
+            }),+
+            _ => unreachable!("{:?}", $FLAG),
+        }
+    };
+    ($FLAG:expr, $FUNC:expr, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr, [$($FLAG_ITEM:tt),+]) => {
+        match $FLAG {
+            $(ScalarFlags::$FLAG_ITEM => {
+                let func = $FUNC;
+                make_function_4args!(
+                    ScalarFlags::$FLAG_ITEM,
+                    func,
+                    $ARG0,
+                    $ARG1,
+                    $ARG2,
+                    $ARG3
+                )
+            }),+
+            _ => unreachable!("{:?}", $FLAG),
+        }
+    };
+}
+
+macro_rules! invoke_function {
+    ($FLAG:expr, $FUNC:expr, $ARG0:expr, $ARG1:expr, $ARG2:expr) => {
+        invoke_function_impl!(
+            $FLAG,
+            $FUNC,
+            $ARG0,
+            $ARG1,
+            $ARG2,
+            [None, A, B, C, AB, AC, BC, ABC]
+        )
+    };
+    ($FLAG:expr, $FUNC:expr, $ARG0:expr, $ARG1:expr, $ARG2:expr, $ARG3:expr) => {
+        invoke_function_impl!(
+            $FLAG,
+            $FUNC,
+            $ARG0,
+            $ARG1,
+            $ARG2,
+            $ARG3,
+            [None, A, B, C, D, AB, AC, AD, BC, BD, CD, ABC, ABD, ACD, BCD, ABCD]
+        )
+    };
+}

--- a/datafusion/functions/src/string/overlay.rs
+++ b/datafusion/functions/src/string/overlay.rs
@@ -18,7 +18,6 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow::array::Array;
 use arrow::array::{ArrayRef, GenericStringArray, OffsetSizeTrait};
 use arrow::datatypes::DataType;
 
@@ -29,8 +28,7 @@ use datafusion_expr::{ColumnarValue, Volatility};
 use datafusion_expr::{ScalarUDFImpl, Signature};
 use datafusion_physical_expr::functions::Hint;
 
-use crate::create_adaptive_array_iter;
-use crate::utils::{make_scalar_function, utf8_to_str_type};
+use crate::utils::{adaptive_array_iter, make_scalar_function, utf8_to_str_type};
 
 #[derive(Debug)]
 pub struct OverlayFunc {
@@ -107,8 +105,8 @@ pub fn overlay<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             let characters_array = as_generic_string_array::<T>(&args[1])?;
             let pos_num = as_int64_array(&args[2])?;
 
-            let characters_array_iter = create_adaptive_array_iter!(characters_array);
-            let pos_num_iter = create_adaptive_array_iter!(pos_num);
+            let characters_array_iter = adaptive_array_iter(characters_array.iter());
+            let pos_num_iter = adaptive_array_iter(pos_num.iter());
 
             let result = string_array
                 .iter()
@@ -148,9 +146,9 @@ pub fn overlay<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             let pos_num = as_int64_array(&args[2])?;
             let len_num = as_int64_array(&args[3])?;
 
-            let characters_array_iter = create_adaptive_array_iter!(characters_array);
-            let pos_num_iter = create_adaptive_array_iter!(pos_num);
-            let len_num_iter = create_adaptive_array_iter!(len_num);
+            let characters_array_iter = adaptive_array_iter(characters_array.iter());
+            let pos_num_iter = adaptive_array_iter(pos_num.iter());
+            let len_num_iter = adaptive_array_iter(len_num.iter());
 
             let result = string_array
                 .iter()

--- a/datafusion/functions/src/string/overlay.rs
+++ b/datafusion/functions/src/string/overlay.rs
@@ -18,7 +18,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, GenericStringArray, OffsetSizeTrait};
+use arrow::array::{Array, ArrayRef, GenericStringArray, OffsetSizeTrait};
 use arrow::datatypes::DataType;
 
 use datafusion_common::cast::{as_generic_string_array, as_int64_array};
@@ -28,7 +28,7 @@ use datafusion_expr::{ColumnarValue, Volatility};
 use datafusion_expr::{ScalarUDFImpl, Signature};
 use datafusion_physical_expr::functions::Hint;
 
-use crate::utils::{adaptive_array_iter, make_scalar_function, utf8_to_str_type};
+use crate::utils::{make_scalar_function, utf8_to_str_type, ScalarFlags};
 
 #[derive(Debug)]
 pub struct OverlayFunc {
@@ -94,6 +94,80 @@ impl ScalarUDFImpl for OverlayFunc {
     }
 }
 
+pub fn overlay3<'a, T: OffsetSizeTrait>(
+    string_array_iter: impl Iterator<Item = Option<&'a str>>,
+    characters_array_iter: impl Iterator<Item = Option<&'a str>>,
+    pos_num_iter: impl Iterator<Item = Option<i64>>,
+) -> Result<ArrayRef> {
+    let result = string_array_iter
+        .zip(characters_array_iter)
+        .zip(pos_num_iter)
+        .map(|((string, characters), start_pos)| {
+            match (string, characters, start_pos) {
+                (Some(string), Some(characters), Some(start_pos)) => {
+                    let string_len = string.chars().count();
+                    let characters_len = characters.chars().count();
+                    let replace_len = characters_len as i64;
+                    let mut res = String::with_capacity(string_len.max(characters_len));
+
+                    //as sql replace index start from 1 while string index start from 0
+                    if start_pos > 1 && start_pos - 1 < string_len as i64 {
+                        let start = (start_pos - 1) as usize;
+                        res.push_str(&string[..start]);
+                    }
+                    res.push_str(characters);
+                    // if start + replace_len - 1 >= string_length, just to string end
+                    if start_pos + replace_len - 1 < string_len as i64 {
+                        let end = (start_pos + replace_len - 1) as usize;
+                        res.push_str(&string[end..]);
+                    }
+                    Ok(Some(res))
+                }
+                _ => Ok(None),
+            }
+        })
+        .collect::<Result<GenericStringArray<T>>>()?;
+    Ok(Arc::new(result) as ArrayRef)
+}
+
+pub fn overlay4<'a, T: OffsetSizeTrait>(
+    string_array_iter: impl Iterator<Item = Option<&'a str>>,
+    characters_array_iter: impl Iterator<Item = Option<&'a str>>,
+    pos_num_iter: impl Iterator<Item = Option<i64>>,
+    len_num_iter: impl Iterator<Item = Option<i64>>,
+) -> Result<ArrayRef> {
+    let result = string_array_iter
+        .zip(characters_array_iter)
+        .zip(pos_num_iter)
+        .zip(len_num_iter)
+        .map(|(((string, characters), start_pos), len)| {
+            match (string, characters, start_pos, len) {
+                (Some(string), Some(characters), Some(start_pos), Some(len)) => {
+                    let string_len = string.chars().count();
+                    let characters_len = characters.chars().count();
+                    let replace_len = len.min(string_len as i64);
+                    let mut res = String::with_capacity(string_len.max(characters_len));
+
+                    //as sql replace index start from 1 while string index start from 0
+                    if start_pos > 1 && start_pos - 1 < string_len as i64 {
+                        let start = (start_pos - 1) as usize;
+                        res.push_str(&string[..start]);
+                    }
+                    res.push_str(characters);
+                    // if start + replace_len - 1 >= string_length, just to string end
+                    if start_pos + replace_len - 1 < string_len as i64 {
+                        let end = (start_pos + replace_len - 1) as usize;
+                        res.push_str(&string[end..]);
+                    }
+                    Ok(Some(res))
+                }
+                _ => Ok(None),
+            }
+        })
+        .collect::<Result<GenericStringArray<T>>>()?;
+    Ok(Arc::new(result) as ArrayRef)
+}
+
 /// OVERLAY(string1 PLACING string2 FROM integer FOR integer2)
 /// Replaces a substring of string1 with string2 starting at the integer bit
 /// pgsql overlay('Txxxxas' placing 'hom' from 2 for 4) → Thomas
@@ -104,84 +178,31 @@ pub fn overlay<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             let string_array = as_generic_string_array::<T>(&args[0])?;
             let characters_array = as_generic_string_array::<T>(&args[1])?;
             let pos_num = as_int64_array(&args[2])?;
+            let flag = ScalarFlags::try_create(args)?;
 
-            let characters_array_iter = adaptive_array_iter(characters_array.iter());
-            let pos_num_iter = adaptive_array_iter(pos_num.iter());
-
-            let result = string_array
-                .iter()
-                .zip(characters_array_iter)
-                .zip(pos_num_iter)
-                .map(|((string, characters), start_pos)| {
-                    match (string, characters, start_pos) {
-                        (Some(string), Some(characters), Some(start_pos)) => {
-                            let string_len = string.chars().count();
-                            let characters_len = characters.chars().count();
-                            let replace_len = characters_len as i64;
-                            let mut res =
-                                String::with_capacity(string_len.max(characters_len));
-
-                            //as sql replace index start from 1 while string index start from 0
-                            if start_pos > 1 && start_pos - 1 < string_len as i64 {
-                                let start = (start_pos - 1) as usize;
-                                res.push_str(&string[..start]);
-                            }
-                            res.push_str(characters);
-                            // if start + replace_len - 1 >= string_length, just to string end
-                            if start_pos + replace_len - 1 < string_len as i64 {
-                                let end = (start_pos + replace_len - 1) as usize;
-                                res.push_str(&string[end..]);
-                            }
-                            Ok(Some(res))
-                        }
-                        _ => Ok(None),
-                    }
-                })
-                .collect::<Result<GenericStringArray<T>>>()?;
-            Ok(Arc::new(result) as ArrayRef)
+            invoke_function!(
+                flag,
+                |arg0, arg1, arg2| overlay3::<T>(arg0, arg1, arg2),
+                string_array,
+                characters_array,
+                pos_num
+            )
         }
         4 => {
             let string_array = as_generic_string_array::<T>(&args[0])?;
             let characters_array = as_generic_string_array::<T>(&args[1])?;
             let pos_num = as_int64_array(&args[2])?;
             let len_num = as_int64_array(&args[3])?;
+            let flag = ScalarFlags::try_create(args)?;
 
-            let characters_array_iter = adaptive_array_iter(characters_array.iter());
-            let pos_num_iter = adaptive_array_iter(pos_num.iter());
-            let len_num_iter = adaptive_array_iter(len_num.iter());
-
-            let result = string_array
-                .iter()
-                .zip(characters_array_iter)
-                .zip(pos_num_iter)
-                .zip(len_num_iter)
-                .map(|(((string, characters), start_pos), len)| {
-                    match (string, characters, start_pos, len) {
-                        (Some(string), Some(characters), Some(start_pos), Some(len)) => {
-                            let string_len = string.chars().count();
-                            let characters_len = characters.chars().count();
-                            let replace_len = len.min(string_len as i64);
-                            let mut res =
-                                String::with_capacity(string_len.max(characters_len));
-
-                            //as sql replace index start from 1 while string index start from 0
-                            if start_pos > 1 && start_pos - 1 < string_len as i64 {
-                                let start = (start_pos - 1) as usize;
-                                res.push_str(&string[..start]);
-                            }
-                            res.push_str(characters);
-                            // if start + replace_len - 1 >= string_length, just to string end
-                            if start_pos + replace_len - 1 < string_len as i64 {
-                                let end = (start_pos + replace_len - 1) as usize;
-                                res.push_str(&string[end..]);
-                            }
-                            Ok(Some(res))
-                        }
-                        _ => Ok(None),
-                    }
-                })
-                .collect::<Result<GenericStringArray<T>>>()?;
-            Ok(Arc::new(result) as ArrayRef)
+            invoke_function!(
+                flag,
+                |arg0, arg1, arg2, arg3| overlay4::<T>(arg0, arg1, arg2, arg3),
+                string_array,
+                characters_array,
+                pos_num,
+                len_num
+            )
         }
         other => {
             exec_err!("overlay was called with {other} arguments. It requires 3 or 4.")

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -124,8 +124,8 @@ where
 /// NOTE:
 /// 1. When using this function, be sure to ensure that the corresponding `Hint` for
 /// `array_iter` must be `Hint::AcceptsSingular`.
-/// 2. You cannot call this function on all `args` of `inner` at the same time; there
-/// is a risk of never being able to exit the iteration!
+/// 2. You cannot call this function on all `args` of `inner` of `make_scalar_function`
+/// at the same time; there is a risk of never being able to exit the iteration!
 pub(super) fn adaptive_array_iter<'a, T>(
     mut array_iter: ArrayIter<T>,
 ) -> impl Iterator<Item = Option<T::Item>> + 'a
@@ -135,9 +135,9 @@ where
 {
     if array_iter.len() == 1 {
         let value = array_iter.next().expect("Contains a value");
-        Either::Left(std::iter::repeat(value).into_iter())
+        Either::Left(std::iter::repeat(value))
     } else {
-        Either::Right(array_iter.into_iter())
+        Either::Right(array_iter)
     }
 }
 

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -116,6 +116,18 @@ where
     })
 }
 
+#[macro_export]
+macro_rules! create_adaptive_array_iter {
+    ($ARRAY:expr) => {{
+        let first_value = if $ARRAY.is_null(0) {
+            None
+        } else {
+            Some($ARRAY.value(0))
+        };
+        $ARRAY.iter().chain(std::iter::repeat(first_value))
+    }};
+}
+
 #[cfg(test)]
 pub mod test {
     /// $FUNC ScalarUDFImpl to test


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion/issues/10053

## Rationale for this change

### Benchmark

#### `overlay` function

```shell
Gnuplot not found, using plotters backend
4args_with_3scalars/overlay/1024
                        time:   [36.540 µs 36.560 µs 36.587 µs]
                        change: [-12.476% -12.385% -12.284%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

4args_with_3scalars/overlay/4096
                        time:   [141.54 µs 141.65 µs 141.82 µs]
                        change: [-12.584% -12.425% -12.231%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

4args_with_3scalars/overlay/8192
                        time:   [282.77 µs 283.42 µs 284.20 µs]
                        change: [-13.658% -13.353% -12.997%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

4args_without_scalar/overlay/1024
                        time:   [37.682 µs 37.717 µs 37.757 µs]
                        change: [+1.8225% +1.9984% +2.1754%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

4args_without_scalar/overlay/4096
                        time:   [147.68 µs 147.77 µs 147.91 µs]
                        change: [+2.7595% +3.0052% +3.2531%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 20 outliers among 100 measurements (20.00%)
  4 (4.00%) high mild
  16 (16.00%) high severe

4args_without_scalar/overlay/8192
                        time:   [298.84 µs 299.63 µs 300.27 µs]
                        change: [+1.6336% +2.0972% +2.5438%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

#### Discussion🤔

According to the benchmark, there can be about a 12% performance improvement 🚀 when there are 3 scalar args; however, when all args are arrays, there is a 2% ~ 3% performance loss 😔. Does anyone have any ideas on how to avoid this loss?

## What changes are included in this PR?

Currently, this approach has only been validated based on the `overlay` function. If everyone thinks it's appropriate, it can be applied to other functions as well.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
