### PR TITLE
Minor: Use slice in `ConcreteTreeNode`

### DIFF
--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -903,7 +903,7 @@ impl<T: DynTreeNode + ?Sized> TreeNode for Arc<T> {
 /// involving payloads, by enforcing rules for detaching and reattaching child nodes.
 pub trait ConcreteTreeNode: Sized {
     /// Provides read-only access to child nodes.
-    fn children(&self) -> Vec<&Self>;
+    fn children(&self) -> &[Self];
 
     /// Detaches the node from its children, returning the node itself and its detached children.
     fn take_children(self) -> (Self, Vec<Self>);
@@ -917,7 +917,7 @@ impl<T: ConcreteTreeNode> TreeNode for T {
         &self,
         f: F,
     ) -> Result<TreeNodeRecursion> {
-        self.children().into_iter().apply_until_stop(f)
+        self.children().iter().apply_until_stop(f)
     }
 
     fn map_children<F: FnMut(Self) -> Result<Transformed<Self>>>(

--- a/datafusion/physical-expr-common/src/tree_node.rs
+++ b/datafusion/physical-expr-common/src/tree_node.rs
@@ -84,8 +84,8 @@ impl<T: Display> Display for ExprContext<T> {
 }
 
 impl<T> ConcreteTreeNode for ExprContext<T> {
-    fn children(&self) -> Vec<&Self> {
-        self.children.iter().collect()
+    fn children(&self) -> &[Self] {
+        &self.children
     }
 
     fn take_children(mut self) -> (Self, Vec<Self>) {

--- a/datafusion/physical-plan/src/tree_node.rs
+++ b/datafusion/physical-plan/src/tree_node.rs
@@ -86,8 +86,8 @@ impl<T: Display> Display for PlanContext<T> {
 }
 
 impl<T> ConcreteTreeNode for PlanContext<T> {
-    fn children(&self) -> Vec<&Self> {
-        self.children.iter().collect()
+    fn children(&self) -> &[Self] {
+        &self.children
     }
 
     fn take_children(mut self) -> (Self, Vec<Self>) {


### PR DESCRIPTION
The idea of using slices to return a node's children came up here: https://github.com/apache/datafusion/pull/10543#discussion_r1614057653.
While it is not possible in all `TreeNode` implementations, the 2 `ConcreteTreeNode` implementations (`ExprContext` and `PlanContext`) own their children in `Vec` form, so there is a way to return a slice like `&[Self]` (instead of the current `Vec<&Self>`).