### PR TITLE
Minor: reuse Rows buffer in GroupValuesRows

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/row.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/row.rs
@@ -59,8 +59,11 @@ pub struct GroupValuesRows {
     /// [`Row`]: arrow::row::Row
     group_values: Option<Rows>,
 
-    // buffer to be reused to store hashes
+    /// reused buffer to store hashes
     hashes_buffer: Vec<u64>,
+
+    /// reused buffer to store rows
+    rows_buffer: Rows,
 
     /// Random state for creating hashes
     random_state: RandomState,
@@ -78,6 +81,10 @@ impl GroupValuesRows {
 
         let map = RawTable::with_capacity(0);
 
+        let starting_rows_capacity = 1000;
+        let starting_data_capacity = 64 * starting_rows_capacity;
+        let rows_buffer =
+            row_converter.empty_rows(starting_rows_capacity, starting_data_capacity);
         Ok(Self {
             schema,
             row_converter,
@@ -85,6 +92,7 @@ impl GroupValuesRows {
             map_size: 0,
             group_values: None,
             hashes_buffer: Default::default(),
+            rows_buffer,
             random_state: Default::default(),
         })
     }
@@ -93,8 +101,9 @@ impl GroupValuesRows {
 impl GroupValues for GroupValuesRows {
     fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<usize>) -> Result<()> {
         // Convert the group keys into the row format
-        // Avoid reallocation when https://github.com/apache/arrow-rs/issues/4479 is available
-        let group_rows = self.row_converter.convert_columns(cols)?;
+        let group_rows = &mut self.rows_buffer;
+        group_rows.clear();
+        self.row_converter.append(group_rows, cols)?;
         let n_rows = group_rows.num_rows();
 
         let mut group_values = match self.group_values.take() {
@@ -150,6 +159,7 @@ impl GroupValues for GroupValuesRows {
         self.row_converter.size()
             + group_values_size
             + self.map_size
+            + self.rows_buffer.size()
             + self.hashes_buffer.allocated_size()
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #7000 

## Rationale for this change

While working with @jayzhan211 on https://github.com/apache/datafusion/pull/10976 I noticed a TODO that could avoid some allocations

## What changes are included in this PR?

Use the API added in https://github.com/apache/arrow-rs/issues/4479  to reuse the temporary `Rows` allocation in the Hash grouping


## Are these changes tested?
Functionally tested by CI

Performance benchmarks show maybe a slight improvement in performance (but not major)

<details><summary>Details</summary>
<p>

```
--------------------
Benchmark clickbench_1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃  main_base ┃ alamb_less_allocation ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 0     │     0.86ms │                0.84ms │     no change │
│ QQuery 1     │    92.70ms │               94.15ms │     no change │
│ QQuery 2     │   190.53ms │              196.09ms │     no change │
│ QQuery 3     │   201.00ms │              200.44ms │     no change │
│ QQuery 4     │  2173.58ms │             2226.78ms │     no change │
│ QQuery 5     │  2004.80ms │             1953.20ms │     no change │
│ QQuery 6     │    85.72ms │               79.90ms │ +1.07x faster │
│ QQuery 7     │    96.01ms │               96.83ms │     no change │
│ QQuery 8     │  3291.22ms │             3273.42ms │     no change │
│ QQuery 9     │  2444.68ms │             2434.64ms │     no change │
│ QQuery 10    │   815.80ms │              821.98ms │     no change │
│ QQuery 11    │   907.62ms │              905.48ms │     no change │
│ QQuery 12    │  2107.15ms │             2093.34ms │     no change │
│ QQuery 13    │  4500.31ms │             4538.54ms │     no change │
│ QQuery 14    │  2859.02ms │             2870.15ms │     no change │
│ QQuery 15    │  2428.72ms │             2451.61ms │     no change │
│ QQuery 16    │  5881.12ms │             5806.99ms │     no change │
│ QQuery 17    │  5844.94ms │             5815.43ms │     no change │
│ QQuery 18    │ 11879.07ms │            11810.61ms │     no change │
│ QQuery 19    │   163.56ms │              168.11ms │     no change │
│ QQuery 20    │  2696.77ms │             2682.39ms │     no change │
│ QQuery 21    │  3457.38ms │             3452.12ms │     no change │
│ QQuery 22    │  9344.43ms │             9269.06ms │     no change │
│ QQuery 23    │ 21928.19ms │            21221.30ms │     no change │
│ QQuery 24    │  1375.81ms │             1336.89ms │     no change │
│ QQuery 25    │  1178.67ms │             1153.24ms │     no change │
│ QQuery 26    │  1490.72ms │             1461.23ms │     no change │
│ QQuery 27    │  4056.40ms │             3962.94ms │     no change │
│ QQuery 28    │ 27492.83ms │            27450.70ms │     no change │
│ QQuery 29    │  1073.24ms │             1060.23ms │     no change │
│ QQuery 30    │  2544.87ms │             2511.73ms │     no change │
│ QQuery 31    │  3253.81ms │             3192.78ms │     no change │
│ QQuery 32    │ 16524.21ms │            16493.70ms │     no change │
│ QQuery 33    │  9428.88ms │             9251.73ms │     no change │
│ QQuery 34    │  9383.64ms │             9261.48ms │     no change │
│ QQuery 35    │  4059.25ms │             4133.75ms │     no change │
│ QQuery 36    │   350.34ms │              357.19ms │     no change │
│ QQuery 37    │   231.59ms │              228.12ms │     no change │
│ QQuery 38    │   190.21ms │              191.66ms │     no change │
│ QQuery 39    │  1148.60ms │             1183.20ms │     no change │
│ QQuery 40    │    85.51ms │               91.20ms │  1.07x slower │
│ QQuery 41    │    80.75ms │               81.69ms │     no change │
│ QQuery 42    │    98.06ms │              100.15ms │     no change │
└──────────────┴────────────┴───────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Benchmark Summary                    ┃             ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ Total Time (main_base)               │ 169442.60ms │
│ Total Time (alamb_less_allocation)   │ 167967.01ms │
│ Average Time (main_base)             │   3940.53ms │
│ Average Time (alamb_less_allocation) │   3906.21ms │
│ Queries Faster                       │           1 │
│ Queries Slower                       │           1 │
│ Queries with No Change               │          41 │
└──────────────────────────────────────┴─────────────┘

--------------------
Benchmark clickbench_extended.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃ main_base ┃ alamb_less_allocation ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 0     │ 3706.96ms │             3692.16ms │     no change │
│ QQuery 1     │ 1575.43ms │             1458.20ms │ +1.08x faster │
│ QQuery 2     │ 3138.34ms │             3067.49ms │     no change │
└──────────────┴───────────┴───────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Summary                    ┃           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Total Time (main_base)               │ 8420.72ms │
│ Total Time (alamb_less_allocation)   │ 8217.85ms │
│ Average Time (main_base)             │ 2806.91ms │
│ Average Time (alamb_less_allocation) │ 2739.28ms │
│ Queries Faster                       │         1 │
│ Queries Slower                       │         0 │
│ Queries with No Change               │         2 │
└──────────────────────────────────────┴───────────┘
```

</p>
</details> 

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
