### PR TITLE
Add support for Substrait Struct literals and type

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1160,6 +1160,15 @@ pub(crate) fn from_substrait_type(dt: &substrait::proto::Type) -> Result<DataTyp
                     "Unsupported Substrait type variation {v} of type {s_kind:?}"
                 ),
             },
+            r#type::Kind::Struct(s) => {
+                let mut fields = vec![];
+                for (i, f) in s.types.iter().enumerate() {
+                    let field =
+                        Field::new(&format!("c{i}"), from_substrait_type(f)?, true);
+                    fields.push(field);
+                }
+                Ok(DataType::Struct(fields.into()))
+            }
             _ => not_impl_err!("Unsupported Substrait type: {s_kind:?}"),
         },
         _ => not_impl_err!("`None` Substrait kind is not supported"),

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -2141,12 +2141,14 @@ mod test {
             ),
         )))?;
 
-        let struct_field_1 = Field::new("c0", DataType::Boolean, true);
-        let struct_field_2 = Field::new("c1", DataType::Int32, true);
+        let c0 = Field::new("c0", DataType::Boolean, true);
+        let c1 = Field::new("c1", DataType::Int32, true);
+        let c2 = Field::new("c2", DataType::Utf8, true);
         round_trip_literal(
             ScalarStructBuilder::new()
-                .with_scalar(struct_field_1, ScalarValue::Boolean(Some(true)))
-                .with_scalar(struct_field_2, ScalarValue::Int32(Some(1)))
+                .with_scalar(c0, ScalarValue::Boolean(Some(true)))
+                .with_scalar(c1, ScalarValue::Int32(Some(1)))
+                .with_scalar(c2, ScalarValue::Utf8(None))
                 .build()?,
         )?;
 

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -2194,6 +2194,13 @@ mod test {
         round_trip_type(DataType::LargeList(
             Field::new_list_field(DataType::Int32, true).into(),
         ))?;
+        round_trip_type(DataType::Struct(
+            vec![
+                Field::new("c0", DataType::Int32, true),
+                Field::new("c1", DataType::Utf8, true),
+            ]
+                .into(),
+        ))?;
 
         Ok(())
     }

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -2199,7 +2199,7 @@ mod test {
                 Field::new("c0", DataType::Int32, true),
                 Field::new("c1", DataType::Utf8, true),
             ]
-                .into(),
+            .into(),
         ))?;
 
         Ok(())

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -675,6 +675,16 @@ async fn roundtrip_literal_list() -> Result<()> {
     .await
 }
 
+#[tokio::test]
+async fn roundtrip_literal_struct() -> Result<()> {
+    assert_expected_plan(
+        "SELECT STRUCT(1, true, CAST(NULL AS STRING)) FROM data",
+        "Projection: Struct({c0:1,c1:true,c2:})\
+        \n  TableScan: data projection=[]",
+    )
+    .await
+}
+
 /// Construct a plan that cast columns. Only those SQL types are supported for now.
 #[tokio::test]
 async fn new_test_grammar() -> Result<()> {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

Extracted part of https://github.com/apache/datafusion/pull/10531 - not necessary part for it but somewhat related

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Adds support for converting from un-named DataFusion Struct ScalarValues into Substrait Struct Literals and back, as well as converting from Substrait Struct type into DF Struct type (other direction already existed).

Substrait doesn't contain names in its Struct fields. For e.g. initial schema, the names are provided separately. This PR only properly supports un-named structs - which in DataFusion get default field names of form "c0", "c1", ... Other structs can also be converted but they'll be renamed automatically into the default names.

The VirtualTable PR will then provide better support for named structs.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Adds round-trip unit tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

More things are now supported, but I don't think Substrait support status is covered by documentation currently?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
