### PR TITLE
feat: Add eliminate group by constant optimizer rule

### DIFF
--- a/datafusion/optimizer/src/eliminate_group_by_constant.rs
+++ b/datafusion/optimizer/src/eliminate_group_by_constant.rs
@@ -1,0 +1,318 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`EliminateGroupByConstant`] removes constant expressions from `GROUP BY` clause
+use crate::optimizer::ApplyOrder;
+use crate::{OptimizerConfig, OptimizerRule};
+
+use datafusion_common::tree_node::Transformed;
+use datafusion_common::{internal_err, Result};
+use datafusion_expr::{Aggregate, Expr, LogicalPlan, LogicalPlanBuilder, Volatility};
+
+/// Optimizer rule that removes constant expressions from `GROUP BY` clause
+/// and places additional projection on top of aggregation, to preserve
+/// original schema
+#[derive(Default)]
+pub struct EliminateGroupByConstant {}
+
+impl EliminateGroupByConstant {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for EliminateGroupByConstant {
+    fn supports_rewrite(&self) -> bool {
+        true
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>> {
+        match plan {
+            LogicalPlan::Aggregate(aggregate) => {
+                let (const_group_expr, nonconst_group_expr): (Vec<_>, Vec<_>) = aggregate
+                    .group_expr
+                    .iter()
+                    .partition(|expr| is_constant_expression(expr));
+
+                // If no constant expressions found (nothing to optimize) or
+                // constant expression is the only expression in aggregate,
+                // optimization is skipped
+                if const_group_expr.is_empty()
+                    || (!const_group_expr.is_empty()
+                        && nonconst_group_expr.is_empty()
+                        && aggregate.aggr_expr.is_empty())
+                {
+                    return Ok(Transformed::no(LogicalPlan::Aggregate(aggregate)));
+                }
+
+                let simplified_aggregate = LogicalPlan::Aggregate(Aggregate::try_new(
+                    aggregate.input,
+                    nonconst_group_expr.into_iter().cloned().collect(),
+                    aggregate.aggr_expr.clone(),
+                )?);
+
+                let projection_expr =
+                    aggregate.group_expr.into_iter().chain(aggregate.aggr_expr);
+
+                let projection = LogicalPlanBuilder::from(simplified_aggregate)
+                    .project(projection_expr)?
+                    .build()?;
+
+                Ok(Transformed::yes(projection))
+            }
+            _ => Ok(Transformed::no(plan)),
+        }
+    }
+
+    fn try_optimize(
+        &self,
+        _plan: &LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> Result<Option<LogicalPlan>> {
+        internal_err!("Should have called EliminateGroupByConstant::rewrite")
+    }
+
+    fn name(&self) -> &str {
+        "eliminate_group_by_constant"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::BottomUp)
+    }
+}
+
+/// Checks if expression is constant, and can be eliminated from group by.
+///
+/// Intended to be used only within this rule, helper function, which heavily
+/// reiles on `SimplifyExpressions` result.
+fn is_constant_expression(expr: &Expr) -> bool {
+    match expr {
+        Expr::Alias(e) => is_constant_expression(&e.expr),
+        Expr::BinaryExpr(e) => {
+            is_constant_expression(&e.left) && is_constant_expression(&e.right)
+        }
+        Expr::Literal(_) => true,
+        Expr::ScalarFunction(e) => {
+            matches!(
+                e.func.signature().volatility,
+                Volatility::Immutable | Volatility::Stable
+            ) && e.args.iter().all(is_constant_expression)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::*;
+
+    use arrow::datatypes::DataType;
+    use datafusion_common::Result;
+    use datafusion_expr::expr::ScalarFunction;
+    use datafusion_expr::{
+        col, count, lit, ColumnarValue, LogicalPlanBuilder, ScalarUDF, ScalarUDFImpl,
+        Signature, TypeSignature,
+    };
+
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    struct ScalarUDFMock {
+        signature: Signature,
+    }
+
+    impl ScalarUDFMock {
+        fn new_with_volatility(volatility: Volatility) -> Self {
+            Self {
+                signature: Signature::new(TypeSignature::Any(1), volatility),
+            }
+        }
+    }
+
+    impl ScalarUDFImpl for ScalarUDFMock {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn name(&self) -> &str {
+            "scalar_fn_mock"
+        }
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+        fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Int32)
+        }
+        fn invoke(&self, _args: &[ColumnarValue]) -> Result<ColumnarValue> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn test_eliminate_gby_literal() -> Result<()> {
+        let scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(scan)
+            .aggregate(vec![col("a"), lit(1u32)], vec![count(col("c"))])?
+            .build()?;
+
+        let expected = "\
+            Projection: test.a, UInt32(1), COUNT(test.c)\
+            \n  Aggregate: groupBy=[[test.a]], aggr=[[COUNT(test.c)]]\
+            \n    TableScan: test\
+        ";
+
+        assert_optimized_plan_eq(
+            Arc::new(EliminateGroupByConstant::new()),
+            plan,
+            expected,
+        )
+    }
+
+    #[test]
+    fn test_eliminate_constant() -> Result<()> {
+        let scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(scan)
+            .aggregate(vec![lit("test"), lit(123u32)], vec![count(col("c"))])?
+            .build()?;
+
+        let expected = "\
+            Projection: Utf8(\"test\"), UInt32(123), COUNT(test.c)\
+            \n  Aggregate: groupBy=[[]], aggr=[[COUNT(test.c)]]\
+            \n    TableScan: test\
+        ";
+
+        assert_optimized_plan_eq(
+            Arc::new(EliminateGroupByConstant::new()),
+            plan,
+            expected,
+        )
+    }
+
+    #[test]
+    fn test_no_op_no_constants() -> Result<()> {
+        let scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(scan)
+            .aggregate(vec![col("a"), col("b")], vec![count(col("c"))])?
+            .build()?;
+
+        let expected = "\
+            Aggregate: groupBy=[[test.a, test.b]], aggr=[[COUNT(test.c)]]\
+            \n  TableScan: test\
+        ";
+
+        assert_optimized_plan_eq(
+            Arc::new(EliminateGroupByConstant::new()),
+            plan,
+            expected,
+        )
+    }
+
+    #[test]
+    fn test_no_op_only_constant() -> Result<()> {
+        let scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(scan)
+            .aggregate(vec![lit(123u32)], Vec::<Expr>::new())?
+            .build()?;
+
+        let expected = "\
+            Aggregate: groupBy=[[UInt32(123)]], aggr=[[]]\
+            \n  TableScan: test\
+        ";
+
+        assert_optimized_plan_eq(
+            Arc::new(EliminateGroupByConstant::new()),
+            plan,
+            expected,
+        )
+    }
+
+    #[test]
+    fn test_eliminate_constant_with_alias() -> Result<()> {
+        let scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(scan)
+            .aggregate(
+                vec![lit(123u32).alias("const"), col("a")],
+                vec![count(col("c"))],
+            )?
+            .build()?;
+
+        let expected = "\
+            Projection: UInt32(123) AS const, test.a, COUNT(test.c)\
+            \n  Aggregate: groupBy=[[test.a]], aggr=[[COUNT(test.c)]]\
+            \n    TableScan: test\
+        ";
+
+        assert_optimized_plan_eq(
+            Arc::new(EliminateGroupByConstant::new()),
+            plan,
+            expected,
+        )
+    }
+
+    #[test]
+    fn test_eliminate_scalar_fn_with_constant_arg() -> Result<()> {
+        let udf = ScalarUDF::new_from_impl(ScalarUDFMock::new_with_volatility(
+            Volatility::Immutable,
+        ));
+        let udf_expr =
+            Expr::ScalarFunction(ScalarFunction::new_udf(udf.into(), vec![lit(123u32)]));
+        let scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(scan)
+            .aggregate(vec![udf_expr, col("a")], vec![count(col("c"))])?
+            .build()?;
+
+        let expected = "\
+            Projection: scalar_fn_mock(UInt32(123)), test.a, COUNT(test.c)\
+            \n  Aggregate: groupBy=[[test.a]], aggr=[[COUNT(test.c)]]\
+            \n    TableScan: test\
+        ";
+
+        assert_optimized_plan_eq(
+            Arc::new(EliminateGroupByConstant::new()),
+            plan,
+            expected,
+        )
+    }
+
+    #[test]
+    fn test_no_op_volatile_scalar_fn_with_constant_arg() -> Result<()> {
+        let udf = ScalarUDF::new_from_impl(ScalarUDFMock::new_with_volatility(
+            Volatility::Volatile,
+        ));
+        let udf_expr =
+            Expr::ScalarFunction(ScalarFunction::new_udf(udf.into(), vec![lit(123u32)]));
+        let scan = test_table_scan()?;
+        let plan = LogicalPlanBuilder::from(scan)
+            .aggregate(vec![udf_expr, col("a")], vec![count(col("c"))])?
+            .build()?;
+
+        let expected = "\
+            Aggregate: groupBy=[[scalar_fn_mock(UInt32(123)), test.a]], aggr=[[COUNT(test.c)]]\
+            \n  TableScan: test\
+        ";
+
+        assert_optimized_plan_eq(
+            Arc::new(EliminateGroupByConstant::new()),
+            plan,
+            expected,
+        )
+    }
+}

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -35,6 +35,7 @@ pub mod decorrelate_predicate_subquery;
 pub mod eliminate_cross_join;
 pub mod eliminate_duplicated_expr;
 pub mod eliminate_filter;
+pub mod eliminate_group_by_constant;
 pub mod eliminate_join;
 pub mod eliminate_limit;
 pub mod eliminate_nested_union;

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -35,6 +35,7 @@ use crate::decorrelate_predicate_subquery::DecorrelatePredicateSubquery;
 use crate::eliminate_cross_join::EliminateCrossJoin;
 use crate::eliminate_duplicated_expr::EliminateDuplicatedExpr;
 use crate::eliminate_filter::EliminateFilter;
+use crate::eliminate_group_by_constant::EliminateGroupByConstant;
 use crate::eliminate_join::EliminateJoin;
 use crate::eliminate_limit::EliminateLimit;
 use crate::eliminate_nested_union::EliminateNestedUnion;
@@ -262,6 +263,7 @@ impl Optimizer {
             Arc::new(SimplifyExpressions::new()),
             Arc::new(UnwrapCastInComparison::new()),
             Arc::new(CommonSubexprEliminate::new()),
+            Arc::new(EliminateGroupByConstant::new()),
             Arc::new(OptimizeProjections::new()),
         ];
 

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -209,6 +209,7 @@ logical_plan after single_distinct_aggregation_to_group_by SAME TEXT AS ABOVE
 logical_plan after simplify_expressions SAME TEXT AS ABOVE
 logical_plan after unwrap_cast_in_comparison SAME TEXT AS ABOVE
 logical_plan after common_sub_expression_eliminate SAME TEXT AS ABOVE
+logical_plan after eliminate_group_by_constant SAME TEXT AS ABOVE
 logical_plan after optimize_projections TableScan: simple_explain_test projection=[a, b, c]
 logical_plan after eliminate_nested_union SAME TEXT AS ABOVE
 logical_plan after simplify_expressions SAME TEXT AS ABOVE
@@ -235,6 +236,7 @@ logical_plan after single_distinct_aggregation_to_group_by SAME TEXT AS ABOVE
 logical_plan after simplify_expressions SAME TEXT AS ABOVE
 logical_plan after unwrap_cast_in_comparison SAME TEXT AS ABOVE
 logical_plan after common_sub_expression_eliminate SAME TEXT AS ABOVE
+logical_plan after eliminate_group_by_constant SAME TEXT AS ABOVE
 logical_plan after optimize_projections SAME TEXT AS ABOVE
 logical_plan TableScan: simple_explain_test projection=[a, b, c]
 initial_physical_plan CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/example.csv]]}, projection=[a, b, c], has_header=true

