### PR TITLE
Minor: SMJ fuzz tests fix for rowcounts

### DIFF
--- a/datafusion/core/tests/fuzz_cases/join_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/join_fuzz.rs
@@ -55,7 +55,7 @@ async fn test_inner_join_1k() {
     .await
 }
 
-fn less_than_10_join_filter(schema1: Arc<Schema>, _schema2: Arc<Schema>) -> JoinFilter {
+fn less_than_100_join_filter(schema1: Arc<Schema>, _schema2: Arc<Schema>) -> JoinFilter {
     let less_than_100 = Arc::new(BinaryExpr::new(
         Arc::new(Column::new("a", 0)),
         Operator::Lt,
@@ -77,7 +77,7 @@ async fn test_inner_join_1k_filtered() {
         make_staggered_batches(1000),
         make_staggered_batches(1000),
         JoinType::Inner,
-        Some(Box::new(less_than_10_join_filter)),
+        Some(Box::new(less_than_100_join_filter)),
     )
     .run_test()
     .await
@@ -113,7 +113,7 @@ async fn test_left_join_1k_filtered() {
         make_staggered_batches(1000),
         make_staggered_batches(1000),
         JoinType::Left,
-        Some(Box::new(less_than_10_join_filter)),
+        Some(Box::new(less_than_100_join_filter)),
     )
     .run_test()
     .await
@@ -138,7 +138,7 @@ async fn test_right_join_1k_filtered() {
         make_staggered_batches(1000),
         make_staggered_batches(1000),
         JoinType::Right,
-        Some(Box::new(less_than_10_join_filter)),
+        Some(Box::new(less_than_100_join_filter)),
     )
     .run_test()
     .await
@@ -162,7 +162,7 @@ async fn test_full_join_1k_filtered() {
         make_staggered_batches(1000),
         make_staggered_batches(1000),
         JoinType::Full,
-        Some(Box::new(less_than_10_join_filter)),
+        Some(Box::new(less_than_100_join_filter)),
     )
     .run_test()
     .await
@@ -179,15 +179,14 @@ async fn test_semi_join_1k() {
     .run_test()
     .await
 }
-// See https://github.com/apache/datafusion/issues/10886
-#[ignore]
+
 #[tokio::test]
 async fn test_semi_join_1k_filtered() {
     JoinFuzzTestCase::new(
         make_staggered_batches(1000),
         make_staggered_batches(1000),
         JoinType::LeftSemi,
-        Some(Box::new(less_than_10_join_filter)),
+        Some(Box::new(less_than_100_join_filter)),
     )
     .run_test()
     .await
@@ -213,7 +212,7 @@ async fn test_anti_join_1k_filtered() {
         make_staggered_batches(1000),
         make_staggered_batches(1000),
         JoinType::LeftAnti,
-        Some(Box::new(less_than_10_join_filter)),
+        Some(Box::new(less_than_100_join_filter)),
     )
     .run_test()
     .await
@@ -392,6 +391,15 @@ impl JoinFuzzTestCase {
             let hj = self.hash_join();
             let hj_collected = collect(hj, task_ctx.clone()).await.unwrap();
 
+            // Get actual row counts(without formatting overhead) for HJ and SMJ
+            let hj_rows = hj_collected.iter().fold(0, |acc, b| acc + b.num_rows());
+            let smj_rows = smj_collected.iter().fold(0, |acc, b| acc + b.num_rows());
+
+            assert_eq!(
+                hj_rows, smj_rows,
+                "SortMergeJoinExec and HashJoinExec produced different row counts"
+            );
+
             let nlj = self.nested_loop_join();
             let nlj_collected = collect(nlj, task_ctx.clone()).await.unwrap();
 
@@ -414,21 +422,20 @@ impl JoinFuzzTestCase {
                 nlj_formatted.trim().lines().collect();
             nlj_formatted_sorted.sort_unstable();
 
-            assert_eq!(
-                smj_formatted_sorted.len(),
-                hj_formatted_sorted.len(),
-                "SortMergeJoinExec and HashJoinExec produced different row counts"
-            );
-            for (i, (smj_line, hj_line)) in smj_formatted_sorted
-                .iter()
-                .zip(&hj_formatted_sorted)
-                .enumerate()
-            {
-                assert_eq!(
-                    (i, smj_line),
-                    (i, hj_line),
-                    "SortMergeJoinExec and HashJoinExec produced different results"
-                );
+            // row level compare if any of joins returns the result
+            // the reason is different formatting when there is no rows
+            if smj_rows > 0 || hj_rows > 0 {
+                for (i, (smj_line, hj_line)) in smj_formatted_sorted
+                    .iter()
+                    .zip(&hj_formatted_sorted)
+                    .enumerate()
+                {
+                    assert_eq!(
+                        (i, smj_line),
+                        (i, hj_line),
+                        "SortMergeJoinExec and HashJoinExec produced different results"
+                    );
+                }
             }
 
             for (i, (nlj_line, hj_line)) in nlj_formatted_sorted

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -1415,9 +1415,6 @@ fn get_filter_column(
             .map(|i| buffered_columns[i.index].clone())
             .collect::<Vec<_>>();
 
-        //        dbg!(&left_columns);
-        //        dbg!(&right_columns);
-
         filter_columns.extend(left_columns);
         filter_columns.extend(right_columns);
     }

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -1415,6 +1415,9 @@ fn get_filter_column(
             .map(|i| buffered_columns[i.index].clone())
             .collect::<Vec<_>>();
 
+//        dbg!(&left_columns);
+//        dbg!(&right_columns);
+
         filter_columns.extend(left_columns);
         filter_columns.extend(right_columns);
     }

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -1415,8 +1415,8 @@ fn get_filter_column(
             .map(|i| buffered_columns[i.index].clone())
             .collect::<Vec<_>>();
 
-//        dbg!(&left_columns);
-//        dbg!(&right_columns);
+        //        dbg!(&left_columns);
+        //        dbg!(&right_columns);
 
         filter_columns.extend(left_columns);
         filter_columns.extend(right_columns);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10886.

## Rationale for this change

The fuzz tests for filtered SMJ introduced in https://github.com/apache/datafusion/pull/10728 has a flaw when calculating the rowcounts, it fact it caculcated batches which are not always the same and led to false negatives.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
