### PR TITLE
Int64 as default type for make_array function empty or null case

### DIFF
--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -346,8 +346,8 @@ AS VALUES
   (arrow_cast(make_array([[1,2]], [[3, 4]]), 'FixedSizeList(2, List(List(Int64)))'), arrow_cast(make_array([1], [2]), 'FixedSizeList(2, List(Int64))')),
   (arrow_cast(make_array([[1,2]], [[4, 4]]), 'FixedSizeList(2, List(List(Int64)))'), arrow_cast(make_array([1,2], [3, 4]), 'FixedSizeList(2, List(Int64))')),
   (arrow_cast(make_array([[1,2]], [[4, 4]]), 'FixedSizeList(2, List(List(Int64)))'), arrow_cast(make_array([1,2,3], [1]), 'FixedSizeList(2, List(Int64))')),
-  (arrow_cast(make_array([[1], [2]], []), 'FixedSizeList(2, List(List(Int64)))'), arrow_cast(make_array([2], [3]), 'FixedSizeList(2, List(Int64))')),
-  (arrow_cast(make_array([[1], [2]], []), 'FixedSizeList(2, List(List(Int64)))'), arrow_cast(make_array([1], [2]), 'FixedSizeList(2, List(Int64))')),
+  (arrow_cast(make_array([[1], [2]], [[]]), 'FixedSizeList(2, List(List(Int64)))'), arrow_cast(make_array([2], [3]), 'FixedSizeList(2, List(Int64))')),
+  (arrow_cast(make_array([[1], [2]], [[]]), 'FixedSizeList(2, List(List(Int64)))'), arrow_cast(make_array([1], [2]), 'FixedSizeList(2, List(Int64))')),
   (arrow_cast(make_array([[1], [2]], [[2], [3]]), 'FixedSizeList(2, List(List(Int64)))'), arrow_cast(make_array([1], [2]), 'FixedSizeList(2, List(Int64))')),
   (arrow_cast(make_array([[1], [2]], [[2], [3]]), 'FixedSizeList(2, List(List(Int64)))'), arrow_cast(make_array([1], [2]), 'FixedSizeList(2, List(Int64))'))
 ;