--- a/datafusion/sqllogictest/test_files/optimizer_group_by_constant.slt
+++ b/datafusion/sqllogictest/test_files/optimizer_group_by_constant.slt
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+statement ok
+CREATE EXTERNAL TABLE test_table (
+  c1  VARCHAR NOT NULL,
+  c2  TINYINT NOT NULL,
+  c3  SMALLINT NOT NULL,
+  c4  SMALLINT,
+  c5  INT,
+  c6  BIGINT NOT NULL,
+  c7  SMALLINT NOT NULL,
+  c8  INT NOT NULL,
+  c9  INT UNSIGNED NOT NULL,
+  c10 BIGINT UNSIGNED NOT NULL,
+  c11 FLOAT NOT NULL,
+  c12 DOUBLE NOT NULL,
+  c13 VARCHAR NOT NULL
+)
+STORED AS CSV
+LOCATION '../../testing/data/csv/aggregate_test_100.csv'
+OPTIONS ('format.has_header' 'true');
+
+statement ok
+SET datafusion.execution.target_partitions = 1;
+
+statement ok
+SET datafusion.explain.logical_plan_only = true;
+
+query TT
+EXPLAIN
+SELECT c1, 99999, c5 + c8, 'test', count(1)
+FROM test_table t
+GROUP BY 1, 2, 3, 4
+----
+logical_plan
+01)Projection: t.c1, Int64(99999), t.c5 + t.c8, Utf8("test"), COUNT(Int64(1))
+02)--Aggregate: groupBy=[[t.c1, t.c5 + t.c8]], aggr=[[COUNT(Int64(1))]]
+03)----SubqueryAlias: t
+04)------TableScan: test_table projection=[c1, c5, c8]
+
+query TT
+EXPLAIN
+SELECT 123, 456, 789, count(1), avg(c12)
+FROM test_table t
+group by 1, 2, 3
+----
+logical_plan
+01)Projection: Int64(123), Int64(456), Int64(789), COUNT(Int64(1)), AVG(t.c12)
+02)--Aggregate: groupBy=[[]], aggr=[[COUNT(Int64(1)), AVG(t.c12)]]
+03)----SubqueryAlias: t
+04)------TableScan: test_table projection=[c12]
+
+query TT
+EXPLAIN 
+SELECT to_date('2023-05-04') as dt, extract(day from now()) < 1000 as today_filter, count(1)
+FROM test_table t
+GROUP BY 1, 2
+----
+logical_plan
+01)Projection: Date32("19481") AS dt, Boolean(true) AS today_filter, COUNT(Int64(1))
+02)--Aggregate: groupBy=[[]], aggr=[[COUNT(Int64(1))]]
+03)----SubqueryAlias: t
+04)------TableScan: test_table projection=[]
+
+query TT
+EXPLAIN 
+SELECT 
+    not (
+        cast(
+            extract(month from now()) AS INT
+        )
+        between 50 and 60
+    ), count(1)
+FROM test_table t
+GROUP BY 1
+----
+logical_plan
+01)Projection: Boolean(true) AS NOT date_part(Utf8("MONTH"),now()) BETWEEN Int64(50) AND Int64(60), COUNT(Int64(1))
+02)--Aggregate: groupBy=[[]], aggr=[[COUNT(Int64(1))]]
+03)----SubqueryAlias: t
+04)------TableScan: test_table projection=[]
+
+query TT
+EXPLAIN 
+SELECT 123
+FROM test_table t
+GROUP BY 1
+----
+logical_plan
+01)Aggregate: groupBy=[[Int64(123)]], aggr=[[]]
+02)--SubqueryAlias: t
+03)----TableScan: test_table projection=[]
+
+query TT
+EXPLAIN 
+SELECT random()
+FROM test_table t
+GROUP BY 1
+----
+logical_plan
+01)Aggregate: groupBy=[[random()]], aggr=[[]]
+02)--SubqueryAlias: t
+03)----TableScan: test_table projection=[]

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -755,13 +755,13 @@ logical_plan
 02)--Union
 03)----SubqueryAlias: u
 04)------Projection: Int64(0) AS m, m0.t
