### PR TITLE
Add redirect to old cli location `user-guide/cli.html` --> `user-guide/cli/index.html`

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -103,3 +103,9 @@ Please see the `developer’s guide`_ for contributing and `communication`_ for 
    contributor-guide/roadmap
    contributor-guide/quarterly_roadmap
    contributor-guide/specification/index
+
+.. toctree::
+   :caption: Other
+   :hidden:
+
+   user-guide/cli

--- a/docs/source/user-guide/cli.rst
+++ b/docs/source/user-guide/cli.rst
@@ -1,0 +1,26 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+.. Redirects to cli/index.html
+.. https://github.com/apache/datafusion/issues/10124
+
+(Old CLI documentation location)
+================================
+This page exists to redirect users to the new location of the DataFusion CLI documentation.
+
+.. meta::
+   :http-equiv=Refresh: 0; url='cli/index.html'


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/10124

## Rationale for this change

Old links (and google) direct to cli.html, which I reorganized in https://github.com/apache/datafusion/pull/10078

## What changes are included in this PR?

Add a redirect page at the old location `cli.html`

## Are these changes tested?

I tested it manually

## Are there any user-facing changes?
Hopefully non broken links
