### PR TITLE
Fix typo in Cargo.toml (unused manifest key: dependencies.regex.worksapce)

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -80,7 +80,7 @@ itertools = { workspace = true }
 log = { workspace = true }
 md-5 = { version = "^0.10.0", optional = true }
 rand = { workspace = true }
-regex = { worksapce = true, optional = true }
+regex = { workspace = true, optional = true }
 sha2 = { version = "^0.10.1", optional = true }
 unicode-segmentation = { version = "^1.7.1", optional = true }
 uuid = { version = "1.7", features = ["v4"], optional = true }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

When running `cargo build` locally I see

```
warning: /Users/andrewlamb/Software/datafusion/datafusion/functions/Cargo.toml: dependency (regex) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
warning: /Users/andrewlamb/Software/datafusion/datafusion/functions/Cargo.toml: unused manifest key: dependencies.regex.worksapce
```

I think this is due to a typo introduced in #10573

## What changes are included in this PR?

Fix typo
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
