### PR TITLE
feat: optional args for regexp_* UDFs

### DIFF
--- a/datafusion/core/tests/dataframe/dataframe_functions.rs
+++ b/datafusion/core/tests/dataframe/dataframe_functions.rs
@@ -639,7 +639,7 @@ async fn test_fn_regexp_match() -> Result<()> {
 #[tokio::test]
 #[cfg(feature = "unicode_expressions")]
 async fn test_fn_regexp_replace() -> Result<()> {
-    let expr = regexp_replace(col("a"), lit("[a-z]"), lit("x"), lit("g"));
+    let expr = regexp_replace(col("a"), lit("[a-z]"), lit("x"), Some(lit("g")));
 
     let expected = [
         "+----------------------------------------------------------+",
@@ -650,6 +650,21 @@ async fn test_fn_regexp_replace() -> Result<()> {
         "| CBAxxx                                                   |",
         "| 123AxxDxx                                                |",
         "+----------------------------------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    let expr = regexp_replace(col("a"), lit("[a-z]"), lit("x"), None);
+
+    let expected = [
+        "+------------------------------------------------+",
+        "| regexp_replace(test.a,Utf8(\"[a-z]\"),Utf8(\"x\")) |",
+        "+------------------------------------------------+",
+        "| xbcDEF                                         |",
+        "| xbc123                                         |",
+        "| CBAxef                                         |",
+        "| 123AxcDef                                      |",
+        "+------------------------------------------------+",
     ];
 
     assert_fn_batches!(expr, expected);

--- a/datafusion/core/tests/dataframe/dataframe_functions.rs
+++ b/datafusion/core/tests/dataframe/dataframe_functions.rs
@@ -618,7 +618,7 @@ async fn test_fn_regexp_like() -> Result<()> {
 #[tokio::test]
 #[cfg(feature = "unicode_expressions")]
 async fn test_fn_regexp_match() -> Result<()> {
-    let expr = regexp_match(col("a"), lit("[a-z]"));
+    let expr = regexp_match(col("a"), lit("[a-z]"), None);
 
     let expected = [
         "+------------------------------------+",
@@ -629,6 +629,21 @@ async fn test_fn_regexp_match() -> Result<()> {
         "| [d]                                |",
         "| [b]                                |",
         "+------------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    let expr = regexp_match(col("a"), lit("[A-Z]"), Some(lit("i")));
+
+    let expected = [
+        "+----------------------------------------------+",
+        "| regexp_match(test.a,Utf8(\"[A-Z]\"),Utf8(\"i\")) |",
+        "+----------------------------------------------+",
+        "| [a]                                          |",
+        "| [a]                                          |",
+        "| [C]                                          |",
+        "| [A]                                          |",
+        "+----------------------------------------------+",
     ];
 
     assert_fn_batches!(expr, expected);

--- a/datafusion/core/tests/dataframe/dataframe_functions.rs
+++ b/datafusion/core/tests/dataframe/dataframe_functions.rs
@@ -597,7 +597,7 @@ async fn test_fn_md5() -> Result<()> {
 #[tokio::test]
 #[cfg(feature = "unicode_expressions")]
 async fn test_fn_regexp_like() -> Result<()> {
-    let expr = regexp_like(col("a"), lit("[a-z]"));
+    let expr = regexp_like(col("a"), lit("[a-z]"), None);
 
     let expected = [
         "+-----------------------------------+",
@@ -608,6 +608,21 @@ async fn test_fn_regexp_like() -> Result<()> {
         "| true                              |",
         "| true                              |",
         "+-----------------------------------+",
+    ];
+
+    assert_fn_batches!(expr, expected);
+
+    let expr = regexp_like(col("a"), lit("abc"), Some(lit("i")));
+
+    let expected = [
+        "+-------------------------------------------+",
+        "| regexp_like(test.a,Utf8(\"abc\"),Utf8(\"i\")) |",
+        "+-------------------------------------------+",
+        "| true                                      |",
+        "| true                                      |",
+        "| false                                     |",
+        "| true                                      |",
+        "+-------------------------------------------+",
     ];
 
     assert_fn_batches!(expr, expected);

--- a/datafusion/functions/src/regex/mod.rs
+++ b/datafusion/functions/src/regex/mod.rs
@@ -30,8 +30,7 @@ make_udf_function!(
 );
 
 pub mod expr_fn {
-    #[doc = "returns a list of regular expression matches in a string. "]
-    #[doc = r" Return $name(arg)"]
+    /// Returns a list of regular expression matches in a string.
     pub fn regexp_match(
         values: datafusion_expr::Expr,
         regex: datafusion_expr::Expr,
@@ -44,8 +43,7 @@ pub mod expr_fn {
         super::regexp_match().call(args)
     }
 
-    #[doc = "Returns true if a has at least one match in a string,false otherwise."]
-    #[doc = r" Return $name(arg)"]
+    /// Returns true if a has at least one match in a string, false otherwise.
     pub fn regexp_like(
         values: datafusion_expr::Expr,
         regex: datafusion_expr::Expr,
@@ -58,8 +56,7 @@ pub mod expr_fn {
         super::regexp_like().call(args)
     }
 
-    #[doc = "Replaces substrings in a string that match"]
-    #[doc = r" Return $name(arg)"]
+    /// Replaces substrings in a string that match.
     pub fn regexp_replace(
         string: datafusion_expr::Expr,
         pattern: datafusion_expr::Expr,

--- a/datafusion/functions/src/regex/mod.rs
+++ b/datafusion/functions/src/regex/mod.rs
@@ -28,12 +28,42 @@ make_udf_function!(
     REGEXP_REPLACE,
     regexp_replace
 );
-export_functions!((
-    regexp_match,
-    input_arg1 input_arg2,
-    "returns a list of regular expression matches in a string. "
-),(
-    regexp_like,
-    input_arg1 input_arg2,
-    "Returns true if a has at least one match in a string,false otherwise."
-),(regexp_replace, arg1 arg2 arg3 arg4, "Replaces substrings in a string that match"));
+
+pub mod expr_fn {
+    #[doc = "returns a list of regular expression matches in a string. "]
+    #[doc = r" Return $name(arg)"]
+    pub fn regexp_match(
+        input_arg1: datafusion_expr::Expr,
+        input_arg2: datafusion_expr::Expr,
+    ) -> datafusion_expr::Expr {
+        let args = vec![input_arg1, input_arg2];
+        super::regexp_match().call(args)
+    }
+
+    #[doc = "Returns true if a has at least one match in a string,false otherwise."]
+    #[doc = r" Return $name(arg)"]
+    pub fn regexp_like(
+        input_arg1: datafusion_expr::Expr,
+        input_arg2: datafusion_expr::Expr,
+    ) -> datafusion_expr::Expr {
+        let args = vec![input_arg1, input_arg2];
+        super::regexp_like().call(args)
+    }
+
+    #[doc = "Replaces substrings in a string that match"]
+    #[doc = r" Return $name(arg)"]
+    pub fn regexp_replace(
+        arg1: datafusion_expr::Expr,
+        arg2: datafusion_expr::Expr,
+        arg3: datafusion_expr::Expr,
+        arg4: datafusion_expr::Expr,
+    ) -> datafusion_expr::Expr {
+        let args = vec![arg1, arg2, arg3, arg4];
+        super::regexp_replace().call(args)
+    }
+}
+
+#[doc = r" Return a list of all functions in this package"]
+pub fn functions() -> Vec<std::sync::Arc<datafusion_expr::ScalarUDF>> {
+    vec![regexp_match(), regexp_like(), regexp_replace()]
+}

--- a/datafusion/functions/src/regex/mod.rs
+++ b/datafusion/functions/src/regex/mod.rs
@@ -47,10 +47,14 @@ pub mod expr_fn {
     #[doc = "Returns true if a has at least one match in a string,false otherwise."]
     #[doc = r" Return $name(arg)"]
     pub fn regexp_like(
-        input_arg1: datafusion_expr::Expr,
-        input_arg2: datafusion_expr::Expr,
+        values: datafusion_expr::Expr,
+        regex: datafusion_expr::Expr,
+        flags: Option<datafusion_expr::Expr>,
     ) -> datafusion_expr::Expr {
-        let args = vec![input_arg1, input_arg2];
+        let mut args = vec![values, regex];
+        if let Some(flags) = flags {
+            args.push(flags);
+        };
         super::regexp_like().call(args)
     }
 

--- a/datafusion/functions/src/regex/mod.rs
+++ b/datafusion/functions/src/regex/mod.rs
@@ -30,12 +30,10 @@ make_udf_function!(
 );
 
 pub mod expr_fn {
+    use datafusion_expr::Expr;
+
     /// Returns a list of regular expression matches in a string.
-    pub fn regexp_match(
-        values: datafusion_expr::Expr,
-        regex: datafusion_expr::Expr,
-        flags: Option<datafusion_expr::Expr>,
-    ) -> datafusion_expr::Expr {
+    pub fn regexp_match(values: Expr, regex: Expr, flags: Option<Expr>) -> Expr {
         let mut args = vec![values, regex];
         if let Some(flags) = flags {
             args.push(flags);
@@ -44,11 +42,7 @@ pub mod expr_fn {
     }
 
     /// Returns true if a has at least one match in a string, false otherwise.
-    pub fn regexp_like(
-        values: datafusion_expr::Expr,
-        regex: datafusion_expr::Expr,
-        flags: Option<datafusion_expr::Expr>,
-    ) -> datafusion_expr::Expr {
+    pub fn regexp_like(values: Expr, regex: Expr, flags: Option<Expr>) -> Expr {
         let mut args = vec![values, regex];
         if let Some(flags) = flags {
             args.push(flags);
@@ -58,11 +52,11 @@ pub mod expr_fn {
 
     /// Replaces substrings in a string that match.
     pub fn regexp_replace(
-        string: datafusion_expr::Expr,
-        pattern: datafusion_expr::Expr,
-        replacement: datafusion_expr::Expr,
-        flags: Option<datafusion_expr::Expr>,
-    ) -> datafusion_expr::Expr {
+        string: Expr,
+        pattern: Expr,
+        replacement: Expr,
+        flags: Option<Expr>,
+    ) -> Expr {
         let mut args = vec![string, pattern, replacement];
         if let Some(flags) = flags {
             args.push(flags);

--- a/datafusion/functions/src/regex/mod.rs
+++ b/datafusion/functions/src/regex/mod.rs
@@ -53,12 +53,15 @@ pub mod expr_fn {
     #[doc = "Replaces substrings in a string that match"]
     #[doc = r" Return $name(arg)"]
     pub fn regexp_replace(
-        arg1: datafusion_expr::Expr,
-        arg2: datafusion_expr::Expr,
-        arg3: datafusion_expr::Expr,
-        arg4: datafusion_expr::Expr,
+        string: datafusion_expr::Expr,
+        pattern: datafusion_expr::Expr,
+        replacement: datafusion_expr::Expr,
+        flags: Option<datafusion_expr::Expr>,
     ) -> datafusion_expr::Expr {
-        let args = vec![arg1, arg2, arg3, arg4];
+        let mut args = vec![string, pattern, replacement];
+        if let Some(flags) = flags {
+            args.push(flags);
+        };
         super::regexp_replace().call(args)
     }
 }

--- a/datafusion/functions/src/regex/mod.rs
+++ b/datafusion/functions/src/regex/mod.rs
@@ -33,10 +33,14 @@ pub mod expr_fn {
     #[doc = "returns a list of regular expression matches in a string. "]
     #[doc = r" Return $name(arg)"]
     pub fn regexp_match(
-        input_arg1: datafusion_expr::Expr,
-        input_arg2: datafusion_expr::Expr,
+        values: datafusion_expr::Expr,
+        regex: datafusion_expr::Expr,
+        flags: Option<datafusion_expr::Expr>,
     ) -> datafusion_expr::Expr {
-        let args = vec![input_arg1, input_arg2];
+        let mut args = vec![values, regex];
+        if let Some(flags) = flags {
+            args.push(flags);
+        };
         super::regexp_match().call(args)
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10512

## Rationale for this change

The inner implementations of these UDFs depend on the number of arguments passed. This exposes that to users of the UDFs.

## What changes are included in this PR?

for each of `regexp_match` regexp_like` and `regexp_replace`

- Changes / adds optional arguments to match inner impl
- Updates argument names to match inner impl

## Are these changes tested?

Yes. Each function already had a test case, and were updated to include variants for the optional arguments.

## Are there any user-facing changes?

Yes.

- `expr_fn::regexp_replace` signature has changed
- `expr_fn::regexp_like` signature has changed
- `expr_fn::regexp_match` signature has changed