### PR TITLE
feat: allow `array_slice` to take an optional stride parameter

### DIFF
--- a/datafusion/functions-array/src/array_has.rs
+++ b/datafusion/functions-array/src/array_has.rs
@@ -34,19 +34,19 @@ use std::any::Any;
 use std::sync::Arc;
 
 // Create static instances of ScalarUDFs for each function
-make_udf_function!(ArrayHas,
+make_udf_expr_and_func!(ArrayHas,
     array_has,
     first_array second_array, // arg name
     "returns true, if the element appears in the first array, otherwise false.", // doc
     array_has_udf // internal function name
 );
-make_udf_function!(ArrayHasAll,
+make_udf_expr_and_func!(ArrayHasAll,
     array_has_all,
     first_array second_array, // arg name
     "returns true if each element of the second array appears in the first array; otherwise, it returns false.", // doc
     array_has_all_udf // internal function name
 );
-make_udf_function!(ArrayHasAny,
+make_udf_expr_and_func!(ArrayHasAny,
     array_has_any,
     first_array second_array, // arg name
     "returns true if at least one element of the second array appears in the first array; otherwise, it returns false.", // doc

--- a/datafusion/functions-array/src/cardinality.rs
+++ b/datafusion/functions-array/src/cardinality.rs
@@ -29,7 +29,7 @@ use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility}
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     Cardinality,
     cardinality,
     array,

--- a/datafusion/functions-array/src/concat.rs
+++ b/datafusion/functions-array/src/concat.rs
@@ -36,7 +36,7 @@ use datafusion_expr::{
 
 use crate::utils::{align_array_dimensions, check_datatypes, make_scalar_function};
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayAppend,
     array_append,
     array element,                                // arg name
@@ -96,7 +96,7 @@ impl ScalarUDFImpl for ArrayAppend {
     }
 }
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayPrepend,
     array_prepend,
     element array,
@@ -156,7 +156,7 @@ impl ScalarUDFImpl for ArrayPrepend {
     }
 }
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayConcat,
     array_concat,
     "Concatenates arrays.",

--- a/datafusion/functions-array/src/dimension.rs
+++ b/datafusion/functions-array/src/dimension.rs
@@ -33,7 +33,7 @@ use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayDims,
     array_dims,
     array,
@@ -88,7 +88,7 @@ impl ScalarUDFImpl for ArrayDims {
     }
 }
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayNdims,
     array_ndims,
     array,

--- a/datafusion/functions-array/src/empty.rs
+++ b/datafusion/functions-array/src/empty.rs
@@ -28,7 +28,7 @@ use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility}
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayEmpty,
     array_empty,
     array,

--- a/datafusion/functions-array/src/except.rs
+++ b/datafusion/functions-array/src/except.rs
@@ -31,7 +31,7 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayExcept,
     array_except,
     first_array second_array,

--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -52,13 +52,7 @@ make_udf_function!(
     array_element_udf
 );
 
-make_udf_function!(
-    ArraySlice,
-    array_slice,
-    array begin end stride,
-    "returns a slice of the array.",
-    array_slice_udf
-);
+make_udf_function!(ArraySlice, array_slice_udf);
 
 make_udf_function!(
     ArrayPopFront,
@@ -222,6 +216,21 @@ where
 
     let data = mutable.freeze();
     Ok(arrow::array::make_array(data))
+}
+
+#[doc = "returns a slice of the array."]
+pub fn array_slice(array: Expr, begin: Expr, end: Expr, stride: Option<Expr>) -> Expr {
+    if let Some(stride) = stride {
+        Expr::ScalarFunction(ScalarFunction::new_udf(
+            array_slice_udf(),
+            vec![array, begin, end, stride],
+        ))
+    } else {
+        Expr::ScalarFunction(ScalarFunction::new_udf(
+            array_slice_udf(),
+            vec![array, begin, end],
+        ))
+    }
 }
 
 #[derive(Debug)]

--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 use crate::utils::make_scalar_function;
 
 // Create static instances of ScalarUDFs for each function
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayElement,
     array_element,
     array element,
@@ -52,9 +52,9 @@ make_udf_function!(
     array_element_udf
 );
 
-make_udf_function!(ArraySlice, array_slice_udf);
+create_func!(ArraySlice, array_slice_udf);
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayPopFront,
     array_pop_front,
     array,
@@ -62,7 +62,7 @@ make_udf_function!(
     array_pop_front_udf
 );
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayPopBack,
     array_pop_back,
     array,

