### PR TITLE
Minor: Avoid a clone in ArrayFunctionRewriter

### DIFF
--- a/datafusion/functions-array/src/rewrite.rs
+++ b/datafusion/functions-array/src/rewrite.rs
@@ -152,9 +152,8 @@ impl FunctionRewrite for ArrayFunctionRewriter {
                 expr,
                 field: GetFieldAccess::NamedStructField { name },
             }) => {
-                let expr = *expr.clone();
                 let name = Expr::Literal(name);
-                Transformed::yes(get_field(expr, name.clone()))
+                Transformed::yes(get_field(*expr, name))
             }
 
             // expr[idx] ==> array_element(expr, idx)


### PR DESCRIPTION
## Which issue does this PR close?
Part of https://github.com/apache/datafusion/issues/9637

## Rationale for this change

I was looking for why ApplyFunctionRewrite takes so much time in planning benchmarks (see https://github.com/apache/datafusion/issues/9637#issuecomment-2073325456) and noticed this. Note that this particular change is tiny and likely won't make a change but I figured I would at least make a PR for it

## What changes are included in this PR?
Avoid a few clones
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
