### PR TITLE
Stop copying LogicalPlan and Exprs in `OptimizeProjections` (2% faster planning)

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1079,6 +1079,34 @@ impl Expr {
         }
     }
 
+    /// Recursively potentially multiple aliases from an expression.
+    ///
+    /// If the expression is not an alias, the expression is returned unchanged.
+    /// This method removes directly nested aliases, but not other nested
+    /// aliases.
+    ///
+    /// # Example
+    /// ```
+    /// # use datafusion_expr::col;
+    /// // `foo as "bar"` is unaliased to `foo`
+    /// let expr = col("foo").alias("bar");
+    /// assert_eq!(expr.unalias_nested(), col("foo"));
+    ///
+    /// // `foo as "bar" + baz` is not unaliased
+    /// let expr = col("foo").alias("bar") + col("baz");
+    /// assert_eq!(expr.clone().unalias_nested(), expr);
+    ///
+    /// // `foo as "bar" as "baz" is unalaised to foo
+    /// let expr = col("foo").alias("bar").alias("baz");
+    /// assert_eq!(expr.unalias_nested(), col("foo"));
+    /// ```
+    pub fn unalias_nested(self) -> Expr {
+        match self {
+            Expr::Alias(alias) => alias.expr.unalias_nested(),
+            _ => self,
+        }
+    }
+
     /// Return `self IN <list>` if `negated` is false, otherwise
     /// return `self NOT IN <list>`.a
     pub fn in_list(self, list: Vec<Expr>, negated: bool) -> Expr {

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -295,6 +295,13 @@ impl NamePreserver {
         }
     }
 
+    /// Create a new NamePreserver for rewriting the `expr`s in `Projection`
+    ///
+    /// This will use aliases
+    pub fn new_for_projection() -> Self {
+        Self { use_alias: true }
+    }
+
     pub fn save(&self, expr: &Expr) -> Result<SavedName> {
         let original_name = if self.use_alias {
             Some(expr.name_for_alias()?)

--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -31,10 +31,9 @@ query TT
 EXPLAIN WITH "NUMBERS" AS (SELECT 1 as a, 2 as b, 3 as c) SELECT "NUMBERS".* FROM "NUMBERS"
 ----
 logical_plan
-01)Projection: NUMBERS.a, NUMBERS.b, NUMBERS.c
-02)--SubqueryAlias: NUMBERS
-03)----Projection: Int64(1) AS a, Int64(2) AS b, Int64(3) AS c
-04)------EmptyRelation
+01)SubqueryAlias: NUMBERS
+02)--Projection: Int64(1) AS a, Int64(2) AS b, Int64(3) AS c
+03)----EmptyRelation
 physical_plan
 01)ProjectionExec: expr=[1 as a, 2 as b, 3 as c]
 02)--PlaceholderRowExec
@@ -105,14 +104,13 @@ EXPLAIN WITH RECURSIVE nodes AS (
 SELECT * FROM nodes
 ----
 logical_plan
-01)Projection: nodes.id
-02)--SubqueryAlias: nodes
-03)----RecursiveQuery: is_distinct=false
-04)------Projection: Int64(1) AS id
-05)--------EmptyRelation
-06)------Projection: nodes.id + Int64(1) AS id
-07)--------Filter: nodes.id < Int64(10)
-08)----------TableScan: nodes
+01)SubqueryAlias: nodes
+02)--RecursiveQuery: is_distinct=false
+03)----Projection: Int64(1) AS id
+04)------EmptyRelation
+05)----Projection: nodes.id + Int64(1) AS id
+06)------Filter: nodes.id < Int64(10)
+07)--------TableScan: nodes
 physical_plan
 01)RecursiveQueryExec: name=nodes, is_distinct=false
 02)--ProjectionExec: expr=[1 as id]
@@ -152,14 +150,13 @@ ORDER BY time, name, account_balance
 ----
 logical_plan
 01)Sort: balances.time ASC NULLS LAST, balances.name ASC NULLS LAST, balances.account_balance ASC NULLS LAST
-02)--Projection: balances.time, balances.name, balances.account_balance
-03)----SubqueryAlias: balances
-04)------RecursiveQuery: is_distinct=false
-05)--------Projection: balance.time, balance.name, balance.account_balance
-06)----------TableScan: balance
-07)--------Projection: balances.time + Int64(1) AS time, balances.name, balances.account_balance + Int64(10) AS account_balance
-08)----------Filter: balances.time < Int64(10)
-09)------------TableScan: balances
+02)--SubqueryAlias: balances
+03)----RecursiveQuery: is_distinct=false
+04)------Projection: balance.time, balance.name, balance.account_balance
+05)--------TableScan: balance
+06)------Projection: balances.time + Int64(1) AS time, balances.name, balances.account_balance + Int64(10) AS account_balance
+07)--------Filter: balances.time < Int64(10)
+08)----------TableScan: balances
 physical_plan
 01)SortExec: expr=[time@0 ASC NULLS LAST,name@1 ASC NULLS LAST,account_balance@2 ASC NULLS LAST], preserve_partitioning=[false]
 02)--RecursiveQueryExec: name=balances, is_distinct=false