--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -220,17 +220,11 @@ where
 
 #[doc = "returns a slice of the array."]
 pub fn array_slice(array: Expr, begin: Expr, end: Expr, stride: Option<Expr>) -> Expr {
-    if let Some(stride) = stride {
-        Expr::ScalarFunction(ScalarFunction::new_udf(
-            array_slice_udf(),
-            vec![array, begin, end, stride],
-        ))
-    } else {
-        Expr::ScalarFunction(ScalarFunction::new_udf(
-            array_slice_udf(),
-            vec![array, begin, end],
-        ))
-    }
+    let args = match stride {
+        Some(stride) => vec![array, begin, end, stride],
+        None => vec![array, begin, end],
+    };
+    array_slice_udf().call(args)
 }
 
 #[derive(Debug)]

--- a/datafusion/functions-array/src/flatten.rs
+++ b/datafusion/functions-array/src/flatten.rs
@@ -31,7 +31,7 @@ use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility}
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     Flatten,
     flatten,
     array,

--- a/datafusion/functions-array/src/length.rs
+++ b/datafusion/functions-array/src/length.rs
@@ -32,7 +32,7 @@ use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility}
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayLength,
     array_length,
     array,

--- a/datafusion/functions-array/src/macros.rs
+++ b/datafusion/functions-array/src/macros.rs
@@ -76,6 +76,7 @@ macro_rules! make_udf_expr_and_func {
 /// function named `$SCALAR_UDF_FUNC` which returns that function named `STATIC_$(UDF)`.
 ///
 /// This is used to ensure creating the list of `ScalarUDF` only happens once.
+///
 /// # Arguments
 /// * `UDF`: name of the [`ScalarUDFImpl`]
 /// * `SCALAR_UDF_FUNC`: name of the function to create (just) the `ScalarUDF`

--- a/datafusion/functions-array/src/macros.rs
+++ b/datafusion/functions-array/src/macros.rs
@@ -80,6 +80,8 @@ macro_rules! make_udf_expr_and_func {
 /// # Arguments
 /// * `UDF`: name of the [`ScalarUDFImpl`]
 /// * `SCALAR_UDF_FUNC`: name of the function to create (just) the `ScalarUDF`
+///
+/// [`ScalarUDFImpl`]: datafusion_expr::ScalarUDFImpl
 macro_rules! create_func {
     ($UDF:ty, $SCALAR_UDF_FN:ident) => {
         paste::paste! {

--- a/datafusion/functions-array/src/macros.rs
+++ b/datafusion/functions-array/src/macros.rs
@@ -19,8 +19,8 @@
 ///
 /// 1. Single `ScalarUDF` instance
 ///
-/// Creates a singleton `ScalarUDF` of the `$UDF` function named `STATIC_$UDF` and a
-/// function named `$NAME` which returns that function named $NAME.
+/// Creates a singleton `ScalarUDF` of the `$UDF` function named `STATIC_$(UDF)` and a
+/// function named `$SCALAR_UDF_FUNC` which returns that function named `STATIC_$(UDF)`.
 ///
 /// This is used to ensure creating the list of `ScalarUDF` only happens once.
 ///
@@ -43,7 +43,7 @@
 /// * `SCALAR_UDF_FUNC`: name of the function to create (just) the `ScalarUDF`
 ///
 /// [`ScalarUDFImpl`]: datafusion_expr::ScalarUDFImpl
-macro_rules! make_udf_function {
+macro_rules! make_udf_expr_and_func {
     ($UDF:ty, $EXPR_FN:ident, $($arg:ident)*, $DOC:expr , $SCALAR_UDF_FN:ident) => {
         paste::paste! {
             // "fluent expr_fn" style function
@@ -54,25 +54,7 @@ macro_rules! make_udf_function {
                     vec![$($arg),*],
                 ))
             }
-
-            /// Singleton instance of [`$UDF`], ensures the UDF is only created once
-            /// named STATIC_$(UDF). For example `STATIC_ArrayToString`
-            #[allow(non_upper_case_globals)]
-            static [< STATIC_ $UDF >]: std::sync::OnceLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
-                std::sync::OnceLock::new();
-
-            /// ScalarFunction that returns a [`ScalarUDF`] for [`$UDF`]
-            ///
-            /// [`ScalarUDF`]: datafusion_expr::ScalarUDF
-            pub fn $SCALAR_UDF_FN() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
-                [< STATIC_ $UDF >]
-                    .get_or_init(|| {
-                        std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
-                            <$UDF>::new(),
-                        ))
-                    })
-                    .clone()
-            }
+            create_func!($UDF, $SCALAR_UDF_FN);
         }
     };
     ($UDF:ty, $EXPR_FN:ident, $DOC:expr , $SCALAR_UDF_FN:ident) => {
@@ -85,27 +67,19 @@ macro_rules! make_udf_function {
                     arg,
                 ))
             }
-
-            /// Singleton instance of [`$UDF`], ensures the UDF is only created once
-            /// named STATIC_$(UDF). For example `STATIC_ArrayToString`
-            #[allow(non_upper_case_globals)]
-            static [< STATIC_ $UDF >]: std::sync::OnceLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
-                std::sync::OnceLock::new();
-            /// ScalarFunction that returns a [`ScalarUDF`] for [`$UDF`]
-            ///
-            /// [`ScalarUDF`]: datafusion_expr::ScalarUDF
-            pub fn $SCALAR_UDF_FN() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
-                [< STATIC_ $UDF >]
-                    .get_or_init(|| {
-                        std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
-                            <$UDF>::new(),
-                        ))
-                    })
-                    .clone()
-            }
+            create_func!($UDF, $SCALAR_UDF_FN);
         }
     };
