### PR TITLE
Fix: StatisticsConverter `counts` for missing columns

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_groups.rs
@@ -381,6 +381,7 @@ impl<'a> PruningStatistics for RowGroupPruningStatistics<'a> {
         self.statistics_converter(column)
             .and_then(|c| c.row_group_null_counts(self.metadata_iter()))
             .ok()
+            .map(|counts| Arc::new(counts) as ArrayRef)
     }
 
     fn row_counts(&self, _column: &Column) -> Option<ArrayRef> {

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -1045,7 +1045,7 @@ impl<'a> StatisticsConverter<'a> {
         column_offset_index: &ParquetOffsetIndex,
         row_group_metadatas: &'a [RowGroupMetaData],
         row_group_indices: I,
-    ) -> Result<UInt64Array>
+    ) -> Result<Option<UInt64Array>>
     where
         I: IntoIterator<Item = &'a usize>,
     {
@@ -1053,8 +1053,7 @@ impl<'a> StatisticsConverter<'a> {
             // no matching column found in parquet_index;
             // thus we cannot extract page_locations in order to determine
             // the row count on a per DataPage basis.
-            // We use `row_group_row_counts` instead.
-            return Self::row_group_row_counts(row_group_metadatas);
+            return Ok(None);
         };
 
         let mut row_count_total = Vec::new();
@@ -1077,7 +1076,7 @@ impl<'a> StatisticsConverter<'a> {
             row_count_total.extend(row_count_per_page);
         }
 
-        Ok(UInt64Array::from_iter(row_count_total))
+        Ok(Some(UInt64Array::from_iter(row_count_total)))
     }
 
     /// Returns a null array of data_type with one element per row group

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -243,7 +243,6 @@ impl<'a> Test<'a> {
         } = self;
 
         let row_groups = reader.metadata().row_groups();
