### PR TITLE
Move FileSinkExec::metrics to the correct place

### DIFF
--- a/datafusion/physical-plan/src/insert.rs
+++ b/datafusion/physical-plan/src/insert.rs
@@ -175,11 +175,6 @@ impl DataSinkExec {
         &self.sort_order
     }
 
-    /// Returns the metrics of the underlying [DataSink]
-    pub fn metrics(&self) -> Option<MetricsSet> {
-        self.sink.metrics()
-    }
-
     fn create_schema(
         input: &Arc<dyn ExecutionPlan>,
         schema: SchemaRef,
@@ -288,6 +283,11 @@ impl ExecutionPlan for DataSinkExec {
             count_schema,
             stream,
         )))
+    }
+
+    /// Returns the metrics of the underlying [DataSink]
+    fn metrics(&self) -> Option<MetricsSet> {
+        self.sink.metrics()
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7779.

## Rationale for this change

`DataSink` metrics were added in https://github.com/apache/datafusion/pull/7778 but the `metrics` interface was not correctly implemented by `DataSinkExec`.

## What changes are included in this PR?

Moves the `metrics` function from `impl DataSinkExec` to `impl ExecutionPlan for DataSinkExec`.

## Are these changes tested?

Not currently.

## Are there any user-facing changes?

After this change `DataSinkExec` will forward to the `DataSink` metrics as intended.