-    // This pattern does not generate the "fluent expr_fn" style function, it should be provided externally.
+}
+
+/// Creates a singleton `ScalarUDF` of the `$UDF` function named `STATIC_$(UDF)` and a
+/// function named `$SCALAR_UDF_FUNC` which returns that function named `STATIC_$(UDF)`.
+///
+/// This is used to ensure creating the list of `ScalarUDF` only happens once.
+/// # Arguments
+/// * `UDF`: name of the [`ScalarUDFImpl`]
+/// * `SCALAR_UDF_FUNC`: name of the function to create (just) the `ScalarUDF`
+macro_rules! create_func {
     ($UDF:ty, $SCALAR_UDF_FN:ident) => {
         paste::paste! {
             /// Singleton instance of [`$UDF`], ensures the UDF is only created once

--- a/datafusion/functions-array/src/make_array.rs
+++ b/datafusion/functions-array/src/make_array.rs
@@ -35,7 +35,7 @@ use datafusion_expr::{Expr, TypeSignature};
 
 use crate::utils::make_scalar_function;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     MakeArray,
     make_array,
     "Returns an Arrow array using the specified input expressions.",

--- a/datafusion/functions-array/src/position.rs
+++ b/datafusion/functions-array/src/position.rs
@@ -37,7 +37,7 @@ use itertools::Itertools;
 
 use crate::utils::{compare_element_to_list, make_scalar_function};
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayPosition,
     array_position,
     array element index,
@@ -168,7 +168,7 @@ fn generic_position<OffsetSize: OffsetSizeTrait>(
     Ok(Arc::new(UInt64Array::from(data)))
 }
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayPositions,
     array_positions,
     array element, // arg name

--- a/datafusion/functions-array/src/range.rs
+++ b/datafusion/functions-array/src/range.rs
@@ -35,7 +35,7 @@ use datafusion_expr::{
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     Range,
     range,
     start stop step,
@@ -106,7 +106,7 @@ impl ScalarUDFImpl for Range {
     }
 }
 
-make_udf_function!(
+make_udf_expr_and_func!(
     GenSeries,
     gen_series,
     start stop step,

--- a/datafusion/functions-array/src/remove.rs
+++ b/datafusion/functions-array/src/remove.rs
@@ -32,7 +32,7 @@ use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility}
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayRemove,
     array_remove,
     array element,
@@ -81,7 +81,7 @@ impl ScalarUDFImpl for ArrayRemove {
     }
 }
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayRemoveN,
     array_remove_n,
     array element max,
@@ -130,7 +130,7 @@ impl ScalarUDFImpl for ArrayRemoveN {
     }
 }
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayRemoveAll,
     array_remove_all,
     array element,

--- a/datafusion/functions-array/src/repeat.rs
+++ b/datafusion/functions-array/src/repeat.rs
@@ -34,7 +34,7 @@ use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility}
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayRepeat,
     array_repeat,
     element count, // arg name

--- a/datafusion/functions-array/src/replace.rs
+++ b/datafusion/functions-array/src/replace.rs
@@ -38,19 +38,19 @@ use std::any::Any;
 use std::sync::Arc;
 
 // Create static instances of ScalarUDFs for each function
-make_udf_function!(ArrayReplace,
+make_udf_expr_and_func!(ArrayReplace,
     array_replace,
     array from to,
     "replaces the first occurrence of the specified element with another specified element.",
     array_replace_udf
 );
-make_udf_function!(ArrayReplaceN,
+make_udf_expr_and_func!(ArrayReplaceN,
     array_replace_n,
     array from to max,
     "replaces the first `max` occurrences of the specified element with another specified element.",
     array_replace_n_udf
 );
-make_udf_function!(ArrayReplaceAll,
+make_udf_expr_and_func!(ArrayReplaceAll,
     array_replace_all,
     array from to,
     "replaces all occurrences of the specified element with another specified element.",

--- a/datafusion/functions-array/src/resize.rs
+++ b/datafusion/functions-array/src/resize.rs
@@ -30,7 +30,7 @@ use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility}
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayResize,
     array_resize,
     array size value,

--- a/datafusion/functions-array/src/reverse.rs
+++ b/datafusion/functions-array/src/reverse.rs
@@ -30,7 +30,7 @@ use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility}
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayReverse,
     array_reverse,
     array,

--- a/datafusion/functions-array/src/rewrite.rs
+++ b/datafusion/functions-array/src/rewrite.rs
@@ -171,7 +171,7 @@ impl FunctionRewrite for ArrayFunctionRewriter {
                         stop,
                         stride,
                     },
-            }) => Transformed::yes(array_slice(*expr, *start, *stop, *stride)),
+            }) => Transformed::yes(array_slice(*expr, *start, *stop, Some(*stride))),
 
             _ => Transformed::no(expr),
         };

