### PR TITLE
Fix `ScalarUDFImpl::propagate_constraints` doc

### DIFF
--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -244,8 +244,7 @@ impl ScalarUDF {
     /// # Example
     ///
     /// If the function is `ABS(a)`, the current `interval` is `[4, 5]` and the
-    /// input `a` is given as `[-7, -6]`, then propagation would would return
-    /// `[-5, 5]`.
+    /// input `a` is given as `[-7, 3]`, then propagation would return `[-5, 3]`.
     pub fn propagate_constraints(
         &self,
         interval: &Interval,
@@ -504,8 +503,7 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     /// # Example
     ///
     /// If the function is `ABS(a)`, the current `interval` is `[4, 5]` and the
-    /// input `a` is given as `[-7, -6]`, then propagation would would return
-    /// `[-5, 5]`.
+    /// input `a` is given as `[-7, 3]`, then propagation would return `[-5, 3]`.
     fn propagate_constraints(
         &self,
         _interval: &Interval,

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -112,8 +112,8 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + PartialEq<dyn Any> {
     ///
     /// If the expression is `a + b`, the current `interval` is `[4, 5]` and the
     /// inputs `a` and `b` are respectively given as `[0, 2]` and `[-∞, 4]`, then
-    /// propagation would would return `[0, 2]` and `[2, 4]` as `b` must be at
-    /// least `2` to make the output at least `4`.
+    /// propagation would return `[0, 2]` and `[2, 4]` as `b` must be at least
+    /// `2` to make the output at least `4`.
     fn propagate_constraints(
         &self,
         _interval: &Interval,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I'm reading somd udf code, and found the example in `ScalarUDFImpl::propagate_constraints` doc is confused. I checked `PhysicalExpr::propagate_constraints` doc example
```
    /// If the expression is `a + b`, the current `interval` is `[4, 5]` and the
    /// inputs `a` and `b` are respectively given as `[0, 2]` and `[-∞, 4]`, then
    /// propagation would would return `[0, 2]` and `[2, 4]` as `b` must be at
    /// least `2` to make the output at least `4`.
```
If I understand correctly, the updated bounds of child expressions should be subinterval of their original intervals.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
