### PR TITLE
chore: update some error messages for clarity

### DIFF
--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -141,7 +141,7 @@ impl ExprSchemable for Expr {
                         // verify that function is invoked with correct number and type of arguments as defined in `TypeSignature`
                         data_types_with_scalar_udf(&arg_data_types, func).map_err(|err| {
                             plan_datafusion_err!(
-                                "{} and {}",
+                                "{} {}",
                                 err,
                                 utils::generate_signature_error_msg(
                                     func.name(),
@@ -164,7 +164,7 @@ impl ExprSchemable for Expr {
                     WindowFunctionDefinition::AggregateUDF(udf) => {
                         let new_types = data_types_with_aggregate_udf(&data_types, udf).map_err(|err| {
                             plan_datafusion_err!(
-                                "{} and {}",
+                                "{} {}",
                                 err,
                                 utils::generate_signature_error_msg(
                                     fun.name(),
@@ -192,7 +192,7 @@ impl ExprSchemable for Expr {
                     AggregateFunctionDefinition::UDF(fun) => {
                         let new_types = data_types_with_aggregate_udf(&data_types, fun).map_err(|err| {
                             plan_datafusion_err!(
-                                "{} and {}",
+                                "{} {}",
                                 err,
                                 utils::generate_signature_error_msg(
                                     fun.name(),

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -49,10 +49,7 @@ pub fn data_types_with_scalar_udf(
         if signature.type_signature.supports_zero_argument() {
             return Ok(vec![]);
         } else {
-            return plan_err!(
-                "[data_types_with_scalar_udf] signature {:?} does not support zero arguments.",
-                &signature.type_signature
-            );
+            return plan_err!("{} does not support zero arguments.", func.name());
         }
     }
 
@@ -79,11 +76,7 @@ pub fn data_types_with_aggregate_udf(
         if signature.type_signature.supports_zero_argument() {
             return Ok(vec![]);
         } else {
-            return plan_err!(
-                "[data_types_with_aggregate_udf] Coercion from {:?} to the signature {:?} failed.",
-                current_types,
-                &signature.type_signature
-            );
+            return plan_err!("{} does not support zero arguments.", func.name());
         }
     }
 
@@ -118,8 +111,7 @@ pub fn data_types(
             return Ok(vec![]);
         } else {
             return plan_err!(
-                "[data_types] Coercion from {:?} to the signature {:?} failed.",
-                current_types,
+                "signature {:?} does not support zero arguments.",
                 &signature.type_signature
             );
         }

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1137,7 +1137,7 @@ from arrays_values_without_nulls;
 ## array_element (aliases: array_extract, list_extract, list_element)
 
 # Testing with empty arguments should result in an error
-query error DataFusion error: Error during planning: Error during planning: \[data_types_with_scalar_udf\] signature ArraySignature\(ArrayAndIndex\) does not support zero arguments.
+query error DataFusion error: Error during planning: Error during planning: array_element does not support zero arguments.
 select array_element();
 
 # array_element error
@@ -1979,7 +1979,7 @@ select array_slice(a, -1, 2, 1), array_slice(a, -1, 2),
 [6.0] [6.0] [] []
 
 # Testing with empty arguments should result in an error
-query error DataFusion error: Error during planning: Error during planning: \[data_types_with_scalar_udf\] signature VariadicAny does not support zero arguments.
+query error DataFusion error: Error during planning: Error during planning: array_slice does not support zero arguments.
 select array_slice();
 
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/10915.

## Rationale for this change
The changes in https://github.com/apache/datafusion/pull/10651/ lead to a change in the error messages given when a function is called without any arguments. I think it can be made a little clearer to the user what actually went wrong, the error message as of this PR vs `main` can be seen below.

The new error message as of this PR:
```
"Error during planning: Error during planning: SUM does not support zero arguments. No function matches the given name and argument types 'SUM()'. You might need to add explicit type casts.\n\tCandidate functions:\n\tSUM(UserDefine
d)"
```

The current error message in main:
```
"Error during planning: Error during planning: [data_types_with_aggregate_udf] Coercion from [] to the signature VariadicAny failed. and No function matches the given name and argument types 'selector_last()'. You might need to add explicit type casts.\n\tCandidate functions:\n\tselector_last(Any, .., Any)"
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

A few error messages are updated to provide users with a bit more context.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
