### PR TITLE
fix: cargo warnings of import item 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
         run: cargo check --all-targets --no-default-features -p datafusion-functions
 
       - name: Check workspace in debug mode
-        run: cargo check
+        run: cargo check --all-targets --workspace
 
       - name: Check workspace with avro,json features
         run: cargo check --workspace --benches --features avro,json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,3 +130,6 @@ rpath = false
 [workspace.lints.clippy]
 # Detects large stack-allocated futures that may cause stack overflow crashes (see threshold in clippy.toml)
 large_futures = "warn"
+
+[workspace.lints.rust]
+unused_imports = "deny"

--- a/datafusion-examples/examples/custom_datasource.rs
+++ b/datafusion-examples/examples/custom_datasource.rs
@@ -24,7 +24,6 @@ use std::time::Duration;
 use datafusion::arrow::array::{UInt64Builder, UInt8Builder};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::dataframe::DataFrame;
 use datafusion::datasource::{provider_as_source, TableProvider, TableType};
 use datafusion::error::Result;
 use datafusion::execution::context::{SessionState, TaskContext};
@@ -34,7 +33,7 @@ use datafusion::physical_plan::{
     Partitioning, PlanProperties, SendableRecordBatchStream,
 };
 use datafusion::prelude::*;
-use datafusion_expr::{Expr, LogicalPlanBuilder};
+use datafusion_expr::LogicalPlanBuilder;
 use datafusion_physical_expr::EquivalenceProperties;
 
 use async_trait::async_trait;

--- a/datafusion-examples/examples/flight/flight_client.rs
+++ b/datafusion-examples/examples/flight/flight_client.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::Schema;

