### PR TITLE
fix: preserve more dictionaries when coercing types

### DIFF
--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -643,9 +643,8 @@ fn dictionary_coercion(
             Dictionary(_lhs_index_type, lhs_value_type),
             Dictionary(_rhs_index_type, rhs_value_type),
         ) => comparison_coercion(lhs_value_type, rhs_value_type),
-        (d @ Dictionary(_, value_type), other_type)
-        | (other_type, d @ Dictionary(_, value_type))
-            if preserve_dictionaries && value_type.as_ref() == other_type =>
+        (d @ Dictionary(_, _), other_type) | (other_type, d @ Dictionary(_, _))
+            if preserve_dictionaries && can_cast_types(other_type, d) =>
         {
             Some(d.clone())
         }

--- a/datafusion/sqllogictest/test_files/dictionary.slt
+++ b/datafusion/sqllogictest/test_files/dictionary.slt
@@ -386,3 +386,53 @@ drop table m3;
 
 statement ok
 drop table m3_source;
+
+
+## Test that filtering on dictionary columns coerces the filter value to the dictionary type
+statement ok
+create table test as values
+  ('row1', arrow_cast('1', 'Dictionary(Int32, Utf8)')),
+  ('row2', arrow_cast('2', 'Dictionary(Int32, Utf8)')),
+  ('row3', arrow_cast('3', 'Dictionary(Int32, Utf8)'))
+;
+
+# query using an string '1' which must be coerced into a dictionary string
+query T?
+SELECT * from test where column2 = '1';
+----
+row1 1
+
+# filter should not have a cast on column2
+query TT
+explain SELECT * from test where column2 = '1';
+----
+logical_plan
+01)Filter: test.column2 = Dictionary(Int32, Utf8("1"))
+02)--TableScan: test projection=[column1, column2]
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=8192
+02)--FilterExec: column2@1 = 1
+03)----MemoryExec: partitions=1, partition_sizes=[1]
+
+
+# Now query using an integer which must be coerced into a dictionary string
+query T?
+SELECT * from test where column2 = 1;
+----
+row1 1
+
+# filter should not have a cast on column2
+query TT
+explain SELECT * from test where column2 = 1;
+----
+logical_plan
+01)Filter: test.column2 = Dictionary(Int32, Utf8("1"))
+02)--TableScan: test projection=[column1, column2]
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=8192
+02)--FilterExec: column2@1 = 1
+03)----MemoryExec: partitions=1, partition_sizes=[1]
+
+
+statement ok
+drop table test;

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1768,52 +1768,61 @@ SELECT make_array(1, 2, 3);
 [1, 2, 3]
 
 # coalesce static empty value
-query T
-SELECT COALESCE('', 'test')
+query TT
+SELECT       COALESCE('', 'test'),
+arrow_typeof(COALESCE('', 'test'))
 ----
-(empty)
+(empty) Utf8
 
 # coalesce static value with null
-query T
-SELECT COALESCE(NULL, 'test')
+query TT
+SELECT       COALESCE(NULL, 'test'),
+arrow_typeof(COALESCE(NULL, 'test'))
 ----
-test
+test Utf8
 
-
+# Create table with a dictionary value
 statement ok
 create table test1 as values (arrow_cast('foo', 'Dictionary(Int32, Utf8)')), (null);
 
-# test coercion string
-query ?
-select  coalesce(column1, 'none_set') from test1;
+# test coercion string (should preserve the dictionary type)
+query ?T
+select       coalesce(column1, 'none_set'),
+arrow_typeof(coalesce(column1, 'none_set'))
+from test1;
 ----
-foo
-none_set
+foo Dictionary(Int32, Utf8)
+none_set Dictionary(Int32, Utf8)
 
 # test coercion Int and Dictionary
-query ?
-select coalesce(34, arrow_cast(123, 'Dictionary(Int32, Int8)'));
+query ?T
+select       coalesce(34, arrow_cast(123, 'Dictionary(Int32, Int8)')),
+arrow_typeof(coalesce(34, arrow_cast(123, 'Dictionary(Int32, Int8)')))
 ----
-34
+34 Dictionary(Int32, Int64)
 
 # test with Int
-query ?
-select coalesce(arrow_cast(123, 'Dictionary(Int32, Int8)'),34);
+query ?T
+select       coalesce(arrow_cast(123, 'Dictionary(Int32, Int8)'),34),
+arrow_typeof(coalesce(arrow_cast(123, 'Dictionary(Int32, Int8)'),34))
 ----
-123
+123 Dictionary(Int32, Int64)
 
 # test with null
-query ?
-select coalesce(null, 34, arrow_cast(123, 'Dictionary(Int32, Int8)'));
+query ?T
+select       coalesce(null, 34, arrow_cast(123, 'Dictionary(Int32, Int8)')),
+arrow_typeof(coalesce(null, 34, arrow_cast(123, 'Dictionary(Int32, Int8)')))
 ----
-34
+34 Dictionary(Int32, Int64)
 
 # test with null
-query ?
-select  coalesce(null, column1, 'none_set') from test1;
+query ?T
+select       coalesce(null, column1, 'none_set'),
+arrow_typeof(coalesce(null, column1, 'none_set'))
+from test1;
 ----
-foo
-none_set
+foo Dictionary(Int32, Utf8)
+none_set Dictionary(Int32, Utf8)
 
 statement ok
 drop table test1

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1790,26 +1790,26 @@ select  coalesce(column1, 'none_set') from test1;
 foo
 none_set
 
-# test coercion Int
-query I
+# test coercion Int and Dictionary
+query ?
 select coalesce(34, arrow_cast(123, 'Dictionary(Int32, Int8)'));
 ----
 34
 
 # test with Int
-query I
+query ?
 select coalesce(arrow_cast(123, 'Dictionary(Int32, Int8)'),34);
 ----
 123
 
 # test with null
-query I
+query ?
 select coalesce(null, 34, arrow_cast(123, 'Dictionary(Int32, Int8)'));
 ----
 34
 
 # test with null
-query T
+query ?
 select  coalesce(null, column1, 'none_set') from test1;
 ----
 foo


### PR DESCRIPTION
## Which issue does this PR close?
Closes https://github.com/apache/datafusion/issues/10220

## Rationale for this change

Loosen the restriction on when type coercion will preserve dictionary types to prevent slow casting of columns with dictionary type.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
There are already tests that would fail on type coercion. Let me know if there additional tests you'd like to see.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Certain coercion operations will now preserve dictionary encoding where before they would downcast to the value type

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
