### PR TITLE
only consider main part of the url when deciding is_collection in listing table

### DIFF
--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -187,10 +187,7 @@ impl ListingTableUrl {
 
     /// Returns `true` if `path` refers to a collection of objects
     pub fn is_collection(&self) -> bool {
-        let mut url = self.url.clone();
-        url.set_query(None);
-        url.set_fragment(None);
-        url.as_str().ends_with(DELIMITER)
+        self.url.path().ends_with(DELIMITER)
     }
 
     /// Strips the prefix of this [`ListingTableUrl`] from the provided path, returning

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -472,9 +472,25 @@ mod tests {
         }
 
         test("https://a.b.c/path/", true, "path ends with / - collection");
-        test("https://a.b.c/path/?a=b", true, "path ends with / - with query args - collection");
-        test("https://a.b.c/path?a=b/", false, "path not ends with / - query ends with / - not collection");
-        test("https://a.b.c/path/#a=b", true, "path ends with / - with fragment - collection" );
-        test("https://a.b.c/path#a=b/", false, "path not ends with / - fragment ends with / - not collection");
+        test(
+            "https://a.b.c/path/?a=b",
+            true,
+            "path ends with / - with query args - collection",
+        );
+        test(
+            "https://a.b.c/path?a=b/",
+            false,
+            "path not ends with / - query ends with / - not collection",
+        );
+        test(
+            "https://a.b.c/path/#a=b",
+            true,
+            "path ends with / - with fragment - collection",
+        );
+        test(
+            "https://a.b.c/path#a=b/",
+            false,
+            "path not ends with / - fragment ends with / - not collection",
+        );
     }
 }

--- a/datafusion/core/src/datasource/listing/url.rs
+++ b/datafusion/core/src/datasource/listing/url.rs
@@ -187,7 +187,10 @@ impl ListingTableUrl {
 
     /// Returns `true` if `path` refers to a collection of objects
     pub fn is_collection(&self) -> bool {
-        self.url.as_str().ends_with(DELIMITER)
+        let mut url = self.url.clone();
+        url.set_query(None);
+        url.set_fragment(None);
+        url.as_str().ends_with(DELIMITER)
     }
 
     /// Strips the prefix of this [`ListingTableUrl`] from the provided path, returning
@@ -462,5 +465,19 @@ mod tests {
             "/a/b/c//alltypes_plain*.parquet",
             Some(("/a/b/c//", "alltypes_plain*.parquet")),
         );
+    }
+
+    #[test]
+    fn test_is_collection() {
+        fn test(input: &str, expected: bool, message: &str) {
+            let url = ListingTableUrl::parse(input).unwrap();
+            assert_eq!(url.is_collection(), expected, "{message}");
+        }
+
+        test("https://a.b.c/path/", true, "path ends with / - collection");
+        test("https://a.b.c/path/?a=b", true, "path ends with / - with query args - collection");
+        test("https://a.b.c/path?a=b/", false, "path not ends with / - query ends with / - not collection");
+        test("https://a.b.c/path/#a=b", true, "path ends with / - with fragment - collection" );
+        test("https://a.b.c/path#a=b/", false, "path not ends with / - fragment ends with / - not collection");
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Query string and fragment should not be considered when deciding if the path is a collection
Will open one if needed, but the PR itself is descriptive enough.

## Rationale for this change

See tests in the PR. It can be common if a remote object store takes query string or fragment for other perspective, e.g. tracking.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No