### PR TITLE
chore: Add datatype info to error message

### DIFF
--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -1517,9 +1517,13 @@ fn compare_join_arrays(
             },
             DataType::Date32 => compare_value!(Date32Array),
             DataType::Date64 => compare_value!(Date64Array),
-            _ => {
+            dt => {
                 return not_impl_err!(
-                    "Unsupported data type in sort merge join comparator"
+                    "{}",
+                    format!(
+                        "Unsupported data type in sort merge join comparator: {}",
+                        dt
+                    )
                 );
             }
         }
@@ -1583,9 +1587,13 @@ fn is_join_arrays_equal(
             },
             DataType::Date32 => compare_value!(Date32Array),
             DataType::Date64 => compare_value!(Date64Array),
-            _ => {
+            dt => {
                 return not_impl_err!(
-                    "Unsupported data type in sort merge join comparator"
+                    "{}",
+                    format!(
+                        "Unsupported data type in sort merge join comparator: {}",
+                        dt
+                    )
                 );
             }
         }

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -1519,11 +1519,8 @@ fn compare_join_arrays(
             DataType::Date64 => compare_value!(Date64Array),
             dt => {
                 return not_impl_err!(
-                    "{}",
-                    format!(
-                        "Unsupported data type in sort merge join comparator: {}",
-                        dt
-                    )
+                    "Unsupported data type in sort merge join comparator: {}",
+                    dt
                 );
             }
         }
@@ -1589,11 +1586,8 @@ fn is_join_arrays_equal(
             DataType::Date64 => compare_value!(Date64Array),
             dt => {
                 return not_impl_err!(
-                    "{}",
-                    format!(
-                        "Unsupported data type in sort merge join comparator: {}",
-                        dt
-                    )
+                    "Unsupported data type in sort merge join comparator: {}",
+                    dt
                 );
             }
         }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I saw this error message `Unsupported data type in sort merge join comparator` when debugging some issues in Comet. It reads a bit confusing and doesn't provide useful info. It would be better at least we can add the data type info into the error message.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
