### PR TITLE
refactor: remove extra default in max rows

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -133,7 +133,7 @@ struct Args {
 
     #[clap(
         long,
-        help = "The max number of rows to display for 'Table' format\n[default: 40] [possible values: numbers(0/10/...), inf(no limit)]",
+        help = "The max number of rows to display for 'Table' format\n[possible values: numbers(0/10/...), inf(no limit)]",
         default_value = "40"
     )]
     maxrows: MaxRows,

--- a/docs/source/user-guide/cli/usage.md
+++ b/docs/source/user-guide/cli/usage.md
@@ -52,7 +52,7 @@ OPTIONS:
 
         --maxrows <MAXROWS>
             The max number of rows to display for 'Table' format
-            [default: 40] [possible values: numbers(0/10/...), inf(no limit)]
+            [possible values: numbers(0/10/...), inf(no limit)] [default: 40]
 
         --mem-pool-type <MEM_POOL_TYPE>
             Specify the memory pool type 'greedy' or 'fair', default to 'greedy'


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Currently `-h` in the datafusion CLI shows the default for max rows twice.

## What changes are included in this PR?

This PR removes the value from the argument help, so the default is only shown once.

## Are these changes tested?

Yes, compiled and looked at the help.

currenly main shows:

```
        --maxrows <MAXROWS>
            The max number of rows to display for 'Table' format
            [default: 40] [possible values: numbers(0/10/...), inf(no limit)] [default: 40]
```

but after this PR, it'll show

```
        --maxrows <MAXROWS>
            The max number of rows to display for 'Table' format
            [possible values: numbers(0/10/...), inf(no limit)] [default: 40]
```

Note the how the 2nd one only has one `[default: 40]`.

## Are there any user-facing changes?

Minor, CLI help.