### PR TITLE
Custom operator support

### DIFF
--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -60,7 +60,7 @@ use datafusion_execution::registry::SerializerRegistry;
 use datafusion_expr::{
     expr_rewriter::FunctionRewrite,
     logical_plan::{DdlStatement, Statement},
-    Expr, UserDefinedLogicalNode, WindowUDF,
+    Expr, ParseCustomOperator, UserDefinedLogicalNode, WindowUDF,
 };
 
 // backwards compatibility
@@ -76,7 +76,6 @@ pub use datafusion_execution::config::SessionConfig;
 pub use datafusion_execution::TaskContext;
 pub use datafusion_expr::execution_props::ExecutionProps;
 use datafusion_optimizer::{AnalyzerRule, OptimizerRule};
-use datafusion_sql::planner::ParseCustomOperator;
 
 mod avro;
 mod csv;
@@ -1354,19 +1353,6 @@ impl SessionContext {
             .write()
             .register_table_options_extension(extension)
     }
-
-    /// Registers a new [`ParseCustomOperator`] with the registry.
-    ///
-    /// `ParseCustomOperator` is used to parse custom operators from SQL,
-    /// e.g. `->>` or `?`.
-    pub fn register_parse_custom_operator(
-        &mut self,
-        parse_custom_operator: Arc<dyn ParseCustomOperator>,
-    ) -> Result<()> {
-        self.state
-            .write()
-            .register_parse_custom_operator(parse_custom_operator)
-    }
 }
 
 impl FunctionRegistry for SessionContext {
@@ -1403,6 +1389,19 @@ impl FunctionRegistry for SessionContext {
         rewrite: Arc<dyn FunctionRewrite + Send + Sync>,
     ) -> Result<()> {
         self.state.write().register_function_rewrite(rewrite)
+    }
+
+    fn register_parse_custom_operator(
+        &mut self,
+        parse_custom_operator: Arc<dyn ParseCustomOperator>,
+    ) -> Result<()> {
+        self.state
+            .write()
+            .register_parse_custom_operator(parse_custom_operator)
+    }
+
+    fn parse_custom_operators(&self) -> Vec<Arc<dyn ParseCustomOperator>> {
+        todo!();
     }
 }
 

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -1401,7 +1401,7 @@ impl FunctionRegistry for SessionContext {
     }
 
     fn parse_custom_operators(&self) -> Vec<Arc<dyn ParseCustomOperator>> {
-        todo!();
+        self.state.read().parse_custom_operators()
     }
 }
 

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -18,6 +18,7 @@
 //! [`SessionContext`] API for registering data sources and executing queries
 
 use std::collections::HashSet;
+use std::fmt::Debug;
 use std::sync::{Arc, Weak};
 
 use super::options::ReadOptions;
