### PR TITLE
Fix incorrect Schema over aggregate function, Remove unnecessary `exprlist_to_fields_aggregate`

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1587,8 +1587,9 @@ mod tests {
     use datafusion_common::{Constraint, Constraints};
     use datafusion_common_runtime::SpawnedTask;
     use datafusion_expr::{
-        cast, count_distinct, create_udf, expr, lit, sum, BuiltInWindowFunction,
-        ScalarFunctionImplementation, Volatility, WindowFrame, WindowFunctionDefinition,
+        array_agg, cast, count_distinct, create_udf, expr, lit, sum,
+        BuiltInWindowFunction, ScalarFunctionImplementation, Volatility, WindowFrame,
+        WindowFunctionDefinition,
     };
     use datafusion_physical_expr::expressions::Column;
     use datafusion_physical_plan::{get_plan_string, ExecutionPlanProperties};
@@ -2040,6 +2041,24 @@ mod tests {
             ],
             &df_results
         );
+
+        Ok(())
+    }
+
+    // Test issue: https://github.com/apache/datafusion/issues/10346
+    #[tokio::test]
+    async fn test_select_over_aggregate_schema() -> Result<()> {
+        let df = test_table()
+            .await?
+            .with_column("c", col("c1"))?
+            .aggregate(vec![], vec![array_agg(col("c")).alias("c")])?
+            .select(vec![col("c")])?;
+
+        assert_eq!(df.schema().fields().len(), 1);
+        let field = df.schema().field(0);
+        // There are two columns named 'c', one from the input of the aggregate and the other from the output.
+        // Select should return the column from the output of the aggregate, which is a list.
+        assert!(matches!(field.data_type(), DataType::List(_)));
 
         Ok(())
     }

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 
 use crate::expr::{Alias, Sort, WindowFunction};
 use crate::expr_rewriter::strip_outer_reference;
-use crate::logical_plan::Aggregate;
 use crate::signature::{Signature, TypeSignature};
 use crate::{
     and, BinaryExpr, Cast, Expr, ExprSchemable, Filter, GroupingSet, LogicalPlan,
@@ -725,53 +724,14 @@ pub fn from_plan(
     plan.with_new_exprs(expr.to_vec(), inputs.to_vec())
 }
 
-/// Find all columns referenced from an aggregate query
-fn agg_cols(agg: &Aggregate) -> Vec<Column> {
-    agg.aggr_expr
-        .iter()
-        .chain(&agg.group_expr)
-        .flat_map(find_columns_referenced_by_expr)
-        .collect()
-}
-
-fn exprlist_to_fields_aggregate(
-    exprs: &[Expr],
-    agg: &Aggregate,
-) -> Result<Vec<(Option<TableReference>, Arc<Field>)>> {
-    let agg_cols = agg_cols(agg);
-    let mut fields = vec![];
-    for expr in exprs {
-        match expr {
-            Expr::Column(c) if agg_cols.iter().any(|x| x == c) => {
-                // resolve against schema of input to aggregate
-                fields.push(expr.to_field(agg.input.schema())?);
-            }
-            _ => fields.push(expr.to_field(&agg.schema)?),
-        }
-    }
-    Ok(fields)
-}
-
 /// Create field meta-data from an expression, for use in a result set schema
 pub fn exprlist_to_fields(
     exprs: &[Expr],
     plan: &LogicalPlan,
 ) -> Result<Vec<(Option<TableReference>, Arc<Field>)>> {
-    // when dealing with aggregate plans we cannot simply look in the aggregate output schema
-    // because it will contain columns representing complex expressions (such a column named
-    // `GROUPING(person.state)` so in order to resolve `person.state` in this case we need to
-    // look at the input to the aggregate instead.
-    let fields = match plan {
-        LogicalPlan::Aggregate(agg) => Some(exprlist_to_fields_aggregate(exprs, agg)),
-        _ => None,
-    };
-    if let Some(fields) = fields {
-        fields
-    } else {
-        // look for exact match in plan's output schema
-        let input_schema = &plan.schema();
-        exprs.iter().map(|e| e.to_field(input_schema)).collect()
-    }
+    // look for exact match in plan's output schema
+    let input_schema = &plan.schema();
+    exprs.iter().map(|e| e.to_field(input_schema)).collect()
 }
 
 /// Convert an expression into Column expression if it's already provided as input plan.


### PR DESCRIPTION
## Which issue does this PR close?


Closes #10346.

## Rationale for this change

[exprlist_to_fields_aggregate](https://github.com/apache/datafusion/blob/a0fccbf886346fde5dfbda136149ec98bbd6e952/datafusion/expr/src/utils.rs#L737) was introduced by https://github.com/apache/datafusion/pull/2486. 
It was necessary for the test `aggregate_with_rollup_with_grouping`.
https://github.com/apache/datafusion/blob/5335f8055636a0e11f8bcda8a3084edba825f79e/datafusion/core/src/sql/planner.rs#L4698-L4705
In this test, the grouped-by expression `person.state` was not included in the aggregate's output schema,  so we need to further check the aggregate's input, as mentioned in the comments.
> // when dealing with aggregate plans we cannot simply look in the aggregate output schema
    // because it will contain columns representing complex expressions (such a column named
    // `#GROUPING(person.state)` so in order to resolve `person.state` in this case we need to
    // look at the input to the aggregate instead.


But on the current main branch, `person.state` is already included in the aggregate's output schema, which is achieved through the function [grouping_set_to_exprlist](https://github.com/apache/datafusion/blob/c8b8c74904972c57f559a167dd0ccd52c8f91076/datafusion/expr/src/utils.rs#L251). It adds all the grouped-by expressions.
https://github.com/apache/datafusion/blob/c8b8c74904972c57f559a167dd0ccd52c8f91076/datafusion/expr/src/logical_plan/plan.rs#L2273
Therefore, `exprlist_to_fields_aggregate` should become unnecessary. Besides, it takes columns from the aggregate's input and might override a column with the same name in the output, leading to the bug in #10346..

## What changes are included in this PR?
Remove the unnecessary `exprlist_to_fields_aggregate` and fix a bug.

## Are these changes tested?
Yes


## Are there any user-facing changes?
No