@@ -720,18 +717,17 @@ explain WITH RECURSIVE recursive_cte AS (
 SELECT * FROM recursive_cte;
 ----
 logical_plan
-01)Projection: recursive_cte.val
-02)--SubqueryAlias: recursive_cte
-03)----RecursiveQuery: is_distinct=false
-04)------Projection: Int64(1) AS val
-05)--------EmptyRelation
-06)------Projection: Int64(2) AS val
-07)--------CrossJoin:
-08)----------Filter: recursive_cte.val < Int64(2)
-09)------------TableScan: recursive_cte
-10)----------SubqueryAlias: sub_cte
-11)------------Projection: Int64(2) AS val
-12)--------------EmptyRelation
+01)SubqueryAlias: recursive_cte
+02)--RecursiveQuery: is_distinct=false
+03)----Projection: Int64(1) AS val
+04)------EmptyRelation
+05)----Projection: Int64(2) AS val
+06)------CrossJoin:
+07)--------Filter: recursive_cte.val < Int64(2)
+08)----------TableScan: recursive_cte
+09)--------SubqueryAlias: sub_cte
+10)----------Projection: Int64(2) AS val
+11)------------EmptyRelation
 physical_plan
 01)RecursiveQueryExec: name=recursive_cte, is_distinct=false
 02)--ProjectionExec: expr=[1 as val]

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3602,17 +3602,16 @@ EXPLAIN SELECT * FROM (
 ) as a FULL JOIN (SELECT 1 as e, 3 AS f) AS rhs ON a.c=rhs.e;
 ----
 logical_plan
-01)Projection: a.c, a.d, rhs.e, rhs.f
-02)--Full Join: a.c = rhs.e
-03)----SubqueryAlias: a
-04)------Union
-05)--------Projection: Int64(1) AS c, Int64(2) AS d
-06)----------EmptyRelation
-07)--------Projection: Int64(1) AS c, Int64(3) AS d
-08)----------EmptyRelation
-09)----SubqueryAlias: rhs
-10)------Projection: Int64(1) AS e, Int64(3) AS f
-11)--------EmptyRelation
+01)Full Join: a.c = rhs.e
+02)--SubqueryAlias: a
+03)----Union
+04)------Projection: Int64(1) AS c, Int64(2) AS d
+05)--------EmptyRelation
+06)------Projection: Int64(1) AS c, Int64(3) AS d
+07)--------EmptyRelation
+08)--SubqueryAlias: rhs
+09)----Projection: Int64(1) AS e, Int64(3) AS f
+10)------EmptyRelation
 physical_plan
 01)ProjectionExec: expr=[c@2 as c, d@3 as d, e@0 as e, f@1 as f]
 02)--CoalesceBatchesExec: target_batch_size=2
@@ -3650,17 +3649,16 @@ EXPLAIN SELECT * FROM (
 ) as a FULL JOIN (SELECT 1 as e, 3 AS f) AS rhs ON a.c=rhs.e;
 ----
 logical_plan
-01)Projection: a.c, a.d, rhs.e, rhs.f
-02)--Full Join: a.c = rhs.e
-03)----SubqueryAlias: a
-04)------Union
-05)--------Projection: Int64(1) AS c, Int64(2) AS d
-06)----------EmptyRelation
-07)--------Projection: Int64(1) AS c, Int64(3) AS d
-08)----------EmptyRelation
-09)----SubqueryAlias: rhs
-10)------Projection: Int64(1) AS e, Int64(3) AS f
-11)--------EmptyRelation
+01)Full Join: a.c = rhs.e
+02)--SubqueryAlias: a
+03)----Union
+04)------Projection: Int64(1) AS c, Int64(2) AS d
+05)--------EmptyRelation
+06)------Projection: Int64(1) AS c, Int64(3) AS d
+07)--------EmptyRelation
+08)--SubqueryAlias: rhs
+09)----Projection: Int64(1) AS e, Int64(3) AS f
+10)------EmptyRelation
 physical_plan
 01)ProjectionExec: expr=[c@2 as c, d@3 as d, e@0 as e, f@1 as f]
 02)--CoalesceBatchesExec: target_batch_size=2


### PR DESCRIPTION
Note this also has the changes from https://github.com/apache/datafusion/pull/10410 in it

## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/10209

## Rationale for this change

Make planning faster by not copying as much

## What changes are included in this PR?

1. Rewrite `OptimizeProjections` to use treenode APIs

## Are these changes tested?
Existing tests

## Are there any user-facing changes?
1. More types of projections can be combined (e.g. `CASE` expressions)
1. Faster planning 

Benchmark Results show a moderate improvement (2% overall in tpch, but some queries like Q3 are like 10% faster)

