### PR TITLE
Add support for Substrait List/EmptyList literals

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1283,7 +1283,7 @@ pub(crate) fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
             let elements = l
                 .values
                 .iter()
-                .map(|el| from_substrait_literal(el))
+                .map(from_substrait_literal)
                 .collect::<Result<Vec<_>>>()?;
             let element_type = elements[0].data_type();
             match lit.type_variation_reference {

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1285,6 +1285,11 @@ pub(crate) fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
                 .iter()
                 .map(from_substrait_literal)
                 .collect::<Result<Vec<_>>>()?;
+            if elements.is_empty() {
+                return substrait_err!(
+                    "Empty list must be encoded as EmptyList literal type, not List"
+                );
+            }
             let element_type = elements[0].data_type();
             match lit.type_variation_reference {
                 DEFAULT_CONTAINER_TYPE_REF => ScalarValue::List(ScalarValue::new_list(

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1059,7 +1059,7 @@ pub async fn from_substrait_rex(
     }
 }
 
-fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
+pub(crate) fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
     match &dt.kind {
         Some(s_kind) => match s_kind {
             r#type::Kind::Bool(_) => Ok(DataType::Boolean),

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1397,14 +1397,6 @@ fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
                 d.scale as i8,
             )),
             r#type::Kind::List(l) => {
-                // let field = Field::new_list_field(
-                //     from_substrait_type(l.r#type.clone().unwrap().as_ref())?,
-                //     true,
-                // );
-                // Ok(ScalarValue::List(Arc::new(GenericListArray::new_null(
-                //     field.into(),
-                //     1,
-                // ))))
                 let field = Field::new_list_field(
                     from_substrait_type(l.r#type.clone().unwrap().as_ref())?,
                     true,

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -61,6 +61,7 @@ use substrait::proto::{
 };
 use substrait::proto::{FunctionArgument, SortField};
 
+use datafusion::arrow::array::GenericListArray;
 use datafusion::common::plan_err;
 use datafusion::logical_expr::expr::{InList, InSubquery, Sort};
 use std::collections::HashMap;
@@ -1138,7 +1139,7 @@ fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataType> {
                     from_substrait_type(list.r#type.as_ref().ok_or_else(|| {
                         substrait_datafusion_err!("List type must have inner type")
                     })?)?;
-                let field = Arc::new(Field::new("list_item", inner_type, true));
+                let field = Arc::new(Field::new_list_field(inner_type, true));
                 match list.type_variation_reference {
                     DEFAULT_CONTAINER_TYPE_REF => Ok(DataType::List(field)),
                     LARGE_CONTAINER_TYPE_REF => Ok(DataType::LargeList(field)),
@@ -1278,6 +1279,40 @@ pub(crate) fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
                 s,
             )
         }
+        Some(LiteralType::List(l)) => {
+            let elements = l
+                .values
+                .iter()
+                .map(|el| from_substrait_literal(el))
+                .collect::<Result<Vec<_>>>()?;
+            let element_type = elements[0].data_type();
+            match lit.type_variation_reference {
+                DEFAULT_CONTAINER_TYPE_REF => ScalarValue::List(ScalarValue::new_list(
+                    elements.as_slice(),
+                    &element_type,
+                )),
+                LARGE_CONTAINER_TYPE_REF => ScalarValue::LargeList(
+                    ScalarValue::new_large_list(elements.as_slice(), &element_type),
+                ),
+                others => {
+                    return substrait_err!("Unknown type variation reference {others}");
+                }
+            }
+        }
+        Some(LiteralType::EmptyList(l)) => {
+            let element_type = from_substrait_type(l.r#type.clone().unwrap().as_ref())?;
+            match lit.type_variation_reference {
+                DEFAULT_CONTAINER_TYPE_REF => {
+                    ScalarValue::List(ScalarValue::new_list(&[], &element_type))
+                }
+                LARGE_CONTAINER_TYPE_REF => ScalarValue::LargeList(
+                    ScalarValue::new_large_list(&[], &element_type),
+                ),
+                others => {
+                    return substrait_err!("Unknown type variation reference {others}");
+                }
+            }
+        }
         Some(LiteralType::Null(ntype)) => from_substrait_null(ntype)?,
         _ => return not_impl_err!("Unsupported literal_type: {:?}", lit.literal_type),
     };
@@ -1361,7 +1396,25 @@ fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
                 d.precision as u8,
                 d.scale as i8,
             )),
-            _ => not_impl_err!("Unsupported Substrait type: {kind:?}"),
+            r#type::Kind::List(l) => {
+                // let field = Field::new_list_field(
+                //     from_substrait_type(l.r#type.clone().unwrap().as_ref())?,
+                //     true,
+                // );
+                // Ok(ScalarValue::List(Arc::new(GenericListArray::new_null(
+                //     field.into(),
+                //     1,
+                // ))))
+                let field = Field::new_list_field(
+                    from_substrait_type(l.r#type.clone().unwrap().as_ref())?,
+                    true,
+                );
+                Ok(ScalarValue::List(Arc::new(GenericListArray::new_null(
+                    field.into(),
+                    1,
+                ))))
+            }
+            _ => not_impl_err!("Unsupported Substrait type for null: {kind:?}"),
         }
     } else {
         not_impl_err!("Null type without kind is not supported")

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1401,10 +1401,17 @@ fn from_substrait_null(null_type: &Type) -> Result<ScalarValue> {
                     from_substrait_type(l.r#type.clone().unwrap().as_ref())?,
                     true,
                 );
-                Ok(ScalarValue::List(Arc::new(GenericListArray::new_null(
-                    field.into(),
-                    1,
-                ))))
+                match l.type_variation_reference {
+                    DEFAULT_CONTAINER_TYPE_REF => Ok(ScalarValue::List(Arc::new(
+                        GenericListArray::new_null(field.into(), 1),
+                    ))),
+                    LARGE_CONTAINER_TYPE_REF => Ok(ScalarValue::LargeList(Arc::new(
+                        GenericListArray::new_null(field.into(), 1),
+                    ))),
+                    v => not_impl_err!(
+                        "Unsupported Substrait type variation {v} of type {kind:?}"
+                    ),
+                }
             }
             _ => not_impl_err!("Unsupported Substrait type for null: {kind:?}"),
         }

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -2058,7 +2058,7 @@ fn substrait_field_ref(index: usize) -> Result<Expression> {
 
 #[cfg(test)]
 mod test {
-    use crate::logical_plan::consumer::from_substrait_literal;
+    use crate::logical_plan::consumer::{from_substrait_literal, from_substrait_type};
     use datafusion::arrow::array::GenericListArray;
     use datafusion::arrow::datatypes::Field;
 
@@ -2134,6 +2134,51 @@ mod test {
         let substrait_literal = to_substrait_literal(&scalar)?;
         let roundtrip_scalar = from_substrait_literal(&substrait_literal)?;
         assert_eq!(scalar, roundtrip_scalar);
+        Ok(())
+    }
+
+    #[test]
+    fn round_trip_types() -> Result<()> {
+        round_trip_type(DataType::Boolean)?;
+        round_trip_type(DataType::Int8)?;
+        round_trip_type(DataType::UInt8)?;
+        round_trip_type(DataType::Int16)?;
+        round_trip_type(DataType::UInt16)?;
+        round_trip_type(DataType::Int32)?;
+        round_trip_type(DataType::UInt32)?;
+        round_trip_type(DataType::Int64)?;
+        round_trip_type(DataType::UInt64)?;
+        round_trip_type(DataType::Float32)?;
+        round_trip_type(DataType::Float64)?;
+        round_trip_type(DataType::Timestamp(TimeUnit::Second, None))?;
+        round_trip_type(DataType::Timestamp(TimeUnit::Millisecond, None))?;
+        round_trip_type(DataType::Timestamp(TimeUnit::Microsecond, None))?;
+        round_trip_type(DataType::Timestamp(TimeUnit::Nanosecond, None))?;
+        round_trip_type(DataType::Date32)?;
+        round_trip_type(DataType::Date64)?;
+        round_trip_type(DataType::Binary)?;
+        round_trip_type(DataType::FixedSizeBinary(10))?;
+        round_trip_type(DataType::LargeBinary)?;
+        round_trip_type(DataType::Utf8)?;
+        round_trip_type(DataType::LargeUtf8)?;
+        round_trip_type(DataType::Decimal128(10, 2))?;
+        round_trip_type(DataType::Decimal256(30, 2))?;
+        round_trip_type(DataType::List(
+            Field::new_list_field(DataType::Int32, true).into(),
+        ))?;
+        round_trip_type(DataType::LargeList(
+            Field::new_list_field(DataType::Int32, true).into(),
+        ))?;
+
+        Ok(())
+    }
+
+    fn round_trip_type(dt: DataType) -> Result<()> {
+        println!("Checking round trip of {dt:?}");
+
+        let substrait = to_substrait_type(&dt)?;
+        let roundtrip_dt = from_substrait_type(&substrait)?;
+        assert_eq!(dt, roundtrip_dt);
         Ok(())
     }
 }

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -1772,7 +1772,7 @@ fn convert_array_to_literal_list<T: OffsetSizeTrait>(
         .collect::<Result<Vec<_>>>()?;
 
     if values.is_empty() {
-        let et = match to_substrait_type(&array.data_type())? {
+        let et = match to_substrait_type(array.data_type())? {
             substrait::proto::Type {
                 kind: Some(r#type::Kind::List(lt)),
             } => lt.as_ref().to_owned(),

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -895,12 +895,10 @@ async fn assert_expected_plan(sql: &str, expected_plan_str: &str) -> Result<()> 
     let df = ctx.sql(sql).await?;
     let plan = df.into_optimized_plan()?;
     let proto = to_substrait_plan(&plan, &ctx)?;
-    println!("{proto:#?}");
     let plan2 = from_substrait_plan(&ctx, &proto).await?;
     let plan2 = ctx.state().optimize(&plan2)?;
     let plan2str = format!("{plan2:?}");
     assert_eq!(expected_plan_str, &plan2str);
-    ctx.execute_logical_plan(plan2).await?.show().await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

Extracted part of #10531 - not necessary part for it but somewhat related

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Adds support for converting from DataFusion List/LargeList ScalarValues into Substrait List/EmptyList Literals and back

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->



## Are these changes tested?

Adds a round-trip unit test

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

More things are now supported, but I don't think Substrait support status is covered by documentation currently?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
