### PR TITLE
Array agg groups accumulator, second attempt

### DIFF
--- a/datafusion-examples/examples/advanced_udaf.rs
+++ b/datafusion-examples/examples/advanced_udaf.rs
@@ -289,10 +289,12 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
             opt_filter,
             total_num_groups,
             |group_index, new_value| {
-                let prod = &mut self.prods[group_index];
-                *prod = prod.mul_wrapping(new_value);
+                if let Some(new_value) = new_value {
+                    let prod = &mut self.prods[group_index];
+                    *prod = prod.mul_wrapping(new_value);
 
-                self.counts[group_index] += 1;
+                    self.counts[group_index] += 1;
+                }
             },
         );
 
@@ -319,7 +321,9 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
             opt_filter,
             total_num_groups,
             |group_index, partial_count| {
-                self.counts[group_index] += partial_count;
+                if let Some(partial_count) = partial_count {
+                    self.counts[group_index] += partial_count;
+                }
             },
         );
 
@@ -330,9 +334,12 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
             partial_prods,
             opt_filter,
             total_num_groups,
-            |group_index, new_value: <Float64Type as ArrowPrimitiveType>::Native| {
-                let prod = &mut self.prods[group_index];
-                *prod = prod.mul_wrapping(new_value);
+            |group_index,
+             new_value: Option<<Float64Type as ArrowPrimitiveType>::Native>| {
+                if let Some(new_value) = new_value {
+                    let prod = &mut self.prods[group_index];
+                    *prod = prod.mul_wrapping(new_value);
+                }
             },
         );
 

--- a/datafusion/physical-expr-common/src/aggregate/groups_accumulator/accumulate.rs
+++ b/datafusion/physical-expr-common/src/aggregate/groups_accumulator/accumulate.rs
@@ -19,7 +19,10 @@
 //!
 //! [`GroupsAccumulator`]: datafusion_expr::GroupsAccumulator
 
-use arrow::array::{Array, BooleanArray, BooleanBufferBuilder, PrimitiveArray};
+use arrow::array::{
+    Array, ArrayRef, BooleanArray, BooleanBufferBuilder, ListArray, PrimitiveArray,
+    StringArray,
+};
 use arrow::buffer::{BooleanBuffer, NullBuffer};
 use arrow::datatypes::ArrowPrimitiveType;
 
@@ -320,6 +323,166 @@ impl NullState {
                             }
                         }
                     })