@@ -1477,7 +1478,7 @@ impl SerializerRegistry for EmptySerializerRegistry {
 /// Describes which SQL statements can be run.
 ///
 /// See [`SessionContext::sql_with_options`] for more details.
-#[derive(Clone)]
+#[derive(Clone, Debug, Copy)]
 pub struct SQLOptions {
     /// See [`Self::with_allow_ddl`]
     allow_ddl: bool,

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -61,7 +61,6 @@ use datafusion_expr::{
     logical_plan::{DdlStatement, Statement},
     Expr, UserDefinedLogicalNode, WindowUDF,
 };
-use datafusion_sql::planner::ParseCustomOperator;
 
 // backwards compatibility
 pub use crate::execution::session_state::SessionState;
@@ -76,6 +75,7 @@ pub use datafusion_execution::config::SessionConfig;
 pub use datafusion_execution::TaskContext;
 pub use datafusion_expr::execution_props::ExecutionProps;
 use datafusion_optimizer::{AnalyzerRule, OptimizerRule};
+use datafusion_sql::planner::ParseCustomOperator;
 
 mod avro;
 mod csv;
@@ -488,7 +488,7 @@ impl SessionContext {
         sql: &str,
         options: SQLOptions,
     ) -> Result<DataFrame> {
-        let plan = self.state().create_logical_plan(sql, options.parse_custom_operator.clone()).await?;
+        let plan = self.state().create_logical_plan(sql).await?;
         options.verify_plan(&plan)?;
 
         self.execute_logical_plan(plan).await
@@ -1353,6 +1353,19 @@ impl SessionContext {
             .write()
             .register_table_options_extension(extension)
     }
+
+    /// Registers a new [`ParseCustomOperator`] with the registry.
+    ///
+    /// `ParseCustomOperator` is used to parse custom operators from SQL,
+    /// e.g. `->>` or `?`.
+    pub fn register_parse_custom_operator(
+        &mut self,
+        parse_custom_operator: Arc<dyn ParseCustomOperator>,
+    ) -> Result<()> {
+        self.state
+            .write()
+            .register_parse_custom_operator(parse_custom_operator)
+    }
 }
 
 impl FunctionRegistry for SessionContext {
@@ -1472,8 +1485,6 @@ pub struct SQLOptions {
     allow_dml: bool,
     /// See [`Self::with_allow_statements`]
     allow_statements: bool,
-    /// Custom SQL operator parser
-    parse_custom_operator: Option<ParseCustomOperator>,
 }
 
 impl Default for SQLOptions {
@@ -1482,7 +1493,6 @@ impl Default for SQLOptions {
             allow_ddl: true,
             allow_dml: true,
             allow_statements: true,
-            parse_custom_operator: None,
         }
     }
 }
@@ -1508,12 +1518,6 @@ impl SQLOptions {
     /// Should Statements such as (e.g. `SET VARIABLE and `BEGIN TRANSACTION` ...`) be run?. Defaults to `true`
     pub fn with_allow_statements(mut self, allow: bool) -> Self {
         self.allow_statements = allow;
-        self
-    }
-
-    /// Set the custom SQL operator parser
-    pub fn with_parse_custom_operator(mut self, parse_custom_operator: Option<ParseCustomOperator>) -> Self {
-        self.parse_custom_operator = parse_custom_operator;
         self
     }
 

--- a/datafusion/core/tests/user_defined/mod.rs
+++ b/datafusion/core/tests/user_defined/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 /// Tests for user defined Scalar functions
+mod user_defined_custom_operators;
 mod user_defined_scalar_functions;
 
 /// Tests for User Defined Aggregate Functions

--- a/datafusion/core/tests/user_defined/mod.rs
+++ b/datafusion/core/tests/user_defined/mod.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// Tests for user defined Scalar functions
+/// Tests for custom operator parsing and substitution
 mod user_defined_custom_operators;
+/// Tests for user defined Scalar functions
 mod user_defined_scalar_functions;
 
 /// Tests for User Defined Aggregate Functions

--- a/datafusion/core/tests/user_defined/user_defined_custom_operators.rs
+++ b/datafusion/core/tests/user_defined/user_defined_custom_operators.rs
@@ -14,13 +14,14 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use arrow_array::RecordBatch;
+
 use std::sync::Arc;
+use arrow_array::RecordBatch;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::Transformed;
-use datafusion::common::DFSchema;
+use datafusion::common::{DFSchema, assert_batches_eq};
 use datafusion::error::Result;
 use datafusion::execution::FunctionRegistry;
 use datafusion::logical_expr::expr_rewriter::FunctionRewrite;
@@ -29,7 +30,6 @@ use datafusion::logical_expr::{
 };
 use datafusion::prelude::*;
 use datafusion::sql::sqlparser::ast::BinaryOperator;
-use datafusion_common::assert_batches_eq;
 
 #[derive(Debug)]
 enum MyCustomOperator {

--- a/datafusion/core/tests/user_defined/user_defined_custom_operators.rs
+++ b/datafusion/core/tests/user_defined/user_defined_custom_operators.rs
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
 use arrow_array::RecordBatch;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::Transformed;
-use datafusion::common::{DFSchema, assert_batches_eq};
+use datafusion::common::{assert_batches_eq, DFSchema};
 use datafusion::error::Result;
 use datafusion::execution::FunctionRegistry;
 use datafusion::logical_expr::expr_rewriter::FunctionRewrite;

--- a/datafusion/core/tests/user_defined/user_defined_custom_operators.rs
+++ b/datafusion/core/tests/user_defined/user_defined_custom_operators.rs
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+use arrow_array::RecordBatch;
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::Transformed;
+use datafusion::common::DFSchema;
+use datafusion::error::Result;
+use datafusion::execution::FunctionRegistry;
+use datafusion::logical_expr::expr_rewriter::FunctionRewrite;
+use datafusion::logical_expr::{
+    CustomOperator, Operator, ParseCustomOperator, WrapCustomOperator,
+};
+use datafusion::prelude::*;
+use datafusion::sql::sqlparser::ast::BinaryOperator;
+use datafusion_common::assert_batches_eq;
+
+#[derive(Debug)]
+enum MyCustomOperator {
+    Arrow,
+    LongArrow,
+}
+
+impl std::fmt::Display for MyCustomOperator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MyCustomOperator::Arrow => write!(f, "->"),
+            MyCustomOperator::LongArrow => write!(f, "->>"),
+        }
+    }
+}
+
+impl CustomOperator for MyCustomOperator {
+    fn binary_signature(
+        &self,
+        lhs: &DataType,
+        rhs: &DataType,
+    ) -> Result<(DataType, DataType, DataType)> {
+        Ok((lhs.clone(), rhs.clone(), lhs.clone()))
+    }
+
+    fn op_to_sql(&self) -> Result<BinaryOperator> {
+        match self {
+            MyCustomOperator::Arrow => Ok(BinaryOperator::Arrow),
+            MyCustomOperator::LongArrow => Ok(BinaryOperator::LongArrow),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            MyCustomOperator::Arrow => "Arrow",
+            MyCustomOperator::LongArrow => "LongArrow",
+        }
+    }
+}
+
+impl TryFrom<&str> for MyCustomOperator {
+    type Error = ();
+
+    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+        match value {
+            "Arrow" => Ok(MyCustomOperator::Arrow),
+            "LongArrow" => Ok(MyCustomOperator::LongArrow),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CustomOperatorParser;
+
+impl ParseCustomOperator for CustomOperatorParser {
+    fn name(&self) -> &str {
+        "CustomOperatorParser"
+    }
+
+    fn op_from_ast(&self, op: &BinaryOperator) -> Result<Option<Operator>> {
+        match op {
+            BinaryOperator::Arrow => Ok(Some(MyCustomOperator::Arrow.into())),
+            BinaryOperator::LongArrow => Ok(Some(MyCustomOperator::LongArrow.into())),
+            _ => Ok(None),
+        }
+    }
+
+    fn op_from_name(&self, raw_op: &str) -> Result<Option<Operator>> {
+        if let Ok(op) = MyCustomOperator::try_from(raw_op) {
+            Ok(Some(op.into()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl FunctionRewrite for CustomOperatorParser {
+    fn name(&self) -> &str {
+        "CustomOperatorParser"
+    }
+
+    fn rewrite(
+        &self,
+        expr: Expr,
+        _schema: &DFSchema,
+        _config: &ConfigOptions,
+    ) -> Result<Transformed<Expr>> {
+        if let Expr::BinaryExpr(bin_expr) = &expr {
+            if let Operator::Custom(WrapCustomOperator(op)) = &bin_expr.op {
+                if let Ok(pg_op) = MyCustomOperator::try_from(op.name()) {
+                    // return BinaryExpr with a different operator
+                    let mut bin_expr = bin_expr.clone();
+                    bin_expr.op = match pg_op {
+                        MyCustomOperator::Arrow => Operator::StringConcat,
+                        MyCustomOperator::LongArrow => Operator::Plus,
+                    };
+                    return Ok(Transformed::yes(Expr::BinaryExpr(bin_expr)));
+                }
+            }
+        }
+        Ok(Transformed::no(expr))
+    }
+}
+
+async fn plan_and_collect(sql: &str) -> Result<Vec<RecordBatch>> {
+    let mut ctx = SessionContext::new();
+    ctx.register_function_rewrite(Arc::new(CustomOperatorParser))?;
+    ctx.register_parse_custom_operator(Arc::new(CustomOperatorParser))?;
+    ctx.sql(sql).await?.collect().await
+}
+
+#[tokio::test]
+async fn test_custom_operators_arrow() {
+    let actual = plan_and_collect("select 'foo'->'bar';").await.unwrap();
+    let expected = [
+        "+----------------------------+",
+        "| Utf8(\"foo\") -> Utf8(\"bar\") |",
+        "+----------------------------+",
+        "| foobar                     |",
+        "+----------------------------+",
+    ];
+    assert_batches_eq!(&expected, &actual);
+}
+
+#[tokio::test]
+async fn test_custom_operators_long_arrow() {
+    let actual = plan_and_collect("select 1->>2;").await.unwrap();
+    let expected = [
+        "+-----------------------+",
+        "| Int64(1) ->> Int64(2) |",
+        "+-----------------------+",
+        "| 3                     |",
+        "+-----------------------+",
+    ];
+    assert_batches_eq!(&expected, &actual);
+}

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -76,7 +76,7 @@ pub use function::{
 pub use groups_accumulator::{EmitTo, GroupsAccumulator};
 pub use literal::{lit, lit_timestamp_nano, Literal, TimestampLiteral};
 pub use logical_plan::*;
-pub use operator::Operator;
+pub use operator::{Operator, CustomOperator};
 pub use partition_evaluator::PartitionEvaluator;
 pub use signature::{
     ArrayFunctionSignature, Signature, TypeSignature, Volatility, TIMEZONE_WILDCARD,

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -76,7 +76,7 @@ pub use function::{
 pub use groups_accumulator::{EmitTo, GroupsAccumulator};
 pub use literal::{lit, lit_timestamp_nano, Literal, TimestampLiteral};
 pub use logical_plan::*;
-pub use operator::{CustomOperator, Operator};
+pub use operator::{CustomOperator, Operator, WrapCustomOperator};
 pub use partition_evaluator::PartitionEvaluator;
 pub use signature::{
     ArrayFunctionSignature, Signature, TypeSignature, Volatility, TIMEZONE_WILDCARD,

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -48,6 +48,7 @@ pub mod function;
 pub mod groups_accumulator;
 pub mod interval_arithmetic;
 pub mod logical_plan;
+pub mod parse_custom_operator;
 pub mod registry;
 pub mod simplify;
 pub mod sort_properties;
@@ -77,6 +78,7 @@ pub use groups_accumulator::{EmitTo, GroupsAccumulator};
 pub use literal::{lit, lit_timestamp_nano, Literal, TimestampLiteral};
 pub use logical_plan::*;
 pub use operator::{CustomOperator, Operator, WrapCustomOperator};
+pub use parse_custom_operator::ParseCustomOperator;
 pub use partition_evaluator::PartitionEvaluator;
 pub use signature::{
     ArrayFunctionSignature, Signature, TypeSignature, Volatility, TIMEZONE_WILDCARD,

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -76,7 +76,7 @@ pub use function::{
 pub use groups_accumulator::{EmitTo, GroupsAccumulator};
 pub use literal::{lit, lit_timestamp_nano, Literal, TimestampLiteral};
 pub use logical_plan::*;
-pub use operator::{Operator, CustomOperator};
+pub use operator::{CustomOperator, Operator};
 pub use partition_evaluator::PartitionEvaluator;
 pub use signature::{
     ArrayFunctionSignature, Signature, TypeSignature, Volatility, TIMEZONE_WILDCARD,

--- a/datafusion/expr/src/parse_custom_operator.rs
+++ b/datafusion/expr/src/parse_custom_operator.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::fmt::Debug;
 
 use datafusion_common::Result;

--- a/datafusion/expr/src/parse_custom_operator.rs
+++ b/datafusion/expr/src/parse_custom_operator.rs
@@ -1,0 +1,18 @@
+use std::fmt::Debug;
+
+use datafusion_common::Result;
+use sqlparser::ast::BinaryOperator;
+
+use crate::Operator;
+
+pub trait ParseCustomOperator: Debug + Send + Sync {
+    /// Return a human-readable name for this parser
+    fn name(&self) -> &str;
+
+    /// potentially parse a custom operator.
+    ///
+    /// Return `None` if the operator is not recognized
+    fn op_from_ast(&self, op: &BinaryOperator) -> Result<Option<Operator>>;
+
+    fn op_from_name(&self, raw_op: &str) -> Result<Option<Operator>>;
+}

--- a/datafusion/expr/src/registry.rs
+++ b/datafusion/expr/src/registry.rs
@@ -18,7 +18,9 @@
 //! FunctionRegistry trait
 
 use crate::expr_rewriter::FunctionRewrite;
-use crate::{AggregateUDF, ScalarUDF, UserDefinedLogicalNode, WindowUDF};
+use crate::{
+    AggregateUDF, ParseCustomOperator, ScalarUDF, UserDefinedLogicalNode, WindowUDF,
+};
 use datafusion_common::{not_impl_err, plan_datafusion_err, Result};
 use std::collections::HashMap;
 use std::{collections::HashSet, sync::Arc};
@@ -107,6 +109,21 @@ pub trait FunctionRegistry {
         _rewrite: Arc<dyn FunctionRewrite + Send + Sync>,
     ) -> Result<()> {
         not_impl_err!("Registering FunctionRewrite")
+    }
+
+    /// Registers a new [`ParseCustomOperator`] with the registry.
+    ///
+    /// `ParseCustomOperator` is used to parse custom operators from SQL,
+    /// e.g. `->>` or `?`.
+    fn register_parse_custom_operator(
+        &mut self,
+        _parse_custom_operator: Arc<dyn ParseCustomOperator>,
+    ) -> Result<()> {
+        not_impl_err!("Registering ParseCustomOperator")
+    }
+
+    fn parse_custom_operators(&self) -> Vec<Arc<dyn ParseCustomOperator>> {
+        vec![]
     }
 }
 

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -29,6 +29,7 @@ use arrow::datatypes::{
     DECIMAL256_MAX_PRECISION, DECIMAL256_MAX_SCALE,
 };
 
+use crate::operator::WrapCustomOperator;
 use datafusion_common::{exec_datafusion_err, plan_datafusion_err, plan_err, Result};
 
 /// The type signature of an instantiation of binary operator expression such as
@@ -189,8 +190,8 @@ fn signature(lhs: &DataType, op: &Operator, rhs: &DataType) -> Result<Signature>
                 )
             }
         }
-        Custom(op) => {
-            let (lhs, rhs, ret) = op.0.binary_signature(lhs, rhs)?;
+        Custom(WrapCustomOperator(op)) => {
+            let (lhs, rhs, ret) = op.binary_signature(lhs, rhs)?;
             Ok(Signature { lhs, rhs, ret })
         }
     }

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -189,6 +189,10 @@ fn signature(lhs: &DataType, op: &Operator, rhs: &DataType) -> Result<Signature>
                 )
             }
         }
+        Custom(op) => {
+            let (lhs, rhs, ret) = op.0.binary_signature(lhs, rhs)?;
+            Ok(Signature { lhs, rhs, ret })
+        }
     }
 }
 

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -20,7 +20,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::Operator;
+use crate::{Operator, WrapCustomOperator};
 
 use arrow::array::{new_empty_array, Array};
 use arrow::compute::can_cast_types;
@@ -29,7 +29,6 @@ use arrow::datatypes::{
     DECIMAL256_MAX_PRECISION, DECIMAL256_MAX_SCALE,
 };
 
-use crate::operator::WrapCustomOperator;
 use datafusion_common::{exec_datafusion_err, plan_datafusion_err, plan_err, Result};
 
 /// The type signature of an instantiation of binary operator expression such as

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -638,6 +638,7 @@ impl BinaryExpr {
             AtArrow | ArrowAt => {
                 unreachable!("ArrowAt and AtArrow should be rewritten to function")
             }
+            Custom(_) => internal_err!("Custom operator should be rewritten to functions"),
         }
     }
 }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -638,7 +638,9 @@ impl BinaryExpr {
             AtArrow | ArrowAt => {
                 unreachable!("ArrowAt and AtArrow should be rewritten to function")
             }
-            Custom(_) => internal_err!("Custom operator should be rewritten to functions"),
+            Custom(_) => {
+                internal_err!("Custom operator should be rewritten to functions")
+            }
         }
     }
 }

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -241,7 +241,10 @@ pub fn parse_physical_expr(
                 input_schema,
                 codec,
             )?,
-            logical_plan::from_proto::from_proto_binary_op(&binary_expr.op)?,
+            logical_plan::from_proto::from_proto_binary_op(
+                &binary_expr.op,
+                &registry.parse_custom_operators(),
+            )?,
             parse_required_physical_expr(
                 binary_expr.r.as_deref(),
                 registry,

--- a/datafusion/sql/src/expr/binary_op.rs
+++ b/datafusion/sql/src/expr/binary_op.rs
@@ -23,7 +23,7 @@ use sqlparser::ast::BinaryOperator;
 impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     pub(crate) fn parse_sql_binary_op(&self, op: BinaryOperator) -> Result<Operator> {
         for parse_custom_op in &self.options.parse_custom_operator {
-            if let Some(op) = parse_custom_op.parse(&op)? {
+            if let Some(op) = parse_custom_op.op_from_ast(&op)? {
                 return Ok(op);
             }
         }

--- a/datafusion/sql/src/expr/binary_op.rs
+++ b/datafusion/sql/src/expr/binary_op.rs
@@ -53,7 +53,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             BinaryOperator::StringConcat => Ok(Operator::StringConcat),
             BinaryOperator::ArrowAt => Ok(Operator::ArrowAt),
             BinaryOperator::AtArrow => Ok(Operator::AtArrow),
-            _ => not_impl_err!("Unsupported SQL binary operator {op:?}"),
+            _ => {
+                if let Some(parse_custom_op) = &self.options.parse_custom_operator {
+                    parse_custom_op(op).map(Operator::custom)
+                } else {
+                    not_impl_err!("Unsupported SQL binary operator {op:?}")
+                }
+            },
         }
     }
 }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -18,13 +18,13 @@
 //! [`SqlToRel`]: SQL Query Planner (produces [`LogicalPlan`] from SQL AST)
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::{fmt, vec};
+use std::vec;
 
 use arrow_schema::*;
 use datafusion_common::{
     field_not_found, internal_err, plan_datafusion_err, DFSchemaRef, SchemaError,
 };
-use datafusion_expr::{Operator, WindowUDF};
+use datafusion_expr::{ParseCustomOperator, WindowUDF};
 use sqlparser::ast::TimezoneInfo;
 use sqlparser::ast::{ArrayElemTypeDef, ExactNumberInfo};
 use sqlparser::ast::{ColumnDef as SQLColumnDef, ColumnOption};
@@ -90,16 +90,6 @@ pub trait ContextProvider {
 
     /// Get all user defined window function names
     fn udwf_names(&self) -> Vec<String>;
-}
-
-pub trait ParseCustomOperator: fmt::Debug + Send + Sync {
-    /// Return a human readable name for this parser
-    fn name(&self) -> &str;
-
-    /// potentially parse a custom operator.
-    ///
-    /// Return `None` if the operator is not recognized
-    fn parse(&self, op: &sqlparser::ast::BinaryOperator) -> Result<Option<Operator>>;
 }
 
 /// SQL parser options

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -41,6 +41,7 @@ use datafusion_common::{
 use datafusion_expr::{
     expr::{Alias, Exists, InList, ScalarFunction, Sort, WindowFunction},
     Between, BinaryExpr, Case, Cast, Expr, GroupingSet, Like, Operator, TryCast,
+    WrapCustomOperator,
 };
 
 use super::Unparser;
@@ -649,7 +650,7 @@ impl Unparser<'_> {
             Operator::BitwiseShiftRight => Ok(ast::BinaryOperator::PGBitwiseShiftRight),
             Operator::BitwiseShiftLeft => Ok(ast::BinaryOperator::PGBitwiseShiftLeft),
             Operator::StringConcat => Ok(ast::BinaryOperator::StringConcat),
-            Operator::Custom(op) => op.0.op_to_sql(),
+            Operator::Custom(WrapCustomOperator(op)) => op.op_to_sql(),
             Operator::AtArrow => not_impl_err!("unsupported operation: {op:?}"),
             Operator::ArrowAt => not_impl_err!("unsupported operation: {op:?}"),
         }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -649,6 +649,7 @@ impl Unparser<'_> {
             Operator::BitwiseShiftRight => Ok(ast::BinaryOperator::PGBitwiseShiftRight),
             Operator::BitwiseShiftLeft => Ok(ast::BinaryOperator::PGBitwiseShiftLeft),
             Operator::StringConcat => Ok(ast::BinaryOperator::StringConcat),
+            Operator::Custom(op) => op.0.op_to_sql(),
             Operator::AtArrow => not_impl_err!("unsupported operation: {op:?}"),
             Operator::ArrowAt => not_impl_err!("unsupported operation: {op:?}"),
         }

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -84,6 +84,7 @@ fn parse_decimals() {
             ParserOptions {
                 parse_float_as_decimal: true,
                 enable_ident_normalization: false,
+                ..Default::default()
             },
         );
     }
