### PR TITLE
Fix broken build/test from merge

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -141,7 +141,8 @@ impl Unparser<'_> {
                 let mut builder = TableRelationBuilder::default();
                 let mut table_parts = vec![];
                 if let Some(catalog_name) = scan.table_name.catalog() {
-                    table_parts.push(self.new_ident(catalog_name.to_string()));
+                    table_parts
+                        .push(self.new_ident_quoted_if_needs(catalog_name.to_string()));
                 }
                 if let Some(schema_name) = scan.table_name.schema() {
                     table_parts

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -515,35 +515,3 @@ impl From<BuilderError> for DataFusionError {
         DataFusionError::External(Box::new(e))
     }
 }
-
-#[cfg(test)]
-mod test {
-    use crate::unparser::plan_to_sql;
-    use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_expr::{col, logical_plan::table_scan};
-    #[test]
-    fn test_table_references_in_plan_to_sql() {
-        fn test(table_name: &str, expected_sql: &str) {
-            let schema = Schema::new(vec![
-                Field::new("id", DataType::Utf8, false),
-                Field::new("value", DataType::Utf8, false),
-            ]);
-            let plan = table_scan(Some(table_name), &schema, None)
-                .unwrap()
-                .project(vec![col("id"), col("value")])
-                .unwrap()
-                .build()
-                .unwrap();
-            let sql = plan_to_sql(&plan).unwrap();
-
-            assert_eq!(format!("{}", sql), expected_sql)
-        }
-
-        test("catalog.schema.table", "SELECT \"catalog\".\"schema\".\"table\".\"id\", \"catalog\".\"schema\".\"table\".\"value\" FROM \"catalog\".\"schema\".\"table\"");
-        test("schema.table", "SELECT \"schema\".\"table\".\"id\", \"schema\".\"table\".\"value\" FROM \"schema\".\"table\"");
-        test(
-            "table",
-            "SELECT \"table\".\"id\", \"table\".\"value\" FROM \"table\"",
-        );
-    }
-}


### PR DESCRIPTION
## Which issue does this PR close?

Fixes a merge issue that resulted in a broken build/test.

## Rationale for this change

We should have working builds and tests!

## What changes are included in this PR?

Moves the test `test_table_references_in_plan_to_sql` to where the rest of the `plan_to_sql` tests are for now. Also fixes a merge issue between https://github.com/apache/datafusion/commit/7757d63432c92bc49e76e0b50f83aeb1acbfba60 and https://github.com/apache/datafusion/commit/7bd4b53ffa12589340e4d7b4cf70df11f3403865

## Are these changes tested?

Yes

## Are there any user-facing changes?

No