-05)--------Aggregate: groupBy=[[Int64(0), m0.t]], aggr=[[]]
+05)--------Aggregate: groupBy=[[m0.t]], aggr=[[]]
 06)----------SubqueryAlias: m0
 07)------------Projection: column1 AS t
 08)--------------Values: (Int64(0)), (Int64(1)), (Int64(2))
 09)----SubqueryAlias: v
 10)------Projection: Int64(1) AS m, m1.t
-11)--------Aggregate: groupBy=[[Int64(1), m1.t]], aggr=[[]]
+11)--------Aggregate: groupBy=[[m1.t]], aggr=[[]]
 12)----------SubqueryAlias: m1
 13)------------Projection: column1 AS t
 14)--------------Values: (Int64(0)), (Int64(1))
@@ -769,20 +769,20 @@ physical_plan
 01)SortPreservingMergeExec: [m@0 ASC NULLS LAST,t@1 ASC NULLS LAST]
 02)--SortExec: expr=[m@0 ASC NULLS LAST,t@1 ASC NULLS LAST], preserve_partitioning=[true]
 03)----InterleaveExec
-04)------ProjectionExec: expr=[Int64(0)@0 as m, t@1 as t]
-05)--------AggregateExec: mode=FinalPartitioned, gby=[Int64(0)@0 as Int64(0), t@1 as t], aggr=[], ordering_mode=PartiallySorted([0])
+04)------ProjectionExec: expr=[0 as m, t@0 as t]
+05)--------AggregateExec: mode=FinalPartitioned, gby=[t@0 as t], aggr=[]
 06)----------CoalesceBatchesExec: target_batch_size=8192