@@ -137,6 +138,7 @@ fn parse_ident_normalization() {
             ParserOptions {
                 parse_float_as_decimal: false,
                 enable_ident_normalization,
+                ..Default::default()
             },
         );
         if plan.is_ok() {

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -723,6 +723,7 @@ pub fn operator_to_name(op: Operator) -> &'static str {
         Operator::BitwiseXor => "bitwise_xor",
         Operator::BitwiseShiftRight => "bitwise_shift_right",
         Operator::BitwiseShiftLeft => "bitwise_shift_left",
+        Operator::Custom(op) => op.0.name(),
     }
 }
 

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use arrow_buffer::ToByteSlice;
 use datafusion::arrow::datatypes::IntervalUnit;
 use datafusion::logical_expr::{
-    CrossJoin, Distinct, Like, Partitioning, WindowFrameUnits,
+    CrossJoin, Distinct, Like, Partitioning, WindowFrameUnits, WrapCustomOperator,
 };
 use datafusion::{
     arrow::datatypes::{DataType, TimeUnit},
@@ -723,7 +723,7 @@ pub fn operator_to_name(op: Operator) -> &'static str {
         Operator::BitwiseXor => "bitwise_xor",
         Operator::BitwiseShiftRight => "bitwise_shift_right",
         Operator::BitwiseShiftLeft => "bitwise_shift_left",
-        Operator::Custom(op) => op.0.name(),
+        Operator::Custom(WrapCustomOperator(op)) => op.name(),
     }
 }
 


