### PR TITLE
Support for median(distinct) aggregation function

### DIFF
--- a/datafusion/core/benches/aggregate_query_sql.rs
+++ b/datafusion/core/benches/aggregate_query_sql.rs
@@ -163,6 +163,16 @@ fn criterion_benchmark(c: &mut Criterion) {
             )
         })
     });
+
+    c.bench_function("aggregate_query_distinct_median", |b| {
+        b.iter(|| {
+            query(
+                ctx.clone(),
+                "SELECT MEDIAN(DISTINCT u64_wide), MEDIAN(DISTINCT u64_narrow) \
+                 FROM t",
+            )
+        })
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -357,9 +357,11 @@ pub fn create_aggregate_expr(
             name,
             data_type,
         )),
-        (AggregateFunction::Median, true) => {
-            return not_impl_err!("MEDIAN(DISTINCT) aggregations are not available");
-        }
+        (AggregateFunction::Median, true) => Arc::new(expressions::DistinctMedian::new(
+            input_phy_exprs[0].clone(),
+            name,
+            data_type,
+        )),
         (AggregateFunction::FirstValue, _) => Arc::new(
             expressions::FirstValue::new(
                 input_phy_exprs[0].clone(),

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -352,15 +352,11 @@ pub fn create_aggregate_expr(
                 "APPROX_MEDIAN(DISTINCT) aggregations are not available"
             );
         }
-        (AggregateFunction::Median, false) => Arc::new(expressions::Median::new(
+        (AggregateFunction::Median, distinct) => Arc::new(expressions::Median::new(
             input_phy_exprs[0].clone(),
             name,
             data_type,
-        )),
-        (AggregateFunction::Median, true) => Arc::new(expressions::DistinctMedian::new(
-            input_phy_exprs[0].clone(),
-            name,
-            data_type,
+            distinct,
         )),
         (AggregateFunction::FirstValue, _) => Arc::new(
             expressions::FirstValue::new(

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -54,6 +54,7 @@ pub use crate::aggregate::count::Count;
 pub use crate::aggregate::count_distinct::DistinctCount;
 pub use crate::aggregate::covariance::{Covariance, CovariancePop};
 pub use crate::aggregate::grouping::Grouping;
+pub use crate::aggregate::median::DistinctMedian;
 pub use crate::aggregate::median::Median;
 pub use crate::aggregate::min_max::{Max, Min};
 pub use crate::aggregate::min_max::{MaxAccumulator, MinAccumulator};

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -1800,6 +1800,7 @@ mod tests {
             col("a", &input_schema)?,
             "MEDIAN(a)".to_string(),
             DataType::UInt32,
+            false,
         ))];
 
         // use slow-path in `hash.rs`

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -472,8 +472,10 @@ SELECT median(distinct col_i8) FROM median_table
 ----
 100
 
-statement error DataFusion error: This feature is not implemented: MEDIAN\(DISTINCT\) aggregations are not available
+query II
 SELECT median(col_i8), median(distinct col_i8) FROM median_table
+----
+-14 100
 
 # approx_distinct_median_i8
 query I


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2411

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Support for explicit distinct median aggregation function, allowing queries such as below to execute now:

```sql
select median(a), median(distinct a) from t
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Essentially duplicated the existing Median aggregation function but aggregate into HashSet instead of a Vec.

Chose HashSet over BTreeMap as figured the insert path is hotter than the fetch path (which is essentially once at evaluation), and (limited) benchmarking didn't show too significant a difference between the two.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, tests added

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
