### PR TITLE
Remove any aliases in `Filter::try_new` rather than erroring

### DIFF
--- a/datafusion/core/tests/user_defined/user_defined_sql_planner.rs
+++ b/datafusion/core/tests/user_defined/user_defined_sql_planner.rs
@@ -24,6 +24,8 @@ use datafusion::execution::FunctionRegistry;
 use datafusion::logical_expr::Operator;
 use datafusion::prelude::*;
 use datafusion::sql::sqlparser::ast::BinaryOperator;
+use datafusion_common::ScalarValue;
+use datafusion_expr::expr::Alias;
 use datafusion_expr::planner::{PlannerResult, RawBinaryExpr, UserDefinedSQLPlanner};
 use datafusion_expr::BinaryExpr;
 
@@ -50,13 +52,22 @@ impl UserDefinedSQLPlanner for MyCustomPlanner {
                     op: Operator::Plus,
                 })))
             }
+            BinaryOperator::Question => {
+                Ok(PlannerResult::Planned(Expr::Alias(Alias::new(
+                    Expr::Literal(ScalarValue::Boolean(Some(true))),
+                    None::<&str>,
+                    format!("{} ? {}", expr.left, expr.right),
+                ))))
+            }
             _ => Ok(PlannerResult::Original(expr)),
         }
     }
 }
 
 async fn plan_and_collect(sql: &str) -> Result<Vec<RecordBatch>> {
-    let mut ctx = SessionContext::new();
+    let config =
+        SessionConfig::new().set_str("datafusion.sql_parser.dialect", "postgres");
+    let mut ctx = SessionContext::new_with_config(config);
     ctx.register_user_defined_sql_planner(Arc::new(MyCustomPlanner))?;
     ctx.sql(sql).await?.collect().await
 }
@@ -84,5 +95,29 @@ async fn test_custom_operators_long_arrow() {
         "| 3                   |",
         "+---------------------+",
     ];
+    assert_batches_eq!(&expected, &actual);
+}
+
+#[tokio::test]
+async fn test_question_sekect() {
+    let actual = plan_and_collect("select a ? 2 from (select 1 as a);")
+        .await
+        .unwrap();
+    let expected = [
+        "+--------------+",
+        "| a ? Int64(2) |",
+        "+--------------+",
+        "| true         |",
+        "+--------------+",
+    ];
+    assert_batches_eq!(&expected, &actual);
+}
+
+#[tokio::test]
+async fn test_question_filter() {
+    let actual = plan_and_collect("select a from (select 1 as a) where a ? 2;")
+        .await
+        .unwrap();
+    let expected = ["+---+", "| a |", "+---+", "| 1 |", "+---+"];
     assert_batches_eq!(&expected, &actual);
 }

--- a/datafusion/core/tests/user_defined/user_defined_sql_planner.rs
+++ b/datafusion/core/tests/user_defined/user_defined_sql_planner.rs
@@ -99,7 +99,7 @@ async fn test_custom_operators_long_arrow() {
 }
 
 #[tokio::test]
-async fn test_question_sekect() {
+async fn test_question_select() {
     let actual = plan_and_collect("select a ? 2 from (select 1 as a);")
         .await
         .unwrap();

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2130,7 +2130,10 @@ impl Filter {
             }
         }
 
-        Ok(Self { predicate, input })
+        Ok(Self {
+            predicate: predicate.unalias(),
+            input,
+        })
     }
 
     /// Is this filter guaranteed to return 0 or 1 row in a given instantiation?

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2131,7 +2131,7 @@ impl Filter {
         }
 
         Ok(Self {
-            predicate: predicate.unalias(),
+            predicate: predicate.unalias_nested().data,
             input,
         })
     }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use super::dml::CopyTo;
 use super::DdlStatement;
 use crate::builder::{change_redundant_column, unnest_with_options};
-use crate::expr::{Alias, Placeholder, Sort as SortExpr, WindowFunction};
+use crate::expr::{Placeholder, Sort as SortExpr, WindowFunction};
 use crate::expr_rewriter::{create_col_from_scalar_expr, normalize_cols};
 use crate::logical_plan::display::{GraphvizVisitor, IndentVisitor};
 use crate::logical_plan::extension::UserDefinedLogicalNode;
@@ -2128,15 +2128,6 @@ impl Filter {
                     "Cannot create filter with non-boolean predicate '{predicate}' returning {predicate_type}"
                 );
             }
-        }
-
-        // filter predicates should not be aliased
-        if let Expr::Alias(Alias { expr, name, .. }) = predicate {
-            return plan_err!(
-                "Attempted to create Filter predicate with \
-                expression `{expr}` aliased as '{name}'. Filter predicates should not be \
-                aliased."
-            );
         }
 
         Ok(Self { predicate, input })


### PR DESCRIPTION
## Which issue does this PR close?

fix #11306.

## Rationale for this change

See https://github.com/datafusion-contrib/datafusion-functions-json/pull/26 and #11306

## What changes are included in this PR?

Remove the block on aliases as prediates, add test.

## Are these changes tested?

Yes, the only way I could get a failure without this change.

## Are there any user-facing changes?

AFAIK, we just allow something that should be allowed.

**NOTE:** Aliases were already allowed in binary expressions, just not as full predicates, so this restriction seemed unusually strict. Also the SQL parser wouldn't allow me to build such an expression directly in SQL, e.g. `from x where (y = z) as the_alias` was invalid SQL.
