### PR TITLE
minor: inconsistent group by position planning

### DIFF
--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -131,7 +131,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 //
                 //   SELECT c1, MAX(c2) AS m FROM t GROUP BY c1 HAVING MAX(c2) > 10;
                 //
-                let having_expr = resolve_aliases_to_exprs(&having_expr, &alias_map)?;
+                let having_expr = resolve_aliases_to_exprs(having_expr, &alias_map)?;
                 normalize_col(having_expr, &projected_plan)
             })
             .transpose()?;
@@ -163,10 +163,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         alias_map.remove(f.name());
                     }
                     let group_by_expr =
-                        resolve_aliases_to_exprs(&group_by_expr, &alias_map)?;
+                        resolve_aliases_to_exprs(group_by_expr, &alias_map)?;
                     let group_by_expr =
-                        resolve_positions_to_exprs(&group_by_expr, &select_exprs)
-                            .unwrap_or(group_by_expr);
+                        resolve_positions_to_exprs(group_by_expr, &select_exprs)?;
                     let group_by_expr = normalize_col(group_by_expr, &projected_plan)?;
                     self.validate_schema_satisfies_exprs(
                         base_plan.schema(),

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -170,7 +170,8 @@ pub(crate) fn resolve_positions_to_exprs(
             })
         }
         Expr::Literal(ScalarValue::Int64(Some(position))) => plan_err!(
-            "Cannot find column with position {} in SELECT clause",
+            "Cannot find column with position {} in SELECT clause. Valid columns: 1 to {}",
+            select_exprs.len()
             position
         ),
         _ => Ok(expr),

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -171,8 +171,7 @@ pub(crate) fn resolve_positions_to_exprs(
         }
         Expr::Literal(ScalarValue::Int64(Some(position))) => plan_err!(
             "Cannot find column with position {} in SELECT clause. Valid columns: 1 to {}",
-            select_exprs.len()
-            position
+            position, select_exprs.len()
         ),
         _ => Ok(expr),
     }