<details><summary>Details</summary>
<p>

```
++ critcmp main projection_pushdown
group                                         main                                   projection_pushdown
-----                                         ----                                   -------------------
logical_aggregate_with_join                   1.01  1217.9±11.93µs        ? ?/sec    1.00  1208.1±12.12µs        ? ?/sec
logical_plan_tpcds_all                        1.00    160.7±1.72ms        ? ?/sec    1.00    160.6±1.78ms        ? ?/sec
logical_plan_tpch_all                         1.02     17.1±0.20ms        ? ?/sec    1.00     16.8±0.21ms        ? ?/sec
logical_select_all_from_1000                  1.00     18.7±0.14ms        ? ?/sec    1.01     18.9±0.11ms        ? ?/sec
logical_select_one_from_700                   1.01    820.9±9.73µs        ? ?/sec    1.00   816.1±20.75µs        ? ?/sec
logical_trivial_join_high_numbered_columns    1.00   765.5±18.71µs        ? ?/sec    1.00   764.8±64.26µs        ? ?/sec
logical_trivial_join_low_numbered_columns     1.01    749.8±8.67µs        ? ?/sec    1.00    742.3±7.49µs        ? ?/sec
physical_plan_tpcds_all                       1.03  1364.1±11.01ms        ? ?/sec    1.00  1330.1±16.93ms        ? ?/sec
physical_plan_tpch_all                        1.03     94.8±1.43ms        ? ?/sec    1.00     92.1±1.28ms        ? ?/sec
physical_plan_tpch_q1                         1.06      5.2±0.05ms        ? ?/sec    1.00      4.9±0.07ms        ? ?/sec
physical_plan_tpch_q10                        1.03      4.4±0.06ms        ? ?/sec    1.00      4.3±0.08ms        ? ?/sec
physical_plan_tpch_q11                        1.02      3.9±0.06ms        ? ?/sec    1.00      3.8±0.08ms        ? ?/sec
physical_plan_tpch_q12                        1.00      3.0±0.04ms        ? ?/sec    1.02      3.1±0.06ms        ? ?/sec
physical_plan_tpch_q13                        1.03      2.1±0.04ms        ? ?/sec    1.00      2.1±0.03ms        ? ?/sec
physical_plan_tpch_q14                        1.08      2.9±0.07ms        ? ?/sec    1.00      2.7±0.04ms        ? ?/sec
physical_plan_tpch_q16                        1.06      3.8±0.06ms        ? ?/sec    1.00      3.6±0.05ms        ? ?/sec
physical_plan_tpch_q17                        1.04      3.6±0.07ms        ? ?/sec    1.00      3.5±0.07ms        ? ?/sec
physical_plan_tpch_q18                        1.07      4.1±0.05ms        ? ?/sec    1.00      3.9±0.05ms        ? ?/sec
physical_plan_tpch_q19                        1.10      6.5±0.07ms        ? ?/sec    1.00      5.9±0.07ms        ? ?/sec
physical_plan_tpch_q2                         1.04      8.0±0.04ms        ? ?/sec    1.00      7.7±0.09ms        ? ?/sec
physical_plan_tpch_q20                        1.04      4.8±0.06ms        ? ?/sec    1.00      4.6±0.06ms        ? ?/sec
physical_plan_tpch_q21                        1.02      6.4±0.08ms        ? ?/sec    1.00      6.2±0.06ms        ? ?/sec
physical_plan_tpch_q22                        1.00      3.4±0.06ms        ? ?/sec    1.00      3.4±0.08ms        ? ?/sec
physical_plan_tpch_q3                         1.11      3.4±0.07ms        ? ?/sec    1.00      3.1±0.06ms        ? ?/sec
physical_plan_tpch_q4                         1.12      2.5±0.04ms        ? ?/sec    1.00      2.2±0.02ms        ? ?/sec
physical_plan_tpch_q5                         1.09      4.8±0.05ms        ? ?/sec    1.00      4.4±0.06ms        ? ?/sec
physical_plan_tpch_q6                         1.05  1615.2±30.14µs        ? ?/sec    1.00  1543.2±24.24µs        ? ?/sec
physical_plan_tpch_q7                         1.03      5.9±0.06ms        ? ?/sec    1.00      5.7±0.09ms        ? ?/sec
physical_plan_tpch_q8                         1.02      7.5±0.15ms        ? ?/sec    1.00      7.4±0.08ms        ? ?/sec
physical_plan_tpch_q9                         1.01      5.6±0.07ms        ? ?/sec    1.00      5.5±0.11ms        ? ?/sec
physical_select_all_from_1000                 1.01     61.5±0.34ms        ? ?/sec    1.00     61.2±0.52ms        ? ?/sec
physical_select_one_from_700                  1.02      3.7±0.05ms        ? ?/sec    1.00      3.6±0.04ms        ? ?/sec
```

</p>
</details> 