### PR TITLE
Minor: inline unwrap_arc, rewrite_arc, rewrite_arcs

### DIFF
--- a/datafusion/expr/src/logical_plan/tree_node.rs
+++ b/datafusion/expr/src/logical_plan/tree_node.rs
@@ -371,6 +371,7 @@ impl TreeNode for LogicalPlan {
 
 /// Converts a `Arc<LogicalPlan>` without copying, if possible. Copies the plan
 /// if there is a shared reference
+#[inline(always)]
 pub fn unwrap_arc(plan: Arc<LogicalPlan>) -> LogicalPlan {
     Arc::try_unwrap(plan)
         // if None is returned, there is another reference to this
@@ -379,6 +380,7 @@ pub fn unwrap_arc(plan: Arc<LogicalPlan>) -> LogicalPlan {
 }
 
 /// Applies `f` to rewrite a `Arc<LogicalPlan>` without copying, if possible
+#[inline(always)]
 fn rewrite_arc<F: FnMut(LogicalPlan) -> Result<Transformed<LogicalPlan>>>(
     plan: Arc<LogicalPlan>,
     mut f: F,
@@ -387,6 +389,7 @@ fn rewrite_arc<F: FnMut(LogicalPlan) -> Result<Transformed<LogicalPlan>>>(
 }
 
 /// rewrite a `Vec` of `Arc<LogicalPlan>` without copying, if possible
+#[inline(always)]
 fn rewrite_arcs<F: FnMut(LogicalPlan) -> Result<Transformed<LogicalPlan>>>(
     input_plans: Vec<Arc<LogicalPlan>>,
     mut f: F,

--- a/datafusion/expr/src/logical_plan/tree_node.rs
+++ b/datafusion/expr/src/logical_plan/tree_node.rs
@@ -380,7 +380,6 @@ pub fn unwrap_arc(plan: Arc<LogicalPlan>) -> LogicalPlan {
 }
 
 /// Applies `f` to rewrite a `Arc<LogicalPlan>` without copying, if possible
-#[inline(always)]
 fn rewrite_arc<F: FnMut(LogicalPlan) -> Result<Transformed<LogicalPlan>>>(
     plan: Arc<LogicalPlan>,
     mut f: F,
@@ -389,7 +388,6 @@ fn rewrite_arc<F: FnMut(LogicalPlan) -> Result<Transformed<LogicalPlan>>>(
 }
 
 /// rewrite a `Vec` of `Arc<LogicalPlan>` without copying, if possible
-#[inline(always)]
 fn rewrite_arcs<F: FnMut(LogicalPlan) -> Result<Transformed<LogicalPlan>>>(
     input_plans: Vec<Arc<LogicalPlan>>,
     mut f: F,


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/5637

Closes #.

## Rationale for this change

When profiling on main these functions show up many times 
<img width="1309" alt="Screenshot 2024-06-19 at 11 13 16 AM" src="https://github.com/apache/datafusion/assets/490673/f31d92f6-3021-4817-9469-f540ae981b43">


## What changes are included in this PR?
Changes
Mark the functions as `#[inline(always)]` - I think they are not inlined without the `#inline` attribute as they are in different crates

This makes the profiles much easier to read and understand:

<img width="1728" alt="Screenshot 2024-06-19 at 10 39 30 AM" src="https://github.com/apache/datafusion/assets/490673/df631763-1e26-42ca-ba1a-90650ce92bd9">


## Are these changes tested?

Functionally by exisitng tests

Performance:
(performance measurements in progress)

Code size:

I also made sure this didn't bloat the binary size:
```shell
cd datafusion-cli
cargo build --release
```

Before this PR:
TODO

After this PR:
TODO

## Are there any user-facing changes?
Hopefuly
