### PR TITLE
Minor: Fix `ArrayFunctionRewriter` name reporting

### DIFF
--- a/datafusion/functions-array/src/rewrite.rs
+++ b/datafusion/functions-array/src/rewrite.rs
@@ -33,7 +33,7 @@ pub(crate) struct ArrayFunctionRewriter {}
 
 impl FunctionRewrite for ArrayFunctionRewriter {
     fn name(&self) -> &str {
-        "FunctionRewrite"
+        "ArrayFunctionRewriter"
     }
 
     fn rewrite(


### PR DESCRIPTION
This confused me while debugging something else, so lets have the name that is logged match the struct name in the code