### PR TITLE
Simplify `ParquetExec::new()`

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -258,12 +258,11 @@ impl FileFormat for ParquetFormat {
         // will not prune data based on the statistics.
         let predicate = self.enable_pruning().then(|| filters.cloned()).flatten();
 
-        Ok(Arc::new(ParquetExec::new(
-            conf,
-            predicate,
-            self.metadata_size_hint(),
-            self.options.clone(),
-        )))
+        Ok(Arc::new(
+            ParquetExec::new_with_options(conf, self.options.clone())
+                .with_predicate(predicate)
+                .with_metadata_size_hint(self.metadata_size_hint()),
+        ))
     }
 
     async fn create_writer_physical_plan(

--- a/datafusion/core/src/physical_optimizer/combine_partial_final_agg.rs
+++ b/datafusion/core/src/physical_optimizer/combine_partial_final_agg.rs
@@ -245,21 +245,16 @@ mod tests {
     }
 
     fn parquet_exec(schema: &SchemaRef) -> Arc<ParquetExec> {
-        Arc::new(ParquetExec::new(
-            FileScanConfig {
-                object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
-                file_schema: schema.clone(),
-                file_groups: vec![vec![PartitionedFile::new("x".to_string(), 100)]],
-                statistics: Statistics::new_unknown(schema),
-                projection: None,
-                limit: None,
-                table_partition_cols: vec![],
-                output_ordering: vec![],
-            },
-            None,
-            None,
-            Default::default(),
-        ))
+        Arc::new(ParquetExec::new(FileScanConfig {
+            object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
+            file_schema: schema.clone(),
+            file_groups: vec![vec![PartitionedFile::new("x".to_string(), 100)]],
+            statistics: Statistics::new_unknown(schema),
+            projection: None,
+            limit: None,
+            table_partition_cols: vec![],
+            output_ordering: vec![],
+        }))
     }
 
     fn partial_aggregate_exec(

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -1431,21 +1431,16 @@ pub(crate) mod tests {
     pub(crate) fn parquet_exec_with_sort(
         output_ordering: Vec<Vec<PhysicalSortExpr>>,
     ) -> Arc<ParquetExec> {
-        Arc::new(ParquetExec::new(
-            FileScanConfig {
-                object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
-                file_schema: schema(),
-                file_groups: vec![vec![PartitionedFile::new("x".to_string(), 100)]],
-                statistics: Statistics::new_unknown(&schema()),
-                projection: None,
-                limit: None,
-                table_partition_cols: vec![],
-                output_ordering,
-            },
-            None,
-            None,
-            Default::default(),
-        ))
+        Arc::new(ParquetExec::new(FileScanConfig {
+            object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
+            file_schema: schema(),
+            file_groups: vec![vec![PartitionedFile::new("x".to_string(), 100)]],
+            statistics: Statistics::new_unknown(&schema()),
+            projection: None,
+            limit: None,
+            table_partition_cols: vec![],
+            output_ordering,
+        }))
     }
 
     fn parquet_exec_multiple() -> Arc<ParquetExec> {
@@ -1456,24 +1451,19 @@ pub(crate) mod tests {
     fn parquet_exec_multiple_sorted(
         output_ordering: Vec<Vec<PhysicalSortExpr>>,
     ) -> Arc<ParquetExec> {
-        Arc::new(ParquetExec::new(
-            FileScanConfig {
-                object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
-                file_schema: schema(),
-                file_groups: vec![
-                    vec![PartitionedFile::new("x".to_string(), 100)],
-                    vec![PartitionedFile::new("y".to_string(), 100)],
-                ],
-                statistics: Statistics::new_unknown(&schema()),
-                projection: None,
-                limit: None,
-                table_partition_cols: vec![],
-                output_ordering,
-            },
-            None,
-            None,
-            Default::default(),
-        ))
+        Arc::new(ParquetExec::new(FileScanConfig {
+            object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
+            file_schema: schema(),
+            file_groups: vec![
+                vec![PartitionedFile::new("x".to_string(), 100)],
+                vec![PartitionedFile::new("y".to_string(), 100)],
+            ],
+            statistics: Statistics::new_unknown(&schema()),
+            projection: None,
+            limit: None,
+            table_partition_cols: vec![],
+            output_ordering,
+        }))
     }
 
     fn csv_exec() -> Arc<CsvExec> {

--- a/datafusion/core/src/physical_optimizer/test_utils.rs
+++ b/datafusion/core/src/physical_optimizer/test_utils.rs
@@ -274,21 +274,16 @@ pub fn sort_preserving_merge_exec(
 
 /// Create a non sorted parquet exec
 pub fn parquet_exec(schema: &SchemaRef) -> Arc<ParquetExec> {
-    Arc::new(ParquetExec::new(
-        FileScanConfig {
-            object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
-            file_schema: schema.clone(),
-            file_groups: vec![vec![PartitionedFile::new("x".to_string(), 100)]],
-            statistics: Statistics::new_unknown(schema),
-            projection: None,
-            limit: None,
-            table_partition_cols: vec![],
-            output_ordering: vec![],
-        },
-        None,
-        None,
-        Default::default(),
-    ))
+    Arc::new(ParquetExec::new(FileScanConfig {
+        object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
+        file_schema: schema.clone(),
+        file_groups: vec![vec![PartitionedFile::new("x".to_string(), 100)]],
+        statistics: Statistics::new_unknown(schema),
+        projection: None,
+        limit: None,
+        table_partition_cols: vec![],
+        output_ordering: vec![],
+    }))
 }
 
 // Created a sorted parquet exec
@@ -298,21 +293,16 @@ pub fn parquet_exec_sorted(
 ) -> Arc<dyn ExecutionPlan> {
     let sort_exprs = sort_exprs.into_iter().collect();
 
-    Arc::new(ParquetExec::new(
-        FileScanConfig {
-            object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
-            file_schema: schema.clone(),
-            file_groups: vec![vec![PartitionedFile::new("x".to_string(), 100)]],
-            statistics: Statistics::new_unknown(schema),
-            projection: None,
-            limit: None,
-            table_partition_cols: vec![],
-            output_ordering: vec![sort_exprs],
-        },
-        None,
-        None,
-        Default::default(),
-    ))
+    Arc::new(ParquetExec::new(FileScanConfig {
+        object_store_url: ObjectStoreUrl::parse("test:///").unwrap(),
+        file_schema: schema.clone(),
+        file_groups: vec![vec![PartitionedFile::new("x".to_string(), 100)]],
+        statistics: Statistics::new_unknown(schema),
+        projection: None,
+        limit: None,
+        table_partition_cols: vec![],
+        output_ordering: vec![sort_exprs],
+    }))
 }
 
 pub fn union_exec(input: Vec<Arc<dyn ExecutionPlan>>) -> Arc<dyn ExecutionPlan> {

--- a/datafusion/core/src/test_util/parquet.rs
+++ b/datafusion/core/src/test_util/parquet.rs
@@ -172,20 +172,16 @@ impl TestParquetFile {
             let filter = simplifier.coerce(filter, &df_schema).unwrap();
             let physical_filter_expr =
                 create_physical_expr(&filter, &df_schema, &ExecutionProps::default())?;
-            let parquet_exec = Arc::new(ParquetExec::new(
-                scan_config,
-                Some(physical_filter_expr.clone()),
-                None,
-                parquet_options,
-            ));
+            let parquet_exec = Arc::new(
+                ParquetExec::new_with_options(scan_config, parquet_options)
+                    .with_predicate(Some(physical_filter_expr.clone())),
+            );
 
             let exec = Arc::new(FilterExec::try_new(physical_filter_expr, parquet_exec)?);
             Ok(exec)
         } else {
-            Ok(Arc::new(ParquetExec::new(
+            Ok(Arc::new(ParquetExec::new_with_options(
                 scan_config,
-                None,
-                None,
                 parquet_options,
             )))
         }


### PR DESCRIPTION
## Which issue does this PR close?

Part of #10546

## Rationale for this change

While working on https://github.com/apache/datafusion/pull/10549 it was cumbersome
to create a `ParquetExec` -- specifically there are a few fields on `ParquetExec::new` that
must always be provided even though they are `Option`s and most of the rest of the options can be set via builder style
APIs like `with_schema_adapter_factory`

In addition, some fields like `schema_adapter_factory` can not be set by constructor but are instead set
by builder function `with_schema_adapater_factor`. 

Thus it is confusing and imposes a cognitive load that the properties setting is inconsistent.


## What changes are included in this PR?

1. Remove all arguments except FileScanConfig from `ParquetExec::new`
2. Add builder style APIs
2. Improve documentation
2. Add examples

## Are these changes tested?
Yes by existing CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
This is a user API change for anyone who creates ParquetExec's directly (as we do in InfluxDB IOx for example)

There is also better documentation
