### PR TITLE
refactor: Convert `IPCWriter` metrics from `u64` to `usize`

### DIFF
--- a/datafusion/physical-plan/src/common.rs
+++ b/datafusion/physical-plan/src/common.rs
@@ -259,11 +259,11 @@ pub struct IPCWriter {
     /// inner writer
     pub writer: FileWriter<File>,
     /// batches written
-    pub num_batches: u64,
+    pub num_batches: usize,
     /// rows written
-    pub num_rows: u64,
+    pub num_rows: usize,
     /// bytes written
-    pub num_bytes: u64,
+    pub num_bytes: usize,
 }
 
 impl IPCWriter {
@@ -306,9 +306,9 @@ impl IPCWriter {
     pub fn write(&mut self, batch: &RecordBatch) -> Result<()> {
         self.writer.write(batch)?;
         self.num_batches += 1;
-        self.num_rows += batch.num_rows() as u64;
+        self.num_rows += batch.num_rows();
         let num_bytes: usize = batch.get_array_memory_size();
-        self.num_bytes += num_bytes as u64;
+        self.num_bytes += num_bytes;
         Ok(())
     }
 


### PR DESCRIPTION
## Which issue does this PR close?
Closes #9937.

## What changes are included in this PR?
Currently, `IPCWriter` metrics types are `u64` based but source values are based on `usize` so this requires redundant casting on `IPCWriter.write()` and `ExternalSorter.spill()`. On the other hand, another benefit of `usize` is that it guarantees to reference enough memory location by depending on the architecture such as `u32` or `u64`.
**Ref Discussion:** https://github.com/apache/datafusion/pull/9885#discussion_r1545794898

## Are these changes tested?
Yes by using existing UT case such as `SortExec.test_sort_spill`

## Are there any user-facing changes?
No