### PR DESCRIPTION
I think this is ready to review.

~~WIP to decide if we progress cc @alamb.~~

~~This is based on #11132 since I need `Operator` to be non-copyable. If we decide to progress I can rebase this, or cherry pick and create a new branch.~~

~~You can see this without the churn of #11132 at https://github.com/samuelcolvin/datafusion/pull/1.~~

## high level question

Is all the effort here worth it, should we just add the 20 or so extra operators from the sql library to `Operator`?

Advantages of this route:
* more flexibility in how operators behave, what their signatures is, precedence, negation etc.
* easier to use custom operators or new operators adding to the SQL library without waiting for datafusion to support them

Disadvantages:
* ~~a lot of faff here~~ it's not that bad

## To to

* [x] How should `ParseCustomOperator` be passed into the SQL parser, it definitely shouldn't be as it is now, perhaps we should have an equivalent of `register_function_rewrite` like, e.g. `register_custom_operators`? DONE
* [x] ~~is the hack with `WrapCustomOperator` necessary and acceptable, maybe someone else's Rust foo could avoid this?~~ I think what we have is good
* [x] ~~should `CustomOperator` provide a `get_udf` method, then we rewrite to that function automatically, rather than relying on `register_function_rewrite`?~~ I don't think so, the current write logic is more powerful
* [x] what should we do about `from_proto_binary_op`, we can't keep the same signature and support custom operators, this might be easy to fix - done by adding the register methods to `FunctionRegistry`
* [x] ~~is it okay to rely on `name()` of the operator to implement equality, ordering and hashing?~~ I think it's good
* [x] Needs tests - basic tests are done, LMK what more is needed

