### PR TITLE
Fix running examples readme

### DIFF
--- a/ci/scripts/rust_example.sh
+++ b/ci/scripts/rust_example.sh
@@ -19,7 +19,6 @@
 
 set -ex
 cd datafusion-examples/examples/
-cargo fmt --all -- --check
 cargo check --examples
 
 files=$(ls .)

--- a/datafusion-examples/README.md
+++ b/datafusion-examples/README.md
@@ -36,6 +36,9 @@ cd datafusion
 # Download test data
 git submodule update --init
 
+# Change to the examples directory
+cd datafusion-examples/examples
+
 # Run the `dataframe` example:
 # ... use the equivalent for other examples
 cargo run --example dataframe


### PR DESCRIPTION
Some examples are runnable from any place (e.g. `csv_sql`), but some expect a specific working directory (e.g. `regexp`). Running from `datafusion-examples/examples` is tested on CI so guaranteed to work, let's put this path in the README.

As a follow-up, we should look what it would take to make examples runnable directly from an IDE such as RustRover.