+            }
+        }
+    }
+
+    /// Invokes `value_fn(group_index, value)` for each non null, non
+    /// filtered value in `values`, while tracking which groups have
+    /// seen null inputs and which groups have seen any inputs, for
+    /// [`ListArray`]s.
+    ///
+    /// See [`Self::accumulate`], which handles `PrimitiveArray`s, for
+    /// more details on other arguments.
+    pub fn accumulate_array<F>(
+        &mut self,
+        group_indices: &[usize],
+        values: &ListArray,
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+        mut value_fn: F,
+    ) where
+        F: FnMut(usize, ArrayRef) + Send,
+    {
+        assert_eq!(values.len(), group_indices.len());
+
+        // ensure the seen_values is big enough (start everything at
+        // "not seen" valid)
+        let seen_values =
+            initialize_builder(&mut self.seen_values, total_num_groups, false);
+
+        match (values.null_count() > 0, opt_filter) {
+            // no nulls, no filter,
+            (false, None) => {
+                let iter = group_indices.iter().zip(values.iter());
+                for (&group_index, new_value) in iter {
+                    seen_values.set_bit(group_index, true);
+                    value_fn(group_index, new_value.unwrap());
+                }
+            }
+            // nulls, no filter
+            (true, None) => {
+                let nulls = values.nulls().unwrap();
+                group_indices
+                    .iter()
+                    .zip(values.iter())
+                    .zip(nulls.iter())
+                    .for_each(|((&group_index, new_value), is_valid)| {
+                        if is_valid {
+                            seen_values.set_bit(group_index, true);
+                            value_fn(group_index, new_value.unwrap());
+                        }
+                    })
+            }
+            // no nulls, but a filter
+            (false, Some(filter)) => {
+                assert_eq!(filter.len(), group_indices.len());
+                group_indices
+                    .iter()
+                    .zip(values.iter())
+                    .zip(filter.iter())
+                    .for_each(|((&group_index, new_value), filter_value)| {
+                        if let Some(true) = filter_value {
+                            seen_values.set_bit(group_index, true);
+                            value_fn(group_index, new_value.unwrap());
+                        }
+                    });
+            }
+            // both null values and filters
+            (true, Some(filter)) => {
+                assert_eq!(filter.len(), group_indices.len());
+                filter
+                    .iter()
+                    .zip(group_indices.iter())
+                    .zip(values.iter())
+                    .for_each(|((filter_value, &group_index), new_value)| {
+                        if let Some(true) = filter_value {
+                            if let Some(new_value) = new_value {
+                                seen_values.set_bit(group_index, true);
+                                value_fn(group_index, new_value);
+                            }
+                        }
+                    });
+            }
+        }
+    }
+
+    /// Invokes `value_fn(group_index, value)` for each non-null,
+    /// non-filtered value in `values`, while tracking which groups have
+    /// seen null inputs and which groups have seen any inputs, for
+    /// [`ListArray`]s.
+    ///
+    /// See [`Self::accumulate`], which handles `PrimitiveArray`s, for
+    /// more details on other arguments.
+    pub fn accumulate_string<F>(
+        &mut self,
+        group_indices: &[usize],
+        values: &StringArray,
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+        mut value_fn: F,
+    ) where
+        F: FnMut(usize, &str) + Send,
+    {
+        assert_eq!(values.len(), group_indices.len());
+
+        // ensure the seen_values is big enough (start everything at
+        // "not seen" valid)
+        let seen_values =
+            initialize_builder(&mut self.seen_values, total_num_groups, false);
+
+        match (values.null_count() > 0, opt_filter) {
+            // no nulls, no filter,
+            (false, None) => {
+                let iter = group_indices.iter().zip(values.iter());
+                for (&group_index, new_value) in iter {
+                    seen_values.set_bit(group_index, true);
+                    value_fn(group_index, new_value.unwrap());
+                }
+            }
+            // nulls, no filter
+            (true, None) => {
+                let nulls = values.nulls().unwrap();
+                group_indices
+                    .iter()
+                    .zip(values.iter())
+                    .zip(nulls.iter())
+                    .for_each(|((&group_index, new_value), is_valid)| {
+                        if is_valid {
+                            seen_values.set_bit(group_index, true);
+                            value_fn(group_index, new_value.unwrap());
+                        }
+                    })
+            }
+            // no nulls, but a filter
+            (false, Some(filter)) => {
+                assert_eq!(filter.len(), group_indices.len());
+                group_indices
+                    .iter()
+                    .zip(values.iter())
+                    .zip(filter.iter())
+                    .for_each(|((&group_index, new_value), filter_value)| {
+                        if let Some(true) = filter_value {
+                            seen_values.set_bit(group_index, true);
+                            value_fn(group_index, new_value.unwrap());
+                        }
+                    });
+            }
+            // both null values and filters
+            (true, Some(filter)) => {
+                assert_eq!(filter.len(), group_indices.len());
+                filter
+                    .iter()
+                    .zip(group_indices.iter())
+                    .zip(values.iter())
+                    .for_each(|((filter_value, &group_index), new_value)| {
+                        if let Some(true) = filter_value {
+                            if let Some(new_value) = new_value {
+                                seen_values.set_bit(group_index, true);
+                                value_fn(group_index, new_value);
+                            }
+                        }
+                    });
             }
         }
     }

