### PR TITLE
Minor: Refactor memory size estimation for HashTable

### DIFF
--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -35,7 +35,7 @@ use crate::{DataFusionError, Result};
 ///     buckets.
 ///   - One byte overhead for each bucket.
 ///   - The fixed size overhead of the collection.
-/// - Returns `usize::MAX` if an overflow occurs.
+/// - If the estimation overflows, we return a [`DataFusionError`]
 ///
 /// # Examples
 /// ---
@@ -43,7 +43,8 @@ use crate::{DataFusionError, Result};
 /// ## From within a struct
 ///
 /// ```rust
-/// use datafusion_common::utils::memory::estimate_memory_size;
+/// # use datafusion_common::utils::memory::estimate_memory_size;
+/// # use datafusion_common::Result;
 ///
 /// struct MyStruct<T> {
 ///     values: Vec<T>,
@@ -51,7 +52,7 @@ use crate::{DataFusionError, Result};
 /// }
 ///
 /// impl<T> MyStruct<T> {
-///     fn size(&self) -> usize {
+///     fn size(&self) -> Result<usize> {
 ///         let num_elements = self.values.len();
 ///         let fixed_size = std::mem::size_of_val(self) +
 ///           std::mem::size_of_val(&self.values);
@@ -64,13 +65,14 @@ use crate::{DataFusionError, Result};
 /// ## With a simple collection
 ///
 /// ```rust
-/// use datafusion_common::utils::memory::estimate_memory_size;
-/// use std::collections::HashMap;
+/// # use datafusion_common::utils::memory::estimate_memory_size;
+/// # use std::collections::HashMap;
 ///
 /// let num_rows = 100;
 /// let fixed_size = std::mem::size_of::<HashMap<u64, u64>>();
 /// let estimated_hashtable_size =
