### PR TITLE
Implement unparse `IS_NULL` to String and enhance the tests

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -863,9 +863,9 @@ mod tests {
     use arrow::datatypes::{Field, Schema};
     use datafusion_common::TableReference;
     use datafusion_expr::{
-        case, col, exists, when,
+        case, col, exists,
         expr::{AggregateFunction, AggregateFunctionDefinition},
-        lit, not, not_exists, table_scan, wildcard, ColumnarValue, ScalarUDF,
+        lit, not, not_exists, table_scan, when, wildcard, ColumnarValue, ScalarUDF,
         ScalarUDFImpl, Signature, Volatility, WindowFrame, WindowFunctionDefinition,
     };
 
@@ -970,11 +970,15 @@ mod tests {
                 r#"dummy_udf("a", "b")"#,
             ),
             (
-                ScalarUDF::new_from_impl(DummyUDF::new()).call(vec![col("a"), col("b")]).is_null(),
+                ScalarUDF::new_from_impl(DummyUDF::new())
+                    .call(vec![col("a"), col("b")])
+                    .is_null(),
                 r#"dummy_udf("a", "b") IS NULL"#,
             ),
             (
-                ScalarUDF::new_from_impl(DummyUDF::new()).call(vec![col("a"), col("b")]).is_not_null(),
+                ScalarUDF::new_from_impl(DummyUDF::new())
+                    .call(vec![col("a"), col("b")])
+                    .is_not_null(),
                 r#"dummy_udf("a", "b") IS NOT NULL"#,
             ),
             (

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -391,7 +391,9 @@ impl Unparser<'_> {
             Expr::ScalarVariable(_, _) => {
                 not_impl_err!("Unsupported Expr conversion: {expr:?}")
             }
-            Expr::IsNull(_) => not_impl_err!("Unsupported Expr conversion: {expr:?}"),
+            Expr::IsNull(expr) => {
+                Ok(ast::Expr::IsNull(Box::new(self.expr_to_sql(expr)?)))
+            }
             Expr::IsNotFalse(_) => not_impl_err!("Unsupported Expr conversion: {expr:?}"),
             Expr::GetIndexedField(_) => {
                 not_impl_err!("Unsupported Expr conversion: {expr:?}")
@@ -861,7 +863,7 @@ mod tests {
     use arrow::datatypes::{Field, Schema};
     use datafusion_common::TableReference;
     use datafusion_expr::{
-        case, col, exists,
+        case, col, exists, when,
         expr::{AggregateFunction, AggregateFunctionDefinition},
         lit, not, not_exists, table_scan, wildcard, ColumnarValue, ScalarUDF,
         ScalarUDFImpl, Signature, Volatility, WindowFrame, WindowFunctionDefinition,
@@ -934,6 +936,14 @@ mod tests {
                 r#"CASE "a" WHEN 1 THEN true WHEN 0 THEN false ELSE NULL END"#,
             ),
             (
+                when(col("a").is_null(), lit(true)).otherwise(lit(false))?,
+                r#"CASE WHEN "a" IS NULL THEN true ELSE false END"#,
+            ),
+            (
+                when(col("a").is_not_null(), lit(true)).otherwise(lit(false))?,
+                r#"CASE WHEN "a" IS NOT NULL THEN true ELSE false END"#,
+            ),
+            (
                 Expr::Cast(Cast {
                     expr: Box::new(col("a")),
                     data_type: DataType::Date64,
@@ -958,6 +968,14 @@ mod tests {
             (
                 ScalarUDF::new_from_impl(DummyUDF::new()).call(vec![col("a"), col("b")]),
                 r#"dummy_udf("a", "b")"#,
+            ),
+            (
+                ScalarUDF::new_from_impl(DummyUDF::new()).call(vec![col("a"), col("b")]).is_null(),
+                r#"dummy_udf("a", "b") IS NULL"#,
+            ),
+            (
+                ScalarUDF::new_from_impl(DummyUDF::new()).call(vec![col("a"), col("b")]).is_not_null(),
+                r#"dummy_udf("a", "b") IS NOT NULL"#,
             ),
             (
                 Expr::Like(Like {
@@ -1081,6 +1099,7 @@ mod tests {
                 r#"COUNT(*) OVER (ORDER BY "a" DESC NULLS FIRST RANGE BETWEEN 6 PRECEDING AND 2 FOLLOWING)"#,
             ),
             (col("a").is_not_null(), r#""a" IS NOT NULL"#),
+            (col("a").is_null(), r#""a" IS NULL"#),
             (
                 (col("a") + col("b")).gt(lit(4)).is_true(),
                 r#"(("a" + "b") > 4) IS TRUE"#,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10519 

## Rationale for this change

## What changes are included in this PR?
I found that `is_not_null` has been supported. I only implement 'is_null` here.

## Are these changes tested?
Yes, I also added more test cases for `is_null` and `is_not_null` (e.g. function call and case when).

## Are there any user-facing changes?
No