### PR TITLE
Disabling test for semi join with filters

### DIFF
--- a/datafusion/core/tests/fuzz_cases/join_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/join_fuzz.rs
@@ -179,7 +179,8 @@ async fn test_semi_join_1k() {
     .run_test()
     .await
 }
-
+// See https://github.com/apache/datafusion/issues/10886
+#[ignore]
 #[tokio::test]
 async fn test_semi_join_1k_filtered() {
     JoinFuzzTestCase::new(


### PR DESCRIPTION
Temporary addresses build failed on main due to #10886 