@@ -2030,6 +2030,13 @@ NULL
 [, 51, 52, 54, 55, 56, 57, 58, 59, 60]
 [61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
 
+# test with empty array
+query ?
+select array_sort([]);
+----
+[]
+
+# test with empty row, the row that does not match the condition has row count 0
 statement ok
 create table t1(a int, b int) as values (100, 1), (101, 2), (102, 3), (101, 2);
 
@@ -2075,10 +2082,10 @@ select
 
 query ????
 select
-  array_append(arrow_cast(make_array(), 'LargeList(Null)'), 4),
-  array_append(arrow_cast(make_array(), 'LargeList(Null)'), null),
+  array_append(arrow_cast(make_array(), 'LargeList(Int64)'), 4),
+  array_append(arrow_cast(make_array(), 'LargeList(Int64)'), null),
   array_append(arrow_cast(make_array(1, null, 3), 'LargeList(Int64)'), 4),
-  array_append(arrow_cast(make_array(null, null), 'LargeList(Null)'), 1)
+  array_append(arrow_cast(make_array(null, null), 'LargeList(Int64)'), 1)
 ;
 ----
 [4] [] [1, , 3, 4] [, , 1]
@@ -2559,7 +2566,7 @@ query ????
 select
   array_repeat(arrow_cast([1], 'LargeList(Int64)'), 5),
   array_repeat(arrow_cast([1.1, 2.2, 3.3], 'LargeList(Float64)'), 3),
-  array_repeat(arrow_cast([null, null], 'LargeList(Null)'), 3),
+  array_repeat(arrow_cast([null, null], 'LargeList(Int64)'), 3),
   array_repeat(arrow_cast([[1, 2], [3, 4]], 'LargeList(List(Int64))'), 2);
 ----
 [[1], [1], [1], [1], [1]] [[1.1, 2.2, 3.3], [1.1, 2.2, 3.3], [1.1, 2.2, 3.3]] [[, ], [, ], [, ]] [[[1, 2], [3, 4]], [[1, 2], [3, 4]]]
@@ -2622,6 +2629,12 @@ drop table large_array_repeat_table;
 
 ## array_concat (aliases: `array_cat`, `list_concat`, `list_cat`)
 
+# test with empty array
+query ?
+select array_concat([]);
+----
+[]
+
 # array_concat error
 query error DataFusion error: Error during planning: The array_concat function can only accept list as the args\.
 select array_concat(1, 2);
@@ -2666,19 +2679,19 @@ select array_concat(make_array(), make_array(2, 3));
 query ?
 select array_concat(make_array(make_array(1, 2), make_array(3, 4)), make_array(make_array()));
 ----
-[[1, 2], [3, 4]]
+[[1, 2], [3, 4], []]
 
 # array_concat scalar function #8 (with empty arrays)
 query ?
 select array_concat(make_array(make_array(1, 2), make_array(3, 4)), make_array(make_array()), make_array(make_array(), make_array()), make_array(make_array(5, 6), make_array(7, 8)));
 ----
-[[1, 2], [3, 4], [5, 6], [7, 8]]
+[[1, 2], [3, 4], [], [], [], [5, 6], [7, 8]]
 
 # array_concat scalar function #9 (with empty arrays)
 query ?
 select array_concat(make_array(make_array()), make_array(make_array(1, 2), make_array(3, 4)));
 ----
-[[1, 2], [3, 4]]
+[[], [1, 2], [3, 4]]
 
 # array_cat scalar function #10 (function alias `array_concat`)
 query ??
@@ -3780,7 +3793,7 @@ select array_union([1,2,3], []);
 [1, 2, 3]
 
 query ?
-select array_union(arrow_cast([1,2,3], 'LargeList(Int64)'), arrow_cast([], 'LargeList(Null)'));
+select array_union(arrow_cast([1,2,3], 'LargeList(Int64)'), arrow_cast([], 'LargeList(Int64)'));
 ----
 [1, 2, 3]
 
@@ -3828,7 +3841,7 @@ select array_union([], []);
 []
 
 query ?
-select array_union(arrow_cast([], 'LargeList(Null)'), arrow_cast([], 'LargeList(Null)'));
+select array_union(arrow_cast([], 'LargeList(Int64)'), arrow_cast([], 'LargeList(Int64)'));
 ----
 []
 
@@ -3839,7 +3852,7 @@ select array_union([[null]], []);
 [[]]
 
 query ?
-select array_union(arrow_cast([[null]], 'LargeList(List(Null))'), arrow_cast([], 'LargeList(Null)'));
+select array_union(arrow_cast([[null]], 'LargeList(List(Int64))'), arrow_cast([], 'LargeList(Int64)'));
 ----
 [[]]
 
@@ -3850,7 +3863,7 @@ select array_union([null], [null]);
 []
 
 query ?
-select array_union(arrow_cast([[null]], 'LargeList(List(Null))'), arrow_cast([[null]], 'LargeList(List(Null))'));
+select array_union(arrow_cast([[null]], 'LargeList(List(Int64))'), arrow_cast([[null]], 'LargeList(List(Int64))'));
 ----
 [[]]
 
@@ -3861,7 +3874,7 @@ select array_union(null, []);
 []
 
 query ?
-select array_union(null, arrow_cast([], 'LargeList(Null)'));
+select array_union(null, arrow_cast([], 'LargeList(Int64)'));
 ----
 []
 
@@ -4098,14 +4111,14 @@ select cardinality(make_array()), cardinality(make_array(make_array()))
 NULL 0
 
 query II
-select cardinality(arrow_cast(make_array(), 'LargeList(Null)')), cardinality(arrow_cast(make_array(make_array()), 'LargeList(List(Null))'))
+select cardinality(arrow_cast(make_array(), 'LargeList(Int64)')), cardinality(arrow_cast(make_array(make_array()), 'LargeList(List(Int64))'))
 ----
 NULL 0
 
 #TODO
 #https://github.com/apache/datafusion/issues/9158
 #query II
-#select cardinality(arrow_cast(make_array(), 'FixedSizeList(1, Null)')), cardinality(arrow_cast(make_array(make_array()), 'FixedSizeList(1, List(Null))'))
+#select cardinality(arrow_cast(make_array(), 'FixedSizeList(1, Null)')), cardinality(arrow_cast(make_array(make_array()), 'FixedSizeList(1, List(Int64))'))
 #----
 #NULL 0
 
@@ -4691,7 +4704,7 @@ select array_dims(make_array()), array_dims(make_array(make_array()))
 NULL [1, 0]
 
 query ??
-select array_dims(arrow_cast(make_array(), 'LargeList(Null)')), array_dims(arrow_cast(make_array(make_array()), 'LargeList(List(Null))'))
+select array_dims(arrow_cast(make_array(), 'LargeList(Int64)')), array_dims(arrow_cast(make_array(make_array()), 'LargeList(List(Int64))'))
 ----
 NULL [1, 0]
 
@@ -4853,7 +4866,7 @@ select array_ndims(make_array()), array_ndims(make_array(make_array()))
 1 2
 
 query II
-select array_ndims(arrow_cast(make_array(), 'LargeList(Null)')), array_ndims(arrow_cast(make_array(make_array()), 'LargeList(List(Null))'))
+select array_ndims(arrow_cast(make_array(), 'LargeList(Int64)')), array_ndims(arrow_cast(make_array(make_array()), 'LargeList(List(Int64))'))
 ----
 1 2
 
@@ -4874,7 +4887,7 @@ select list_ndims(make_array()), list_ndims(make_array(make_array()))
 1 2
 
 query II
-select list_ndims(arrow_cast(make_array(), 'LargeList(Null)')), list_ndims(arrow_cast(make_array(make_array()), 'LargeList(List(Null))'))
+select list_ndims(arrow_cast(make_array(), 'LargeList(Int64)')), list_ndims(arrow_cast(make_array(make_array()), 'LargeList(List(Int64))'))
 ----
 1 2
 
@@ -5492,7 +5505,7 @@ select array_intersect([], []);
 []
 
 query ?
-select array_intersect(arrow_cast([], 'LargeList(Null)'), arrow_cast([], 'LargeList(Null)'));
+select array_intersect(arrow_cast([], 'LargeList(Int64)'), arrow_cast([], 'LargeList(Int64)'));
 ----
 []
 
@@ -5522,7 +5535,17 @@ select array_intersect([], null);
 []
 
 query ?
-select array_intersect(arrow_cast([], 'LargeList(Null)'), null);
+select array_intersect([[1,2,3]], [[]]);
+----
+[]
+
+query ?
+select array_intersect([[null]], [[]]);
+----
+[]
+
+query ?
+select array_intersect(arrow_cast([], 'LargeList(Int64)'), null);
 ----
 []
 
@@ -5532,7 +5555,7 @@ select array_intersect(null, []);
 NULL
 
 query ?
-select array_intersect(null, arrow_cast([], 'LargeList(Null)'));
+select array_intersect(null, arrow_cast([], 'LargeList(Int64)'));
 ----
 NULL
 
@@ -6188,7 +6211,7 @@ select empty(make_array());
 true
 
 query B
-select empty(arrow_cast(make_array(), 'LargeList(Null)'));
+select empty(arrow_cast(make_array(), 'LargeList(Int64)'));
 ----
 true
 
@@ -6205,12 +6228,12 @@ select empty(make_array(NULL));
 false
 
 query B
-select empty(arrow_cast(make_array(NULL), 'LargeList(Null)'));
+select empty(arrow_cast(make_array(NULL), 'LargeList(Int64)'));
 ----
 false
 
 query B
-select empty(arrow_cast(make_array(NULL), 'FixedSizeList(1, Null)'));
+select empty(arrow_cast(make_array(NULL), 'FixedSizeList(1, Int64)'));
 ----
 false
 
@@ -6274,7 +6297,7 @@ select array_empty(make_array());
 true
 
 query B
-select array_empty(arrow_cast(make_array(), 'LargeList(Null)'));
+select array_empty(arrow_cast(make_array(), 'LargeList(Int64)'));
 ----
 true
 
@@ -6285,7 +6308,7 @@ select array_empty(make_array(NULL));
 false
 
 query B
-select array_empty(arrow_cast(make_array(NULL), 'LargeList(Null)'));
+select array_empty(arrow_cast(make_array(NULL), 'LargeList(Int64)'));
 ----
 false
 
@@ -6308,7 +6331,7 @@ select list_empty(make_array());
 true
 
 query B
-select list_empty(arrow_cast(make_array(), 'LargeList(Null)'));
+select list_empty(arrow_cast(make_array(), 'LargeList(Int64)'));
 ----
 true
 
@@ -6319,7 +6342,7 @@ select list_empty(make_array(NULL));
 false
 
 query B
-select list_empty(arrow_cast(make_array(NULL), 'LargeList(Null)'));
+select list_empty(arrow_cast(make_array(NULL), 'LargeList(Int64)'));
 ----
 false
 

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -84,12 +84,12 @@ select * from unnest(null);
 
 
 ## Unnest empty array in select list
-query ?
+query I
 select unnest([]);
 ----
 
 ## Unnest empty array in from clause
-query ?
+query I
 select * from unnest([]);
 ----
 
@@ -177,7 +177,7 @@ query error DataFusion error: This feature is not implemented: unnest\(\) does n
 select unnest(null) from unnest_table;
 
 ## Multiple unnest functions in selection
-query ?I
+query II
 select unnest([]), unnest(NULL::int[]);
 ----
 
@@ -250,7 +250,7 @@ select * from unnest(
 2 b NULL NULL
 NULL c NULL NULL
 
-query ?I
+query II
 select * from unnest([], NULL::int[]);
 ----
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10789 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Slt:
1. Convert List(Null) and LargeList(Null) to List(I64) and LargeList(I64) respectively
2. Fix related array function


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
