### PR TITLE
chore: fix `last_value` coercion

### DIFF
--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -29,7 +29,6 @@ use datafusion_common::{
     arrow_datafusion_err, internal_err, DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
-use datafusion_expr::type_coercion::aggregates::NUMERICS;
 use datafusion_expr::utils::{format_state_name, AggregateOrderSensitivity};
 use datafusion_expr::{
     Accumulator, AggregateUDFImpl, ArrayFunctionSignature, Signature, TypeSignature,
@@ -374,7 +373,8 @@ impl LastValue {
                 vec![
                     // TODO: we can introduce more strict signature that only numeric of array types are allowed
                     TypeSignature::ArraySignature(ArrayFunctionSignature::Array),
-                    TypeSignature::Uniform(1, NUMERICS.to_vec()),
+                    TypeSignature::Numeric(1),
+                    TypeSignature::Uniform(1, vec![DataType::Utf8]),
                 ],
                 Volatility::Immutable,
             ),

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -958,6 +958,8 @@ SELECT foo, last_value(time ORDER BY time DESC NULLS LAST) AS time FROM table1 G
 me 1970-01-01T00:00:00.000000010Z
 you 1970-01-01T00:00:00.000000020Z
 
+statement ok
+drop table table1;
 
 
 

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -952,14 +952,11 @@ SELECT foo, first_value(time ORDER BY time DESC NULLS LAST) AS time FROM table1 
 me 1970-01-01T00:00:00.000000040Z
 you 1970-01-01T00:00:00.000000020Z
 
-query error
+query TP
 SELECT foo, last_value(time ORDER BY time DESC NULLS LAST) AS time FROM table1 GROUP BY foo ORDER BY foo;
 ----
-DataFusion error: Error during planning: Error during planning: Coercion from [Timestamp(Nanosecond, Some("+00:00"))] to the signature OneOf([ArraySignature(Array), Uniform(1, [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64])]) failed. and No function matches the given name and argument types 'last_value(Timestamp(Nanosecond, Some("+00:00")))'. You might need to add explicit type casts.
-	Candidate functions:
-	last_value(array)
-	last_value(Int8/Int16/Int32/Int64/UInt8/UInt16/UInt32/UInt64/Float32/Float64)
-
+me 1970-01-01T00:00:00.000000010Z
+you 1970-01-01T00:00:00.000000020Z
 
 
 

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -925,11 +925,43 @@ SELECT
 2022-09-29T15:16:34 2 1 1
 2022-09-30T19:03:14 1 1 1
 
+
 statement ok
 drop table t
 
 statement ok
 drop table temp
+
+statement ok
+CREATE TABLE table1 (
+    bar DECIMAL(10,1),
+    foo VARCHAR(10),
+    time TIMESTAMP WITH TIME ZONE
+);
+
+statement ok
+INSERT INTO table1 (bar, foo, time) VALUES
+(200.0, 'me', '1970-01-01T00:00:00.000000010Z'),
+(1.0, 'me', '1970-01-01T00:00:00.000000030Z'),
+(1.0, 'me', '1970-01-01T00:00:00.000000040Z'),
+(2.0, 'you', '1970-01-01T00:00:00.000000020Z');
+
+query TP
+SELECT foo, first_value(time ORDER BY time DESC NULLS LAST) AS time FROM table1 GROUP BY foo ORDER BY foo;
+----
+me 1970-01-01T00:00:00.000000040Z
+you 1970-01-01T00:00:00.000000020Z
+
+query error
+SELECT foo, last_value(time ORDER BY time DESC NULLS LAST) AS time FROM table1 GROUP BY foo ORDER BY foo;
+----
+DataFusion error: Error during planning: Error during planning: Coercion from [Timestamp(Nanosecond, Some("+00:00"))] to the signature OneOf([ArraySignature(Array), Uniform(1, [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64])]) failed. and No function matches the given name and argument types 'last_value(Timestamp(Nanosecond, Some("+00:00")))'. You might need to add explicit type casts.
+	Candidate functions:
+	last_value(array)
+	last_value(Int8/Int16/Int32/Int64/UInt8/UInt16/UInt32/UInt64/Float32/Float64)
+
+
+
 
 
 #fn window_frame_ranges_unbounded_preceding_err


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10781 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fix coercion bug in `last_value()`

## What changes are included in this PR?

Support type signature for numeric string

## Are these changes tested?

Yes, tests are added

## Are there any user-facing changes?

Yes, users will no longer get an error when query with `last_value()`