--- a/datafusion/physical-expr-common/src/aggregate/groups_accumulator/prim_op.rs
+++ b/datafusion/physical-expr-common/src/aggregate/groups_accumulator/prim_op.rs
@@ -103,8 +103,10 @@ where
             opt_filter,
             total_num_groups,
             |group_index, new_value| {
-                let value = &mut self.values[group_index];
-                (self.prim_fn)(value, new_value);
+                if let Some(new_value) = new_value {
+                    let value = &mut self.values[group_index];
+                    (self.prim_fn)(value, new_value);
+                }
             },
         );
 

--- a/datafusion/physical-expr/src/aggregate/array_agg.rs
+++ b/datafusion/physical-expr/src/aggregate/array_agg.rs
@@ -20,14 +20,24 @@
 use crate::aggregate::utils::down_cast_any_ref;
 use crate::expressions::format_state_name;
 use crate::{AggregateExpr, PhysicalExpr};
-use arrow::array::ArrayRef;
-use arrow::datatypes::{DataType, Field};
-use arrow_array::Array;
+use arrow::array::{ArrayRef, AsArray, ListBuilder, PrimitiveBuilder, StringBuilder};
+use arrow::datatypes::{
+    ArrowPrimitiveType, DataType, Date32Type, Date64Type, Decimal128Type, Decimal256Type,
+    DurationMicrosecondType, DurationMillisecondType, DurationNanosecondType,
+    DurationSecondType, Field, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type,
+    Int8Type, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalYearMonthType,
+    Time32MillisecondType, Time32SecondType, Time64MicrosecondType, Time64NanosecondType,
+    TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
+    TimestampSecondType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+};
+use arrow_array::{Array, BooleanArray};
+use arrow_schema::{IntervalUnit, TimeUnit};
 use datafusion_common::cast::as_list_array;
 use datafusion_common::utils::array_into_list_array;
-use datafusion_common::Result;
 use datafusion_common::ScalarValue;
-use datafusion_expr::Accumulator;
+use datafusion_common::{DataFusionError, Result};
+use datafusion_expr::{Accumulator, EmitTo, GroupsAccumulator};
+use datafusion_physical_expr_common::aggregate::groups_accumulator::accumulate::NullState;
 use std::any::Any;
 use std::sync::Arc;
 
