### PR TITLE
Update links to point to datafusion.apache.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,4 +17,4 @@
   under the License.
 -->
 
-See the [Contributor Guide](https://arrow.apache.org/datafusion/contributor-guide/index.html)
+See the [Contributor Guide](https://datafusion.apache.org/contributor-guide/index.html)

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ in-memory format. [Python Bindings](https://github.com/apache/datafusion-python)
 
 Here are links to some important information
 
-- [Project Site](https://arrow.apache.org/datafusion)
-- [Installation](https://arrow.apache.org/datafusion/user-guide/cli/installation.html)
-- [Rust Getting Started](https://arrow.apache.org/datafusion/user-guide/example-usage.html)
-- [Rust DataFrame API](https://arrow.apache.org/datafusion/user-guide/dataframe.html)
+- [Project Site](https://datafusion.apache.org/)
+- [Installation](https://datafusion.apache.org/user-guide/cli/installation.html)
+- [Rust Getting Started](https://datafusion.apache.org/user-guide/example-usage.html)
+- [Rust DataFrame API](https://datafusion.apache.org/user-guide/dataframe.html)
 - [Rust API docs](https://docs.rs/datafusion/latest/datafusion)
 - [Rust Examples](https://github.com/apache/datafusion/tree/master/datafusion-examples)
 - [Python DataFrame API](https://arrow.apache.org/datafusion-python/)
@@ -58,14 +58,14 @@ Here are links to some important information
 ## What can you do with this crate?
 
 DataFusion is great for building projects such as domain specific query engines, new database platforms and data pipelines, query languages and more.
-It lets you start quickly from a fully working engine, and then customize those features specific to your use. [Click Here](https://arrow.apache.org/datafusion/user-guide/introduction.html#known-users) to see a list known users.
+It lets you start quickly from a fully working engine, and then customize those features specific to your use. [Click Here](https://datafusion.apache.org/user-guide/introduction.html#known-users) to see a list known users.
 
 ## Contributing to DataFusion
 
 Please see the [contributor guide] and [communication] pages for more information.
 
-[contributor guide]: https://arrow.apache.org/datafusion/contributor-guide
-[communication]: https://arrow.apache.org/datafusion/contributor-guide/communication.html
+[contributor guide]: https://datafusion.apache.org/contributor-guide
+[communication]: https://datafusion.apache.org/contributor-guide/communication.html
 
 ## Crate features
 

--- a/datafusion-cli/README.md
+++ b/datafusion-cli/README.md
@@ -21,7 +21,7 @@
 
 # DataFusion Command-line Interface
 
-[DataFusion](https://arrow.apache.org/datafusion/) is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
+[DataFusion](https://datafusion.apache.org/) is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
 DataFusion CLI (`datafusion-cli`) is a small command line utility that runs SQL queries using the DataFusion engine.
 
@@ -29,7 +29,7 @@ DataFusion CLI (`datafusion-cli`) is a small command line utility that runs SQL 
 
 ## Where can I find more information?
 
-See the [`datafusion-cli` documentation](https://arrow.apache.org/datafusion/user-guide/cli.html) for further information.
+See the [`datafusion-cli` documentation](https://datafusion.apache.org/user-guide/cli/index.html) for further information.
 
 ## How do I make my IDE work with `datafusion-cli`?
 

--- a/datafusion/core/README.md
+++ b/datafusion/core/README.md
@@ -27,5 +27,5 @@ This crate contains the main entry points and high level DataFusion APIs such as
 
 For more information, please see:
 
-- [DataFusion Website](https://arrow.apache.org/datafusion)
+- [DataFusion Website](https://datafusion.apache.org)
 - [DataFusion API Docs](https://docs.rs/datafusion/latest/datafusion/)

--- a/datafusion/core/src/catalog/mod.rs
+++ b/datafusion/core/src/catalog/mod.rs
@@ -175,7 +175,7 @@ impl CatalogProviderList for MemoryCatalogProviderList {
 ///  * [delta-rs]:  [`UnityCatalogProvider`] implementation that can
 ///  read from Delta Lake tables
 ///
-/// [`datafusion-cli`]: https://arrow.apache.org/datafusion/user-guide/cli.html
+/// [`datafusion-cli`]: https://datafusion.apache.org/user-guide/cli/index.html
 /// [`DynamicFileCatalogProvider`]: https://github.com/apache/datafusion/blob/31b9b48b08592b7d293f46e75707aad7dadd7cbc/datafusion-cli/src/catalog.rs#L75
 /// [`catalog.rs`]: https://github.com/apache/datafusion/blob/main/datafusion-examples/examples/catalog.rs
 /// [delta-rs]: https://github.com/delta-io/delta-rs

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -30,10 +30,10 @@
 //! additional data sources, query languages, functions, custom
 //! operators and more. See the [Architecture] section for more details.
 //!
-//! [DataFusion]: https://arrow.apache.org/datafusion/
+//! [DataFusion]: https://datafusion.apache.org/
 //! [Apache Arrow]: https://arrow.apache.org
-//! [use cases]: https://arrow.apache.org/datafusion/user-guide/introduction.html#use-cases
-//! [SQL]: https://arrow.apache.org/datafusion/user-guide/sql/index.html
+//! [use cases]: https://datafusion.apache.org/user-guide/introduction.html#use-cases
+//! [SQL]: https://datafusion.apache.org/user-guide/sql/index.html
 //! [`DataFrame`]: dataframe::DataFrame
 //! [Architecture]: #architecture
 //!

--- a/datafusion/expr/src/aggregate_function.rs
+++ b/datafusion/expr/src/aggregate_function.rs
@@ -30,7 +30,7 @@ use strum_macros::EnumIter;
 
 /// Enum of all built-in aggregate functions
 // Contributor's guide for adding new aggregate functions
-// https://arrow.apache.org/datafusion/contributor-guide/index.html#how-to-add-a-new-aggregate-function
+// https://datafusion.apache.org/contributor-guide/index.html#how-to-add-a-new-aggregate-function
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, EnumIter)]
 pub enum AggregateFunction {
     /// Count

--- a/datafusion/proto/CONTRIBUTING.md
+++ b/datafusion/proto/CONTRIBUTING.md
@@ -29,4 +29,4 @@ valid installation of [protoc] (see [installation instructions] for details).
 ```
 
 [protoc]: https://github.com/protocolbuffers/protobuf#protocol-compiler-installation
-[installation instructions]: https://arrow.apache.org/datafusion/contributor-guide/#protoc-installation
+[installation instructions]: https://datafusion.apache.org/contributor-guide/#protoc-installation

--- a/datafusion/proto/README.md
+++ b/datafusion/proto/README.md
@@ -25,5 +25,5 @@ when building a distributed query engine.
 
 See [API Docs] for details and examples.
 
-[datafusion]: https://arrow.apache.org/datafusion
+[datafusion]: https://datafusion.apache.org
 [api docs]: http://docs.rs/datafusion-proto/latest

--- a/dev/changelog/15.0.0.md
+++ b/dev/changelog/15.0.0.md
@@ -89,7 +89,7 @@
 - Consider to categorize Operator [\#3216](https://github.com/apache/datafusion/issues/3216)
 - Replace Projection.alias with SubqueryAlias [\#2212](https://github.com/apache/datafusion/issues/2212)
 - \[Optimizer\] Eliminate the distinct [\#2045](https://github.com/apache/datafusion/issues/2045)
-- beautify datafusion's site: https://arrow.apache.org/datafusion/ [\#1819](https://github.com/apache/datafusion/issues/1819)
+- beautify datafusion's site: https://datafusion.apache.org/ [\#1819](https://github.com/apache/datafusion/issues/1819)
 - split datafusion-logical-plan sub-module [\#1755](https://github.com/apache/datafusion/issues/1755)
 - convert `outer join` to `inner join` to improve performance [\#1585](https://github.com/apache/datafusion/issues/1585)
 - Add sqllogictest for datafusion [\#1453](https://github.com/apache/datafusion/issues/1453)

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -463,7 +463,7 @@ svn delete -m "delete old DataFusion release" https://dist.apache.org/repos/dist
 - Checkout the `asf-site` branch
 - Copy content from `docs/build/html/*` to the `datafusion` directory in arrow-site
 - Create a PR against the `asf-site` branch ([example](https://github.com/apache/arrow-site/pull/237))
-- Once the PR is merged, the content will be published to https://arrow.apache.org/datafusion/ by GitHub Pages (this
+- Once the PR is merged, the content will be published to https://datafusion.apache.org/ by GitHub Pages (this
   can take some time).
 
 ### Optional: Write a blog post announcing the release

--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -348,8 +348,8 @@ new specifications as you see fit.
 
 Here is the list current active specifications:
 
-- [Output field name semantic](https://arrow.apache.org/datafusion/contributor-guide/specification/output-field-name-semantic.html)
-- [Invariants](https://arrow.apache.org/datafusion/contributor-guide/specification/invariants.html)
+- [Output field name semantic](https://datafusion.apache.org/contributor-guide/specification/output-field-name-semantic.html)
+- [Invariants](https://datafusion.apache.org/contributor-guide/specification/invariants.html)
 
 All specifications are stored in the `docs/source/specification` folder.
 

--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -39,7 +39,7 @@ Arrow](https://arrow.apache.org/).
 
 ## Features
 
-- Feature-rich [SQL support](https://arrow.apache.org/datafusion/user-guide/sql/index.html) and [DataFrame API](https://arrow.apache.org/datafusion/user-guide/dataframe.html)
+- Feature-rich [SQL support](https://datafusion.apache.org/user-guide/sql/index.html) and [DataFrame API](https://datafusion.apache.org/user-guide/dataframe.html)
 - Blazingly fast, vectorized, multi-threaded, streaming execution engine.
 - Native support for Parquet, CSV, JSON, and Avro file formats. Support
   for custom file formats and non file datasources via the `TableProvider` trait.
@@ -49,7 +49,7 @@ Arrow](https://arrow.apache.org/).
   Azure Blob Storage, and Google Cloud Storage (Other storage systems are supported via the
   `ObjectStore` trait).
 - [Excellent Documentation](https://docs.rs/datafusion/latest) and a
-  [welcoming community](https://arrow.apache.org/datafusion/contributor-guide/communication.html).
+  [welcoming community](https://datafusion.apache.org/contributor-guide/communication.html).
 - A state of the art query optimizer with expression coercion and
   simplification, projection and filter pushdown, sort and distribution
   aware optimizations, automatic join reordering, and more.

--- a/docs/source/user-guide/sql/select.md
+++ b/docs/source/user-guide/sql/select.md
@@ -22,7 +22,7 @@
 The queries in DataFusion scan data from tables and return 0 or more rows.
 Please be aware that column names in queries are made lower-case, but not on the inferred schema. Accordingly, if you
 want to query against a capitalized field, make sure to use double quotes. Please see this
-[example](https://arrow.apache.org/datafusion/user-guide/example-usage.html) for clarification.
+[example](https://datafusion.apache.org/user-guide/example-usage.html) for clarification.
 In this documentation we describe the SQL syntax in DataFusion.
 
 DataFusion supports the following syntax for queries:

--- a/docs/source/user-guide/sql/write_options.md
+++ b/docs/source/user-guide/sql/write_options.md
@@ -95,7 +95,7 @@ The following options are available when writing CSV files. Note: if any unsuppo
 
 ### Parquet Format Specific Options
 
-The following options are available when writing parquet files. If any unsupported option is specified an error will be raised and the query will fail. If a column specific option is specified for a column which does not exist, the option will be ignored without error. For default values, see: [Configuration Settings](https://arrow.apache.org/datafusion/user-guide/configs.html).
+The following options are available when writing parquet files. If any unsupported option is specified an error will be raised and the query will fail. If a column specific option is specified for a column which does not exist, the option will be ignored without error. For default values, see: [Configuration Settings](https://datafusion.apache.org/user-guide/configs.html).
 
 | Option                       | Can be Column Specific? | Description                                                                                                                         |
 | ---------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Which issue does this PR close?

Part of #9691

## Rationale for this change

Updates the links in the repo to point to https://datafusion.apache.org instead of https://arrow.apache.org/datafusion

## What changes are included in this PR?

## Are these changes tested?

I clicked through each link as I made the change.

## Are there any user-facing changes?

