### PR TITLE
Fix build with missing `use` ( `" return internal_err!("UDF returned a different ..."`)

### DIFF
--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -37,7 +37,7 @@ use std::sync::Arc;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
-use datafusion_common::Result;
+use datafusion_common::{internal_err, Result};
 use datafusion_expr::{
     expr_vec_fmt, ColumnarValue, FuncMonotonicity, ScalarFunctionDefinition,
 };
@@ -153,7 +153,7 @@ impl PhysicalExpr for ScalarFunctionExpr {
 
                 if let ColumnarValue::Array(array) = &output {
                     if array.len() != batch.num_rows() {
-                        return internal_err!("UDF returned a different number of rows than expected. Expected: {}, Got: {}", 
+                        return internal_err!("UDF returned a different number of rows than expected. Expected: {}, Got: {}",
                         batch.num_rows(), array.len());
                     }
                 }


### PR DESCRIPTION
## Which issue does this PR close?

It appears https://github.com/apache/datafusion/pull/10277 had a logical conflict

https://github.com/apache/datafusion/actions/runs/8899641374/job/24439454308

```
error: cannot find macro `internal_err` in this scope
   --> datafusion/physical-expr/src/scalar_function.rs:156:32
    |
156 |                         return internal_err!("UDF returned a different number of rows than expected. Expected: {}, Got: {}", 
    |                                ^^^^^^^^^^^^
    |
help: consider importing this macro
    |
32  + use datafusion_common::internal_err;
```

## Rationale for this change

Fix build

## What changes are included in this PR?
Add required `use`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
