### PR TITLE
Strip table qualifiers from schema in `UNION ALL` for unparser

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -2255,29 +2255,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[test]
-    fn test_union_strips_qualifiers() -> Result<()> {
-        let schema = Schema::new(vec![
-            Field::new("foo", DataType::Int32, false),
-            Field::new("bar", DataType::Int32, false),
-        ]);
-        let result = table_scan(Some("t1"), &schema, None)?
-            .union(table_scan(Some("t2"), &schema, None)?.build()?)?
-            .build()?;
-
-        let LogicalPlan::Union(union) = result else {
-            panic!("expected union, got {result:?}")
-        };
-
-        assert!(
-            union
-                .schema
-                .iter()
-                .all(|(qualifier, _)| qualifier.is_none()),
-            "Expected the schema from a Union to not have any table qualifiers"
-        );
-
-        Ok(())
-    }
 }

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -2255,4 +2255,29 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_union_strips_qualifiers() -> Result<()> {
+        let schema = Schema::new(vec![
+            Field::new("foo", DataType::Int32, false),
+            Field::new("bar", DataType::Int32, false),
+        ]);
+        let result = table_scan(Some("t1"), &schema, None)?
+            .union(table_scan(Some("t2"), &schema, None)?.build()?)?
+            .build()?;
+
+        let LogicalPlan::Union(union) = result else {
+            panic!("expected union, got {result:?}")
+        };
+
+        assert!(
+            union
+                .schema
+                .iter()
+                .all(|(qualifier, _)| qualifier.is_none()),
+            "Expected the schema from a Union to not have any table qualifiers"
+        );
+
+        Ok(())
+    }
 }

--- a/datafusion/sql/src/unparser/mod.rs
+++ b/datafusion/sql/src/unparser/mod.rs
@@ -18,6 +18,7 @@
 mod ast;
 mod expr;
 mod plan;
+mod rewrite;
 mod utils;
 
 pub use expr::expr_to_sql;

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -15,11 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion_common::{
-    internal_err, not_impl_err, plan_err,
-    tree_node::{TransformedResult, TreeNode},
-    DataFusionError, Result,
-};
+use datafusion_common::{internal_err, not_impl_err, plan_err, DataFusionError, Result};
 use datafusion_expr::{
     expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan, Projection,
 };
@@ -32,7 +28,7 @@ use super::{
         BuilderError, DerivedRelationBuilder, QueryBuilder, RelationBuilder,
         SelectBuilder, TableRelationBuilder, TableWithJoinsBuilder,
     },
-    rewrite::NormalizeUnionSchema,
+    rewrite::normalize_union_schema,
     utils::{find_agg_node_within_select, unproject_window_exprs, AggVariant},
     Unparser,
 };
@@ -68,8 +64,7 @@ pub fn plan_to_sql(plan: &LogicalPlan) -> Result<ast::Statement> {
 
 impl Unparser<'_> {
     pub fn plan_to_sql(&self, plan: &LogicalPlan) -> Result<ast::Statement> {
-        let mut union_schema_normalizer = NormalizeUnionSchema::new();
-        let plan = plan.clone().rewrite(&mut union_schema_normalizer).data()?;
+        let plan = normalize_union_schema(plan)?;
 
         match plan {
             LogicalPlan::Projection(_)

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use datafusion_common::{
+    tree_node::{Transformed, TransformedResult, TreeNode, TreeNodeRewriter},
+    Result,
+};
+use datafusion_expr::{Expr, LogicalPlan, Sort};
+
+/// Normalize the schema of a union plan to remove qualifiers from the schema fields.
+pub(super) struct NormalizeUnionSchema {}
+
+impl NormalizeUnionSchema {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TreeNodeRewriter for NormalizeUnionSchema {
+    type Node = LogicalPlan;
+
+    /// Invoked while traversing down the tree before any children are rewritten.
+    /// Default implementation returns the node as is and continues recursion.
+    fn f_down(&mut self, plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+        match plan {
+            LogicalPlan::Union(mut union) => {
+                let schema = match Arc::try_unwrap(union.schema) {
+                    Ok(inner) => inner,
+                    Err(schema) => (*schema).clone(),
+                };
+                let schema = schema.strip_qualifiers();
+
+                union.schema = Arc::new(schema);
+                Ok(Transformed::yes(LogicalPlan::Union(union)))
+            }
+            LogicalPlan::Sort(sort) => {
+                if !matches!(&*sort.input, LogicalPlan::Union(_)) {
+                    return Ok(Transformed::no(LogicalPlan::Sort(sort)));
+                }
+
+                let mut sort_expr_rewriter = NormalizeSortExprForUnion::new();
+                let sort_exprs: Vec<Expr> = sort
+                    .expr
+                    .into_iter()
+                    .map(|expr| expr.rewrite(&mut sort_expr_rewriter).data())
+                    .collect::<Result<Vec<_>>>()?;
+
+                Ok(Transformed::yes(LogicalPlan::Sort(Sort {
+                    expr: sort_exprs,
+                    input: sort.input,
+                    fetch: sort.fetch,
+                })))
+            }
+            _ => Ok(Transformed::no(plan)),
+        }
+    }
+}
+
+/// Normalize the schema of sort expressions that follow a Union to remove any column relations.
+struct NormalizeSortExprForUnion {}
+
+impl NormalizeSortExprForUnion {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TreeNodeRewriter for NormalizeSortExprForUnion {
+    type Node = Expr;
+
+    fn f_down(&mut self, expr: Expr) -> Result<Transformed<Expr>> {
+        match expr {
+            Expr::Column(mut col) => {
+                col.relation = None;
+                Ok(Transformed::yes(Expr::Column(col)))
+            }
+            _ => Ok(Transformed::no(expr)),
+        }
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10706

## Rationale for this change

The schema that is the result of a UNION ALL should not have any table qualifiers, as the table information has effectively been erased and is no longer a valid reference.

Consider the following SQL:

```sql
SELECT table1.foo FROM table1
UNION ALL
SELECT table2.foo FROM table2
```

The logical schema from this UNION ALL should be just `foo`, but it is currently taking the first input's schema directly, resulting in a schema of `table1.foo`.

This came up as an issue when trying to validate the unparser works correctly for UNION ALL statements, which I added in https://github.com/apache/datafusion/pull/10603

Slightly modifying the above example, if I add an ORDER BY clause to the input SQL:

```sql
SELECT table1.foo FROM table1
UNION ALL
SELECT table2.foo FROM table2
ORDER BY foo
```

Then the resulting unparsed SQL will be:

```sql
SELECT table1.foo FROM table1
UNION ALL
SELECT table2.foo FROM table2
ORDER BY table1.foo
```

Because the unparser takes the schema directly from the Union node when writing out the column expressions.

This is my second attempt to fix #10706, my [first attempt](https://github.com/apache/datafusion/pull/10707) was to remove the table qualifiers when building the Union plan directly, but that caused issues documented here: https://github.com/apache/datafusion/pull/10707#discussion_r1618338309

This attempt scopes the problem to just removing the table qualifiers during the unparsing.

## What changes are included in this PR?

Rewrite the LogicalPlan before unparsing to remove table identifiers from the Union All plan and any sort expressions that take a Union All plan as input.

## Are these changes tested?

Yes, I added a test in the Unparser `sql_integration` test.

## Are there any user-facing changes?

No