### PR TITLE
Docs: clarify when the parquet reader will read from object store when using cached metadata

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/reader.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 //! [`ParquetFileReaderFactory`] and [`DefaultParquetFileReaderFactory`] for
-//! creating parquet file readers
+//! low level control of parquet file readers
 
 use crate::datasource::physical_plan::{FileMeta, ParquetFileMetrics};
 use bytes::Bytes;
@@ -33,11 +33,18 @@ use std::sync::Arc;
 ///
 /// The combined implementations of [`ParquetFileReaderFactory`] and
 /// [`AsyncFileReader`] can be used to provide custom data access operations
-/// such as pre-cached data, I/O coalescing, etc.
+/// such as pre-cached metadata, I/O coalescing, etc.
 ///
 /// See [`DefaultParquetFileReaderFactory`] for a simple implementation.
 pub trait ParquetFileReaderFactory: Debug + Send + Sync + 'static {
     /// Provides an `AsyncFileReader` for reading data from a parquet file specified
+    ///
+    /// # Notes
+    ///
+    /// If the resulting [`AsyncFileReader`]  returns `ParquetMetaData` without
+    /// page index information, the reader will load it on demand. Thus it is important
+    /// to ensure that the returned `ParquetMetaData` has the necessary information
+    /// if you wish to avoid a subsequent I/O
     ///
     /// # Arguments
     /// * partition_index - Index of the partition (for reporting metrics)


### PR DESCRIPTION

## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/10580

## Rationale for this change

While working on https://github.com/apache/datafusion/pull/10701  it was quite unclear to me why the parquet reader was doing a second object store request even when I had passed it pre-existing `ParquetMetadata`

It turns out the it was because the cached `ParquetMetadata` didn't have the page index strutures loaded, and so the parquet exec will load them on demand if required.


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

1. Add documentation

Note: I documented this in arrow-rs too: https://github.com/apache/arrow-rs/pull/5887 


## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
