### PR TITLE
chore: remove DataPtr trait since Arc::ptr_eq ignores pointer metadata

### DIFF
--- a/datafusion/common/src/utils.rs
+++ b/datafusion/common/src/utils.rs
@@ -525,34 +525,6 @@ pub fn list_ndims(data_type: &DataType) -> u64 {
     }
 }
 
-/// An extension trait for smart pointers. Provides an interface to get a
-/// raw pointer to the data (with metadata stripped away).
-///
-/// This is useful to see if two smart pointers point to the same allocation.
-pub trait DataPtr {
-    /// Returns a raw pointer to the data, stripping away all metadata.
-    fn data_ptr(this: &Self) -> *const ();
-
-    /// Check if two pointers point to the same data.
-    fn data_ptr_eq(this: &Self, other: &Self) -> bool {
-        // Discard pointer metadata (including the v-table).
-        let this = Self::data_ptr(this);
-        let other = Self::data_ptr(other);
-
-        std::ptr::eq(this, other)
-    }
-}
-
-// Currently, it's brittle to compare `Arc`s of dyn traits with `Arc::ptr_eq`
-// due to this check including v-table equality. It may be possible to use
-// `Arc::ptr_eq` directly if a fix to https://github.com/rust-lang/rust/issues/103763
-// is stabilized.
-impl<T: ?Sized> DataPtr for Arc<T> {
-    fn data_ptr(this: &Self) -> *const () {
-        Arc::as_ptr(this) as *const ()
-    }
-}
-
 /// Adopted from strsim-rs for string similarity metrics
 pub mod datafusion_strsim {
     // Source: https://github.com/dguo/strsim-rs/blob/master/src/lib.rs

--- a/datafusion/common/src/utils.rs
+++ b/datafusion/common/src/utils.rs
@@ -947,26 +947,6 @@ mod tests {
     }
 
     #[test]
-    fn arc_data_ptr_eq() {
-        let x = Arc::new(());
-        let y = Arc::new(());
-        let y_clone = Arc::clone(&y);
-
-        assert!(
-            Arc::data_ptr_eq(&x, &x),
-            "same `Arc`s should point to same data"
-        );
-        assert!(
-            !Arc::data_ptr_eq(&x, &y),
-            "different `Arc`s should point to different data"
-        );
-        assert!(
-            Arc::data_ptr_eq(&y, &y_clone),
-            "cloned `Arc` should point to same data as the original"
-        );
-    }
-
-    #[test]
     fn test_merge_and_order_indices() {
         assert_eq!(
             merge_and_order_indices([0, 3, 4], [1, 3, 5]),

--- a/datafusion/core/src/physical_optimizer/join_selection.rs
+++ b/datafusion/core/src/physical_optimizer/join_selection.rs
@@ -1544,7 +1544,6 @@ mod hash_join_tests {
 
     use arrow::datatypes::{DataType, Field};
     use arrow::record_batch::RecordBatch;
-    use datafusion_common::utils::DataPtr;
 
     struct TestCase {
         case: String,
@@ -1937,8 +1936,8 @@ mod hash_join_tests {
             ..
         }) = plan.as_any().downcast_ref::<HashJoinExec>()
         {
-            let left_changed = Arc::data_ptr_eq(left, &right_exec);
-            let right_changed = Arc::data_ptr_eq(right, &left_exec);
+            let left_changed = Arc::ptr_eq(left, &right_exec);
+            let right_changed = Arc::ptr_eq(right, &left_exec);
             // If this is not equal, we have a bigger problem.
             assert_eq!(left_changed, right_changed);
             assert_eq!(

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -24,7 +24,6 @@ use arrow::array::BooleanArray;
 use arrow::compute::filter_record_batch;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
-use datafusion_common::utils::DataPtr;
 use datafusion_common::{internal_err, not_impl_err, Result};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::ColumnarValue;
@@ -188,7 +187,7 @@ pub fn with_new_children_if_necessary(
         || children
             .iter()
             .zip(old_children.iter())
-            .any(|(c1, c2)| !Arc::data_ptr_eq(c1, c2))
+            .any(|(c1, c2)| !Arc::ptr_eq(c1, c2))
     {
         Ok(expr.with_new_children(children)?)
     } else {

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -30,7 +30,6 @@ use crate::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::utils::DataPtr;
 use datafusion_common::Result;
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::{
@@ -684,7 +683,7 @@ pub fn with_new_children_if_necessary(
         || children
             .iter()
             .zip(old_children.iter())
-            .any(|(c1, c2)| !Arc::data_ptr_eq(c1, c2))
+            .any(|(c1, c2)| !Arc::ptr_eq(c1, c2))
     {
         plan.with_new_children(children)
     } else {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10377.

## Rationale for this change
According to https://github.com/rust-lang/rust/pull/106450, Arc::ptr_eq now compares two pointer without metadata. 
So, it is safe to remove DataPtr trait and use Arc::ptr_eq directly.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
This PR removed the DataPtr trait and replace all Arc::data_ptr_eq with Arc::ptr_eq.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
