### PR TITLE
Fix docs.rs build for datafusion-proto (hopefully)

### DIFF
--- a/datafusion/proto/src/generated/mod.rs
+++ b/datafusion/proto/src/generated/mod.rs
@@ -17,7 +17,6 @@
 
 #[allow(clippy::all)]
 #[rustfmt::skip]
-#[cfg(not(docsrs))]
 pub mod datafusion {
     include!("prost.rs");
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/10163

## Rationale for this change

Docs.rs is broken failed for https://docs.rs/crate/datafusion-proto/latest 

![Screenshot 2024-04-21 at 1 04 04 PM](https://github.com/apache/datafusion/assets/490673/86012fea-da25-45c2-b287-0582f0365f42)

The build has a log https://docs.rs/crate/datafusion-proto/37.0.0/builds/1179419 shows the error that the `generated` module isn't working

## What changes are included in this PR?

Remove cfg to get working again (maybe)

## Are these changes tested?
No -- I don't know how to test them. In the other hands the docs are broken so this isn't going to make them any more broken 🤷 

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
