### PR TITLE
Minor: make some physical_optimizer rules public

### DIFF
--- a/datafusion/core/src/physical_optimizer/mod.rs
+++ b/datafusion/core/src/physical_optimizer/mod.rs
@@ -31,12 +31,12 @@ pub mod limited_distinct_aggregation;
 pub mod optimizer;
 pub mod output_requirements;
 pub mod pipeline_checker;
-mod projection_pushdown;
+pub mod projection_pushdown;
 pub mod pruning;
 pub mod replace_with_order_preserving_variants;
 mod sort_pushdown;
 pub mod topk_aggregation;
-mod update_aggr_exprs;
+pub mod update_aggr_exprs;
 mod utils;
 
 #[cfg(test)]

--- a/datafusion/core/src/physical_optimizer/update_aggr_exprs.rs
+++ b/datafusion/core/src/physical_optimizer/update_aggr_exprs.rs
@@ -52,6 +52,7 @@ use datafusion_physical_plan::{
 pub struct OptimizeAggregateOrder {}
 
 impl OptimizeAggregateOrder {
+    #[allow(missing_docs)]
     pub fn new() -> Self {
         Self::default()
     }


### PR DESCRIPTION
This patch makes public some physical_optimizer mod's. This allows external code to use optimizations passes from these submodules.

## Which issue does this PR close?

## Rationale for this change

To have an ability to use all of the existing physical optimizer passes in the user code that setup some optimization pipeline.

## What changes are included in this PR?

- Made projection_pushdown mod public
- Made update_aggr_exprs mod public 

## Are these changes tested?

No, because there are no changes in the logic.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
