### PR TITLE
refactor: improve PoolType argument handling for CLI

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::process::ExitCode;
-use std::str::FromStr;
 use std::sync::{Arc, OnceLock};
 
 use datafusion::error::{DataFusionError, Result};
@@ -31,6 +30,7 @@ use datafusion_cli::catalog::DynamicFileCatalog;
 use datafusion_cli::functions::ParquetMetadataFunc;
 use datafusion_cli::{
     exec,
+    pool_type::PoolType,
     print_format::PrintFormat,
     print_options::{MaxRows, PrintOptions},
     DATAFUSION_CLI_VERSION,
@@ -41,24 +41,6 @@ use mimalloc::MiMalloc;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
-
-#[derive(PartialEq, Debug)]
-enum PoolType {
-    Greedy,
-    Fair,
-}
-
-impl FromStr for PoolType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "Greedy" | "greedy" => Ok(PoolType::Greedy),
-            "Fair" | "fair" => Ok(PoolType::Fair),
-            _ => Err(format!("Invalid memory pool type '{}'", s)),
-        }
-    }
-}
 
 #[derive(Debug, Parser, PartialEq)]
 #[clap(author, version, about, long_about= None)]
@@ -127,9 +109,10 @@ struct Args {
 
     #[clap(
         long,
-        help = "Specify the memory pool type 'greedy' or 'fair', default to 'greedy'"
+        help = "Specify the memory pool type 'greedy' or 'fair'",
+        default_value_t = PoolType::Greedy
     )]
-    mem_pool_type: Option<PoolType>,
+    mem_pool_type: PoolType,
 
     #[clap(
         long,
@@ -181,9 +164,9 @@ async fn main_inner() -> Result<()> {
             let memory_limit = extract_memory_pool_size(&memory_limit).unwrap();
             // set memory pool type
             match args.mem_pool_type {
-                Some(PoolType::Fair) => rt_config
+                PoolType::Fair => rt_config
                     .with_memory_pool(Arc::new(FairSpillPool::new(memory_limit))),
-                None | Some(PoolType::Greedy) => rt_config
+                PoolType::Greedy => rt_config
                     .with_memory_pool(Arc::new(GreedyMemoryPool::new(memory_limit)))
             }
         } else {

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -183,7 +183,7 @@ async fn main_inner() -> Result<()> {
             match args.mem_pool_type {
                 Some(PoolType::Fair) => rt_config
                     .with_memory_pool(Arc::new(FairSpillPool::new(memory_limit))),
-                _ => rt_config
+                None | Some(PoolType::Greedy) => rt_config
                     .with_memory_pool(Arc::new(GreedyMemoryPool::new(memory_limit)))
             }
         } else {

--- a/datafusion-cli/src/pool_type.rs
+++ b/datafusion-cli/src/pool_type.rs
@@ -15,16 +15,34 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![doc = include_str!("../README.md")]
-pub const DATAFUSION_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
 
-pub mod catalog;
-pub mod command;
-pub mod exec;
-pub mod functions;
-pub mod helper;
-pub mod highlighter;
-pub mod object_storage;
-pub mod pool_type;
-pub mod print_format;
-pub mod print_options;
+#[derive(PartialEq, Debug)]
+pub enum PoolType {
+    Greedy,
+    Fair,
+}
+
+impl FromStr for PoolType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Greedy" | "greedy" => Ok(PoolType::Greedy),
+            "Fair" | "fair" => Ok(PoolType::Fair),
+            _ => Err(format!("Invalid memory pool type '{}'", s)),
+        }
+    }
+}
+
+impl Display for PoolType {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            PoolType::Greedy => write!(f, "greedy"),
+            PoolType::Fair => write!(f, "fair"),
+        }
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Currently for the PoolType option handling in the CLI, the argument is an Option, but Clap can handle the default explicitly for the enum, which simplifies the enum handling later in the enum. The default handling logic no longer "leaks" into the runtime configuration.

## What changes are included in this PR?

1. Move `PoolType` to its own file and implement `Display` for it so it can be used as a default w/ clap.
2. Specify `PoolType::Greedy` as the default and change the arg type from `Option<PoolType>` to `PoolType`
3. Update the main CLI function to account for the fact its no longer an option and make the match arms explicit.


CLI `-h` changes from:

```
        --mem-pool-type <MEM_POOL_TYPE>
            Specify the memory pool type 'greedy' or 'fair', default to 'greedy'
```

to

```
        --mem-pool-type <MEM_POOL_TYPE>
            Specify the memory pool type 'greedy' or 'fair' [default: greedy]
```

## Are these changes tested?

Compiled the CLI and ran it to check, otherwise tests remain the same.

## Are there any user-facing changes?

No