-07)------------RepartitionExec: partitioning=Hash([Int64(0)@0, t@1], 2), input_partitions=2
+07)------------RepartitionExec: partitioning=Hash([t@0], 2), input_partitions=2
 08)--------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-09)----------------AggregateExec: mode=Partial, gby=[0 as Int64(0), t@0 as t], aggr=[], ordering_mode=PartiallySorted([0])
+09)----------------AggregateExec: mode=Partial, gby=[t@0 as t], aggr=[]
 10)------------------ProjectionExec: expr=[column1@0 as t]
 11)--------------------ValuesExec
-12)------ProjectionExec: expr=[Int64(1)@0 as m, t@1 as t]
-13)--------AggregateExec: mode=FinalPartitioned, gby=[Int64(1)@0 as Int64(1), t@1 as t], aggr=[], ordering_mode=PartiallySorted([0])
+12)------ProjectionExec: expr=[1 as m, t@0 as t]
+13)--------AggregateExec: mode=FinalPartitioned, gby=[t@0 as t], aggr=[]
 14)----------CoalesceBatchesExec: target_batch_size=8192
-15)------------RepartitionExec: partitioning=Hash([Int64(1)@0, t@1], 2), input_partitions=2
+15)------------RepartitionExec: partitioning=Hash([t@0], 2), input_partitions=2
 16)--------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
