### PR TITLE
Fix compilation "comparison_binary_numeric_coercion not found"

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -30,7 +30,7 @@ use datafusion_common::{
     exec_err, internal_datafusion_err, internal_err, plan_err, Result,
 };
 
-use super::binary::comparison_coercion;
+use super::binary::{binary_numeric_coercion, comparison_coercion};
 
 /// Performs type coercion for scalar function arguments.
 ///
@@ -332,9 +332,7 @@ fn get_valid_types(
 
             let mut valid_type = current_types.first().unwrap().clone();
             for t in current_types.iter().skip(1) {
-                if let Some(coerced_type) =
-                    comparison_binary_numeric_coercion(&valid_type, t)
-                {
+                if let Some(coerced_type) = binary_numeric_coercion(&valid_type, t) {
                     valid_type = coerced_type;
                 } else {
                     return plan_err!(


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change

There was a logical conflict between https://github.com/apache/datafusion/pull/10644 and https://github.com/apache/datafusion/pull/10268

## What changes are included in this PR?

Fix conflict and compile

## Are these changes tested?
CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
