### PR TITLE
DRAFT: example fix to make `stride` optional in `array_slice` UDF

### DIFF
--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -52,13 +52,48 @@ make_udf_function!(
     array_element_udf
 );
 
-make_udf_function!(
-    ArraySlice,
-    array_slice,
-    array begin end stride,
-    "returns a slice of the array.",
-    array_slice_udf
-);
+// make_udf_function!(
+//     ArraySlice,
+//     array_slice,
+//     array begin end stride,
+//     "returns a slice of the array.",
+//     array_slice_udf
+// );
+
+
+#[doc = "returns a slice of the array."]
+pub fn array_slice(array: Expr, begin: Expr, end: Expr, stride: Option<Expr>) -> Expr {
+    if let Some(stride) = stride {
+        Expr::ScalarFunction(ScalarFunction::new_udf(
+            array_slice_udf(),
+            vec![array, begin, end, stride],
+        ))
+    } else {
+        Expr::ScalarFunction(ScalarFunction::new_udf(
+            array_slice_udf(),
+            vec![array, begin, end],
+        ))
+    }
+}
+
+#[doc = r" Singleton instance of [`$UDF`], ensures the UDF is only created once"]
+#[doc = r" named STATIC_$(UDF). For example `STATIC_ArrayToString`"]
+#[allow(non_upper_case_globals)]
+static STATIC_ArraySlice: std::sync::OnceLock<
+    std::sync::Arc<datafusion_expr::ScalarUDF>,
+> = std::sync::OnceLock::new();
+#[doc = r" ScalarFunction that returns a [`ScalarUDF`] for [`$UDF`]"]
+#[doc = r""]
+#[doc = r" [`ScalarUDF`]: datafusion_expr::ScalarUDF"]
+pub fn array_slice_udf() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
+    STATIC_ArraySlice
+        .get_or_init(|| {
+            std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
+                <ArraySlice>::new(),
+            ))
+        })
+        .clone()
+}
 
 make_udf_function!(
     ArrayPopFront,

--- a/datafusion/functions-array/src/rewrite.rs
+++ b/datafusion/functions-array/src/rewrite.rs
@@ -171,7 +171,7 @@ impl FunctionRewrite for ArrayFunctionRewriter {
                         stop,
                         stride,
                     },
-            }) => Transformed::yes(array_slice(*expr, *start, *stop, *stride)),
+            }) => Transformed::yes(array_slice(*expr, *start, *stop, Some(*stride))),
 
             _ => Transformed::no(expr),
         };

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -581,7 +581,7 @@ async fn roundtrip_expr_api() -> Result<()> {
             make_array(vec![lit(1), lit(2), lit(3)]),
             lit(1),
             lit(2),
-            lit(1),
+            Some(lit(1)),
         ),
         array_pop_front(make_array(vec![lit(1), lit(2), lit(3)])),
         array_pop_back(make_array(vec![lit(1), lit(2), lit(3)])),


### PR DESCRIPTION
All i did was expand the `make_udf_function` macro and add the `if let Some(stride) = stride` conditional.

To me, making the argument `Option<_>` is the natural way to make it optional in rust.

I don't know if this solution violates other datafusion constraints, but `cargo test` all passed.

Ref: https://github.com/apache/datafusion/issues/10424