-17)----------------AggregateExec: mode=Partial, gby=[1 as Int64(1), t@0 as t], aggr=[], ordering_mode=PartiallySorted([0])
+17)----------------AggregateExec: mode=Partial, gby=[t@0 as t], aggr=[]
 18)------------------ProjectionExec: expr=[column1@0 as t]
 19)--------------------ValuesExec
 

--- a/datafusion/sqllogictest/test_files/subquery.slt
+++ b/datafusion/sqllogictest/test_files/subquery.slt
@@ -252,23 +252,21 @@ logical_plan
 03)----TableScan: t1 projection=[t1_id]
 04)----SubqueryAlias: __scalar_sq_1
 05)------Projection: SUM(t2.t2_int), t2.t2_id
-06)--------Aggregate: groupBy=[[t2.t2_id, Utf8("a")]], aggr=[[SUM(CAST(t2.t2_int AS Int64))]]
+06)--------Aggregate: groupBy=[[t2.t2_id]], aggr=[[SUM(CAST(t2.t2_int AS Int64))]]
 07)----------TableScan: t2 projection=[t2_id, t2_int]
 physical_plan
-01)ProjectionExec: expr=[t1_id@0 as t1_id, SUM(t2.t2_int)@1 as t2_sum]
+01)ProjectionExec: expr=[t1_id@1 as t1_id, SUM(t2.t2_int)@0 as t2_sum]
 02)--CoalesceBatchesExec: target_batch_size=2
