### PR TITLE
WIP Upgrade to arrow/parquet `52.1.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,3 +153,20 @@ large_futures = "warn"
 
 [workspace.lints.rust]
 unused_imports = "deny"
+
+[patch.crates-io]
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-arith = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-json = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-row = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,18 +155,18 @@ large_futures = "warn"
 unused_imports = "deny"
 
 [patch.crates-io]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-arith = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-json = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-row = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-parquet = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-arith = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-json = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-row = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -131,8 +131,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "arrow"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -152,8 +151,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7029a5b3efbeafbf4a12d12dc16b8f9e9bff20a410b8c25c5d28acc089e1043"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -167,8 +165,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33238427c60271710695f17742f45b1a5dc5bcfc5c15331c25ddfe7abf70d97"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -184,8 +181,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9b95e825ae838efaf77e366c00d3fc8cca78134c9db497d6bda425f2e7b7c1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "bytes",
  "half",
@@ -195,8 +191,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cf8385a9d5b5fcde771661dd07652b79b9139fea66193eda6a88664400ccab"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -216,8 +211,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea5068bef430a86690059665e40034625ec323ffa4dd21972048eebb0127adc"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -235,8 +229,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb29be98f987bcf217b070512bb7afba2f65180858bca462edf4a39d84a23e10"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -247,8 +240,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc68f6523970aa6f7ce1dc9a33a7d9284cfb9af77d4ad3e617dbe5d79cc6ec8"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -262,8 +254,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2041380f94bd6437ab648e6c2085a045e45a0c44f91a1b9a4fe3fed3d379bfb1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -282,8 +273,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb56ed1547004e12203652f12fe12e824161ff9d1e5cf2a7dc4ff02ba94f413"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -297,8 +287,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575b42f1fc588f2da6977b94a5ca565459f5ab07b60545e17243fb9a7ed6d43e"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -312,14 +301,12 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 
 [[package]]
 name = "arrow-select"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -332,8 +319,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e435ada8409bcafc910bc3e0077f532a4daa20e99060a496685c0e3e53cc2597"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2579,8 +2565,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c3b5322cc1bbf67f11c079c42be41a55949099b78732f7dba9e15edde40eab"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4336,3 +4321,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "arrow-flight"
+version = "52.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -130,8 +130,8 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -150,8 +150,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -164,8 +164,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -180,8 +180,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "bytes",
  "half",
@@ -190,8 +190,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -210,8 +210,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -228,8 +228,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -239,8 +239,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -253,8 +253,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -286,8 +286,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -300,13 +300,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 
 [[package]]
 name = "arrow-select"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -318,8 +318,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -361,8 +361,8 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "xz2",
- "zstd 0.13.0",
- "zstd-safe 7.0.0",
+ "zstd 0.13.1",
+ "zstd-safe 7.1.0",
 ]
 
 [[package]]
@@ -1158,7 +1158,7 @@ dependencies = [
  "url",
  "uuid",
  "xz2",
- "zstd 0.13.0",
+ "zstd 0.13.1",
 ]
 
 [[package]]
@@ -2564,8 +2564,8 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"
+version = "52.1.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=a9cc791f1982387bc00807a0fdcdbffd7ff63c85#a9cc791f1982387bc00807a0fdcdbffd7ff63c85"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2593,7 +2593,7 @@ dependencies = [
  "thrift",
  "tokio",
  "twox-hash",
- "zstd 0.13.0",
+ "zstd 0.13.1",
  "zstd-sys",
 ]
 
@@ -4286,11 +4286,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
 dependencies = [
- "zstd-safe 7.0.0",
+ "zstd-safe 7.1.0",
 ]
 
 [[package]]
@@ -4305,24 +4305,19 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "arrow-flight"
-version = "52.0.0"
-source = "git+https://github.com/apache/arrow-rs.git?rev=bb1250ceb8afe9367fe577821d2d384cd38c2d6e#bb1250ceb8afe9367fe577821d2d384cd38c2d6e"

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -757,9 +757,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blake2"
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 dependencies = [
  "jobserver",
  "libc",
@@ -981,7 +981,7 @@ version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width",
 ]
@@ -1099,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1262,7 +1262,7 @@ dependencies = [
  "paste",
  "serde_json",
  "sqlparser",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros 0.26.4",
 ]
 
@@ -1426,7 +1426,7 @@ dependencies = [
  "log",
  "regex",
  "sqlparser",
- "strum 0.26.2",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -1504,9 +1504,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "endian-type"
@@ -1685,7 +1685,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1964,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2005,7 +2005,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "hyper-util",
  "rustls 0.23.10",
  "rustls-native-certs 0.7.0",
@@ -2017,16 +2017,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2253,9 +2253,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.38"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7bb23d733dfcc8af652a78b7bf232f0e967710d044732185e561e47c0336b6"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
 dependencies = [
  "cc",
  "libc",
@@ -2267,7 +2267,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -2289,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lz4_flex"
@@ -2331,9 +2331,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9186d86b79b52f4a77af65604b51225e8db1d6ee7e3f41aec1e40829c71a176"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -2406,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2482,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -2501,7 +2501,7 @@ dependencies = [
  "chrono",
  "futures",
  "humantime",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "itertools",
  "md-5",
  "parking_lot",
@@ -2698,7 +2698,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2912,7 +2912,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2975,7 +2975,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
@@ -3095,7 +3095,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3264,7 +3264,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3310,14 +3310,14 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -3445,7 +3445,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3474,9 +3474,9 @@ checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros 0.26.4",
 ]
@@ -3491,7 +3491,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3504,14 +3504,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3526,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.67"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3591,7 +3591,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3646,9 +3646,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3686,7 +3686,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3783,7 +3783,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3828,7 +3828,7 @@ checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3907,9 +3907,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
  "serde",
@@ -3982,7 +3982,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -4016,7 +4016,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4281,7 +4281,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -64,17 +64,17 @@ predicates = "3.0"
 rstest = "0.17"
 
 [patch.crates-io]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-arith = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-json = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-arrow-row = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
-parquet = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-arith = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-json = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+arrow-row = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev="a9cc791f1982387bc00807a0fdcdbffd7ff63c85" }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -62,3 +62,19 @@ assert_cmd = "2.0"
 ctor = "0.2.0"
 predicates = "3.0"
 rstest = "0.17"
+
+[patch.crates-io]
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-arith = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-json = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+arrow-row = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev="bb1250ceb8afe9367fe577821d2d384cd38c2d6e" }

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -1076,7 +1076,7 @@ fn temporal_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataTyp
                 (Nanosecond, Microsecond) => Microsecond,
                 (l, r) => {
                     assert_eq!(l, r);
-                    *l,
+                    *l
                 }
             };
 

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -1076,7 +1076,7 @@ fn temporal_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataTyp
                 (Nanosecond, Microsecond) => Microsecond,
                 (l, r) => {
                     assert_eq!(l, r);
-                    l.clone()
+                    *l,
                 }
             };
 

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -607,11 +607,11 @@ fn coerced_from<'a>(
         (Timestamp(unit, Some(tz)), _) if tz.as_ref() == TIMEZONE_WILDCARD => {
             match type_from {
                 Timestamp(_, Some(from_tz)) => {
-                    Some(Timestamp(unit.clone(), Some(from_tz.clone())))
+                    Some(Timestamp(*unit, Some(from_tz.clone())))
                 }
                 Null | Date32 | Utf8 | LargeUtf8 | Timestamp(_, None) => {
                     // In the absence of any other information assume the time zone is "+00" (UTC).
-                    Some(Timestamp(unit.clone(), Some("+00".into())))
+                    Some(Timestamp(*unit, Some("+00".into())))
                 }
                 _ => None,
             }

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -57,35 +57,35 @@ impl DateBinFunc {
             vec![
                 Exact(vec![
                     DataType::Interval(MonthDayNano),
-                    Timestamp(array_type.clone(), None),
+                    Timestamp(array_type, None),
                     Timestamp(Nanosecond, None),
                 ]),
                 Exact(vec![
                     DataType::Interval(MonthDayNano),
-                    Timestamp(array_type.clone(), Some(TIMEZONE_WILDCARD.into())),
+                    Timestamp(array_type, Some(TIMEZONE_WILDCARD.into())),
                     Timestamp(Nanosecond, Some(TIMEZONE_WILDCARD.into())),
                 ]),
                 Exact(vec![
                     DataType::Interval(DayTime),
-                    Timestamp(array_type.clone(), None),
+                    Timestamp(array_type, None),
                     Timestamp(Nanosecond, None),
                 ]),
                 Exact(vec![
                     DataType::Interval(DayTime),
-                    Timestamp(array_type.clone(), Some(TIMEZONE_WILDCARD.into())),
+                    Timestamp(array_type, Some(TIMEZONE_WILDCARD.into())),
                     Timestamp(Nanosecond, Some(TIMEZONE_WILDCARD.into())),
                 ]),
                 Exact(vec![
                     DataType::Interval(MonthDayNano),
-                    Timestamp(array_type.clone(), None),
+                    Timestamp(array_type, None),
                 ]),
                 Exact(vec![
                     DataType::Interval(MonthDayNano),
-                    Timestamp(array_type.clone(), Some(TIMEZONE_WILDCARD.into())),
+                    Timestamp(array_type, Some(TIMEZONE_WILDCARD.into())),
                 ]),
                 Exact(vec![
                     DataType::Interval(DayTime),
-                    Timestamp(array_type.clone(), None),
+                    Timestamp(array_type, None),
                 ]),
                 Exact(vec![
                     DataType::Interval(DayTime),


### PR DESCRIPTION
## Which issue does this PR close?


Related to  https://github.com/apache/arrow-rs/issues/5905


## Rationale for this change

This PR tests that updating to the next version of arrow and parquet are in fact not breaking changes

## What changes are included in this PR?

Temporarily pin the version to arrow 52.1.0

## Are these changes tested?
Yes
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
