### PR TITLE
fix: Be more lenient in interpreting input args for builtin window functions

### DIFF
--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -1139,7 +1139,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_cast_args() -> Result<()> {}
 }

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -258,10 +258,10 @@ fn create_built_in_window_expr(
             }
 
             if n.is_unsigned() {
-                let n: u64 = n.try_into()?;
+                let n: u64 = n.cast_to(&DataType::UInt64)?.try_into()?;
                 Arc::new(Ntile::new(name, n, out_data_type))
             } else {
-                let n: i64 = n.try_into()?;
+                let n: i64 = n.cast_to(&DataType::Int64)?.try_into()?;
                 if n <= 0 {
                     return exec_err!("NTILE requires a positive integer");
                 }
@@ -271,7 +271,7 @@ fn create_built_in_window_expr(
         BuiltInWindowFunction::Lag => {
             let arg = args[0].clone();
             let shift_offset = get_scalar_value_from_args(args, 1)?
-                .map(|v| v.try_into())
+                .map(|v| v.cast_to(&DataType::Int64)?.try_into())
                 .and_then(|v| v.ok());
             let default_value =
                 get_casted_value(get_scalar_value_from_args(args, 2)?, out_data_type)?;
@@ -287,7 +287,7 @@ fn create_built_in_window_expr(
         BuiltInWindowFunction::Lead => {
             let arg = args[0].clone();
             let shift_offset = get_scalar_value_from_args(args, 1)?
-                .map(|v| v.try_into())
+                .map(|v| v.cast_to(&DataType::Int64)?.try_into())
                 .and_then(|v| v.ok());
             let default_value =
                 get_casted_value(get_scalar_value_from_args(args, 2)?, out_data_type)?;
@@ -305,6 +305,7 @@ fn create_built_in_window_expr(
             let n = args[1].as_any().downcast_ref::<Literal>().unwrap().value();
             let n: i64 = n
                 .clone()
+                .cast_to(&DataType::Int64)?
                 .try_into()
                 .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
             Arc::new(NthValue::nth(
@@ -1138,4 +1139,7 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_cast_args() -> Result<()> {}
 }

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -634,7 +634,6 @@ mod tests {
     use datafusion_execution::TaskContext;
 
     use datafusion_functions_aggregate::count::count_udaf;
-    use datafusion_physical_expr_common::expressions::lit;
     use futures::FutureExt;
     use InputOrderMode::{Linear, PartiallySorted, Sorted};
 

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -4830,6 +4830,8 @@ NULL 3
 NULL 2
 NULL 1
 
+statement ok
+drop table t
 
 ### Test for window functions with arrays
 statement ok
@@ -4852,3 +4854,38 @@ c [4, 5, 6] NULL
 
 statement ok
 drop table array_data
+
+# Test for non-i64 offsets for NTILE, LAG, LEAD, NTH_VALUE
+statement ok
+CREATE TABLE t AS VALUES  (3, 3), (4, 4), (5, 5), (6, 6);
+
+query IIIIIIIII
+SELECT
+  column1,
+  ntile(2) OVER (order by column1),
+  ntile(arrow_cast(2, 'Int32')) OVER (order by column1),
+  lag(column2, -1) OVER (order by column1),
+  lag(column2, arrow_cast(-1, 'Int32')) OVER (order by column1),
+  lead(column2, -1) OVER (order by column1),
+  lead(column2, arrow_cast(-1, 'Int32')) OVER (order by column1),
+  nth_value(column2, 2) OVER (order by column1),
+  nth_value(column2, arrow_cast(2, 'Int32')) OVER (order by column1)
+FROM t;
+----
+3 1 1 4    4    NULL NULL NULL NULL
+4 1 1 5    5    3    3    4    4
+5 2 2 6    6    4    4    4    4
+6 2 2 NULL NULL 5    5    4    4
+
+# NTILE specifies the argument types so the error is different
+query error
+SELECT ntile(1.1) OVER (order by column1) FROM t;
+
+query error DataFusion error: Execution error: Expected an integer value
+SELECT lag(column2, 1.1) OVER (order by column1) FROM t;
+
+query error DataFusion error: Execution error: Expected an integer value
+SELECT lead(column2, 1.1) OVER (order by column1) FROM t;
+
+query error DataFusion error: Execution error: Expected an integer value
+SELECT nth_value(column2, 1.1) OVER (order by column1) FROM t;


### PR DESCRIPTION
The built-in window functions Lag, Lead, NthValue, Ntile accept integer arguments. However while they should allow any integers, currently as they just use ScalarValue's try_from to convert into an i64, they actually only accept i64s. Any other argument, e.g. an  i32, would be converted into a None and ignored (for lag and lead), or throw (for ntile and nth_value).

I noticed this as Spark and Substrait defines these functions as using int32 args.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Before - lag and lead would silently ignore the argument, ntile and nth_value would fail:
```
> SELECT id, lead(id, -1) OVER (ORDER BY id) AS correct, lead(id, arrow_cast(-1,'Int32')) OVER (ORDER BY id) as wrong from (values (1), (2)) as tbl(id);
+----+---------+-------+
| id | correct | wrong |
+----+---------+-------+
| 1  |         | 2     |
| 2  | 1       |       |
+----+---------+-------+

> SELECT id, lag(id, -1) OVER (ORDER BY id) AS correct, lag(id, arrow_cast(-1,'Int32')) OVER (ORDER BY id) as wrong from (values (1), (2)) as tbl(id);
+----+---------+-------+
| id | correct | wrong |
+----+---------+-------+
| 1  | 2       |       |
| 2  |         | 1     |
+----+---------+-------+

> SELECT id, nth_value(id, 2) OVER (ORDER BY id) AS correct, nth_value(id, arrow_cast(2,'Int32')) OVER (ORDER BY id) as corrected from (values (1), (2)) as tbl(id);
Execution error: Internal("Cannot convert Int32(2) to i64")

> SELECT id, ntile(2) OVER (ORDER BY id) AS correct, ntile(arrow_cast(2,'Int32')) OVER (ORDER BY id) as corrected from (values (1), (2)) as tbl(id);
Internal error: Cannot convert Int32(2) to i64.
This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
```

After - all four produce expected results:
```
SELECT id, lead(id, -1) OVER (ORDER BY id) AS correct, lead(id, arrow_cast(-1,'Int32')) OVER (ORDER BY id) as corrected from (values (1), (2)) as tbl(id)
+----+---------+-----------+
| id | correct | corrected |
+----+---------+-----------+
| 1  |         |           |
| 2  | 1       | 1         |
+----+---------+-----------+

SELECT id, lag(id, -1) OVER (ORDER BY id) AS correct, lag(id, arrow_cast(-1,'Int32')) OVER (ORDER BY id) as corrected from (values (1), (2)) as tbl(id)
+----+---------+-----------+
| id | correct | corrected |
+----+---------+-----------+
| 1  | 2       | 2         |
| 2  |         |           |
+----+---------+-----------+

SELECT id, nth_value(id, 2) OVER (ORDER BY id) AS correct, nth_value(id, arrow_cast(2,'Int32')) OVER (ORDER BY id) as corrected from (values (1), (2)) as tbl(id)
+----+---------+-----------+
| id | correct | corrected |
+----+---------+-----------+
| 1  |         |           |
| 2  | 2       | 2         |
+----+---------+-----------+

SELECT id, ntile(2) OVER (ORDER BY id) AS correct, ntile(arrow_cast(2,'Int32')) OVER (ORDER BY id) as corrected from (values (1), (2)) as tbl(id)
+----+---------+-----------+
| id | correct | corrected |
+----+---------+-----------+
| 1  | 1       | 1         |
| 2  | 2       | 2         |
+----+---------+-----------+
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Try casting the scalar value args for lag, lead, ntile and nth_value into Int64 before extracting an i64 out of them.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

I've tested the fix manually (see above). Happy to add unit tests as well, any recommendations how/where? I didn't see any previous art for exactly these kind of tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

Previously erronously ignored args, if existing, would get applied; previously throwing queries, if existing, would now succeed.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
