### PR TITLE
Support consuming Substrait with compound signature function names

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -39,7 +39,6 @@ itertools = { workspace = true }
 object_store = { workspace = true }
 pbjson-types = "0.6"
 prost = "0.12"
-prost-types = "0.12"
 substrait = { version = "0.34.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -37,11 +37,13 @@ chrono = { workspace = true }
 datafusion = { workspace = true, default-features = true }
 itertools = { workspace = true }
 object_store = { workspace = true }
+pbjson-types = "0.6"
 prost = "0.12"
 prost-types = "0.12"
-substrait = "0.34.0"
+substrait = { version = "0.34.0", features = ["serde"] }
 
 [dev-dependencies]
+serde_json = "1.0"
 tokio = { workspace = true }
 
 [features]

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -122,7 +122,7 @@ fn scalar_function_type_from_str(
     name: &str,
 ) -> Result<ScalarFunctionType> {
     let s = ctx.state();
-    let name = match name.rsplit_once(":") {
+    let name = match name.rsplit_once(':') {
         // Since 0.32.0, Substrait requires the function names to be in a compound format
         // https://substrait.io/extensions/#function-signature-compound-names
         // On the consumer side, we don't really care about the signature though, just the name.

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -122,6 +122,14 @@ fn scalar_function_type_from_str(
     name: &str,
 ) -> Result<ScalarFunctionType> {
     let s = ctx.state();
+    let name = match name.rsplit_once(":") {
+        // Since 0.32.0, Substrait requires the function names to be in a compound format
+        // https://substrait.io/extensions/#function-signature-compound-names
+        // On the consumer side, we don't really care about the signature though, just the name.
+        Some((name, _)) => name,
+        None => name,
+    };
+
     if let Some(func) = s.scalar_functions().get(name) {
         return Ok(ScalarFunctionType::Udf(func.to_owned()));
     }

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -125,6 +125,7 @@ fn scalar_function_type_from_str(
     let name = match name.rsplit_once(':') {
         // Since 0.32.0, Substrait requires the function names to be in a compound format
         // https://substrait.io/extensions/#function-signature-compound-names
+        // for example, `add:i8_i8`.
         // On the consumer side, we don't really care about the signature though, just the name.
         Some((name, _)) => name,
         None => name,

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1422,7 +1422,7 @@ pub(crate) fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
                         return substrait_err!("Interval year month value is empty");
                     };
                     let value_slice: [u8; 4] =
-                        raw_val.value.clone().try_into().map_err(|_| {
+                        (*raw_val.value).try_into().map_err(|_| {
                             substrait_datafusion_err!(
                                 "Failed to parse interval year month value"
                             )
@@ -1434,7 +1434,7 @@ pub(crate) fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
                         return substrait_err!("Interval day time value is empty");
                     };
                     let value_slice: [u8; 8] =
-                        raw_val.value.clone().try_into().map_err(|_| {
+                        (*raw_val.value).try_into().map_err(|_| {
                             substrait_datafusion_err!(
                                 "Failed to parse interval day time value"
                             )
@@ -1446,7 +1446,7 @@ pub(crate) fn from_substrait_literal(lit: &Literal) -> Result<ScalarValue> {
                         return substrait_err!("Interval month day nano value is empty");
                     };
                     let value_slice: [u8; 16] =
-                        raw_val.value.clone().try_into().map_err(|_| {
+                        (*raw_val.value).try_into().map_err(|_| {
                             substrait_datafusion_err!(
                                 "Failed to parse interval month day nano value"
                             )

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -42,7 +42,7 @@ use datafusion::logical_expr::expr::{
 };
 use datafusion::logical_expr::{expr, Between, JoinConstraint, LogicalPlan, Operator};
 use datafusion::prelude::Expr;
-use prost_types::Any as ProtoAny;
+use pbjson_types::Any as ProtoAny;
 use substrait::proto::exchange_rel::{ExchangeKind, RoundRobin, ScatterFields};
 use substrait::proto::expression::literal::user_defined::Val;
 use substrait::proto::expression::literal::UserDefined;
@@ -487,7 +487,7 @@ pub fn to_substrait_rel(
                 .serialize_logical_plan(extension_plan.node.as_ref())?;
             let detail = ProtoAny {
                 type_url: extension_plan.node.name().to_string(),
-                value: extension_bytes,
+                value: extension_bytes.into(),
             };
             let mut inputs_rel = extension_plan
                 .node
@@ -1802,7 +1802,7 @@ fn to_substrait_literal(value: &ScalarValue) -> Result<Literal> {
                     }],
                     val: Some(Val::Value(ProtoAny {
                         type_url: INTERVAL_YEAR_MONTH_TYPE_URL.to_string(),
-                        value: bytes.to_vec(),
+                        value: bytes.to_vec().into(),
                     })),
                 }),
                 INTERVAL_YEAR_MONTH_TYPE_REF,
@@ -1825,7 +1825,7 @@ fn to_substrait_literal(value: &ScalarValue) -> Result<Literal> {
                     type_parameters: vec![i64_param.clone(), i64_param],
                     val: Some(Val::Value(ProtoAny {
                         type_url: INTERVAL_MONTH_DAY_NANO_TYPE_URL.to_string(),
-                        value: bytes.to_vec(),
+                        value: bytes.to_vec().into(),
                     })),
                 }),
                 INTERVAL_MONTH_DAY_NANO_TYPE_REF,
@@ -1848,7 +1848,7 @@ fn to_substrait_literal(value: &ScalarValue) -> Result<Literal> {
                     }],
                     val: Some(Val::Value(ProtoAny {
                         type_url: INTERVAL_DAY_TIME_TYPE_URL.to_string(),
-                        value: bytes.to_vec(),
+                        value: bytes.to_vec().into(),
                     })),
                 }),
                 INTERVAL_DAY_TIME_TYPE_REF,

--- a/datafusion/substrait/tests/cases/logical_plans.rs
+++ b/datafusion/substrait/tests/cases/logical_plans.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Tests for reading substrait plans produced by other systems
+
 #[cfg(test)]
 mod tests {
     use datafusion::common::Result;

--- a/datafusion/substrait/tests/cases/logical_plans.rs
+++ b/datafusion/substrait/tests/cases/logical_plans.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #[cfg(test)]
 mod tests {
     use datafusion::common::Result;

--- a/datafusion/substrait/tests/cases/logical_plans.rs
+++ b/datafusion/substrait/tests/cases/logical_plans.rs
@@ -1,0 +1,44 @@
+#[cfg(test)]
+mod tests {
+    use datafusion::common::Result;
+    use datafusion::prelude::{CsvReadOptions, SessionContext};
+    use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
+    use std::fs::File;
+    use std::io::BufReader;
+    use substrait::proto::Plan;
+
+    #[tokio::test]
+    async fn function_compound_signature() -> Result<()> {
+        // DataFusion currently produces Substrait that refers to functions only by their name.
+        // However, the Substrait spec requires that functions be identified by their compound signature.
+        // This test confirms that DataFusion is able to consume plans following the spec, even though
+        // we don't yet produce such plans.
+        // Once we start producing plans with compound signatures, this test can be replaced by the roundtrip tests.
+
+        let ctx = create_context().await?;
+
+        // File generated with substrait-java's Isthmus:
+        // ./isthmus-cli/build/graal/isthmus "select not d from data" -c "create table data (d boolean)"
+        let path = "tests/testdata/select_not_bool.substrait.json";
+        let proto = serde_json::from_reader::<_, Plan>(BufReader::new(
+            File::open(path).expect("file not found"),
+        ))
+        .expect("failed to parse json");
+
+        let plan = from_substrait_plan(&ctx, &proto).await?;
+
+        assert_eq!(
+            format!("{:?}", plan),
+            "Projection: NOT DATA.a\
+            \n  TableScan: DATA projection=[a, b, c, d, e, f]"
+        );
+        Ok(())
+    }
+
+    async fn create_context() -> datafusion::common::Result<SessionContext> {
+        let ctx = SessionContext::new();
+        ctx.register_csv("DATA", "tests/testdata/data.csv", CsvReadOptions::new())
+            .await?;
+        Ok(ctx)
+    }
+}

--- a/datafusion/substrait/tests/cases/mod.rs
+++ b/datafusion/substrait/tests/cases/mod.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+mod logical_plans;
 mod roundtrip_logical_plan;
 mod roundtrip_physical_plan;
 mod serialize;

--- a/datafusion/substrait/tests/testdata/select_not_bool.substrait.json
+++ b/datafusion/substrait/tests/testdata/select_not_bool.substrait.json
@@ -1,0 +1,98 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_boolean.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 0,
+        "name": "not:bool"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  1
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {
+                  }
+                },
+                "baseSchema": {
+                  "names": [
+                    "D"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "bool": {
+                          "typeVariationReference": 0,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "typeVariationReference": 0,
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "DATA"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 0,
+                  "args": [],
+                  "outputType": {
+                    "bool": {
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 0
+                            }
+                          },
+                          "rootReference": {
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "options": []
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "EXPR$0"
+        ]
+      }
+    }
+  ],
+  "expectedTypeUrls": []
+}


### PR DESCRIPTION
Substrait 0.32.0+ requires functions to be specified using compound names, which include the function name as well as the arguments it takes. We don't necessarily need that information while consuming the plans, but we need to support those compound names.

## Which issue does this PR close?

Closes #10412, but doesn't fix the part where DataFusion _generates_ those outdated simple names. But that's a bit bigger fix - this small thing would be enough to unblock me if it'd be okay to merge this before fixing the producer side. 

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


## Rationale for this change

See issue.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

When consuming Substrait, checks if given function names are compound names, if so strips the arguments part.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Tested manually, but will still need to add unit tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
