### PR TITLE
Minor: use venv in benchmark compare

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,2 +1,3 @@
 data
 results
+venv

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -37,6 +37,7 @@ DATA_DIR=${DATA_DIR:-$SCRIPT_DIR/data}
 #CARGO_COMMAND=${CARGO_COMMAND:-"cargo run --release"}
 CARGO_COMMAND=${CARGO_COMMAND:-"cargo run --profile release-nonlto"}  # for faster iterations
 PREFER_HASH_JOIN=${PREFER_HASH_JOIN:-true}
+VIRTUAL_ENV=${VIRTUAL_ENV:-$SCRIPT_DIR/venv}
 
 usage() {
     echo "
@@ -46,6 +47,7 @@ Usage:
 $0 data [benchmark]
 $0 run [benchmark]
 $0 compare <branch1> <branch2>
+$0 venv
 
 **********
 Examples:
@@ -62,6 +64,7 @@ DATAFUSION_DIR=/source/datafusion ./bench.sh run tpch
 data:         Generates or downloads data needed for benchmarking
 run:          Runs the named benchmark
 compare:      Compares results from benchmark runs
+venv:         Creates new venv (unless already exists) and installs compare's requirements into it
 
 **********
 * Benchmarks
@@ -84,7 +87,8 @@ DATA_DIR            directory to store datasets
 CARGO_COMMAND       command that runs the benchmark binary
 DATAFUSION_DIR      directory to use (default $DATAFUSION_DIR)
 RESULTS_NAME        folder where the benchmark files are stored
-PREFER_HASH_JOIN    Prefer hash join algorithm(default true)
+PREFER_HASH_JOIN    Prefer hash join algorithm (default true)
+VENV_PATH           Python venv to use for compare and venv commands (default ./venv, override by <your-venv>/bin/activate)
 "
     exit 1
 }
@@ -242,6 +246,9 @@ main() {
             ;;
         compare)
             compare_benchmarks "$ARG2" "$ARG3"
+            ;;
+        venv)
+            setup_venv
             ;;
         "")
             usage
@@ -448,12 +455,17 @@ compare_benchmarks() {
             echo "--------------------"
             echo "Benchmark ${bench}"
             echo "--------------------"
-            python3 "${SCRIPT_DIR}"/compare.py "${RESULTS_FILE1}" "${RESULTS_FILE2}"
+            PATH=$VIRTUAL_ENV/bin:$PATH python3 "${SCRIPT_DIR}"/compare.py "${RESULTS_FILE1}" "${RESULTS_FILE2}"
         else
             echo "Note: Skipping ${RESULTS_FILE1} as ${RESULTS_FILE2} does not exist"
         fi
     done
 
+}
+
+setup_venv() {
+    python3 -m venv $VIRTUAL_ENV
+    PATH=$VIRTUAL_ENV/bin:$PATH python3 -m pip install -r requirements.txt
 }
 
 # And start the process up

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -29,7 +29,7 @@ try:
     from rich.console import Console
     from rich.table import Table
 except ImportError:
-    print("Try `pip install rich` for using this script.")
+    print("Couldn't import modules -- run `./bench.sh venv` first")
     raise
 
 

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+rich


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/10022

(Note: this PR follows up on https://github.com/apache/datafusion/pull/10070 which worked on the same issue but looks like got kinda stale)

## Rationale for this change

Make it more convenient to run `bench.sh compare`

## What changes are included in this PR?

Updates to bench.sh to include a new command `venv`, and edit the `compare` command to use the respective `venv`

Separates requirements.txt in case `compare.py` would ever need something else

## Are these changes tested?

I tested by hand `./bench.sh compare` and `./bench.sh venv`, in multiple scenarios:
 - create empty venv with bench.sh, then run compare
 - have existing venv, update with bench.sh venv, then run compare
 - have no venv but install `rich` into system, and just run compare
In all cases compare works correctly.

## Are there any user-facing changes?

No -- if the `compare` worked for the user before, it will still do, regardless of whether they used venv or not.
If it didn't work, then the user would see improved error message, run `./bench.sh venv` without a need to configure any env var, and the new venv would be created in a gitignored folder in the repo
