### PR TITLE
refactor: reduce string allocations with Cow

### DIFF
--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -22,6 +22,7 @@ use arrow_schema::{Field, FieldRef};
 use crate::error::_schema_err;
 use crate::utils::{parse_identifiers_normalized, quote_identifier};
 use crate::{DFSchema, DataFusionError, Result, SchemaError, TableReference};
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::convert::Infallible;
 use std::fmt;
@@ -132,6 +133,13 @@ impl Column {
         match &self.relation {
             Some(r) => format!("{}.{}", r, self.name),
             None => self.name.clone(),
+        }
+    }
+
+    pub fn flat_name_cow(&self) -> Cow<str> {
+        match &self.relation {
+            Some(r) => Cow::Owned(format!("{}.{}", r, self.name)),
+            None => Cow::Borrowed(self.name.as_str()),
         }
     }
 

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -47,7 +47,8 @@ pub mod utils;
 pub use arrow;
 pub use column::Column;
 pub use dfschema::{
-    qualified_name, DFSchema, DFSchemaRef, ExprSchema, SchemaExt, ToDFSchema,
+    qualified_name, qualified_name_cow, DFSchema, DFSchemaRef, ExprSchema, SchemaExt,
+    ToDFSchema,
 };
 pub use error::{
     field_not_found, unqualified_field_not_found, DataFusionError, Result, SchemaError,

--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -274,7 +274,7 @@ pub fn rewrite_preserving_name<R>(expr: Expr, rewriter: &mut R) -> Result<Expr>
 where
     R: TreeNodeRewriter<Node = Expr>,
 {
-    let original_name = expr.name_for_alias()?;
+    let original_name = expr.name_for_alias()?.into_owned();
     let expr = expr.rewrite(rewriter)?.data;
     expr.alias_if_changed(original_name)
 }

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -767,9 +767,9 @@ pub fn columnize_expr(e: Expr, input_schema: &DFSchema) -> Expr {
             data_type,
         )),
         Expr::ScalarSubquery(_) => e.clone(),
-        _ => match e.display_name() {
+        _ => match e.display_name_cow() {
             Ok(name) => {
-                match input_schema.qualified_field_with_unqualified_name(&name) {
+                match input_schema.qualified_field_with_unqualified_name(name.as_ref()) {
                     Ok((qualifier, field)) => {
                         Expr::Column(Column::from((qualifier, field)))
                     }

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -254,7 +254,7 @@ impl CommonSubexprEliminate {
                 .zip(orig_window_expr.iter())
                 .map(|(new_window_expr, window_expr)| {
                     let original_name = window_expr.name_for_alias()?;
-                    new_window_expr.alias_if_changed(original_name)
+                    new_window_expr.alias_if_changed(original_name.as_ref())
                 })
                 .collect::<Result<Vec<_>>>()?;
             plan = LogicalPlan::Window(Window::try_new(new_window_expr, Arc::new(plan))?);
@@ -322,7 +322,9 @@ impl CommonSubexprEliminate {
                 .iter()
                 .zip(aggr_expr.iter())
                 .map(|(new_expr, old_expr)| {
-                    new_expr.clone().alias_if_changed(old_expr.display_name()?)
+                    new_expr
+                        .clone()
+                        .alias_if_changed(old_expr.display_name_cow()?.as_ref())
                 })
                 .collect::<Result<Vec<Expr>>>()?;
             // Since group_epxr changes, schema changes also. Use try_new method.
@@ -837,7 +839,7 @@ fn replace_common_expr(
 mod test {
     use std::iter;
 
-    use arrow::datatypes::Schema;
+    use arrow::datatypes::{Field, Schema};
 
     use datafusion_expr::logical_plan::{table_scan, JoinType};
     use datafusion_expr::{avg, lit, logical_plan::builder::LogicalPlanBuilder, sum};

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -178,9 +178,9 @@ impl OptimizerRule for ScalarSubqueryToJoin {
 
                 let mut proj_exprs = vec![];
                 for expr in projection.expr.iter() {
-                    let old_expr_name = expr.display_name()?;
+                    let old_expr_name = expr.display_name_cow()?;
                     let new_expr = expr_to_rewrite_expr_map.get(expr).unwrap();
-                    let new_expr_name = new_expr.display_name()?;
+                    let new_expr_name = new_expr.display_name_cow()?;
                     if new_expr_name != old_expr_name {
                         proj_exprs.push(new_expr.clone().alias(old_expr_name))
                     } else {

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -133,7 +133,7 @@ impl SimplifyExpressions {
         plan.map_expressions(|e| {
             let new_e = if use_alias {
                 // TODO: unify with `rewrite_preserving_name`
-                let original_name = e.name_for_alias()?;
+                let original_name = e.name_for_alias()?.into_owned();
                 simplifier.simplify(e)?.alias_if_changed(original_name)
             } else {
                 simplifier.simplify(e)

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -304,7 +304,7 @@ impl NamePreserver {
 
     pub fn save(&self, expr: &Expr) -> Result<SavedName> {
         let original_name = if self.use_alias {
-            Some(expr.name_for_alias()?)
+            Some(expr.name_for_alias()?.into_owned())
         } else {
             None
         };


### PR DESCRIPTION
This is an experiment to see if reducing string allocations with `Cow` has any performance improvement.

My local benchmarks show mixed results. My guess is that there is a small additional overhead due to branching when destructuring the `Cow` enum. 

It might be worthwhile to further split these changes into individual branches to target benchmarks on specific changes instead of testing all of them at once.