### PR TITLE
RFC / Prototype user defined sql planner might look like

### DIFF
--- a/datafusion/functions-array/src/lib.rs
+++ b/datafusion/functions-array/src/lib.rs
@@ -51,7 +51,6 @@ pub mod set_ops;
 pub mod sort;
 pub mod string;
 pub mod utils;
-
 use datafusion_common::Result;
 use datafusion_execution::FunctionRegistry;
 use datafusion_expr::ScalarUDF;


### PR DESCRIPTION
I don't intend to merge this PR. 

## Which issue does this PR close?

Prototype of what the API described in https://github.com/apache/datafusion/issues/10534 might look like

Inspired by https://github.com/apache/datafusion/pull/11155 from @jayzhan211 and  @samuelcolvin on https://github.com/apache/datafusion/pull/11137 there


## Rationale for this change

I feel like our sql planner needs some way for it to be extended so that we can plan sql queries with operators that are not hard coded into the core engine. There are currently two different approaches

* https://github.com/apache/datafusion/pull/11155 from @jayzhan211 for operators --> functions
* https://github.com/apache/datafusion/pull/11137 from @samuelcolvin for custom operations --> functions


## What changes are included in this PR?

Prototype out what a "user defined planner" might look like

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