-03)----HashJoinExec: mode=Partitioned, join_type=Left, on=[(t1_id@0, t2_id@1)], projection=[t1_id@0, SUM(t2.t2_int)@1]
-04)------CoalesceBatchesExec: target_batch_size=2
-05)--------RepartitionExec: partitioning=Hash([t1_id@0], 4), input_partitions=4
-06)----------MemoryExec: partitions=4, partition_sizes=[1, 0, 0, 0]
-07)------CoalesceBatchesExec: target_batch_size=2
-08)--------RepartitionExec: partitioning=Hash([t2_id@1], 4), input_partitions=4
-09)----------ProjectionExec: expr=[SUM(t2.t2_int)@2 as SUM(t2.t2_int), t2_id@0 as t2_id]
-10)------------AggregateExec: mode=FinalPartitioned, gby=[t2_id@0 as t2_id, Utf8("a")@1 as Utf8("a")], aggr=[SUM(t2.t2_int)], ordering_mode=PartiallySorted([1])
-11)--------------CoalesceBatchesExec: target_batch_size=2
-12)----------------RepartitionExec: partitioning=Hash([t2_id@0, Utf8("a")@1], 4), input_partitions=4
-13)------------------AggregateExec: mode=Partial, gby=[t2_id@0 as t2_id, a as Utf8("a")], aggr=[SUM(t2.t2_int)], ordering_mode=PartiallySorted([1])
-14)--------------------MemoryExec: partitions=4, partition_sizes=[1, 0, 0, 0]
+03)----HashJoinExec: mode=Partitioned, join_type=Right, on=[(t2_id@1, t1_id@0)], projection=[SUM(t2.t2_int)@0, t1_id@2]
+04)------ProjectionExec: expr=[SUM(t2.t2_int)@1 as SUM(t2.t2_int), t2_id@0 as t2_id]
+05)--------AggregateExec: mode=FinalPartitioned, gby=[t2_id@0 as t2_id], aggr=[SUM(t2.t2_int)]
+06)----------CoalesceBatchesExec: target_batch_size=2
+07)------------RepartitionExec: partitioning=Hash([t2_id@0], 4), input_partitions=4
+08)--------------AggregateExec: mode=Partial, gby=[t2_id@0 as t2_id], aggr=[SUM(t2.t2_int)]
+09)----------------MemoryExec: partitions=4, partition_sizes=[1, 0, 0, 0]
+10)------CoalesceBatchesExec: target_batch_size=2
+11)--------RepartitionExec: partitioning=Hash([t1_id@0], 4), input_partitions=4
+12)----------MemoryExec: partitions=4, partition_sizes=[1, 0, 0, 0]
 
 query II rowsort
 SELECT t1_id, (SELECT sum(t2_int) FROM t2 WHERE t2.t2_id = t1.t1_id group by t2_id, 'a') as t2_sum from t1
