### PR TITLE
fix: parsing timestamp with date format

### DIFF
--- a/datafusion/functions/src/datetime/common.rs
+++ b/datafusion/functions/src/datetime/common.rs
@@ -93,7 +93,9 @@ pub(crate) fn string_to_datetime_formatted<T: TimeZone>(
 
     if let Err(e) = &dt {
         // no timezone or other failure, try without a timezone
-        let ndt = parsed.to_naive_datetime_with_offset(0);
+        let ndt = parsed
+            .to_naive_datetime_with_offset(0)
+            .or_else(|_| parsed.to_naive_date().map(|nd| nd.into()));
         if let Err(e) = &ndt {
             return Err(err(&e.to_string()));
         }

--- a/datafusion/functions/src/datetime/to_timestamp.rs
+++ b/datafusion/functions/src/datetime/to_timestamp.rs
@@ -670,6 +670,10 @@ mod tests {
             parse_timestamp_formatted("09-08-2020 13/42/29", "%m-%d-%Y %H/%M/%S")
                 .unwrap()
         );
+        assert_eq!(
+            1642896000000000000,
+            parse_timestamp_formatted("2022-01-23", "%Y-%m-%d").unwrap()
+        );
     }
 
     fn parse_timestamp_formatted(s: &str, format: &str) -> Result<i64, DataFusionError> {

--- a/datafusion/sqllogictest/test_files/dates.slt
+++ b/datafusion/sqllogictest/test_files/dates.slt
@@ -224,5 +224,11 @@ SELECT to_date(t.ts, '%Y-%m-%d %H/%M/%S%#z', '%s', '%q', '%d-%m-%Y %H:%M:%S%#z',
 query error function unsupported data type at index 1:
 SELECT to_date(t.ts, make_array('%Y-%m-%d %H/%M/%S%#z', '%s', '%q', '%d-%m-%Y %H:%M:%S%#z', '%+')) from ts_utf8_data as t
 
+# verify to_date with format
+query D
+select to_date('2022-01-23', '%Y-%m-%d');
+----
+2022-01-23
+
 statement ok
 drop table ts_utf8_data


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10471.

## Rationale for this change

Fallback to `Parsed::to_naive_date` when `Parsed::to_naive_datetime_with_offset` failed if there is only date in format string.

## What changes are included in this PR?

Same as above.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

1. Add unit test
The timestamp of "2022-01-23" is `1642896000000000000` as written in the test.
<img width="670" alt="Screenshot 2024-05-13 at 1 09 45 PM" src="https://github.com/apache/datafusion/assets/169244206/a1cc9649-6bcd-4ee8-91f7-906726009cdb">

2. Test using datafusion-cli
<img width="375" alt="Screenshot 2024-05-13 at 1 01 13 PM" src="https://github.com/apache/datafusion/assets/169244206/c6f803f6-0e86-4b02-bef6-7779744b86e6">

## Are there any user-facing changes?

No
