### PR TITLE
Update docs for `protoc` minimum installed version

### DIFF
--- a/datafusion/proto/CONTRIBUTING.md
+++ b/datafusion/proto/CONTRIBUTING.md
@@ -29,4 +29,4 @@ valid installation of [protoc] (see [installation instructions] for details).
 ```
 
 [protoc]: https://github.com/protocolbuffers/protobuf#protocol-compiler-installation
-[installation instructions]: https://datafusion.apache.org/contributor-guide/#protoc-installation
+[installation instructions]: https://datafusion.apache.org/contributor-guide/getting_started.html#protoc-installation

--- a/docs/source/contributor-guide/getting_started.md
+++ b/docs/source/contributor-guide/getting_started.md
@@ -50,11 +50,11 @@ $ pacman -S protobuf
 $ brew install protobuf
 ```
 
-You will want to verify the version installed is `3.12` or greater, which introduced support for explicit [field presence](https://github.com/protocolbuffers/protobuf/blob/v3.12.0/docs/field_presence.md). Older versions may fail to compile.
+You will want to verify the version installed is `3.15` or greater, which introduced support for explicit [field presence](https://github.com/protocolbuffers/protobuf/blob/v3.15.0/docs/field_presence.md). Older versions may fail to compile.
 
 ```shell
 $ protoc --version
-libprotoc 3.12.4
+libprotoc 3.15.0
 ```
 
 Alternatively a binary release can be downloaded from the [Release Page](https://github.com/protocolbuffers/protobuf/releases) or [built from source](https://github.com/protocolbuffers/protobuf/blob/main/src/README.md).

--- a/docs/source/contributor-guide/getting_started.md
+++ b/docs/source/contributor-guide/getting_started.md
@@ -50,7 +50,7 @@ $ pacman -S protobuf
 $ brew install protobuf
 ```
 
-You will want to verify the version installed is `3.15` or greater, which introduced support for explicit [field presence](https://github.com/protocolbuffers/protobuf/blob/v3.15.0/docs/field_presence.md). Older versions may fail to compile.
+You will want to verify the version installed is `3.15` or greater, which has support for explicit [field presence](https://github.com/protocolbuffers/protobuf/blob/v3.15.0/docs/field_presence.md). Older versions may fail to compile.
 
 ```shell
 $ protoc --version


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10979.

## What changes are included in this PR?

* Changes minimum version from v3.12 to v3.15
* Fixes link to `protoc` installation instructions