@@ -768,8 +766,8 @@ logical_plan
 02)--Left Join: t1.t1_int = __scalar_sq_1.t2_int
 03)----TableScan: t1 projection=[t1_id, t1_int]
 04)----SubqueryAlias: __scalar_sq_1
-05)------Projection: COUNT(*), t2.t2_int, __always_true
-06)--------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+05)------Projection: COUNT(*), t2.t2_int, Boolean(true) AS __always_true
+06)--------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 07)----------TableScan: t2 projection=[t2_int]
 
 query II rowsort
@@ -790,8 +788,8 @@ logical_plan
 02)--Left Join: t1.t1_int = __scalar_sq_1.t2_int
 03)----TableScan: t1 projection=[t1_id, t1_int]
 04)----SubqueryAlias: __scalar_sq_1
-05)------Projection: COUNT(*), t2.t2_int, __always_true
-06)--------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+05)------Projection: COUNT(*), t2.t2_int, Boolean(true) AS __always_true
+06)--------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 07)----------TableScan: t2 projection=[t2_int]
 
 query II rowsort
@@ -811,8 +809,8 @@ logical_plan
 02)--Left Join: t1.t1_int = __scalar_sq_1.t2_int
 03)----TableScan: t1 projection=[t1_id, t1_int]
 04)----SubqueryAlias: __scalar_sq_1
-05)------Projection: COUNT(*) AS _cnt, t2.t2_int, __always_true
-06)--------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+05)------Projection: COUNT(*) AS _cnt, t2.t2_int, Boolean(true) AS __always_true
+06)--------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 07)----------TableScan: t2 projection=[t2_int]
 
 query II rowsort
@@ -832,8 +830,8 @@ logical_plan
 02)--Left Join: t1.t1_int = __scalar_sq_1.t2_int
 03)----TableScan: t1 projection=[t1_id, t1_int]
 04)----SubqueryAlias: __scalar_sq_1
-05)------Projection: COUNT(*) + Int64(2) AS _cnt, t2.t2_int, __always_true
-06)--------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+05)------Projection: COUNT(*) + Int64(2) AS _cnt, t2.t2_int, Boolean(true) AS __always_true
+06)--------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 07)----------TableScan: t2 projection=[t2_int]
 
 query II rowsort
@@ -855,8 +853,8 @@ logical_plan
 04)------Left Join: t1.t1_id = __scalar_sq_1.t2_id
 05)--------TableScan: t1 projection=[t1_id, t1_int]
 06)--------SubqueryAlias: __scalar_sq_1
-07)----------Projection: COUNT(*), t2.t2_id, __always_true
-08)------------Aggregate: groupBy=[[t2.t2_id, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+07)----------Projection: COUNT(*), t2.t2_id, Boolean(true) AS __always_true
+08)------------Aggregate: groupBy=[[t2.t2_id]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 09)--------------TableScan: t2 projection=[t2_id]
 
 query I rowsort
@@ -878,9 +876,8 @@ logical_plan
 04)----SubqueryAlias: __scalar_sq_1
 05)------Projection: COUNT(*) + Int64(2) AS cnt_plus_2, t2.t2_int
 06)--------Filter: COUNT(*) > Int64(1)
-07)----------Projection: t2.t2_int, COUNT(*)
-08)------------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
-09)--------------TableScan: t2 projection=[t2_int]
+07)----------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+08)------------TableScan: t2 projection=[t2_int]
 
 query II rowsort
 SELECT t1_id, (SELECT count(*) + 2 as cnt_plus_2 FROM t2 WHERE t2.t2_int = t1.t1_int having count(*) >1) from t1
