### PR TITLE
fix: `array_slice` and `array_element` panicked on empty args

### DIFF
--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -40,7 +40,7 @@ use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 use std::sync::Arc;
 
-use crate::utils::make_scalar_function;
+use crate::utils::{get_arg_name, make_scalar_function};
 
 // Create static instances of ScalarUDFs for each function
 make_udf_expr_and_func!(
@@ -97,8 +97,11 @@ impl ScalarUDFImpl for ArrayElement {
     }
 
     fn display_name(&self, args: &[Expr]) -> Result<String> {
-        let args_name: Vec<String> = args.iter().map(|e| e.to_string()).collect();
-        Ok(format!("{}[{}]", args_name[0], args_name[1]))
+        Ok(format!(
+            "{}[{}]",
+            get_arg_name(args, 0),
+            get_arg_name(args, 1)
+        ))
     }
 
     fn signature(&self) -> &Signature {
@@ -251,8 +254,14 @@ impl ScalarUDFImpl for ArraySlice {
     }
 
     fn display_name(&self, args: &[Expr]) -> Result<String> {
-        let args_name: Vec<String> = args.iter().map(|e| e.to_string()).collect();
-        Ok(format!("{}[{}]", args_name[0], args_name[1..].join(":")))
+        Ok(format!(
+            "{}[{}]",
+            get_arg_name(args, 0),
+            (1..args.len())
+                .map(|i| get_arg_name(args, i))
+                .collect::<Vec<String>>()
+                .join(":")
+        ))
     }
 
     fn name(&self) -> &str {

--- a/datafusion/functions-array/src/utils.rs
+++ b/datafusion/functions-array/src/utils.rs
@@ -32,7 +32,7 @@ use datafusion_common::{exec_err, plan_err, Result, ScalarValue};
 
 use core::any::type_name;
 use datafusion_common::DataFusionError;
-use datafusion_expr::{ColumnarValue, ScalarFunctionImplementation};
+use datafusion_expr::{ColumnarValue, Expr, ScalarFunctionImplementation};
 
 macro_rules! downcast_arg {
     ($ARG:expr, $ARRAY_TYPE:ident) => {{
@@ -251,6 +251,11 @@ pub(crate) fn compute_array_dims(
             _ => return Ok(Some(res)),
         }
     }
+}
+
+/// Returns the name of the argument at index `i`, or an empty string if the index is out of bounds.
+pub(super) fn get_arg_name(args: &[Expr], i: usize) -> String {
+    args.get(i).map(ToString::to_string).unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1137,13 +1137,8 @@ from arrays_values_without_nulls;
 ## array_element (aliases: array_extract, list_extract, list_element)
 
 # Testing with empty arguments should result in an error
-query error
+query error DataFusion error: Error during planning: Error during planning: \[data_types_with_scalar_udf\] signature ArraySignature\(ArrayAndIndex\) does not support zero arguments.
 select array_element();
-----
-DataFusion error: Error during planning: Error during planning: [data_types_with_scalar_udf] signature ArraySignature(ArrayAndIndex) does not support zero arguments. and No function matches the given name and argument types 'array_element()'. You might need to add explicit type casts.
-	Candidate functions:
-	array_element(array, index)
-
 
 # array_element error
 query error
@@ -1984,13 +1979,8 @@ select array_slice(a, -1, 2, 1), array_slice(a, -1, 2),
 [6.0] [6.0] [] []
 
 # Testing with empty arguments should result in an error
-query error
+query error DataFusion error: Error during planning: Error during planning: \[data_types_with_scalar_udf\] signature VariadicAny does not support zero arguments.
 select array_slice();
-----
-DataFusion error: Error during planning: Error during planning: [data_types_with_scalar_udf] signature VariadicAny does not support zero arguments. and No function matches the given name and argument types 'array_slice()'. You might need to add explicit type casts.
-	Candidate functions:
-	array_slice(Any, .., Any)
-
 
 
 # make_array with nulls

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1136,6 +1136,15 @@ from arrays_values_without_nulls;
 
 ## array_element (aliases: array_extract, list_extract, list_element)
 
+# Testing with empty arguments should result in an error
+query error
+select array_element();
+----
+DataFusion error: Error during planning: Error during planning: [data_types_with_scalar_udf] signature ArraySignature(ArrayAndIndex) does not support zero arguments. and No function matches the given name and argument types 'array_element()'. You might need to add explicit type casts.
+	Candidate functions:
+	array_element(array, index)
+
+
 # array_element error
 query error
 select array_element(1, 2);
@@ -1973,6 +1982,15 @@ select array_slice(a, -1, 2, 1), array_slice(a, -1, 2),
 [] [] [] []
 [] [] [] []
 [6.0] [6.0] [] []
+
+# Testing with empty arguments should result in an error
+query error
+select array_slice();
+----
+DataFusion error: Error during planning: Error during planning: [data_types_with_scalar_udf] signature VariadicAny does not support zero arguments. and No function matches the given name and argument types 'array_slice()'. You might need to add explicit type casts.
+	Candidate functions:
+	array_slice(Any, .., Any)
+
 
 
 # make_array with nulls


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10791.

## Rationale for this change
When the `args` are empty, they panic at [display_name](https://github.com/apache/datafusion/blob/ece7ae5eca451bb2599f13f9f9197fd93b2a8bc2/datafusion/functions-array/src/extract.rs#L255),  due to "index out of bounds".
https://github.com/apache/datafusion/blob/ece7ae5eca451bb2599f13f9f9197fd93b2a8bc2/datafusion/functions-array/src/extract.rs#L253-L256

The fix is to use an empty string as the arg name if it is out of bounds,  allow `display_name` to pass through, and subsequently generating an error by checking the signature.
## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
