### PR TITLE
Compute gcd with u64 instead of i64 because of overflows

### DIFF
--- a/datafusion/functions/src/math/gcd.rs
+++ b/datafusion/functions/src/math/gcd.rs
@@ -143,22 +143,4 @@ mod test {
         assert_eq!(ints.value(2), 5);
         assert_eq!(ints.value(3), 8);
     }
-
-    // from issue https://github.com/apache/datafusion/issues/11031 we know that the previous implementation could
-    // not handle cases were one or both of the inputs were an i64::MAX or i64::MIN coupled with other values (neg or pos)
-    #[test]
-    fn test_gcd_i64_maxes() {
-        let args: Vec<ArrayRef> = vec![
-            Arc::new(Int64Array::from(vec![i64::MAX, i64::MIN, i64::MAX])), // x
-            Arc::new(Int64Array::from(vec![i64::MIN, -1, -1])),             // y
-        ];
-
-        let result = gcd(&args).expect("failed to initialize function gcd");
-        let ints = as_int64_array(&result).expect("failed to initialize function gcd");
-
-        assert_eq!(ints.len(), 3);
-        assert_eq!(ints.value(0), 1);
-        assert_eq!(ints.value(1), 1);
-        assert_eq!(ints.value(1), 1);
-    }
 }

--- a/datafusion/functions/src/math/gcd.rs
+++ b/datafusion/functions/src/math/gcd.rs
@@ -88,16 +88,15 @@ fn gcd(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Computes greatest common divisor using Binary GCD algorithm.
 pub fn compute_gcd(x: i64, y: i64) -> i64 {
-    // because the input values are i64, casting these u64's back to i64 causes no overflow
+    if x == 0 {
+        return y;
+    }
+    if y == 0 {
+        return x;
+    }
+
     let mut a = x.unsigned_abs();
     let mut b = y.unsigned_abs();
-
-    if a == 0 {
-        return b as i64;
-    }
-    if b == 0 {
-        return a as i64;
-    }
 
     let shift = (a | b).trailing_zeros();
     a >>= shift;
@@ -113,6 +112,7 @@ pub fn compute_gcd(x: i64, y: i64) -> i64 {
         b -= a;
 
         if b == 0 {
+            // because the input values are i64, casting this back to i64 is safe
             return (a << shift) as i64;
         }
     }

--- a/datafusion/functions/src/math/gcd.rs
+++ b/datafusion/functions/src/math/gcd.rs
@@ -88,14 +88,15 @@ fn gcd(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Computes greatest common divisor using Binary GCD algorithm.
 pub fn compute_gcd(x: i64, y: i64) -> i64 {
-    let mut a = x.wrapping_abs();
-    let mut b = y.wrapping_abs();
+    // because the input values are i64, casting these u64's back to i64 causes no overflow
+    let mut a = x.unsigned_abs();
+    let mut b = y.unsigned_abs();
 
     if a == 0 {
-        return b;
+        return b as i64;
     }
     if b == 0 {
-        return a;
+        return a as i64;
     }
 
     let shift = (a | b).trailing_zeros();
@@ -112,7 +113,7 @@ pub fn compute_gcd(x: i64, y: i64) -> i64 {
         b -= a;
 
         if b == 0 {
-            return a << shift;
+            return (a << shift) as i64;
         }
     }
 }

--- a/datafusion/functions/src/math/gcd.rs
+++ b/datafusion/functions/src/math/gcd.rs
@@ -143,4 +143,22 @@ mod test {
         assert_eq!(ints.value(2), 5);
         assert_eq!(ints.value(3), 8);
     }
+
+    // from issue https://github.com/apache/datafusion/issues/11031 we know that the previous implementation could
+    // not handle cases were one or both of the inputs were an i64::MAX or i64::MIN coupled with other values (neg or pos)
+    #[test]
+    fn test_gcd_i64_maxes() {
+        let args: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![i64::MAX, i64::MIN, i64::MAX])), // x
+            Arc::new(Int64Array::from(vec![i64::MIN, -1, -1])),             // y
+        ];
+
+        let result = gcd(&args).expect("failed to initialize function gcd");
+        let ints = as_int64_array(&result).expect("failed to initialize function gcd");
+
+        assert_eq!(ints.len(), 3);
+        assert_eq!(ints.value(0), 1);
+        assert_eq!(ints.value(1), 1);
+        assert_eq!(ints.value(1), 1);
+    }
 }

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -474,6 +474,16 @@ select gcd(null, null);
 ----
 NULL
 
+# scalar maxes and/or negative 1
+query III rowsort
+select 
+  gcd(9223372036854775807, -9223372036854775808), -- i64::MIN, i64::MAX
+  -- wait till fix, cause it fails gcd(-9223372036854775808, -9223372036854775808), -- -i64::MIN, i64::MIN
+  gcd(9223372036854775807, -1), -- i64::MAX, -1
+  gcd(-9223372036854775808, -1); -- i64::MIN, -1
+----
+1 1 1
+
 # gcd with columns
 query III rowsort
 select gcd(a, b), gcd(c, d), gcd(e, f) from signed_integers;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11031.

## Rationale for this change
The issue mentioned 2 problems, I'll give an explanation here why this happened:

LCM depends on GCD, and the problems are indeed in GCD, so I expect that a fix to GCD will also fix LCM.

### Problem 1
This is because of using `i64` when computing the gcd, but the gcd is never negative. Rust doc also says that `i64::MIN.wrapping_abs() == i64::MIN`, so in the error case mentioned the gcd_compute goes like this:\
- Initial values
`a` = i64::MAX, `b` = i64::MIN
- After `wrapping_abs`:
`a` = still i64::MAX, `b` = still i64::MIN
- After the binary shifts:
`a` = still i64::MAX, b = -1 (here lies the problem)
- we swap `a` and `b` because a > b:
`a` = -1, `b` = i64::MAX
- Now we subtract a from b:
i64::MAX - (-1) = i64::MAX + 1 (here is our integer overflow)\

And because LCM depends on GCD, it also crashed similarly.

### Problem 2
The exact same reason as problem 1: when we do the `wrapping_abs`, we don't change the value of `i64::MIN`, causing the function to stall because it keeps switching `a` and `b`, which either have values -1 or 2.

These edge cases cause overflows or infinite loops, which are bugs, so we fix them.

### Solution
I propose we do the computations with `u64` and in the end, cast the result back to `i64`; this is safe since the input is never bigger than `i64::MAX` or smaller than `i64::MIN`.
This fixes both GCD and LCM


## What changes are included in this PR?
Compute GCD with `u64` and after computation, cast them back to `i64`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Tested this against the values used in the issue, also created an extra test case for this.
Other test also passed.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