-        let expected_null_counts = Arc::new(expected_null_counts) as ArrayRef;
 
         if check.data_page() {
             let column_page_index = reader

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -303,7 +303,6 @@ impl<'a> Test<'a> {
                 .data_page_row_counts(column_offset_index, row_groups, &row_group_indices)
                 .unwrap();
             // https://github.com/apache/datafusion/issues/10926
-            let expected_row_counts: ArrayRef = Arc::new(expected_row_counts.clone());
             assert_eq!(
                 &row_counts, &expected_row_counts,
                 "{column_name}: Mismatch with expected row counts. \

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -255,11 +255,7 @@ impl<'a> Test<'a> {
                 .offset_index()
                 .expect("File should have column offset indices");
 
-            let row_group_indices = row_groups
-                .iter()
-                .enumerate()
-                .map(|(i, _)| i)
-                .collect::<Vec<_>>();
+            let row_group_indices: Vec<_> = (0..row_groups.len()).collect();
 
             let min = converter
                 .data_page_mins(

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -201,7 +201,7 @@ struct Test<'a> {
     expected_min: ArrayRef,
     expected_max: ArrayRef,
     expected_null_counts: UInt64Array,
-    expected_row_counts: UInt64Array,
+    expected_row_counts: Option<UInt64Array>,
     /// Which column to extract statistics from
     column_name: &'static str,
     /// What statistics should be checked?
@@ -302,9 +302,8 @@ impl<'a> Test<'a> {
             let row_counts = converter
                 .data_page_row_counts(column_offset_index, row_groups, &row_group_indices)
                 .unwrap();
-            // https://github.com/apache/datafusion/issues/10926
             assert_eq!(
-                &row_counts, &expected_row_counts,
+                row_counts, expected_row_counts,
                 "{column_name}: Mismatch with expected row counts. \
                 Actual: {row_counts:?}. Expected: {expected_row_counts:?}"
             );
@@ -334,6 +333,7 @@ impl<'a> Test<'a> {
                 reader.metadata().row_groups().iter(),
             )
             .unwrap();
+            let row_counts = Some(row_counts);
             assert_eq!(
                 row_counts, expected_row_counts,
                 "{column_name}: Mismatch with expected row counts. \
@@ -390,7 +390,7 @@ async fn test_one_row_group_without_null() {
         // no nulls
         expected_null_counts: UInt64Array::from(vec![0]),
         // 3 rows
-        expected_row_counts: UInt64Array::from(vec![3]),
+        expected_row_counts: Some(UInt64Array::from(vec![3])),
         column_name: "i64",
         check: Check::RowGroup,
     }
@@ -417,7 +417,7 @@ async fn test_one_row_group_with_null_and_negative() {
         // 2 nulls
         expected_null_counts: UInt64Array::from(vec![2]),
         // 8 rows
-        expected_row_counts: UInt64Array::from(vec![8]),
+        expected_row_counts: Some(UInt64Array::from(vec![8])),
         column_name: "i64",
         check: Check::RowGroup,
     }
@@ -444,7 +444,7 @@ async fn test_two_row_group_with_null() {
         // nulls are [0, 2]
         expected_null_counts: UInt64Array::from(vec![0, 2]),
         // row counts are [10, 5]
-        expected_row_counts: UInt64Array::from(vec![10, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![10, 5])),
         column_name: "i64",
         check: Check::RowGroup,
     }
@@ -471,7 +471,7 @@ async fn test_two_row_groups_with_all_nulls_in_one() {
         // nulls are [1, 3]
         expected_null_counts: UInt64Array::from(vec![1, 3]),
         // row counts are [5, 3]
-        expected_row_counts: UInt64Array::from(vec![5, 3]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 3])),
         column_name: "i64",
         check: Check::RowGroup,
     }
@@ -502,7 +502,7 @@ async fn test_multiple_data_pages_nulls_and_negatives() {
         expected_min: Arc::new(Int64Array::from(vec![Some(-1), Some(3), Some(7), None])),
         expected_max: Arc::new(Int64Array::from(vec![Some(2), Some(6), Some(9), None])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 1, 2]),
-        expected_row_counts: UInt64Array::from(vec![4, 4, 4, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![4, 4, 4, 2])),
         column_name: "i64",
         check: Check::DataPage,
     }
@@ -535,7 +535,7 @@ async fn test_int_64() {
         // nulls are [0, 0, 0, 0]
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "i64",
         check: Check::Both,
     }
@@ -561,7 +561,7 @@ async fn test_int_32() {
         // nulls are [0, 0, 0, 0]
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "i32",
         check: Check::RowGroup,
     }
@@ -602,7 +602,7 @@ async fn test_int_16() {
         // nulls are [0, 0, 0, 0]
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "i16",
         check: Check::RowGroup,
     }
@@ -631,7 +631,7 @@ async fn test_int_8() {
         // nulls are [0, 0, 0, 0]
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "i8",
         check: Check::RowGroup,
     }
@@ -681,7 +681,7 @@ async fn test_timestamp() {
         // nulls are [1, 1, 1, 1]
         expected_null_counts: UInt64Array::from(vec![1, 1, 1, 1]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "nanos",
         check: Check::RowGroup,
     }
@@ -710,7 +710,7 @@ async fn test_timestamp() {
         // nulls are [1, 1, 1, 1]
         expected_null_counts: UInt64Array::from(vec![1, 1, 1, 1]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "nanos_timezoned",
         check: Check::RowGroup,
     }
@@ -732,7 +732,7 @@ async fn test_timestamp() {
             TimestampMicrosecondType::parse("2020-01-12T01:01:01"),
         ])),
         expected_null_counts: UInt64Array::from(vec![1, 1, 1, 1]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "micros",
         check: Check::RowGroup,
     }
@@ -761,7 +761,7 @@ async fn test_timestamp() {
         // nulls are [1, 1, 1, 1]
         expected_null_counts: UInt64Array::from(vec![1, 1, 1, 1]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "micros_timezoned",
         check: Check::RowGroup,
     }
@@ -783,7 +783,7 @@ async fn test_timestamp() {
             TimestampMillisecondType::parse("2020-01-12T01:01:01"),
         ])),
         expected_null_counts: UInt64Array::from(vec![1, 1, 1, 1]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "millis",
         check: Check::RowGroup,
     }
@@ -812,7 +812,7 @@ async fn test_timestamp() {
         // nulls are [1, 1, 1, 1]
         expected_null_counts: UInt64Array::from(vec![1, 1, 1, 1]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "millis_timezoned",
         check: Check::RowGroup,
     }
@@ -834,7 +834,7 @@ async fn test_timestamp() {
             TimestampSecondType::parse("2020-01-12T01:01:01"),
         ])),
         expected_null_counts: UInt64Array::from(vec![1, 1, 1, 1]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "seconds",
         check: Check::RowGroup,
     }
@@ -863,7 +863,7 @@ async fn test_timestamp() {
         // nulls are [1, 1, 1, 1]
         expected_null_counts: UInt64Array::from(vec![1, 1, 1, 1]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "seconds_timezoned",
         check: Check::RowGroup,
     }
@@ -909,7 +909,7 @@ async fn test_timestamp_diff_rg_sizes() {
         // nulls are [1, 2, 1]
         expected_null_counts: UInt64Array::from(vec![1, 2, 1]),
         // row counts are [8, 8, 4]
-        expected_row_counts: UInt64Array::from(vec![8, 8, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![8, 8, 4])),
         column_name: "nanos",
         check: Check::RowGroup,
     }
@@ -936,7 +936,7 @@ async fn test_timestamp_diff_rg_sizes() {
         // nulls are [1, 2, 1]
         expected_null_counts: UInt64Array::from(vec![1, 2, 1]),
         // row counts are [8, 8, 4]
-        expected_row_counts: UInt64Array::from(vec![8, 8, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![8, 8, 4])),
         column_name: "nanos_timezoned",
         check: Check::RowGroup,
     }
@@ -956,7 +956,7 @@ async fn test_timestamp_diff_rg_sizes() {
             TimestampMicrosecondType::parse("2020-01-12T01:01:01"),
         ])),
         expected_null_counts: UInt64Array::from(vec![1, 2, 1]),
