### PR TITLE
Remove `AggregateFunctionDefinition::Name`

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -276,9 +276,6 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
                     .collect::<Result<Vec<_>>>()?;
                 Ok(format!("{}({})", fun.name(), names.join(",")))
             }
-            AggregateFunctionDefinition::Name(_) => {
-                internal_err!("Aggregate function `Expr` with name should be resolved.")
-            }
         },
         Expr::GroupingSet(grouping_set) => match grouping_set {
             GroupingSet::Rollup(exprs) => Ok(format!(
@@ -1946,11 +1943,6 @@ pub fn create_aggregate_expr_with_name_and_maybe_filter(
                         ignore_nulls,
                     )?;
                     (agg_expr, filter, physical_sort_exprs)
-                }
-                AggregateFunctionDefinition::Name(_) => {
-                    return internal_err!(
-                        "Aggregate function name should have been resolved"
-                    )
                 }
             };
             Ok((agg_expr, filter, order_by))

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -515,9 +515,6 @@ pub enum AggregateFunctionDefinition {
     BuiltIn(aggregate_function::AggregateFunction),
     /// Resolved to a user defined aggregate function
     UDF(Arc<crate::AggregateUDF>),
-    /// A aggregation function constructed with name. This variant can not be executed directly
-    /// and instead must be resolved to one of the other variants prior to physical planning.
-    Name(Arc<str>),
 }
 
 impl AggregateFunctionDefinition {
@@ -526,7 +523,6 @@ impl AggregateFunctionDefinition {
         match self {
             AggregateFunctionDefinition::BuiltIn(fun) => fun.name(),
             AggregateFunctionDefinition::UDF(udf) => udf.name(),
-            AggregateFunctionDefinition::Name(func_name) => func_name.as_ref(),
         }
     }
 }
@@ -1829,8 +1825,7 @@ pub(crate) fn create_name(e: &Expr) -> Result<String> {
             null_treatment,
         }) => {
             let name = match func_def {
-                AggregateFunctionDefinition::BuiltIn(..)
-                | AggregateFunctionDefinition::Name(..) => {
+                AggregateFunctionDefinition::BuiltIn(..) => {
                     create_function_name(func_def.name(), *distinct, args)?
                 }
                 AggregateFunctionDefinition::UDF(..) => {
@@ -1850,8 +1845,7 @@ pub(crate) fn create_name(e: &Expr) -> Result<String> {
                 info += &format!(" {}", nt);
             }
             match func_def {
-                AggregateFunctionDefinition::BuiltIn(..)
-                | AggregateFunctionDefinition::Name(..) => {
+                AggregateFunctionDefinition::BuiltIn(..) => {
                     Ok(format!("{}{}", name, info))
                 }
                 AggregateFunctionDefinition::UDF(fun) => {

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -173,9 +173,6 @@ impl ExprSchemable for Expr {
                     AggregateFunctionDefinition::UDF(fun) => {
                         Ok(fun.return_type(&data_types)?)
                     }
-                    AggregateFunctionDefinition::Name(_) => {
-                        internal_err!("Function `Expr` with name should be resolved.")
-                    }
                 }
             }
             Expr::Not(_)

--- a/datafusion/expr/src/tree_node.rs
+++ b/datafusion/expr/src/tree_node.rs
@@ -27,7 +27,7 @@ use crate::{Expr, GetFieldAccess};
 use datafusion_common::tree_node::{
     Transformed, TreeNode, TreeNodeIterator, TreeNodeRecursion,
 };
-use datafusion_common::{internal_err, map_until_stop_and_collect, Result};
+use datafusion_common::{map_until_stop_and_collect, Result};
 
 impl TreeNode for Expr {
     fn apply_children<F: FnMut(&Self) -> Result<TreeNodeRecursion>>(
@@ -347,9 +347,6 @@ impl TreeNode for Expr {
                             new_order_by,
                             null_treatment,
                         )))
-                    }
-                    AggregateFunctionDefinition::Name(_) => {
-                        internal_err!("Function `Expr` with name should be resolved.")
                     }
                 },
             )?,

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -353,9 +353,6 @@ impl<'a> TreeNodeRewriter for TypeCoercionRewriter<'a> {
                         ),
                     )))
                 }
-                AggregateFunctionDefinition::Name(_) => {
-                    internal_err!("Function `Expr` with name should be resolved.")
-                }
             },
             Expr::WindowFunction(WindowFunction {
                 fun,

--- a/datafusion/optimizer/src/decorrelate.rs
+++ b/datafusion/optimizer/src/decorrelate.rs
@@ -398,9 +398,6 @@ fn agg_exprs_evaluation_result_on_empty_batch(
                         AggregateFunctionDefinition::UDF { .. } => {
                             Transformed::yes(Expr::Literal(ScalarValue::Null))
                         }
-                        AggregateFunctionDefinition::Name(_) => {
-                            Transformed::yes(Expr::Literal(ScalarValue::Null))
-                        }
                     },
                     _ => Transformed::no(expr),
                 };

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -750,12 +750,6 @@ pub fn serialize_expr(
                     },
                 ))),
             },
-            AggregateFunctionDefinition::Name(_) => {
-                return Err(Error::NotImplemented(
-                    "Proto serialization error: Trying to serialize a unresolved function"
-                        .to_string(),
-                ));
-            }
         },
 
         Expr::ScalarVariable(_, _) => {

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -733,9 +733,6 @@ pub fn to_substrait_agg_measure(
                         }
                     })
                 }
-                AggregateFunctionDefinition::Name(name) => {
-                    internal_err!("AggregateFunctionDefinition::Name({:?}) should be resolved during `AnalyzerRule`", name)
-                }
             }
 
         }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Remove `AggregateFunctionDefinition::Name` as it's useless.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
