### PR TITLE
fix: make `columnize_expr` resistant to display_name collisions

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -2045,6 +2045,62 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_aggregate_subexpr() -> Result<()> {
+        let df = test_table().await?;
+
+        let group_expr = col("c2") + lit(1);
+        let aggr_expr = sum(col("c3") + lit(2));
+
+        let df = df
+            // GROUP BY `c2 + 1`
+            .aggregate(vec![group_expr.clone()], vec![aggr_expr.clone()])?
+            // SELECT `c2 + 1` as c2 + 10, sum(c3 + 2) + 20
+            // SELECT expressions contain aggr_expr and group_expr as subexpressions
+            .select(vec![
+                group_expr.alias("c2") + lit(10),
+                (aggr_expr + lit(20)).alias("sum"),
+            ])?;
+
+        let df_results = df.collect().await?;
+
+        #[rustfmt::skip]
+        assert_batches_sorted_eq!([
+                "+----------------+------+",
+                "| c2 + Int32(10) | sum  |",
+                "+----------------+------+",
+                "| 12             | 431  |",
+                "| 13             | 248  |",
+                "| 14             | 453  |",
+                "| 15             | 95   |",
+                "| 16             | -146 |",
+                "+----------------+------+",
+            ],
+            &df_results
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_aggregate_name_collision() -> Result<()> {
+        let df = test_table().await?;
+
+        let group_expr = lit(1).alias("aggregate_test_100.c2 + aggregate_test_100.c3");
+
+        let df = df
+            // GROUP BY 1
+            .aggregate(vec![group_expr], vec![])?
+            // SELECT aggregate_test_100.c2 + aggregate_test_100.c3
+            .select(vec![(col("c2") + col("c3"))])
+            .expect_err("Expected error");
+        let expected = "Schema error: No field named aggregate_test_100.c2. \
+            Valid fields are \"aggregate_test_100.c2 + aggregate_test_100.c3\".";
+        assert_eq!(df.strip_backtrace(), expected);
+
+        Ok(())
+    }
+
     // Test issue: https://github.com/apache/datafusion/issues/10346
     #[tokio::test]
     async fn test_select_over_aggregate_schema() -> Result<()> {

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -210,6 +210,7 @@ async fn test_count_wildcard_on_aggregate() -> Result<()> {
     let sql_results = ctx
         .sql("select count(*) from t1")
         .await?
+        .select(vec![col("COUNT(*)")])?
         .explain(false, false)?
         .collect()
         .await?;

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -210,7 +210,6 @@ async fn test_count_wildcard_on_aggregate() -> Result<()> {
     let sql_results = ctx
         .sql("select count(*) from t1")
         .await?
-        .select(vec![count(wildcard())])?
         .explain(false, false)?
         .collect()
         .await?;

--- a/datafusion/core/tests/user_defined/user_defined_table_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_table_functions.rs
@@ -156,8 +156,8 @@ impl SimpleCsvTable {
         let logical_plan = Projection::try_new(
             vec![columnize_expr(
                 normalize_col(self.exprs[0].clone(), &plan)?,
-                plan.schema(),
-            )],
+                &plan,
+            )?],
             Arc::new(plan),
         )
         .map(LogicalPlan::Projection)?;

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -837,15 +837,16 @@ impl GroupingSet {
     /// Return all distinct exprs in the grouping set. For `CUBE` and `ROLLUP` this
     /// is just the underlying list of exprs. For `GROUPING SET` we need to deduplicate
     /// the exprs in the underlying sets.
-    pub fn distinct_expr(&self) -> Vec<Expr> {
+    pub fn distinct_expr(&self) -> Vec<&Expr> {
         match self {
-            GroupingSet::Rollup(exprs) => exprs.clone(),
-            GroupingSet::Cube(exprs) => exprs.clone(),
+            GroupingSet::Rollup(exprs) | GroupingSet::Cube(exprs) => {
+                exprs.iter().collect()
+            }
             GroupingSet::GroupingSets(groups) => {
-                let mut exprs: Vec<Expr> = vec![];
+                let mut exprs: Vec<&Expr> = vec![];
                 for exp in groups.iter().flatten() {
-                    if !exprs.contains(exp) {
-                        exprs.push(exp.clone());
+                    if !exprs.contains(&exp) {
+                        exprs.push(exp);
                     }
                 }
                 exprs

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1409,8 +1409,7 @@ pub fn project(
                 input_schema,
                 None,
             )?),
-            _ => projected_expr
-                .push(columnize_expr(normalize_col(e, &plan)?, input_schema)),
+            _ => projected_expr.push(columnize_expr(normalize_col(e, &plan)?, &plan)?),
         }
     }
 

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1208,9 +1208,6 @@ impl LogicalPlan {
     /// Get the output expressions and their corresponding columns.
     pub(crate) fn columnized_output_exprs(&self) -> Result<Vec<(Expr, Column)>> {
         match self {
-            LogicalPlan::Projection(Projection { expr, schema, .. }) => {
-                Ok(expr.clone().into_iter().zip(schema.columns()).collect())
-            }
             LogicalPlan::Aggregate(aggregate) => Ok(aggregate
                 .output_expressions()?
                 .into_iter()

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2569,7 +2569,7 @@ impl Aggregate {
     }
 
     /// Get the output expressions.
-    fn output_expressions(&self) -> Result<Vec<Expr>> {
+    fn output_expressions(&self) -> Result<Vec<&Expr>> {
         let mut exprs = grouping_set_to_exprlist(self.group_expr.as_slice())?;
         exprs.extend(self.aggr_expr.clone());
         debug_assert!(exprs.len() == self.schema.fields().len());

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -248,7 +248,7 @@ pub fn enumerate_grouping_sets(group_expr: Vec<Expr>) -> Result<Vec<Expr>> {
 
 /// Find all distinct exprs in a list of group by expressions. If the
 /// first element is a `GroupingSet` expression then it must be the only expr.
-pub fn grouping_set_to_exprlist(group_expr: &[Expr]) -> Result<Vec<Expr>> {
+pub fn grouping_set_to_exprlist(group_expr: &[Expr]) -> Result<Vec<&Expr>> {
     if let Some(Expr::GroupingSet(grouping_set)) = group_expr.first() {
         if group_expr.len() > 1 {
             return plan_err!(
@@ -257,7 +257,7 @@ pub fn grouping_set_to_exprlist(group_expr: &[Expr]) -> Result<Vec<Expr>> {
         }
         Ok(grouping_set.distinct_expr())
     } else {
-        Ok(group_expr.to_vec())
+        Ok(group_expr.iter().collect())
     }
 }
 
@@ -726,13 +726,16 @@ pub fn from_plan(
 }
 
 /// Create field meta-data from an expression, for use in a result set schema
-pub fn exprlist_to_fields(
-    exprs: &[Expr],
+pub fn exprlist_to_fields<'a>(
+    exprs: impl IntoIterator<Item = &'a Expr>,
     plan: &LogicalPlan,
 ) -> Result<Vec<(Option<TableReference>, Arc<Field>)>> {
     // look for exact match in plan's output schema
     let input_schema = &plan.schema();
-    exprs.iter().map(|e| e.to_field(input_schema)).collect()
+    exprs
+        .into_iter()
+        .map(|e| e.to_field(input_schema))
+        .collect()
 }
 
 /// Convert an expression into Column expression if it's already provided as input plan.
@@ -755,7 +758,7 @@ pub fn columnize_expr(e: Expr, input: &LogicalPlan) -> Result<Expr> {
         Ok(exprs) if !exprs.is_empty() => exprs,
         _ => return Ok(e),
     };
-    let exprs_map: HashMap<Expr, Column> = output_exprs.into_iter().collect();
+    let exprs_map: HashMap<&Expr, Column> = output_exprs.into_iter().collect();
     e.transform_down(|node: Expr| match exprs_map.get(&node) {
         Some(column) => Ok(Transformed::new(
             Expr::Column(column.clone()),

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -751,10 +751,8 @@ pub fn exprlist_to_fields(
 /// .project(vec![col("c1"), col("SUM(c2)")?
 /// ```
 pub fn columnize_expr(e: Expr, input: &LogicalPlan) -> Result<Expr> {
-    let output_exprs = match input {
-        LogicalPlan::Aggregate(aggregate) => aggregate.columnized_output_exprs()?,
-        LogicalPlan::Window(window) => window.columnized_output_exprs(),
-        LogicalPlan::Projection(projection) => projection.columnized_output_exprs(),
+    let output_exprs = match input.columnized_output_exprs() {
+        Ok(exprs) if !exprs.is_empty() => exprs,
         _ => return Ok(e),
     };
     let exprs_map: HashMap<Expr, Column> = output_exprs.into_iter().collect();

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -756,7 +756,6 @@ pub fn columnize_expr(e: Expr, input: &LogicalPlan) -> Result<Expr> {
         _ => return Ok(e),
     };
     let exprs_map: HashMap<Expr, Column> = output_exprs.into_iter().collect();
-
     e.transform_down(|node: Expr| match exprs_map.get(&node) {
         Some(column) => Ok(Transformed::new(
             Expr::Column(column.clone()),

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -1154,12 +1154,12 @@ mod test {
         let table_scan = test_table_scan()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
-            .project(vec![lit(1) + col("a")])?
+            .project(vec![lit(1) + col("a"), col("a")])?
             .project(vec![lit(1) + col("a")])?
             .build()?;
 
         let expected = "Projection: Int32(1) + test.a\
-        \n  Projection: Int32(1) + test.a\
+        \n  Projection: Int32(1) + test.a, test.a\
         \n    TableScan: test";
 
         assert_optimized_plan_eq(expected, &plan);

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -22,15 +22,15 @@ use std::sync::Arc;
 use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 
-use datafusion_common::{qualified_name, DFSchema, Result};
+use datafusion_common::{qualified_name, Result};
+use datafusion_expr::builder::project;
 use datafusion_expr::expr::AggregateFunctionDefinition;
 use datafusion_expr::{
     aggregate_function::AggregateFunction::{Max, Min, Sum},
     col,
     expr::AggregateFunction,
-    logical_plan::{Aggregate, LogicalPlan, Projection},
-    utils::columnize_expr,
-    Expr, ExprSchemable,
+    logical_plan::{Aggregate, LogicalPlan},
+    Expr,
 };
 
 use hashbrown::HashSet;
@@ -228,29 +228,10 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                         .collect::<Result<Vec<_>>>()?;
 
                     // construct the inner AggrPlan
-                    let inner_fields = inner_group_exprs
-                        .iter()
-                        .chain(inner_aggr_exprs.iter())
-                        .map(|expr| expr.to_field(input.schema()))
-                        .collect::<Result<Vec<_>>>()?;
-                    let inner_schema = DFSchema::new_with_metadata(
-                        inner_fields,
-                        input.schema().metadata().clone(),
-                    )?;
                     let inner_agg = LogicalPlan::Aggregate(Aggregate::try_new(
                         input.clone(),
                         inner_group_exprs,
                         inner_aggr_exprs,
-                    )?);
-
-                    let outer_fields = outer_group_exprs
-                        .iter()
-                        .chain(outer_aggr_exprs.iter())
-                        .map(|expr| expr.to_field(&inner_schema))
-                        .collect::<Result<Vec<_>>>()?;
-                    let outer_aggr_schema = Arc::new(DFSchema::new_with_metadata(
-                        outer_fields,
-                        input.schema().metadata().clone(),
                     )?);
 
                     // so the aggregates are displayed in the same way even after the rewrite
@@ -258,7 +239,7 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                     // - group_by aggr
                     // - aggr expr
                     let group_size = group_expr.len();
-                    let alias_expr = out_group_expr_with_alias
+                    let alias_expr: Vec<_> = out_group_expr_with_alias
                         .into_iter()
                         .map(|(group_expr, original_field)| {
                             if let Some(name) = original_field {
@@ -271,7 +252,7 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                             let idx = idx + group_size;
                             let (qualifier, field) = schema.qualified_field(idx);
                             let name = qualified_name(qualifier, field.name());
-                            columnize_expr(expr.clone().alias(name), &outer_aggr_schema)
+                            expr.clone().alias(name)
                         }))
                         .collect();
 
@@ -280,11 +261,7 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                         outer_group_exprs,
                         outer_aggr_exprs,
                     )?);
-
-                    Ok(Some(LogicalPlan::Projection(Projection::try_new(
-                        alias_expr,
-                        Arc::new(outer_aggr),
-                    )?)))
+                    Ok(Some(project(outer_aggr, alias_expr)?))
                 } else {
                     Ok(None)
                 }

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -1621,6 +1621,15 @@ select a + b from (select 1 as a, 2 as b, 1 as "a + b");
 ----
 3
 
+# Can't reference an output column by expression over projection.
+query error DataFusion error: Schema error: No field named a\. Valid fields are "a \+ Int64\(1\)"\.
+select a + 1 from (select a+1 from (select 1 as a));
+
+query I
+select "a + Int64(1)" + 10 from (select a+1 from (select 1 as a));
+----
+12
+
 # run below query without logical optimizations
 statement ok
 set datafusion.optimizer.max_passes=0;

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -1619,7 +1619,7 @@ select count(1) from v;
 query I
 select a + b from (select 1 as a, 2 as b, 1 as "a + b");
 ----
-1
+3
 
 # run below query without logical optimizations
 statement ok

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -592,7 +592,6 @@ async fn simple_intersect_table_reuse() -> Result<()> {
         .await
 }
 
-#[ignore]
 #[tokio::test]
 async fn simple_window_function() -> Result<()> {
     roundtrip("SELECT RANK() OVER (PARTITION BY a ORDER BY b), d, SUM(b) OVER (PARTITION BY a) FROM data;").await

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -592,6 +592,7 @@ async fn simple_intersect_table_reuse() -> Result<()> {
         .await
 }
 
+#[ignore]
 #[tokio::test]
 async fn simple_window_function() -> Result<()> {
     roundtrip("SELECT RANK() OVER (PARTITION BY a ORDER BY b), d, SUM(b) OVER (PARTITION BY a) FROM data;").await


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10413.

## Rationale for this change
### Background
[`columnize_expr`](https://github.com/apache/datafusion/blob/8cc92a921f3b0296caf035edb66a4b3c422f084d/datafusion/expr/src/logical_plan/builder.rs#L1413) is used during planning projections.  Usually, a projected expr can only reference the output data of the input plan through a column reference, but this does not work for aggregation and window functions. For example
```rust
let aggr_expr = sum(col("c2"));
let df = test_table()
      .await?
      .aggregate(vec![], vec![aggr_expr.clone()])?
      .select(vec![aggr_expr])?;
```
The aggregate expression `sum(col("c2"))` is calculated in the aggregate logical plan, and the projection plan references its result through the aggregate expression directly. To make it work appropriately, we need to convert the aggregate expression in the projection into a column reference of the aggregate plan, which is done by `columnize_expr`.

### Problem And Fix
Previously, `columnize_expr` [searched](https://github.com/apache/datafusion/blob/721974456742bf44bdae291b3114bc23fe478bcd/datafusion/expr/src/utils.rs#L772) for the corresponding column from the input schema through the display name of projected expr. However, different expressions may have the same display name. It is easy to reproduce by creating the same alias for another differenct expression. Collisions of display name will cause `columnize_expr` to find the wrong column, producing incorrect results as in issue #10413.

The fix is to search from input plan's output expressions directly based on the expression itself, instead of searching by display name.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Refactor columnize_expr so that it can correctly find the column corresponding to the expression.

## Are these changes tested?
Yes. 

## Are there any user-facing changes?
Yes. columnize_expr is a public method, although it may only be used internally in DataFusion.
