### PR TITLE
Update cli Dockerfile to a newer ubuntu release, newer rust release

### DIFF
--- a/datafusion-cli/Dockerfile
+++ b/datafusion-cli/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.73-bullseye as builder
+FROM rust:1.78-bookworm as builder
 
 COPY . /usr/src/arrow-datafusion
 COPY ./datafusion /usr/src/arrow-datafusion/datafusion
@@ -28,7 +28,7 @@ RUN rustup component add rustfmt
 
 RUN cargo build --release
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY --from=builder /usr/src/arrow-datafusion/datafusion-cli/target/release/datafusion-cli /usr/local/bin
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10472

## Rationale for this change

The current Dockerfile is based on a pretty old ubuntu release which doesn't build when run on a newer ubuntu release. I can see no good reason why the cli should be built using old ubuntu and rust versions.

## What changes are included in this PR?

Dockerfile update.

## Are these changes tested?

Built and tested locally on wsl2/ubuntyu 22.04.4


## Are there any user-facing changes?

No