-        expected_row_counts: UInt64Array::from(vec![8, 8, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![8, 8, 4])),
         column_name: "micros",
         check: Check::RowGroup,
     }
@@ -983,7 +983,7 @@ async fn test_timestamp_diff_rg_sizes() {
         // nulls are [1, 2, 1]
         expected_null_counts: UInt64Array::from(vec![1, 2, 1]),
         // row counts are [8, 8, 4]
-        expected_row_counts: UInt64Array::from(vec![8, 8, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![8, 8, 4])),
         column_name: "micros_timezoned",
         check: Check::RowGroup,
     }
@@ -1003,7 +1003,7 @@ async fn test_timestamp_diff_rg_sizes() {
             TimestampMillisecondType::parse("2020-01-12T01:01:01"),
         ])),
         expected_null_counts: UInt64Array::from(vec![1, 2, 1]),
-        expected_row_counts: UInt64Array::from(vec![8, 8, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![8, 8, 4])),
         column_name: "millis",
         check: Check::RowGroup,
     }
@@ -1030,7 +1030,7 @@ async fn test_timestamp_diff_rg_sizes() {
         // nulls are [1, 2, 1]
         expected_null_counts: UInt64Array::from(vec![1, 2, 1]),
         // row counts are [8, 8, 4]
-        expected_row_counts: UInt64Array::from(vec![8, 8, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![8, 8, 4])),
         column_name: "millis_timezoned",
         check: Check::RowGroup,
     }
@@ -1050,7 +1050,7 @@ async fn test_timestamp_diff_rg_sizes() {
             TimestampSecondType::parse("2020-01-12T01:01:01"),
         ])),
         expected_null_counts: UInt64Array::from(vec![1, 2, 1]),
-        expected_row_counts: UInt64Array::from(vec![8, 8, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![8, 8, 4])),
         column_name: "seconds",
         check: Check::RowGroup,
     }
@@ -1077,7 +1077,7 @@ async fn test_timestamp_diff_rg_sizes() {
         // nulls are [1, 2, 1]
         expected_null_counts: UInt64Array::from(vec![1, 2, 1]),
         // row counts are [8, 8, 4]
-        expected_row_counts: UInt64Array::from(vec![8, 8, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![8, 8, 4])),
         column_name: "seconds_timezoned",
         check: Check::RowGroup,
     }
