### PR TITLE
Check list size before concat in ScalarValue

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -2207,9 +2207,9 @@ impl ScalarValue {
 
     fn list_to_array_of_size(arr: &dyn Array, size: usize) -> Result<ArrayRef> {
         let arrays = std::iter::repeat(arr).take(size).collect::<Vec<_>>();
-        let ret = match arrays.len() > 0 {
+        let ret = match !arrays.is_empty() {
             true => arrow::compute::concat(arrays.as_slice())?,
-            false => arr.slice(0, 0)
+            false => arr.slice(0, 0),
         };
         Ok(ret)
     }

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -2207,7 +2207,11 @@ impl ScalarValue {
 
     fn list_to_array_of_size(arr: &dyn Array, size: usize) -> Result<ArrayRef> {
         let arrays = std::iter::repeat(arr).take(size).collect::<Vec<_>>();
-        Ok(arrow::compute::concat(arrays.as_slice())?)
+        let ret = match arrays.len() > 0 {
+            true => arrow::compute::concat(arrays.as_slice())?,
+            false => arr.slice(0, 0)
+        };
+        Ok(ret)
     }
 
     /// Retrieve ScalarValue for each row in `array`
@@ -3560,6 +3564,12 @@ mod tests {
             &expected_arr,
             as_fixed_size_list_array(actual_arr.as_ref()).unwrap()
         );
+
+        let empty_array = sv
+            .to_array_of_size(0)
+            .expect("Failed to convert to empty array");
+
+        assert_eq!(empty_array.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
This PR resolves an issue in which we get a panic attempting to concatenate empty arrays. This prevents lead and lag functions from working on these data types.

## Which issue does this PR close?

Closes #10328.

## Rationale for this change

When we call `WindowAggState::new` with a data type of a list, we will call `ScalarValue::try_from(out_type)?.to_array_of_size(0)` which in turn calls `list_to_array_of_size`. Within this function there is no check on the return size. It could be zero due to either an empty array input or a request for 0 elements. In either of these conditions, you will get a panic from `concat`.

## What changes are included in this PR?

This is a small change to check the return size. When zero it will just take an empty slice of the original array.

## Are these changes tested?

I have included an expansion to an existing unit test to cover this. In my bug report I have also shown minimal example to reproduce the problem and the updated results from it's inclusion.

## Are there any user-facing changes?

There are no user facing changes.