@@ -95,6 +105,139 @@ impl AggregateExpr for ArrayAgg {
 
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn groups_accumulator_supported(&self) -> bool {
+        self.input_data_type.is_primitive() || self.input_data_type == DataType::Utf8
+    }
+
+    fn create_groups_accumulator(&self) -> Result<Box<dyn GroupsAccumulator>> {
+        match self.input_data_type {
+            DataType::Int8 => Ok(Box::new(ArrayAggGroupsAccumulator::<Int8Type>::new(
+                &self.input_data_type,
+            ))),
+            DataType::Int16 => Ok(Box::new(ArrayAggGroupsAccumulator::<Int16Type>::new(
+                &self.input_data_type,
+            ))),
+            DataType::Int32 => Ok(Box::new(ArrayAggGroupsAccumulator::<Int32Type>::new(
+                &self.input_data_type,
+            ))),
+            DataType::Int64 => Ok(Box::new(ArrayAggGroupsAccumulator::<Int64Type>::new(
+                &self.input_data_type,
+            ))),
+            DataType::UInt8 => Ok(Box::new(ArrayAggGroupsAccumulator::<UInt8Type>::new(
+                &self.input_data_type,
+            ))),
+            DataType::UInt16 => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<UInt16Type>::new(&self.input_data_type),
+            )),
+            DataType::UInt32 => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<UInt32Type>::new(&self.input_data_type),
+            )),
+            DataType::UInt64 => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<UInt64Type>::new(&self.input_data_type),
+            )),
+            DataType::Float32 => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<Float32Type>::new(&self.input_data_type),
+            )),
+            DataType::Float64 => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<Float64Type>::new(&self.input_data_type),
+            )),
+            DataType::Decimal128(_, _) => {
+                Ok(Box::new(ArrayAggGroupsAccumulator::<Decimal128Type>::new(
+                    &self.input_data_type,
+                )))
+            }
+            DataType::Decimal256(_, _) => {
+                Ok(Box::new(ArrayAggGroupsAccumulator::<Decimal256Type>::new(
+                    &self.input_data_type,
+                )))
+            }
+            DataType::Date32 => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<Date32Type>::new(&self.input_data_type),
+            )),
+            DataType::Date64 => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<Date64Type>::new(&self.input_data_type),
+            )),
+            DataType::Timestamp(TimeUnit::Second, _) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<TimestampSecondType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Timestamp(TimeUnit::Millisecond, _) => {
+                Ok(Box::new(ArrayAggGroupsAccumulator::<
+                    TimestampMillisecondType,
+                >::new(&self.input_data_type)))
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                Ok(Box::new(ArrayAggGroupsAccumulator::<
+                    TimestampMicrosecondType,
+                >::new(&self.input_data_type)))
+            }
+            DataType::Timestamp(TimeUnit::Nanosecond, _) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<TimestampNanosecondType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Time32(TimeUnit::Second) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<Time32SecondType>::new(&self.input_data_type),
+            )),
+            DataType::Time32(TimeUnit::Millisecond) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<Time32MillisecondType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Time64(TimeUnit::Microsecond) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<Time64MicrosecondType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Time64(TimeUnit::Nanosecond) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<Time64NanosecondType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Duration(TimeUnit::Second) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<DurationSecondType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Duration(TimeUnit::Millisecond) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<DurationMillisecondType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Duration(TimeUnit::Microsecond) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<DurationMicrosecondType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Duration(TimeUnit::Nanosecond) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<DurationNanosecondType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Interval(IntervalUnit::YearMonth) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<IntervalYearMonthType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Interval(IntervalUnit::DayTime) => Ok(Box::new(
+                ArrayAggGroupsAccumulator::<IntervalDayTimeType>::new(
+                    &self.input_data_type,
+                ),
+            )),
+            DataType::Interval(IntervalUnit::MonthDayNano) => {
+                Ok(Box::new(ArrayAggGroupsAccumulator::<
+                    IntervalMonthDayNanoType,
+                >::new(&self.input_data_type)))
+            }
+            DataType::Utf8 => Ok(Box::new(StringArrayAggGroupsAccumulator::new())),
+            _ => Err(DataFusionError::Internal(format!(
+                "ArrayAggGroupsAccumulator not supported for data type {:?}",
+                self.input_data_type
+            ))),
+        }
     }
 }
 
