### PR TITLE
Minor: fix ScalarValue::new_ten error message (cites one not ten)

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -1077,7 +1077,7 @@ impl ScalarValue {
             DataType::Float64 => ScalarValue::Float64(Some(10.0)),
             _ => {
                 return _not_impl_err!(
-                    "Can't create a negative one scalar from data_type \"{datatype:?}\""
+                    "Can't create a ten scalar from data_type \"{datatype:?}\""
                 );
             }
         })


### PR DESCRIPTION
Closes #11125