### PR TITLE
fix: no longer support the `substring` function

### DIFF
--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -467,7 +467,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 expr,
                 substring_from,
                 substring_for,
-                special: false,
+                special: true,
             } => self.sql_substring_to_expr(
                 expr,
                 substring_from,

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -467,7 +467,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 expr,
                 substring_from,
                 substring_for,
-                special: true,
+                ..
             } => self.sql_substring_to_expr(
                 expr,
                 substring_from,
@@ -475,13 +475,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 schema,
                 planner_context,
             ),
-
-            #[cfg(not(feature = "unicode_expressions"))]
-            SQLExpr::Substring { .. } => {
-                internal_err!(
-                    "statement substring requires compilation with feature flag: unicode_expressions."
-                )
-            }
 
             SQLExpr::Trim {
                 expr,

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -467,7 +467,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 expr,
                 substring_from,
                 substring_for,
-                ..
+                special: _,
             } => self.sql_substring_to_expr(
                 expr,
                 substring_from,
@@ -475,6 +475,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 schema,
                 planner_context,
             ),
+
+            #[cfg(not(feature = "unicode_expressions"))]
+            SQLExpr::Substring { .. } => {
+                internal_err!(
+                    "statement substring requires compilation with feature flag: unicode_expressions."
+                )
+            }
 
             SQLExpr::Trim {
                 expr,

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -1897,7 +1897,8 @@ SELECT substring('alphabet' for 1);
 ----
 a
 
-# String arguments are not supported because they might contain regular expressions.
+# The 'from' and 'for' parameters don't support string types, because they should be treated as 
+# regular expressions, which we have not implemented yet.
 query error DataFusion error: Error during planning: No function matches the given name and argument types
 SELECT substring('alphabet' FROM '3')
 

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -1871,6 +1871,17 @@ SELECT digest('','blake3');
 ----
 af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
 
+
+query T
+SELECT substring('alphabet', 1)
+----
+alphabet
+
+query T
+SELECT substring('alphabet', 3, 2)
+----
+ph
+
 query T
 SELECT substring('alphabet' from 2 for 1);
 ----
@@ -1885,6 +1896,23 @@ query T
 SELECT substring('alphabet' for 1);
 ----
 a
+
+# String arguments are not supported because they might contain regular expressions.
+query error DataFusion error: Error during planning: No function matches the given name and argument types
+SELECT substring('alphabet' FROM '3')
+
+query error DataFusion error: Error during planning: No function matches the given name and argument types
+SELECT substring('alphabet' FROM '3' FOR '2')
+
+query error DataFusion error: Error during planning: No function matches the given name and argument types
+SELECT substring('alphabet' FROM '3' FOR 2)
+
+query error DataFusion error: Error during planning: No function matches the given name and argument types
+SELECT substring('alphabet' FROM 3 FOR '2')
+
+query error DataFusion error: Error during planning: No function matches the given name and argument types
+SELECT substring('alphabet' FOR '2')
+
 
 ##### csv_query_nullif_divide_by_0
 

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -420,6 +420,26 @@ statement error The SUBSTR function can only accept strings, but got Int64.
 SELECT substr(1, 3, 4)
 
 query T
+SELECT substring('alphabet', 1)
+---
+----
+alphabet
+
+query T
+SELECT substring('alphabet', 3, 2)
+----
+ph
+
+query error DataFusion error: This feature is not implemented: Unsupported ast node in sqltorel: Substring \{ expr: Value\(SingleQuotedString\("alphabet"\)\), substring_from: Some\(Value\(Number\("3", false\)\)\), substring_for: None, special: false \}
+SELECT substring('alphabet' FROM 3)
+
+query error DataFusion error: This feature is not implemented: Unsupported ast node in sqltorel: Substring \{ expr: Value\(SingleQuotedString\("alphabet"\)\), substring_from: Some\(Value\(Number\("3", false\)\)\), substring_for: Some\(Value\(Number\("2", false\)\)\), special: false \}
+SELECT substring('alphabet' FROM 3 FOR 2)
+
+query error DataFusion error: This feature is not implemented: Unsupported ast node in sqltorel: Substring \{ expr: Value\(SingleQuotedString\("alphabet"\)\), substring_from: None, substring_for: Some\(Value\(Number\("2", false\)\)\), special: false \}
+SELECT substring('alphabet' FOR 2)
+
+query T
 SELECT translate('12345', '143', 'ax')
 ----
 a2x5

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -420,26 +420,6 @@ statement error The SUBSTR function can only accept strings, but got Int64.
 SELECT substr(1, 3, 4)
 
 query T
-SELECT substring('alphabet', 1)
----
-----
-alphabet
-
-query T
-SELECT substring('alphabet', 3, 2)
-----
-ph
-
-query error DataFusion error: This feature is not implemented: Unsupported ast node in sqltorel: Substring \{ expr: Value\(SingleQuotedString\("alphabet"\)\), substring_from: Some\(Value\(Number\("3", false\)\)\), substring_for: None, special: false \}
-SELECT substring('alphabet' FROM 3)
-
-query error DataFusion error: This feature is not implemented: Unsupported ast node in sqltorel: Substring \{ expr: Value\(SingleQuotedString\("alphabet"\)\), substring_from: Some\(Value\(Number\("3", false\)\)\), substring_for: Some\(Value\(Number\("2", false\)\)\), special: false \}
-SELECT substring('alphabet' FROM 3 FOR 2)
-
-query error DataFusion error: This feature is not implemented: Unsupported ast node in sqltorel: Substring \{ expr: Value\(SingleQuotedString\("alphabet"\)\), substring_from: None, substring_for: Some\(Value\(Number\("2", false\)\)\), special: false \}
-SELECT substring('alphabet' FOR 2)
-
-query T
 SELECT translate('12345', '143', 'ax')
 ----
 a2x5


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10240.

## Rationale for this change
Before version 0.45.0 of sqlparser, the `special` flag for both `substring('xxxx', 1, 2)` and `substring('xxxx' from 1 for 2)` was false. 

After https://github.com/sqlparser-rs/sqlparser-rs/pull/1173, the `special` flag for `substring('xxxx', 1, 2)` becomes true.

We need to support both formats  as before, so there's no need to check the `special` flag.

The 'from' and 'for' parameters don't support string types because they should be treated as regular expressions. Currently, substring is just an alias of`substr`. This PR adds tests to verify this.

Reference document: https://www.postgresql.org/docs/current/functions-string.html



## What changes are included in this PR?
Re-enable `substring('xxxx', 1, 2)`.

## Are these changes tested?
Yes
## Are there any user-facing changes?

No