@@ -1115,7 +1115,7 @@ async fn test_dates_32_diff_rg_sizes() {
         // nulls are [2, 2]
         expected_null_counts: UInt64Array::from(vec![2, 2]),
         // row counts are [13, 7]
-        expected_row_counts: UInt64Array::from(vec![13, 7]),
+        expected_row_counts: Some(UInt64Array::from(vec![13, 7])),
         column_name: "date32",
         check: Check::RowGroup,
     }
@@ -1138,7 +1138,7 @@ async fn test_time32_second_diff_rg_sizes() {
         expected_min: Arc::new(Time32SecondArray::from(vec![18506, 18510, 18514, 18518])),
         expected_max: Arc::new(Time32SecondArray::from(vec![18509, 18513, 18517, 18521])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]), // Assuming 1 null per row group for simplicity
-        expected_row_counts: UInt64Array::from(vec![4, 4, 4, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4, 4, 4, 4])),
         column_name: "second",
         check: Check::RowGroup,
     }
@@ -1165,7 +1165,7 @@ async fn test_time32_millisecond_diff_rg_sizes() {
             3600003, 3600007, 3600011, 3600015,
         ])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]), // Assuming 1 null per row group for simplicity
-        expected_row_counts: UInt64Array::from(vec![4, 4, 4, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4, 4, 4, 4])),
         column_name: "millisecond",
         check: Check::RowGroup,
     }
@@ -1198,7 +1198,7 @@ async fn test_time64_microsecond_diff_rg_sizes() {
             1234567890138,
         ])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]), // Assuming 1 null per row group for simplicity
-        expected_row_counts: UInt64Array::from(vec![4, 4, 4, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4, 4, 4, 4])),
         column_name: "microsecond",
         check: Check::RowGroup,
     }
@@ -1231,7 +1231,7 @@ async fn test_time64_nanosecond_diff_rg_sizes() {
             987654321012360,
         ])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]), // Assuming 1 null per row group for simplicity
-        expected_row_counts: UInt64Array::from(vec![4, 4, 4, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4, 4, 4, 4])),
         column_name: "nanosecond",
         check: Check::RowGroup,
     }
@@ -1258,7 +1258,7 @@ async fn test_dates_64_diff_rg_sizes() {
             Date64Type::parse("2029-11-12"),
         ])),
         expected_null_counts: UInt64Array::from(vec![2, 2]),
-        expected_row_counts: UInt64Array::from(vec![13, 7]),
+        expected_row_counts: Some(UInt64Array::from(vec![13, 7])),
         column_name: "date64",
         check: Check::RowGroup,
     }
@@ -1286,7 +1286,7 @@ async fn test_uint() {
         expected_min: Arc::new(UInt8Array::from(vec![0, 1, 4, 7, 251])),
         expected_max: Arc::new(UInt8Array::from(vec![3, 4, 6, 250, 254])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![4, 4, 4, 4, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4, 4, 4, 4, 4])),
         column_name: "u8",
         check: Check::RowGroup,
     }
@@ -1297,7 +1297,7 @@ async fn test_uint() {
         expected_min: Arc::new(UInt16Array::from(vec![0, 1, 4, 7, 251])),
         expected_max: Arc::new(UInt16Array::from(vec![3, 4, 6, 250, 254])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![4, 4, 4, 4, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4, 4, 4, 4, 4])),
         column_name: "u16",
         check: Check::RowGroup,
     }
@@ -1308,7 +1308,7 @@ async fn test_uint() {
         expected_min: Arc::new(UInt32Array::from(vec![0, 1, 4, 7, 251])),
         expected_max: Arc::new(UInt32Array::from(vec![3, 4, 6, 250, 254])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![4, 4, 4, 4, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4, 4, 4, 4, 4])),
         column_name: "u32",
         check: Check::RowGroup,
     }
@@ -1319,7 +1319,7 @@ async fn test_uint() {
         expected_min: Arc::new(UInt64Array::from(vec![0, 1, 4, 7, 251])),
         expected_max: Arc::new(UInt64Array::from(vec![3, 4, 6, 250, 254])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![4, 4, 4, 4, 4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4, 4, 4, 4, 4])),
         column_name: "u64",
         check: Check::RowGroup,
     }
