### PR TITLE
minor: Refactor some unparser methods to improve readability

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -17,7 +17,7 @@
 
 use datafusion_common::{internal_err, not_impl_err, plan_err, DataFusionError, Result};
 use datafusion_expr::{
-    expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan,
+    expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan, Projection,
 };
 use sqlparser::ast::{self, SetExpr};
 
@@ -131,6 +131,87 @@ impl Unparser<'_> {
         Ok(ast::SetExpr::Select(Box::new(select_builder.build()?)))
     }
 
+    /// Reconstructs a SELECT SQL statement from a logical plan by unprojecting column expressions
+    /// found in a [Projection] node. This requires scanning the plan tree for relevant Aggregate
+    /// and Window nodes and matching column expressions to the appropriate agg or window expressions.
+    fn reconstruct_select_statement(
+        &self,
+        plan: &LogicalPlan,
+        p: &Projection,
+        select: &mut SelectBuilder,
+    ) -> Result<()> {
+        match find_agg_node_within_select(plan, None, true) {
+            Some(AggVariant::Aggregate(agg)) => {
+                let items = p
+                    .expr
+                    .iter()
+                    .map(|proj_expr| {
+                        let unproj = unproject_agg_exprs(proj_expr, agg)?;
+                        self.select_item_to_sql(&unproj)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                select.projection(items);
+                select.group_by(ast::GroupByExpr::Expressions(
+                    agg.group_expr
+                        .iter()
+                        .map(|expr| self.expr_to_sql(expr))
+                        .collect::<Result<Vec<_>>>()?,
+                ));
+            }
+            Some(AggVariant::Window(window)) => {
+                let items = p
+                    .expr
+                    .iter()
+                    .map(|proj_expr| {
+                        let unproj = unproject_window_exprs(proj_expr, &window)?;
+                        self.select_item_to_sql(&unproj)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                select.projection(items);
+            }
+            None => {
+                let items = p
+                    .expr
+                    .iter()
+                    .map(|e| self.select_item_to_sql(e))
+                    .collect::<Result<Vec<_>>>()?;
+                select.projection(items);
+            }
+        }
+        Ok(())
+    }
+
+    fn projection_to_sql(
+        &self,
+        plan: &LogicalPlan,
+        p: &Projection,
+        query: &mut Option<QueryBuilder>,
+        select: &mut SelectBuilder,
+        relation: &mut RelationBuilder,
+    ) -> Result<()> {
+        // A second projection implies a derived tablefactor
+        if !select.already_projected() {
+            self.reconstruct_select_statement(plan, p, select)?;
+            self.select_to_sql_recursively(p.input.as_ref(), query, select, relation)
+        } else {
+            let mut derived_builder = DerivedRelationBuilder::default();
+            derived_builder.lateral(false).alias(None).subquery({
+                let inner_statment = self.plan_to_sql(plan)?;
+                if let ast::Statement::Query(inner_query) = inner_statment {
+                    inner_query
+                } else {
+                    return internal_err!(
+                        "Subquery must be a Query, but found {inner_statment:?}"
+                    );
+                }
+            });
+            relation.derived(derived_builder);
+            Ok(())
+        }
+    }
+
     fn select_to_sql_recursively(
         &self,
         plan: &LogicalPlan,
@@ -159,74 +240,7 @@ impl Unparser<'_> {
                 Ok(())
             }
             LogicalPlan::Projection(p) => {
-                // A second projection implies a derived tablefactor
-                if !select.already_projected() {
-                    // Special handling when projecting an agregation plan
-                    if let Some(aggvariant) =
-                        find_agg_node_within_select(plan, None, true)
-                    {
-                        match aggvariant {
-                            AggVariant::Aggregate(agg) => {
-                                let items = p
-                                    .expr
-                                    .iter()
-                                    .map(|proj_expr| {
-                                        let unproj = unproject_agg_exprs(proj_expr, agg)?;
-                                        self.select_item_to_sql(&unproj)
-                                    })
-                                    .collect::<Result<Vec<_>>>()?;
-
-                                select.projection(items);
-                                select.group_by(ast::GroupByExpr::Expressions(
-                                    agg.group_expr
-                                        .iter()
-                                        .map(|expr| self.expr_to_sql(expr))
-                                        .collect::<Result<Vec<_>>>()?,
-                                ));
-                            }
-                            AggVariant::Window(window) => {
-                                let items = p
-                                    .expr
-                                    .iter()
-                                    .map(|proj_expr| {
-                                        let unproj =
-                                            unproject_window_exprs(proj_expr, &window)?;
-                                        self.select_item_to_sql(&unproj)
-                                    })
-                                    .collect::<Result<Vec<_>>>()?;
-
-                                select.projection(items);
-                            }
-                        }
-                    } else {
-                        let items = p
-                            .expr
-                            .iter()
-                            .map(|e| self.select_item_to_sql(e))
-                            .collect::<Result<Vec<_>>>()?;
-                        select.projection(items);
-                    }
-                    self.select_to_sql_recursively(
-                        p.input.as_ref(),
-                        query,
-                        select,
-                        relation,
-                    )
-                } else {
-                    let mut derived_builder = DerivedRelationBuilder::default();
-                    derived_builder.lateral(false).alias(None).subquery({
-                        let inner_statment = self.plan_to_sql(plan)?;
-                        if let ast::Statement::Query(inner_query) = inner_statment {
-                            inner_query
-                        } else {
-                            return internal_err!(
-                                "Subquery must be a Query, but found {inner_statment:?}"
-                            );
-                        }
-                    });
-                    relation.derived(derived_builder);
-                    Ok(())
-                }
+                self.projection_to_sql(plan, p, query, select, relation)
             }
             LogicalPlan::Filter(filter) => {
                 if let Some(AggVariant::Aggregate(agg)) =


### PR DESCRIPTION
## Which issue does this PR close?

none

## Rationale for this change

I noticed while working on #10767 some unparser methods have grown unwieldy and difficult to understand. This PR attempts to break some of the more confusing methods up with the aim of making them more easily readable. 

## What changes are included in this PR?

- Break up handling of `LogicalPlan::Projection` nodes in `select_to_sql_recursively` into multiple helpers
- Rewrite `find_agg_node_within_select` to use a `match` statement rather than several `if let`s

## Are these changes tested?

Yes, by existing tests (no new features or bug fixes in this PR)

## Are there any user-facing changes?

No, purely reorganizing code.
