### PR TITLE
Minor: Fix name in ArrayFunctionRewriter, error not panic if `Expr::GetStructField` is planned

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -216,29 +216,27 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
             let expr = create_physical_name(expr, false)?;
             Ok(format!("{expr} IS NOT UNKNOWN"))
         }
-        Expr::GetIndexedField(GetIndexedField { expr: _, field }) => {
-            match field {
-                GetFieldAccess::NamedStructField { name: _ } => {
-                    return internal_err!(
-                        "NamedStructField is no longer supported. Should use the get_field function instead",
+        Expr::GetIndexedField(GetIndexedField { expr: _, field }) => match field {
+            GetFieldAccess::NamedStructField { name: _ } => {
+                internal_err!(
+                        "NamedStructField is no longer supported. Should use the get_field function instead"
                     )
-                }
-                GetFieldAccess::ListIndex { key: _ } => {
-                    return internal_err!(
-                        "ListIndex is no longer supported. Should use the get_field function instead",
+            }
+            GetFieldAccess::ListIndex { key: _ } => {
+                internal_err!(
+                        "ListIndex is no longer supported. Should use the get_field function instead"
                     )
-                }
-                GetFieldAccess::ListRange {
-                    start: _,
-                    stop: _,
-                    stride: _,
-                } => {
-                    return internal_err!(
-                        "ListRange is no longer supported. Should use the get_field function instead",
+            }
+            GetFieldAccess::ListRange {
+                start: _,
+                stop: _,
+                stride: _,
+            } => {
+                internal_err!(
+                        "ListRange is no longer supported. Should use the get_field function instead"
                     )
-                }
-            };
-        }
+            }
+        },
         Expr::ScalarFunction(fun) => fun.func.display_name(&fun.args),
         Expr::WindowFunction(WindowFunction {
             fun,

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -220,12 +220,12 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
             match field {
                 GetFieldAccess::NamedStructField { name: _ } => {
                     unreachable!(
-                        "NamedStructField should have been rewritten in OperatorToFunction"
+                        "NamedStructField should have been rewritten in ArrayFunctionRewriter"
                     )
                 }
                 GetFieldAccess::ListIndex { key: _ } => {
                     unreachable!(
-                        "ListIndex should have been rewritten in OperatorToFunction"
+                        "ListIndex should have been rewritten in ArrayFunctionRewriter"
                     )
                 }
                 GetFieldAccess::ListRange {
@@ -234,7 +234,7 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
                     stride: _,
                 } => {
                     unreachable!(
-                        "ListRange should have been rewritten in OperatorToFunction"
+                        "ListRange should have been rewritten in ArrayFunctionRewriter"
                     )
                 }
             };

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -219,13 +219,13 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
         Expr::GetIndexedField(GetIndexedField { expr: _, field }) => {
             match field {
                 GetFieldAccess::NamedStructField { name: _ } => {
-                    unreachable!(
-                        "NamedStructField should have been rewritten in ArrayFunctionRewriter"
+                    return internal_err!(
+                        "NamedStructField is no longer supported. Should use the get_field function instead",
                     )
                 }
                 GetFieldAccess::ListIndex { key: _ } => {
-                    unreachable!(
-                        "ListIndex should have been rewritten in ArrayFunctionRewriter"
+                    return internal_err!(
+                        "ListIndex is no longer supported. Should use the get_field function instead",
                     )
                 }
                 GetFieldAccess::ListRange {
@@ -233,8 +233,8 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
                     stop: _,
                     stride: _,
                 } => {
-                    unreachable!(
-                        "ListRange should have been rewritten in ArrayFunctionRewriter"
+                    return internal_err!(
+                        "ListRange is no longer supported. Should use the get_field function instead",
                     )
                 }
             };

--- a/datafusion/functions-array/src/rewrite.rs
+++ b/datafusion/functions-array/src/rewrite.rs
@@ -33,7 +33,7 @@ pub(crate) struct ArrayFunctionRewriter {}
 
 impl FunctionRewrite for ArrayFunctionRewriter {
     fn name(&self) -> &str {
-        "FunctionRewrite"
+        "ArrayFunctionRewriter"
     }
 
     fn rewrite(


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

While debugging a DataFusion upgrade in InfluxDB the different names for the same thing is making it hard to understand what is going on

## What changes are included in this PR?

1. Change name reported by ArrayFunctionRewriter to be correct
2. Update error to reflect how these should be rewritten
## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
