### PR TITLE
Make `arrow_cast::parse_data_type` public

### DIFF
--- a/datafusion/functions/src/core/arrow_cast.rs
+++ b/datafusion/functions/src/core/arrow_cast.rs
@@ -149,7 +149,7 @@ fn data_type_from_args(args: &[Expr]) -> Result<DataType> {
 /// `parse_data_type(data_type.to_string()) == data_type`
 ///
 /// Remove if added to arrow: <https://github.com/apache/arrow-rs/issues/3821>
-fn parse_data_type(val: &str) -> Result<DataType> {
+pub fn parse_data_type(val: &str) -> Result<DataType> {
     Parser::new(val).parse()
 }
 


### PR DESCRIPTION
## Rationale for this change

Until https://github.com/apache/arrow-rs/issues/3821 gets closed and `parse_data_type` gets moved to arrow-rs, it would be extremely helpful for us if `parse_data_type` was public.

Currently we have some home rolled logic for inferring arrow datatypes from strings when we define schema in toml files.

## What changes are included in this PR?

```rs
datafusion::functions::core::arrow_cast::parse_data_type
```

Is now public

## Are these changes tested?

I tried to add a test for this specifically in `datafusion/functions/src/core/arrow_cast.rs` but it works regardless of whether the function is public. Let me know if you'd like me to add a test somewhere else?

## Are there any user-facing changes?

```rs
datafusion::functions::core::arrow_cast::parse_data_type
```

Is now public