### PR TITLE
Minor: (Doc) Enable rt-multi-thread feature for sample code

### DIFF
--- a/docs/source/user-guide/example-usage.md
+++ b/docs/source/user-guide/example-usage.md
@@ -30,7 +30,7 @@ crates.io] page. Add the dependency to your `Cargo.toml` file:
 
 ```toml
 datafusion = "latest_version"
-tokio = "1.0"
+tokio = { version = "1.0", features = ["rt-multi-thread"] }
 ```
 
 ## Add latest non published DataFusion dependency


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

 - The sample code in `docs/source/user-guide/example-usage.md` is not working with `tokio = "1.0"` dependency. The error I got is

```shell
error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
 --> src/main.rs:3:1
  |
3 | #[tokio::main]
  | ^^^^^^^^^^^^^^
  |
  = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
 - Enabled `rt-multi-thread` feature in `tokio`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes. I got the expected output

```shell
+---+----------------+
| a | MIN(example.b) |
+---+----------------+
| 1 | 2              |
+---+----------------+
```

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
Nope
