### PR TITLE
Make statistics_from_parquet_meta a sync function

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -544,8 +544,10 @@ pub fn statistics_from_parquet_meta_calc(
 }
 
 /// Deprecated
-/// Use [`statistics_from_parquet_meta_calc`] instead
-/// #[deprecated(since="40.0.0", note="please use `statistics_from_parquet_meta_calc` instead")]
+/// Use [`statistics_from_parquet_meta_calc`] instead.
+/// This method was deprecated because it didn't need to be async so a new method was created
+/// that exposes a synchronous API.
+#[deprecated(since="40.0.0", note="please use `statistics_from_parquet_meta_calc` instead")]
 pub async fn statistics_from_parquet_meta(
     metadata: &ParquetMetaData,
     table_schema: SchemaRef,

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -547,7 +547,10 @@ pub fn statistics_from_parquet_meta_calc(
 /// Use [`statistics_from_parquet_meta_calc`] instead.
 /// This method was deprecated because it didn't need to be async so a new method was created
 /// that exposes a synchronous API.
-#[deprecated(since="40.0.0", note="please use `statistics_from_parquet_meta_calc` instead")]
+#[deprecated(
+    since = "40.0.0",
+    note = "please use `statistics_from_parquet_meta_calc` instead"
+)]
 pub async fn statistics_from_parquet_meta(
     metadata: &ParquetMetaData,
     table_schema: SchemaRef,
@@ -1479,7 +1482,7 @@ mod tests {
 
         // Fetch statistics for first file
         let pq_meta = fetch_parquet_metadata(store.as_ref(), &files[0], None).await?;
-        let stats = statistics_from_parquet_meta(&pq_meta, schema.clone()).await?;
+        let stats = statistics_from_parquet_meta_calc(&pq_meta, schema.clone())?;
         assert_eq!(stats.num_rows, Precision::Exact(4));
 
         // column c_dic

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -460,14 +460,14 @@ async fn fetch_statistics(
     metadata_size_hint: Option<usize>,
 ) -> Result<Statistics> {
     let metadata = fetch_parquet_metadata(store, file, metadata_size_hint).await?;
-    statistics_from_parquet_meta(&metadata, table_schema).await
+    statistics_from_parquet_meta_calc(&metadata, table_schema)
 }
 
 /// Convert statistics in  [`ParquetMetaData`] into [`Statistics`] using ['StatisticsConverter`]
 ///
 /// The statistics are calculated for each column in the table schema
 /// using the row group statistics in the parquet metadata.
-pub async fn statistics_from_parquet_meta(
+pub fn statistics_from_parquet_meta_calc(
     metadata: &ParquetMetaData,
     table_schema: SchemaRef,
 ) -> Result<Statistics> {
@@ -541,6 +541,16 @@ pub async fn statistics_from_parquet_meta(
     };
 
     Ok(statistics)
+}
+
+/// Deprecated
+/// Use [`statistics_from_parquet_meta_calc`] instead
+/// #[deprecated(since="0.40.0", note="please use `statistics_from_parquet_meta_calc` instead")]
+pub async fn statistics_from_parquet_meta(
+    metadata: &ParquetMetaData,
+    table_schema: SchemaRef,
+) -> Result<Statistics> {
+    statistics_from_parquet_meta_calc(metadata, table_schema)
 }
 
 fn summarize_min_max_null_counts(
@@ -1514,7 +1524,7 @@ mod tests {
 
         // Fetch statistics for first file
         let pq_meta = fetch_parquet_metadata(store.as_ref(), &files[0], None).await?;
-        let stats = statistics_from_parquet_meta(&pq_meta, schema.clone()).await?;
+        let stats = statistics_from_parquet_meta_calc(&pq_meta, schema.clone())?;
         //
         assert_eq!(stats.num_rows, Precision::Exact(3));
         // column c1
@@ -1536,7 +1546,7 @@ mod tests {
 
         // Fetch statistics for second file
         let pq_meta = fetch_parquet_metadata(store.as_ref(), &files[1], None).await?;
-        let stats = statistics_from_parquet_meta(&pq_meta, schema.clone()).await?;
+        let stats = statistics_from_parquet_meta_calc(&pq_meta, schema.clone())?;
         assert_eq!(stats.num_rows, Precision::Exact(3));
         // column c1: missing from the file so the table treats all 3 rows as null
         let c1_stats = &stats.column_statistics[0];

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -545,7 +545,7 @@ pub fn statistics_from_parquet_meta_calc(
 
 /// Deprecated
 /// Use [`statistics_from_parquet_meta_calc`] instead
-/// #[deprecated(since="0.40.0", note="please use `statistics_from_parquet_meta_calc` instead")]
+/// #[deprecated(since="40.0.0", note="please use `statistics_from_parquet_meta_calc` instead")]
 pub async fn statistics_from_parquet_meta(
     metadata: &ParquetMetaData,
     table_schema: SchemaRef,


### PR DESCRIPTION
It seems like this function doesn't need to be async. I exposed a sync version and deprecated the async one.