### PR TITLE
Minor: fix signature `fn octect_length()`

### DIFF
--- a/datafusion/core/tests/expr_api/mod.rs
+++ b/datafusion/core/tests/expr_api/mod.rs
@@ -29,6 +29,23 @@ use std::sync::{Arc, OnceLock};
 mod simplification;
 
 #[test]
+fn test_octet_length() {
+    #[rustfmt::skip]
+    evaluate_expr_test(
+        octet_length(col("list")),
+        vec![
+            "+------+",
+            "| expr |",
+            "+------+",
+            "| 5    |",
+            "| 18   |",
+            "| 6    |",
+            "+------+",
+        ],
+    );
+}
+
+#[test]
 fn test_eq() {
     // id = '2'
     evaluate_expr_test(

--- a/datafusion/functions/src/string/mod.rs
+++ b/datafusion/functions/src/string/mod.rs
@@ -128,8 +128,8 @@ pub mod expr_fn {
     }
 
     #[doc = "returns the number of bytes of a string"]
-    pub fn octet_length(args: Vec<Expr>) -> Expr {
-        super::octet_length().call(args)
+    pub fn octet_length(args: Expr) -> Expr {
+        super::octet_length().call(vec![args])
     }
 
     #[doc = "replace the substring of string that starts at the start'th character and extends for count characters with new substring"]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10676.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
- fix a minor issue about consistency
- fn signature should be the same as `fn bit_length()`

## What changes are included in this PR?
- changed `octet_length` to accept `Expr` instead of `Vec<Expr>`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. Existing tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
