### PR TITLE
Allow expr_to_sql unparsing with no quotes

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -26,7 +26,7 @@ pub struct DefaultDialect {}
 
 impl Dialect for DefaultDialect {
     fn identifier_quote_style(&self) -> Option<char> {
-        None
+        Some('"')
     }
 }
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -965,4 +965,20 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn custom_dialect_none() -> Result<()> {
+        let dialect = CustomDialect::new(None);
+        let unparser = Unparser::new(&dialect);
+
+        let expr = col("a").gt(lit(4));
+        let ast = unparser.expr_to_sql(&expr)?;
+
+        let actual = format!("{}", ast);
+
+        let expected = r#"(a > 4)"#;
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -358,7 +358,7 @@ impl Unparser<'_> {
     pub(super) fn new_ident(&self, str: String) -> ast::Ident {
         ast::Ident {
             value: str,
-            quote_style: Some(self.dialect.identifier_quote_style().unwrap_or('"')),
+            quote_style: self.dialect.identifier_quote_style(),
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10197

## Rationale for this change

I'm using the Unparser.expr_to_sql function to translate a DataFusion Expr into an expression for Spark Connect. Unlike most SQL engines, Spark doesn't like quoting the column identifiers. I want to be able to generate an expression like `a > 4` but currently I can only get `"a" > 4`

I believe this might be useful beyond Spark for other database systems that can handle unquoted column identifiers.

## What changes are included in this PR?

Changes the DefaultDialect for the Unparser to return `Some('"')` for `identifier_quote_style`, and then changes the usage of `identifier_quote_style` to not unwrap to `"` if it is None, but pass the Option through.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No, this change is backwards-compatible.