### PR TITLE
Temporary Fix: Query error when grouping by case expressions

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -156,13 +156,18 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
         Expr::Case(case) => {
             let mut name = "CASE ".to_string();
             if let Some(e) = &case.expr {
-                let _ = write!(name, "{e} ");
+                let _ = write!(name, "{} ", create_physical_name(e, false)?);
             }
             for (w, t) in &case.when_then_expr {
-                let _ = write!(name, "WHEN {w} THEN {t} ");
+                let _ = write!(
+                    name,
+                    "WHEN {} THEN {} ",
+                    create_physical_name(w, false)?,
+                    create_physical_name(t, false)?
+                );
             }
             if let Some(e) = &case.else_expr {
-                let _ = write!(name, "ELSE {e} ");
+                let _ = write!(name, "ELSE {} ", create_physical_name(e, false)?);
             }
             name += "END";
             Ok(name)

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -5135,3 +5135,22 @@ GROUP BY
     ts_chunk;
 ----
 2024-01-01T00:00:00 4
+
+# Issue: https://github.com/apache/datafusion/issues/11118
+statement ok
+CREATE TABLE test_case_expr(a INT, b TEXT) AS VALUES (1,'hello'), (2,'world')
+
+query T
+SELECT (CASE WHEN CONCAT(b, 'hello') = 'test' THEN 'good' ELSE 'bad' END) AS c 
+  FROM test_case_expr GROUP BY c;
+----
+bad
+
+query I rowsort
+SELECT (CASE a::BIGINT WHEN 1 THEN 1 END) AS c FROM test_case_expr GROUP BY c;
+----
+1
+NULL
+
+statement ok
+drop table test_case_expr


### PR DESCRIPTION
## Which issue does this PR close?
Temporary fix for #11118


## Rationale for this change
The query in the issue seems to require that the `physical_name` and `display_name` of the grouping expr must be the same. This is a temporary fix. 

I think this requirement might be unreasonable. Having multiple different types of names for expressions, while also ensuring they are the same, seems somewhat burdensome and error-prone.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
