### PR TITLE
Extract Parquet statistics from `Interval` column

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -19,7 +19,10 @@
 
 // TODO: potentially move this to arrow-rs: https://github.com/apache/arrow-rs/issues/4328
 
-use arrow::{array::ArrayRef, datatypes::i256, datatypes::DataType, datatypes::TimeUnit};
+use arrow::{
+    array::ArrayRef, datatypes::i256, datatypes::DataType, datatypes::IntervalUnit,
+    datatypes::TimeUnit,
+};
 use arrow_array::{new_empty_array, new_null_array, UInt64Array};
 use arrow_schema::{Field, FieldRef, Schema};
 use datafusion_common::{
@@ -258,8 +261,8 @@ macro_rules! get_statistic {
                     }
                     Some(DataType::Interval(unit)) => {
                         match unit {
-                            IntervalUnit::YearMonth => unimplemented!("Interval statistics not yet supported by parquet")
-                            IntervalUnit::DayTime => unimplemented!("Interval statistics not yet supported by parquet")
+                            IntervalUnit::YearMonth => unimplemented!("Interval statistics not yet supported by parquet"),
+                            IntervalUnit::DayTime => unimplemented!("Interval statistics not yet supported by parquet"),
                             IntervalUnit::MonthDayNano => unimplemented!("Interval statistics not yet supported by parquet")
                         }
                     }

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -256,6 +256,13 @@ macro_rules! get_statistic {
                     Some(DataType::Float16) => {
                         Some(ScalarValue::Float16(from_bytes_to_f16(s.$bytes_func())))
                     }
+                    Some(DataType::Interval(unit)) => {
+                        match unit {
+                            IntervalUnit::YearMonth => unimplemented!("Interval statistics not yet supported by parquet")
+                            IntervalUnit::DayTime => unimplemented!("Interval statistics not yet supported by parquet")
+                            IntervalUnit::MonthDayNano => unimplemented!("Interval statistics not yet supported by parquet")
+                        }
+                    }
                     _ => None,
                 }
             }

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -1096,12 +1096,12 @@ async fn test_interval_diff_rg_sizes() {
     Test {
         reader: &reader,
         expected_min: Arc::new(IntervalYearMonthArray::from(vec![
-            IntervalYearMonthType::make_value(1, 1),
-            IntervalYearMonthType::make_value(4, 4),
+            IntervalYearMonthType::make_value(1, 10),
+            IntervalYearMonthType::make_value(4, 13),
         ])),
         expected_max: Arc::new(IntervalYearMonthArray::from(vec![
-            IntervalYearMonthType::make_value(6, 6),
-            IntervalYearMonthType::make_value(8, 8),
+            IntervalYearMonthType::make_value(6, 51),
+            IntervalYearMonthType::make_value(8, 53),
         ])),
         expected_null_counts: UInt64Array::from(vec![2, 2]),
         expected_row_counts: UInt64Array::from(vec![13, 7]),
@@ -1112,12 +1112,12 @@ async fn test_interval_diff_rg_sizes() {
     Test {
         reader: &reader,
         expected_min: Arc::new(IntervalDayTimeArray::from(vec![
-            IntervalDayTimeType::make_value(1, 1),
-            IntervalDayTimeType::make_value(4, 4),
+            IntervalDayTimeType::make_value(1, 10),
+            IntervalDayTimeType::make_value(4, 13),
         ])),
         expected_max: Arc::new(IntervalDayTimeArray::from(vec![
-            IntervalDayTimeType::make_value(6, 6),
-            IntervalDayTimeType::make_value(8, 8),
+            IntervalDayTimeType::make_value(6, 51),
+            IntervalDayTimeType::make_value(8, 53),
         ])),
         expected_null_counts: UInt64Array::from(vec![2, 2]),
         expected_row_counts: UInt64Array::from(vec![13, 7]),
@@ -1128,12 +1128,12 @@ async fn test_interval_diff_rg_sizes() {
     Test {
         reader: &reader,
         expected_min: Arc::new(IntervalMonthDayNanoArray::from(vec![
-            IntervalMonthDayNanoType::make_value(1, 1, 1),
-            IntervalMonthDayNanoType::make_value(4, 4, 4),
+            IntervalMonthDayNanoType::make_value(1, 10, 100),
+            IntervalMonthDayNanoType::make_value(4, 13, 103),
         ])),
         expected_max: Arc::new(IntervalMonthDayNanoArray::from(vec![
-            IntervalMonthDayNanoType::make_value(6, 6, 6),
-            IntervalMonthDayNanoType::make_value(8, 8, 8),
+            IntervalMonthDayNanoType::make_value(6, 51, 501),
+            IntervalMonthDayNanoType::make_value(8, 53, 503),
         ])),
         expected_null_counts: UInt64Array::from(vec![2, 2]),
         expected_row_counts: UInt64Array::from(vec![13, 7]),

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -24,8 +24,7 @@ use std::sync::Arc;
 use crate::parquet::{struct_array, Scenario};
 use arrow::compute::kernels::cast_utils::Parser;
 use arrow::datatypes::{
-    i256, Date32Type, Date64Type, IntervalDayTimeType, IntervalMonthDayNanoType,
-    IntervalYearMonthType, TimestampMicrosecondType, TimestampMillisecondType,
+    i256, Date32Type, Date64Type, TimestampMicrosecondType, TimestampMillisecondType,
     TimestampNanosecondType, TimestampSecondType,
 };
 use arrow_array::{
@@ -1076,8 +1075,11 @@ async fn test_dates_64_diff_rg_sizes() {
 
 #[tokio::test]
 #[should_panic]
-// Statistics for `Intervals` are not supported yet, see for ref:
-// https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#interval
+// Currently this test `should_panic` since statistics for `Intervals`
+// are not supported and `IntervalMonthDayNano` cannot be written
+// to parquet yet.
+// Refer to issue: https://github.com/apache/arrow-rs/issues/5847
+// and https://github.com/apache/arrow-rs/blob/master/parquet/src/arrow/arrow_writer/mod.rs#L747
 async fn test_interval_diff_rg_sizes() {
     // This creates a parquet files of 3 columns:
     // "year_month" --> IntervalYearMonthArray
@@ -1093,48 +1095,55 @@ async fn test_interval_diff_rg_sizes() {
     .build()
     .await;
 
+    // TODO: expected values need to be changed once issue is resolved
+    // expected_min: Arc::new(IntervalYearMonthArray::from(vec![
+    //     IntervalYearMonthType::make_value(1, 10),
+    //     IntervalYearMonthType::make_value(4, 13),
+    // ])),
+    // expected_max: Arc::new(IntervalYearMonthArray::from(vec![
+    //     IntervalYearMonthType::make_value(6, 51),
+    //     IntervalYearMonthType::make_value(8, 53),
+    // ])),
     Test {
         reader: &reader,
-        expected_min: Arc::new(IntervalYearMonthArray::from(vec![
-            IntervalYearMonthType::make_value(1, 10),
-            IntervalYearMonthType::make_value(4, 13),
-        ])),
-        expected_max: Arc::new(IntervalYearMonthArray::from(vec![
-            IntervalYearMonthType::make_value(6, 51),
-            IntervalYearMonthType::make_value(8, 53),
-        ])),
+        expected_min: Arc::new(IntervalYearMonthArray::from(vec![None, None])),
+        expected_max: Arc::new(IntervalYearMonthArray::from(vec![None, None])),
         expected_null_counts: UInt64Array::from(vec![2, 2]),
         expected_row_counts: UInt64Array::from(vec![13, 7]),
         column_name: "year_month",
     }
     .run();
 
+    // expected_min: Arc::new(IntervalDayTimeArray::from(vec![
+    //     IntervalDayTimeType::make_value(1, 10),
+    //     IntervalDayTimeType::make_value(4, 13),
+    // ])),
+    // expected_max: Arc::new(IntervalDayTimeArray::from(vec![
+    //     IntervalDayTimeType::make_value(6, 51),
+    //     IntervalDayTimeType::make_value(8, 53),
+    // ])),
     Test {
         reader: &reader,
-        expected_min: Arc::new(IntervalDayTimeArray::from(vec![
-            IntervalDayTimeType::make_value(1, 10),
-            IntervalDayTimeType::make_value(4, 13),
-        ])),
-        expected_max: Arc::new(IntervalDayTimeArray::from(vec![
-            IntervalDayTimeType::make_value(6, 51),
-            IntervalDayTimeType::make_value(8, 53),
-        ])),
+        expected_min: Arc::new(IntervalDayTimeArray::from(vec![None, None])),
+        expected_max: Arc::new(IntervalDayTimeArray::from(vec![None, None])),
         expected_null_counts: UInt64Array::from(vec![2, 2]),
         expected_row_counts: UInt64Array::from(vec![13, 7]),
         column_name: "day_time",
     }
     .run();
 
+    // expected_min: Arc::new(IntervalMonthDayNanoArray::from(vec![
+    //     IntervalMonthDayNanoType::make_value(1, 10, 100),
+    //     IntervalMonthDayNanoType::make_value(4, 13, 103),
+    // ])),
+    // expected_max: Arc::new(IntervalMonthDayNanoArray::from(vec![
+    //     IntervalMonthDayNanoType::make_value(6, 51, 501),
+    //     IntervalMonthDayNanoType::make_value(8, 53, 503),
+    // ])),
     Test {
         reader: &reader,
-        expected_min: Arc::new(IntervalMonthDayNanoArray::from(vec![
-            IntervalMonthDayNanoType::make_value(1, 10, 100),
-            IntervalMonthDayNanoType::make_value(4, 13, 103),
-        ])),
-        expected_max: Arc::new(IntervalMonthDayNanoArray::from(vec![
-            IntervalMonthDayNanoType::make_value(6, 51, 501),
-            IntervalMonthDayNanoType::make_value(8, 53, 503),
-        ])),
+        expected_min: Arc::new(IntervalMonthDayNanoArray::from(vec![None, None])),
+        expected_max: Arc::new(IntervalMonthDayNanoArray::from(vec![None, None])),
         expected_null_counts: UInt64Array::from(vec![2, 2]),
         expected_row_counts: UInt64Array::from(vec![13, 7]),
         column_name: "month_day_nano",

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -24,14 +24,16 @@ use std::sync::Arc;
 use crate::parquet::{struct_array, Scenario};
 use arrow::compute::kernels::cast_utils::Parser;
 use arrow::datatypes::{
-    i256, Date32Type, Date64Type, IntervalYearMonthType, TimestampMicrosecondType,
-    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType,
+    i256, Date32Type, Date64Type, IntervalDayTimeType, IntervalMonthDayNanoType,
+    IntervalYearMonthType, TimestampMicrosecondType, TimestampMillisecondType,
+    TimestampNanosecondType, TimestampSecondType,
 };
 use arrow_array::{
     make_array, Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Date64Array,
     Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Float16Array, Float32Array,
-    Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, IntervalYearMonthArray,
-    LargeBinaryArray, LargeStringArray, RecordBatch, StringArray, Time32MillisecondArray,
+    Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, IntervalDayTimeArray,
+    IntervalMonthDayNanoArray, IntervalYearMonthArray, LargeBinaryArray,
+    LargeStringArray, RecordBatch, StringArray, Time32MillisecondArray,
     Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
     TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
     TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
@@ -1105,6 +1107,38 @@ async fn test_interval_diff_rg_sizes() {
         expected_null_counts: UInt64Array::from(vec![2, 2]),
         expected_row_counts: UInt64Array::from(vec![13, 7]),
         column_name: "year_month",
+    }
+    .run();
+
+    Test {
+        reader: &reader,
+        expected_min: Arc::new(IntervalDayTimeArray::from(vec![
+            IntervalDayTimeType::make_value(1, 1),
+            IntervalDayTimeType::make_value(4, 4),
+        ])),
+        expected_max: Arc::new(IntervalDayTimeArray::from(vec![
+            IntervalDayTimeType::make_value(6, 6),
+            IntervalDayTimeType::make_value(8, 8),
+        ])),
+        expected_null_counts: UInt64Array::from(vec![2, 2]),
+        expected_row_counts: UInt64Array::from(vec![13, 7]),
+        column_name: "day_time",
+    }
+    .run();
+
+    Test {
+        reader: &reader,
+        expected_min: Arc::new(IntervalMonthDayNanoArray::from(vec![
+            IntervalMonthDayNanoType::make_value(1, 1, 1),
+            IntervalMonthDayNanoType::make_value(4, 4, 4),
+        ])),
+        expected_max: Arc::new(IntervalMonthDayNanoArray::from(vec![
+            IntervalMonthDayNanoType::make_value(6, 6, 6),
+            IntervalMonthDayNanoType::make_value(8, 8, 8),
+        ])),
+        expected_null_counts: UInt64Array::from(vec![2, 2]),
+        expected_row_counts: UInt64Array::from(vec![13, 7]),
+        column_name: "month_day_nano",
     }
     .run();
 }

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -964,7 +964,7 @@ fn make_interval_batch(offset: i32) -> RecordBatch {
         Some(IntervalDayTimeType::make_value(5 + offset, 50 + offset)),
     ]);
 
-    // Not yet implemented, see for ref:
+    // Not yet implemented, refer to:
     // https://github.com/apache/arrow-rs/blob/master/parquet/src/arrow/arrow_writer/mod.rs#L747
     let mdn_arr = IntervalMonthDayNanoArray::from(vec![
         Some(IntervalMonthDayNanoType::make_value(

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -17,7 +17,9 @@
 
 //! Parquet integration tests
 use arrow::array::Decimal128Array;
-use arrow::datatypes::i256;
+use arrow::datatypes::{
+    i256, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalYearMonthType,
+};
 use arrow::{
     array::{
         make_array, Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Date64Array,
@@ -33,6 +35,10 @@ use arrow::{
     record_batch::RecordBatch,
     util::pretty::pretty_format_batches,
 };
+use arrow_array::{
+    IntervalDayTimeArray, IntervalMonthDayNanoArray, IntervalYearMonthArray,
+};
+use arrow_schema::IntervalUnit;
 use chrono::{Datelike, Duration, TimeDelta};
 use datafusion::{
     datasource::{physical_plan::ParquetExec, provider_as_source, TableProvider},
@@ -80,6 +86,7 @@ enum Scenario {
     Time32Millisecond,
     Time64Nanosecond,
     Time64Microsecond,
+    Interval,
     /// 7 Rows, for each i8, i16, i32, i64, u8, u16, u32, u64, f32, f64
     /// -MIN, -100, -1, 0, 1, 100, MAX
     NumericLimits,
@@ -925,6 +932,69 @@ fn make_dict_batch() -> RecordBatch {
     .unwrap()
 }
 
+fn make_interval_batch(offset: i32) -> RecordBatch {
+    let schema = Schema::new(vec![
+        Field::new(
+            "year_month",
+            DataType::Interval(IntervalUnit::YearMonth),
+            true,
+        ),
+        Field::new("day_time", DataType::Interval(IntervalUnit::DayTime), true),
+        Field::new(
+            "month_day_nano",
+            DataType::Interval(IntervalUnit::MonthDayNano),
+            true,
+        ),
+    ]);
+    let schema = Arc::new(schema);
+
+    let ym_arr = IntervalYearMonthArray::from(vec![
+        Some(IntervalYearMonthType::make_value(1 + offset, 1 + offset)),
+        Some(IntervalYearMonthType::make_value(2 + offset, 2 + offset)),
+        Some(IntervalYearMonthType::make_value(3 + offset, 3 + offset)),
+        None,
+        Some(IntervalYearMonthType::make_value(5 + offset, 5 + offset)),
+    ]);
+
+    let dt_arr = IntervalDayTimeArray::from(vec![
+        Some(IntervalDayTimeType::make_value(1 + offset, 1 + offset)),
+        Some(IntervalDayTimeType::make_value(2 + offset, 2 + offset)),
+        Some(IntervalDayTimeType::make_value(3 + offset, 3 + offset)),
+        None,
+        Some(IntervalDayTimeType::make_value(5 + offset, 5 + offset)),
+    ]);
+
+    let mdn_arr = IntervalMonthDayNanoArray::from(vec![
+        Some(IntervalMonthDayNanoType::make_value(
+            1 + offset,
+            1 + offset,
+            1 + (offset as i64),
+        )),
+        Some(IntervalMonthDayNanoType::make_value(
+            2 + offset,
+            2 + offset,
+            2 + (offset as i64),
+        )),
+        Some(IntervalMonthDayNanoType::make_value(
+            3 + offset,
+            3 + offset,
+            3 + (offset as i64),
+        )),
+        None,
+        Some(IntervalMonthDayNanoType::make_value(
+            5 + offset,
+            5 + offset,
+            5 + (offset as i64),
+        )),
+    ]);
+
+    RecordBatch::try_new(
+        schema,
+        vec![Arc::new(ym_arr), Arc::new(dt_arr), Arc::new(mdn_arr)],
+    )
+    .unwrap()
+}
+
 fn create_data_batch(scenario: Scenario) -> Vec<RecordBatch> {
     match scenario {
         Scenario::Boolean => {
@@ -1346,6 +1416,12 @@ fn create_data_batch(scenario: Scenario) -> Vec<RecordBatch> {
                 ]),
             ]
         }
+        Scenario::Interval => vec![
+            make_interval_batch(0),
+            make_interval_batch(1),
+            make_interval_batch(2),
+            make_interval_batch(3),
+        ],
     }
 }
 

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -964,6 +964,8 @@ fn make_interval_batch(offset: i32) -> RecordBatch {
         Some(IntervalDayTimeType::make_value(5 + offset, 5 + offset)),
     ]);
 
+    // Not yet implemented, see for ref:
+    // https://github.com/apache/arrow-rs/blob/master/parquet/src/arrow/arrow_writer/mod.rs#L747
     let mdn_arr = IntervalMonthDayNanoArray::from(vec![
         Some(IntervalMonthDayNanoType::make_value(
             1 + offset,

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -949,19 +949,19 @@ fn make_interval_batch(offset: i32) -> RecordBatch {
     let schema = Arc::new(schema);
 
     let ym_arr = IntervalYearMonthArray::from(vec![
-        Some(IntervalYearMonthType::make_value(1 + offset, 1 + offset)),
-        Some(IntervalYearMonthType::make_value(2 + offset, 2 + offset)),
-        Some(IntervalYearMonthType::make_value(3 + offset, 3 + offset)),
+        Some(IntervalYearMonthType::make_value(1 + offset, 10 + offset)),
+        Some(IntervalYearMonthType::make_value(2 + offset, 20 + offset)),
+        Some(IntervalYearMonthType::make_value(3 + offset, 30 + offset)),
         None,
-        Some(IntervalYearMonthType::make_value(5 + offset, 5 + offset)),
+        Some(IntervalYearMonthType::make_value(5 + offset, 50 + offset)),
     ]);
 
     let dt_arr = IntervalDayTimeArray::from(vec![
-        Some(IntervalDayTimeType::make_value(1 + offset, 1 + offset)),
-        Some(IntervalDayTimeType::make_value(2 + offset, 2 + offset)),
-        Some(IntervalDayTimeType::make_value(3 + offset, 3 + offset)),
+        Some(IntervalDayTimeType::make_value(1 + offset, 10 + offset)),
+        Some(IntervalDayTimeType::make_value(2 + offset, 20 + offset)),
+        Some(IntervalDayTimeType::make_value(3 + offset, 30 + offset)),
         None,
-        Some(IntervalDayTimeType::make_value(5 + offset, 5 + offset)),
+        Some(IntervalDayTimeType::make_value(5 + offset, 50 + offset)),
     ]);
 
     // Not yet implemented, see for ref:
@@ -969,24 +969,24 @@ fn make_interval_batch(offset: i32) -> RecordBatch {
     let mdn_arr = IntervalMonthDayNanoArray::from(vec![
         Some(IntervalMonthDayNanoType::make_value(
             1 + offset,
-            1 + offset,
-            1 + (offset as i64),
+            10 + offset,
+            100 + (offset as i64),
         )),
         Some(IntervalMonthDayNanoType::make_value(
             2 + offset,
-            2 + offset,
-            2 + (offset as i64),
+            20 + offset,
+            200 + (offset as i64),
         )),
         Some(IntervalMonthDayNanoType::make_value(
             3 + offset,
-            3 + offset,
-            3 + (offset as i64),
+            30 + offset,
+            300 + (offset as i64),
         )),
         None,
         Some(IntervalMonthDayNanoType::make_value(
             5 + offset,
-            5 + offset,
-            5 + (offset as i64),
+            50 + offset,
+            500 + (offset as i64),
         )),
     ]);
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10752.

## Rationale for this change
Since parquet does not support statistics for `Interval` columns, this PR only prepares test cases and some necessary setup.
Once parquet supports statistics, a follow-up PR will be needed to finish the implementation. 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- added test cases for interval columns
- added `get_statistic` match arm (stub)
- added comments to highlight the not yet supported parts
- for now the test_cases `should_panic`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
