### PR TITLE
feat: Add CrossJoin match case to unparser

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -300,6 +300,38 @@ impl Unparser<'_> {
 
                 Ok(())
             }
+            LogicalPlan::CrossJoin(cross_join) => {
+                // Cross joins are the same as unconditional inner joins
+                let mut right_relation = RelationBuilder::default();
+
+                self.select_to_sql_recursively(
+                    cross_join.left.as_ref(),
+                    query,
+                    select,
+                    relation,
+                )?;
+                self.select_to_sql_recursively(
+                    cross_join.right.as_ref(),
+                    query,
+                    select,
+                    &mut right_relation,
+                )?;
+
+                let ast_join = ast::Join {
+                    relation: right_relation.build()?,
+                    join_operator: self.join_operator_to_sql(
+                        JoinType::Inner,
+                        ast::JoinConstraint::On(ast::Expr::Value(ast::Value::Boolean(
+                            true,
+                        ))),
+                    ),
+                };
+                let mut from = select.pop_from().unwrap();
+                from.push_join(ast_join);
+                select.push_from(from);
+
+                Ok(())
+            }
             LogicalPlan::SubqueryAlias(plan_alias) => {
                 // Handle bottom-up to allocate relation
                 self.select_to_sql_recursively(

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4674,6 +4674,39 @@ fn roundtrip_statement() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn roundtrip_crossjoin() -> Result<()> {
+    let query = "select j1.j1_id, j2.j2_string from j1, j2";
+
+    let dialect = GenericDialect {};
+    let statement = Parser::new(&dialect)
+        .try_with_sql(query)?
+        .parse_statement()?;
+
+    let context = MockContextProvider::default();
+    let sql_to_rel = SqlToRel::new(&context);
+    let plan = sql_to_rel.sql_statement_to_plan(statement).unwrap();
+
+    let roundtrip_statement = plan_to_sql(&plan)?;
+
+    let actual = format!("{}", &roundtrip_statement);
+    println!("roundtrip sql: {actual}");
+    println!("plan {}", plan.display_indent());
+
+    let plan_roundtrip = sql_to_rel
+        .sql_statement_to_plan(roundtrip_statement.clone())
+        .unwrap();
+
+    let expected = "Projection: j1.j1_id, j2.j2_string\
+        \n  Inner Join:  Filter: Boolean(true)\
+        \n    TableScan: j1\
+        \n    TableScan: j2";
+
+    assert_eq!(format!("{plan_roundtrip:?}"), expected);
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[ctor::ctor]
 fn init() {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion/issues/8661

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Came across this issue when trying to federate a query selecting from multiple tables with different sources. For example, `SELECT a_1, b_1 FROM table_a, table_b` is evaluated as a cross join, but the unparser wasn't handling cross joins yet.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Allow unparsing of cross joins into the equivalent inner join.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added a test for cross join roundtrip. It is slightly different from the other roundtrips because `sqlparser` doesn't have an implementation for Cross Join, so it gets converted into an Inner Join.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
