### PR TITLE
Fix compilation of datafusion-cli on 32bit targets

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -304,7 +304,7 @@ enum ByteUnit {
 }
 
 impl ByteUnit {
-    fn multiplier(&self) -> usize {
+    fn multiplier(&self) -> u64 {
         match self {
             ByteUnit::Byte => 1,
             ByteUnit::KiB => 1 << 10,
@@ -349,8 +349,12 @@ fn extract_memory_pool_size(size: &str) -> Result<usize, String> {
         let unit = byte_suffixes()
             .get(suffix)
             .ok_or_else(|| format!("Invalid memory pool size '{}'", size))?;
+        let memory_pool_size = usize::try_from(unit.multiplier())
+            .ok()
+            .and_then(|multiplier| num.checked_mul(multiplier))
+            .ok_or_else(|| format!("Memory pool size '{}' is too large", size))?;
 
-        Ok(num * unit.multiplier())
+        Ok(memory_pool_size)
     } else {
         Err(format!("Invalid memory pool size '{}'", size))
     }


### PR DESCRIPTION
## Which issue does this PR close?
Closes #10552.

## Rationale for this change
This PR fixes compilation of the datafusion-cli crate on 32bit targets. 

## What changes are included in this PR?
A constant assumed that a usize was at least 64 bits wide. I changed the constant type to be a u64, before translating it into a usize later on, throwing an error if it overflows.

## Are these changes tested?
These changes are not tested. I assumed adding CI for 32bit targets was too invasive for this PR.

## Are there any user-facing changes?
There should be no user-facing changes or breaking changes.