### PR TITLE
minor: Add `PhysicalSortExpr::new`

### DIFF
--- a/datafusion/physical-expr-common/src/sort_expr.rs
+++ b/datafusion/physical-expr-common/src/sort_expr.rs
@@ -40,8 +40,9 @@ pub struct PhysicalSortExpr {
 }
 
 impl PhysicalSortExpr {
+    /// Create a new PhysicalSortExpr
     pub fn new(expr: Arc<dyn PhysicalExpr>, options: SortOptions) -> Self {
-        Self {expr, options }
+        Self { expr, options }
     }
 }
 
@@ -161,10 +162,7 @@ impl From<PhysicalSortRequirement> for PhysicalSortExpr {
             descending: false,
             nulls_first: false,
         });
-        PhysicalSortExpr {
-            expr: value.expr,
-            options,
-        }
+        PhysicalSortExpr::new(value.expr, options)
     }
 }
 
@@ -287,16 +285,13 @@ pub fn limited_convert_logical_sort_exprs_to_physical(
         let Expr::Sort(sort) = expr else {
             return exec_err!("Expects to receive sort expression");
         };
-        sort_exprs.push(PhysicalSortExpr {
-            expr: limited_convert_logical_expr_to_physical_expr(
-                sort.expr.as_ref(),
-                schema,
-            )?,
-            options: SortOptions {
+        sort_exprs.push(PhysicalSortExpr::new(
+            limited_convert_logical_expr_to_physical_expr(sort.expr.as_ref(), schema)?,
+            SortOptions {
                 descending: !sort.asc,
                 nulls_first: sort.nulls_first,
             },
-        });
+        ))
     }
     Ok(sort_exprs)
 }

--- a/datafusion/physical-expr-common/src/sort_expr.rs
+++ b/datafusion/physical-expr-common/src/sort_expr.rs
@@ -39,6 +39,12 @@ pub struct PhysicalSortExpr {
     pub options: SortOptions,
 }
 
+impl PhysicalSortExpr {
+    pub fn new(expr: Arc<dyn PhysicalExpr>, options: SortOptions) -> Self {
+        Self {expr, options }
+    }
+}
+
 impl PartialEq for PhysicalSortExpr {
     fn eq(&self, other: &PhysicalSortExpr) -> bool {
         self.options == other.options && self.expr.eq(&other.expr)

--- a/datafusion/physical-expr-common/src/utils.rs
+++ b/datafusion/physical-expr-common/src/utils.rs
@@ -104,10 +104,7 @@ pub fn scatter(mask: &BooleanArray, truthy: &dyn Array) -> Result<ArrayRef> {
 pub fn reverse_order_bys(order_bys: &[PhysicalSortExpr]) -> Vec<PhysicalSortExpr> {
     order_bys
         .iter()
-        .map(|e| PhysicalSortExpr {
-            expr: e.expr.clone(),
-            options: !e.options,
-        })
+        .map(|e| PhysicalSortExpr::new(e.expr.clone(), !e.options))
         .collect()
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I am working on some perf tests where I manually construct physical plans and noticed that in most cases we can use `new` or `try_new` for creating physical expressions, but this was not possible for `PhysicalSortExpr`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add a constructor
- Update call sites in the same crate to use the new constructor

I did not think that it would be a good use of my time to update the other 291 cases where we create this struct.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
