### PR TITLE
Minor: Add usecase to comments in `LogicalPlan::recompute_schema`

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -479,6 +479,11 @@ impl LogicalPlan {
     /// expressions. For example [`LogicalPlan::Filter`] schema is always the
     /// same as its input schema.
     ///
+    /// This is useful after modifying a plans `Expr`s (or input plans) via
+    /// methods such as [Self::map_children] and [Self::map_expressions]. Unlike
+    /// [Self::with_new_exprs], this method does not require a new set of
+    /// expressions or inputs plans.
+    ///
     /// # Return value
     /// Returns an error if there is some issue recomputing the schema.
     ///


### PR DESCRIPTION
## Which issue does this PR close?



## Rationale for this change

As part of the review https://github.com/apache/datafusion/pull/10410 @yyy1000 had a good question https://github.com/apache/datafusion/pull/10410#discussion_r1594990402

Adding some additional explanation I think will help make this clearer

## What changes are included in this PR?
Add doc comments

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
by CI doc checks
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
More docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
