### PR TITLE
Fix data page statistics when all rows are null in a data page

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -635,9 +635,7 @@ macro_rules! get_decimal_page_stats_iterator {
                                 .indexes
                                 .iter()
                                 .map(|x| {
-                                    Some($stat_value_type::from(
-                                        x.$func.unwrap_or_default(),
-                                    ))
+                                    x.$func.and_then(|x| Some($stat_value_type::from(x)))
                                 })
                                 .collect::<Vec<_>>(),
                         ),
@@ -646,9 +644,7 @@ macro_rules! get_decimal_page_stats_iterator {
                                 .indexes
                                 .iter()
                                 .map(|x| {
-                                    Some($stat_value_type::from(
-                                        x.$func.unwrap_or_default(),
-                                    ))
+                                    x.$func.and_then(|x| Some($stat_value_type::from(x)))
                                 })
                                 .collect::<Vec<_>>(),
                         ),
@@ -657,9 +653,9 @@ macro_rules! get_decimal_page_stats_iterator {
                                 .indexes
                                 .iter()
                                 .map(|x| {
-                                    Some($convert_func(
-                                        x.clone().$func.unwrap_or_default().data(),
-                                    ))
+                                    x.clone()
+                                        .$func
+                                        .and_then(|x| Some($convert_func(x.data())))
                                 })
                                 .collect::<Vec<_>>(),
                         ),
@@ -668,9 +664,9 @@ macro_rules! get_decimal_page_stats_iterator {
                                 .indexes
                                 .iter()
                                 .map(|x| {
-                                    Some($convert_func(
-                                        x.clone().$func.unwrap_or_default().data(),
-                                    ))
+                                    x.clone()
+                                        .$func
+                                        .and_then(|x| Some($convert_func(x.data())))
                                 })
                                 .collect::<Vec<_>>(),
                         ),

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -823,7 +823,7 @@ macro_rules! get_data_page_statistics {
                                     x.and_then(|x| from_bytes_to_f16(x.data()))
                                 })
                             })
-                            .flatten().collect::<Vec<_>>()
+                            .flatten()
                     )
                 )),
                 Some(DataType::Float32) => Ok(Arc::new(Float32Array::from_iter([<$stat_type_prefix Float32DataPageStatsIterator>]::new($iterator).flatten()))),

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -601,6 +601,31 @@ make_data_page_stats_iterator!(
     Index::DOUBLE,
     f64
 );