@@ -1342,7 +1342,7 @@ async fn test_int32_range() {
         expected_min: Arc::new(Int32Array::from(vec![0])),
         expected_max: Arc::new(Int32Array::from(vec![300000])),
         expected_null_counts: UInt64Array::from(vec![0]),
-        expected_row_counts: UInt64Array::from(vec![4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4])),
         column_name: "i",
         check: Check::RowGroup,
     }
@@ -1365,7 +1365,7 @@ async fn test_uint32_range() {
         expected_min: Arc::new(UInt32Array::from(vec![0])),
         expected_max: Arc::new(UInt32Array::from(vec![300000])),
         expected_null_counts: UInt64Array::from(vec![0]),
-        expected_row_counts: UInt64Array::from(vec![4]),
+        expected_row_counts: Some(UInt64Array::from(vec![4])),
         column_name: "u",
         check: Check::RowGroup,
     }
@@ -1387,7 +1387,7 @@ async fn test_numeric_limits_unsigned() {
         expected_min: Arc::new(UInt8Array::from(vec![u8::MIN, 100])),
         expected_max: Arc::new(UInt8Array::from(vec![100, u8::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "u8",
         check: Check::RowGroup,
     }
@@ -1398,7 +1398,7 @@ async fn test_numeric_limits_unsigned() {
         expected_min: Arc::new(UInt16Array::from(vec![u16::MIN, 100])),
         expected_max: Arc::new(UInt16Array::from(vec![100, u16::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "u16",
         check: Check::RowGroup,
     }
@@ -1409,7 +1409,7 @@ async fn test_numeric_limits_unsigned() {
         expected_min: Arc::new(UInt32Array::from(vec![u32::MIN, 100])),
         expected_max: Arc::new(UInt32Array::from(vec![100, u32::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "u32",
         check: Check::RowGroup,
     }
@@ -1420,7 +1420,7 @@ async fn test_numeric_limits_unsigned() {
         expected_min: Arc::new(UInt64Array::from(vec![u64::MIN, 100])),
         expected_max: Arc::new(UInt64Array::from(vec![100, u64::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "u64",
         check: Check::RowGroup,
     }
@@ -1442,7 +1442,7 @@ async fn test_numeric_limits_signed() {
         expected_min: Arc::new(Int8Array::from(vec![i8::MIN, -100])),
         expected_max: Arc::new(Int8Array::from(vec![100, i8::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "i8",
         check: Check::RowGroup,
     }
@@ -1453,7 +1453,7 @@ async fn test_numeric_limits_signed() {
         expected_min: Arc::new(Int16Array::from(vec![i16::MIN, -100])),
         expected_max: Arc::new(Int16Array::from(vec![100, i16::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "i16",
         check: Check::RowGroup,
     }
@@ -1464,7 +1464,7 @@ async fn test_numeric_limits_signed() {
         expected_min: Arc::new(Int32Array::from(vec![i32::MIN, -100])),
         expected_max: Arc::new(Int32Array::from(vec![100, i32::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "i32",
         check: Check::RowGroup,
     }
@@ -1475,7 +1475,7 @@ async fn test_numeric_limits_signed() {
         expected_min: Arc::new(Int64Array::from(vec![i64::MIN, -100])),
         expected_max: Arc::new(Int64Array::from(vec![100, i64::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "i64",
         check: Check::RowGroup,
     }
@@ -1497,7 +1497,7 @@ async fn test_numeric_limits_float() {
         expected_min: Arc::new(Float32Array::from(vec![f32::MIN, -100.0])),
         expected_max: Arc::new(Float32Array::from(vec![100.0, f32::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "f32",
         check: Check::RowGroup,
     }
@@ -1508,7 +1508,7 @@ async fn test_numeric_limits_float() {
         expected_min: Arc::new(Float64Array::from(vec![f64::MIN, -100.0])),
         expected_max: Arc::new(Float64Array::from(vec![100.0, f64::MAX])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "f64",
         check: Check::RowGroup,
     }
@@ -1519,7 +1519,7 @@ async fn test_numeric_limits_float() {
         expected_min: Arc::new(Float32Array::from(vec![-1.0, -100.0])),
         expected_max: Arc::new(Float32Array::from(vec![100.0, -100.0])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "f32_nan",
         check: Check::RowGroup,
     }
@@ -1530,7 +1530,7 @@ async fn test_numeric_limits_float() {
         expected_min: Arc::new(Float64Array::from(vec![-1.0, -100.0])),
         expected_max: Arc::new(Float64Array::from(vec![100.0, -100.0])),
         expected_null_counts: UInt64Array::from(vec![0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "f64_nan",
         check: Check::RowGroup,
     }
@@ -1553,7 +1553,7 @@ async fn test_float64() {
         expected_min: Arc::new(Float64Array::from(vec![-5.0, -4.0, -0.0, 5.0])),
         expected_max: Arc::new(Float64Array::from(vec![-1.0, 0.0, 4.0, 9.0])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "f",
         check: Check::RowGroup,
     }
@@ -1586,7 +1586,7 @@ async fn test_float16() {
                 .collect::<Vec<_>>(),
         )),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "f",
         check: Check::RowGroup,
     }
@@ -1617,7 +1617,7 @@ async fn test_decimal() {
                 .unwrap(),
         ),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5])),
         column_name: "decimal_col",
         check: Check::RowGroup,
     }
@@ -1655,7 +1655,7 @@ async fn test_decimal_256() {
             .unwrap(),
         ),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5])),
         column_name: "decimal256_col",
         check: Check::RowGroup,
     }
@@ -1675,7 +1675,7 @@ async fn test_dictionary() {
         expected_min: Arc::new(StringArray::from(vec!["abc", "aaa"])),
         expected_max: Arc::new(StringArray::from(vec!["def", "fffff"])),
         expected_null_counts: UInt64Array::from(vec![1, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "string_dict_i8",
         check: Check::RowGroup,
     }
@@ -1686,7 +1686,7 @@ async fn test_dictionary() {
         expected_min: Arc::new(StringArray::from(vec!["abc", "aaa"])),
         expected_max: Arc::new(StringArray::from(vec!["def", "fffff"])),
         expected_null_counts: UInt64Array::from(vec![1, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "string_dict_i32",
         check: Check::RowGroup,
     }
@@ -1697,7 +1697,7 @@ async fn test_dictionary() {
         expected_min: Arc::new(Int64Array::from(vec![-100, 0])),
         expected_max: Arc::new(Int64Array::from(vec![0, 100])),
         expected_null_counts: UInt64Array::from(vec![1, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 2]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 2])),
         column_name: "int_dict_i8",
         check: Check::RowGroup,
     }
@@ -1735,7 +1735,7 @@ async fn test_byte() {
             "all backends",
         ])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5])),
         column_name: "name",
         check: Check::RowGroup,
     }
@@ -1755,7 +1755,7 @@ async fn test_byte() {
             "backend six",
         ])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5])),
         column_name: "service_string",
         check: Check::RowGroup,
     }
@@ -1774,7 +1774,7 @@ async fn test_byte() {
         expected_min: Arc::new(BinaryArray::from(expected_service_binary_min_values)),
         expected_max: Arc::new(BinaryArray::from(expected_service_binary_max_values)),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5])),
         column_name: "service_binary",
         check: Check::RowGroup,
     }
@@ -1795,7 +1795,7 @@ async fn test_byte() {
             FixedSizeBinaryArray::try_from_iter(max_input.into_iter()).unwrap(),
         ),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5])),
         column_name: "service_fixedsize",
         check: Check::RowGroup,
     }
@@ -1816,7 +1816,7 @@ async fn test_byte() {
             expected_service_large_binary_max_values,
         )),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5])),
         column_name: "service_large_binary",
         check: Check::RowGroup,
     }
@@ -1849,7 +1849,7 @@ async fn test_period_in_column_names() {
             "HTTP GET / DISPATCH",
         ])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5])),
         column_name: "name",
         check: Check::RowGroup,
     }