@@ -184,5 +327,247 @@ impl Accumulator for ArrayAggAccumulator {
                 .sum::<usize>()
             + self.datatype.size()
             - std::mem::size_of_val(&self.datatype)
+    }
+}
+
+struct ArrayAggGroupsAccumulator<T>
+where
+    T: ArrowPrimitiveType + Send,
+{
+    values: Vec<PrimitiveBuilder<T>>,
+    data_type: DataType,
+    null_state: NullState,
+}
+
+impl<T> ArrayAggGroupsAccumulator<T>
+where
+    T: ArrowPrimitiveType + Send,
+{
+    pub fn new(data_type: &DataType) -> Self {
+        Self {
+            values: vec![],
+            data_type: data_type.clone(),
+            null_state: NullState::new(),
+        }
+    }
+}
+
+impl<T: ArrowPrimitiveType + Send> ArrayAggGroupsAccumulator<T> {
+    fn build_list(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
+        let arrays = emit_to.take_needed(&mut self.values);
+        let nulls = self.null_state.build(emit_to);
+
+        let len = nulls.len();
+        assert_eq!(arrays.len(), len);
+
+        let mut builder = ListBuilder::with_capacity(
+            PrimitiveBuilder::<T>::new().with_data_type(self.data_type.clone()),
+            len,
+        );
+
+        for (is_valid, mut arr) in nulls.iter().zip(arrays.into_iter()) {
+            if is_valid {
+                builder.append_value(arr.finish().into_iter());
+            } else {
+                builder.append_null();
+            }
+        }
+
+        Ok(Arc::new(builder.finish()))
+    }
+}
+
+impl<T> GroupsAccumulator for ArrayAggGroupsAccumulator<T>
+where
+    T: ArrowPrimitiveType + Send + Sync,
+{
+    fn update_batch(
+        &mut self,
+        new_values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> Result<()> {
+        assert_eq!(new_values.len(), 1, "single argument to update_batch");
+        let new_values = new_values[0].as_primitive::<T>();
+
+        for _ in self.values.len()..total_num_groups {
+            self.values.push(
+                PrimitiveBuilder::<T>::new().with_data_type(self.data_type.clone()),
+            );
+        }
+
+        self.null_state.accumulate(
+            group_indices,
+            new_values,
+            opt_filter,
+            total_num_groups,
+            |group_index, new_value| {
+                self.values[group_index].append_value(new_value);
+            },
+        );
+
+        Ok(())
+    }
+
+    fn merge_batch(
+        &mut self,
+        values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> Result<()> {
+        assert_eq!(values.len(), 1, "single argument to merge_batch");
+        let values = values[0].as_list();
+
+        for _ in self.values.len()..total_num_groups {
+            self.values.push(
+                PrimitiveBuilder::<T>::new().with_data_type(self.data_type.clone()),
+            );
+        }
+
+        self.null_state.accumulate_array(
+            group_indices,
+            values,
+            opt_filter,
+            total_num_groups,
+            |group_index, new_value: ArrayRef| {
+                let new_value = new_value.as_primitive::<T>();
+                self.values[group_index].extend(new_value);
+            },
+        );
+
+        Ok(())
+    }
+
+    fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
+        self.build_list(emit_to)
+    }
+
+    fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
+        Ok(vec![self.build_list(emit_to)?])
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+            + std::mem::size_of::<PrimitiveBuilder<T>>() * self.values.capacity()
+            + self.values.iter().map(|arr| arr.capacity()).sum::<usize>()
+                * std::mem::size_of::<<T as ArrowPrimitiveType>::Native>()
+            + self.null_state.size()
+    }
+}
+
+struct StringArrayAggGroupsAccumulator {
+    values: Vec<StringBuilder>,
+    null_state: NullState,
+}
+
+impl StringArrayAggGroupsAccumulator {
+    pub fn new() -> Self {
+        Self {
+            values: vec![],
+            null_state: NullState::new(),
+        }
+    }
+}
+
+impl StringArrayAggGroupsAccumulator {
+    fn build_list(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
+        let array = emit_to.take_needed(&mut self.values);
+        let nulls = self.null_state.build(emit_to);
+
+        assert_eq!(array.len(), nulls.len());
+
+        let mut builder = ListBuilder::with_capacity(StringBuilder::new(), nulls.len());
+        for (is_valid, mut arr) in nulls.iter().zip(array.into_iter()) {
+            if is_valid {
+                builder.append_value(arr.finish().into_iter());
+            } else {
+                builder.append_null();
+            }
+        }
+
+        Ok(Arc::new(builder.finish()))
+    }
+}
+
+impl GroupsAccumulator for StringArrayAggGroupsAccumulator {
+    fn update_batch(
+        &mut self,
+        new_values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> Result<()> {
+        assert_eq!(new_values.len(), 1, "single argument to update_batch");
+        let new_values = new_values[0].as_string();
+
+        for _ in self.values.len()..total_num_groups {
+            self.values.push(StringBuilder::new());
+        }
+
+        self.null_state.accumulate_string(
+            group_indices,
+            new_values,
+            opt_filter,
+            total_num_groups,
+            |group_index, new_value| {
+                self.values[group_index].append_value(new_value);
+            },
+        );
+
+        Ok(())
+    }
+
+    fn merge_batch(
+        &mut self,
+        values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> Result<()> {
+        assert_eq!(values.len(), 1, "single argument to merge_batch");
+        let values = values[0].as_list();
+
+        for _ in self.values.len()..total_num_groups {
+            self.values.push(StringBuilder::new());
+        }
+
+        self.null_state.accumulate_array(
+            group_indices,
+            values,
+            opt_filter,
+            total_num_groups,
+            |group_index, new_value: ArrayRef| {
+                let new_value = new_value.as_string::<i32>();
+                self.values[group_index]
+                    .extend(new_value.into_iter().map(|s| s.map(|s| s.to_string())));
+            },
+        );
+
+        Ok(())
+    }
+
+    fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
+        self.build_list(emit_to)
+    }
+
+    fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
+        Ok(vec![self.build_list(emit_to)?])
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+            + std::mem::size_of::<StringBuilder>() * self.values.capacity()
+            + self
+                .values
+                .iter()
+                .map(|arr| {
+                    std::mem::size_of_val(arr.values_slice())
+                        + std::mem::size_of_val(arr.offsets_slice())
+                        + arr.validity_slice().map(std::mem::size_of_val).unwrap_or(0)
+                })
+                .sum::<usize>()
+            + self.null_state.size()
     }
 }

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -459,10 +459,12 @@ where
             opt_filter,
             total_num_groups,
             |group_index, new_value| {
-                let sum = &mut self.sums[group_index];
-                *sum = sum.add_wrapping(new_value);
+                if let Some(new_value) = new_value {
+                    let sum = &mut self.sums[group_index];
+                    *sum = sum.add_wrapping(new_value);
 
-                self.counts[group_index] += 1;
+                    self.counts[group_index] += 1;
+                }
             },
         );
 
