### PR TITLE
chore: Make DFSchema::datatype_is_logically_equal function public

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -666,7 +666,7 @@ impl DFSchema {
     /// than datatype_is_semantically_equal in that a Dictionary<K,V> type is logically
     /// equal to a plain V type, but not semantically equal. Dictionary<K1, V1> is also
     /// logically equal to Dictionary<K2, V1>.
-    fn datatype_is_logically_equal(dt1: &DataType, dt2: &DataType) -> bool {
+    pub fn datatype_is_logically_equal(dt1: &DataType, dt2: &DataType) -> bool {
         // check nested fields
         match (dt1, dt2) {
             (DataType::Dictionary(_, v1), DataType::Dictionary(_, v2)) => {


### PR DESCRIPTION
## Which issue does this PR close?
Follow-up on #10031

## Rationale for this change
As discussed in https://github.com/apache/datafusion/pull/10031#discussion_r1561945088, a followup PR to make
the function `datatype_is_logically_equal` in DFSchema public and reuses in the in_list code.

## What changes are included in this PR?
1. make `datatype_is_logically_equal` public in DFSchema
2. remove duplicate code in `in_list`

## Are these changes tested?
Existing tests.

## Are there any user-facing changes?
No
