### PR TITLE
Minor: add a test for `current_time` (no args)

### DIFF
--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -2795,3 +2795,9 @@ SELECT '2000-12-01 04:04:12' AT TIME ZONE 'America/New York';
 # abbreviated timezone is not supported
 statement error
 SELECT '2023-03-12 02:00:00' AT TIME ZONE 'EDT';
+
+# Test current_time without parentheses
+query B
+select current_time = current_time;
+----
+true


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change

While working with @tisonkun  on https://github.com/apache/datafusion/pull/10392 I realized there was no test coverage for the `current_time` form (with no parens). I added a test and a fix to that branch but I want to make sure we don't accidentally break it before that PR lands

## What changes are included in this PR?
1. Add sqllogictest for `current_time` syntax


## Are these changes tested?
All tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