-///   estimate_memory_size::<(u64, u64)>(num_rows,fixed_size);
+///   estimate_memory_size::<(u64, u64)>(num_rows,fixed_size)
+///     .expect("Size estimation failed");
 /// ```
 pub fn estimate_memory_size<T>(num_elements: usize, fixed_size: usize) -> Result<usize> {
     // For the majority of cases hashbrown overestimates the bucket quantity

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -82,8 +82,8 @@ pub fn estimate_memory_size<T>(num_elements: usize, fixed_size: usize) -> Result
     // but should be fine overall.
     num_elements
         .checked_mul(8)
-        .and_then(|estimate| Some((estimate / 7).next_power_of_two()))
-        .and_then(|estimated_buckets| {
+        .and_then(|overestimate| {
+            let estimated_buckets = (overestimate / 7).next_power_of_two();
             // + size of entry * number of buckets
             // + 1 byte for each bucket
             // + fixed size of collection (HashSet/HashTable)

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -35,6 +35,41 @@
 ///   - The fixed size overhead of the collection.
 /// - Returns `usize::MAX` if an overflow occurs.
 ///
+/// # Examples
+/// ---
+///
+/// ## From within a struct
+///
+/// ```rust
+/// use datafusion_common::utils::memory::estimate_memory_size;
+///
+/// struct MyStruct<T> {
+///     values: Vec<T>,
+///     other_data: usize,
+/// }
+///
+/// impl<T> MyStruct<T> {
+///     fn size(&self) -> usize {
+///         let num_elements = self.values.len();
+///         let fixed_size = std::mem::size_of_val(self) +
+///           std::mem::size_of_val(&self.values);
+///
+///         estimate_memory_size::<T>(num_elements, fixed_size)
+///     }
+/// }
+/// ```
+/// ---
+/// ## With a simple collection
+///
+/// ```rust
+/// use datafusion_common::utils::memory::estimate_memory_size;
+/// use std::collections::HashMap;
+///
+/// let num_rows = 100;
+/// let fixed_size = std::mem::size_of::<HashMap<u64, u64>>();
+/// let estimated_hashtable_size =
+///   estimate_memory_size::<(u64, u64)>(num_rows,fixed_size);
+/// ```
 pub fn estimate_memory_size<T>(num_elements: usize, fixed_size: usize) -> usize {
     // For the majority of cases hashbrown overestimates the bucket quantity
     // to keep ~1/8 of them empty. We take this factor into account by

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! This module provides a function to estimate the memory size of a HashTable prior to alloaction
+
+use crate::{DataFusionError, Result};
+
+/// Estimates the memory size required for a hash table prior to allocation.
+///
+/// # Parameters
+/// - `num_elements`: The number of elements expected in the hash table.
+/// - `fixed_size`: A fixed overhead size associated with the collection
+/// (e.g., HashSet or HashTable).
+/// - `T`: The type of elements stored in the hash table.
+///
+/// # Details
+/// This function calculates the estimated memory size by considering:
+/// - An overestimation of buckets to keep approximately 1/8 of them empty.
+/// - The total memory size is computed as:
+///   - The size of each entry (`T`) multiplied by the estimated number of
+///     buckets.
+///   - One byte overhead for each bucket.
+///   - The fixed size overhead of the collection.
+///
+/// # Panics
+/// - Returns an error if the multiplication of `num_elements` by 8 overflows
+///   `usize`.
+pub fn estimate_memory_size<T>(num_elements: usize, fixed_size: usize) -> Result<usize> {
+    // For the majority of cases hashbrown overestimates the bucket quantity
+    // to keep ~1/8 of them empty. We take this factor into account by
+    // multiplying the number of elements with a fixed ratio of 8/7 (~1.14).
+    // This formula leads to overallocation for small tables (< 8 elements)
+    // but should be fine overall.
+    let estimated_buckets = (num_elements.checked_mul(8).ok_or_else(|| {
+        DataFusionError::Execution(
+            "usize overflow while estimating number of buckets".to_string(),
+        )
+    })? / 7)
+        .next_power_of_two();
+
+    // + size of entry * number of buckets
+    // + 1 byte for each bucket
+    // + fixed size of collection (HashSet/HashTable)
+    Ok(std::mem::size_of::<T>() * estimated_buckets + estimated_buckets + fixed_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::estimate_memory_size;
+
+    #[test]
+    fn test_estimate_memory() {
+        let num_elements = 8;
+        // size: 48
+        let fixed_size = std::mem::size_of::<HashSet<u32>>();
+        // size: 128 = 16 * 4 + 16 + 48
+        let estimated = estimate_memory_size::<u32>(num_elements, fixed_size).unwrap();
+
+        assert_eq!(estimated, 128);
+    }
+
+    #[test]
+    fn test_estimate_memory_overflow() {
+        let num_elements = usize::MAX;
+        let fixed_size = std::mem::size_of::<HashSet<u32>>();
+        let estimated = estimate_memory_size::<u32>(num_elements, fixed_size);
+
+        assert!(estimated.is_err());
+    }
+}

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -82,8 +82,7 @@ pub fn estimate_memory_size<T>(num_elements: usize, fixed_size: usize) -> Result
     // but should be fine overall.
     num_elements
         .checked_mul(8)
-        .and_then(|estimate| estimate.checked_div(7))
-        .map(|buckets| buckets.next_power_of_two())
+        .and_then(|estimate| Some((estimate / 7).next_power_of_two()))
         .and_then(|estimated_buckets| {
             // + size of entry * number of buckets
             // + 1 byte for each bucket

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -17,6 +17,7 @@
 
 //! This module provides the bisect function, which implements binary search.
 
+pub mod memory;
 pub mod proxy;
 
 use crate::error::{_internal_datafusion_err, _internal_err};

--- a/datafusion/physical-expr/src/aggregate/count_distinct/native.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct/native.rs
@@ -33,6 +33,7 @@ use arrow_schema::DataType;
 
 use datafusion_common::cast::{as_list_array, as_primitive_array};
 use datafusion_common::utils::array_into_list_array;
+use datafusion_common::utils::memory::estimate_memory_size;
 use datafusion_common::ScalarValue;
 use datafusion_expr::Accumulator;
 
@@ -115,18 +116,11 @@ where
     }
 
     fn size(&self) -> usize {
-        let estimated_buckets = (self.values.len().checked_mul(8).unwrap_or(usize::MAX)
-            / 7)
-        .next_power_of_two();
+        let num_elements = self.values.len();
+        let fixed_size =
+            std::mem::size_of_val(self) + std::mem::size_of_val(&self.values);
 
-        // Size of accumulator
-        // + size of entry * number of buckets
-        // + 1 byte for each bucket
-        // + fixed size of HashSet
-        std::mem::size_of_val(self)
-            + std::mem::size_of::<T::Native>() * estimated_buckets
-            + estimated_buckets
-            + std::mem::size_of_val(&self.values)
+        estimate_memory_size::<T::Native>(num_elements, fixed_size)
     }
 }
 
@@ -202,17 +196,10 @@ where
     }
 
     fn size(&self) -> usize {
-        let estimated_buckets = (self.values.len().checked_mul(8).unwrap_or(usize::MAX)
-            / 7)
-        .next_power_of_two();
+        let num_elements = self.values.len();
+        let fixed_size =
+            std::mem::size_of_val(self) + std::mem::size_of_val(&self.values);
 
-        // Size of accumulator
-        // + size of entry * number of buckets
-        // + 1 byte for each bucket
-        // + fixed size of HashSet
-        std::mem::size_of_val(self)
-            + std::mem::size_of::<T::Native>() * estimated_buckets
-            + estimated_buckets
-            + std::mem::size_of_val(&self.values)
+        estimate_memory_size::<T::Native>(num_elements, fixed_size)
     }
 }

--- a/datafusion/physical-expr/src/aggregate/count_distinct/native.rs
+++ b/datafusion/physical-expr/src/aggregate/count_distinct/native.rs
@@ -120,7 +120,7 @@ where
         let fixed_size =
             std::mem::size_of_val(self) + std::mem::size_of_val(&self.values);
 
-        estimate_memory_size::<T::Native>(num_elements, fixed_size)
+        estimate_memory_size::<T::Native>(num_elements, fixed_size).unwrap()
     }
 }
 
@@ -200,6 +200,6 @@ where
         let fixed_size =
             std::mem::size_of_val(self) + std::mem::size_of_val(&self.values);
 
-        estimate_memory_size::<T::Native>(num_elements, fixed_size)
+        estimate_memory_size::<T::Native>(num_elements, fixed_size).unwrap()
     }
 }

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -18,7 +18,6 @@
 //! [`HashJoinExec`] Partitioned Hash Join Operator
 
 use std::fmt;
-use std::mem::size_of;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::Poll;
@@ -59,6 +58,7 @@ use arrow::record_batch::RecordBatch;
 use arrow::util::bit_util;
 use arrow_array::cast::downcast_array;
 use arrow_schema::ArrowError;
+use datafusion_common::utils::memory::estimate_memory_size;
 use datafusion_common::{
     internal_datafusion_err, internal_err, plan_err, project_schema, DataFusionError,
     JoinSide, JoinType, Result,
@@ -875,23 +875,12 @@ async fn collect_left_input(
 
     // Estimation of memory size, required for hashtable, prior to allocation.
     // Final result can be verified using `RawTable.allocation_info()`
-    //
-    // For majority of cases hashbrown overestimates buckets qty to keep ~1/8 of them empty.
-    // This formula leads to overallocation for small tables (< 8 elements) but fine overall.
-    let estimated_buckets = (num_rows.checked_mul(8).ok_or_else(|| {
-        DataFusionError::Execution(
-            "usize overflow while estimating number of hasmap buckets".to_string(),
-        )
-    })? / 7)
-        .next_power_of_two();
-    // 16 bytes per `(u64, u64)`
-    // + 1 byte for each bucket
-    // + fixed size of JoinHashMap (RawTable + Vec)
-    let estimated_hastable_size =
-        16 * estimated_buckets + estimated_buckets + size_of::<JoinHashMap>();
+    let fixed_size = std::mem::size_of::<JoinHashMap>();
+    let estimated_hashtable_size =
+        estimate_memory_size::<(u64, u64)>(num_rows, fixed_size);
 
-    reservation.try_grow(estimated_hastable_size)?;
-    metrics.build_mem_used.add(estimated_hastable_size);
+    reservation.try_grow(estimated_hashtable_size)?;
+    metrics.build_mem_used.add(estimated_hashtable_size);
 
     let mut hashmap = JoinHashMap::with_capacity(num_rows);
     let mut hashes_buffer = Vec::new();

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -877,7 +877,7 @@ async fn collect_left_input(
     // Final result can be verified using `RawTable.allocation_info()`
     let fixed_size = std::mem::size_of::<JoinHashMap>();
     let estimated_hashtable_size =
-        estimate_memory_size::<(u64, u64)>(num_rows, fixed_size);
+        estimate_memory_size::<(u64, u64)>(num_rows, fixed_size)?;
 
     reservation.try_grow(estimated_hashtable_size)?;
     metrics.build_mem_used.add(estimated_hashtable_size);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8764.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
As stated in the issue [here](https://github.com/apache/datafusion/issues/8764#issuecomment-2141501909) the goal is to consolidate estimation logic into a single function. This allows for better documentation as well as better maintainability.
Also there was an [issue ](https://github.com/apache/datafusion/issues/8764#issuecomment-2143467627)with the existing implementation that could still overflow if the `checked_mul` was capped at usize::MAX. I tried to fix this by checking for overflows and returning usize::MAX as a 'max cap'.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- extract logic into single function
- fixed missing overflow checks
- moved logic into datfusion common
- used the new function in `count_distinct/native.rs` and `hash_join.rs`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes.

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
