### PR TITLE
HashJoin can preserve the right ordering when join type is Right

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -1451,7 +1451,7 @@ impl HashJoinStream {
             index_alignment_range_start..index_alignment_range_end,
             self.join_type,
             self.right_side_ordered,
-        );
+        )?;
 
         let result = build_batch_from_indices(
             &self.schema,

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -1111,7 +1111,7 @@ struct HashJoinStream {
     batch_size: usize,
     /// Scratch space for computing hashes
     hashes_buffer: Vec<u64>,
-    // Specifies whether the right side has an ordering to potentially preserve
+    /// Specifies whether the right side has an ordering to potentially preserve
     right_side_ordered: bool,
 }
 

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -1451,7 +1451,7 @@ impl HashJoinStream {
             index_alignment_range_start..index_alignment_range_end,
             self.join_type,
             self.right_side_ordered,
-        )?;
+        );
 
         let result = build_batch_from_indices(
             &self.schema,

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -605,7 +605,7 @@ fn join_left_and_right_batch(
                 0..right_batch.num_rows(),
                 join_type,
                 false,
-            )?;
+            );
 
             build_batch_from_indices(
                 schema,

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -605,7 +605,7 @@ fn join_left_and_right_batch(
                 0..right_batch.num_rows(),
                 join_type,
                 false,
-            );
+            )?;
 
             build_batch_from_indices(
                 schema,

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -604,6 +604,7 @@ fn join_left_and_right_batch(
                 right_side,
                 0..right_batch.num_rows(),
                 join_type,
+                false,
             );
 
             build_batch_from_indices(
@@ -647,7 +648,6 @@ impl RecordBatchStream for NestedLoopJoinStream {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::{
         common, expressions::Column, memory::MemoryExec, repartition::RepartitionExec,

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -1333,9 +1333,21 @@ pub(crate) fn adjust_indices_by_join_type(
     }
 }
 
-/// Appends the `right_unmatched_indices` to the `right_indices`,
-/// and fills Null to tail of `left_indices` to
-/// keep the length of `right_indices` and `left_indices` consistent.
+/// Appends right indices to left indices based on the specified order mode.
+///
+/// The function operates in two modes:
+/// 1. If `preserve_order_for_right` is true, probe matched and unmatched indices
+///    are inserted in order using the `append_probe_indices_in_order()` method.
+/// 2. Otherwise, unmatched probe indices are simply appended after matched ones.
+///
+/// # Parameters
+/// - `left_indices`: UInt64Array of left indices.
+/// - `right_indices`: UInt32Array of right indices.
+/// - `adjust_range`: Range to adjust the right indices.
+/// - `preserve_order_for_right`: Boolean flag to determine the mode of operation.
+///
+/// # Returns
+/// A tuple of updated `UInt64Array` and `UInt32Array`.
 pub(crate) fn append_right_indices(
     left_indices: UInt64Array,
     right_indices: UInt32Array,

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3814,6 +3814,13 @@ logical_plan
 02)--Projection: Int64(1) AS a
 03)----EmptyRelation
 
+
+statement ok
+set datafusion.execution.target_partitions = 1;
+
+statement ok
+set datafusion.explain.logical_plan_only = false;
+
 # Right Hash Joins preserve the right ordering
 query IIII
 SELECT * FROM (
@@ -3827,3 +3834,37 @@ SELECT * FROM (
 ----
 NULL NULL 1 0
 1 1 3 1
+
+query TT
+EXPLAIN SELECT * FROM (
+    SELECT 1 as a, 1 as b
+) as lhs RIGHT JOIN (
+    SELECT 1 as x, 0 as y
+    UNION ALL
+    SELECT 3 as x, 1 AS y
+    ORDER BY y
+) AS rhs ON lhs.b=rhs.y
+----
+logical_plan
+01)Right Join: lhs.b = rhs.y
+02)--SubqueryAlias: lhs
+03)----Projection: Int64(1) AS a, Int64(1) AS b
+04)------EmptyRelation
+05)--SubqueryAlias: rhs
+06)----Sort: y ASC NULLS LAST
+07)------Union
+08)--------Projection: Int64(1) AS x, Int64(0) AS y
+09)----------EmptyRelation
+10)--------Projection: Int64(3) AS x, Int64(1) AS y
+11)----------EmptyRelation
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=2
+02)--HashJoinExec: mode=CollectLeft, join_type=Right, on=[(b@1, y@1)]
+03)----ProjectionExec: expr=[1 as a, 1 as b]
+04)------PlaceholderRowExec
+05)----SortPreservingMergeExec: [y@1 ASC NULLS LAST]
+06)------UnionExec
+07)--------ProjectionExec: expr=[1 as x, 0 as y]
+08)----------PlaceholderRowExec
+09)--------ProjectionExec: expr=[3 as x, 1 as y]
+10)----------PlaceholderRowExec

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3818,8 +3818,6 @@ logical_plan
 query IIII
 SELECT * FROM (
     SELECT 1 as a, 1 as b
-    UNION ALL
-    SELECT 2 as a, 1 AS b
 ) as lhs RIGHT JOIN (
     SELECT 1 as x, 0 as y
     UNION ALL
@@ -3829,4 +3827,3 @@ SELECT * FROM (
 ----
 NULL NULL 1 0
 1 1 3 1
-2 1 3 1

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3813,3 +3813,20 @@ logical_plan
 01)SubqueryAlias: b
 02)--Projection: Int64(1) AS a
 03)----EmptyRelation
