### PR TITLE
fix: Ignore nullability in Substrait structs

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1499,7 +1499,7 @@ fn from_substrait_struct_type(
         let field = Field::new(
             next_struct_field_name(i, dfs_names, name_idx)?,
             from_substrait_type(f, dfs_names, name_idx)?,
-            is_substrait_type_nullable(f)?,
+            true, // We assume everything to be nullable since that's easier than ensuring it matches
         );
         fields.push(field);
     }
@@ -1541,47 +1541,6 @@ fn from_substrait_named_struct(base_schema: &NamedStruct) -> Result<DFSchemaRef>
                             );
     }
     Ok(DFSchemaRef::new(DFSchema::try_from(Schema::new(fields?))?))
-}
-
-fn is_substrait_type_nullable(dtype: &Type) -> Result<bool> {
-    fn is_nullable(nullability: i32) -> bool {
-        nullability != substrait::proto::r#type::Nullability::Required as i32
-    }
-
-    let nullable = match dtype
-        .kind
-        .as_ref()
-        .ok_or_else(|| substrait_datafusion_err!("Type must contain Kind"))?
-    {
-        r#type::Kind::Bool(val) => is_nullable(val.nullability),
-        r#type::Kind::I8(val) => is_nullable(val.nullability),
-        r#type::Kind::I16(val) => is_nullable(val.nullability),
-        r#type::Kind::I32(val) => is_nullable(val.nullability),
-        r#type::Kind::I64(val) => is_nullable(val.nullability),
-        r#type::Kind::Fp32(val) => is_nullable(val.nullability),
-        r#type::Kind::Fp64(val) => is_nullable(val.nullability),
-        r#type::Kind::String(val) => is_nullable(val.nullability),
-        r#type::Kind::Binary(val) => is_nullable(val.nullability),
-        r#type::Kind::Timestamp(val) => is_nullable(val.nullability),
-        r#type::Kind::Date(val) => is_nullable(val.nullability),
-        r#type::Kind::Time(val) => is_nullable(val.nullability),
-        r#type::Kind::IntervalYear(val) => is_nullable(val.nullability),
-        r#type::Kind::IntervalDay(val) => is_nullable(val.nullability),
-        r#type::Kind::TimestampTz(val) => is_nullable(val.nullability),
-        r#type::Kind::Uuid(val) => is_nullable(val.nullability),
-        r#type::Kind::FixedChar(val) => is_nullable(val.nullability),
-        r#type::Kind::Varchar(val) => is_nullable(val.nullability),
-        r#type::Kind::FixedBinary(val) => is_nullable(val.nullability),
-        r#type::Kind::Decimal(val) => is_nullable(val.nullability),
-        r#type::Kind::PrecisionTimestamp(val) => is_nullable(val.nullability),
-        r#type::Kind::PrecisionTimestampTz(val) => is_nullable(val.nullability),
-        r#type::Kind::Struct(val) => is_nullable(val.nullability),
-        r#type::Kind::List(val) => is_nullable(val.nullability),
-        r#type::Kind::Map(val) => is_nullable(val.nullability),
-        r#type::Kind::UserDefined(val) => is_nullable(val.nullability),
-        r#type::Kind::UserDefinedTypeReference(_) => true, // not implemented, assume nullable
-    };
-    Ok(nullable)
 }
 
 fn from_substrait_bound(
@@ -1763,8 +1722,9 @@ fn from_substrait_literal(
             for (i, field) in s.fields.iter().enumerate() {
                 let name = next_struct_field_name(i, dfs_names, name_idx)?;
                 let sv = from_substrait_literal(field, dfs_names, name_idx)?;
-                builder = builder
-                    .with_scalar(Field::new(name, sv.data_type(), field.nullable), sv);
+                // We assume everything to be nullable, since Arrow's strict about things matching
+                // and it's hard to match otherwise.
+                builder = builder.with_scalar(Field::new(name, sv.data_type(), true), sv);
             }
             builder.build()?
         }

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -2258,8 +2258,8 @@ mod test {
             ),
         )))?;
 
-        let c0 = Field::new("c0", DataType::Boolean, false);
-        let c1 = Field::new("c1", DataType::Int32, false);
+        let c0 = Field::new("c0", DataType::Boolean, true);
+        let c1 = Field::new("c1", DataType::Int32, true);
         let c2 = Field::new("c2", DataType::Utf8, true);
         round_trip_literal(
             ScalarStructBuilder::new()
@@ -2319,7 +2319,7 @@ mod test {
         round_trip_type(DataType::Struct(
             vec![
                 Field::new("c0", DataType::Int32, true),
-                Field::new("c1", DataType::Utf8, false),
+                Field::new("c1", DataType::Utf8, true),
             ]
             .into(),
         ))?;


### PR DESCRIPTION
Similar to https://github.com/apache/datafusion/pull/10874/files


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Arrow requires schema to match exactly to literals. Substrait contains nullability separate in literals and types, and the nullability of a literal may vary
row-by-row.

The only reliable way I can think of is to either not use nullability at all (this PR), or alternatively pass the expected type into from_substrait_literal so that it can use the expected nullability.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Ignore nullability when consuming Substrait struct type and literal, always erring on the side of `nullable = true`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Tested by existing unit tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
