### PR TITLE
Add input_nullable for UDAF args StateField and Accumulator

### DIFF
--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -83,6 +83,9 @@ pub struct AccumulatorArgs<'a> {
     /// The input type of the aggregate function.
     pub input_type: &'a DataType,
 
+    /// If the input type is nullable.
+    pub input_nullable: bool,
+
     /// The logical expression of arguments the aggregate function takes.
     pub input_exprs: &'a [Expr],
 }
@@ -97,6 +100,9 @@ pub struct StateFieldsArgs<'a> {
 
     /// The input type of the aggregate function.
     pub input_type: &'a DataType,
+
+    /// If the input type is nullable.
+    pub input_nullable: bool,
 
     /// The return type of the aggregate function.
     pub return_type: &'a DataType,

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -440,6 +440,7 @@ impl AggregateUDFImpl for LastValue {
         let StateFieldsArgs {
             name,
             input_type,
+            input_nullable: _,
             return_type: _,
             ordering_fields,
             is_distinct: _,

--- a/datafusion/physical-expr-common/src/aggregate/mod.rs
+++ b/datafusion/physical-expr-common/src/aggregate/mod.rs
@@ -87,6 +87,7 @@ pub fn create_aggregate_expr(
         ordering_fields,
         is_distinct,
         input_type: input_exprs_types[0].clone(),
+        input_nullable: input_phy_exprs[0].nullable(&schema)?,
     }))
 }
 
@@ -248,6 +249,7 @@ pub struct AggregateFunctionExpr {
     ordering_fields: Vec<Field>,
     is_distinct: bool,
     input_type: DataType,
+    input_nullable: bool,
 }
 
 impl AggregateFunctionExpr {
@@ -276,6 +278,7 @@ impl AggregateExpr for AggregateFunctionExpr {
         let args = StateFieldsArgs {
             name: &self.name,
             input_type: &self.input_type,
+            input_nullable: self.input_nullable,
             return_type: &self.data_type,
             ordering_fields: &self.ordering_fields,
             is_distinct: self.is_distinct,
@@ -296,6 +299,7 @@ impl AggregateExpr for AggregateFunctionExpr {
             sort_exprs: &self.sort_exprs,
             is_distinct: self.is_distinct,
             input_type: &self.input_type,
+            input_nullable: self.input_nullable,
             input_exprs: &self.logical_args,
             name: &self.name,
         };
@@ -311,6 +315,7 @@ impl AggregateExpr for AggregateFunctionExpr {
             sort_exprs: &self.sort_exprs,
             is_distinct: self.is_distinct,
             input_type: &self.input_type,
+            input_nullable: self.input_nullable,
             input_exprs: &self.logical_args,
             name: &self.name,
         };
@@ -381,6 +386,7 @@ impl AggregateExpr for AggregateFunctionExpr {
             sort_exprs: &self.sort_exprs,
             is_distinct: self.is_distinct,
             input_type: &self.input_type,
+            input_nullable: self.input_nullable,
             input_exprs: &self.logical_args,
             name: &self.name,
         };
@@ -395,6 +401,7 @@ impl AggregateExpr for AggregateFunctionExpr {
             sort_exprs: &self.sort_exprs,
             is_distinct: self.is_distinct,
             input_type: &self.input_type,
+            input_nullable: self.input_nullable,
             input_exprs: &self.logical_args,
             name: &self.name,
         };


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #8708

## Rationale for this change
This is need when we are moving `arrag_agg`  (#11045) to udaf where one of the
states nullability will depend on the nullability of the input.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
This follows how it done for input_type and only provide a single value.
But might need to be changed into a Vec in the future.


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Existing tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
New fields in the args struct in UDAF APIs.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
