### PR TITLE
feat: support `grouping` aggregate function

### DIFF
--- a/datafusion-examples/examples/advanced_udaf.rs
+++ b/datafusion-examples/examples/advanced_udaf.rs
@@ -277,6 +277,7 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
         group_indices: &[usize],
         opt_filter: Option<&arrow::array::BooleanArray>,
         total_num_groups: usize,
+        _grouping_set: &[bool],
     ) -> Result<()> {
         assert_eq!(values.len(), 1, "single argument to update_batch");
         let values = values[0].as_primitive::<Float64Type>();

--- a/datafusion/core/tests/user_defined/user_defined_aggregates.rs
+++ b/datafusion/core/tests/user_defined/user_defined_aggregates.rs
@@ -763,6 +763,7 @@ impl GroupsAccumulator for TestGroupsAccumulator {
         _group_indices: &[usize],
         _opt_filter: Option<&arrow_array::BooleanArray>,
         _total_num_groups: usize,
+        _grouping_set: &[bool],
     ) -> Result<()> {
         Ok(())
     }

--- a/datafusion/expr/src/aggregate_function.rs
+++ b/datafusion/expr/src/aggregate_function.rs
@@ -320,10 +320,12 @@ impl AggregateFunction {
     pub fn signature(&self) -> Signature {
         // note: the physical expression must accept the type returned by this function or the execution panics.
         match self {
-            AggregateFunction::Count => Signature::variadic_any(Volatility::Immutable),
-            AggregateFunction::ApproxDistinct
-            | AggregateFunction::Grouping
-            | AggregateFunction::ArrayAgg => Signature::any(1, Volatility::Immutable),
+            AggregateFunction::Count | AggregateFunction::Grouping => {
+                Signature::variadic_any(Volatility::Immutable)
+            }
+            AggregateFunction::ApproxDistinct | AggregateFunction::ArrayAgg => {
+                Signature::any(1, Volatility::Immutable)
+            }
             AggregateFunction::Min | AggregateFunction::Max => {
                 let valid = STRINGS
                     .iter()

--- a/datafusion/expr/src/groups_accumulator.rs
+++ b/datafusion/expr/src/groups_accumulator.rs
@@ -92,6 +92,9 @@ pub trait GroupsAccumulator: Send {
     /// * `total_num_groups`: the number of groups (the largest
     /// group_index is thus `total_num_groups - 1`).
     ///
+    /// * `grouping_set`: An indicator of whether the columns in the
+    /// GroupingSet is null, typically used in GROUPING aggregate function.
+    ///
     /// Note that subsequent calls to update_batch may have larger
     /// total_num_groups as new groups are seen.
     fn update_batch(
@@ -100,6 +103,7 @@ pub trait GroupsAccumulator: Send {
         group_indices: &[usize],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
+        grouping_set: &[bool],
     ) -> Result<()>;
 
     /// Returns the final aggregate value for each group as a single

--- a/datafusion/expr/src/type_coercion/aggregates.rs
+++ b/datafusion/expr/src/type_coercion/aggregates.rs
@@ -297,7 +297,7 @@ pub fn coerce_types(
         | AggregateFunction::FirstValue
         | AggregateFunction::LastValue => Ok(input_types.to_vec()),
         AggregateFunction::NthValue => Ok(input_types.to_vec()),
-        AggregateFunction::Grouping => Ok(vec![input_types[0].clone()]),
+        AggregateFunction::Grouping => Ok(input_types.to_vec()),
         AggregateFunction::StringAgg => {
             if !is_string_agg_supported_arg_type(&input_types[0]) {
                 return plan_err!(

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -446,6 +446,7 @@ where
         group_indices: &[usize],
         opt_filter: Option<&arrow_array::BooleanArray>,
         total_num_groups: usize,
+        _grouping_set: &[bool],
     ) -> Result<()> {
         assert_eq!(values.len(), 1, "single argument to update_batch");
         let values = values[0].as_primitive::<T>();

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -69,11 +69,9 @@ pub fn create_aggregate_expr(
             input_phy_exprs[0].clone(),
             name,
         )),
-        (AggregateFunction::Grouping, _) => Arc::new(expressions::Grouping::new(
-            input_phy_exprs[0].clone(),
-            name,
-            data_type,
-        )),
+        (AggregateFunction::Grouping, _) => {
+            Arc::new(expressions::Grouping::new(input_phy_exprs, name, data_type))
+        }
         (AggregateFunction::BitAnd, _) => Arc::new(expressions::BitAnd::new(
             input_phy_exprs[0].clone(),
             name,

--- a/datafusion/physical-expr/src/aggregate/count.rs
+++ b/datafusion/physical-expr/src/aggregate/count.rs
@@ -113,6 +113,7 @@ impl GroupsAccumulator for CountGroupsAccumulator {
         group_indices: &[usize],
         opt_filter: Option<&arrow_array::BooleanArray>,
         total_num_groups: usize,
+        _grouping_set: &[bool],
     ) -> Result<()> {
         assert_eq!(values.len(), 1, "single argument to update_batch");
         let values = &values[0];

--- a/datafusion/physical-expr/src/aggregate/grouping.rs
+++ b/datafusion/physical-expr/src/aggregate/grouping.rs
@@ -18,14 +18,20 @@
 //! Defines physical expressions that can evaluated at runtime during query execution
 
 use std::any::Any;
+use std::fmt::Debug;
 use std::sync::Arc;
 
+use crate::aggregate::groups_accumulator::accumulate::accumulate_indices;
 use crate::aggregate::utils::down_cast_any_ref;
 use crate::{AggregateExpr, PhysicalExpr};
 use arrow::datatypes::DataType;
 use arrow::datatypes::Field;
-use datafusion_common::{not_impl_err, Result};
-use datafusion_expr::Accumulator;
+use arrow_array::cast::AsArray;
+use arrow_array::types::Int32Type;
+use arrow_array::{Array, ArrayRef, Int32Array, PrimitiveArray};
+use datafusion_common::{not_impl_err, DataFusionError, Result};
+use datafusion_expr::{Accumulator, EmitTo, GroupsAccumulator};
+use datafusion_physical_expr_common::expressions::column::Column;
 
 use crate::expressions::format_state_name;
 
@@ -36,22 +42,33 @@ pub struct Grouping {
     name: String,
     data_type: DataType,
     nullable: bool,
-    expr: Arc<dyn PhysicalExpr>,
+    exprs: Vec<Arc<dyn PhysicalExpr>>,
 }
 
 impl Grouping {
     /// Create a new GROUPING aggregate function.
     pub fn new(
-        expr: Arc<dyn PhysicalExpr>,
+        exprs: Vec<Arc<dyn PhysicalExpr>>,
         name: impl Into<String>,
         data_type: DataType,
     ) -> Self {
         Self {
             name: name.into(),
-            expr,
+            exprs,
             data_type,
             nullable: true,
         }
+    }
+
+    /// Create a new GroupingGroupsAccumulator
+    pub fn create_grouping_groups_accumulator(
+        &self,
+        group_by_exprs: &[(Arc<dyn PhysicalExpr>, String)],
+    ) -> Result<Box<dyn GroupsAccumulator>> {
+        Ok(Box::new(GroupingGroupsAccumulator::new(
+            &self.exprs,
+            group_by_exprs,
+        )?))
     }
 }
 
@@ -65,6 +82,12 @@ impl AggregateExpr for Grouping {
         Ok(Field::new(&self.name, DataType::Int32, self.nullable))
     }
 
+    fn create_accumulator(&self) -> Result<Box<dyn Accumulator>> {
+        not_impl_err!(
+            "physical plan is not yet implemented for GROUPING aggregate function"
+        )
+    }
+
     fn state_fields(&self) -> Result<Vec<Field>> {
         Ok(vec![Field::new(
             format_state_name(&self.name, "grouping"),
@@ -74,13 +97,7 @@ impl AggregateExpr for Grouping {
     }
 
     fn expressions(&self) -> Vec<Arc<dyn PhysicalExpr>> {
-        vec![self.expr.clone()]
-    }
-
-    fn create_accumulator(&self) -> Result<Box<dyn Accumulator>> {
-        not_impl_err!(
-            "physical plan is not yet implemented for GROUPING aggregate function"
-        )
+        self.exprs.clone()
     }
 
     fn name(&self) -> &str {
@@ -96,8 +113,172 @@ impl PartialEq<dyn Any> for Grouping {
                 self.name == x.name
                     && self.data_type == x.data_type
                     && self.nullable == x.nullable
-                    && self.expr.eq(&x.expr)
+                    && self.exprs.len() == x.exprs.len()
+                    && self
+                        .exprs
+                        .iter()
+                        .zip(x.exprs.iter())
+                        .all(|(expr1, expr2)| expr1.eq(expr2))
             })
             .unwrap_or(false)
+    }
+}
+
+#[derive(Debug)]
+struct GroupingGroupsAccumulator {
+    /// Grouping columns' indices in grouping set
+    indices: Vec<usize>,
+
+    /// Mask per group.
+    ///
+    /// Note this is an i32 and not a u32 (or usize) because the
+    /// output type of grouping is `DataType::Int32`. Thus by using `i32`
+    /// for the grouping, the output [`Int32Array`] can be created
+    /// without copy.
+    masks: Vec<i32>,
+}
+
+impl GroupingGroupsAccumulator {
+    pub fn new(
+        grouping_exprs: &[Arc<dyn PhysicalExpr>],
+        group_by_exprs: &[(Arc<dyn PhysicalExpr>, String)],
+    ) -> Result<Self> {
+        macro_rules! downcast_column {
+            ($EXPR:expr) => {{
+                if let Some(column) = $EXPR.as_any().downcast_ref::<Column>() {
+                    column
+                } else {
+                    return Err(DataFusionError::Execution(
+                        "Grouping only supports grouping set which only contains Column Expr".to_string(),
+                    ));
+                }
+            }}
+        }
+
+        // collect column indices of group_by_exprs, only Column Expr
+        let mut group_by_column_indices = Vec::with_capacity(group_by_exprs.len());
+        for (group_by_expr, _) in group_by_exprs.iter() {
+            let column = downcast_column!(group_by_expr);
+            group_by_column_indices.push(column.index());
+        }
+
+        // collect grouping_exprs' indices in group_by_exprs list, eg:
+        // SQL: SELECT c1, c2, grouping(c2, c1) FROM t GROUP BY ROLLUP(c1, c2);
+        // group_by_exprs: [c1, c2]
+        // grouping_exprs: [c2, c1]
+        // indices: [1, 0]
+        let mut indices = Vec::with_capacity(grouping_exprs.len());
+        for grouping_expr in grouping_exprs {
+            let column = downcast_column!(grouping_expr);
+            indices.push(find_grouping_column_index(
+                &group_by_column_indices,
+                column.index(),
+            )?);
+        }
+
+        Ok(Self {
+            indices,
+            masks: vec![],
+        })
+    }
+}
+
+fn find_grouping_column_index(
+    group_by_column_indices: &[usize],
+    grouping_column_index: usize,
+) -> Result<usize> {
+    for (i, group_by_column_index) in group_by_column_indices.iter().enumerate() {
+        if grouping_column_index == *group_by_column_index {
+            return Ok(i);
+        }
+    }
+    Err(DataFusionError::Execution(
+        "Not found grouping column in group by columns".to_string(),
+    ))
+}
+
+fn compute_mask(indices: &[usize], grouping_set: &[bool]) -> i32 {
+    let mut mask = 0;
+    for (i, index) in indices.iter().rev().enumerate() {
+        if grouping_set[*index] {
+            mask |= 1 << i;
+        }
+    }
+    mask
+}
+
+impl GroupsAccumulator for GroupingGroupsAccumulator {
+    fn update_batch(
+        &mut self,
+        _values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&arrow_array::BooleanArray>,
+        total_num_groups: usize,
+        grouping_set: &[bool],
+    ) -> Result<()> {
+        self.masks.resize(total_num_groups, 0);
+        accumulate_indices(group_indices, None, opt_filter, |group_index| {
+            self.masks[group_index] = compute_mask(&self.indices, grouping_set);
+        });
+        Ok(())
+    }
+
+    fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
+        let masks = emit_to.take_needed(&mut self.masks);
+
+        // Mask is always non null (null inputs just don't contribute to the overall values)
+        let nulls = None;
+        let array = PrimitiveArray::<Int32Type>::new(masks.into(), nulls);
+
+        Ok(Arc::new(array))
+    }
+
+    // return arrays for masks
+    fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
+        let masks = emit_to.take_needed(&mut self.masks);
+        let masks: PrimitiveArray<Int32Type> = Int32Array::from(masks); // zero copy, no nulls
+        Ok(vec![Arc::new(masks) as ArrayRef])
+    }
+
+    fn merge_batch(
+        &mut self,
+        values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&arrow_array::BooleanArray>,
+        total_num_groups: usize,
+    ) -> Result<()> {
+        assert_eq!(values.len(), 1, "one argument to merge_batch");
+        let masks = values[0].as_primitive::<Int32Type>();
+
+        // intermediate masks are always created as non null
+        assert_eq!(masks.null_count(), 0);
+        let masks = masks.values();
+
+        self.masks.resize(total_num_groups, 0);
+        match opt_filter {
+            Some(filter) => filter
+                .iter()
+                .zip(group_indices.iter())
+                .zip(masks.iter())
+                .for_each(|((filter_value, &group_index), mask)| {
+                    if let Some(true) = filter_value {
+                        self.masks[group_index] = *mask;
+                    }
+                }),
+            None => {
+                group_indices
+                    .iter()
+                    .zip(masks.iter())
+                    .for_each(|(&group_index, mask)| {
+                        self.masks[group_index] = *mask;
+                    })
+            }
+        }
+
+        Ok(())
+    }
+
+    fn size(&self) -> usize {
+        self.masks.capacity() * std::mem::size_of::<usize>()
     }
 }

--- a/datafusion/physical-expr/src/aggregate/groups_accumulator/adapter.rs
+++ b/datafusion/physical-expr/src/aggregate/groups_accumulator/adapter.rs
@@ -251,6 +251,7 @@ impl GroupsAccumulator for GroupsAccumulatorAdapter {
         group_indices: &[usize],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
+        _grouping_set: &[bool],
     ) -> Result<()> {
         self.invoke_per_accumulator(
             values,

--- a/datafusion/physical-expr/src/aggregate/groups_accumulator/bool_op.rs
+++ b/datafusion/physical-expr/src/aggregate/groups_accumulator/bool_op.rs
@@ -72,6 +72,7 @@ where
         group_indices: &[usize],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
+        _grouping_set: &[bool],
     ) -> Result<()> {
         assert_eq!(values.len(), 1, "single argument to update_batch");
         let values = values[0].as_boolean();
@@ -129,7 +130,7 @@ where
         total_num_groups: usize,
     ) -> Result<()> {
         // update / merge are the same
-        self.update_batch(values, group_indices, opt_filter, total_num_groups)
+        self.update_batch(values, group_indices, opt_filter, total_num_groups, &[])
     }
 
     fn size(&self) -> usize {

--- a/datafusion/physical-expr/src/aggregate/groups_accumulator/prim_op.rs
+++ b/datafusion/physical-expr/src/aggregate/groups_accumulator/prim_op.rs
@@ -89,6 +89,7 @@ where
         group_indices: &[usize],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
+        _grouping_set: &[bool],
     ) -> Result<()> {
         assert_eq!(values.len(), 1, "single argument to update_batch");
         let values = values[0].as_primitive::<T>();
@@ -131,7 +132,7 @@ where
         total_num_groups: usize,
     ) -> Result<()> {
         // update / merge are the same
-        self.update_batch(values, group_indices, opt_filter, total_num_groups)
+        self.update_batch(values, group_indices, opt_filter, total_num_groups, &[])
     }
 
     fn size(&self) -> usize {

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -273,7 +273,7 @@ pub(crate) mod tests {
             })
             .collect::<Result<Vec<_>>>()?;
         let indices = vec![0; batch.num_rows()];
-        accum.update_batch(&values, &indices, None, 1)?;
+        accum.update_batch(&values, &indices, None, 1, &[])?;
         accum.evaluate(EmitTo::All)
     }
 }

--- a/datafusion/sqllogictest/test_files/grouping.slt
+++ b/datafusion/sqllogictest/test_files/grouping.slt
@@ -24,10 +24,10 @@ query TTIIII
 select
   c1,
   c2,
-  grouping(c1),
-  grouping(c2),
-  grouping(c1, c2),
-  grouping(c2, c1)
+  grouping(c1) as g0,
+  grouping(c2) as g1,
+  grouping(c1, c2) as g2,
+  grouping(c2, c1) as g3
 from
   test
 group by
@@ -36,36 +36,40 @@ group by
     (c1),
     (c2),
     ()
-  );
+  )
+order by
+  c1, c2, g0, g1, g2, g3;
 ----
 a A 0 0 0 0
-b B 0 0 0 0
 a NULL 0 1 1 2
-NULL A 1 0 2 1
-NULL NULL 1 1 3 3
+b B 0 0 0 0
 b NULL 0 1 1 2
+NULL A 1 0 2 1
 NULL B 1 0 2 1
+NULL NULL 1 1 3 3
 
 # grouping_with_cube
 query TTIIII
 select
   c1,
   c2,
-  grouping(c1),
-  grouping(c2),
-  grouping(c1, c2),
-  grouping(c2, c1)
+  grouping(c1) as g0,
+  grouping(c2) as g1,
+  grouping(c1, c2) as g2,
+  grouping(c2, c1) as g3
 from
   test
 group by
-  cube(c1, c2);
+  cube(c1, c2)
+order by
+  c1, c2, g0, g1, g2, g3;
 ----
-b NULL 0 1 1 2
-NULL B 1 0 2 1
 a A 0 0 0 0
-b B 0 0 0 0
-NULL A 1 0 2 1
 a NULL 0 1 1 2
+b B 0 0 0 0
+b NULL 0 1 1 2
+NULL A 1 0 2 1
+NULL B 1 0 2 1
 NULL NULL 1 1 3 3
 
 # grouping_with_rollup
@@ -73,20 +77,22 @@ query TTIIII
 select
   c1,
   c2,
-  grouping(c1),
-  grouping(c2),
-  grouping(c1, c2),
-  grouping(c2, c1)
+  grouping(c1) as g0,
+  grouping(c2) as g1,
+  grouping(c1, c2) as g2,
+  grouping(c2, c1) as g3
 from
   test
 group by
-  rollup(c1, c2);
+  rollup(c1, c2)
+order by
+  c1, c2, g0, g1, g2, g3;
 ----
+a A 0 0 0 0
+a NULL 0 1 1 2
+b B 0 0 0 0
 b NULL 0 1 1 2
 NULL NULL 1 1 3 3
-a NULL 0 1 1 2
-a A 0 0 0 0
-b B 0 0 0 0
 
 # grouping_with_add
 query TTI
@@ -99,11 +105,11 @@ from
 group by
   rollup(c1, c2)
 order by
-  g0;
+  c1, c2, g0;
 ----
 a A 0
-b B 0
 a NULL 1
+b B 0
 b NULL 1
 NULL NULL 2
 
@@ -125,11 +131,14 @@ from
 group by
   rollup(c1, c2)
 order by
+  c1,
+  c2,
+  cnt,
   g0 desc,
   rank_within_parent;
 ----
-NULL NULL 2 2 1
-b NULL 1 1 1
+a A 1 0 1
 a NULL 1 1 1
 b B 1 0 1
-a A 1 0 1
+b NULL 1 1 1
+NULL NULL 2 2 1

--- a/datafusion/sqllogictest/test_files/grouping.slt
+++ b/datafusion/sqllogictest/test_files/grouping.slt
@@ -16,8 +16,8 @@
 # under the License.
 
 statement ok
-CREATE TABLE test (c1 VARCHAR,c2 VARCHAR) as values
-('a','A'), ('b','B')
+CREATE TABLE test (c1 VARCHAR,c2 VARCHAR,c3 INT) as values
+('a','A',1), ('b','B',2)
 
 # grouping_with_grouping_sets
 query TTIIII
@@ -94,6 +94,33 @@ b B 0 0 0 0
 b NULL 0 1 1 2
 NULL NULL 1 1 3 3
 
+query TTIIIIIIII
+select
+  c1,
+  c2,
+  c3,
+  grouping(c1) as g0,
+  grouping(c2) as g1,
+  grouping(c1, c2) as g2,
+  grouping(c2, c1) as g3,
+  grouping(c1, c2, c3) as g4,
+  grouping(c2, c3, c1) as g5,
+  grouping(c3, c2, c1) as g6
+from
+  test
+group by
+  rollup(c1, c2, c3)
+order by
+  c1, c2, g0, g1, g2, g3, g4, g5, g6;
+----
+a A 1 0 0 0 0 0 0 0
+a A NULL 0 0 0 0 1 2 4
+a NULL NULL 0 1 1 2 3 6 6
+b B 2 0 0 0 0 0 0 0
+b B NULL 0 0 0 0 1 2 4
+b NULL NULL 0 1 1 2 3 6 6
+NULL NULL NULL 1 1 3 3 7 7 7
+
 # grouping_with_add
 query TTI
 select
@@ -142,3 +169,30 @@ a NULL 1 1 1
 b B 1 0 1
 b NULL 1 1 1
 NULL NULL 2 2 1
+
+# grouping_with_non_columns
+query TIIIII
+select
+  c1,
+  c3 + 1 as c3_add_one,
+  grouping(c1) as g0,
+  grouping(c3 + 1) as g1,
+  grouping(c1, c3 + 1) as g2,
+  grouping(c3 + 1, c1) as g3
+from
+  test
+group by
+  grouping sets (
+    (c1, c3 + 1),
+    (c3 + 1),
+    (c1)
+  )
+order by
+  c1, c3_add_one, g0, g1, g2, g3;
+----
+a 2 0 0 0 0
+a NULL 0 1 1 2
+b 3 0 0 0 0
+b NULL 0 1 1 2
+NULL 2 1 0 2 1
+NULL 3 1 0 2 1

--- a/datafusion/sqllogictest/test_files/grouping.slt
+++ b/datafusion/sqllogictest/test_files/grouping.slt
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+statement ok
+CREATE TABLE test (c1 VARCHAR,c2 VARCHAR) as values
+('a','A'), ('b','B')
+
+# grouping_with_grouping_sets
+query TTIIII
+select
+  c1,
+  c2,
+  grouping(c1),
+  grouping(c2),
+  grouping(c1, c2),
+  grouping(c2, c1)
+from
+  test
+group by
+  grouping sets (
+    (c1, c2),
+    (c1),
+    (c2),
+    ()
+  );
+----
+a A 0 0 0 0
+b B 0 0 0 0
+a NULL 0 1 1 2
+NULL A 1 0 2 1
+NULL NULL 1 1 3 3
+b NULL 0 1 1 2
+NULL B 1 0 2 1
+
+# grouping_with_cube
+query TTIIII
+select
+  c1,
+  c2,
+  grouping(c1),
+  grouping(c2),
+  grouping(c1, c2),
+  grouping(c2, c1)
+from
+  test
+group by
+  cube(c1, c2);
+----
+b NULL 0 1 1 2
+NULL B 1 0 2 1
+a A 0 0 0 0
+b B 0 0 0 0
+NULL A 1 0 2 1
+a NULL 0 1 1 2
+NULL NULL 1 1 3 3
+
+# grouping_with_rollup
+query TTIIII
+select
+  c1,
+  c2,
+  grouping(c1),
+  grouping(c2),
+  grouping(c1, c2),
+  grouping(c2, c1)
+from
+  test
+group by
+  rollup(c1, c2);
+----
+b NULL 0 1 1 2
+NULL NULL 1 1 3 3
+a NULL 0 1 1 2
+a A 0 0 0 0
+b B 0 0 0 0
+
+# grouping_with_add
+query TTI
+select
+  c1,
+  c2,
+  grouping(c1)+grouping(c2) as g0
+from
+  test
+group by
+  rollup(c1, c2)
+order by
+  g0;
+----
+a A 0
+b B 0
+a NULL 1
+b NULL 1
+NULL NULL 2
+
+#grouping_with_windown_function
+query TTIII
+select
+  c1,
+  c2,
+  count(c1) as cnt,
+  grouping(c1)+ grouping(c2) as g0,
+  rank() over (
+    partition by grouping(c1)+grouping(c2),
+    case when grouping(c2) = 0 then c1 end
+    order by
+      count(c1) desc
+  ) as rank_within_parent
+from
+  test
+group by
+  rollup(c1, c2)
+order by
+  g0 desc,
+  rank_within_parent;
+----
+NULL NULL 2 2 1
+b NULL 1 1 1
+a NULL 1 1 1
+b B 1 0 1
+a A 1 0 1


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/5647

## Rationale for this change

Currently datafusion does not implement `grouping` function.
https://github.com/apache/datafusion/blob/4edbdd7d09d97f361748c086afbd7b3dda972f76/datafusion/physical-expr/src/aggregate/grouping.rs#L80-L84

## What changes are included in this PR?

Complete the `grouping` function.

https://www.postgresql.org/docs/9.5/functions-aggregate.html
https://learn.microsoft.com/en-us/sql/t-sql/functions/grouping-transact-sql?view=sql-server-ver15

## Are these changes tested?

Yes

## Are there any user-facing changes?

Yes. Perhaps we need to include in the documentation instructions for the `grouping` function.
https://arrow.apache.org/datafusion/user-guide/sql/aggregate_functions.html
