### PR TITLE
fix: Support dictionary type in parquet metadata statistics.

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -1149,7 +1149,8 @@ mod tests {
     use crate::physical_plan::metrics::MetricValue;
     use crate::prelude::{SessionConfig, SessionContext};
     use arrow::array::{Array, ArrayRef, StringArray};
-    use arrow_array::Int64Array;
+    use arrow_array::types::Int32Type;
+    use arrow_array::{DictionaryArray, Int32Array, Int64Array};
     use arrow_schema::{DataType, Field};
     use async_trait::async_trait;
     use datafusion_common::cast::{
@@ -1158,6 +1159,7 @@ mod tests {
     };
     use datafusion_common::config::ParquetOptions;
     use datafusion_common::ScalarValue;
+    use datafusion_common::ScalarValue::Utf8;
     use datafusion_execution::object_store::ObjectStoreUrl;
     use datafusion_execution::runtime_env::RuntimeEnv;
     use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
@@ -1435,6 +1437,57 @@ mod tests {
             .expect("error reading metadata with hint");
 
         assert_eq!(store.request_count(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_statistics_from_parquet_metadata_dictionary() -> Result<()> {
+        // Data for column c_dic: ["a", "b", "c", "d"]
+        let values = StringArray::from_iter_values(["a", "b", "c", "d"]);
+        let keys = Int32Array::from_iter_values([0, 0, 1, 2]);
+        let dic_array =
+            DictionaryArray::<Int32Type>::try_new(keys, Arc::new(values)).unwrap();
+        let boxed_array: Box<dyn arrow_array::Array> = Box::new(dic_array);
+        let c_dic: ArrayRef = Arc::from(boxed_array);
+
+        // Define the schema
+        let field = Field::new(
+            "c_dic",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            false,
+        );
+        let schema = Schema::new(vec![field]);
+        // Create the RecordBatch
+        let batch1 = RecordBatch::try_new(Arc::new(schema), vec![c_dic]).unwrap();
+
+        // Use store_parquet to write each batch to its own file
+        // . batch1 written into first file and includes:
+        //    - column c_dic that has 4 rows with no null. Stats min and max of string column is missing for this test even the column has values
+        let store = Arc::new(LocalFileSystem::new()) as _;
+        let (files, _file_names) = store_parquet(vec![batch1], false).await?;
+
+        let state = SessionContext::new().state();
+        let format = ParquetFormat::default();
+        let schema = format.infer_schema(&state, &store, &files).await.unwrap();
+
+        // Fetch statistics for first file
+        let pq_meta = fetch_parquet_metadata(store.as_ref(), &files[0], None).await?;
+        let stats = statistics_from_parquet_meta(&pq_meta, schema.clone()).await?;
+        assert_eq!(stats.num_rows, Precision::Exact(4));
+
+        // column c_dic
+        let c_dic_stats = &stats.column_statistics[0];
+
+        assert_eq!(c_dic_stats.null_count, Precision::Exact(0));
+        assert_eq!(
+            c_dic_stats.max_value,
+            Precision::Exact(Utf8(Some("c".into())))
+        );
+        assert_eq!(
+            c_dic_stats.min_value,
+            Precision::Exact(Utf8(Some("a".into())))
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11145.

## Rationale for this change

## What changes are included in this PR?

Modifies `create_max_min_accs` to instantiate accumulators for unpacked data - the value DataType of the Dictionary. 

This bug is very similar to a previous bug that impacted the Min/Max aggregate functions. https://github.com/apache/datafusion/pull/1235

In addition, the `min_max_aggregate_data_type` fn is copied from https://github.com/apache/datafusion/blob/8216e32e87b2238d8814fe16215c8770d6c327c8/datafusion/physical-expr/src/aggregate/min_max.rs#L63-L73

I'm unsure if copying the function is the right thing to do in order to prevent coupling between the crates or if it should be moved to some core crate? It also seems like the dedicated min and max functions are to be refactored into a user defined functions?

## Are these changes tested?

Yes - a new test has been added.

## Are there any user-facing changes?

Currently implemented so the column statistics are returned as an unpacked type. So for `DataType::Dictionary(Int32, Utf8)` the min or max value is returned as `Exact(Utf8("a"))`. Would it be better to return it as `Exact(Dictionary(Int32, Utf8("a")))`? I'm unsure what the previous implementation would have returned and whether or not it was correct. But it's possible that returning it as an unpacked type would be a breaking change if it previously returned it as a Dictionary type. 

Happy to change the implementation to return a Dictionary type. I'm just unsure which offers the best experience.
