### PR TITLE
Minor: Add sql level test for lead/lag on arrays

### DIFF
--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -4799,3 +4799,33 @@ NULL 4
 NULL 3
 NULL 2
 NULL 1
+
+
+### Test for window functions with arrays
+statement ok
+create table array_data
+as values
+  ('a',make_array(1, 2, 3)),
+  ('b', make_array(4, 5, 6)),
+  ('c', make_array(7, 8, 9));
+
+query T?
+SELECT column1, column2 FROM array_data ORDER BY column1;
+----
+a [1, 2, 3]
+b [4, 5, 6]
+c [7, 8, 9]
+
+query T??
+SELECT
+  column1,
+  lag(column2) OVER (order by column1),
+  lead(column2) OVER (order by column1)
+FROM array_data;
+----
+a NULL [4, 5, 6]
+b [1, 2, 3] [7, 8, 9]
+c [4, 5, 6] NULL
+
+statement ok
+drop table array_data

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -4809,13 +4809,6 @@ as values
   ('b', make_array(4, 5, 6)),
   ('c', make_array(7, 8, 9));
 
-query T?
-SELECT column1, column2 FROM array_data ORDER BY column1;
-----
-a [1, 2, 3]
-b [4, 5, 6]
-c [7, 8, 9]
-
 query T??
 SELECT
   column1,


### PR DESCRIPTION
## Which issue does this PR close?

re https://github.com/apache/datafusion/issues/10328
follow on to https://github.com/apache/datafusion/pull/10329

## Rationale for this change
In addition to the unit test from @timsaucer  in https://github.com/apache/datafusion/pull/10329 I thought it would be good to have an end to end test showing window functions on arrays

## What changes are included in this PR?
add sqllogictest
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
only tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
