### PR TITLE
Rename monotonicity as output_ordering in ScalarUDF's

### DIFF
--- a/datafusion-examples/examples/advanced_udf.rs
+++ b/datafusion-examples/examples/advanced_udf.rs
@@ -181,7 +181,7 @@ impl ScalarUDFImpl for PowUdf {
         &self.aliases
     }
 
-    fn monotonicity(&self, input: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
         // The POW function preserves the order of its argument.
         Ok(input[0].sort_properties)
     }

--- a/datafusion-examples/examples/function_factory.rs
+++ b/datafusion-examples/examples/function_factory.rs
@@ -157,7 +157,7 @@ impl ScalarUDFImpl for ScalarFunctionWrapper {
         &[]
     }
 
-    fn monotonicity(&self, _input: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, _input: &[ExprProperties]) -> Result<SortProperties> {
         Ok(SortProperties::Unordered)
     }
 }

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -256,8 +256,8 @@ impl ScalarUDF {
 
     /// Calculates the [`SortProperties`] of this function based on its
     /// children's properties.
-    pub fn monotonicity(&self, inputs: &[ExprProperties]) -> Result<SortProperties> {
-        self.inner.monotonicity(inputs)
+    pub fn output_ordering(&self, inputs: &[ExprProperties]) -> Result<SortProperties> {
+        self.inner.output_ordering(inputs)
     }
 
     /// See [`ScalarUDFImpl::coerce_types`] for more details.
@@ -516,7 +516,7 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
 
     /// Calculates the [`SortProperties`] of this function based on its
     /// children's properties.
-    fn monotonicity(&self, _inputs: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, _inputs: &[ExprProperties]) -> Result<SortProperties> {
         Ok(SortProperties::Unordered)
     }
 

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -147,7 +147,7 @@ impl ScalarUDFImpl for DateBinFunc {
         }
     }
 
-    fn monotonicity(&self, input: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
         // The DATE_BIN function preserves the order of its second argument.
         let step = &input[0];
         let date_value = &input[1];

--- a/datafusion/functions/src/datetime/date_trunc.rs
+++ b/datafusion/functions/src/datetime/date_trunc.rs
@@ -204,7 +204,7 @@ impl ScalarUDFImpl for DateTruncFunc {
         &self.aliases
     }
 
-    fn monotonicity(&self, input: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
         // The DATE_TRUNC function preserves the order of its second argument.
         let precision = &input[0];
         let date_value = &input[1];

--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -154,9 +154,9 @@ macro_rules! downcast_arg {
 /// $GNAME: a singleton instance of the UDF
 /// $NAME: the name of the function
 /// $UNARY_FUNC: the unary function to apply to the argument
-/// $MONOTONIC_FUNC: the monotonicity of the function
+/// $OUTPUT_ORDERING: the output ordering calculation method of the function
 macro_rules! make_math_unary_udf {
-    ($UDF:ident, $GNAME:ident, $NAME:ident, $UNARY_FUNC:ident, $MONOTONICITY:expr) => {
+    ($UDF:ident, $GNAME:ident, $NAME:ident, $UNARY_FUNC:ident, $OUTPUT_ORDERING:expr) => {
         make_udf_function!($NAME::$UDF, $GNAME, $NAME);
 
         mod $NAME {
@@ -209,11 +209,11 @@ macro_rules! make_math_unary_udf {
                     }
                 }
 
-                fn monotonicity(
+                fn output_ordering(
                     &self,
                     input: &[ExprProperties],
                 ) -> Result<SortProperties> {
-                    $MONOTONICITY(input)
+                    $OUTPUT_ORDERING(input)
                 }
 
                 fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
@@ -261,9 +261,9 @@ macro_rules! make_math_unary_udf {
 /// $GNAME: a singleton instance of the UDF
 /// $NAME: the name of the function
 /// $BINARY_FUNC: the binary function to apply to the argument
-/// $MONOTONIC_FUNC: the monotonicity of the function
+/// $OUTPUT_ORDERING: the output ordering calculation method of the function
 macro_rules! make_math_binary_udf {
-    ($UDF:ident, $GNAME:ident, $NAME:ident, $BINARY_FUNC:ident, $MONOTONICITY:expr) => {
+    ($UDF:ident, $GNAME:ident, $NAME:ident, $BINARY_FUNC:ident, $OUTPUT_ORDERING:expr) => {
         make_udf_function!($NAME::$UDF, $GNAME, $NAME);
 
         mod $NAME {
@@ -319,11 +319,11 @@ macro_rules! make_math_binary_udf {
                     }
                 }
 
-                fn monotonicity(
+                fn output_ordering(
                     &self,
                     input: &[ExprProperties],
                 ) -> Result<SortProperties> {
-                    $MONOTONICITY(input)
+                    $OUTPUT_ORDERING(input)
                 }
 
                 fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {

--- a/datafusion/functions/src/math/abs.rs
+++ b/datafusion/functions/src/math/abs.rs
@@ -170,7 +170,7 @@ impl ScalarUDFImpl for AbsFunc {
         abs_fun(&args).map(ColumnarValue::Array)
     }
 
-    fn monotonicity(&self, input: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
         // Non-decreasing for x ≥ 0 and symmetrically non-increasing for x ≤ 0.
         let arg = &input[0];
         let range = &arg.range;

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -81,7 +81,7 @@ impl ScalarUDFImpl for LogFunc {
         }
     }
 
-    fn monotonicity(&self, input: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
         match (input[0].sort_properties, input[1].sort_properties) {
             (first @ SortProperties::Ordered(value), SortProperties::Ordered(base))
                 if !value.descending && base.descending

--- a/datafusion/functions/src/math/mod.rs
+++ b/datafusion/functions/src/math/mod.rs
@@ -41,36 +41,36 @@ pub mod trunc;
 
 // Create UDFs
 make_udf_function!(abs::AbsFunc, ABS, abs);
-make_math_unary_udf!(AcosFunc, ACOS, acos, acos, super::acos_monotonicity);
-make_math_unary_udf!(AcoshFunc, ACOSH, acosh, acosh, super::acosh_monotonicity);
-make_math_unary_udf!(AsinFunc, ASIN, asin, asin, super::asin_monotonicity);
-make_math_unary_udf!(AsinhFunc, ASINH, asinh, asinh, super::asinh_monotonicity);
-make_math_unary_udf!(AtanFunc, ATAN, atan, atan, super::atan_monotonicity);
-make_math_unary_udf!(AtanhFunc, ATANH, atanh, atanh, super::atanh_monotonicity);
-make_math_binary_udf!(Atan2, ATAN2, atan2, atan2, super::atan2_monotonicity);
-make_math_unary_udf!(CbrtFunc, CBRT, cbrt, cbrt, super::cbrt_monotonicity);
-make_math_unary_udf!(CeilFunc, CEIL, ceil, ceil, super::ceil_monotonicity);
-make_math_unary_udf!(CosFunc, COS, cos, cos, super::cos_monotonicity);
-make_math_unary_udf!(CoshFunc, COSH, cosh, cosh, super::cosh_monotonicity);
+make_math_unary_udf!(AcosFunc, ACOS, acos, acos, super::acos_order);
+make_math_unary_udf!(AcoshFunc, ACOSH, acosh, acosh, super::acosh_order);
+make_math_unary_udf!(AsinFunc, ASIN, asin, asin, super::asin_order);
+make_math_unary_udf!(AsinhFunc, ASINH, asinh, asinh, super::asinh_order);
+make_math_unary_udf!(AtanFunc, ATAN, atan, atan, super::atan_order);
+make_math_unary_udf!(AtanhFunc, ATANH, atanh, atanh, super::atanh_order);
+make_math_binary_udf!(Atan2, ATAN2, atan2, atan2, super::atan2_order);
+make_math_unary_udf!(CbrtFunc, CBRT, cbrt, cbrt, super::cbrt_order);
+make_math_unary_udf!(CeilFunc, CEIL, ceil, ceil, super::ceil_order);
+make_math_unary_udf!(CosFunc, COS, cos, cos, super::cos_order);
+make_math_unary_udf!(CoshFunc, COSH, cosh, cosh, super::cosh_order);
 make_udf_function!(cot::CotFunc, COT, cot);
 make_math_unary_udf!(
     DegreesFunc,
     DEGREES,
     degrees,
     to_degrees,
-    super::degrees_monotonicity
+    super::degrees_order
 );
-make_math_unary_udf!(ExpFunc, EXP, exp, exp, super::exp_monotonicity);
+make_math_unary_udf!(ExpFunc, EXP, exp, exp, super::exp_order);
 make_udf_function!(factorial::FactorialFunc, FACTORIAL, factorial);
-make_math_unary_udf!(FloorFunc, FLOOR, floor, floor, super::floor_monotonicity);
+make_math_unary_udf!(FloorFunc, FLOOR, floor, floor, super::floor_order);
 make_udf_function!(log::LogFunc, LOG, log);
 make_udf_function!(gcd::GcdFunc, GCD, gcd);
 make_udf_function!(nans::IsNanFunc, ISNAN, isnan);
 make_udf_function!(iszero::IsZeroFunc, ISZERO, iszero);
 make_udf_function!(lcm::LcmFunc, LCM, lcm);
-make_math_unary_udf!(LnFunc, LN, ln, ln, super::ln_monotonicity);
-make_math_unary_udf!(Log2Func, LOG2, log2, log2, super::log2_monotonicity);
-make_math_unary_udf!(Log10Func, LOG10, log10, log10, super::log10_monotonicity);
+make_math_unary_udf!(LnFunc, LN, ln, ln, super::ln_order);
+make_math_unary_udf!(Log2Func, LOG2, log2, log2, super::log2_order);
+make_math_unary_udf!(Log10Func, LOG10, log10, log10, super::log10_order);
 make_udf_function!(nanvl::NanvlFunc, NANVL, nanvl);
 make_udf_function!(pi::PiFunc, PI, pi);
 make_udf_function!(power::PowerFunc, POWER, power);
@@ -79,22 +79,16 @@ make_math_unary_udf!(
     RADIANS,
     radians,
     to_radians,
-    super::radians_monotonicity
+    super::radians_order
 );
 make_udf_function!(random::RandomFunc, RANDOM, random);
 make_udf_function!(round::RoundFunc, ROUND, round);
-make_math_unary_udf!(
-    SignumFunc,
-    SIGNUM,
-    signum,
-    signum,
-    super::signum_monotonicity
-);
-make_math_unary_udf!(SinFunc, SIN, sin, sin, super::sin_monotonicity);
-make_math_unary_udf!(SinhFunc, SINH, sinh, sinh, super::sinh_monotonicity);
-make_math_unary_udf!(SqrtFunc, SQRT, sqrt, sqrt, super::sqrt_monotonicity);
-make_math_unary_udf!(TanFunc, TAN, tan, tan, super::tan_monotonicity);
-make_math_unary_udf!(TanhFunc, TANH, tanh, tanh, super::tanh_monotonicity);
+make_math_unary_udf!(SignumFunc, SIGNUM, signum, signum, super::signum_order);
+make_math_unary_udf!(SinFunc, SIN, sin, sin, super::sin_order);
+make_math_unary_udf!(SinhFunc, SINH, sinh, sinh, super::sinh_order);
+make_math_unary_udf!(SqrtFunc, SQRT, sqrt, sqrt, super::sqrt_order);
+make_math_unary_udf!(TanFunc, TAN, tan, tan, super::tan_order);
+make_math_unary_udf!(TanhFunc, TANH, tanh, tanh, super::tanh_order);
 make_udf_function!(trunc::TruncFunc, TRUNC, trunc);
 
 pub mod expr_fn {

--- a/datafusion/functions/src/math/monotonicity.rs
+++ b/datafusion/functions/src/math/monotonicity.rs
@@ -28,7 +28,7 @@ fn symmetric_unit_interval(data_type: &DataType) -> Result<Interval> {
 }
 
 /// Non-increasing on the interval \[−1, 1\], undefined otherwise.
-pub fn acos_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn acos_order(input: &[ExprProperties]) -> Result<SortProperties> {
     let arg = &input[0];
     let range = &arg.range;
 
@@ -42,7 +42,7 @@ pub fn acos_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
 }
 
 /// Non-decreasing for x ≥ 1, undefined otherwise.
-pub fn acosh_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn acosh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     let arg = &input[0];
     let range = &arg.range;
 
@@ -59,7 +59,7 @@ pub fn acosh_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
 }
 
 /// Non-decreasing on the interval \[−1, 1\], undefined otherwise.
-pub fn asin_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn asin_order(input: &[ExprProperties]) -> Result<SortProperties> {
     let arg = &input[0];
     let range = &arg.range;
 
@@ -73,17 +73,17 @@ pub fn asin_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
 }
 
 /// Non-decreasing for all real numbers.
-pub fn asinh_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn asinh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-decreasing for all real numbers.
-pub fn atan_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn atan_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-decreasing on the interval \[−1, 1\], undefined otherwise.
-pub fn atanh_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn atanh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     let arg = &input[0];
     let range = &arg.range;
 
@@ -96,31 +96,31 @@ pub fn atanh_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-/// Monotonicity depends on the quadrant.
-// TODO: Implement monotonicity of the ATAN2 function.
-pub fn atan2_monotonicity(_input: &[ExprProperties]) -> Result<SortProperties> {
+/// Order depends on the quadrant.
+// TODO: Implement ordering rule of the ATAN2 function.
+pub fn atan2_order(_input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(SortProperties::Unordered)
 }
 
 /// Non-decreasing for all real numbers.
-pub fn cbrt_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn cbrt_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-decreasing for all real numbers.
-pub fn ceil_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn ceil_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-increasing on \[0, π\] and then non-decreasing on \[π, 2π\].
 /// This pattern repeats periodically with a period of 2π.
-// TODO: Implement monotonicity of the ATAN2 function.
-pub fn cos_monotonicity(_input: &[ExprProperties]) -> Result<SortProperties> {
+// TODO: Implement ordering rule of the ATAN2 function.
+pub fn cos_order(_input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(SortProperties::Unordered)
 }
 
 /// Non-decreasing for x ≥ 0 and symmetrically non-increasing for x ≤ 0.
-pub fn cosh_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn cosh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     let arg = &input[0];
     let range = &arg.range;
 
@@ -136,22 +136,22 @@ pub fn cosh_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
 }
 
 /// Non-decreasing function that converts radians to degrees.
-pub fn degrees_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn degrees_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-decreasing for all real numbers.
-pub fn exp_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn exp_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-decreasing for all real numbers.
-pub fn floor_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn floor_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
-pub fn ln_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn ln_order(input: &[ExprProperties]) -> Result<SortProperties> {
     let arg = &input[0];
     let range = &arg.range;
 
@@ -165,7 +165,7 @@ pub fn ln_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
-pub fn log2_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn log2_order(input: &[ExprProperties]) -> Result<SortProperties> {
     let arg = &input[0];
     let range = &arg.range;
 
@@ -179,7 +179,7 @@ pub fn log2_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
-pub fn log10_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn log10_order(input: &[ExprProperties]) -> Result<SortProperties> {
     let arg = &input[0];
     let range = &arg.range;
 
@@ -193,29 +193,29 @@ pub fn log10_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
 }
 
 /// Non-decreasing for all real numbers x.
-pub fn radians_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn radians_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-decreasing for all real numbers x.
-pub fn signum_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn signum_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-decreasing on \[0, π\] and then non-increasing on \[π, 2π\].
 /// This pattern repeats periodically with a period of 2π.
-// TODO: Implement monotonicity of the SIN function.
-pub fn sin_monotonicity(_input: &[ExprProperties]) -> Result<SortProperties> {
+// TODO: Implement ordering rule of the SIN function.
+pub fn sin_order(_input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(SortProperties::Unordered)
 }
 
 /// Non-decreasing for all real numbers.
-pub fn sinh_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn sinh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
-pub fn sqrt_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn sqrt_order(input: &[ExprProperties]) -> Result<SortProperties> {
     let arg = &input[0];
     let range = &arg.range;
 
@@ -230,12 +230,12 @@ pub fn sqrt_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
 
 /// Non-decreasing between vertical asymptotes at x = k * π ± π / 2 for any
 /// integer k.
-// TODO: Implement monotonicity of the TAN function.
-pub fn tan_monotonicity(_input: &[ExprProperties]) -> Result<SortProperties> {
+// TODO: Implement ordering rule of the TAN function.
+pub fn tan_order(_input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(SortProperties::Unordered)
 }
 
 /// Non-decreasing for all real numbers.
-pub fn tanh_monotonicity(input: &[ExprProperties]) -> Result<SortProperties> {
+pub fn tanh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }

--- a/datafusion/functions/src/math/pi.rs
+++ b/datafusion/functions/src/math/pi.rs
@@ -69,7 +69,7 @@ impl ScalarUDFImpl for PiFunc {
         ))))
     }
 
-    fn monotonicity(&self, _input: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, _input: &[ExprProperties]) -> Result<SortProperties> {
         // This function returns a constant value.
         Ok(SortProperties::Singleton)
     }

--- a/datafusion/functions/src/math/round.rs
+++ b/datafusion/functions/src/math/round.rs
@@ -80,7 +80,7 @@ impl ScalarUDFImpl for RoundFunc {
         make_scalar_function(round, vec![])(args)
     }
 
-    fn monotonicity(&self, input: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
         // round preserves the order of the first argument
         let value = &input[0];
         let precision = input.get(1);

--- a/datafusion/functions/src/math/trunc.rs
+++ b/datafusion/functions/src/math/trunc.rs
@@ -86,7 +86,7 @@ impl ScalarUDFImpl for TruncFunc {
         make_scalar_function(trunc, vec![])(args)
     }
 
-    fn monotonicity(&self, input: &[ExprProperties]) -> Result<SortProperties> {
+    fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
         // trunc preserves the order of the first argument
         let value = &input[0];
         let precision = input.get(1);

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -180,7 +180,7 @@ impl PhysicalExpr for ScalarFunctionExpr {
     }
 
     fn get_properties(&self, children: &[ExprProperties]) -> Result<ExprProperties> {
-        let sort_properties = self.fun.monotonicity(children)?;
+        let sort_properties = self.fun.output_ordering(children)?;
         let children_range = children
             .iter()
             .map(|props| &props.range)

--- a/datafusion/physical-expr/src/utils/mod.rs
+++ b/datafusion/physical-expr/src/utils/mod.rs
@@ -308,7 +308,7 @@ pub(crate) mod tests {
             }
         }
 
-        fn monotonicity(&self, input: &[ExprProperties]) -> Result<SortProperties> {
+        fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
             Ok(input[0].sort_properties)
         }
 

--- a/datafusion/physical-plan/src/joins/stream_join_utils.rs
+++ b/datafusion/physical-plan/src/joins/stream_join_utils.rs
@@ -246,7 +246,7 @@ pub fn map_origin_col_to_filter_col(
     Ok(col_to_col_map)
 }
 
-/// This function analyzes [`PhysicalSortExpr`] graphs with respect to monotonicity
+/// This function analyzes [`PhysicalSortExpr`] graphs with respect to output orderings
 /// (sorting) properties. This is necessary since monotonically increasing and/or
 /// decreasing expressions are required when using join filter expressions for
 /// data pruning purposes.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The signature and usage of the monotonicity API have significantly changed. Therefore, we believe that `output_ordering()` better reflects the new approach. https://github.com/apache/datafusion/pull/10504#discussion_r1608069310

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR just renames the `monotonicity()` methods as `output_ordering()` in both `ScalarUDF` and `ScalarUDFImpl`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
