### PR TITLE
Minor: Fix `bench.sh tpch data`

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -302,7 +302,7 @@ data_tpch() {
     else
         echo " creating parquet files using benchmark binary ..."
         pushd "${SCRIPT_DIR}" > /dev/null
-        $CARGO_COMMAND --bin tpch -- convert --input "${TPCH_DIR}" --prefer_hash_join ${PREFER_HASH_JOIN} --output "${TPCH_DIR}" --format parquet
+        $CARGO_COMMAND --bin tpch -- convert --input "${TPCH_DIR}" --output "${TPCH_DIR}" --format parquet
         popd > /dev/null
     fi
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

While reviewing https://github.com/apache/datafusion/pull/10894 I noticed the tpch data generator seems broken

```

andrewlamb@Andrews-MacBook-Pro-2:~/Software/datafusion$ ./benchmarks/bench.sh data
...

warning: field `range` is never read
   --> datafusion/physical-expr/src/window/window_expr.rs:562:9
    |
561 | pub struct NthValueState {
    |            ------------- field in this struct
562 |     pub range: Range<usize>,
    |         ^^^^^
    |
    = note: `NthValueState` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
    = note: `#[warn(dead_code)]` on by default

warning: `datafusion-physical-expr` (lib) generated 1 warning
    Finished `release-nonlto` profile [optimized] target(s) in 0.10s
     Running `/Users/andrewlamb/Software/datafusion/target/release-nonlto/tpch convert --input /Users/andrewlamb/Software/datafusion/benchmarks/data/tpch_sf1 --prefer_hash_join true --output /Users/andrewlamb/Software/datafusion/benchmarks/data/tpch_sf1 --format parquet`
error: Found argument '--prefer_hash_join' which wasn't expected, or isn't valid in this context
```

## What changes are included in this PR?
fix the script
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
