### PR TITLE
Deprecate Expr::column_refs

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1329,6 +1329,7 @@ impl Expr {
     }
 
     /// Return all referenced columns of this expression.
+    #[deprecated(since = "40.0.0", note = "use Expr::column_refs instead")]
     pub fn to_columns(&self) -> Result<HashSet<Column>> {
         let mut using_columns = HashSet::new();
         expr_to_columns(self, &mut using_columns)?;


### PR DESCRIPTION
## Which issue does this PR close?


Closes https://github.com/apache/datafusion/issues/10505

Follow on to https://github.com/apache/datafusion/pull/11067

## Rationale for this change

`Expr::column_refs` is much more efficient than `Expr::to_columns` as it avoids copying strings. Thus we should
use it more in the codebase and encourage users to do the same


## What changes are included in this PR?

Deprecate the function

## Are these changes tested?

By existing CI

## Are there any user-facing changes?

Function is deprcated