### PR TITLE
feat: add CliSessionContext trait for cli

### DIFF
--- a/datafusion-cli/examples/cli-session-context.rs
+++ b/datafusion-cli/examples/cli-session-context.rs
@@ -51,7 +51,7 @@ impl CliSessionContext for MyUnionerContext {
         self.ctx.task_ctx()
     }
 
-    fn state(&self) -> SessionState {
+    fn session_state(&self) -> SessionState {
         self.ctx.state()
     }
 
@@ -63,7 +63,7 @@ impl CliSessionContext for MyUnionerContext {
         self.ctx.register_object_store(url, object_store)
     }
 
-    fn register_options(&self, _scheme: &str) {
+    fn register_table_options_extension_from_scheme(&self, _scheme: &str) {
         unimplemented!()
     }
 

--- a/datafusion-cli/examples/cli-session-context.rs
+++ b/datafusion-cli/examples/cli-session-context.rs
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shows an example of a custom session context that unions the input plan with itself.
+//! To run this example, use `cargo run --example cli-session-context` from within the `datafusion-cli` directory.
+
+use std::{process::ExitCode, sync::Arc};
+
+use datafusion::{
+    dataframe::DataFrame,
+    error::DataFusionError,
+    execution::{context::SessionState, TaskContext},
+    logical_expr::{LogicalPlan, LogicalPlanBuilder},
+    prelude::SessionContext,
+};
+use datafusion_cli::{
+    cli_context::CliSessionContext, exec::exec_from_repl, print_options::PrintOptions,
+};
+use object_store::ObjectStore;
+
+/// This is a toy example of a custom session context that unions the input plan with itself.
+struct MyUnionerContext {
+    ctx: SessionContext,
+}
+
+impl Default for MyUnionerContext {
+    fn default() -> Self {
+        Self {
+            ctx: SessionContext::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CliSessionContext for MyUnionerContext {
+    fn task_ctx(&self) -> Arc<TaskContext> {
+        self.ctx.task_ctx()
+    }
+
+    fn state(&self) -> SessionState {
+        self.ctx.state()
+    }
+
+    fn register_object_store(
+        &self,
+        url: &url::Url,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Option<Arc<dyn ObjectStore + 'static>> {
+        self.ctx.register_object_store(url, object_store)
+    }
+
+    fn register_options(&self, _scheme: &str) {
+        unimplemented!()
+    }
+
+    async fn execute_logical_plan(
+        &self,
+        plan: LogicalPlan,
+    ) -> Result<DataFrame, DataFusionError> {
+        let new_plan = LogicalPlanBuilder::from(plan.clone())
+            .union(plan.clone())?
+            .build()?;
+
+        self.ctx.execute_logical_plan(new_plan).await
+    }
+}
+
+#[tokio::main]
+/// Calls [`main_inner`], then handles printing errors and returning the correct exit code
+pub async fn main() -> ExitCode {
+    let mut my_ctx = MyUnionerContext::default();
+
+    let mut print_options = PrintOptions {
+        format: datafusion_cli::print_format::PrintFormat::Automatic,
+        quiet: false,
+        maxrows: datafusion_cli::print_options::MaxRows::Unlimited,
+        color: true,
+    };
+
+    exec_from_repl(&mut my_ctx, &mut print_options)
+        .await
+        .unwrap();
+
+    ExitCode::SUCCESS
+}

--- a/datafusion-cli/examples/cli-session-context.rs
+++ b/datafusion-cli/examples/cli-session-context.rs
@@ -18,7 +18,7 @@
 //! Shows an example of a custom session context that unions the input plan with itself.
 //! To run this example, use `cargo run --example cli-session-context` from within the `datafusion-cli` directory.
 
-use std::{process::ExitCode, sync::Arc};
+use std::sync::Arc;
 
 use datafusion::{
     dataframe::DataFrame,
@@ -80,8 +80,8 @@ impl CliSessionContext for MyUnionerContext {
 }
 
 #[tokio::main]
-/// Calls [`main_inner`], then handles printing errors and returning the correct exit code
-pub async fn main() -> ExitCode {
+/// Runs the example.
+pub async fn main() {
     let mut my_ctx = MyUnionerContext::default();
 
     let mut print_options = PrintOptions {
@@ -94,6 +94,4 @@ pub async fn main() -> ExitCode {
     exec_from_repl(&mut my_ctx, &mut print_options)
         .await
         .unwrap();
-
-    ExitCode::SUCCESS
 }

--- a/datafusion-cli/src/cli_context.rs
+++ b/datafusion-cli/src/cli_context.rs
@@ -33,7 +33,7 @@ use crate::object_storage::{AwsOptions, GcpOptions};
 pub trait CliSessionContext {
     fn task_ctx(&self) -> Arc<TaskContext>;
 
-    fn state(&self) -> SessionState;
+    fn session_state(&self) -> SessionState;
 
     fn register_object_store(
         &self,
@@ -41,7 +41,7 @@ pub trait CliSessionContext {
         object_store: Arc<dyn ObjectStore>,
     ) -> Option<Arc<dyn ObjectStore + 'static>>;
 
-    fn register_options(&self, scheme: &str);
+    fn register_table_options_extension_from_scheme(&self, scheme: &str);
 
     async fn execute_logical_plan(
         &self,
@@ -55,7 +55,7 @@ impl CliSessionContext for SessionContext {
         self.task_ctx()
     }
 
-    fn state(&self) -> SessionState {
+    fn session_state(&self) -> SessionState {
         self.state()
     }
 
@@ -67,7 +67,7 @@ impl CliSessionContext for SessionContext {
         self.register_object_store(url, object_store)
     }
 
-    fn register_options(&self, scheme: &str) {
+    fn register_table_options_extension_from_scheme(&self, scheme: &str) {
         match scheme {
             // For Amazon S3 or Alibaba Cloud OSS
             "s3" | "oss" | "cos" => {

--- a/datafusion-cli/src/cli_context.rs
+++ b/datafusion-cli/src/cli_context.rs
@@ -31,18 +31,23 @@ use crate::object_storage::{AwsOptions, GcpOptions};
 #[async_trait::async_trait]
 /// The CLI session context trait provides a way to have a session context that can be used with datafusion's CLI code.
 pub trait CliSessionContext {
+    /// Get an atomic reference counted task context.
     fn task_ctx(&self) -> Arc<TaskContext>;
 
+    /// Get the session state.
     fn session_state(&self) -> SessionState;
 
+    /// Register an object store with the session context.
     fn register_object_store(
         &self,
         url: &url::Url,
         object_store: Arc<dyn ObjectStore>,
     ) -> Option<Arc<dyn ObjectStore + 'static>>;
 
+    /// Register table options extension from scheme.
     fn register_table_options_extension_from_scheme(&self, scheme: &str);
 
+    /// Execute a logical plan and return a DataFrame.
     async fn execute_logical_plan(
         &self,
         plan: LogicalPlan,

--- a/datafusion-cli/src/cli_context.rs
+++ b/datafusion-cli/src/cli_context.rs
@@ -17,22 +17,36 @@
 
 use std::sync::Arc;
 
-use datafusion::{dataframe::DataFrame, error::DataFusionError, execution::{context::SessionState, TaskContext}, logical_expr::LogicalPlan, prelude::SessionContext};
+use datafusion::{
+    dataframe::DataFrame,
+    error::DataFusionError,
+    execution::{context::SessionState, TaskContext},
+    logical_expr::LogicalPlan,
+    prelude::SessionContext,
+};
 use object_store::ObjectStore;
 
 use crate::object_storage::{AwsOptions, GcpOptions};
 
 #[async_trait::async_trait]
+/// The CLI session context trait provides a way to have a session context that can be used with datafusion's CLI code.
 pub trait CliSessionContext {
     fn task_ctx(&self) -> Arc<TaskContext>;
 
     fn state(&self) -> SessionState;
 
-    fn register_object_store(&self, url: &url::Url, object_store: Arc<dyn ObjectStore>) -> Option<Arc<dyn ObjectStore + 'static>>;
+    fn register_object_store(
+        &self,
+        url: &url::Url,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Option<Arc<dyn ObjectStore + 'static>>;
 
     fn register_options(&self, scheme: &str);
 
-    async fn execute_logical_plan(&self, plan: LogicalPlan) -> Result<DataFrame, DataFusionError>;
+    async fn execute_logical_plan(
+        &self,
+        plan: LogicalPlan,
+    ) -> Result<DataFrame, DataFusionError>;
 }
 
 #[async_trait::async_trait]
@@ -45,7 +59,11 @@ impl CliSessionContext for SessionContext {
         self.state()
     }
 
-    fn register_object_store(&self, url: &url::Url, object_store: Arc<dyn ObjectStore>) -> Option<Arc<dyn ObjectStore + 'static>> {
+    fn register_object_store(
+        &self,
+        url: &url::Url,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Option<Arc<dyn ObjectStore + 'static>> {
         self.register_object_store(url, object_store)
     }
 
@@ -66,8 +84,10 @@ impl CliSessionContext for SessionContext {
         }
     }
 
-    async fn execute_logical_plan(&self, plan: LogicalPlan) -> Result<DataFrame, DataFusionError> {
+    async fn execute_logical_plan(
+        &self,
+        plan: LogicalPlan,
+    ) -> Result<DataFrame, DataFusionError> {
         self.execute_logical_plan(plan).await
     }
-
 }

--- a/datafusion-cli/src/command.rs
+++ b/datafusion-cli/src/command.rs
@@ -17,6 +17,7 @@
 
 //! Command within CLI
 
+use crate::cli_context::CliSessionContext;
 use crate::exec::{exec_and_print, exec_from_lines};
 use crate::functions::{display_all_functions, Function};
 use crate::print_format::PrintFormat;
@@ -28,7 +29,6 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::exec_err;
 use datafusion::common::instant::Instant;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::prelude::SessionContext;
 use std::fs::File;
 use std::io::BufReader;
 use std::str::FromStr;
@@ -55,7 +55,7 @@ pub enum OutputFormat {
 impl Command {
     pub async fn execute(
         &self,
-        ctx: &mut SessionContext,
+        ctx: &mut dyn CliSessionContext,
         print_options: &mut PrintOptions,
     ) -> Result<()> {
         match self {

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -29,7 +29,7 @@ use crate::print_format::PrintFormat;
 use crate::{
     command::{Command, OutputFormat},
     helper::{unescape_input, CliHelper},
-    object_storage::{get_object_store},
+    object_storage::get_object_store,
     print_options::{MaxRows, PrintOptions},
 };
 
@@ -39,7 +39,6 @@ use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{DdlStatement, LogicalPlan};
 use datafusion::physical_plan::{collect, execute_stream, ExecutionPlanProperties};
-use datafusion::prelude::SessionContext;
 use datafusion::sql::parser::{DFParser, Statement};
 use datafusion::sql::sqlparser::dialect::dialect_from_str;
 
@@ -51,7 +50,7 @@ use tokio::signal;
 
 /// run and execute SQL statements and commands, against a context with the given print options
 pub async fn exec_from_commands(
-    ctx: &mut SessionContext,
+    ctx: &mut dyn CliSessionContext,
     commands: Vec<String>,
     print_options: &PrintOptions,
 ) -> Result<()> {
@@ -395,6 +394,7 @@ mod tests {
     use datafusion::common::config::FormatOptions;
     use datafusion::common::plan_err;
 
+    use datafusion::prelude::SessionContext;
     use url::Url;
 
     async fn create_external_table_test(location: &str, sql: &str) -> Result<()> {

--- a/datafusion-cli/src/lib.rs
+++ b/datafusion-cli/src/lib.rs
@@ -27,3 +27,4 @@ pub mod highlighter;
 pub mod object_storage;
 pub mod print_format;
 pub mod print_options;
+pub mod cli_context;

--- a/datafusion-cli/src/lib.rs
+++ b/datafusion-cli/src/lib.rs
@@ -19,6 +19,7 @@
 pub const DATAFUSION_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod catalog;
+pub mod cli_context;
 pub mod command;
 pub mod exec;
 pub mod functions;
@@ -27,4 +28,3 @@ pub mod highlighter;
 pub mod object_storage;
 pub mod print_format;
 pub mod print_options;
-pub mod cli_context;

--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -391,48 +391,6 @@ impl ConfigExtension for GcpOptions {
     const PREFIX: &'static str = "gcp";
 }
 
-/// Registers storage options for different cloud storage schemes in a given
-/// session context.
-///
-/// This function is responsible for extending the session context with specific
-/// options based on the storage scheme being used. These options are essential
-/// for handling interactions with different cloud storage services such as Amazon
-/// S3, Alibaba Cloud OSS, Google Cloud Storage, etc.
-///
-/// # Parameters
-///
-/// * `ctx` - A mutable reference to the session context where table options are
-///   to be registered. The session context holds configuration and environment
-///   for the current session.
-/// * `scheme` - A string slice that represents the cloud storage scheme. This
-///   determines which set of options will be registered in the session context.
-///
-/// # Supported Schemes
-///
-/// * `s3` or `oss` - Registers `AwsOptions` which are configurations specific to
-///   Amazon S3 and Alibaba Cloud OSS.
-/// * `gs` or `gcs` - Registers `GcpOptions` which are configurations specific to
-///   Google Cloud Storage.
-///
-/// NOTE: This function will not perform any action when given an unsupported scheme.
-// pub(crate) fn register_options(ctx: &dyn CliSessionContext, scheme: &str) {
-//     // Match the provided scheme against supported cloud storage schemes:
-//     match scheme {
-//         // For Amazon S3 or Alibaba Cloud OSS
-//         "s3" | "oss" | "cos" => {
-//             // Register AWS specific table options in the session context:
-//             ctx.register_table_options_extension(AwsOptions::default())
-//         }
-//         // For Google Cloud Storage
-//         "gs" | "gcs" => {
-//             // Register GCP specific table options in the session context:
-//             ctx.register_table_options_extension(GcpOptions::default())
-//         }
-//         // For unsupported schemes, do nothing:
-//         _ => {}
-//     }
-// }
-
 pub(crate) async fn get_object_store(
     state: &SessionState,
     scheme: &str,
@@ -535,7 +493,6 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            // register_options(&ctx, scheme);
             ctx.register_options(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
@@ -672,7 +629,6 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            // register_options(&ctx, scheme);
             ctx.register_options(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;

--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -493,7 +493,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            ctx.register_options(scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
@@ -538,7 +538,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            ctx.register_options(scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
@@ -564,7 +564,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            ctx.register_options(scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
@@ -592,7 +592,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            ctx.register_options(scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
@@ -629,7 +629,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            ctx.register_options(scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let gcp_options = table_options.extensions.get::<GcpOptions>().unwrap();


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

The idea is to add a `CliSessionContext` trait, which is used in the CLI in place of `SessionContext`. In doing so, I hope to make it possible for code in the `datafusion-cli` crate to be used for a custom `SessionContext` (e.g. running a REPL). See the example for something more complete.

IMO it also makes the CLI code a little cleaner (e.g. making `register_options` into a method), but that's more subjective.

## What changes are included in this PR?

* Adds a `CliSessionContext` trait.
* Updates the CLI entrypoint and related code to use a `CliSessionContext` instead of a `SessionContext` directly. 
* Adds an example: 
* Implements `CliSessionContext` for `SessionContext`

## Are these changes tested?

The CLI tests seem to pass w/ the trait being the main arg. Additionally, I've done some manual testing.

## Are there any user-facing changes?

No
