### PR TITLE
Minor: Clarify `SessionContext::state` docs

### DIFF
--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -1249,8 +1249,18 @@ impl SessionContext {
         Arc::new(TaskContext::from(self))
     }
 
-    /// Snapshots the [`SessionState`] of this [`SessionContext`] setting the
-    /// `query_execution_start_time` to the current time
+    /// Return a new  [`SessionState`] suitable for executing a single query.
+    ///
+    /// Notes:
+    ///
+    /// 1. `query_execution_start_time` us set to the current time for the
+    /// returned state
+    ///
+    /// 2. The returned state is not shared with the current session state
+    /// and this changes to the returned `SessionState` such as changing
+    /// [`ConfigOptions`] will not be reflected in this `SessionContext`.
+    ///
+    /// [`ConfigOptions`]: crate::config::ConfigOptions
     pub fn state(&self) -> SessionState {
         let mut state = self.state.read().clone();
         state.execution_props_mut().start_execution();


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change

@goldmedal  reports on discord: https://discord.com/channels/885562378132000778/1166447479609376850/1249052209388326922

> Hi, I tried to implement some AnalyzerRule to rewrite and analyze the logical plan. I have implemented the AnalyzerRules that work fine with Analyzer::with_rules. However, when I tried to register them to the SessionContext, I couldn't find any method for it. I can only do something like:

```rust
let ctx = SessionContext::new();
let new_st = ctx.state().add_analyzer_rule(Arc::new(ModelAnalyzeRule::new(Arc::clone(&analyzed_mdl))));
let new_st = new_st.add_analyzer_rule(Arc::new(ModelGenerationRule::new(Arc::clone(&analyzed_mdl))));
let new_ctx = SessionContext::new_with_state(new_st);
```

The reason is that `SessionContext::state()` returns a copy of the current state and thus any changes are not reflected in the overall `SessionState`

I have been confused by this before too and I think others have as well

Thus we should at least improve the documentation



## What changes are included in this PR?

 Clearer documentation on [`SessionContext::state()` ](https://docs.rs/datafusion/latest/datafusion/execution/context/struct.SessionContext.html#method.state) that it is a copy is returned and any changes made to that copy are not reflected in the original `SessionContext`


## Are these changes tested?
N/A

## Are there any user-facing changes?
docs only, no functional change
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
