### PR TITLE
fix: `array_slice` panics

### DIFF
--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -418,12 +418,7 @@ where
 
         if let (Some(from), Some(to)) = (from_index, to_index) {
             let stride = stride.map(|s| s.value(row_index));
-            // array_slice with stride in duckdb, return empty array if stride is not supported and from > to.
-            if stride.is_none() && from > to {
-                // return empty array
-                offsets.push(offsets[row_index]);
-                continue;
-            }
+            // Default stride is 1 if not provided
             let stride = stride.unwrap_or(1);
             if stride.is_zero() {
                 return exec_err!(
@@ -432,6 +427,10 @@ where
                 );
             } else if from <= to && stride.is_negative() {
                 // return empty array
+                offsets.push(offsets[row_index]);
+                continue;
+            } else if from > to && stride.is_positive() {
+                // return empty array if from > to and stride is positive
                 offsets.push(offsets[row_index]);
                 continue;
             }

--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -430,7 +430,7 @@ where
                 offsets.push(offsets[row_index]);
                 continue;
             } else if from > to && stride.is_positive() {
-                // return empty array if from > to and stride is positive
+                // return empty array
                 offsets.push(offsets[row_index]);
                 continue;
             }

--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -425,11 +425,9 @@ where
                     "array_slice got invalid stride: {:?}, it cannot be 0",
                     stride
                 );
-            } else if from <= to && stride.is_negative() {
-                // return empty array
-                offsets.push(offsets[row_index]);
-                continue;
-            } else if from > to && stride.is_positive() {
+            } else if (from <= to && stride.is_negative())
+                || (from > to && stride.is_positive())
+            {
                 // return empty array
                 offsets.push(offsets[row_index]);
                 continue;

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1964,13 +1964,13 @@ select array_slice(arrow_cast(make_array(1, 2, 3, 4, 5), 'LargeList(Int64)'), co
 [5] [, 54, 55, 56, 57, 58, 59, 60] [55]
 
 # Test issue: https://github.com/apache/datafusion/issues/10425
-query ?
-select array_slice(a, -1, 2, 1) from (values ([1.0, 2.0, 3.0, 3.0]), ([4.0, 5.0, 3.0]), ([6.0])) t(a);
----
+query ??
+select array_slice(a, -1, 2, 1), array_slice(a, -1, 2) 
+  from (values ([1.0, 2.0, 3.0, 3.0]), ([4.0, 5.0, 3.0]), ([6.0])) t(a);
 ----
-[]
-[]
-[6.0]
+[] []
+[] []
+[6.0] [6.0]
 
 # make_array with nulls
 query ???????

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1964,6 +1964,7 @@ select array_slice(arrow_cast(make_array(1, 2, 3, 4, 5), 'LargeList(Int64)'), co
 [5] [, 54, 55, 56, 57, 58, 59, 60] [55]
 
 # Test issue: https://github.com/apache/datafusion/issues/10425
+# `from` may be larger than `to` and `stride` is positive
 query ????
 select array_slice(a, -1, 2, 1), array_slice(a, -1, 2),
        array_slice(a, 3, 2, 1), array_slice(a, 3, 2) 

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1964,13 +1964,15 @@ select array_slice(arrow_cast(make_array(1, 2, 3, 4, 5), 'LargeList(Int64)'), co
 [5] [, 54, 55, 56, 57, 58, 59, 60] [55]
 
 # Test issue: https://github.com/apache/datafusion/issues/10425
-query ??
-select array_slice(a, -1, 2, 1), array_slice(a, -1, 2) 
+query ????
+select array_slice(a, -1, 2, 1), array_slice(a, -1, 2),
+       array_slice(a, 3, 2, 1), array_slice(a, 3, 2) 
   from (values ([1.0, 2.0, 3.0, 3.0]), ([4.0, 5.0, 3.0]), ([6.0])) t(a);
 ----
-[] []
-[] []
-[6.0] [6.0]
+[] [] [] []
+[] [] [] []
+[6.0] [6.0] [] []
+
 
 # make_array with nulls
 query ???????

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1963,6 +1963,15 @@ select array_slice(arrow_cast(make_array(1, 2, 3, 4, 5), 'LargeList(Int64)'), co
 [1, 2, 3, 4, 5] [43, 44, 45, 46] [41, 42, 43, 44, 45]
 [5] [, 54, 55, 56, 57, 58, 59, 60] [55]
 
+# Test issue: https://github.com/apache/datafusion/issues/10425
+query ?
+select array_slice(a, -1, 2, 1) from (values ([1.0, 2.0, 3.0, 3.0]), ([4.0, 5.0, 3.0]), ([6.0])) t(a);
+---
+----
+[]
+[]
+[6.0]
+
 # make_array with nulls
 query ???????
 select make_array(make_array('a','b'), null),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10425.

## Rationale for this change

Note:  Negative `from` or `to` implies counting from the end of the list and both are standardized to the corresponding positive index.

When `from` is greater than `to` and `stride` is a positive, the following loop becomes infinite, until the `index` becomes excessively large and panics.

https://github.com/apache/datafusion/blob/842f3933e3496a022984c2a37254475a3bcde1bf/datafusion/functions-array/src/extract.rs#L468-L478

The fix is to return an empty list directly in this situation.

## What changes are included in this PR?
Fix panic.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes

## Are there any user-facing changes?
No