@@ -1863,7 +1863,7 @@ async fn test_period_in_column_names() {
             "frontend", "frontend", "backend",
         ])),
         expected_null_counts: UInt64Array::from(vec![0, 0, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5])),
         column_name: "service.name",
         check: Check::RowGroup,
     }
@@ -1887,7 +1887,7 @@ async fn test_boolean() {
         expected_min: Arc::new(BooleanArray::from(vec![false, false])),
         expected_max: Arc::new(BooleanArray::from(vec![true, false])),
         expected_null_counts: UInt64Array::from(vec![1, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5])),
         column_name: "bool",
         check: Check::RowGroup,
     }
@@ -1914,7 +1914,7 @@ async fn test_struct() {
         expected_min: Arc::new(struct_array(vec![(Some(1), Some(6.0), Some(12.0))])),
         expected_max: Arc::new(struct_array(vec![(Some(2), Some(8.5), Some(14.0))])),
         expected_null_counts: UInt64Array::from(vec![0]),
-        expected_row_counts: UInt64Array::from(vec![3]),
+        expected_row_counts: Some(UInt64Array::from(vec![3])),
         column_name: "struct",
         check: Check::RowGroup,
     }
@@ -1937,7 +1937,7 @@ async fn test_utf8() {
         expected_min: Arc::new(StringArray::from(vec!["a", "e"])),
         expected_max: Arc::new(StringArray::from(vec!["d", "i"])),
         expected_null_counts: UInt64Array::from(vec![1, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5])),
         column_name: "utf8",
         check: Check::RowGroup,
     }
