### PR TITLE
Add support for `AggregateExpr`, `WindowExpr` rewrite.

### DIFF
--- a/datafusion/physical-expr-common/src/aggregate/mod.rs
+++ b/datafusion/physical-expr-common/src/aggregate/mod.rs
@@ -196,7 +196,10 @@ pub trait AggregateExpr: Send + Sync + Debug + PartialEq<dyn Any> {
             .iter()
             .map(|sort_expr| sort_expr.expr.clone())
             .collect::<Vec<_>>();
-        (args, order_by_exprs)
+        AggregatePhysicalExpressions {
+            args,
+            order_by_exprs,
+        }
     }
 
     /// Rewrites [`AggregateExpr`], with new expressions given. The argument should be consistent
@@ -211,10 +214,13 @@ pub trait AggregateExpr: Send + Sync + Debug + PartialEq<dyn Any> {
     }
 }
 
-/// Tuple contains the all physical expressions used in the aggregate expression
-/// each entry corresponds to function arguments, order by expressions respectively
-type AggregatePhysicalExpressions =
-    (Vec<Arc<dyn PhysicalExpr>>, Vec<Arc<dyn PhysicalExpr>>);
+/// Stores the physical expressions used inside the `AggregateExpr`.
+pub struct AggregatePhysicalExpressions {
+    /// Aggregate function arguments
+    pub args: Vec<Arc<dyn PhysicalExpr>>,
+    /// Order by expressions
+    pub order_by_exprs: Vec<Arc<dyn PhysicalExpr>>,
+}
 
 /// Physical aggregate expression of a UDAF.
 #[derive(Debug)]

--- a/datafusion/physical-expr-common/src/aggregate/mod.rs
+++ b/datafusion/physical-expr-common/src/aggregate/mod.rs
@@ -187,8 +187,7 @@ pub trait AggregateExpr: Send + Sync + Debug + PartialEq<dyn Any> {
     }
 
     /// Returns all expressions used in the [`AggregateExpr`].