--- a/datafusion-examples/examples/simple_udaf.rs
+++ b/datafusion-examples/examples/simple_udaf.rs
@@ -23,7 +23,6 @@ use datafusion::arrow::{
 use datafusion::{error::Result, physical_plan::Accumulator};
 use datafusion::{logical_expr::Volatility, prelude::*, scalar::ScalarValue};
 use datafusion_common::cast::as_float64_array;
-use datafusion_expr::create_udaf;
 use std::sync::Arc;
 
 // create local session context with an in-memory table

--- a/datafusion-examples/examples/simple_udwf.rs
+++ b/datafusion-examples/examples/simple_udwf.rs
@@ -22,7 +22,6 @@ use arrow::{
     datatypes::Float64Type,
 };
 use arrow_schema::DataType;
-use datafusion::datasource::file_format::options::CsvReadOptions;
 
 use datafusion::error::Result;
 use datafusion::prelude::*;

--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -373,7 +373,7 @@ impl fmt::Display for Column {
 mod tests {
     use super::*;
     use arrow::datatypes::DataType;
-    use arrow_schema::{Field, SchemaBuilder};
+    use arrow_schema::SchemaBuilder;
 
     fn create_qualified_schema(qualifier: &str, names: Vec<&str>) -> Result<DFSchema> {
         let mut schema_builder = SchemaBuilder::new();

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -19,7 +19,6 @@
 //! fields with optional relation names.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::sync::Arc;
@@ -453,7 +452,7 @@ impl DFSchema {
         let matches = self.qualified_fields_with_unqualified_name(name);
         match matches.len() {
             0 => Err(unqualified_field_not_found(name, self)),
-            1 => Ok((matches[0].0, &matches[0].1)),
+            1 => Ok((matches[0].0, (matches[0].1))),
             _ => {
                 // When `matches` size > 1, it doesn't necessarily mean an `ambiguous name` problem.
                 // Because name may generate from Alias/... . It means that it don't own qualifier.
@@ -1004,7 +1003,6 @@ mod tests {
     use crate::assert_contains;
 
     use super::*;
-    use arrow::datatypes::DataType;
 
     #[test]
     fn qualifier_in_name() -> Result<()> {

--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -24,7 +24,6 @@ use arrow::array::*;
 use arrow::datatypes::*;
 use arrow::row::Rows;
 use arrow::{downcast_dictionary_array, downcast_primitive_array};
-use arrow_buffer::i256;
 
 use crate::cast::{
     as_boolean_array, as_fixed_size_list_array, as_generic_binary_array,
@@ -450,7 +449,6 @@ pub fn create_row_hashes_v2<'a>(
 #[cfg(test)]
 mod tests {
     use arrow::{array::*, datatypes::*};
-    use std::sync::Arc;
 
     use super::*;
 

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -22,7 +22,7 @@ mod struct_builder;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::{HashSet, VecDeque};
-use std::convert::{Infallible, TryFrom, TryInto};
+use std::convert::Infallible;
 use std::fmt;
 use std::hash::Hash;
 use std::iter::repeat;
@@ -52,7 +52,6 @@ use arrow::{
         UInt16Type, UInt32Type, UInt64Type, UInt8Type, DECIMAL128_MAX_PRECISION,
     },
 };
-use arrow_array::{ArrowNativeTypeOp, Scalar};
 use arrow_buffer::Buffer;
 use arrow_schema::{UnionFields, UnionMode};
 
@@ -3424,8 +3423,6 @@ impl ScalarType<i32> for Date32Type {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Ordering;
-    use std::sync::Arc;
 
     use super::*;
     use crate::cast::{
@@ -3435,9 +3432,7 @@ mod tests {
     use crate::assert_batches_eq;
     use arrow::buffer::OffsetBuffer;
     use arrow::compute::{is_null, kernels};
-    use arrow::datatypes::{ArrowNumericType, ArrowPrimitiveType};
     use arrow::util::pretty::pretty_format_columns;
-    use arrow_buffer::Buffer;
     use arrow_schema::Fields;
     use chrono::NaiveDate;
     use rand::Rng;

--- a/datafusion/common/src/utils.rs
+++ b/datafusion/common/src/utils.rs
@@ -681,12 +681,8 @@ pub fn find_indices<T: PartialEq, S: Borrow<T>>(
 
 #[cfg(test)]
 mod tests {
-    use crate::ScalarValue;
     use crate::ScalarValue::Null;
     use arrow::array::Float64Array;
-    use arrow_array::Array;
-    use std::ops::Range;
-    use std::sync::Arc;
 
     use super::*;
 

--- a/datafusion/core/benches/physical_plan.rs
+++ b/datafusion/core/benches/physical_plan.rs
@@ -21,7 +21,7 @@ use criterion::{BatchSize, Criterion};
 extern crate arrow;
 extern crate datafusion;
 
-use std::{iter::FromIterator, sync::Arc};
+use std::sync::Arc;
 
 use arrow::{
     array::{ArrayRef, Int64Array, StringArray},

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1570,19 +1570,17 @@ mod tests {
     use std::vec;
 
     use super::*;
+    use crate::assert_batches_sorted_eq;
     use crate::execution::context::SessionConfig;
     use crate::physical_plan::{ColumnarValue, Partitioning, PhysicalExpr};
     use crate::test_util::{register_aggregate_csv, test_table, test_table_with_name};
-    use crate::{assert_batches_sorted_eq, execution::context::SessionContext};
 
     use arrow::array::{self, Int32Array};
-    use arrow::datatypes::DataType;
     use datafusion_common::{Constraint, Constraints};
     use datafusion_common_runtime::SpawnedTask;
     use datafusion_expr::{
-        avg, cast, count, count_distinct, create_udf, expr, lit, max, min, sum,
-        BuiltInWindowFunction, ScalarFunctionImplementation, Volatility, WindowFrame,
-        WindowFunctionDefinition,
+        cast, count_distinct, create_udf, expr, lit, sum, BuiltInWindowFunction,
+        ScalarFunctionImplementation, Volatility, WindowFrame, WindowFunctionDefinition,
     };
     use datafusion_physical_expr::expressions::Column;
     use datafusion_physical_plan::{get_plan_string, ExecutionPlanProperties};

--- a/datafusion/core/src/datasource/file_format/avro.rs
+++ b/datafusion/core/src/datasource/file_format/avro.rs
@@ -21,7 +21,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use arrow::datatypes::Schema;
-use arrow::{self, datatypes::SchemaRef};
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion_common::FileType;
 use datafusion_physical_expr::PhysicalExpr;

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -37,8 +37,8 @@ use crate::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 
 use arrow::array::RecordBatch;
 use arrow::csv::WriterBuilder;
+use arrow::datatypes::SchemaRef;
 use arrow::datatypes::{DataType, Field, Fields, Schema};
-use arrow::{self, datatypes::SchemaRef};
 use datafusion_common::config::CsvOptions;
 use datafusion_common::file_options::csv_writer::CsvWriterOptions;
 use datafusion_common::{exec_err, not_impl_err, DataFusionError, FileType};
@@ -537,12 +537,10 @@ mod tests {
     use arrow::compute::concat_batches;
     use datafusion_common::cast::as_string_array;
     use datafusion_common::stats::Precision;
-    use datafusion_common::{internal_err, FileType, GetExt};
+    use datafusion_common::{internal_err, GetExt};
     use datafusion_expr::{col, lit};
 
-    use bytes::Bytes;
     use chrono::DateTime;
-    use futures::StreamExt;
     use object_store::local::LocalFileSystem;
     use object_store::path::Path;
     use regex::Regex;

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -1021,10 +1021,7 @@ pub(crate) mod test_util {
     use super::*;
     use crate::test::object_store::local_unpartitioned_file;
 
-    use arrow::record_batch::RecordBatch;
-
     use parquet::arrow::ArrowWriter;
-    use parquet::file::properties::WriterProperties;
     use tempfile::NamedTempFile;
 
     /// How many rows per page should be written
@@ -1112,7 +1109,6 @@ mod tests {
     use crate::physical_plan::metrics::MetricValue;
     use crate::prelude::{SessionConfig, SessionContext};
     use arrow::array::{Array, ArrayRef, StringArray};
-    use arrow::record_batch::RecordBatch;
     use arrow_schema::Field;
     use async_trait::async_trait;
     use bytes::Bytes;
@@ -1121,16 +1117,13 @@ mod tests {
         as_int32_array, as_timestamp_nanosecond_array,
     };
     use datafusion_common::config::ParquetOptions;
-    use datafusion_common::config::TableParquetOptions;
     use datafusion_common::ScalarValue;
     use datafusion_execution::object_store::ObjectStoreUrl;
     use datafusion_execution::runtime_env::RuntimeEnv;
     use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
     use futures::stream::BoxStream;
-    use futures::StreamExt;
     use log::error;
     use object_store::local::LocalFileSystem;
-    use object_store::path::Path;
     use object_store::{
         GetOptions, GetResult, ListResult, MultipartId, PutOptions, PutResult,
     };
@@ -1139,7 +1132,6 @@ mod tests {
     use parquet::file::metadata::{ParquetColumnIndex, ParquetOffsetIndex};
     use parquet::file::page_index::index::Index;
     use tokio::fs::File;
-    use tokio::io::AsyncWrite;
 
     #[tokio::test]
     async fn read_merged_batches() -> Result<()> {

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -423,8 +423,6 @@ where
 mod tests {
     use std::ops::Not;
 
-    use futures::StreamExt;
-
     use crate::logical_expr::{case, col, lit};
     use crate::test::object_store::make_test_store_and_state;
 

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1004,23 +1004,18 @@ impl ListingTable {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
     use super::*;
     #[cfg(feature = "parquet")]
-    use crate::datasource::file_format::parquet::ParquetFormat;
     use crate::datasource::{provider_as_source, MemTable};
     use crate::execution::options::ArrowReadOptions;
     use crate::physical_plan::collect;
     use crate::prelude::*;
     use crate::{
         assert_batches_eq,
-        datasource::file_format::avro::AvroFormat,
-        logical_expr::{col, lit},
         test::{columns, object_store::register_test_store},
     };
 
-    use arrow::datatypes::{DataType, Schema};
     use arrow::record_batch::RecordBatch;
     use arrow_schema::SortOptions;
     use datafusion_common::stats::Precision;

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -363,7 +363,6 @@ impl DataSink for MemSink {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
     use super::*;
     use crate::datasource::provider_as_source;
@@ -375,8 +374,6 @@ mod tests {
     use arrow::error::ArrowError;
     use datafusion_common::DataFusionError;
     use datafusion_expr::LogicalPlanBuilder;
-
-    use futures::StreamExt;
 
     #[tokio::test]
     async fn test_with_projection() -> Result<()> {

--- a/datafusion/core/src/datasource/physical_plan/csv.rs
+++ b/datafusion/core/src/datasource/physical_plan/csv.rs
@@ -526,7 +526,6 @@ mod tests {
     use datafusion_common::test_util::arrow_test_data;
     use datafusion_common::FileType;
 
-    use futures::StreamExt;
     use object_store::chunked::ChunkedStore;
     use object_store::local::LocalFileSystem;
     use rstest::*;

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -521,19 +521,13 @@ mod tests {
     use super::*;
     use crate::datasource::file_format::write::BatchSerializer;
     use crate::datasource::object_store::ObjectStoreUrl;
-    use crate::datasource::physical_plan::FileMeta;
-    use crate::physical_plan::metrics::ExecutionPlanMetricsSet;
     use crate::prelude::SessionContext;
-    use crate::{
-        error::Result,
-        test::{make_partition, object_store::register_test_store},
-    };
+    use crate::test::{make_partition, object_store::register_test_store};
 
     use arrow_schema::Schema;
     use datafusion_common::{internal_err, Statistics};
 
     use bytes::Bytes;
-    use futures::StreamExt;
 
     /// Test `FileOpener` which will simulate errors during file opening or scanning
     #[derive(Default)]

--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -44,7 +44,7 @@ use datafusion_physical_expr::{EquivalenceProperties, LexOrdering};
 use bytes::{Buf, Bytes};
 use futures::{ready, StreamExt, TryStreamExt};
 use object_store::buffered::BufWriter;
-use object_store::{self, GetOptions, GetResultPayload, ObjectStore};
+use object_store::{GetOptions, GetResultPayload, ObjectStore};
 use tokio::io::AsyncWriteExt;
 use tokio::task::JoinSet;
 
@@ -387,7 +387,6 @@ mod tests {
     use crate::dataframe::DataFrameWriteOptions;
     use crate::datasource::file_format::file_compression_type::FileTypeExt;
     use crate::datasource::file_format::{json::JsonFormat, FileFormat};
-    use crate::datasource::listing::PartitionedFile;
     use crate::datasource::object_store::ObjectStoreUrl;
     use crate::execution::context::SessionState;
     use crate::prelude::{
@@ -401,7 +400,6 @@ mod tests {
     use datafusion_common::FileType;
     use flate2::write::GzEncoder;
     use flate2::Compression;
-    use futures::StreamExt;
     use object_store::chunked::ChunkedStore;
     use object_store::local::LocalFileSystem;
     use rstest::*;

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -773,7 +773,7 @@ mod tests {
     use crate::datasource::file_format::options::CsvReadOptions;
     use crate::datasource::file_format::parquet::test_util::store_parquet;
     use crate::datasource::file_format::test_util::scan_format;
-    use crate::datasource::listing::{FileRange, ListingOptions, PartitionedFile};
+    use crate::datasource::listing::{FileRange, ListingOptions};
     use crate::datasource::object_store::ObjectStoreUrl;
     use crate::execution::context::SessionState;
     use crate::physical_plan::displayable;
@@ -790,7 +790,7 @@ mod tests {
         StructArray,
     };
 
-    use arrow::datatypes::{DataType, Field, Schema, SchemaBuilder};
+    use arrow::datatypes::{Field, Schema, SchemaBuilder};
     use arrow::record_batch::RecordBatch;
     use arrow_schema::Fields;
     use datafusion_common::{assert_contains, FileType, GetExt, ScalarValue, ToDFSchema};
@@ -799,9 +799,7 @@ mod tests {
     use datafusion_physical_expr::create_physical_expr;
 
     use chrono::{TimeZone, Utc};
-    use futures::StreamExt;
     use object_store::local::LocalFileSystem;
-    use object_store::path::Path;
     use object_store::ObjectMeta;
     use parquet::arrow::ArrowWriter;
     use tempfile::TempDir;

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -359,7 +359,6 @@ mod tests {
     use crate::datasource::physical_plan::parquet::ParquetFileReader;
     use crate::physical_plan::metrics::ExecutionPlanMetricsSet;
     use arrow::datatypes::DataType::Decimal128;
-    use arrow::datatypes::Schema;
     use arrow::datatypes::{DataType, Field};
     use datafusion_common::{Result, ToDFSchema};
     use datafusion_expr::execution_props::ExecutionProps;
@@ -370,8 +369,7 @@ mod tests {
     use parquet::basic::LogicalType;
     use parquet::data_type::{ByteArray, FixedLenByteArray};
     use parquet::{
-        basic::Type as PhysicalType,
-        file::{metadata::RowGroupMetaData, statistics::Statistics as ParquetStatistics},
+        basic::Type as PhysicalType, file::statistics::Statistics as ParquetStatistics,
         schema::types::SchemaDescPtr,
     };
     use std::ops::Rem;

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -20,7 +20,6 @@
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::fmt::Debug;
 use std::ops::ControlFlow;
-use std::string::String;
 use std::sync::{Arc, Weak};
 
 use super::options::ReadOptions;
@@ -2359,19 +2358,15 @@ impl<'a> TreeNodeVisitor for BadPlanVisitor<'a> {
 mod tests {
     use std::env;
     use std::path::PathBuf;
-    use std::sync::Weak;
 
     use super::{super::options::CsvReadOptions, *};
     use crate::assert_batches_eq;
-    use crate::execution::context::QueryPlanner;
     use crate::execution::memory_pool::MemoryConsumer;
     use crate::execution::runtime_env::RuntimeConfig;
     use crate::test;
     use crate::test_util::{plan_and_collect, populate_csv_partitions};
-    use crate::variable::VarType;
 
     use datafusion_common_runtime::SpawnedTask;
-    use datafusion_expr::Expr;
 
     use async_trait::async_trait;
     use tempfile::TempDir;

--- a/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/core/src/physical_optimizer/aggregate_statistics.rs
@@ -295,12 +295,10 @@ fn take_optimizable_max(
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Arc;
 
     use super::*;
-    use crate::error::Result;
     use crate::logical_expr::Operator;
-    use crate::physical_plan::aggregates::{AggregateExec, PhysicalGroupBy};
+    use crate::physical_plan::aggregates::PhysicalGroupBy;
     use crate::physical_plan::coalesce_partitions::CoalescePartitionsExec;
     use crate::physical_plan::common;
     use crate::physical_plan::expressions::Count;

--- a/datafusion/core/src/physical_optimizer/combine_partial_final_agg.rs
+++ b/datafusion/core/src/physical_optimizer/combine_partial_final_agg.rs
@@ -201,16 +201,12 @@ mod tests {
     use crate::datasource::listing::PartitionedFile;
     use crate::datasource::object_store::ObjectStoreUrl;
     use crate::datasource::physical_plan::{FileScanConfig, ParquetExec};
-    use crate::physical_plan::aggregates::{
-        AggregateExec, AggregateMode, PhysicalGroupBy,
-    };
     use crate::physical_plan::expressions::lit;
     use crate::physical_plan::repartition::RepartitionExec;
     use crate::physical_plan::{displayable, Partitioning, Statistics};
 
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
     use datafusion_physical_expr::expressions::{col, Count, Sum};
-    use datafusion_physical_expr::AggregateExpr;
 
     /// Runs the CombinePartialFinalAggregate optimizer and asserts the plan against the expected
     macro_rules! assert_optimized {

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -1290,31 +1290,21 @@ pub(crate) mod tests {
     use crate::physical_optimizer::test_utils::{
         check_integrity, coalesce_partitions_exec, repartition_exec,
     };
-    use crate::physical_plan::aggregates::{
-        AggregateExec, AggregateMode, PhysicalGroupBy,
-    };
     use crate::physical_plan::coalesce_batches::CoalesceBatchesExec;
     use crate::physical_plan::expressions::col;
     use crate::physical_plan::filter::FilterExec;
-    use crate::physical_plan::joins::{
-        utils::JoinOn, HashJoinExec, PartitionMode, SortMergeJoinExec,
-    };
+    use crate::physical_plan::joins::utils::JoinOn;
     use crate::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
-    use crate::physical_plan::projection::ProjectionExec;
     use crate::physical_plan::sorts::sort::SortExec;
-    use crate::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
     use crate::physical_plan::{displayable, DisplayAs, DisplayFormatType, Statistics};
 
-    use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-    use datafusion_common::tree_node::TransformedResult;
     use datafusion_common::ScalarValue;
-    use datafusion_expr::logical_plan::JoinType;
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{BinaryExpr, Literal};
     use datafusion_physical_expr::{
-        expressions, expressions::binary, expressions::lit, expressions::Column,
-        LexOrdering, PhysicalExpr, PhysicalSortExpr, PhysicalSortRequirement,
+        expressions, expressions::binary, expressions::lit, LexOrdering,
+        PhysicalSortExpr, PhysicalSortRequirement,
     };
     use datafusion_physical_plan::PlanProperties;
 

--- a/datafusion/core/src/physical_optimizer/enforce_sorting.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_sorting.rs
@@ -611,7 +611,6 @@ fn get_sort_exprs(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::physical_optimizer::enforce_distribution::EnforceDistribution;
@@ -622,7 +621,6 @@ mod tests {
         repartition_exec, sort_exec, sort_expr, sort_expr_options, sort_merge_join_exec,
         sort_preserving_merge_exec, spr_repartition_exec, union_exec,
     };
-    use crate::physical_plan::repartition::RepartitionExec;
     use crate::physical_plan::{displayable, get_plan_string, Partitioning};
     use crate::prelude::{SessionConfig, SessionContext};
     use crate::test::{csv_exec_ordered, csv_exec_sorted, stream_exec_ordered};

--- a/datafusion/core/src/physical_optimizer/join_selection.rs
+++ b/datafusion/core/src/physical_optimizer/join_selection.rs
@@ -702,21 +702,18 @@ fn apply_subrules(
 
 #[cfg(test)]
 mod tests_statistical {
-    use std::sync::Arc;
 
     use super::*;
     use crate::{
-        physical_plan::{
-            displayable, joins::PartitionMode, ColumnStatistics, Statistics,
-        },
+        physical_plan::{displayable, ColumnStatistics, Statistics},
         test::StatisticsExec,
     };
 
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::datatypes::{DataType, Field};
     use datafusion_common::{stats::Precision, JoinType, ScalarValue};
     use datafusion_expr::Operator;
-    use datafusion_physical_expr::expressions::{BinaryExpr, Column};
-    use datafusion_physical_expr::{PhysicalExpr, PhysicalExprRef};
+    use datafusion_physical_expr::expressions::BinaryExpr;
+    use datafusion_physical_expr::PhysicalExprRef;
 
     use rstest::rstest;
 
@@ -1571,22 +1568,15 @@ mod util_tests {
 
 #[cfg(test)]
 mod hash_join_tests {
-    use std::sync::Arc;
 
     use self::tests_statistical::crosscheck_plans;
     use super::*;
-    use crate::physical_optimizer::join_selection::swap_join_type;
     use crate::physical_optimizer::test_utils::SourceType;
-    use crate::physical_plan::expressions::Column;
-    use crate::physical_plan::joins::PartitionMode;
-    use crate::physical_plan::projection::ProjectionExec;
     use crate::test_util::UnboundedExec;
 
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::datatypes::{DataType, Field};
     use arrow::record_batch::RecordBatch;
     use datafusion_common::utils::DataPtr;
-    use datafusion_common::JoinType;
-    use datafusion_physical_plan::ExecutionPlanProperties;
 
     struct TestCase {
         case: String,

--- a/datafusion/core/src/physical_optimizer/limited_distinct_aggregation.rs
+++ b/datafusion/core/src/physical_optimizer/limited_distinct_aggregation.rs
@@ -191,15 +191,13 @@ impl PhysicalOptimizerRule for LimitedDistinctAggregation {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
-    use crate::error::Result;
     use crate::physical_optimizer::aggregate_statistics::tests::TestAggregate;
     use crate::physical_optimizer::enforce_distribution::tests::{
         parquet_exec_with_sort, schema, trim_plan_display,
     };
-    use crate::physical_plan::aggregates::{AggregateExec, PhysicalGroupBy};
+    use crate::physical_plan::aggregates::PhysicalGroupBy;
     use crate::physical_plan::collect;
     use crate::physical_plan::memory::MemoryExec;
     use crate::prelude::SessionContext;

--- a/datafusion/core/src/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/projection_pushdown.rs
@@ -1288,30 +1288,15 @@ fn new_join_children(
 mod tests {
     use super::*;
     use std::any::Any;
-    use std::sync::Arc;
 
     use crate::datasource::file_format::file_compression_type::FileCompressionType;
     use crate::datasource::listing::PartitionedFile;
-    use crate::datasource::physical_plan::{CsvExec, FileScanConfig};
-    use crate::physical_optimizer::output_requirements::OutputRequirementExec;
-    use crate::physical_optimizer::projection_pushdown::{
-        join_table_borders, update_expr, ProjectionPushdown,
-    };
-    use crate::physical_optimizer::PhysicalOptimizerRule;
-    use crate::physical_plan::coalesce_partitions::CoalescePartitionsExec;
-    use crate::physical_plan::filter::FilterExec;
-    use crate::physical_plan::joins::utils::{ColumnIndex, JoinFilter};
+    use crate::datasource::physical_plan::FileScanConfig;
+    use crate::physical_plan::get_plan_string;
     use crate::physical_plan::joins::StreamJoinPartitionMode;
-    use crate::physical_plan::memory::MemoryExec;
-    use crate::physical_plan::projection::ProjectionExec;
-    use crate::physical_plan::repartition::RepartitionExec;
-    use crate::physical_plan::sorts::sort::SortExec;
-    use crate::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
-    use crate::physical_plan::{get_plan_string, ExecutionPlan};
 
-    use arrow_schema::{DataType, Field, Schema, SchemaRef, SortOptions};
-    use datafusion_common::config::ConfigOptions;
-    use datafusion_common::{JoinSide, JoinType, Result, ScalarValue, Statistics};
+    use arrow_schema::{DataType, Field, Schema, SortOptions};
+    use datafusion_common::{JoinType, ScalarValue, Statistics};
     use datafusion_execution::object_store::ObjectStoreUrl;
     use datafusion_execution::{SendableRecordBatchStream, TaskContext};
     use datafusion_expr::{
@@ -1319,19 +1304,11 @@ mod tests {
         Signature, Volatility,
     };
     use datafusion_physical_expr::expressions::{
-        BinaryExpr, CaseExpr, CastExpr, Column, Literal, NegativeExpr,
+        BinaryExpr, CaseExpr, CastExpr, NegativeExpr,
     };
-    use datafusion_physical_expr::{
-        Distribution, Partitioning, PhysicalExpr, PhysicalSortExpr,
-        PhysicalSortRequirement, ScalarFunctionExpr,
-    };
-    use datafusion_physical_plan::joins::{
-        HashJoinExec, PartitionMode, SymmetricHashJoinExec,
-    };
-    use datafusion_physical_plan::streaming::{PartitionStream, StreamingTableExec};
-    use datafusion_physical_plan::union::UnionExec;
-
-    use itertools::Itertools;
+    use datafusion_physical_expr::ScalarFunctionExpr;
+    use datafusion_physical_plan::joins::PartitionMode;
+    use datafusion_physical_plan::streaming::PartitionStream;
 
     /// Mocked UDF
     #[derive(Debug)]

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -20,7 +20,6 @@
 //!
 //! [`Expr`]: crate::prelude::Expr
 use std::collections::HashSet;
-use std::convert::TryFrom;
 use std::sync::Arc;
 
 use crate::{
@@ -1551,15 +1550,15 @@ pub(crate) enum StatisticsType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::assert_batches_eq;
     use crate::logical_expr::{col, lit};
-    use crate::{assert_batches_eq, physical_optimizer::pruning::StatisticsType};
     use arrow::array::Decimal128Array;
     use arrow::{
         array::{BinaryArray, Int32Array, Int64Array, StringArray},
-        datatypes::{DataType, TimeUnit},
+        datatypes::TimeUnit,
     };
     use arrow_array::UInt64Array;
-    use datafusion_common::{ScalarValue, ToDFSchema};
+    use datafusion_common::ToDFSchema;
     use datafusion_expr::execution_props::ExecutionProps;
     use datafusion_expr::expr::InList;
     use datafusion_expr::{cast, is_null, try_cast, Expr};

--- a/datafusion/core/src/physical_optimizer/replace_with_order_preserving_variants.rs
+++ b/datafusion/core/src/physical_optimizer/replace_with_order_preserving_variants.rs
@@ -279,12 +279,9 @@ mod tests {
     use crate::datasource::physical_plan::{CsvExec, FileScanConfig};
     use crate::physical_optimizer::test_utils::check_integrity;
     use crate::physical_plan::coalesce_batches::CoalesceBatchesExec;
-    use crate::physical_plan::coalesce_partitions::CoalescePartitionsExec;
     use crate::physical_plan::filter::FilterExec;
     use crate::physical_plan::joins::{HashJoinExec, PartitionMode};
-    use crate::physical_plan::repartition::RepartitionExec;
     use crate::physical_plan::sorts::sort::SortExec;
-    use crate::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
     use crate::physical_plan::{
         displayable, get_plan_string, ExecutionPlan, Partitioning,
     };

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2297,8 +2297,6 @@ fn tuple_err<T, R>(value: (Result<T>, Result<R>)) -> Result<(T, R)> {
 #[cfg(test)]
 mod tests {
     use std::any::Any;
-    use std::collections::HashMap;
-    use std::convert::TryFrom;
     use std::fmt::{self, Debug};
     use std::ops::{BitAnd, Not};
 
@@ -2306,22 +2304,19 @@ mod tests {
     use crate::datasource::file_format::options::CsvReadOptions;
     use crate::datasource::MemTable;
     use crate::physical_plan::{
-        expressions, DisplayAs, DisplayFormatType, ExecutionMode, Partitioning,
-        PlanProperties, SendableRecordBatchStream,
+        expressions, DisplayAs, DisplayFormatType, ExecutionMode, PlanProperties,
+        SendableRecordBatchStream,
     };
-    use crate::physical_planner::PhysicalPlanner;
     use crate::prelude::{SessionConfig, SessionContext};
     use crate::test_util::{scan_empty, scan_empty_with_partitions};
 
     use arrow::array::{ArrayRef, DictionaryArray, Int32Array};
-    use arrow::datatypes::{DataType, Field, Int32Type, SchemaRef};
-    use arrow::record_batch::RecordBatch;
-    use datafusion_common::{assert_contains, DFSchema, DFSchemaRef, TableReference};
+    use arrow::datatypes::{DataType, Field, Int32Type};
+    use datafusion_common::{assert_contains, DFSchemaRef, TableReference};
     use datafusion_execution::runtime_env::RuntimeEnv;
     use datafusion_execution::TaskContext;
     use datafusion_expr::{
-        col, lit, sum, Extension, GroupingSet, LogicalPlanBuilder,
-        UserDefinedLogicalNodeCore,
+        col, lit, sum, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
     };
     use datafusion_physical_expr::EquivalenceProperties;
 

--- a/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
@@ -23,8 +23,8 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion::datasource::provider::{TableProvider, TableType};
 use datafusion::error::Result;
-use datafusion::execution::context::{SessionContext, SessionState, TaskContext};
-use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::execution::context::{SessionState, TaskContext};
+use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning,

--- a/datafusion/core/tests/dataframe/dataframe_functions.rs
+++ b/datafusion/core/tests/dataframe/dataframe_functions.rs
@@ -25,19 +25,14 @@ use arrow_array::ListArray;
 use arrow_schema::SchemaRef;
 use std::sync::Arc;
 
-use datafusion::dataframe::DataFrame;
-
 use datafusion::error::Result;
 
 use datafusion::prelude::*;
 
-use datafusion::execution::context::SessionContext;
-
 use datafusion::assert_batches_eq;
 use datafusion_common::DFSchema;
 use datafusion_expr::expr::Alias;
-use datafusion_expr::{approx_median, cast, ExprSchemable};
-use datafusion_functions_array::expr_fn::array_to_string;
+use datafusion_expr::ExprSchemable;
 
 fn test_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![

--- a/datafusion/core/tests/parquet/filter_pushdown.rs
+++ b/datafusion/core/tests/parquet/filter_pushdown.rs
@@ -63,7 +63,6 @@ fn generate_file(tempdir: &TempDir, props: WriterProperties) -> TestParquetFile 
     test_parquet_file
 }
 
-#[cfg(not(target_family = "windows"))]
 #[tokio::test]
 async fn single_file() {
     // Only create the parquet file once as it is fairly large
@@ -222,7 +221,6 @@ async fn single_file() {
     case.run().await;
 }
 
-#[cfg(not(target_family = "windows"))]
 #[tokio::test]
 async fn single_file_small_data_pages() {
     let tempdir = TempDir::new().unwrap();

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -43,6 +43,7 @@ use tempfile::NamedTempFile;
 
 mod custom_reader;
 mod file_statistics;
+#[cfg(not(target_family = "windows"))]
 mod filter_pushdown;
 mod page_pruning;
 mod row_group_pruning;

--- a/datafusion/core/tests/parquet/schema.rs
+++ b/datafusion/core/tests/parquet/schema.rs
@@ -18,7 +18,6 @@
 //! Tests for parquet schema handling
 use std::{collections::HashMap, fs, path::Path};
 
-use ::parquet::arrow::ArrowWriter;
 use tempfile::TempDir;
 
 use super::*;

--- a/datafusion/core/tests/simplification.rs
+++ b/datafusion/core/tests/simplification.rs
@@ -28,7 +28,7 @@ use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::logical_plan::builder::table_scan_with_filters;
 use datafusion_expr::simplify::SimplifyInfo;
 use datafusion_expr::{
-    expr, table_scan, Cast, ColumnarValue, Expr, ExprSchemable, LogicalPlan,
+    expr, table_scan, Cast, ColumnarValue, ExprSchemable, LogicalPlan,
     LogicalPlanBuilder, ScalarUDF, Volatility,
 };
 use datafusion_functions::{math, string};

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -17,7 +17,6 @@
 
 use super::*;
 use datafusion_common::ScalarValue;
-use tempfile::TempDir;
 
 #[tokio::test]
 async fn test_list_query_parameters() -> Result<()> {

--- a/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
@@ -33,8 +33,8 @@ use datafusion_common::{exec_err, internal_err, DataFusionError};
 use datafusion_execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use datafusion_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion_expr::{
-    create_udaf, create_udf, Accumulator, ColumnarValue, CreateFunction, ExprSchemable,
-    LogicalPlanBuilder, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+    Accumulator, ColumnarValue, CreateFunction, ExprSchemable, LogicalPlanBuilder,
+    ScalarUDF, ScalarUDFImpl, Signature, Volatility,
 };
 use rand::{thread_rng, Rng};
 use std::any::Any;

--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -187,10 +187,7 @@ fn create_local_dirs(local_dirs: Vec<PathBuf>) -> Result<Vec<Arc<TempDir>>> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use super::*;
-    use tempfile::TempDir;
 
     #[test]
     fn lazy_temp_dir_creation() -> Result<()> {

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1942,17 +1942,9 @@ pub fn is_volatile(expr: &Expr) -> Result<bool> {
 
 #[cfg(test)]
 mod test {
-    use crate::expr::Cast;
     use crate::expr_fn::col;
-    use crate::{
-        case, lit, ColumnarValue, Expr, ScalarFunctionDefinition, ScalarUDF,
-        ScalarUDFImpl, Signature, Volatility,
-    };
-    use arrow::datatypes::DataType;
-    use datafusion_common::Column;
-    use datafusion_common::{Result, ScalarValue};
+    use crate::{case, lit, ColumnarValue, ScalarUDF, ScalarUDFImpl, Volatility};
     use std::any::Any;
-    use std::sync::Arc;
 
     #[test]
     fn format_case_when() -> Result<()> {

--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -287,8 +287,7 @@ mod test {
     use crate::expr::Sort;
     use crate::{col, lit, Cast};
     use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_common::tree_node::{TreeNode, TreeNodeRewriter};
-    use datafusion_common::{DFSchema, ScalarValue, TableReference};
+    use datafusion_common::ScalarValue;
 
     #[derive(Default)]
     struct RecordingRewriter {

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -545,8 +545,8 @@ pub fn cast_subquery(subquery: Subquery, cast_to_type: &DataType) -> Result<Subq
 mod tests {
     use super::*;
     use crate::{col, lit};
-    use arrow::datatypes::{DataType, Fields, SchemaBuilder};
-    use datafusion_common::{Column, DFSchema, ScalarValue};
+    use arrow::datatypes::{Fields, SchemaBuilder};
+    use datafusion_common::{DFSchema, ScalarValue};
 
     macro_rules! test_is_expr_nullable {
         ($EXPR_TYPE:ident) => {{

--- a/datafusion/expr/src/literal.rs
+++ b/datafusion/expr/src/literal.rs
@@ -180,7 +180,6 @@ mod test {
 
     use super::*;
     use crate::expr_fn::col;
-    use datafusion_common::ScalarValue;
 
     #[test]
     fn test_lit_nonzero() {

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -20,7 +20,6 @@
 use std::any::Any;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
-use std::convert::TryFrom;
 use std::iter::zip;
 use std::sync::Arc;
 
@@ -1611,8 +1610,7 @@ mod tests {
     use crate::logical_plan::StringifiedPlan;
     use crate::{col, expr, expr_fn::exists, in_subquery, lit, scalar_subquery, sum};
 
-    use arrow::datatypes::{DataType, Field};
-    use datafusion_common::{SchemaError, TableReference};
+    use datafusion_common::SchemaError;
 
     #[test]
     fn plan_builder_simple() -> Result<()> {

--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -19,7 +19,7 @@
 use crate::{Expr, LogicalPlan};
 use datafusion_common::{DFSchema, DFSchemaRef};
 use std::hash::{Hash, Hasher};
-use std::{any::Any, cmp::Eq, collections::HashSet, fmt, sync::Arc};
+use std::{any::Any, collections::HashSet, fmt, sync::Arc};
 
 /// This defines the interface for [`LogicalPlan`] nodes that can be
 /// used to extend DataFusion with custom relational operators.

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2526,18 +2526,14 @@ pub struct Unnest {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::builder::LogicalTableSource;
     use crate::logical_plan::table_scan;
     use crate::{col, count, exists, in_subquery, lit, placeholder, GroupingSet};
 
-    use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::tree_node::TreeNodeVisitor;
-    use datafusion_common::{
-        not_impl_err, Constraint, DFSchema, ScalarValue, TableReference,
-    };
+    use datafusion_common::{not_impl_err, Constraint, ScalarValue};
 
     fn employee_schema() -> Schema {
         Schema::new(vec![

--- a/datafusion/expr/src/type_coercion/aggregates.rs
+++ b/datafusion/expr/src/type_coercion/aggregates.rs
@@ -582,8 +582,6 @@ pub fn is_string_agg_supported_arg_type(arg_type: &DataType) -> bool {
 mod tests {
     use super::*;
 
-    use arrow::datatypes::DataType;
-
     #[test]
     fn test_aggregate_coerce_types() {
         // test input args with error number input types

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -858,10 +858,8 @@ fn null_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Operator;
 
-    use arrow::datatypes::DataType;
-    use datafusion_common::{assert_contains, Result};
+    use datafusion_common::assert_contains;
 
     #[test]
     fn test_coercion_error() -> Result<()> {

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -467,12 +467,11 @@ fn coerced_from<'a>(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use crate::Volatility;
 
     use super::*;
-    use arrow::datatypes::{DataType, Field, TimeUnit};
+    use arrow::datatypes::Field;
 
     #[test]
     fn test_maybe_data_types() {

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -23,7 +23,6 @@
 //! - An ending frame boundary,
 //! - An EXCLUDE clause.
 
-use std::convert::{From, TryFrom};
 use std::fmt::{self, Formatter};
 use std::hash::Hash;
 

--- a/datafusion/expr/src/window_state.rs
+++ b/datafusion/expr/src/window_state.rs
@@ -667,14 +667,9 @@ fn check_equality(current: &[ScalarValue], target: &[ScalarValue]) -> Result<boo
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Range;
-    use std::sync::Arc;
-
     use super::*;
-    use crate::{WindowFrame, WindowFrameBound, WindowFrameUnits};
 
-    use arrow::array::{ArrayRef, Float64Array};
-    use datafusion_common::{Result, ScalarValue};
+    use arrow::array::Float64Array;
 
     fn get_test_data() -> (Vec<ArrayRef>, Vec<SortOptions>) {
         let range_columns: Vec<ArrayRef> = vec![Arc::new(Float64Array::from(vec![

--- a/datafusion/functions-array/src/utils.rs
+++ b/datafusion/functions-array/src/utils.rs
@@ -257,8 +257,7 @@ pub(crate) fn compute_array_dims(
 mod tests {
     use super::*;
     use arrow::datatypes::Int64Type;
-    use arrow_array::ListArray;
-    use datafusion_common::{cast::as_list_array, utils::array_into_list_array};
+    use datafusion_common::utils::array_into_list_array;
 
     /// Only test internal functions, array-related sql functions will be tested in sqllogictest `array.slt`
     #[test]

--- a/datafusion/functions/src/core/nullif.rs
+++ b/datafusion/functions/src/core/nullif.rs
@@ -144,7 +144,6 @@ mod tests {
     use arrow::array::*;
 
     use super::*;
-    use datafusion_common::{Result, ScalarValue};
 
     #[test]
     fn nullif_int32() -> Result<()> {

--- a/datafusion/functions/src/core/nvl.rs
+++ b/datafusion/functions/src/core/nvl.rs
@@ -129,7 +129,7 @@ mod tests {
     use arrow::array::*;
 
     use super::*;
-    use datafusion_common::{Result, ScalarValue};
+    use datafusion_common::ScalarValue;
 
     #[test]
     fn nvl_int32() -> Result<()> {

--- a/datafusion/functions/src/string/levenshtein.rs
+++ b/datafusion/functions/src/string/levenshtein.rs
@@ -122,7 +122,7 @@ pub fn levenshtein<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 #[cfg(test)]
 mod tests {
-    use arrow::array::{Int32Array, StringArray};
+    use arrow::array::StringArray;
 
     use datafusion_common::cast::as_int32_array;
 

--- a/datafusion/functions/src/string/to_hex.rs
+++ b/datafusion/functions/src/string/to_hex.rs
@@ -107,10 +107,7 @@ impl ScalarUDFImpl for ToHexFunc {
 
 #[cfg(test)]
 mod tests {
-    use arrow::{
-        array::{Int32Array, StringArray},
-        datatypes::Int32Type,
-    };
+    use arrow::array::{Int32Array, StringArray};
 
     use datafusion_common::cast::as_string_array;
 

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -177,5 +177,6 @@ pub mod test {
         };
     }
 
+    #[allow(unused_imports)]
     pub(crate) use test_function;
 }

--- a/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/count_wildcard_rule.rs
@@ -103,12 +103,12 @@ mod tests {
     use super::*;
     use crate::test::*;
     use arrow::datatypes::DataType;
-    use datafusion_common::{Result, ScalarValue};
+    use datafusion_common::ScalarValue;
     use datafusion_expr::expr::Sort;
     use datafusion_expr::{
-        col, count, exists, expr, in_subquery, lit, logical_plan::LogicalPlanBuilder,
-        max, out_ref_col, scalar_subquery, sum, wildcard, AggregateFunction, Expr,
-        WindowFrame, WindowFrameBound, WindowFrameUnits, WindowFunctionDefinition,
+        col, count, exists, expr, in_subquery, logical_plan::LogicalPlanBuilder, max,
+        out_ref_col, scalar_subquery, sum, wildcard, AggregateFunction, WindowFrame,
+        WindowFrameBound, WindowFrameUnits,
     };
     use std::sync::Arc;
 

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -766,13 +766,10 @@ fn replace_common_expr(
 mod test {
     use std::iter;
 
-    use arrow::datatypes::{Field, Schema};
+    use arrow::datatypes::Schema;
 
-    use datafusion_common::DFSchema;
     use datafusion_expr::logical_plan::{table_scan, JoinType};
-    use datafusion_expr::{
-        avg, col, lit, logical_plan::builder::LogicalPlanBuilder, sum,
-    };
+    use datafusion_expr::{avg, lit, logical_plan::builder::LogicalPlanBuilder, sum};
     use datafusion_expr::{
         grouping_set, AccumulatorFactoryFunction, AggregateUDF, Signature,
         SimpleAggregateUDF, Volatility,

--- a/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
+++ b/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
@@ -331,12 +331,7 @@ mod tests {
     use crate::test::*;
 
     use arrow::datatypes::DataType;
-    use datafusion_common::Result;
-    use datafusion_expr::{
-        and, binary_expr, col, exists, in_subquery, lit,
-        logical_plan::LogicalPlanBuilder, not_exists, not_in_subquery, or, out_ref_col,
-        Operator,
-    };
+    use datafusion_expr::{and, binary_expr, col, lit, or, out_ref_col};
 
     fn assert_optimized_plan_equal(plan: LogicalPlan, expected: &str) -> Result<()> {
         assert_optimized_plan_eq_display_indent(

--- a/datafusion/optimizer/src/eliminate_one_union.rs
+++ b/datafusion/optimizer/src/eliminate_one_union.rs
@@ -63,8 +63,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::ToDFSchema;
     use datafusion_expr::{
-        expr_rewriter::coerce_plan_expr_for_schema,
-        logical_plan::{table_scan, Union},
+        expr_rewriter::coerce_plan_expr_for_schema, logical_plan::table_scan,
     };
     use std::sync::Arc;
 

--- a/datafusion/optimizer/src/filter_null_join_keys.rs
+++ b/datafusion/optimizer/src/filter_null_join_keys.rs
@@ -112,9 +112,9 @@ mod tests {
     use super::*;
     use crate::test::assert_optimized_plan_eq;
     use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_common::{Column, Result};
+    use datafusion_common::Column;
     use datafusion_expr::logical_plan::table_scan;
-    use datafusion_expr::{col, lit, logical_plan::JoinType, LogicalPlanBuilder};
+    use datafusion_expr::{col, lit, LogicalPlanBuilder};
 
     fn assert_optimized_plan_equal(plan: LogicalPlan, expected: &str) -> Result<()> {
         assert_optimized_plan_eq(Arc::new(FilterNullJoinKeys {}), plan, expected)

--- a/datafusion/optimizer/src/plan_signature.rs
+++ b/datafusion/optimizer/src/plan_signature.rs
@@ -89,7 +89,7 @@ mod tests {
     use std::sync::Arc;
 
     use datafusion_common::{DFSchema, Result};
-    use datafusion_expr::{self, lit, LogicalPlan};
+    use datafusion_expr::{lit, LogicalPlan};
 
     use crate::plan_signature::get_node_number;
 

--- a/datafusion/optimizer/src/propagate_empty_relation.rs
+++ b/datafusion/optimizer/src/propagate_empty_relation.rs
@@ -192,8 +192,7 @@ mod tests {
     use datafusion_common::{Column, DFSchema, ScalarValue};
     use datafusion_expr::logical_plan::table_scan;
     use datafusion_expr::{
-        binary_expr, col, lit, logical_plan::builder::LogicalPlanBuilder, Expr, JoinType,
-        Operator,
+        binary_expr, col, lit, logical_plan::builder::LogicalPlanBuilder, Expr, Operator,
     };
 
     use super::*;

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1031,7 +1031,6 @@ mod tests {
     use super::*;
     use std::any::Any;
     use std::fmt::{Debug, Formatter};
-    use std::sync::Arc;
 
     use crate::optimizer::Optimizer;
     use crate::rewrite_disjunctive_predicate::RewriteDisjunctivePredicate;
@@ -1039,12 +1038,11 @@ mod tests {
     use crate::OptimizerContext;
 
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-    use datafusion_common::{DFSchema, DFSchemaRef, ScalarValue};
+    use datafusion_common::ScalarValue;
     use datafusion_expr::expr::ScalarFunction;
     use datafusion_expr::logical_plan::table_scan;
     use datafusion_expr::{
-        and, col, in_list, in_subquery, lit, logical_plan::JoinType, or, sum, BinaryExpr,
-        ColumnarValue, Expr, Extension, LogicalPlanBuilder, Operator, ScalarUDF,
+        col, in_list, in_subquery, lit, sum, ColumnarValue, Extension, ScalarUDF,
         ScalarUDFImpl, Signature, TableSource, TableType, UserDefinedLogicalNodeCore,
         Volatility,
     };

--- a/datafusion/optimizer/src/push_down_limit.rs
+++ b/datafusion/optimizer/src/push_down_limit.rs
@@ -279,11 +279,7 @@ mod test {
     use super::*;
     use crate::test::*;
 
-    use datafusion_expr::{
-        col, exists,
-        logical_plan::{builder::LogicalPlanBuilder, JoinType, LogicalPlan},
-        max,
-    };
+    use datafusion_expr::{col, exists, logical_plan::builder::LogicalPlanBuilder, max};
 
     fn assert_optimized_plan_equal(plan: LogicalPlan, expected: &str) -> Result<()> {
         assert_optimized_plan_eq(Arc::new(PushDownLimit::new()), plan, expected)

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -385,8 +385,6 @@ mod tests {
     use crate::test::*;
 
     use arrow::datatypes::DataType;
-    use datafusion_common::Result;
-    use datafusion_expr::logical_plan::LogicalPlanBuilder;
     use datafusion_expr::{
         col, lit, max, min, out_ref_col, scalar_subquery, sum, Between,
     };

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -1687,11 +1687,8 @@ mod tests {
         sync::Arc,
     };
 
-    use arrow::datatypes::{DataType, Field, Schema};
-
     use datafusion_common::{assert_contains, ToDFSchema};
     use datafusion_expr::{interval_arithmetic::Interval, *};
-    use datafusion_physical_expr::execution_props::ExecutionProps;
 
     use crate::simplify_expressions::SimplifyContext;
     use crate::test::test_table_scan_with_name;

--- a/datafusion/optimizer/src/simplify_expressions/guarantees.rs
+++ b/datafusion/optimizer/src/simplify_expressions/guarantees.rs
@@ -206,7 +206,7 @@ mod tests {
     use arrow::datatypes::DataType;
     use datafusion_common::tree_node::{TransformedResult, TreeNode};
     use datafusion_common::ScalarValue;
-    use datafusion_expr::{col, lit, Operator};
+    use datafusion_expr::{col, Operator};
 
     #[test]
     fn test_null_handling() {

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -309,8 +309,8 @@ mod tests {
     use datafusion_expr::expr;
     use datafusion_expr::expr::GroupingSet;
     use datafusion_expr::{
-        col, count, count_distinct, lit, logical_plan::builder::LogicalPlanBuilder, max,
-        min, sum, AggregateFunction,
+        count, count_distinct, lit, logical_plan::builder::LogicalPlanBuilder, max, min,
+        sum, AggregateFunction,
     };
 
     fn assert_optimized_plan_equal(plan: LogicalPlan, expected: &str) -> Result<()> {

--- a/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
+++ b/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
@@ -475,16 +475,13 @@ fn cast_between_timestamp(from: DataType, to: DataType, value: i128) -> Option<i
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
 
     use super::*;
-    use crate::unwrap_cast_in_comparison::UnwrapCastExprRewriter;
 
     use arrow::compute::{cast_with_options, CastOptions};
-    use arrow::datatypes::{DataType, Field};
-    use datafusion_common::tree_node::{TransformedResult, TreeNode};
-    use datafusion_common::{DFSchema, DFSchemaRef, ScalarValue};
-    use datafusion_expr::{cast, col, in_list, lit, try_cast, Expr};
+    use arrow::datatypes::Field;
+    use datafusion_common::tree_node::TransformedResult;
+    use datafusion_expr::{cast, col, in_list, try_cast};
 
     #[test]
     fn test_not_unwrap_cast_comparison() {

--- a/datafusion/physical-expr/src/aggregate/approx_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_distinct.rs
@@ -34,8 +34,6 @@ use datafusion_common::{
 };
 use datafusion_expr::Accumulator;
 use std::any::Any;
-use std::convert::TryFrom;
-use std::convert::TryInto;
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::sync::Arc;

--- a/datafusion/physical-expr/src/aggregate/array_agg.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg.rs
@@ -192,15 +192,12 @@ mod tests {
     use super::*;
     use crate::expressions::col;
     use crate::expressions::tests::aggregate;
-    use arrow::array::ArrayRef;
     use arrow::array::Int32Array;
     use arrow::datatypes::*;
     use arrow::record_batch::RecordBatch;
-    use arrow_array::Array;
     use arrow_array::ListArray;
     use arrow_buffer::OffsetBuffer;
     use datafusion_common::DataFusionError;
-    use datafusion_common::Result;
 
     macro_rules! test_op {
         ($ARRAY:expr, $DATATYPE:expr, $OP:ident, $EXPECTED:expr) => {

--- a/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg_distinct.rs
@@ -181,8 +181,8 @@ mod tests {
     use super::*;
     use crate::expressions::col;
     use crate::expressions::tests::aggregate;
-    use arrow::array::{ArrayRef, Int32Array};
-    use arrow::datatypes::{DataType, Schema};
+    use arrow::array::Int32Array;
+    use arrow::datatypes::Schema;
     use arrow::record_batch::RecordBatch;
     use arrow_array::types::Int32Type;
     use arrow_array::Array;

--- a/datafusion/physical-expr/src/aggregate/bit_and_or_xor.rs
+++ b/datafusion/physical-expr/src/aggregate/bit_and_or_xor.rs
@@ -702,8 +702,6 @@ mod tests {
     use crate::generic_test_op;
     use arrow::array::*;
     use arrow::datatypes::*;
-    use arrow::record_batch::RecordBatch;
-    use datafusion_common::Result;
 
     #[test]
     fn bit_and_i32() -> Result<()> {

--- a/datafusion/physical-expr/src/aggregate/bool_and_or.rs
+++ b/datafusion/physical-expr/src/aggregate/bool_and_or.rs
@@ -345,8 +345,6 @@ mod tests {
     use crate::generic_test_op;
     use arrow::datatypes::*;
     use arrow::record_batch::RecordBatch;
-    use arrow_array::BooleanArray;
-    use datafusion_common::Result;
 
     #[test]
     fn test_bool_and() -> Result<()> {

--- a/datafusion/physical-expr/src/aggregate/correlation.rs
+++ b/datafusion/physical-expr/src/aggregate/correlation.rs
@@ -252,9 +252,7 @@ mod tests {
     use crate::expressions::col;
     use crate::expressions::tests::aggregate;
     use crate::generic_test_op2;
-    use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
-    use datafusion_common::Result;
 
     #[test]
     fn correlation_f64_1() -> Result<()> {

--- a/datafusion/physical-expr/src/aggregate/count.rs
+++ b/datafusion/physical-expr/src/aggregate/count.rs
@@ -338,9 +338,7 @@ mod tests {
     use crate::expressions::tests::aggregate;
     use crate::expressions::{col, lit};
     use crate::generic_test_op;
-    use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
-    use datafusion_common::Result;
 
     #[test]
     fn count_elements() -> Result<()> {

--- a/datafusion/physical-expr/src/aggregate/count_distinct/mod.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct/mod.rs
@@ -315,13 +315,8 @@ impl Accumulator for DistinctCountAccumulator {
 #[cfg(test)]
 mod tests {
     use arrow::array::{
-        ArrayRef, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
-    };
-    use arrow::datatypes::DataType;
-    use arrow::datatypes::{
-        Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type,
-        UInt32Type, UInt64Type, UInt8Type,
+        BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
+        Int8Array, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
     };
     use arrow_array::Decimal256Array;
     use arrow_buffer::i256;

--- a/datafusion/physical-expr/src/aggregate/count_distinct/native.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct/native.rs
@@ -20,7 +20,6 @@
 //!
 //! [`Int64Array`]: arrow::array::Int64Array
 //! [`Float64Array`]: arrow::array::Float64Array
-use std::cmp::Eq;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::hash::Hash;

--- a/datafusion/physical-expr/src/aggregate/covariance.rs
+++ b/datafusion/physical-expr/src/aggregate/covariance.rs
@@ -412,9 +412,7 @@ mod tests {
     use crate::expressions::col;
     use crate::expressions::tests::aggregate;
     use crate::generic_test_op2;
-    use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
-    use datafusion_common::Result;
 
     #[test]
     fn covariance_f64_1() -> Result<()> {

--- a/datafusion/physical-expr/src/aggregate/groups_accumulator/accumulate.rs
+++ b/datafusion/physical-expr/src/aggregate/groups_accumulator/accumulate.rs
@@ -463,7 +463,6 @@ mod test {
     use super::*;
 
     use arrow_array::UInt32Array;
-    use arrow_buffer::BooleanBuffer;
     use hashbrown::HashSet;
     use rand::{rngs::ThreadRng, Rng};
 

--- a/datafusion/physical-expr/src/aggregate/median.rs
+++ b/datafusion/physical-expr/src/aggregate/median.rs
@@ -202,7 +202,6 @@ mod tests {
     use crate::expressions::col;
     use crate::expressions::tests::aggregate;
     use crate::generic_test_op;
-    use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
 
     #[test]

--- a/datafusion/physical-expr/src/aggregate/min_max.rs
+++ b/datafusion/physical-expr/src/aggregate/min_max.rs
@@ -18,7 +18,6 @@
 //! Defines physical expressions that can evaluated at runtime during query execution
 
 use std::any::Any;
-use std::convert::TryFrom;
 use std::sync::Arc;
 
 use crate::aggregate::groups_accumulator::prim_op::PrimitiveGroupsAccumulator;
@@ -1113,8 +1112,6 @@ mod tests {
     use crate::{generic_test_op, generic_test_op_new};
     use arrow::datatypes::*;
     use arrow::record_batch::RecordBatch;
-    use datafusion_common::Result;
-    use datafusion_common::ScalarValue;
     use datafusion_common::ScalarValue::Decimal128;
 
     #[test]

--- a/datafusion/physical-expr/src/aggregate/stddev.rs
+++ b/datafusion/physical-expr/src/aggregate/stddev.rs
@@ -247,9 +247,7 @@ mod tests {
     use crate::expressions::col;
     use crate::expressions::tests::aggregate;
     use crate::generic_test_op;
-    use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
-    use datafusion_common::Result;
 
     #[test]
     fn stddev_f64_1() -> Result<()> {

--- a/datafusion/physical-expr/src/aggregate/string_agg.rs
+++ b/datafusion/physical-expr/src/aggregate/string_agg.rs
@@ -173,7 +173,6 @@ mod tests {
     use super::*;
     use crate::expressions::tests::aggregate;
     use crate::expressions::{col, create_aggregate_expr, try_cast};
-    use arrow::array::ArrayRef;
     use arrow::datatypes::*;
     use arrow::record_batch::RecordBatch;
     use arrow_array::LargeStringArray;

--- a/datafusion/physical-expr/src/aggregate/sum_distinct.rs
+++ b/datafusion/physical-expr/src/aggregate/sum_distinct.rs
@@ -24,7 +24,7 @@ use ahash::RandomState;
 use arrow::array::{Array, ArrayRef};
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
-use arrow_array::{ArrowNativeTypeOp, ArrowPrimitiveType};
+use arrow_array::ArrowNativeTypeOp;
 use arrow_buffer::ArrowNativeType;
 use std::collections::HashSet;
 
@@ -206,7 +206,6 @@ mod tests {
     use super::*;
     use crate::expressions::tests::assert_aggregate;
     use arrow::array::*;
-    use datafusion_common::Result;
     use datafusion_expr::AggregateFunction;
 
     fn run_update_batch(

--- a/datafusion/physical-expr/src/aggregate/variance.rs
+++ b/datafusion/physical-expr/src/aggregate/variance.rs
@@ -339,9 +339,7 @@ mod tests {
     use crate::expressions::col;
     use crate::expressions::tests::aggregate;
     use crate::generic_test_op;
-    use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
-    use datafusion_common::Result;
 
     #[test]
     fn variance_f64_1() -> Result<()> {

--- a/datafusion/physical-expr/src/binary_map.rs
+++ b/datafusion/physical-expr/src/binary_map.rs
@@ -605,7 +605,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::ArrayRef;
     use arrow_array::{BinaryArray, LargeBinaryArray, StringArray};
     use hashbrown::HashMap;
 

--- a/datafusion/physical-expr/src/equivalence/class.rs
+++ b/datafusion/physical-expr/src/equivalence/class.rs
@@ -481,12 +481,10 @@ impl EquivalenceGroup {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::equivalence::tests::create_test_params;
-    use crate::equivalence::{EquivalenceClass, EquivalenceGroup};
-    use crate::expressions::{lit, Column, Literal};
+    use crate::expressions::{lit, Literal};
 
     use datafusion_common::{Result, ScalarValue};
 

--- a/datafusion/physical-expr/src/equivalence/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/mod.rs
@@ -112,10 +112,9 @@ pub fn add_offset_to_expr(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
-    use crate::expressions::{col, Column};
+    use crate::expressions::col;
     use crate::PhysicalSortExpr;
 
     use arrow::compute::{lexsort_to_indices, SortColumn};

--- a/datafusion/physical-expr/src/equivalence/projection.rs
+++ b/datafusion/physical-expr/src/equivalence/projection.rs
@@ -114,13 +114,12 @@ impl ProjectionMapping {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow_schema::{SortOptions, TimeUnit};
     use itertools::Itertools;
 
-    use datafusion_common::{DFSchema, Result};
+    use datafusion_common::DFSchema;
     use datafusion_expr::{Operator, ScalarUDF};
 
     use crate::equivalence::tests::{

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -1295,13 +1295,11 @@ impl Hash for ExprWrapper {
 #[cfg(test)]
 mod tests {
     use std::ops::Not;
-    use std::sync::Arc;
 
     use arrow::datatypes::{DataType, Field, Schema};
-    use arrow_schema::{Fields, SortOptions, TimeUnit};
-    use itertools::Itertools;
+    use arrow_schema::{Fields, TimeUnit};
 
-    use datafusion_common::{DFSchema, Result};
+    use datafusion_common::DFSchema;
     use datafusion_expr::{Operator, ScalarUDF};
 
     use crate::equivalence::add_offset_to_expr;
@@ -1312,7 +1310,6 @@ mod tests {
     };
     use crate::expressions::{col, BinaryExpr, Column};
     use crate::utils::tests::TestScalarUDF;
-    use crate::PhysicalSortExpr;
 
     use super::*;
 

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -34,7 +34,6 @@ use arrow::compute::kernels::comparison::regexp_is_match_utf8_scalar;
 use arrow::compute::kernels::concat_elements::concat_elements_utf8;
 use arrow::compute::{cast, ilike, like, nilike, nlike};
 use arrow::datatypes::*;
-use arrow::record_batch::RecordBatch;
 
 use datafusion_common::cast::as_boolean_array;
 use datafusion_common::{internal_err, Result, ScalarValue};
@@ -624,10 +623,7 @@ pub fn binary(
 mod tests {
     use super::*;
     use crate::expressions::{col, lit, try_cast, Literal};
-    use arrow::datatypes::{
-        ArrowNumericType, Decimal128Type, Field, Int32Type, SchemaRef,
-    };
-    use datafusion_common::{plan_datafusion_err, Result};
+    use datafusion_common::plan_datafusion_err;
     use datafusion_expr::type_coercion::binary::get_input_types;
 
     /// Performs a binary operation, applying any type coercion necessary

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -28,7 +28,6 @@ use arrow::compute::kernels::cmp::eq;
 use arrow::compute::kernels::zip::zip;
 use arrow::compute::{and, is_null, not, nullif, or, prep_null_mask_filter};
 use arrow::datatypes::{DataType, Schema};
-use arrow::record_batch::RecordBatch;
 use datafusion_common::cast::as_boolean_array;
 use datafusion_common::{exec_err, internal_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::ColumnarValue;
@@ -416,13 +415,12 @@ mod tests {
     use super::*;
     use crate::expressions::{binary, cast, col, lit};
 
-    use arrow::array::StringArray;
     use arrow::buffer::Buffer;
     use arrow::datatypes::DataType::Float64;
     use arrow::datatypes::*;
     use datafusion_common::cast::{as_float64_array, as_int32_array};
+    use datafusion_common::plan_err;
     use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
-    use datafusion_common::{plan_err, ScalarValue};
     use datafusion_expr::type_coercion::binary::comparison_coercion;
     use datafusion_expr::Operator;
 

--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -228,8 +228,6 @@ mod tests {
         datatypes::*,
     };
 
-    use datafusion_common::Result;
-
     // runs an end-to-end test of physical type cast
     // 1. construct a record batch with a column "a" of type A
     // 2. construct a physical expression of CAST(a AS B)

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -31,7 +31,6 @@ use arrow::compute::kernels::boolean::{not, or_kleene};
 use arrow::compute::kernels::cmp::eq;
 use arrow::compute::take;
 use arrow::datatypes::*;
-use arrow::record_batch::RecordBatch;
 use arrow::util::bit_iterator::BitIndexIterator;
 use arrow::{downcast_dictionary_array, downcast_primitive_array};
 use datafusion_common::cast::{
@@ -455,13 +454,11 @@ pub fn in_list(
 
 #[cfg(test)]
 mod tests {
-    use arrow::{array::StringArray, datatypes::Field};
 
     use super::*;
     use crate::expressions;
     use crate::expressions::{col, lit, try_cast};
     use datafusion_common::plan_err;
-    use datafusion_common::Result;
     use datafusion_expr::type_coercion::binary::comparison_coercion;
 
     type InListCastResult = (Arc<dyn PhysicalExpr>, Vec<Arc<dyn PhysicalExpr>>);

--- a/datafusion/physical-expr/src/expressions/is_not_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_not_null.rs
@@ -119,10 +119,8 @@ mod tests {
     use arrow::{
         array::{BooleanArray, StringArray},
         datatypes::*,
-        record_batch::RecordBatch,
     };
     use datafusion_common::cast::as_boolean_array;
-    use std::sync::Arc;
 
     #[test]
     fn is_not_null_op() -> Result<()> {

--- a/datafusion/physical-expr/src/expressions/is_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_null.rs
@@ -120,10 +120,8 @@ mod tests {
     use arrow::{
         array::{BooleanArray, StringArray},
         datatypes::*,
-        record_batch::RecordBatch,
     };
     use datafusion_common::cast::as_boolean_array;
-    use std::sync::Arc;
 
     #[test]
     fn is_null_op() -> Result<()> {

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -118,7 +118,6 @@ mod tests {
     use arrow::array::Int32Array;
     use arrow::datatypes::*;
     use datafusion_common::cast::as_int32_array;
-    use datafusion_common::Result;
 
     #[test]
     fn literal_i32() -> Result<()> {

--- a/datafusion/physical-expr/src/expressions/negative.rs
+++ b/datafusion/physical-expr/src/expressions/negative.rs
@@ -180,7 +180,6 @@ mod tests {
     use arrow_schema::DataType::{Float32, Float64, Int16, Int32, Int64, Int8};
     use datafusion_common::cast::as_primitive_array;
     use datafusion_common::DataFusionError;
-    use datafusion_common::Result;
 
     use paste::paste;
 

--- a/datafusion/physical-expr/src/expressions/not.rs
+++ b/datafusion/physical-expr/src/expressions/not.rs
@@ -125,7 +125,6 @@ mod tests {
     use super::*;
     use crate::expressions::col;
     use arrow::{array::BooleanArray, datatypes::*};
-    use datafusion_common::Result;
 
     #[test]
     fn neg_op() -> Result<()> {

--- a/datafusion/physical-expr/src/expressions/try_cast.rs
+++ b/datafusion/physical-expr/src/expressions/try_cast.rs
@@ -159,7 +159,6 @@ mod tests {
         },
         datatypes::*,
     };
-    use datafusion_common::Result;
 
     // runs an end-to-end test of physical type cast
     // 1. construct a record batch with a column "a" of type A

--- a/datafusion/physical-expr/src/functions.rs
+++ b/datafusion/physical-expr/src/functions.rs
@@ -222,15 +222,14 @@ fn func_order_in_one_dimension(
 #[cfg(test)]
 mod tests {
     use arrow::{
-        array::{Array, ArrayRef, UInt64Array},
+        array::UInt64Array,
         datatypes::{DataType, Field},
     };
     use arrow_schema::DataType::Utf8;
 
     use datafusion_common::cast::as_uint64_array;
+    use datafusion_common::DataFusionError;
     use datafusion_common::{internal_err, plan_err};
-    use datafusion_common::{DataFusionError, Result, ScalarValue};
-    use datafusion_expr::type_coercion::functions::data_types;
     use datafusion_expr::{Signature, Volatility};
 
     use crate::expressions::try_cast;

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -723,7 +723,7 @@ mod tests {
     use crate::intervals::test_utils::gen_conjunctive_numerical_expr;
 
     use arrow::datatypes::TimeUnit;
-    use arrow_schema::{DataType, Field};
+    use arrow_schema::Field;
     use datafusion_common::ScalarValue;
 
     use itertools::Itertools;

--- a/datafusion/physical-expr/src/math_expressions.rs
+++ b/datafusion/physical-expr/src/math_expressions.rs
@@ -79,7 +79,6 @@ pub fn isnan(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 #[cfg(test)]
 mod tests {
-    use arrow::array::Float64Array;
 
     use datafusion_common::cast::as_boolean_array;
 

--- a/datafusion/physical-expr/src/partitioning.rs
+++ b/datafusion/physical-expr/src/partitioning.rs
@@ -236,7 +236,6 @@ impl Distribution {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::expressions::Column;

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -386,9 +386,8 @@ where
 #[cfg(test)]
 mod tests {
     use arrow_array::{ArrayRef, BooleanArray, RecordBatch, StringArray};
-    use arrow_schema::{DataType, Field, Schema};
+    use arrow_schema::{DataType, Field};
 
-    use datafusion_common::{DFSchema, Result};
     use datafusion_expr::{col, lit};
 
     use super::*;

--- a/datafusion/physical-expr/src/utils/mod.rs
+++ b/datafusion/physical-expr/src/utils/mod.rs
@@ -258,14 +258,12 @@ pub(crate) mod tests {
     use arrow_array::{ArrayRef, Float32Array, Float64Array};
     use std::any::Any;
     use std::fmt::{Display, Formatter};
-    use std::sync::Arc;
 
     use super::*;
-    use crate::expressions::{binary, cast, col, in_list, lit, Column, Literal};
-    use crate::PhysicalSortExpr;
+    use crate::expressions::{binary, cast, col, in_list, lit, Literal};
 
     use arrow_schema::{DataType, Field, Schema};
-    use datafusion_common::{exec_err, DataFusionError, Result, ScalarValue};
+    use datafusion_common::{exec_err, DataFusionError, ScalarValue};
 
     use datafusion_expr::{
         ColumnarValue, FuncMonotonicity, ScalarUDFImpl, Signature, Volatility,

--- a/datafusion/physical-expr/src/window/lead_lag.rs
+++ b/datafusion/physical-expr/src/window/lead_lag.rs
@@ -397,10 +397,8 @@ impl PartitionEvaluator for WindowShiftEvaluator {
 mod tests {
     use super::*;
     use crate::expressions::Column;
-    use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
     use datafusion_common::cast::as_int32_array;
-    use datafusion_common::Result;
 
     fn test_i32_result(expr: WindowShift, expected: Int32Array) -> Result<()> {
         let arr: ArrayRef = Arc::new(Int32Array::from(vec![1, -2, 3, -4, 5, -6, 7, 8]));

--- a/datafusion/physical-expr/src/window/nth_value.rs
+++ b/datafusion/physical-expr/src/window/nth_value.rs
@@ -322,10 +322,8 @@ impl PartitionEvaluator for NthValueEvaluator {
 mod tests {
     use super::*;
     use crate::expressions::Column;
-    use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
     use datafusion_common::cast::as_int32_array;
-    use datafusion_common::Result;
 
     fn test_i32_result(expr: NthValue, expected: Int32Array) -> Result<()> {
         let arr: ArrayRef = Arc::new(Int32Array::from(vec![1, -2, 3, -4, 5, -6, 7, 8]));

--- a/datafusion/physical-expr/src/window/row_number.rs
+++ b/datafusion/physical-expr/src/window/row_number.rs
@@ -125,9 +125,8 @@ impl PartitionEvaluator for NumRowsEvaluator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::record_batch::RecordBatch;
     use arrow::{array::*, datatypes::*};
-    use datafusion_common::{cast::as_uint64_array, Result};
+    use datafusion_common::cast::as_uint64_array;
 
     #[test]
     fn row_number_all_null() -> Result<()> {

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -1185,12 +1185,9 @@ pub(crate) fn evaluate_group_by(
 
 #[cfg(test)]
 mod tests {
-    use std::any::Any;
-    use std::sync::Arc;
     use std::task::{Context, Poll};
 
     use super::*;
-    use crate::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
     use crate::coalesce_batches::CoalesceBatchesExec;
     use crate::coalesce_partitions::CoalescePartitionsExec;
     use crate::common;
@@ -1198,18 +1195,14 @@ mod tests {
     use crate::memory::MemoryExec;
     use crate::test::assert_is_pending;
     use crate::test::exec::{assert_strong_count_converges_to_zero, BlockingExec};
-    use crate::{
-        DisplayAs, ExecutionPlan, Partitioning, RecordBatchStream,
-        SendableRecordBatchStream, Statistics,
-    };
+    use crate::RecordBatchStream;
 
     use arrow::array::{Float64Array, UInt32Array};
     use arrow::compute::{concat_batches, SortOptions};
-    use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-    use arrow::record_batch::RecordBatch;
+    use arrow::datatypes::DataType;
     use datafusion_common::{
         assert_batches_eq, assert_batches_sorted_eq, internal_err, DataFusionError,
-        Result, ScalarValue,
+        ScalarValue,
     };
     use datafusion_execution::config::SessionConfig;
     use datafusion_execution::memory_pool::FairSpillPool;
@@ -1217,10 +1210,7 @@ mod tests {
     use datafusion_physical_expr::expressions::{
         lit, ApproxDistinct, Count, FirstValue, LastValue, Median, OrderSensitiveArrayAgg,
     };
-    use datafusion_physical_expr::{
-        reverse_order_bys, AggregateExpr, EquivalenceProperties, PhysicalExpr,
-        PhysicalSortExpr,
-    };
+    use datafusion_physical_expr::{reverse_order_bys, PhysicalSortExpr};
 
     use futures::{FutureExt, Stream};
 

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -36,7 +36,7 @@ use crate::{aggregates, ExecutionPlan, PhysicalExpr};
 use crate::{RecordBatchStream, SendableRecordBatchStream};
 
 use arrow::array::*;
-use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use arrow::datatypes::SchemaRef;
 use arrow_schema::SortOptions;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_execution::disk_manager::RefCountedTempFile;

--- a/datafusion/physical-plan/src/aggregates/topk/hash_table.rs
+++ b/datafusion/physical-plan/src/aggregates/topk/hash_table.rs
@@ -386,7 +386,6 @@ pub fn new_hash_table(limit: usize, kt: DataType) -> Result<Box<dyn ArrowHashTab
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_common::Result;
     use std::collections::BTreeMap;
 
     #[test]

--- a/datafusion/physical-plan/src/aggregates/topk/heap.rs
+++ b/datafusion/physical-plan/src/aggregates/topk/heap.rs
@@ -453,7 +453,6 @@ pub fn new_heap(limit: usize, desc: bool, vt: DataType) -> Result<Box<dyn ArrowH
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_common::Result;
 
     #[test]
     fn should_append() -> Result<()> {

--- a/datafusion/physical-plan/src/aggregates/topk/priority_map.rs
+++ b/datafusion/physical-plan/src/aggregates/topk/priority_map.rs
@@ -117,8 +117,7 @@ mod tests {
     use arrow_array::{Int64Array, RecordBatch, StringArray};
     use arrow_schema::Field;
     use arrow_schema::Schema;
-    use arrow_schema::{DataType, SchemaRef};
-    use datafusion_common::Result;
+    use arrow_schema::SchemaRef;
     use std::sync::Arc;
 
     #[test]

--- a/datafusion/physical-plan/src/common.rs
+++ b/datafusion/physical-plan/src/common.rs
@@ -361,11 +361,10 @@ mod tests {
     use arrow::compute::SortOptions;
     use arrow::{
         array::{Float32Array, Float64Array, UInt64Array},
-        datatypes::{DataType, Field, Schema},
-        record_batch::RecordBatch,
+        datatypes::{DataType, Field},
     };
     use datafusion_expr::Operator;
-    use datafusion_physical_expr::expressions::{col, Column};
+    use datafusion_physical_expr::expressions::col;
 
     #[test]
     fn get_meet_of_orderings_helper_common_prefix_test() -> Result<()> {

--- a/datafusion/physical-plan/src/empty.rs
+++ b/datafusion/physical-plan/src/empty.rs
@@ -162,8 +162,8 @@ impl ExecutionPlan for EmptyExec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test;
     use crate::with_new_children_if_necessary;
-    use crate::{common, test};
 
     #[tokio::test]
     async fn empty() -> Result<()> {

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -433,20 +433,16 @@ pub type EqualAndNonEqual<'a> =
 
 #[cfg(test)]
 mod tests {
-    use std::iter::Iterator;
-    use std::sync::Arc;
 
     use super::*;
     use crate::expressions::*;
     use crate::test;
     use crate::test::exec::StatisticsExec;
-    use crate::ExecutionPlan;
 
     use crate::empty::EmptyExec;
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::datatypes::{Field, Schema};
     use arrow_schema::{UnionFields, UnionMode};
-    use datafusion_common::{ColumnStatistics, ScalarValue};
-    use datafusion_expr::Operator;
+    use datafusion_common::ScalarValue;
 
     #[tokio::test]
     async fn collect_columns_predicates() -> Result<()> {

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -1556,16 +1556,15 @@ impl Stream for HashJoinStream {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::{
-        common, expressions::Column, hash_utils::create_hashes, memory::MemoryExec,
-        repartition::RepartitionExec, test::build_table_i32, test::exec::MockExec,
+        common, expressions::Column, memory::MemoryExec, repartition::RepartitionExec,
+        test::build_table_i32, test::exec::MockExec,
     };
 
-    use arrow::array::{ArrayRef, Date32Array, Int32Array, UInt32Builder, UInt64Builder};
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::array::{Date32Array, Int32Array, UInt32Builder, UInt64Builder};
+    use arrow::datatypes::{DataType, Field};
     use datafusion_common::{
         assert_batches_eq, assert_batches_sorted_eq, assert_contains, exec_err,
         ScalarValue,
@@ -1574,11 +1573,10 @@ mod tests {
     use datafusion_execution::runtime_env::{RuntimeConfig, RuntimeEnv};
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{BinaryExpr, Literal};
-    use datafusion_physical_expr::PhysicalExpr;
 
     use hashbrown::raw::RawTable;
     use rstest::*;
-    use rstest_reuse::{self, *};
+    use rstest_reuse::*;
 
     fn div_ceil(a: usize, b: usize) -> usize {
         (a + b - 1) / b

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -661,7 +661,6 @@ impl RecordBatchStream for NestedLoopJoinStream {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::{
@@ -674,7 +673,7 @@ mod tests {
     use datafusion_execution::runtime_env::{RuntimeConfig, RuntimeEnv};
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{BinaryExpr, Literal};
-    use datafusion_physical_expr::{Partitioning, PhysicalExpr};
+    use datafusion_physical_expr::PhysicalExpr;
 
     fn build_table(
         a: (&str, &Vec<i32>),

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -46,7 +46,6 @@ use arrow::array::*;
 use arrow::compute::{self, concat_batches, take, SortOptions};
 use arrow::datatypes::{DataType, SchemaRef, TimeUnit};
 use arrow::error::ArrowError;
-use arrow::record_batch::RecordBatch;
 use datafusion_common::{
     internal_err, not_impl_err, plan_err, DataFusionError, JoinSide, JoinType, Result,
 };

--- a/datafusion/physical-plan/src/joins/stream_join_utils.rs
+++ b/datafusion/physical-plan/src/joins/stream_join_utils.rs
@@ -1121,22 +1121,12 @@ pub fn prepare_sorted_exprs(
 
 #[cfg(test)]
 pub mod tests {
-    use std::sync::Arc;
 
     use super::*;
-    use crate::joins::stream_join_utils::{
-        build_filter_input_order, check_filter_expr_contains_sort_information,
-        convert_sort_expr_with_filter_schema, PruningJoinHashMap,
-    };
-    use crate::{
-        expressions::{Column, PhysicalSortExpr},
-        joins::test_utils::complicated_filter,
-        joins::utils::{ColumnIndex, JoinFilter},
-    };
+    use crate::{joins::test_utils::complicated_filter, joins::utils::ColumnIndex};
 
     use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_common::JoinSide;
+    use arrow::datatypes::{DataType, Field};
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{binary, cast, col};
 

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -1335,7 +1335,7 @@ mod tests {
     };
 
     use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
+    use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
     use datafusion_common::ScalarValue;
     use datafusion_execution::config::SessionConfig;
     use datafusion_expr::Operator;

--- a/datafusion/physical-plan/src/placeholder_row.rs
+++ b/datafusion/physical-plan/src/placeholder_row.rs
@@ -180,7 +180,7 @@ impl ExecutionPlan for PlaceholderRowExec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{common, test, with_new_children_if_necessary};
+    use crate::{test, with_new_children_if_necessary};
 
     #[test]
     fn with_new_children() -> Result<()> {

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -1010,14 +1010,12 @@ mod tests {
         {collect, expressions::col, memory::MemoryExec},
     };
 
-    use arrow::array::{ArrayRef, StringArray, UInt32Array};
+    use arrow::array::{StringArray, UInt32Array};
     use arrow::datatypes::{DataType, Field, Schema};
-    use arrow::record_batch::RecordBatch;
     use datafusion_common::cast::as_string_array;
     use datafusion_common::{assert_batches_sorted_eq, exec_err};
     use datafusion_execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 
-    use futures::FutureExt;
     use tokio::task::JoinSet;
 
     #[tokio::test]

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -261,7 +261,6 @@ impl ExecutionPlan for SortPreservingMergeExec {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::FromIterator;
 
     use super::*;
     use crate::coalesce_partitions::CoalescePartitionsExec;

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -599,7 +599,6 @@ mod tests {
     use crate::memory::MemoryExec;
     use crate::test;
 
-    use arrow::record_batch::RecordBatch;
     use arrow_schema::{DataType, SortOptions};
     use datafusion_common::ScalarValue;
     use datafusion_physical_expr::expressions::col;

--- a/datafusion/physical-plan/src/unnest.rs
+++ b/datafusion/physical-plan/src/unnest.rs
@@ -590,7 +590,7 @@ fn batch_from_indices(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::{DataType, Field};
+    use arrow::datatypes::Field;
     use arrow_array::{GenericListArray, OffsetSizeTrait, StringArray};
     use arrow_buffer::{BooleanBufferBuilder, NullBuffer, OffsetBuffer};
 

--- a/datafusion/physical-plan/src/values.rs
+++ b/datafusion/physical-plan/src/values.rs
@@ -214,7 +214,7 @@ mod tests {
     use crate::expressions::lit;
     use crate::test::{self, make_partition};
 
-    use arrow_schema::{DataType, Field, Schema};
+    use arrow_schema::{DataType, Field};
 
     #[tokio::test]
     async fn values_empty_case() -> Result<()> {

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -18,7 +18,6 @@
 //! Physical expressions for window functions
 
 use std::borrow::Borrow;
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use crate::{
@@ -559,7 +558,6 @@ mod tests {
     use crate::test::exec::{assert_strong_count_converges_to_zero, BlockingExec};
 
     use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, SchemaRef};
     use datafusion_execution::TaskContext;
 
     use futures::FutureExt;

--- a/datafusion/physical-plan/src/work_table.rs
+++ b/datafusion/physical-plan/src/work_table.rs
@@ -219,9 +219,8 @@ impl ExecutionPlan for WorkTableExec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{ArrayRef, Int32Array, RecordBatch};
+    use arrow_array::{ArrayRef, Int32Array};
     use datafusion_execution::memory_pool::{MemoryConsumer, UnboundedMemoryPool};
-    use std::sync::Arc;
 
     #[test]
     fn test_work_table() {

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -18,7 +18,6 @@
 //! Serde code to convert from protocol buffers to Rust data structures.
 
 use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 
 use arrow::compute::SortOptions;

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::convert::TryInto;
 use std::fmt::Debug;
 use std::sync::Arc;
 

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -16,10 +16,7 @@
 // under the License.language governing permissions and
 // limitations under the License.
 
-use std::{
-    convert::{TryFrom, TryInto},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 #[cfg(feature = "parquet")]
 use datafusion::datasource::file_format::parquet::ParquetSink;

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -46,10 +46,10 @@ use datafusion_expr::expr::{
 };
 use datafusion_expr::logical_plan::{Extension, UserDefinedLogicalNodeCore};
 use datafusion_expr::{
-    col, create_udaf, lit, Accumulator, AggregateFunction, ColumnarValue, Expr,
-    ExprSchemable, LogicalPlan, Operator, PartitionEvaluator, ScalarUDF, ScalarUDFImpl,
-    Signature, TryCast, Volatility, WindowFrame, WindowFrameBound, WindowFrameUnits,
-    WindowFunctionDefinition, WindowUDF, WindowUDFImpl,
+    Accumulator, AggregateFunction, ColumnarValue, ExprSchemable, LogicalPlan, Operator,
+    PartitionEvaluator, ScalarUDF, ScalarUDFImpl, Signature, TryCast, Volatility,
+    WindowFrame, WindowFrameBound, WindowFrameUnits, WindowFunctionDefinition, WindowUDF,
+    WindowUDFImpl,
 };
 use datafusion_proto::bytes::{
     logical_plan_from_bytes, logical_plan_from_bytes_with_extension_codec,

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -1030,7 +1030,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::datatypes::{Field, Schema};
     use sqlparser::dialect::GenericDialect;
     use sqlparser::parser::Parser;
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change


I found there are many warnings in the project. It looks like we don't run "cargo check" for (a large number of) test modules.

The majority kinds are 
- duplicated import from `super::*` or `xx::prelude::*`
- default imported items since rust edition 2021

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Fix the warnings
- Deny `unused_imports` in `Cargo.toml`
- Try to run check for all targets in workspace level.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

N/A

## Are there any user-facing changes?

N/A
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