+
+# Right Hash Joins preserve the right ordering
+query IIII
+SELECT * FROM (
+    SELECT 1 as a, 1 as b
+    UNION ALL
+    SELECT 2 as a, 1 AS b
+) as lhs RIGHT JOIN (
+    SELECT 1 as x, 0 as y
+    UNION ALL
+    SELECT 3 as x, 1 AS y
+    ORDER BY y
+) AS rhs ON lhs.b=rhs.y
+----
+NULL NULL 1 0
+1 1 3 1
+2 1 3 1

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3821,50 +3821,174 @@ set datafusion.execution.target_partitions = 1;
 statement ok
 set datafusion.explain.logical_plan_only = false;
 
+statement ok
+set datafusion.execution.batch_size = 3;
+
 # Right Hash Joins preserve the right ordering
+# No nulls on build side:
+statement ok
+CREATE TABLE left_table_no_nulls(a INT UNSIGNED, b INT UNSIGNED)
+AS VALUES
+(11, 1),
+(12, 3),
+(13, 5),
+(14, 2),
+(15, 4);
+
+statement ok
+CREATE TABLE right_table_no_nulls(a INT UNSIGNED, b INT UNSIGNED)
+AS VALUES
+(21, 1),
+(22, 2),
+(23, 3),
+(24, 4);
+
 query IIII
 SELECT * FROM (
-    SELECT 1 as a, 1 as b
+    SELECT * from left_table_no_nulls
 ) as lhs RIGHT JOIN (
-    SELECT 1 as x, 0 as y
-    UNION ALL
-    SELECT 3 as x, 1 AS y
-    ORDER BY y
-) AS rhs ON lhs.b=rhs.y
+    SELECT * from right_table_no_nulls
+    ORDER BY b
+) AS rhs ON lhs.b=rhs.b
 ----
-NULL NULL 1 0
-1 1 3 1
+11 1 21 1
+14 2 22 2
+12 3 23 3
+15 4 24 4
 
 query TT
 EXPLAIN SELECT * FROM (
-    SELECT 1 as a, 1 as b
+    SELECT * from left_table_no_nulls
 ) as lhs RIGHT JOIN (
-    SELECT 1 as x, 0 as y
-    UNION ALL
-    SELECT 3 as x, 1 AS y
-    ORDER BY y
-) AS rhs ON lhs.b=rhs.y
+    SELECT * from right_table_no_nulls
+    ORDER BY b
+) AS rhs ON lhs.b=rhs.b
 ----
 logical_plan
-01)Right Join: lhs.b = rhs.y
+01)Right Join: lhs.b = rhs.b
 02)--SubqueryAlias: lhs
-03)----Projection: Int64(1) AS a, Int64(1) AS b
-04)------EmptyRelation
-05)--SubqueryAlias: rhs
-06)----Sort: y ASC NULLS LAST
-07)------Union
-08)--------Projection: Int64(1) AS x, Int64(0) AS y
-09)----------EmptyRelation
-10)--------Projection: Int64(3) AS x, Int64(1) AS y
-11)----------EmptyRelation
+03)----TableScan: left_table_no_nulls projection=[a, b]
+04)--SubqueryAlias: rhs
+05)----Sort: right_table_no_nulls.b ASC NULLS LAST
+06)------TableScan: right_table_no_nulls projection=[a, b]
 physical_plan