-    /// First entry in the tuple corresponds to function arguments
-    /// Second entry in the tuple corresponds to order by expressions.
+    /// These expressions are  (1)function arguments, (2) order by expressions.
     fn all_expressions(&self) -> AggregatePhysicalExpressions {
         let args = self.expressions();
         let order_bys = self.order_bys().unwrap_or(&[]);

--- a/datafusion/physical-expr/src/aggregate/count.rs
+++ b/datafusion/physical-expr/src/aggregate/count.rs
@@ -260,6 +260,21 @@ impl AggregateExpr for Count {
         // instantiate specialized accumulator
         Ok(Box::new(CountGroupsAccumulator::new()))
     }
+
+    fn with_new_expressions(
+        &self,
+        args: Vec<Arc<dyn PhysicalExpr>>,
+        order_by_exprs: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Option<Arc<dyn AggregateExpr>> {
+        debug_assert_eq!(self.exprs.len(), args.len());
+        debug_assert!(order_by_exprs.is_empty());
+        Some(Arc::new(Count {
+            name: self.name.clone(),
+            data_type: self.data_type.clone(),
+            nullable: self.nullable,
+            exprs: args,
+        }))
+    }
 }
 
 impl PartialEq<dyn Any> for Count {

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -41,7 +41,9 @@ pub mod execution_props {
 
 pub use aggregate::groups_accumulator::{GroupsAccumulatorAdapter, NullState};
 pub use analysis::{analyze, AnalysisContext, ExprBoundaries};
-pub use datafusion_physical_expr_common::aggregate::AggregateExpr;
+pub use datafusion_physical_expr_common::aggregate::{
+    AggregateExpr, AggregatePhysicalExpressions,
+};
 pub use equivalence::EquivalenceProperties;
 pub use partitioning::{Distribution, Partitioning};
 pub use physical_expr::{

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -135,13 +135,17 @@ pub trait WindowExpr: Send + Sync + Debug {
     /// Third entry in the tuple corresponds to order by expressions.
     fn all_expressions(&self) -> WindowPhysicalExpressions {
         let args = self.expressions();
-        let partition_bys = self.partition_by().to_vec();
+        let partition_by_exprs = self.partition_by().to_vec();
         let order_by_exprs = self
             .order_by()
             .iter()
             .map(|sort_expr| sort_expr.expr.clone())
             .collect::<Vec<_>>();
-        (args, partition_bys, order_by_exprs)
+        WindowPhysicalExpressions {
+            args,
+            partition_by_exprs,
+            order_by_exprs,
+        }
     }
 
     /// Rewrites [`WindowExpr`], with new expressions given. The argument should be consistent
@@ -157,13 +161,15 @@ pub trait WindowExpr: Send + Sync + Debug {
     }
 }
 
-/// Triple contains the all physical expressions used in the window expression
-/// each entry corresponds to function arguments, partition by expressions, order by expressions respectively
-type WindowPhysicalExpressions = (
-    Vec<Arc<dyn PhysicalExpr>>,
-    Vec<Arc<dyn PhysicalExpr>>,
-    Vec<Arc<dyn PhysicalExpr>>,
-);
+/// Stores the physical expressions used inside the `WindowExpr`.
+pub struct WindowPhysicalExpressions {
+    /// Window function arguments
+    pub args: Vec<Arc<dyn PhysicalExpr>>,
+    /// PARTITION BY expressions
+    pub partition_by_exprs: Vec<Arc<dyn PhysicalExpr>>,
+    /// ORDER BY expressions
+    pub order_by_exprs: Vec<Arc<dyn PhysicalExpr>>,
+}
 
 /// Extension trait that adds common functionality to [`AggregateWindowExpr`]s
 pub trait AggregateWindowExpr: WindowExpr {

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -130,9 +130,7 @@ pub trait WindowExpr: Send + Sync + Debug {
     fn get_reverse_expr(&self) -> Option<Arc<dyn WindowExpr>>;
 
     /// Returns all expressions used in the [`WindowExpr`].
-    /// First entry in the tuple corresponds to function arguments
-    /// Second entry in the tuple corresponds to partition by expressions.
-    /// Third entry in the tuple corresponds to order by expressions.
+    /// These expressions are (1) function arguments, (2) partition by expressions, (3) order by expressions.
     fn all_expressions(&self) -> WindowPhysicalExpressions {
         let args = self.expressions();
         let partition_by_exprs = self.partition_by().to_vec();

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -994,13 +994,13 @@ fn aggregate_expressions(
         | AggregateMode::SinglePartitioned => Ok(aggr_expr
             .iter()
             .map(|agg| {
-                let mut result = agg.expressions();
-                // Append ordering requirements to expressions' results. This
+                let mut result = vec![];
+                let (args, order_by_exprs) = agg.all_expressions();
+                result.extend(args);
+                // Append order by expressions to the result. This
                 // way order sensitive aggregators can satisfy requirement
                 // themselves.
-                if let Some(ordering_req) = agg.order_bys() {
-                    result.extend(ordering_req.iter().map(|item| item.expr.clone()));
-                }
+                result.extend(order_by_exprs);
                 result
             })
             .collect()),

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -42,8 +42,9 @@ use datafusion_expr::Accumulator;
 use datafusion_physical_expr::{
     equivalence::{collapse_lex_req, ProjectionMapping},
     expressions::{Column, Max, Min, UnKnownColumn},
-    physical_exprs_contains, AggregateExpr, EquivalenceProperties, LexOrdering,
-    LexRequirement, PhysicalExpr, PhysicalSortRequirement,
+    physical_exprs_contains, AggregateExpr, AggregatePhysicalExpressions,
+    EquivalenceProperties, LexOrdering, LexRequirement, PhysicalExpr,
+    PhysicalSortRequirement,
 };
 
 use itertools::Itertools;
@@ -995,7 +996,10 @@ fn aggregate_expressions(
             .iter()
             .map(|agg| {
                 let mut result = vec![];
-                let (args, order_by_exprs) = agg.all_expressions();
+                let AggregatePhysicalExpressions {
+                    args,
+                    order_by_exprs,
+                } = agg.all_expressions();
                 result.extend(args);
                 // Append order by expressions to the result. This
                 // way order sensitive aggregators can satisfy requirement


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

While working on another PR, in which I implement a new custom rule. I hit a usecase where I want to re-write `AggregateExpr`, and `WindowExpr` according to some kind of projection. (For instance , in terms of the schema of the child). In my use case, I find it useful to define an API `fn all_expressions(&self) -> (function args, order bys, ..)` to return all expressions referred by the aggregate or window function (By the way current `fn expressions(&self)` API only returns function arguments).

With this API in place, we can update `Arc<dyn PhysicalExpr>`s, at the outside (such as inside the rule). Then we can use updated expressions to re-write `Arc<dyn AggregateExpr>` by using following API:
```rust
fn with_new_expressions(
    &self,
    _args: Vec<Arc<dyn PhysicalExpr>>,
    _order_by_exprs: Vec<Arc<dyn PhysicalExpr>>,
) -> Option<Arc<dyn AggregateExpr>>
```
This behaviour, is very similar to the `fn expressions(), `, `fn with_expressions()` methods for `LogicalPlan`s. 
Also as far as I am aware @berkaysynnada's [PR](https://github.com/synnada-ai/datafusion-upstream/pull/3) for projection optimization will also require such an API, to be able to check pushdown an aggregate expression or window expression successfully.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