+make_data_page_stats_iterator!(
+    MinByteArrayDataPageStatsIterator,
+    |x: &PageIndex<ByteArray>| { x.min.clone() },
+    Index::BYTE_ARRAY,
+    ByteArray
+);
+make_data_page_stats_iterator!(
+    MaxByteArrayDataPageStatsIterator,
+    |x: &PageIndex<ByteArray>| { x.max.clone() },
+    Index::BYTE_ARRAY,
+    ByteArray
+);
+make_data_page_stats_iterator!(
+    MaxFixedLenByteArrayDataPageStatsIterator,
+    |x: &PageIndex<FixedLenByteArray>| { x.max.clone() },
+    Index::FIXED_LEN_BYTE_ARRAY,
+    FixedLenByteArray
+);
+
+make_data_page_stats_iterator!(
+    MinFixedLenByteArrayDataPageStatsIterator,
+    |x: &PageIndex<FixedLenByteArray>| { x.min.clone() },
+    Index::FIXED_LEN_BYTE_ARRAY,
+    FixedLenByteArray
+);
 
 macro_rules! get_decimal_page_stats_iterator {
     ($iterator_type: ident, $func: ident, $stat_value_type: ident, $convert_func: ident) => {
@@ -709,18 +734,6 @@ get_decimal_page_stats_iterator!(
     max,
     i256,
     from_bytes_to_i256
-);
-make_data_page_stats_iterator!(
-    MinByteArrayDataPageStatsIterator,
-    |x: &PageIndex<ByteArray>| { x.min.clone() },
-    Index::BYTE_ARRAY,
-    ByteArray
-);
-make_data_page_stats_iterator!(
-    MaxByteArrayDataPageStatsIterator,
-    |x: &PageIndex<ByteArray>| { x.max.clone() },
-    Index::BYTE_ARRAY,
-    ByteArray
 );
 
 macro_rules! get_data_page_statistics {
@@ -930,20 +943,6 @@ macro_rules! get_data_page_statistics {
         }
     }
 }
-
-make_data_page_stats_iterator!(
-    MaxFixedLenByteArrayDataPageStatsIterator,
-    |x: &PageIndex<FixedLenByteArray>| { x.max.clone() },
-    Index::FIXED_LEN_BYTE_ARRAY,
-    FixedLenByteArray
-);
-
-make_data_page_stats_iterator!(
-    MinFixedLenByteArrayDataPageStatsIterator,
-    |x: &PageIndex<FixedLenByteArray>| { x.min.clone() },
-    Index::FIXED_LEN_BYTE_ARRAY,
-    FixedLenByteArray
-);
 
 /// Lookups up the parquet column by name
 ///

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -551,7 +551,7 @@ async fn test_data_page_stats_with_all_null_page() {
         DataType::Decimal256(20, 2), // as FIXED_LEN_BYTE_ARRAY
     ] {
         let batch =
-            RecordBatch::try_from_iter(vec![("col", new_null_array(&data_type, 4))])
+            RecordBatch::try_from_iter(vec![("col", new_null_array(data_type, 4))])
                 .expect("record batch creation");
 
         let reader =

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -29,15 +29,15 @@ use arrow::datatypes::{
     TimestampNanosecondType, TimestampSecondType,
 };
 use arrow_array::{
-    make_array, Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Date64Array,
-    Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Float16Array, Float32Array,
-    Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, LargeBinaryArray,
-    LargeStringArray, RecordBatch, StringArray, Time32MillisecondArray,
+    make_array, new_null_array, Array, ArrayRef, BinaryArray, BooleanArray, Date32Array,
+    Date64Array, Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Float16Array,
+    Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+    LargeBinaryArray, LargeStringArray, RecordBatch, StringArray, Time32MillisecondArray,
     Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
     TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
     TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };
-use arrow_schema::{DataType, Field, Schema};
+use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use datafusion::datasource::physical_plan::parquet::StatisticsConverter;
 use half::f16;
 use parquet::arrow::arrow_reader::{
@@ -91,51 +91,60 @@ impl Int64Case {
 
     // Create a parquet file with the specified settings
     pub fn build(&self) -> ParquetRecordBatchReaderBuilder<File> {
-        let mut output_file = tempfile::Builder::new()
-            .prefix("parquert_statistics_test")
-            .suffix(".parquet")
-            .tempfile()
-            .expect("tempfile creation");
-
-        let mut builder =
-            WriterProperties::builder().set_max_row_group_size(self.row_per_group);
-        if let Some(enable_stats) = self.enable_stats {
-            builder = builder.set_statistics_enabled(enable_stats);
-        }
-        if let Some(data_page_row_count_limit) = self.data_page_row_count_limit {
-            builder = builder.set_data_page_row_count_limit(data_page_row_count_limit);
-        }
-        let props = builder.build();
-
         let batches = vec![self.make_int64_batches_with_null()];
+        build_parquet_file(
+            self.row_per_group,
+            self.enable_stats,
+            self.data_page_row_count_limit,
+            batches,
+        )
+    }
+}
 
-        let schema = batches[0].schema();
+fn build_parquet_file(
+    row_per_group: usize,
+    enable_stats: Option<EnabledStatistics>,
+    data_page_row_count_limit: Option<usize>,
+    batches: Vec<RecordBatch>,
+) -> ParquetRecordBatchReaderBuilder<File> {
+    let mut output_file = tempfile::Builder::new()
+        .prefix("parquert_statistics_test")
+        .suffix(".parquet")
+        .tempfile()
+        .expect("tempfile creation");
 
-        let mut writer =
-            ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
+    let mut builder = WriterProperties::builder().set_max_row_group_size(row_per_group);
+    if let Some(enable_stats) = enable_stats {
+        builder = builder.set_statistics_enabled(enable_stats);
+    }
+    if let Some(data_page_row_count_limit) = data_page_row_count_limit {
+        builder = builder.set_data_page_row_count_limit(data_page_row_count_limit);
+    }
+    let props = builder.build();
 
-        // if we have a datapage limit send the batches in one at a time to give
-        // the writer a chance to be split into multiple pages
-        if self.data_page_row_count_limit.is_some() {
-            for batch in batches {
-                for i in 0..batch.num_rows() {
-                    writer.write(&batch.slice(i, 1)).expect("writing batch");
-                }
-            }
-        } else {
-            for batch in batches {
-                writer.write(&batch).expect("writing batch");
+    let schema = batches[0].schema();
+
+    let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
+
+    // if we have a datapage limit send the batches in one at a time to give
+    // the writer a chance to be split into multiple pages
+    if data_page_row_count_limit.is_some() {
+        for batch in &batches {
+            for i in 0..batch.num_rows() {
+                writer.write(&batch.slice(i, 1)).expect("writing batch");
             }
         }
-
-        // close file
-        let _file_meta = writer.close().unwrap();
-
-        // open the file & get the reader
-        let file = output_file.reopen().unwrap();
-        let options = ArrowReaderOptions::new().with_page_index(true);
-        ArrowReaderBuilder::try_new_with_options(file, options).unwrap()
+    } else {
+        for batch in &batches {
+            writer.write(batch).expect("writing batch");
+        }
     }
+
+    let _file_meta = writer.close().unwrap();
+
+    let file = output_file.reopen().unwrap();
+    let options = ArrowReaderOptions::new().with_page_index(true);
+    ArrowReaderBuilder::try_new_with_options(file, options).unwrap()
 }
 
 /// Defines what data to create in a parquet file
@@ -501,6 +510,62 @@ async fn test_multiple_data_pages_nulls_and_negatives() {
         check: Check::DataPage,
     }
     .run()
+}
+
+#[tokio::test]
+async fn test_data_page_stats_with_all_null_page() {
+    for data_type in &[
+        DataType::Boolean,
+        DataType::UInt64,
+        DataType::UInt32,
+        DataType::UInt16,
+        DataType::UInt8,
+        DataType::Int64,
+        DataType::Int32,
+        DataType::Int16,
+        DataType::Int8,
+        DataType::Float16,
+        DataType::Float32,
+        DataType::Float64,
+        DataType::Date32,
+        DataType::Date64,
+        DataType::Time32(TimeUnit::Millisecond),
+        DataType::Time32(TimeUnit::Second),
+        DataType::Time64(TimeUnit::Microsecond),
+        DataType::Time64(TimeUnit::Nanosecond),
+        DataType::Timestamp(TimeUnit::Second, None),
+        DataType::Timestamp(TimeUnit::Millisecond, None),
+        DataType::Timestamp(TimeUnit::Microsecond, None),
+        DataType::Timestamp(TimeUnit::Nanosecond, None),
+        DataType::Binary,
+        DataType::LargeBinary,
+        // DataType::FixedSizeBinary(3),
+        DataType::Utf8,
+        DataType::LargeUtf8,
+        // DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+        // DataType::Decimal128(10, 2),
+        // DataType::Decimal256(10, 2),
+    ] {
+        let batch =
+            RecordBatch::try_from_iter(vec![("col", new_null_array(&data_type, 4))])
+                .expect("record batch creation");
+
+        let reader =
+            build_parquet_file(4, Some(EnabledStatistics::Page), Some(4), vec![batch]);
+        
+        // There is one data page with 4 nulls
+        // The statistics should be present but null
+        Test {
+            reader: &reader,
+            expected_min: new_null_array(data_type, 1),
+            expected_max: new_null_array(data_type, 1),
+            expected_null_counts: UInt64Array::from(vec![4]),
+            expected_row_counts: Some(UInt64Array::from(vec![4])),
+            column_name: "col",
+            check: Check::DataPage,
+        }
+        .run()
+    }
 }
 
 /////////////// MORE GENERAL TESTS //////////////////////

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -539,7 +539,7 @@ async fn test_data_page_stats_with_all_null_page() {
         DataType::Timestamp(TimeUnit::Nanosecond, None),
         DataType::Binary,
         DataType::LargeBinary,
-        // DataType::FixedSizeBinary(3),
+        DataType::FixedSizeBinary(3),
         DataType::Utf8,
         DataType::LargeUtf8,
         // DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
@@ -552,7 +552,7 @@ async fn test_data_page_stats_with_all_null_page() {
 
         let reader =
             build_parquet_file(4, Some(EnabledStatistics::Page), Some(4), vec![batch]);
-        
+
         // There is one data page with 4 nulls
         // The statistics should be present but null
         Test {

--- a/datafusion/core/tests/parquet/arrow_statistics.rs
+++ b/datafusion/core/tests/parquet/arrow_statistics.rs
@@ -543,8 +543,12 @@ async fn test_data_page_stats_with_all_null_page() {
         DataType::Utf8,
         DataType::LargeUtf8,
         DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-        // DataType::Decimal128(10, 2),
-        // DataType::Decimal256(10, 2),
+        DataType::Decimal128(8, 2),  // as INT32
+        DataType::Decimal128(10, 2), // as INT64
+        DataType::Decimal128(20, 2), // as FIXED_LEN_BYTE_ARRAY
+        DataType::Decimal256(8, 2),  // as INT32
+        DataType::Decimal256(10, 2), // as INT64
+        DataType::Decimal256(20, 2), // as FIXED_LEN_BYTE_ARRAY
     ] {
         let batch =
             RecordBatch::try_from_iter(vec![("col", new_null_array(&data_type, 4))])
@@ -552,7 +556,7 @@ async fn test_data_page_stats_with_all_null_page() {
 
         let reader =
             build_parquet_file(4, Some(EnabledStatistics::Page), Some(4), vec![batch]);
-        
+
         let expected_data_type = match data_type {
             DataType::Dictionary(_, value_type) => value_type.as_ref(),
             _ => data_type,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11280.

## Rationale for this change

When all rows for a data page are null the min and max statistics should be present but null. Some of the data page statistics iterators were incorrectly omitting statistics rather than setting them to null. This results in an array whose length is different from the number of data pages. 

## What changes are included in this PR?

Adds test for data page statistics for all data types when all rows in a data page are null. Fixes data page statistics iterators that fail these tests. 

## Are these changes tested?

Yes.

## Are there any user-facing changes?
No.
