### PR TITLE
Minor: reduce replication for nested comparison

### DIFF
--- a/datafusion/physical-expr-common/src/datum.rs
+++ b/datafusion/physical-expr-common/src/datum.rs
@@ -87,7 +87,7 @@ pub fn apply_cmp_for_nested(
 }
 
 /// Compare on nested type List, Struct, and so on
-fn compare_op_for_nested(
+pub fn compare_op_for_nested(
     op: &Operator,
     lhs: &dyn Datum,
     rhs: &dyn Datum,


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/datafusion/pull/11117

## Rationale for this change

@jayzhan211  had a suggestion on how to simplify the implementation in https://github.com/apache/datafusion/pull/11117#discussion_r1655688627 from @rtyler . 

## What changes are included in this PR?

Use a pre-existing function to compare structured types

## Are these changes tested?
Covered by existing tests (added in https://github.com/apache/datafusion/pull/11117)

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