@@ -488,7 +490,9 @@ where
             opt_filter,
             total_num_groups,
             |group_index, partial_count| {
-                self.counts[group_index] += partial_count;
+                if let Some(partial_count) = partial_count {
+                    self.counts[group_index] += partial_count;
+                }
             },
         );
 
@@ -499,9 +503,11 @@ where
             partial_sums,
             opt_filter,
             total_num_groups,
-            |group_index, new_value: <T as ArrowPrimitiveType>::Native| {
-                let sum = &mut self.sums[group_index];
-                *sum = sum.add_wrapping(new_value);
+            |group_index, new_value: Option<<T as ArrowPrimitiveType>::Native>| {
+                if let Some(new_value) = new_value {
+                    let sum = &mut self.sums[group_index];
+                    *sum = sum.add_wrapping(new_value);
+                }
             },
         );
 

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -46,7 +46,7 @@ pub fn create_aggregate_expr(
     ordering_req: &[PhysicalSortExpr],
     input_schema: &Schema,
     name: impl Into<String>,
-    _ignore_nulls: bool,
+    ignore_nulls: bool,
 ) -> Result<Arc<dyn AggregateExpr>> {
     let name = name.into();
     // get the result data type for this aggregate function
@@ -71,7 +71,13 @@ pub fn create_aggregate_expr(
             let nullable = expr.nullable(input_schema)?;
 
             if ordering_req.is_empty() {
-                Arc::new(expressions::ArrayAgg::new(expr, name, data_type, nullable))
+                Arc::new(expressions::ArrayAgg::new(
+                    expr,
+                    name,
+                    data_type,
+                    nullable,
+                    ignore_nulls,
+                ))
             } else {
                 Arc::new(expressions::OrderSensitiveArrayAgg::new(
                     expr,

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3705,7 +3705,14 @@ query T?
 SELECT tag, array_agg(millis - arrow_cast(secs, 'Timestamp(Millisecond, None)')) FROM t GROUP BY tag ORDER BY tag;
 ----
 X [0 days 0 hours 0 mins 0.011 secs, 0 days 0 hours 0 mins 0.123 secs]
-Y [, 0 days 0 hours 0 mins 0.432 secs]
+Y [0 days 0 hours 0 mins 0.432 secs, ]
+
+# aggregate_duration_array_agg_ignore_nulls
+query T?
+SELECT tag, array_agg(millis - arrow_cast(secs, 'Timestamp(Millisecond, None)')) IGNORE NULLS FROM t GROUP BY tag ORDER BY tag;
+----
+X [0 days 0 hours 0 mins 0.011 secs, 0 days 0 hours 0 mins 0.123 secs]
+Y [0 days 0 hours 0 mins 0.432 secs]
 
 statement ok
 drop table t_source;

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -2770,6 +2770,19 @@ select array_agg(c1) from t;
 statement ok
 drop table t;
 
+# array_agg_str
+
+statement ok
+create table t (c1 string) as values ('a'), ('b'), ('c'), ('d'), ('e');
+
+query ?
+select array_agg(c1) from t;
+----
+[a, b, c, d, e]
+
+statement ok
+drop table t;
+
 # array_agg_nested
 statement ok
 create table t as values (make_array([1, 2, 3], [4, 5])), (make_array([6], [7, 8])), (make_array([9]));

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3705,7 +3705,7 @@ query T?
 SELECT tag, array_agg(millis - arrow_cast(secs, 'Timestamp(Millisecond, None)')) FROM t GROUP BY tag ORDER BY tag;
 ----
 X [0 days 0 hours 0 mins 0.011 secs, 0 days 0 hours 0 mins 0.123 secs]
-Y [0 days 0 hours 0 mins 0.432 secs, ]
+Y [, 0 days 0 hours 0 mins 0.432 secs]
 
 # aggregate_duration_array_agg_ignore_nulls
 query T?


### PR DESCRIPTION
**Continuation of https://github.com/apache/datafusion/pull/10149**

## Which issue does this PR close?

Closes #10145.
Closes https://github.com/apache/datafusion/pull/10149

## Rationale for this change

See the issue.
## What changes are included in this PR?

GroupsAccumulator for `array_agg` aggregation function for:

* Primitive types
* String type

Not included:
* Accumulating arrays of any level of nesting.


## Are these changes tested?

Extended tests in `aggregate.slt`
## Are there any user-facing changes?

Yes, `IGNORE NULLS` now works with array_agg.

---

I have not yet addressed the comments of the original PR:
* support for LargeUtf8 and Binary (https://github.com/apache/datafusion/pull/10149#discussion_r1573482631)
* benchmark

but instead want to first find out if my approach to null handling is generally valid or not.

The problem with null handling is that this implementation originally ignored null values.
However a test in `aggregate.slt` added meanwhile asserts that it is included.
Now I asked in Discord what approach is correct, to which I was informed that DF is trying to follow PG and Spark.
I thus checked PG and Spark, and as it turns out PG includes nulls while Spark does not:

```
>>> from pyspark.sql.types import StringType
>>> from pyspark.sql.functions import array_agg
>>> data = [("value1",), (None,), ("value3",), (None,), ("value5",)]
>>> df = spark.createDataFrame(data, ["column1"], StringType())
>>> df.count()
5
>>> df.agg(array_agg('column1').alias('r')).collect()
[Row(r=['value1', 'value3', 'value5'])]
```
 
However:
```
-- create
CREATE TABLE EMPLOYEE (
  empId INTEGER PRIMARY KEY,
  name TEXT,
  dept TEXT NOT NULL
);

-- insert
INSERT INTO EMPLOYEE VALUES (0001, 'Clark', 'Sales');
INSERT INTO EMPLOYEE VALUES (0002, 'Dave', 'Accounting');
INSERT INTO EMPLOYEE VALUES (0003, 'Ava', 'Sales');
INSERT INTO EMPLOYEE VALUES (0004, NULL, 'Sales');

-- fetch 
SELECT ARRAY_AGG(name), dept FROM EMPLOYEE group by dept;

```

```
    array_agg     |    dept
------------------+------------
 {Dave}           | Accounting
 {Clark,Ava,NULL} | Sales
(2 rows)
```

So I decided to make everyone happy by adding support for `IGNORE NULLS`