### PR TITLE
Change wildcard qualifier type from `String` to `TableReference`

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -307,7 +307,7 @@ pub enum Expr {
     ///
     /// This expr has to be resolved to a list of columns before translating logical
     /// plan into physical plan.
-    Wildcard { qualifier: Option<String> },
+    Wildcard { qualifier: Option<TableReference> },
     /// List of grouping set expressions. Only valid in the context of an aggregate
     /// GROUP BY expression list
     GroupingSet(GroupingSet),

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -318,7 +318,7 @@ fn get_excluded_columns(
     opt_exclude: Option<&ExcludeSelectItem>,
     opt_except: Option<&ExceptSelectItem>,
     schema: &DFSchema,
-    qualifier: &Option<TableReference>,
+    qualifier: Option<&TableReference>,
 ) -> Result<Vec<Column>> {
     let mut idents = vec![];
     if let Some(excepts) = opt_except {
@@ -343,8 +343,7 @@ fn get_excluded_columns(
     let mut result = vec![];
     for ident in unique_idents.into_iter() {
         let col_name = ident.value.as_str();
-        let (qualifier, field) =
-            schema.qualified_field_with_name(qualifier.as_ref(), col_name)?;
+        let (qualifier, field) = schema.qualified_field_with_name(qualifier, col_name)?;
         result.push(Column::from((qualifier, field)));
     }
     Ok(result)
@@ -406,7 +405,7 @@ pub fn expand_wildcard(
         ..
     }) = wildcard_options
     {
-        get_excluded_columns(opt_exclude.as_ref(), opt_except.as_ref(), schema, &None)?
+        get_excluded_columns(opt_exclude.as_ref(), opt_except.as_ref(), schema, None)?
     } else {
         vec![]
     };
@@ -417,12 +416,11 @@ pub fn expand_wildcard(
 
 /// Resolves an `Expr::Wildcard` to a collection of qualified `Expr::Column`'s.
 pub fn expand_qualified_wildcard(
-    qualifier: &str,
+    qualifier: &TableReference,
     schema: &DFSchema,
     wildcard_options: Option<&WildcardAdditionalOptions>,
 ) -> Result<Vec<Expr>> {
-    let qualifier = TableReference::from(qualifier);
-    let qualified_indices = schema.fields_indices_with_qualified(&qualifier);
+    let qualified_indices = schema.fields_indices_with_qualified(qualifier);
     let projected_func_dependencies = schema
         .functional_dependencies()
         .project_functional_dependencies(&qualified_indices, qualified_indices.len());
@@ -445,7 +443,7 @@ pub fn expand_qualified_wildcard(
             opt_exclude.as_ref(),
             opt_except.as_ref(),
             schema,
-            &Some(qualifier),
+            Some(qualifier),
         )?
     } else {
         vec![]

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -369,7 +369,8 @@ message LogicalExprNode {
 }
 
 message Wildcard {
-  string qualifier = 1;
+  string qualifier = 1 [deprecated = true];
+  TableReference relation = 2;
 }
 
 message PlaceholderNode {

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -369,8 +369,7 @@ message LogicalExprNode {
 }
 
 message Wildcard {
-  string qualifier = 1 [deprecated = true];
-  TableReference relation = 2;
+  TableReference qualifier = 1;
 }
 
 message PlaceholderNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -19970,9 +19970,15 @@ impl serde::Serialize for Wildcard {
         if !self.qualifier.is_empty() {
             len += 1;
         }
+        if self.relation.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion.Wildcard", len)?;
         if !self.qualifier.is_empty() {
             struct_ser.serialize_field("qualifier", &self.qualifier)?;
+        }
+        if let Some(v) = self.relation.as_ref() {
+            struct_ser.serialize_field("relation", v)?;
         }
         struct_ser.end()
     }
@@ -19985,11 +19991,13 @@ impl<'de> serde::Deserialize<'de> for Wildcard {
     {
         const FIELDS: &[&str] = &[
             "qualifier",
+            "relation",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Qualifier,
+            Relation,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -20012,6 +20020,7 @@ impl<'de> serde::Deserialize<'de> for Wildcard {
                     {
                         match value {
                             "qualifier" => Ok(GeneratedField::Qualifier),
+                            "relation" => Ok(GeneratedField::Relation),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -20032,6 +20041,7 @@ impl<'de> serde::Deserialize<'de> for Wildcard {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut qualifier__ = None;
+                let mut relation__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Qualifier => {
@@ -20040,10 +20050,17 @@ impl<'de> serde::Deserialize<'de> for Wildcard {
                             }
                             qualifier__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Relation => {
+                            if relation__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("relation"));
+                            }
+                            relation__ = map_.next_value()?;
+                        }
                     }
                 }
                 Ok(Wildcard {
                     qualifier: qualifier__.unwrap_or_default(),
+                    relation: relation__,
                 })
             }
         }

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -19967,18 +19967,12 @@ impl serde::Serialize for Wildcard {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if !self.qualifier.is_empty() {
-            len += 1;
-        }
-        if self.relation.is_some() {
+        if self.qualifier.is_some() {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("datafusion.Wildcard", len)?;
-        if !self.qualifier.is_empty() {
-            struct_ser.serialize_field("qualifier", &self.qualifier)?;
-        }
-        if let Some(v) = self.relation.as_ref() {
-            struct_ser.serialize_field("relation", v)?;
+        if let Some(v) = self.qualifier.as_ref() {
+            struct_ser.serialize_field("qualifier", v)?;
         }
         struct_ser.end()
     }
@@ -19991,13 +19985,11 @@ impl<'de> serde::Deserialize<'de> for Wildcard {
     {
         const FIELDS: &[&str] = &[
             "qualifier",
-            "relation",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Qualifier,
-            Relation,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -20020,7 +20012,6 @@ impl<'de> serde::Deserialize<'de> for Wildcard {
                     {
                         match value {
                             "qualifier" => Ok(GeneratedField::Qualifier),
-                            "relation" => Ok(GeneratedField::Relation),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -20041,26 +20032,18 @@ impl<'de> serde::Deserialize<'de> for Wildcard {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut qualifier__ = None;
-                let mut relation__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Qualifier => {
                             if qualifier__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("qualifier"));
                             }
-                            qualifier__ = Some(map_.next_value()?);
-                        }
-                        GeneratedField::Relation => {
-                            if relation__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("relation"));
-                            }
-                            relation__ = map_.next_value()?;
+                            qualifier__ = map_.next_value()?;
                         }
                     }
                 }
                 Ok(Wildcard {
-                    qualifier: qualifier__.unwrap_or_default(),
-                    relation: relation__,
+                    qualifier: qualifier__,
                 })
             }
         }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -592,8 +592,11 @@ pub mod logical_expr_node {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Wildcard {
+    #[deprecated]
     #[prost(string, tag = "1")]
     pub qualifier: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub relation: ::core::option::Option<TableReference>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -592,11 +592,8 @@ pub mod logical_expr_node {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Wildcard {
-    #[deprecated]
-    #[prost(string, tag = "1")]
-    pub qualifier: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "2")]
-    pub relation: ::core::option::Option<TableReference>,
+    #[prost(message, optional, tag = "1")]
+    pub qualifier: ::core::option::Option<TableReference>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -593,19 +593,8 @@ pub fn parse_expr(
             parse_exprs(&in_list.list, registry, codec)?,
             in_list.negated,
         ))),
-        #[allow(deprecated)]
-        ExprType::Wildcard(protobuf::Wildcard {
-            qualifier,
-            relation,
-        }) => {
-            let qualifier = match (qualifier.as_str(), relation) {
-                ("", None) => None,
-                (qualifier, None) => Some(TableReference::from(qualifier)),
-                ("", Some(relation)) => Some(relation.clone().try_into()?),
-                (_, Some(_)) => {
-                    return Err(proto_error("Cannot specify both qualifier string and table reference for wildcard"));
-                }
-            };
+        ExprType::Wildcard(protobuf::Wildcard { qualifier }) => {
+            let qualifier = qualifier.to_owned().map(|x| x.try_into()).transpose()?;
             Ok(Expr::Wildcard { qualifier })
         }
         ExprType::ScalarUdfExpr(protobuf::ScalarUdfExprNode {

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -617,8 +617,10 @@ pub fn serialize_expr(
             }
         }
         Expr::Wildcard { qualifier } => protobuf::LogicalExprNode {
+            #[allow(deprecated)]
             expr_type: Some(ExprType::Wildcard(protobuf::Wildcard {
-                qualifier: qualifier.clone().unwrap_or("".to_string()),
+                qualifier: "".to_string(),
+                relation: qualifier.to_owned().map(|r| r.into()),
             })),
         },
         Expr::ScalarSubquery(_)

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -618,7 +618,7 @@ pub fn serialize_expr(
         }
         Expr::Wildcard { qualifier } => protobuf::LogicalExprNode {
             expr_type: Some(ExprType::Wildcard(protobuf::Wildcard {
-                qualifier: qualifier.to_owned().map(|r| r.into()),
+                qualifier: qualifier.to_owned().map(|x| x.into()),
             })),
         },
         Expr::ScalarSubquery(_)

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -617,10 +617,8 @@ pub fn serialize_expr(
             }
         }
         Expr::Wildcard { qualifier } => protobuf::LogicalExprNode {
-            #[allow(deprecated)]
             expr_type: Some(ExprType::Wildcard(protobuf::Wildcard {
-                qualifier: "".to_string(),
-                relation: qualifier.to_owned().map(|r| r.into()),
+                qualifier: qualifier.to_owned().map(|r| r.into()),
             })),
         },
         Expr::ScalarSubquery(_)

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -18,7 +18,9 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use crate::planner::{
+    idents_to_table_reference, ContextProvider, PlannerContext, SqlToRel,
+};
 use crate::utils::{
     check_columns_satisfy_exprs, extract_aliases, rebase_expr,
     recursive_transform_unnest, resolve_aliases_to_exprs, resolve_columns,
@@ -475,9 +477,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     Ok(expanded_exprs)
                 }
             }
-            SelectItem::QualifiedWildcard(ref object_name, options) => {
+            SelectItem::QualifiedWildcard(object_name, options) => {
                 Self::check_wildcard_options(&options)?;
-                let qualifier = format!("{object_name}");
+                let qualifier = idents_to_table_reference(object_name.0, false)?;
                 // do not expand from outer schema
                 let expanded_exprs = expand_qualified_wildcard(
                     &qualifier,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11072.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR changes the wildcard qualifier type to `TableReference`. This avoids an implicit SQL parsing during logical planning, and makes the API more consistent.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The PR changes the wildcard qualifier type for `Expr::Wildcard` and updates the `.proto` file.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

The changes are covered by existing tests.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes, this PR contains breaking changes to the public API.
