### PR TITLE
feat: Support duplicate column names in Joins in Substrait consumer

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -413,10 +413,10 @@ fn make_renamed_schema(
             dfs_names.len());
     }
 
-    Ok(DFSchema::from_field_specific_qualified_schema(
+    DFSchema::from_field_specific_qualified_schema(
         qualifiers,
         &Arc::new(Schema::new(fields)),
-    )?)
+    )
 }
 
 /// Convert Substrait Rel to DataFusion DataFrame
@@ -875,7 +875,7 @@ fn requalify_sides_if_needed(
     let right_cols = right.schema().columns();
     if left_cols.iter().any(|l| {
         right_cols.iter().any(|r| {
-            l == r || (l.name == r.name && (l.relation == None || r.relation == None))
+            l == r || (l.name == r.name && (l.relation.is_none() || r.relation.is_none()))
         })
     }) {
         // These names have no connection to the original plan, but they'll make the columns

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -494,19 +494,18 @@ async fn roundtrip_outer_join() -> Result<()> {
 #[tokio::test]
 async fn roundtrip_self_join() -> Result<()> {
     // Substrait does currently NOT maintain the alias of the tables.
-    // Instead, when we consume Substrait, we generate unique aliases for each table in order to
-    // provide unique qualified names for each column.
-    // This test works because we set aliases to what the Substrait consumer will generate
-    roundtrip("SELECT data.a as data_a, data_1.a as data_1_a FROM data JOIN data AS data_1 ON data.a = data_1.a").await?;
-    roundtrip("SELECT data.a as data_a, data_1.a as data_1_a FROM data JOIN data AS data_1 ON data.b = data_1.b").await
+    // Instead, when we consume Substrait, we add aliases before a join that'd otherwise collide.
+    // This roundtrip works because we set aliases to what the Substrait consumer will generate.
+    roundtrip("SELECT left.a as left_a, left.b, right.a as right_a, right.c FROM data AS left JOIN data AS right ON left.a = right.a").await?;
+    roundtrip("SELECT left.a as left_a, left.b, right.a as right_a, right.c FROM data AS left JOIN data AS right ON left.b = right.b").await
 }
 
 #[tokio::test]
 async fn roundtrip_self_implicit_cross_join() -> Result<()> {
     // Substrait does currently NOT maintain the alias of the tables.
-    // Instead, when we consume Substrait, we generate unique aliases for each table.
-    // This test works because we set aliases to what the Substrait consumer will generate
-    roundtrip("SELECT data.a p1_a, data_1.a p2_a FROM data, data data_1").await
+    // Instead, when we consume Substrait, we add aliases before a join that'd otherwise collide.
+    // This roundtrip works because we set aliases to what the Substrait consumer will generate.
+    roundtrip("SELECT left.a left_a, left.b, right.a right_a, right.c FROM data AS left, data AS right").await
 }
 
 #[tokio::test]
@@ -628,7 +627,22 @@ async fn simple_intersect() -> Result<()> {
 
 #[tokio::test]
 async fn simple_intersect_table_reuse() -> Result<()> {
-    roundtrip("SELECT count(1) FROM (SELECT data.a FROM data INTERSECT SELECT data.a FROM data);").await
+    // Substrait does currently NOT maintain the alias of the tables.
+    // Instead, when we consume Substrait, we add aliases before a join that'd otherwise collide.
+    // In this case the aliasing happens at a different point in the plan, so we cannot use roundtrip.
+    // Schema check works because we set aliases to what the Substrait consumer will generate.
+    assert_expected_plan(
+        "SELECT count(1) FROM (SELECT left.a FROM data AS left INTERSECT SELECT right.a FROM data AS right);",
+        "Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]\
+        \n  Projection: \
+        \n    LeftSemi Join: left.a = right.a\
+        \n      SubqueryAlias: left\
+        \n        Aggregate: groupBy=[[data.a]], aggr=[[]]\
+        \n          TableScan: data projection=[a]\
+        \n      SubqueryAlias: right\
+        \n        TableScan: data projection=[a]",
+        true
+    ).await
 }
 
 #[tokio::test]
@@ -644,32 +658,6 @@ async fn qualified_schema_table_reference() -> Result<()> {
 #[tokio::test]
 async fn qualified_catalog_schema_table_reference() -> Result<()> {
     roundtrip("SELECT a,b,c,d,e FROM datafusion.public.data;").await
-}
-
-#[tokio::test]
-async fn roundtrip_inner_join_table_reuse_zero_index() -> Result<()> {
-    assert_expected_plan(
-        "SELECT d1.b, d2.c FROM data d1 JOIN data d2 ON d1.a = d2.a",
-        "Projection: data.b, data.c\
-         \n  Inner Join: data.a = data.a\
-         \n    TableScan: data projection=[a, b]\
-         \n    TableScan: data projection=[a, c]",
-        false, // "d1" vs "data" field qualifier
-    )
-    .await
-}
-
-#[tokio::test]
-async fn roundtrip_inner_join_table_reuse_non_zero_index() -> Result<()> {
-    assert_expected_plan(
-        "SELECT d1.b, d2.c FROM data d1 JOIN data d2 ON d1.b = d2.b",
-        "Projection: data.b, data.c\
-         \n  Inner Join: data.b = data.b\
-         \n    TableScan: data projection=[b]\
-         \n    TableScan: data projection=[b, c]",
-        false, // "d1" vs "data" field qualifier
-    )
-    .await
 }
 
 /// Construct a plan that contains several literals of types that are currently supported.
@@ -758,14 +746,16 @@ async fn roundtrip_values() -> Result<()> {
 
 #[tokio::test]
 async fn roundtrip_values_duplicate_column_join() -> Result<()> {
-    // Set aliases to what the Substrait consumer will generate
+    // Substrait does currently NOT maintain the alias of the tables.
+    // Instead, when we consume Substrait, we add aliases before a join that'd otherwise collide.
+    // In this case the aliasing happens at a different point in the plan, so we cannot use roundtrip.
     roundtrip(
-        "SELECT table.column1 as c1, table_1.column1 as c2 \
+        "SELECT left.column1 as c1, right.column1 as c2 \
     FROM \
-        (VALUES (1)) AS table \
+        (VALUES (1)) AS left \
     JOIN \
-        (VALUES (2)) AS table_1 \
-    ON table.column1 == table_1.column1",
+        (VALUES (2)) AS right \
+    ON left.column1 == right.column1",
     )
     .await
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10815 , and also adds support for joining two VirtualTables with overlapping column names.

## Rationale for this change

Substrait doesn't contain aliases inside the plan: neither table aliases (SubqueryAlias), nor column aliases. Columns are only named at the beginning and end of the plan, while tables are not named by substrait at all. Substrait referes to columns only by their relative indices, so that's name-independent.

When we consumer Substrait plans' ReadRels, the created DataFusion tables may or may not have qualifiers. If the tables are NamedTable reads, then DataFusion uses the name as the qualifier. If the tables are VirtualTables, then we have unqualified tables.

This causes trouble in some cases for DataFusion, as DF requires columns to be uniquely named in at least two places (there’s probably more but these are the ones we’ve hit so far):
1. when joining schemas, in [DFSchema::check_names](https://github.com/apache/datafusion/blob/18042fd69138e19613844580408a71a200ea6caa/datafusion/common/src/dfschema.rs#L218).  This throws when there are two duplicate unqualified names, or if a unqualified name matches the name of a qualified name. This was problematic for joining VirtualTables since they would be unqualified.
2. Interestingly, the (1) does NOT throw when there are two duplicate qualified names. That's why the [existing tests](https://github.com/apache/datafusion/blob/18042fd69138e19613844580408a71a200ea6caa/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs#L634) were working. However, this results in a schema that contains duplicate fields, which then fail if those fields are actually trying to be used - that's #10815



## What changes are included in this PR?

I tried first a slightly different solution in #11048, where I'd create a unique reference for each table at the beginning. However that solution has some gaps (it might not work if there's a project between join and a read, e.g.) and is a bit nasty overall. 

While thinking about it, I concluded there might be a simpler solution: just (re)qualify the tables before joining them. This is what this PR does. We check, before a join, if there are columns that appear both on the left and right sides, and if there are, we requalify both sides (to `left` and `right`). As Substrait only cares about the position of the column, the (re)qualifying doesn't affect the rest of the plan (other than the qualifiers of the output columns).

This ended up looking much better to me. The table qualifiers do now change within the plan created from Substrait, but only if necessary to avoid conflicts. 

This PR also separately fixes a case in the final schema aliasing where we'd unnecessarily add aliases to columns to drop table qualifiers (ie. if our plan had a column `table.a` but the Substrait `names` defines the name to be `a`, we'd alias that: `table.a AS a`. But that's unnecessary since we should only care about the name, not the qualifier.

## Are these changes tested?

Tested by some stricter roundtrip unit tests, + adapting existing tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

Plans produced by Substrait consumer may get different qualifiers for output columns. I think that's unlikely to affect anyone since I dunno why people would be looking at those qualifiers.

Otherwise just improved support for Substrait plans.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