@@ -900,8 +897,8 @@ logical_plan
 02)--Left Join: t1.t1_int = __scalar_sq_1.t2_int
 03)----TableScan: t1 projection=[t1_id, t1_int]
 04)----SubqueryAlias: __scalar_sq_1
-05)------Projection: COUNT(*) + Int64(2) AS cnt_plus_2, t2.t2_int, COUNT(*), __always_true
-06)--------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+05)------Projection: COUNT(*) + Int64(2) AS cnt_plus_2, t2.t2_int, COUNT(*), Boolean(true) AS __always_true
+06)--------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 07)----------TableScan: t2 projection=[t2_int]
 
 query II rowsort
@@ -924,8 +921,8 @@ logical_plan
 05)--------Aggregate: groupBy=[[t1.t1_int]], aggr=[[]]
 06)----------TableScan: t1 projection=[t1_int]
 07)--------SubqueryAlias: __scalar_sq_1
-08)----------Projection: COUNT(*), t2.t2_int, __always_true
-09)------------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+08)----------Projection: COUNT(*), t2.t2_int, Boolean(true) AS __always_true
+09)------------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 10)--------------TableScan: t2 projection=[t2_int]
 
 query I rowsort
@@ -945,8 +942,8 @@ logical_plan
 04)------Left Join: t1.t1_int = __scalar_sq_1.t2_int
 05)--------TableScan: t1 projection=[t1_int]
 06)--------SubqueryAlias: __scalar_sq_1
-07)----------Projection: COUNT(*) AS cnt, t2.t2_int, __always_true
-08)------------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+07)----------Projection: COUNT(*) AS cnt, t2.t2_int, Boolean(true) AS __always_true
+08)------------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 09)--------------TableScan: t2 projection=[t2_int]
 
 
@@ -975,8 +972,8 @@ logical_plan
 04)------Left Join: t1.t1_int = __scalar_sq_1.t2_int
 05)--------TableScan: t1 projection=[t1_int]
 06)--------SubqueryAlias: __scalar_sq_1
-07)----------Projection: COUNT(*) + Int64(1) + Int64(1) AS cnt_plus_two, t2.t2_int, COUNT(*), __always_true
-08)------------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+07)----------Projection: COUNT(*) + Int64(1) + Int64(1) AS cnt_plus_two, t2.t2_int, COUNT(*), Boolean(true) AS __always_true
+08)------------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 09)--------------TableScan: t2 projection=[t2_int]
 
 query I rowsort
@@ -1004,8 +1001,8 @@ logical_plan
 04)------Left Join: t1.t1_int = __scalar_sq_1.t2_int
 05)--------TableScan: t1 projection=[t1_int]
 06)--------SubqueryAlias: __scalar_sq_1
-07)----------Projection: CASE WHEN COUNT(*) = Int64(1) THEN Int64(NULL) ELSE COUNT(*) END AS cnt, t2.t2_int, __always_true
-08)------------Aggregate: groupBy=[[t2.t2_int, Boolean(true) AS __always_true]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
+07)----------Projection: CASE WHEN COUNT(*) = Int64(1) THEN Int64(NULL) ELSE COUNT(*) END AS cnt, t2.t2_int, Boolean(true) AS __always_true
+08)------------Aggregate: groupBy=[[t2.t2_int]], aggr=[[COUNT(Int64(1)) AS COUNT(*)]]
 09)--------------TableScan: t2 projection=[t2_int]
 
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Initial intention was to improve clickbench q34 -- it contains aggregation by constant and URL which makes aggregation switch to row-based mode which is slower that single field group by.

In general, elimination of constants from `GROUP BY` seems to be reasonable optimization.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

New logical optimizer rule which removes constant or originated from constant expressions from `Aggregate::group_expr`, and places additional projection on top of aggregation, to satisfy original schema for downstream operators.

Optimizer rule is placed between last `SimplifyExpressions` and `OptimizeProjections`, since it requires constant evaluation, and projections, produced by this rule, may be merged.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

New unit tests and sqllogictests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
