### PR TITLE
Avoid `Expr` copies `OptimizeProjection`, 12% faster planning, encapsulate indicies

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -347,9 +347,22 @@ impl DFSchema {
         matches.next()
     }
 
-    /// Find the index of the column with the given qualifier and name
-    pub fn index_of_column(&self, col: &Column) -> Result<usize> {
+    /// Find the index of the column with the given qualifier and name,
+    /// returning `None` if not found
+    ///
+    /// See [Self::index_of_column] for a version that returns an error if the
+    /// column is not found
+    pub fn maybe_index_of_column(&self, col: &Column) -> Option<usize> {
         self.index_of_column_by_name(col.relation.as_ref(), &col.name)
+    }
+
+    /// Find the index of the column with the given qualifier and name,
+    /// returning `Err` if not found
+    ///
+    /// See [Self::maybe_index_of_column] for a version that returns `None` if
+    /// the column is not found
+    pub fn index_of_column(&self, col: &Column) -> Result<usize> {
+        self.maybe_index_of_column(col)
             .ok_or_else(|| field_not_found(col.relation.clone(), &col.name, self))
     }
 

--- a/datafusion/optimizer/src/optimize_projections/required_indices.rs
+++ b/datafusion/optimizer/src/optimize_projections/required_indices.rs
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`RequiredIndicies`] helper for OptimizeProjection
+
+use crate::optimize_projections::outer_columns;
+use datafusion_common::tree_node::TreeNodeRecursion;
+use datafusion_common::{Column, DFSchemaRef, Result};
+use datafusion_expr::{Expr, LogicalPlan};
+
+/// Represents columns in a schema which are required (used) by a plan node
+///
+/// Also carries a flag indicating if putting a projection above children is
+/// beneficial for the parent. For example `LogicalPlan::Filter` benefits from
+/// small tables. Hence for filter child this flag would be `true`. Defaults to
+/// `false`
+///
+/// # Invariant
+///
+/// Indices are always in order and without duplicates. For example, if these
+/// indices were added `[3, 2, 4, 3, 6, 1]`,  the instance would be represented
+/// by  `[1, 2, 3, 6]`.
+#[derive(Debug, Clone, Default)]
+pub(super) struct RequiredIndicies {
+    /// The indices of the required columns in the
+    indices: Vec<usize>,
+    /// If putting a projection above children is beneficial for the parent.
+    /// Defaults to false.
+    projection_beneficial: bool,
+}
+
+impl RequiredIndicies {
+    /// Create a new, empty instance
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new instance that requires all columns from the specified plan
+    pub fn new_for_all_exprs(plan: &LogicalPlan) -> Self {
+        Self {
+            indices: (0..plan.schema().fields().len()).collect(),
+            projection_beneficial: false,
+        }
+    }
+
+    /// Create a new instance with the specified indices as required
+    pub fn new_from_indices(indices: Vec<usize>) -> Self {
+        Self {
+            indices,
+            projection_beneficial: false,
+        }
+        .compact()
+    }
+
+    /// Convert the instance to its inner indices
+    pub fn into_inner(self) -> Vec<usize> {
+        self.indices
+    }
+
+    /// Set the projection beneficial flag
+    pub fn with_projection_beneficial(mut self) -> Self {
+        self.projection_beneficial = true;
+        self
+    }
+
+    /// Return the value of projection beneficial flag
+    pub fn projection_beneficial(&self) -> bool {
+        self.projection_beneficial
+    }
+
+    /// Return a reference to the underlying indices
+    pub fn indices(&self) -> &[usize] {
+        &self.indices
+    }
+
+    /// Add required indices for all `exprs` used in plan
+    pub fn with_plan_exprs(
+        mut self,
+        plan: &LogicalPlan,
+        schema: &DFSchemaRef,
+    ) -> Result<Self> {
+        // Add indices of the child fields referred to by the expressions in the
+        // parent
+        plan.apply_expressions(|e| {
+            self.add_expr(schema, e)?;
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+        Ok(self.compact())
+    }
+
+    /// Adds the indices of the fields referred to by the given expression
+    /// `expr` within the given schema (`input_schema`).
+    ///
+    /// Self is NOT compacted (and thus this method is not pub)
+    ///
+    /// # Parameters
+    ///
+    /// * `input_schema`: The input schema to analyze for index requirements.
+    /// * `expr`: An expression for which we want to find necessary field indices.
+    fn add_expr(&mut self, input_schema: &DFSchemaRef, expr: &Expr) -> Result<()> {
+        // TODO could remove these clones (and visit the expression directly)
+        let mut cols = expr.to_columns()?;
+        // Get outer-referenced (subquery) columns:
+        outer_columns(expr, &mut cols);
+        self.indices.reserve(cols.len());
+        for col in cols {
+            if let Some(idx) = input_schema.maybe_index_of_column(&col) {
+                self.indices.push(idx);
+            }
+        }
+        Ok(())
+    }
+
+    /// Adds the indices of the fields referred to by the given expressions
+    /// `within the given schema.
+    ///
+    /// # Parameters
+    ///
+    /// * `input_schema`: The input schema to analyze for index requirements.
+    /// * `exprs`: the expressions for which we want to find field indices.
+    pub fn with_exprs<'a>(
+        self,
+        schema: &DFSchemaRef,
+        exprs: impl IntoIterator<Item = &'a Expr>,
+    ) -> Result<Self> {
+        exprs
+            .into_iter()
+            .try_fold(self, |mut acc, expr| {
+                acc.add_expr(schema, expr)?;
+                Ok(acc)
+            })
+            .map(|acc| acc.compact())
+    }
+
+    /// Adds all `indices` into this instance.
+    pub fn append(mut self, indices: &[usize]) -> Self {
+        self.indices.extend_from_slice(indices);
+        self.compact()
+    }
+
+    /// Splits this instance into a tuple with two instances:
+    /// * The first `n` indices
+    /// * The remaining indices, adjusted down by n
+    pub fn split_off(self, n: usize) -> (Self, Self) {
+        let (l, r) = self.partition(|idx| idx < n);
+        (l, r.map_indices(|idx| idx - n))
+    }
+
+    /// Partitions the indicies in this instance into two groups based on the
+    /// given predicate function `f`.
+    fn partition<F>(&self, f: F) -> (Self, Self)
+    where
+        F: Fn(usize) -> bool,
+    {
+        let (l, r): (Vec<usize>, Vec<usize>) =
+            self.indices.iter().partition(|&&idx| f(idx));
+        let projection_beneficial = self.projection_beneficial;
+
+        (
+            Self {
+                indices: l,
+                projection_beneficial,
+            },
+            Self {
+                indices: r,
+                projection_beneficial,
+            },
+        )
+    }
+
+    /// Map the indices in this instance to a new set of indices based on the
+    /// given function `f`, returning the mapped indices
+    ///
+    /// Not `pub` as it might not preserve the invariant of compacted indices
+    fn map_indices<F>(mut self, f: F) -> Self
+    where
+        F: Fn(usize) -> usize,
+    {
+        self.indices.iter_mut().for_each(|idx| *idx = f(*idx));
+        self
+    }
+
+    /// Apply the given function `f` to each index in this instance, returning
+    /// the mapped indices
+    pub fn into_mapped_indices<F>(self, f: F) -> Vec<usize>
+    where
+        F: Fn(usize) -> usize,
+    {
+        self.map_indices(f).into_inner()
+    }
+
+    /// Returns the `Expr`s from `exprs` that are at the indices in this instance
+    pub fn get_at_indices(&self, exprs: &[Expr]) -> Vec<Expr> {
+        self.indices.iter().map(|&idx| exprs[idx].clone()).collect()
+    }
+
+    /// Generates the required expressions (columns) that reside at `indices` of
+    /// the given `input_schema`.
+    pub fn get_required_exprs(&self, input_schema: &DFSchemaRef) -> Vec<Expr> {
+        self.indices
+            .iter()
+            .map(|&idx| Expr::from(Column::from(input_schema.qualified_field(idx))))
+            .collect()
+    }
+
+    /// Compacts the indices of this instance so they are sorted
+    /// (ascending) and deduplicated.
+    fn compact(mut self) -> Self {
+        self.indices.sort_unstable();
+        self.indices.dedup();
+        self
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/10209




## Rationale for this change

This is part 1 of improving the performance of `OptimizeProjection` (by less copying) in https://github.com/apache/datafusion/issues/10209.

While trying to rework how `OptimizeProjection works`, I found that the population
of child indices pretty much required calling `LogicalPlan::expressions()` which results in an owed copy of all the plans `Expr`s

Removing these copies themselves improves the situation (and I think may make the code easier to reasona about), and sets us up to stop copying the `LogicalPlan` nodes as a follow on PR

## What changes are included in this PR?

This PR encapsulates that logic for managing required indices into a new struct `RequiredIndicies` which avoids some Expr copies (and sets up the rewrite to avoid `LogicalPlan` copies)


## Are these changes tested?
Covered by existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no functional changes

performance benchmarks show an overall 14% improvements for tpch_all and tpcds_all, which is pretty neat

<details><summary>Details</summary>
<p>

```
++ critcmp main optimize_proj_pt1
group                                         main                                   optimize_proj_pt1
-----                                         ----                                   -----------------
logical_aggregate_with_join                   1.02  1210.2±63.66µs        ? ?/sec    1.00  1188.2±32.04µs        ? ?/sec
logical_plan_tpcds_all                        1.02    158.0±1.26ms        ? ?/sec    1.00    154.3±1.56ms        ? ?/sec
logical_plan_tpch_all                         1.05     17.0±0.20ms        ? ?/sec    1.00     16.3±0.18ms        ? ?/sec
logical_select_all_from_1000                  1.04     19.2±0.16ms        ? ?/sec    1.00     18.5±0.09ms        ? ?/sec
logical_select_one_from_700                   1.01   792.6±42.68µs        ? ?/sec    1.00    787.7±7.31µs        ? ?/sec
logical_trivial_join_high_numbered_columns    1.01   743.5±10.96µs        ? ?/sec    1.00   732.9±28.34µs        ? ?/sec
logical_trivial_join_low_numbered_columns     1.01    729.8±8.98µs        ? ?/sec    1.00    720.9±9.40µs        ? ?/sec
physical_plan_tpcds_all                       1.14  1500.3±10.49ms        ? ?/sec    1.00  1311.0±13.83ms        ? ?/sec
physical_plan_tpch_all                        1.14     99.9±0.72ms        ? ?/sec    1.00     87.9±0.39ms        ? ?/sec
physical_plan_tpch_q1                         1.14      5.4±0.02ms        ? ?/sec    1.00      4.7±0.02ms        ? ?/sec
physical_plan_tpch_q10                        1.10      4.6±0.02ms        ? ?/sec    1.00      4.2±0.02ms        ? ?/sec
physical_plan_tpch_q11                        1.08      4.0±0.02ms        ? ?/sec    1.00      3.7±0.02ms        ? ?/sec
physical_plan_tpch_q12                        1.11      3.3±0.01ms        ? ?/sec    1.00      3.0±0.01ms        ? ?/sec
physical_plan_tpch_q13                        1.08      2.2±0.01ms        ? ?/sec    1.00      2.1±0.01ms        ? ?/sec
physical_plan_tpch_q14                        1.11      2.9±0.02ms        ? ?/sec    1.00      2.6±0.03ms        ? ?/sec
physical_plan_tpch_q16                        1.12      4.0±0.03ms        ? ?/sec    1.00      3.6±0.02ms        ? ?/sec
physical_plan_tpch_q17                        1.12      3.8±0.03ms        ? ?/sec    1.00      3.4±0.02ms        ? ?/sec
physical_plan_tpch_q18                        1.11      4.2±0.04ms        ? ?/sec    1.00      3.8±0.02ms        ? ?/sec
physical_plan_tpch_q19                        1.26      8.0±0.09ms        ? ?/sec    1.00      6.3±0.04ms        ? ?/sec
physical_plan_tpch_q2                         1.11      8.5±0.07ms        ? ?/sec    1.00      7.6±0.03ms        ? ?/sec
physical_plan_tpch_q20                        1.12      4.9±0.04ms        ? ?/sec    1.00      4.4±0.02ms        ? ?/sec
physical_plan_tpch_q21                        1.14      6.8±0.07ms        ? ?/sec    1.00      6.0±0.03ms        ? ?/sec
physical_plan_tpch_q22                        1.11      3.6±0.04ms        ? ?/sec    1.00      3.3±0.03ms        ? ?/sec
physical_plan_tpch_q3                         1.09      3.3±0.01ms        ? ?/sec    1.00      3.0±0.02ms        ? ?/sec
physical_plan_tpch_q4                         1.08      2.4±0.01ms        ? ?/sec    1.00      2.2±0.01ms        ? ?/sec
physical_plan_tpch_q5                         1.11      4.8±0.02ms        ? ?/sec    1.00      4.3±0.02ms        ? ?/sec
physical_plan_tpch_q6                         1.11  1735.8±11.71µs        ? ?/sec    1.00   1557.8±9.94µs        ? ?/sec
physical_plan_tpch_q7                         1.13      6.2±0.04ms        ? ?/sec    1.00      5.5±0.02ms        ? ?/sec
physical_plan_tpch_q8                         1.12      8.0±0.07ms        ? ?/sec    1.00      7.1±0.02ms        ? ?/sec
physical_plan_tpch_q9                         1.12      6.0±0.04ms        ? ?/sec    1.00      5.4±0.02ms        ? ?/sec
physical_select_all_from_1000                 1.49     90.9±0.30ms        ? ?/sec    1.00     60.9±0.20ms        ? ?/sec
physical_select_one_from_700                  1.08      3.7±0.05ms        ? ?/sec    1.00      3.4±0.02ms        ? ?/sec
```

</p>
</details> 
