### PR TITLE
Remove `Interval` column test // parquet extraction

### DIFF
--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -30,8 +30,7 @@ use arrow::datatypes::{
 use arrow_array::{
     make_array, Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Date64Array,
     Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Float16Array, Float32Array,
-    Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, IntervalDayTimeArray,
-    IntervalMonthDayNanoArray, IntervalYearMonthArray, LargeBinaryArray,
+    Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, LargeBinaryArray,
     LargeStringArray, RecordBatch, StringArray, Time32MillisecondArray,
     Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
     TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
@@ -1057,84 +1056,6 @@ async fn test_dates_64_diff_rg_sizes() {
         expected_null_counts: UInt64Array::from(vec![2, 2]),
         expected_row_counts: UInt64Array::from(vec![13, 7]),
         column_name: "date64",
-    }
-    .run();
-}
-
-#[tokio::test]
-#[should_panic]
-// Currently this test `should_panic` since statistics for `Intervals`
-// are not supported and `IntervalMonthDayNano` cannot be written
-// to parquet yet.
-// Refer to issue: https://github.com/apache/arrow-rs/issues/5847
-// and https://github.com/apache/arrow-rs/blob/master/parquet/src/arrow/arrow_writer/mod.rs#L747
-async fn test_interval_diff_rg_sizes() {
-    // This creates a parquet files of 3 columns:
-    // "year_month" --> IntervalYearMonthArray
-    // "day_time" --> IntervalDayTimeArray
-    // "month_day_nano" --> IntervalMonthDayNanoArray
-    //
-    // The file is created by 4 record batches (each has a null row)
-    // each has 5 rows but then will be split into 2 row groups with size 13, 7
-    let reader = TestReader {
-        scenario: Scenario::Interval,
-        row_per_group: 13,
-    }
-    .build()
-    .await;
-
-    // TODO: expected values need to be changed once issue is resolved
-    // expected_min: Arc::new(IntervalYearMonthArray::from(vec![
-    //     IntervalYearMonthType::make_value(1, 10),
-    //     IntervalYearMonthType::make_value(4, 13),
-    // ])),
-    // expected_max: Arc::new(IntervalYearMonthArray::from(vec![
-    //     IntervalYearMonthType::make_value(6, 51),
-    //     IntervalYearMonthType::make_value(8, 53),
-    // ])),
-    Test {
-        reader: &reader,
-        expected_min: Arc::new(IntervalYearMonthArray::from(vec![None, None])),
-        expected_max: Arc::new(IntervalYearMonthArray::from(vec![None, None])),
-        expected_null_counts: UInt64Array::from(vec![2, 2]),
-        expected_row_counts: UInt64Array::from(vec![13, 7]),
-        column_name: "year_month",
-    }
-    .run();
-
-    // expected_min: Arc::new(IntervalDayTimeArray::from(vec![
-    //     IntervalDayTimeType::make_value(1, 10),
-    //     IntervalDayTimeType::make_value(4, 13),
-    // ])),
-    // expected_max: Arc::new(IntervalDayTimeArray::from(vec![
-    //     IntervalDayTimeType::make_value(6, 51),
-    //     IntervalDayTimeType::make_value(8, 53),
-    // ])),
-    Test {
-        reader: &reader,
-        expected_min: Arc::new(IntervalDayTimeArray::from(vec![None, None])),
-        expected_max: Arc::new(IntervalDayTimeArray::from(vec![None, None])),
-        expected_null_counts: UInt64Array::from(vec![2, 2]),
-        expected_row_counts: UInt64Array::from(vec![13, 7]),
-        column_name: "day_time",
-    }
-    .run();
-
-    // expected_min: Arc::new(IntervalMonthDayNanoArray::from(vec![
-    //     IntervalMonthDayNanoType::make_value(1, 10, 100),
-    //     IntervalMonthDayNanoType::make_value(4, 13, 103),
-    // ])),
-    // expected_max: Arc::new(IntervalMonthDayNanoArray::from(vec![
-    //     IntervalMonthDayNanoType::make_value(6, 51, 501),
-    //     IntervalMonthDayNanoType::make_value(8, 53, 503),
-    // ])),
-    Test {
-        reader: &reader,
-        expected_min: Arc::new(IntervalMonthDayNanoArray::from(vec![None, None])),
-        expected_max: Arc::new(IntervalMonthDayNanoArray::from(vec![None, None])),
-        expected_null_counts: UInt64Array::from(vec![2, 2]),
-        expected_row_counts: UInt64Array::from(vec![13, 7]),
-        column_name: "month_day_nano",
     }
     .run();
 }


### PR DESCRIPTION
## Which issue does this PR close?
None.
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

## Rationale for this change
Since `Interval` has no defined sort order and writing statistics is not planned upstream in arrow-rs. We remove the already setup test infra. See [comment](https://github.com/apache/datafusion/pull/10801#issuecomment-2163269930) for reference.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
remove test and setup code (make_interval_batch)

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
