### PR TITLE
Update .asf.yaml to publish docs to datafusion.apache.org

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,7 +27,7 @@ notifications:
   jira_options: link label worklog
 github:
   description: "Apache DataFusion SQL Query Engine"
-  homepage: https://arrow.apache.org/datafusion
+  homepage: https://datafusion.apache.org/
   labels:
     - arrow
     - big-data
@@ -50,7 +50,6 @@ github:
         required_approving_review_count: 1
 
 # publishes the content of the `asf-site` branch to
-# https://arrow.apache.org/datafusion/
+# https://datafusion.apache.org/
 publish:
   whoami: asf-site
-  subdir: datafusion

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@
 
 This folder contains the source content of the [User Guide](./source/user-guide)
 and [Contributor Guide](./source/contributor-guide). These are both published to
-https://arrow.apache.org/datafusion/ as part of the release process.
+https://datafusion.apache.org/ as part of the release process.
 
 ## Dependencies
 
@@ -55,7 +55,7 @@ automatically updated.
 
 ## Release Process
 
-This documentation is hosted at https://arrow.apache.org/datafusion/
+This documentation is hosted at https://datafusion.apache.org/
 
 When the PR is merged to the `main` branch of the DataFusion
 repository, a [github workflow](https://github.com/apache/datafusion/blob/main/.github/workflows/docs.yaml) which:
@@ -63,7 +63,7 @@ repository, a [github workflow](https://github.com/apache/datafusion/blob/main/.
 1. Builds the html content
 2. Pushes the html content to the [`asf-site`](https://github.com/apache/datafusion/tree/asf-site) branch in this repository.
 
-The Apache Software Foundation provides https://arrow.apache.org/,
+The Apache Software Foundation provides https://datafusion.apache.org/,
 which serves content based on the configuration in
 [.asf.yaml](https://github.com/apache/datafusion/blob/main/.asf.yaml),
-which specifies the target as https://arrow.apache.org/datafusion/.
+which specifies the target as https://datafusion.apache.org/.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,6 +50,17 @@ Please see the `developer’s guide`_ for contributing and `communication`_ for 
 .. _developer’s guide: contributor-guide/index.html#developer-s-guide
 .. _communication: contributor-guide/communication.html
 
+.. _toc.asf-links:
+.. toctree::
+   :maxdepth: 1
+   :caption: ASF Links
+
+   Apache Software Foundation <https://apache.org>
+   License <https://www.apache.org/licenses/>
+   Donate <https://www.apache.org/foundation/sponsorship.html>
+   Thanks <https://www.apache.org/foundation/thanks.html>
+   Security <https://www.apache.org/security/>
+
 .. _toc.links:
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10151

## Rationale for this change

## What changes are included in this PR?

Updates `.asf.yaml` to point to the new top-level website, and adds the required links to the ASF as required by https://www.apache.org/foundation/marks/pmcs#navigation

I mirrored what https://arrow.apache.org does and grouped these links into an `ASF Links` section

According to https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#publish - removing the `subdir` config in `publish` will do what we want.

## Are these changes tested?

Here is a screenshot of what it looks like locally:
<img width="1400" alt="Screenshot 2024-04-23 at 11 40 35 AM" src="https://github.com/apache/datafusion/assets/879445/15bab8b2-c747-494b-801a-96265f1279f2">


## Are there any user-facing changes?

N/A