@@ -1949,7 +1949,7 @@ async fn test_utf8() {
         expected_min: Arc::new(LargeStringArray::from(vec!["a", "e"])),
         expected_max: Arc::new(LargeStringArray::from(vec!["d", "i"])),
         expected_null_counts: UInt64Array::from(vec![1, 0]),
-        expected_row_counts: UInt64Array::from(vec![5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5])),
         column_name: "large_utf8",
         check: Check::RowGroup,
     }
@@ -1975,7 +1975,7 @@ async fn test_missing_statistics() {
         expected_min: Arc::new(Int64Array::from(vec![None])),
         expected_max: Arc::new(Int64Array::from(vec![None])),
         expected_null_counts: UInt64Array::from(vec![None]),
-        expected_row_counts: UInt64Array::from(vec![3]), // stil has row count statistics
+        expected_row_counts: Some(UInt64Array::from(vec![3])), // stil has row count statistics
         column_name: "i64",
         check: Check::RowGroup,
     }
@@ -1997,7 +1997,7 @@ async fn test_column_not_found() {
         expected_min: Arc::new(Int64Array::from(vec![18262, 18565])),
         expected_max: Arc::new(Int64Array::from(vec![18564, 21865])),
         expected_null_counts: UInt64Array::from(vec![2, 2]),
-        expected_row_counts: UInt64Array::from(vec![13, 7]),
+        expected_row_counts: Some(UInt64Array::from(vec![13, 7])),
         column_name: "not_a_column",
         check: Check::RowGroup,
     }
@@ -2032,9 +2032,24 @@ async fn test_column_non_existent() {
         // nulls are [0, 0, 0, 0]
         expected_null_counts: UInt64Array::from(vec![None, None, None, None]),
         // row counts are [5, 5, 5, 5]
-        expected_row_counts: UInt64Array::from(vec![5, 5, 5, 5]),
+        expected_row_counts: Some(UInt64Array::from(vec![5, 5, 5, 5])),
         column_name: "i_do_not_exist",
-        check: Check::Both,
+        check: Check::RowGroup,
+    }
+    .run_with_schema(&schema);
+
+    Test {
+        reader: &reader,
+        // mins are [-5, -4, 0, 5]
+        expected_min: Arc::new(Int64Array::from(vec![None, None, None, None])),
+        // maxes are [-1, 0, 4, 9]
+        expected_max: Arc::new(Int64Array::from(vec![None, None, None, None])),
+        // nulls are [0, 0, 0, 0]
+        expected_null_counts: UInt64Array::from(vec![None, None, None, None]),
+        // row counts are [5, 5, 5, 5]
+        expected_row_counts: None,
+        column_name: "i_do_not_exist",
+        check: Check::DataPage,
     }
     .run_with_schema(&schema);
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10926.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
- row_group_null_counts, data_page_null_counts
- data_page_row_counts

return an ArrayRef instead of UInt64Array.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- fixed methods to return correct array type
- changed data_page_row_counts to fall back on row_page_row_counts if column is missing
- added a test case in `arrow_statistics`

## Are these changes tested?
Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