## Example Usage:

<details>
<summary>Here's a trivial example of usage that just replaces the "->" operator with string concat:</summary>

```rs
use std::sync::Arc;

use datafusion::arrow::datatypes::DataType;
use datafusion::common::config::ConfigOptions;
use datafusion::common::tree_node::Transformed;
use datafusion::common::DFSchema;
use datafusion::error::Result;
use datafusion::execution::FunctionRegistry;
use datafusion::logical_expr::expr_rewriter::FunctionRewrite;
use datafusion::logical_expr::{
    CustomOperator, Operator, ParseCustomOperator, WrapCustomOperator,
};
use datafusion::prelude::*;
use datafusion::sql::sqlparser::ast::BinaryOperator;

#[derive(Debug)]
enum MyCustomOperator {
    /// Question, like `?`
    Question,
    /// Arrow, like `->`
    Arrow,
    /// Long arrow, like `->>`
    LongArrow,
}

impl std::fmt::Display for MyCustomOperator {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        match self {
            MyCustomOperator::Question => write!(f, "?"),
            MyCustomOperator::Arrow => write!(f, "->"),
            MyCustomOperator::LongArrow => write!(f, "->>"),
        }
    }
}

impl CustomOperator for MyCustomOperator {
    fn binary_signature(
        &self,
        lhs: &DataType,
        rhs: &DataType,
    ) -> Result<(DataType, DataType, DataType)> {
        Ok((lhs.clone(), rhs.clone(), lhs.clone()))
    }

    fn op_to_sql(&self) -> Result<BinaryOperator> {
        match self {
            MyCustomOperator::Question => Ok(BinaryOperator::Question),
            MyCustomOperator::Arrow => Ok(BinaryOperator::Arrow),
            MyCustomOperator::LongArrow => Ok(BinaryOperator::LongArrow),
        }
    }

    fn name(&self) -> &'static str {
        match self {
            MyCustomOperator::Question => "Question",
            MyCustomOperator::Arrow => "Arrow",
            MyCustomOperator::LongArrow => "LongArrow",
        }
    }
}

impl TryFrom<&str> for MyCustomOperator {
    type Error = ();

    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
        match value {
            "Question" => Ok(MyCustomOperator::Question),
            "Arrow" => Ok(MyCustomOperator::Arrow),
            "LongArrow" => Ok(MyCustomOperator::LongArrow),
            _ => Err(()),
        }
    }
}

#[derive(Debug)]
struct CustomOperatorParser;

impl ParseCustomOperator for CustomOperatorParser {
    fn name(&self) -> &str {
        "PostgresParseCustomOperator"
    }

    fn op_from_ast(&self, op: &BinaryOperator) -> Result<Option<Operator>> {
        match op {
            BinaryOperator::Question => Ok(Some(MyCustomOperator::Question.into())),
            BinaryOperator::Arrow => Ok(Some(MyCustomOperator::Arrow.into())),
            BinaryOperator::LongArrow => Ok(Some(MyCustomOperator::LongArrow.into())),
            _ => Ok(None),
        }
    }

    fn op_from_name(&self, raw_op: &str) -> Result<Option<Operator>> {
        if let Ok(op) = MyCustomOperator::try_from(raw_op) {
            Ok(Some(op.into()))
        } else {
            Ok(None)
        }
    }
}

impl FunctionRewrite for CustomOperatorParser {
    fn name(&self) -> &str {
        "PostgresParseCustomOperator"
    }

    fn rewrite(
        &self,
        expr: Expr,
        _schema: &DFSchema,
        _config: &ConfigOptions,
    ) -> Result<Transformed<Expr>> {
        if let Expr::BinaryExpr(bin_expr) = &expr {
            if let Operator::Custom(WrapCustomOperator(op)) = &bin_expr.op {
                if let Ok(pg_op) = MyCustomOperator::try_from(op.name()) {
                    // return BinaryExpr with a different operator
                    let mut bin_expr = bin_expr.clone();
                    bin_expr.op = match pg_op {
                        MyCustomOperator::Arrow => Operator::StringConcat,
                        MyCustomOperator::LongArrow => Operator::Plus,
                        MyCustomOperator::Question => Operator::Minus,
                    };
                    return Ok(Transformed::yes(Expr::BinaryExpr(bin_expr)));
                }
            }
        }
        Ok(Transformed::no(expr))
    }
}

async fn run(sql: &str) -> Result<()> {
    let config = SessionConfig::new().set_str("datafusion.sql_parser.dialect", "postgres");
    let mut ctx = SessionContext::new_with_config(config);
    ctx.register_function_rewrite(Arc::new(CustomOperatorParser))?;
    ctx.register_parse_custom_operator(Arc::new(CustomOperatorParser))?;
    let df = ctx.sql(sql).await?;
    df.show().await
}

#[tokio::main]
async fn main() {
    run("select 'foo'->'bar';").await.unwrap();
    run("select 1->>2;").await.unwrap();
    run("select 1 ? 2;").await.unwrap();
}
```

</details>