### PR TITLE
fix: fix string repeat for negative numbers

### DIFF
--- a/datafusion/functions/src/string/repeat.rs
+++ b/datafusion/functions/src/string/repeat.rs
@@ -88,7 +88,9 @@ fn repeat<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
         .iter()
         .zip(number_array.iter())
         .map(|(string, number)| match (string, number) {
-            (Some(string), Some(number)) if number >= 0 => Some(string.repeat(number as usize)),
+            (Some(string), Some(number)) if number >= 0 => {
+                Some(string.repeat(number as usize))
+            }
             (Some(_), Some(_)) => Some("".to_string()),
             _ => None,
         })

--- a/datafusion/functions/src/string/repeat.rs
+++ b/datafusion/functions/src/string/repeat.rs
@@ -88,7 +88,8 @@ fn repeat<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
         .iter()
         .zip(number_array.iter())
         .map(|(string, number)| match (string, number) {
-            (Some(string), Some(number)) => Some(string.repeat(number as usize)),
+            (Some(string), Some(number)) if number >= 0 => Some(string.repeat(number as usize)),
+            (Some(_), Some(_)) => Some("".to_string()),
             _ => None,
         })
         .collect::<GenericStringArray<T>>();

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -542,6 +542,11 @@ SELECT repeat('Pg', 4)
 PgPgPgPg
 
 query T
+SELECT repeat('Pg', -1)
+----
+(empty)
+
+query T
 SELECT repeat('Pg', CAST(NULL AS INT))
 ----
 NULL


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10759

## Rationale for this change

Repeat should not panic and should match the behavior of other common engines.

## What changes are included in this PR?

Updates the main `repeat` function's logic to only try to cast the i64 to a usize when the count is greater than or equal to 0, otherwise returns an empty string.

## Are these changes tested?

Added a sqllogictest.
