### PR TITLE
Fix typo in bench.sh

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -69,7 +69,7 @@ all(default): Data/Run/Compare for all benchmarks
 tpch:                   TPCH inspired benchmark on Scale Factor (SF) 1 (~1GB), single parquet file per table
 tpch_mem:               TPCH inspired benchmark on Scale Factor (SF) 1 (~1GB), query from memory
 tpch10:                 TPCH inspired benchmark on Scale Factor (SF) 10 (~10GB), single parquet file per table
-tpch10_mem:             TPCH inspired benchmark on Scale Factor (SF) 10 (~10GB), query from memory
+tpch_mem10:             TPCH inspired benchmark on Scale Factor (SF) 10 (~10GB), query from memory
 parquet:                Benchmark of parquet reader's filtering speed
 sort:                   Benchmark of sorting speed
 clickbench_1:           ClickBench queries against a single parquet file
@@ -243,9 +243,7 @@ main() {
             echo "Done"
             ;;
         compare)
-            BRANCH1=$1
-            BRANCH2=$2
-            compare_benchmarks
+            compare_benchmarks "$ARG2" "$ARG3"
             ;;
         "")
             usage
@@ -446,8 +444,8 @@ run_clickbench_extended() {
 
 compare_benchmarks() {
     BASE_RESULTS_DIR="${SCRIPT_DIR}/results"
-    BRANCH1="${ARG2}"
-    BRANCH2="${ARG3}"
+    BRANCH1="$1"
+    BRANCH2="$2"
     if [ -z "$BRANCH1" ] ; then
         echo "<branch1> not specified. Available branches:"
         ls -1 "${BASE_RESULTS_DIR}"


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

### Change 1
 I meet error when I try to run command `./bench.sh data tpch10_mem` as described in usage.

```
Error: unknown benchmark 'tpch10_mem' for data generation
```

I think this is due to a typo in usage

### Change 2
And when I open `bench.sh`, IDE tells me that there is an error in the main function. 

> main references arguments, but none are ever passed.
> See [SC2120](https://github.com/koalaman/shellcheck/wiki/SC2120).

The `main` function is called without passing any arguments, but there is such code `BRANCH1=$1` and `BRANCH2=$2`

## What changes are included in this PR?
1. Fix typo
2. Calling `compare_benchmarks` with parameter passing

## Are these changes tested?
I tested it manually with `bash -x`

## Are there any user-facing changes?
No