--- a/datafusion/functions-array/src/set_ops.rs
+++ b/datafusion/functions-array/src/set_ops.rs
@@ -37,7 +37,7 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 // Create static instances of ScalarUDFs for each function
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayUnion,
     array_union,
     array1 array2,
@@ -45,7 +45,7 @@ make_udf_function!(
     array_union_udf
 );
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayIntersect,
     array_intersect,
     first_array second_array,
@@ -53,7 +53,7 @@ make_udf_function!(
     array_intersect_udf
 );
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayDistinct,
     array_distinct,
     array,

--- a/datafusion/functions-array/src/sort.rs
+++ b/datafusion/functions-array/src/sort.rs
@@ -30,7 +30,7 @@ use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility}
 use std::any::Any;
 use std::sync::Arc;
 
-make_udf_function!(
+make_udf_expr_and_func!(
     ArraySort,
     array_sort,
     array desc null_first,

--- a/datafusion/functions-array/src/string.rs
+++ b/datafusion/functions-array/src/string.rs
@@ -102,7 +102,7 @@ macro_rules! call_array_function {
 }
 
 // Create static instances of ScalarUDFs for each function
-make_udf_function!(
+make_udf_expr_and_func!(
     ArrayToString,
     array_to_string,
     array delimiter, // arg name
@@ -160,7 +160,7 @@ impl ScalarUDFImpl for ArrayToString {
     }
 }
 
-make_udf_function!(
+make_udf_expr_and_func!(
     StringToArray,
     string_to_array,
     string delimiter null_string, // arg name

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -583,6 +583,12 @@ async fn roundtrip_expr_api() -> Result<()> {
             lit(2),
             Some(lit(1)),
         ),
+        array_slice(
+            make_array(vec![lit(1), lit(2), lit(3)]),
+            lit(1),
+            lit(2),
+            None,
+        ),
         array_pop_front(make_array(vec![lit(1), lit(2), lit(3)])),
         array_pop_back(make_array(vec![lit(1), lit(2), lit(3)])),
         array_reverse(make_array(vec![lit(1), lit(2), lit(3)])),

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -581,7 +581,7 @@ async fn roundtrip_expr_api() -> Result<()> {
             make_array(vec![lit(1), lit(2), lit(3)]),
             lit(1),
             lit(2),
-            lit(1),
+            Some(lit(1)),
         ),
         array_pop_front(make_array(vec![lit(1), lit(2), lit(3)])),
         array_pop_back(make_array(vec![lit(1), lit(2), lit(3)])),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10424.

## Rationale for this change
Based on the draft PR #10450, and reuse the existing `make_udf_function` macro as much as possible.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Allow array_slice to take an optional stride parameter

## Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Not sure whether it's necessary to write a test for this.

## Are there any user-facing changes?
Yes
