### PR TITLE
Add example of using Expr::field in `37.1.0`

### DIFF
--- a/datafusion/functions-array/src/rewrite.rs
+++ b/datafusion/functions-array/src/rewrite.rs
@@ -30,16 +30,8 @@ use datafusion_expr::expr_rewriter::FunctionRewrite;
 use datafusion_expr::{BinaryExpr, Expr, GetFieldAccess, GetIndexedField, Operator};
 use datafusion_functions::expr_fn::get_field;
 
-/// Rewrites expressions such as `expr[field]` into function dor array functions
-#[derive(Debug, Default)]
-pub struct ArrayFunctionRewriter {}
-
-impl ArrayFunctionRewriter {
-    /// Create a new `ArrayFunctionRewriter`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
+/// Rewrites expressions into function calls to array functions
+pub(crate) struct ArrayFunctionRewriter {}
 
 impl FunctionRewrite for ArrayFunctionRewriter {
     fn name(&self) -> &str {

--- a/datafusion/functions-array/src/rewrite.rs
+++ b/datafusion/functions-array/src/rewrite.rs
@@ -30,8 +30,16 @@ use datafusion_expr::expr_rewriter::FunctionRewrite;
 use datafusion_expr::{BinaryExpr, Expr, GetFieldAccess, GetIndexedField, Operator};
 use datafusion_functions::expr_fn::get_field;
 
-/// Rewrites expressions into function calls to array functions
-pub(crate) struct ArrayFunctionRewriter {}
+/// Rewrites expressions such as `expr[field]` into function dor array functions
+#[derive(Debug, Default)]
+pub struct ArrayFunctionRewriter {}
+
+impl ArrayFunctionRewriter {
+    /// Create a new `ArrayFunctionRewriter`
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 impl FunctionRewrite for ArrayFunctionRewriter {
     fn name(&self) -> &str {


### PR DESCRIPTION
I don't intend to merge this, but I want to put it up to illustrate how to use the 37.1.0 API to do this reasonably

## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/10181

## Rationale for this change

Some users create expressions outside the context of a query that has an analyzer, etc. Some expressions now can only be used via udfs. 


## What changes are included in this PR?

Add example of using Expr::field in `37.1.0`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
