### PR TITLE
Move coalesce function from math to core

### DIFF
--- a/datafusion/functions/src/core/coalesce.rs
+++ b/datafusion/functions/src/core/coalesce.rs
@@ -132,11 +132,11 @@ mod test {
 
     use datafusion_expr::ScalarUDFImpl;
 
-    use crate::math;
+    use crate::core;
 
     #[test]
     fn test_coalesce_return_types() {
-        let coalesce = math::coalesce::CoalesceFunc::new();
+        let coalesce = core::coalesce::CoalesceFunc::new();
         let return_type = coalesce
             .return_type(&[DataType::Date32, DataType::Date32])
             .unwrap();

--- a/datafusion/functions/src/core/mod.rs
+++ b/datafusion/functions/src/core/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod arrow_cast;
 pub mod arrowtypeof;
+pub mod coalesce;
 pub mod getfield;
 pub mod named_struct;
 pub mod nullif;
@@ -35,6 +36,7 @@ make_udf_function!(arrowtypeof::ArrowTypeOfFunc, ARROWTYPEOF, arrow_typeof);
 make_udf_function!(r#struct::StructFunc, STRUCT, r#struct);
 make_udf_function!(named_struct::NamedStructFunc, NAMED_STRUCT, named_struct);
 make_udf_function!(getfield::GetFieldFunc, GET_FIELD, get_field);
+make_udf_function!(coalesce::CoalesceFunc, COALESCE, coalesce);
 
 // Export the functions out of this package, both as expr_fn as well as a list of functions
 export_functions!(
@@ -45,5 +47,6 @@ export_functions!(
     (arrow_typeof, arg_1, "Returns the Arrow type of the input expression."),
     (r#struct, args, "Returns a struct with the given arguments"),
     (named_struct, args, "Returns a struct with the given names and arguments pairs"),
-    (get_field, arg_1 arg_2, "Returns the value of the field with the given name from the struct")
+    (get_field, arg_1 arg_2, "Returns the value of the field with the given name from the struct"),
+    (coalesce, args, "Returns `coalesce(args...)`, which evaluates to the value of the first [Expr] which is not NULL")
 );

--- a/datafusion/functions/src/core/mod.rs
+++ b/datafusion/functions/src/core/mod.rs
@@ -48,5 +48,5 @@ export_functions!(
     (r#struct, args, "Returns a struct with the given arguments"),
     (named_struct, args, "Returns a struct with the given names and arguments pairs"),
     (get_field, arg_1 arg_2, "Returns the value of the field with the given name from the struct"),
-    (coalesce, args, "Returns `coalesce(args...)`, which evaluates to the value of the first [Expr] which is not NULL")
+    (coalesce, args, "Returns `coalesce(args...)`, which evaluates to the value of the first expr which is not NULL")
 );

--- a/datafusion/functions/src/math/mod.rs
+++ b/datafusion/functions/src/math/mod.rs
@@ -21,7 +21,6 @@ use datafusion_expr::ScalarUDF;
 use std::sync::Arc;
 
 pub mod abs;
-pub mod coalesce;
 pub mod cot;
 pub mod factorial;
 pub mod gcd;
@@ -47,7 +46,6 @@ make_math_unary_udf!(AtanhFunc, ATANH, atanh, atanh, Some(vec![Some(true)]));
 make_math_binary_udf!(Atan2, ATAN2, atan2, atan2, Some(vec![Some(true)]));
 make_math_unary_udf!(CbrtFunc, CBRT, cbrt, cbrt, None);
 make_math_unary_udf!(CeilFunc, CEIL, ceil, ceil, Some(vec![Some(true)]));
-make_udf_function!(coalesce::CoalesceFunc, COALESCE, coalesce);
 make_math_unary_udf!(CosFunc, COS, cos, cos, None);
 make_math_unary_udf!(CoshFunc, COSH, cosh, cosh, None);
 make_udf_function!(cot::CotFunc, COT, cot);
@@ -128,11 +126,6 @@ pub mod expr_fn {
     #[doc = "nearest integer greater than or equal to argument"]
     pub fn ceil(num: Expr) -> Expr {
         super::ceil().call(vec![num])
-    }
-
-    #[doc = "returns `coalesce(args...)`, which evaluates to the value of the first [Expr] which is not NULL"]
-    pub fn coalesce(args: Vec<Expr>) -> Expr {
-        super::coalesce().call(args)
     }
 
     #[doc = "cosine"]
@@ -289,7 +282,6 @@ pub fn functions() -> Vec<Arc<ScalarUDF>> {
         atanh(),
         cbrt(),
         ceil(),
-        coalesce(),
         cos(),
         cosh(),
         cot(),


### PR DESCRIPTION
## Which issue does this PR close?

closes https://github.com/apache/datafusion/issues/10174

## Rationale for this change

The current location of the coalesce function isn't really the best place for it.

## What changes are included in this PR?

Move coalesce function from math to core

## Are these changes tested?

All unit tests, sqllogictests and integration tests have passed.

## Are there any user-facing changes?

No.