@@ -453,12 +452,14 @@ mod tests {
 
         // Assert error if index out of select clause bounds
         let resolved = resolve_positions_to_exprs(lit(-1i64), &select_exprs);
-        assert!(resolved
-            .is_err_and(|e| e.message().contains("Cannot find column with position -1")));
+        assert!(resolved.is_err_and(|e| e.message().contains(
+            "Cannot find column with position -1 in SELECT clause. Valid columns: 1 to 3"
+        )));
 
         let resolved = resolve_positions_to_exprs(lit(5i64), &select_exprs);
-        assert!(resolved
-            .is_err_and(|e| e.message().contains("Cannot find column with position 5")));
+        assert!(resolved.is_err_and(|e| e.message().contains(
+            "Cannot find column with position 5 in SELECT clause. Valid columns: 1 to 3"
+        )));
 
         // Assert expression returned as-is
         let resolved = resolve_positions_to_exprs(lit("text"), &select_exprs)?;

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -149,47 +149,51 @@ pub(crate) fn extract_aliases(exprs: &[Expr]) -> HashMap<String, Expr> {
 }
 
 /// Given an expression that's literal int encoding position, lookup the corresponding expression
-/// in the select_exprs list, if the index is within the bounds and it is indeed a position literal;
-/// Otherwise, return None
+/// in the select_exprs list, if the index is within the bounds and it is indeed a position literal,
+/// otherwise, returns planning error.
+/// If input expression is not an int literal, returns expression as-is.
 pub(crate) fn resolve_positions_to_exprs(
-    expr: &Expr,
+    expr: Expr,
     select_exprs: &[Expr],
-) -> Option<Expr> {
+) -> Result<Expr> {
     match expr {
         // sql_expr_to_logical_expr maps number to i64
         // https://github.com/apache/datafusion/blob/8d175c759e17190980f270b5894348dc4cff9bbf/datafusion/src/sql/planner.rs#L882-L887
         Expr::Literal(ScalarValue::Int64(Some(position)))
-            if position > &0_i64 && position <= &(select_exprs.len() as i64) =>
+            if position > 0_i64 && position <= select_exprs.len() as i64 =>
         {
             let index = (position - 1) as usize;
             let select_expr = &select_exprs[index];
-            Some(match select_expr {
+            Ok(match select_expr {
                 Expr::Alias(Alias { expr, .. }) => *expr.clone(),
                 _ => select_expr.clone(),
             })
         }
-        _ => None,
+        Expr::Literal(ScalarValue::Int64(Some(position))) => plan_err!(
+            "Cannot find column with position {} in SELECT clause",
+            position
+        ),
+        _ => Ok(expr),
     }
 }
 
 /// Rebuilds an `Expr` with columns that refer to aliases replaced by the
 /// alias' underlying `Expr`.
 pub(crate) fn resolve_aliases_to_exprs(
-    expr: &Expr,
+    expr: Expr,
     aliases: &HashMap<String, Expr>,
 ) -> Result<Expr> {
-    expr.clone()
-        .transform_up(|nested_expr| match nested_expr {
-            Expr::Column(c) if c.relation.is_none() => {
-                if let Some(aliased_expr) = aliases.get(&c.name) {
-                    Ok(Transformed::yes(aliased_expr.clone()))
-                } else {
-                    Ok(Transformed::no(Expr::Column(c)))
-                }
+    expr.transform_up(|nested_expr| match nested_expr {
+        Expr::Column(c) if c.relation.is_none() => {
+            if let Some(aliased_expr) = aliases.get(&c.name) {
+                Ok(Transformed::yes(aliased_expr.clone()))
+            } else {
+                Ok(Transformed::no(Expr::Column(c)))
             }
-            _ => Ok(Transformed::no(nested_expr)),
-        })
-        .data()
+        }
+        _ => Ok(Transformed::no(nested_expr)),
+    })
+    .data()
 }
 
 /// given a slice of window expressions sharing the same sort key, find their common partition
@@ -346,9 +350,9 @@ mod tests {
     use arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
     use arrow_schema::Fields;
     use datafusion_common::{DFSchema, Result};
-    use datafusion_expr::{col, lit, unnest, EmptyRelation, LogicalPlan};
+    use datafusion_expr::{col, count, lit, unnest, EmptyRelation, LogicalPlan};
 
-    use crate::utils::recursive_transform_unnest;
+    use crate::utils::{recursive_transform_unnest, resolve_positions_to_exprs};
 
     #[test]
     fn test_recursive_transform_unnest() -> Result<()> {
@@ -434,6 +438,33 @@ mod tests {
                 col("array_col").alias("unnest(array_col)")
             ]
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_positions_to_exprs() -> Result<()> {
+        let select_exprs = vec![col("c1"), col("c2"), count(lit(1))];
+
+        // Assert 1 resolved as first column in select list
+        let resolved = resolve_positions_to_exprs(lit(1i64), &select_exprs)?;
+        assert_eq!(resolved, col("c1"));
+
+        // Assert error if index out of select clause bounds
+        let resolved = resolve_positions_to_exprs(lit(-1i64), &select_exprs);
+        assert!(resolved
+            .is_err_and(|e| e.message().contains("Cannot find column with position -1")));
+
+        let resolved = resolve_positions_to_exprs(lit(5i64), &select_exprs);
+        assert!(resolved
+            .is_err_and(|e| e.message().contains("Cannot find column with position 5")));
+
+        // Assert expression returned as-is
+        let resolved = resolve_positions_to_exprs(lit("text"), &select_exprs)?;
+        assert_eq!(resolved, lit("text"));
+
+        let resolved = resolve_positions_to_exprs(col("fake"), &select_exprs)?;
+        assert_eq!(resolved, col("fake"));
 
         Ok(())
     }

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -1484,16 +1484,16 @@ fn select_simple_aggregate_with_groupby_position_out_of_range() {
     let sql = "SELECT state, MIN(age) FROM person GROUP BY 0";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-        "Error during planning: Projection references non-aggregate values: Expression person.state could not be resolved from available columns: Int64(0), MIN(person.age)",
-            err.strip_backtrace()
-        );
+        "Error during planning: Cannot find column with position 0 in SELECT clause",
+        err.strip_backtrace()
+    );
 
     let sql2 = "SELECT state, MIN(age) FROM person GROUP BY 5";
     let err2 = logical_plan(sql2).expect_err("query should have failed");
     assert_eq!(
-        "Error during planning: Projection references non-aggregate values: Expression person.state could not be resolved from available columns: Int64(5), MIN(person.age)",
-            err2.strip_backtrace()
-        );
+        "Error during planning: Cannot find column with position 5 in SELECT clause",
+        err2.strip_backtrace()
+    );
 }
 
 #[test]

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -1484,14 +1484,14 @@ fn select_simple_aggregate_with_groupby_position_out_of_range() {
     let sql = "SELECT state, MIN(age) FROM person GROUP BY 0";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-        "Error during planning: Cannot find column with position 0 in SELECT clause",
+        "Error during planning: Cannot find column with position 0 in SELECT clause. Valid columns: 1 to 2",
         err.strip_backtrace()
     );
 
     let sql2 = "SELECT state, MIN(age) FROM person GROUP BY 5";
     let err2 = logical_plan(sql2).expect_err("query should have failed");
     assert_eq!(
-        "Error during planning: Cannot find column with position 5 in SELECT clause",
+        "Error during planning: Cannot find column with position 5 in SELECT clause. Valid columns: 1 to 2",
         err2.strip_backtrace()
     );
 }

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -5060,7 +5060,7 @@ SELECT a + 1 AS d, a + 1 + b AS c FROM (SELECT 1 AS a, 2 AS b) GROUP BY a + 1, a
 ----
 2 4
 
-statement error DataFusion error: Error during planning: Cannot find column with position 4 in SELECT clause
+statement error DataFusion error: Error during planning: Cannot find column with position 4 in SELECT clause. Valid columns: 1 to 3
 SELECT a, b, COUNT(1)
 FROM multiple_ordered_table
 GROUP BY 1, 2, 4, 5, 6;

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -5059,3 +5059,8 @@ query II
 SELECT a + 1 AS d, a + 1 + b AS c FROM (SELECT 1 AS a, 2 AS b) GROUP BY a + 1, a + 1 + b;
 ----
 2 4
+
+statement error DataFusion error: Error during planning: Cannot find column with position 4 in SELECT clause
+SELECT a, b, COUNT(1)
+FROM multiple_ordered_table
+GROUP BY 1, 2, 4, 5, 6;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

While #10591 found that planning for INT literals in GROUP BY clause is inconsistent. For example:
```sql
EXPLAIN SELECT "URL", COUNT(1) from hits GROUP BY 1, 3, 4, 5
```
produces following logical plan (this is logical plan before any optimizations):
```sql
Explain
  Projection: hits.URL, COUNT(Int64(1))
    Aggregate: groupBy=[[hits.URL, Int64(3), Int64(4), Int64(5)]], aggr=[[COUNT(Int64(1))]]
      TableScan: hits
```
`1` resolved as column from select clause, and `3, 4, 5` remain as constants. Don't think this behavior is intended + there are couple of tests in `sql_integration.rs` (modified below), for similar cases, expect queries to fail.

The suggestion is to fail while planning phase for such cases, and return error, specifying first index which can not be resolved as select column.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Resolution for positions (integer literals in `GROUP BY` clause) now returns error on first unresolved position.

SIgnature for `resolve_positions_to_exprs` changed to avoid unnecessary cloning. `resolve_aliases_to_exprs` signature has similar changes, for the same reasons (it's been changed just for consistency with resolve_positions_... function).

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added sqllogictests + some test coverage for `resolve_positions_to_exprs`

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Users might experience query planning failures for `GROUP BY %idx%` where `idx` is out of bounds of `SELECT` expressions list (which seems to be OK from SQL semantics point of view -- PG/MySQL handle this case in the same way).

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
