### PR TITLE
feat: support unparsing LogicalPlan::Window nodes

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -236,8 +236,8 @@ impl Unparser<'_> {
                     .map(|expr| expr_to_unparsed(expr)?.into_order_by_expr())
                     .collect::<Result<Vec<_>>>()?;
 
-                let start_bound = self.convert_bound(&window_frame.start_bound);
-                let end_bound = self.convert_bound(&window_frame.end_bound);
+                let start_bound = self.convert_bound(&window_frame.start_bound)?;
+                let end_bound = self.convert_bound(&window_frame.end_bound)?;
                 let over = Some(ast::WindowType::WindowSpec(ast::WindowSpec {
                     window_name: None,
                     partition_by: partition_by
@@ -513,20 +513,30 @@ impl Unparser<'_> {
     fn convert_bound(
         &self,
         bound: &datafusion_expr::window_frame::WindowFrameBound,
-    ) -> ast::WindowFrameBound {
+    ) -> Result<ast::WindowFrameBound> {
         match bound {
             datafusion_expr::window_frame::WindowFrameBound::Preceding(val) => {
-                ast::WindowFrameBound::Preceding(
-                    self.scalar_to_sql(val).map(Box::new).ok(),
-                )
+                Ok(ast::WindowFrameBound::Preceding({
+                    let val = self.scalar_to_sql(val)?;
+                    if let ast::Expr::Value(ast::Value::Null) = &val {
+                        None
+                    } else {
+                        Some(Box::new(val))
+                    }
+                }))
             }
             datafusion_expr::window_frame::WindowFrameBound::Following(val) => {
-                ast::WindowFrameBound::Following(
-                    self.scalar_to_sql(val).map(Box::new).ok(),
-                )
+                Ok(ast::WindowFrameBound::Following({
+                    let val = self.scalar_to_sql(val)?;
+                    if let ast::Expr::Value(ast::Value::Null) = &val {
+                        None
+                    } else {
+                        Some(Box::new(val))
+                    }
+                }))
             }
             datafusion_expr::window_frame::WindowFrameBound::CurrentRow => {
-                ast::WindowFrameBound::CurrentRow
+                Ok(ast::WindowFrameBound::CurrentRow)
             }
         }
     }
@@ -1148,7 +1158,7 @@ mod tests {
                     window_frame: WindowFrame::new(None),
                     null_treatment: None,
                 }),
-                r#"ROW_NUMBER(col) OVER (ROWS BETWEEN NULL PRECEDING AND NULL FOLLOWING)"#,
+                r#"ROW_NUMBER(col) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)"#,
             ),
             (
                 Expr::WindowFunction(WindowFunction {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -162,7 +162,9 @@ impl Unparser<'_> {
                 // A second projection implies a derived tablefactor
                 if !select.already_projected() {
                     // Special handling when projecting an agregation plan
-                    if let Some(aggvariant) = find_agg_node_within_select(plan, true) {
+                    if let Some(aggvariant) =
+                        find_agg_node_within_select(plan, None, true)
+                    {
                         match aggvariant {
                             AggVariant::Aggregate(agg) => {
                                 let items = p
@@ -188,7 +190,7 @@ impl Unparser<'_> {
                                     .iter()
                                     .map(|proj_expr| {
                                         let unproj =
-                                            unproject_window_exprs(proj_expr, window)?;
+                                            unproject_window_exprs(proj_expr, &window)?;
                                         self.select_item_to_sql(&unproj)
                                     })
                                     .collect::<Result<Vec<_>>>()?;
@@ -228,7 +230,7 @@ impl Unparser<'_> {
             }
             LogicalPlan::Filter(filter) => {
                 if let Some(AggVariant::Aggregate(agg)) =
-                    find_agg_node_within_select(plan, select.already_projected())
+                    find_agg_node_within_select(plan, None, select.already_projected())
                 {
                     let unprojected = unproject_agg_exprs(&filter.predicate, agg)?;
                     let filter_expr = self.expr_to_sql(&unprojected)?;

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -28,7 +28,7 @@ use super::{
         BuilderError, DerivedRelationBuilder, QueryBuilder, RelationBuilder,
         SelectBuilder, TableRelationBuilder, TableWithJoinsBuilder,
     },
-    utils::find_agg_node_within_select,
+    utils::{find_agg_node_within_select, unproject_window_exprs, AggVariant},
     Unparser,
 };
 
@@ -162,23 +162,40 @@ impl Unparser<'_> {
                 // A second projection implies a derived tablefactor
                 if !select.already_projected() {
                     // Special handling when projecting an agregation plan
-                    if let Some(agg) = find_agg_node_within_select(plan, true) {
-                        let items = p
-                            .expr
-                            .iter()
-                            .map(|proj_expr| {
-                                let unproj = unproject_agg_exprs(proj_expr, agg)?;
-                                self.select_item_to_sql(&unproj)
-                            })
-                            .collect::<Result<Vec<_>>>()?;
+                    if let Some(aggvariant) = find_agg_node_within_select(plan, true) {
+                        match aggvariant {
+                            AggVariant::Aggregate(agg) => {
+                                let items = p
+                                    .expr
+                                    .iter()
+                                    .map(|proj_expr| {
+                                        let unproj = unproject_agg_exprs(proj_expr, agg)?;
+                                        self.select_item_to_sql(&unproj)
+                                    })
+                                    .collect::<Result<Vec<_>>>()?;
 
-                        select.projection(items);
-                        select.group_by(ast::GroupByExpr::Expressions(
-                            agg.group_expr
-                                .iter()
-                                .map(|expr| self.expr_to_sql(expr))
-                                .collect::<Result<Vec<_>>>()?,
-                        ));
+                                select.projection(items);
+                                select.group_by(ast::GroupByExpr::Expressions(
+                                    agg.group_expr
+                                        .iter()
+                                        .map(|expr| self.expr_to_sql(expr))
+                                        .collect::<Result<Vec<_>>>()?,
+                                ));
+                            }
+                            AggVariant::Window(window) => {
+                                let items = p
+                                    .expr
+                                    .iter()
+                                    .map(|proj_expr| {
+                                        let unproj =
+                                            unproject_window_exprs(proj_expr, window)?;
+                                        self.select_item_to_sql(&unproj)
+                                    })
+                                    .collect::<Result<Vec<_>>>()?;
+
+                                select.projection(items);
+                            }
+                        }
                     } else {
                         let items = p
                             .expr
@@ -210,7 +227,7 @@ impl Unparser<'_> {
                 }
             }
             LogicalPlan::Filter(filter) => {
-                if let Some(agg) =
+                if let Some(AggVariant::Aggregate(agg)) =
                     find_agg_node_within_select(plan, select.already_projected())
                 {
                     let unprojected = unproject_agg_exprs(&filter.predicate, agg)?;
@@ -265,7 +282,7 @@ impl Unparser<'_> {
                 )
             }
             LogicalPlan::Aggregate(agg) => {
-                // Aggregate nodes are handled simulatenously with Projection nodes
+                // Aggregate nodes are handled simultaneously with Projection nodes
                 self.select_to_sql_recursively(
                     agg.input.as_ref(),
                     query,
@@ -441,8 +458,14 @@ impl Unparser<'_> {
 
                 Ok(())
             }
-            LogicalPlan::Window(_window) => {
-                not_impl_err!("Unsupported operator: {plan:?}")
+            LogicalPlan::Window(window) => {
+                // Window nodes are handled simultaneously with Projection nodes
+                self.select_to_sql_recursively(
+                    window.input.as_ref(),
+                    query,
+                    select,
+                    relation,
+                )
             }
             LogicalPlan::Extension(_) => not_impl_err!("Unsupported operator: {plan:?}"),
             _ => not_impl_err!("Unsupported operator: {plan:?}"),

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -107,10 +107,7 @@ pub(crate) fn unproject_agg_exprs(expr: &Expr, agg: &Aggregate) -> Result<Expr> 
 ///
 /// For example, if expr contains the column expr "COUNT(*) PARTITION BY id" it will be transformed
 /// into an actual window expression as identified in the window node.
-pub(crate) fn unproject_window_exprs(
-    expr: &Expr,
-    windows: &[&Window],
-) -> Result<Expr> {
+pub(crate) fn unproject_window_exprs(expr: &Expr, windows: &[&Window]) -> Result<Expr> {
     expr.clone()
         .transform(|sub_expr| {
             if let Expr::Column(c) = sub_expr {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -127,7 +127,10 @@ fn roundtrip_statement() -> Result<()> {
             UNION ALL
             SELECT j2_string as string FROM j2
             ORDER BY string DESC
-            LIMIT 10"#
+            LIMIT 10"#,
+            "SELECT id, count(*) over (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), 
+            last_name, sum(id) over (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), 
+            first_name from person",
         ];
 
     // For each test sql string, we transform as follows:

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -131,6 +131,9 @@ fn roundtrip_statement() -> Result<()> {
             "SELECT id, count(*) over (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), 
             last_name, sum(id) over (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), 
             first_name from person",
+            r#"SELECT id, count(distinct id) over (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), 
+            sum(id) OVER (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) from person"#,
+            "SELECT id, sum(id) OVER (PARTITION BY first_name ROWS BETWEEN 5 PRECEDING AND 2 FOLLOWING) from person",            
         ];
 
     // For each test sql string, we transform as follows:


### PR DESCRIPTION
## Which issue does this PR close?

closes #10664 

## Rationale for this change

Queries involving window functions are common and should be supported for unparsing a plan into SQL.

## What changes are included in this PR?

- Implements logic for unprojecting window function projections, similar to existing logic for aggregate functions
- No longer throw unimplemented error on LogicalPlan::Window nodes
- Fixes a subtle error in unparsing Window expressions

## Are these changes tested?

Yes, with a new round trip plan_to_sql test

## Are there any user-facing changes?

Additional queries can be unparsed