-01)CoalesceBatchesExec: target_batch_size=2
-02)--HashJoinExec: mode=CollectLeft, join_type=Right, on=[(b@1, y@1)]
-03)----ProjectionExec: expr=[1 as a, 1 as b]
-04)------PlaceholderRowExec
-05)----SortPreservingMergeExec: [y@1 ASC NULLS LAST]
-06)------UnionExec
-07)--------ProjectionExec: expr=[1 as x, 0 as y]
-08)----------PlaceholderRowExec
-09)--------ProjectionExec: expr=[3 as x, 1 as y]
-10)----------PlaceholderRowExec
+01)CoalesceBatchesExec: target_batch_size=3
+02)--HashJoinExec: mode=CollectLeft, join_type=Right, on=[(b@1, b@1)]
+03)----MemoryExec: partitions=1, partition_sizes=[1]
+04)----SortExec: expr=[b@1 ASC NULLS LAST], preserve_partitioning=[false]
+05)------MemoryExec: partitions=1, partition_sizes=[1]
+
+
+# Missing probe index in the middle of the batch:
+statement ok
+CREATE TABLE left_table_missing_probe(a INT UNSIGNED, b INT UNSIGNED)
+AS VALUES
+(11, 1),
+(12, 2),
+(13, 3),
+(14, 6),
+(15, 8);
+
+statement ok
+CREATE TABLE right_table_missing_probe(a INT UNSIGNED, b INT UNSIGNED)
+AS VALUES
+(21, 1),
+(22, 4),
+(23, 6),
+(24, 7),
+(25, 8);
+
+query IIII
+SELECT * FROM (
+    SELECT * from left_table_missing_probe
+) as lhs RIGHT JOIN (
+    SELECT * from right_table_missing_probe
+    ORDER BY b
+) AS rhs ON lhs.b=rhs.b
+----
+11 1 21 1
+NULL NULL 22 4
+14 6 23 6
+NULL NULL 24 7
+15 8 25 8
+
+query TT
+EXPLAIN SELECT * FROM (
+    SELECT * from left_table_no_nulls
+) as lhs RIGHT JOIN (
+    SELECT * from right_table_no_nulls
+    ORDER BY b
+) AS rhs ON lhs.b=rhs.b
+----
+logical_plan
+01)Right Join: lhs.b = rhs.b
+02)--SubqueryAlias: lhs
+03)----TableScan: left_table_no_nulls projection=[a, b]
+04)--SubqueryAlias: rhs
+05)----Sort: right_table_no_nulls.b ASC NULLS LAST
+06)------TableScan: right_table_no_nulls projection=[a, b]
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=3
+02)--HashJoinExec: mode=CollectLeft, join_type=Right, on=[(b@1, b@1)]
+03)----MemoryExec: partitions=1, partition_sizes=[1]
+04)----SortExec: expr=[b@1 ASC NULLS LAST], preserve_partitioning=[false]
+05)------MemoryExec: partitions=1, partition_sizes=[1]
+
+
+# Null build indices:
+statement ok
+CREATE TABLE left_table_append_null_build(a INT UNSIGNED, b INT UNSIGNED)
+AS VALUES
+(11, 1),
+(12, 1),
+(13, 5),
+(14, 5),
+(15, 3);
+
+statement ok
+CREATE TABLE right_table_append_null_build(a INT UNSIGNED, b INT UNSIGNED)
+AS VALUES
+(21, 4),
+(22, 5),
+(23, 6),
+(24, 7),
+(25, 8);
+
+query IIII
+SELECT * FROM (
+    SELECT * from left_table_append_null_build
+) as lhs RIGHT JOIN (
+    SELECT * from right_table_append_null_build
+    ORDER BY b
+) AS rhs ON lhs.b=rhs.b
+----
+NULL NULL 21 4
+13 5 22 5
+14 5 22 5
+NULL NULL 23 6
+NULL NULL 24 7
+NULL NULL 25 8
+
+
+query TT
+EXPLAIN SELECT * FROM (
+    SELECT * from left_table_no_nulls
+) as lhs RIGHT JOIN (
+    SELECT * from right_table_no_nulls
+    ORDER BY b
+) AS rhs ON lhs.b=rhs.b
+----
+logical_plan
+01)Right Join: lhs.b = rhs.b
+02)--SubqueryAlias: lhs
+03)----TableScan: left_table_no_nulls projection=[a, b]
+04)--SubqueryAlias: rhs
+05)----Sort: right_table_no_nulls.b ASC NULLS LAST
+06)------TableScan: right_table_no_nulls projection=[a, b]
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=3
+02)--HashJoinExec: mode=CollectLeft, join_type=Right, on=[(b@1, b@1)]
+03)----MemoryExec: partitions=1, partition_sizes=[1]
+04)----SortExec: expr=[b@1 ASC NULLS LAST], preserve_partitioning=[false]
+05)------MemoryExec: partitions=1, partition_sizes=[1]
+


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

HashJoins can preserve the order of the right input when the join type is right.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`HashJoin` and `NestedLoopJoin` uses `append_right_indices()` method to combine matched and unmatched right results. This method simply appends the unmatched ones on matched ones. However, if we know that right is ordered, we can merge these indices in order to preserve order.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, with an .slt test. Added test would result as:

| 1 | 1 | 3 | 1 |
| --- | --- | --- | --- |
| NULL | NULL | 1 | 0 |

before, which breaks the order.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
