### PR TITLE
Support to unparse `ScalarValue::TimestampNanosecond` to String

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -23,7 +23,8 @@ use arrow_array::{Date32Array, Date64Array, TimestampNanosecondArray};
 use arrow_schema::DataType;
 use sqlparser::ast::Value::SingleQuotedString;
 use sqlparser::ast::{
-    self, Expr as AstExpr, Function, FunctionArg, Ident, Interval, TimezoneInfo, UnaryOperator,
+    self, Expr as AstExpr, Function, FunctionArg, Ident, Interval, TimezoneInfo,
+    UnaryOperator,
 };
 
 use datafusion_common::{


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10796 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Instead of `array_value_to_string`, I just follow how to convert `datetime` type because I found the timestamp string converted by the arrow formatter would be 
```
1970-01-01T00:00:00.000010001
```
but I think the result generated by `datetime::to_string` is more suitable for SQL
```
1970-01-01 00:00:00.000010001
```
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
