### PR TITLE
add catalog as part of the table path in plan_to_sql

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -512,7 +512,7 @@ mod test {
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_expr::{col, logical_plan::table_scan};
     #[test]
-    fn test_plan_to_sql() {
+    fn test_table_references_in_plan_to_sql() {
         fn test(table_name: &str, expected_sql: &str) {
             let schema = Schema::new(vec![
                 Field::new("id", DataType::Utf8, false),


### PR DESCRIPTION
## Which issue does this PR close?

TableReference has the catalog information but it's not used in `plan_to_sql`

Part of https://github.com/apache/datafusion/issues/9494

## Rationale for this change

It's common for DBMS to have pattern of `[catalog.][schema.]table_name` in SQL statement. E.g. snowflake.

## What changes are included in this PR?

- Add catalog information if it exists in table reference.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No