### PR TITLE
[Minor] Update link to list of committers in contributor guide

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -68,9 +68,11 @@ ideas with the community to get feedback on implementation.
 
 We welcome pull requests (PRs) from anyone from the community.
 
-DataFusion is a very active fast-moving project and we try to review and merge PRs quickly to keep the review backlog down and the pace up. After review and approval, one of the [many people with commit access](https://arrow.apache.org/committers/) will merge your PR.
+DataFusion is a very active fast-moving project and we try to review and merge PRs quickly to keep the review backlog down and the pace up. After review and approval, one of the [many people with commit access] will merge your PR.
 
 Review bandwidth is currently our most limited resource, and we highly encourage reviews by the broader community. If you are waiting for your PR to be reviewed, consider helping review other PRs that are waiting. Such review both helps the reviewer to learn the codebase and become more expert, as well as helps identify issues in the PR (such as lack of test coverage), that can be addressed and make future reviews faster and more efficient.
+
+[many people with commit access]: https://people.apache.org/phonebook.html?unix=datafusion
 
 ## Creating Pull Requests
 

--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -68,11 +68,11 @@ ideas with the community to get feedback on implementation.
 
 We welcome pull requests (PRs) from anyone from the community.
 
-DataFusion is a very active fast-moving project and we try to review and merge PRs quickly to keep the review backlog down and the pace up. After review and approval, one of the [many people with commit access] will merge your PR.
+DataFusion is a very active fast-moving project and we try to review and merge PRs quickly to keep the review backlog down and the pace up. After review and approval, one of the [committers] will merge your PR.
 
 Review bandwidth is currently our most limited resource, and we highly encourage reviews by the broader community. If you are waiting for your PR to be reviewed, consider helping review other PRs that are waiting. Such review both helps the reviewer to learn the codebase and become more expert, as well as helps identify issues in the PR (such as lack of test coverage), that can be addressed and make future reviews faster and more efficient.
 
-[many people with commit access]: https://people.apache.org/phonebook.html?unix=datafusion
+[committers]: https://people.apache.org/phonebook.html?unix=datafusion
 
 ## Creating Pull Requests
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #9691 

## Rationale for this change

Noticed while reviewing the docs

## What changes are included in this PR?

1. Update the link to list of committers from arrow to datafusion

## Are these changes tested?
CI tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
