### PR TITLE
Improve stats convert performance for Binary/String/Boolean arrays

### DIFF
--- a/datafusion/core/benches/parquet_statistic.rs
+++ b/datafusion/core/benches/parquet_statistic.rs
@@ -198,7 +198,9 @@ fn make_dict_batch() -> RecordBatch {
 fn criterion_benchmark(c: &mut Criterion) {
     let row_groups = 100;
     use TestTypes::*;
-    let types = vec![Int64, UInt64, F64, String, Dictionary];
+    // let types = vec![Int64, UInt64, F64, String, Dictionary];
+    // let types = vec![String];
+    let types = vec![UInt64];
     let data_page_row_count_limits = vec![None, Some(1)];
 
     for dtype in types {

--- a/datafusion/core/benches/parquet_statistic.rs
+++ b/datafusion/core/benches/parquet_statistic.rs
@@ -198,9 +198,7 @@ fn make_dict_batch() -> RecordBatch {
 fn criterion_benchmark(c: &mut Criterion) {
     let row_groups = 100;
     use TestTypes::*;
-    // let types = vec![Int64, UInt64, F64, String, Dictionary];
-    // let types = vec![String];
-    let types = vec![String];
+    let types = vec![Int64, UInt64, F64, String, Dictionary];
     let data_page_row_count_limits = vec![None, Some(1)];
 
     for dtype in types {
@@ -217,8 +215,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             let statistic_type = if data_page_row_count_limit.is_some() {
                 "data page"
             } else {
-                // "row group"
-                continue;
+                "row group"
             };
 
             let mut group = c.benchmark_group(format!(

--- a/datafusion/core/benches/parquet_statistic.rs
+++ b/datafusion/core/benches/parquet_statistic.rs
@@ -200,7 +200,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     use TestTypes::*;
     // let types = vec![Int64, UInt64, F64, String, Dictionary];
     // let types = vec![String];
-    let types = vec![UInt64];
+    let types = vec![String];
     let data_page_row_count_limits = vec![None, Some(1)];
 
     for dtype in types {
@@ -217,7 +217,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             let statistic_type = if data_page_row_count_limit.is_some() {
                 "data page"
             } else {
-                "row group"
+                // "row group"
+                continue;
             };
 
             let mut group = c.benchmark_group(format!(

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -1033,7 +1033,7 @@ where
     get_data_page_statistics!(Min, data_type, iterator)
 }
 
-/// Extracts the min statistics from an iterator
+/// Extracts the max statistics from an iterator
 /// of parquet page [`Index`]'es to an [`ArrayRef`]
 pub(crate) fn max_page_statistics<'a, I>(
     data_type: Option<&DataType>,

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -19,7 +19,9 @@
 
 // TODO: potentially move this to arrow-rs: https://github.com/apache/arrow-rs/issues/4328
 
-use arrow::array::{FixedSizeBinaryBuilder, LargeStringBuilder, StringBuilder};
+use arrow::array::{
+    BooleanBuilder, FixedSizeBinaryBuilder, LargeStringBuilder, StringBuilder,
+};
 use arrow::datatypes::i256;
 use arrow::{array::ArrayRef, datatypes::DataType};
 use arrow_array::{

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -889,22 +889,20 @@ macro_rules! get_data_page_statistics {
                         },
                         "use_builder" => {
                             let mut builder = StringBuilder::new();
-                            let iterator = [<$stat_type_prefix ByteArrayDataPageStatsIterator>]::new($iterator);
+                            let iterator = [<$stat_type_prefix ByteArrayDataPageStatsIterator>]::new($iterator).flatten();
                             for x in iterator {
-                                for x in x.into_iter() {
-                                    let Some(x) = x else {
-                                        builder.append_null(); // no statistics value
-                                        continue;
-                                    };
-        
-                                    let Ok(x) = std::str::from_utf8(x.data()) else {
-                                        log::debug!("Utf8 statistics is a non-UTF8 value, ignoring it.");
-                                        builder.append_null();
-                                        continue;
-                                    };
-        
-                                    builder.append_value(x);
-                                }
+                                let Some(x) = x else {
+                                    builder.append_null(); // no statistics value
+                                    continue;
+                                };
+    
+                                let Ok(x) = std::str::from_utf8(x.data()) else {
+                                    log::debug!("Utf8 statistics is a non-UTF8 value, ignoring it.");
+                                    builder.append_null();
+                                    continue;
+                                };
+    
+                                builder.append_value(x);
                             }
                             Ok(Arc::new(builder.finish()))
                         },

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -445,17 +445,18 @@ macro_rules! get_statistics {
                         continue;
                     };
 
+                    // ignore invalid values
                     if x.len().try_into() != Ok(*size){
                         log::debug!(
                             "FixedSizeBinary({}) statistics is a binary of size {}, ignoring it.",
                             size,
                             x.len(),
                         );
-                        builder.append_null(); // no statistics value
+                        builder.append_null();
                         continue;
                     }
 
-                    let _ = builder.append_value(x);
+                    builder.append_value(x).expect("ensure to append successfully here, because size have been checked before");
                 }
                 Ok(Arc::new(builder.finish()))
             }

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -19,6 +19,7 @@
 
 // TODO: potentially move this to arrow-rs: https://github.com/apache/arrow-rs/issues/4328
 
+use arrow::array::{StringBuilder, UInt64Builder};
 use arrow::datatypes::i256;
 use arrow::{array::ArrayRef, datatypes::DataType};
 use arrow_array::{
@@ -785,16 +786,49 @@ macro_rules! get_data_page_statistics {
                             })
                             .flatten()
                 ))),
-                Some(DataType::UInt64) => Ok(Arc::new(
-                    UInt64Array::from_iter(
-                        [<$stat_type_prefix Int64DataPageStatsIterator>]::new($iterator)
+                // Some(DataType::UInt64) => Ok(Arc::new(
+                //     UInt64Array::from_iter(
+                //         [<$stat_type_prefix Int64DataPageStatsIterator>]::new($iterator)
+                //             .map(|x| {
+                //                 x.into_iter().map(|x| {
+                //                     x.and_then(|x| Some(x as u64))
+                //                 })
+                //             })
+                //             .flatten()
+                // ))),
+
+                // Some(DataType::UInt64) => {
+                //     let iterator = [<$stat_type_prefix Int64DataPageStatsIterator>]::new($iterator)
+                //             .map(|x| {
+                //                 x.into_iter().map(|x| {
+                //                     x.and_then(|x| Some(x as u64))
+                //                 })
+                //             })
+                //             .flatten();
+                //     let mut builder = UInt64Builder::with_capacity(512);
+                //     // let mut builder = UInt64Builder::new();
+                //     for x in iterator {
+                //         let Some(x) = x else {
+                //             builder.append_null();
+                //             continue;
+                //         };
+                //         builder.append_value(x as u64);
+                //     }
+                //     Ok(Arc::new(builder.finish()))
+                // },
+
+                Some(DataType::UInt64) => {
+                    let iterator = [<$stat_type_prefix Int64DataPageStatsIterator>]::new($iterator)
                             .map(|x| {
-                                x.into_iter().filter_map(|x| {
+                                x.into_iter().map(|x| {
                                     x.and_then(|x| Some(x as u64))
                                 })
                             })
-                            .flatten()
-                ))),
+                            .flatten();
+                    let mut builder = UInt64Builder::with_capacity(512);
+                    builder.extend(iterator);
+                    Ok(Arc::new(builder.finish()))
+                },
                 Some(DataType::Int8) => Ok(Arc::new(
                     Int8Array::from_iter(
                         [<$stat_type_prefix Int32DataPageStatsIterator>]::new($iterator)
@@ -834,19 +868,54 @@ macro_rules! get_data_page_statistics {
                 Some(DataType::Float64) => Ok(Arc::new(Float64Array::from_iter([<$stat_type_prefix Float64DataPageStatsIterator>]::new($iterator).flatten()))),
                 Some(DataType::Binary) => Ok(Arc::new(BinaryArray::from_iter([<$stat_type_prefix ByteArrayDataPageStatsIterator>]::new($iterator).flatten()))),
                 Some(DataType::LargeBinary) => Ok(Arc::new(LargeBinaryArray::from_iter([<$stat_type_prefix ByteArrayDataPageStatsIterator>]::new($iterator).flatten()))),
-                Some(DataType::Utf8) => Ok(Arc::new(StringArray::from(
-                    [<$stat_type_prefix ByteArrayDataPageStatsIterator>]::new($iterator).map(|x| {
-                        x.into_iter().filter_map(|x| {
-                        x.and_then(|x| {
-                            let res = std::str::from_utf8(x.data()).map(|s| s.to_string()).ok();
-                            if res.is_none() {
+                // Some(DataType::Utf8) => Ok(Arc::new(StringArray::from_iter(
+                //     [<$stat_type_prefix ByteArrayDataPageStatsIterator>]::new($iterator).map(|x| {
+                //         x.into_iter().map(|x| {
+                //         x.and_then(|x| {
+                //             let res = std::str::from_utf8(x.data()).map(|s| s.to_string()).ok();
+                //             if res.is_none() {
+                //                 log::debug!("Utf8 statistics is a non-UTF8 value, ignoring it.");
+                //             }
+                //             res
+                //         })
+                //     })
+                //     }).flatten(),
+                // ))),
+                Some(DataType::Utf8) => {
+                    let mut builder = StringBuilder::new();
+                    let iterator = [<$stat_type_prefix ByteArrayDataPageStatsIterator>]::new($iterator);
+                    for x in iterator {
+                        for x in x.into_iter() {
+                            let Some(x) = x else {
+                                builder.append_null(); // no statistics value
+                                continue;
+                            };
+
+                            let Ok(x) = std::str::from_utf8(x.data()) else {
                                 log::debug!("Utf8 statistics is a non-UTF8 value, ignoring it.");
-                            }
-                            res
-                        })
-                    })
-                    }).flatten().collect::<Vec<_>>(),
-                ))),
+                                builder.append_null();
+                                continue;
+                            };
+
+                            builder.append_value(x);
+                        }
+                    }
+                    Ok(Arc::new(builder.finish()))
+                },
+                // Some(DataType::Utf8) => Ok(Arc::new(StringArray::from(
+                //     [<$stat_type_prefix ByteArrayDataPageStatsIterator>]::new($iterator).map(|x| {
+                //         x.into_iter().map(|x| {
+                //         x.and_then(|x| {
+                //             let res = std::str::from_utf8(x.data()).map(|s| s.to_string()).ok();
+                //             if res.is_none() {
+                //                 log::debug!("Utf8 statistics is a non-UTF8 value, ignoring it.");
+                //             }
+                //             res
+                //         })
+                //     })
+                //     }).flatten().collect::<Vec<_>>(),
+                // ))),
+
                 Some(DataType::LargeUtf8) => Ok(Arc::new(LargeStringArray::from(
                     [<$stat_type_prefix ByteArrayDataPageStatsIterator>]::new($iterator).map(|x| {
                         x.into_iter().filter_map(|x| {
@@ -994,7 +1063,7 @@ where
     get_data_page_statistics!(Min, data_type, iterator)
 }
 
-/// Extracts the max statistics from an iterator
+/// Extracts the min statistics from an iterator
 /// of parquet page [`Index`]'es to an [`ArrayRef`]
 pub(crate) fn max_page_statistics<'a, I>(
     data_type: Option<&DataType>,
@@ -1005,6 +1074,219 @@ where
 {
     get_data_page_statistics!(Max, data_type, iterator)
 }
+
+/// Extracts the max statistics from an iterator
+/// of parquet page [`Index`]'es to an [`ArrayRef`]
+// pub(crate) fn max_page_statistics<'a, I>(
+//     data_type: Option<&DataType>,
+//     iterator: I,
+// ) -> Result<ArrayRef>
+// where
+//     I: Iterator<Item = (usize, &'a Index)>,
+// {
+//     match data_type {
+//         Some(DataType::Boolean) => Ok(Arc::new(BooleanArray::from_iter(
+//             MaxBooleanDataPageStatsIterator::new(iterator)
+//                 .flatten()
+//                 .collect::<Vec<_>>()
+//                 .into_iter(),
+//         ))),
+//         Some(DataType::UInt8) => Ok(Arc::new(UInt8Array::from_iter(
+//             MaxInt32DataPageStatsIterator::new(iterator)
+//                 .map(|x| {
+//                     x.into_iter()
+//                         .filter_map(|x| x.and_then(|x| u8::try_from(x).ok()))
+//                 })
+//                 .flatten(),
+//         ))),
+//         Some(DataType::UInt16) => Ok(Arc::new(UInt16Array::from_iter(
+//             MaxInt32DataPageStatsIterator::new(iterator)
+//                 .map(|x| {
+//                     x.into_iter()
+//                         .filter_map(|x| x.and_then(|x| u16::try_from(x).ok()))
+//                 })
+//                 .flatten(),
+//         ))),
+//         Some(DataType::UInt32) => Ok(Arc::new(UInt32Array::from_iter(
+//             MaxInt32DataPageStatsIterator::new(iterator)
+//                 .map(|x| x.into_iter().filter_map(|x| x.and_then(|x| Some(x as u32))))
+//                 .flatten(),
+//         ))),
+//         // Some(DataType::UInt64) => Ok(Arc::new(UInt64Array::from_iter(
+//         //     MaxInt64DataPageStatsIterator::new(iterator)
+//         //         .map(|x| x.into_iter().filter_map(|x| x.and_then(|x| Some(x as u64))))
+//         //         .flatten(),
+//         // ))),
+//         Some(DataType::UInt64) => {
+//             let mut builder = UInt64Builder::new();
+//             let iterator = MaxInt64DataPageStatsIterator::new(iterator);
+//             builder.extend(iterator);
+//             for x in iterator {
+//                 for x in x.into_iter() {
+//                     let Some(x) = x else {
+//                         builder.append_null();
+//                         continue;
+//                     };
+//                     builder.append_value(x);
+//                 }
+//             }
+//         }
+//         Some(DataType::Int8) => Ok(Arc::new(Int8Array::from_iter(
+//             MaxInt32DataPageStatsIterator::new(iterator)
+//                 .map(|x| {
+//                     x.into_iter()
+//                         .filter_map(|x| x.and_then(|x| i8::try_from(x).ok()))
+//                 })
+//                 .flatten(),
+//         ))),
+//         Some(DataType::Int16) => Ok(Arc::new(Int16Array::from_iter(
+//             MaxInt32DataPageStatsIterator::new(iterator)
+//                 .map(|x| {
+//                     x.into_iter()
+//                         .filter_map(|x| x.and_then(|x| i16::try_from(x).ok()))
+//                 })
+//                 .flatten(),
+//         ))),
+//         Some(DataType::Int32) => Ok(Arc::new(Int32Array::from_iter(
+//             MaxInt32DataPageStatsIterator::new(iterator).flatten(),
+//         ))),
+//         Some(DataType::Int64) => Ok(Arc::new(Int64Array::from_iter(
+//             MaxInt64DataPageStatsIterator::new(iterator).flatten(),
+//         ))),
+//         Some(DataType::Float16) => Ok(Arc::new(Float16Array::from_iter(
+//             MaxFloat16DataPageStatsIterator::new(iterator)
+//                 .map(|x| {
+//                     x.into_iter()
+//                         .filter_map(|x| x.and_then(|x| Some(from_bytes_to_f16(x.data()))))
+//                 })
+//                 .flatten(),
+//         ))),
+//         Some(DataType::Float32) => Ok(Arc::new(Float32Array::from_iter(
+//             MaxFloat32DataPageStatsIterator::new(iterator).flatten(),
+//         ))),
+//         Some(DataType::Float64) => Ok(Arc::new(Float64Array::from_iter(
+//             MaxFloat64DataPageStatsIterator::new(iterator).flatten(),
+//         ))),
+//         Some(DataType::Binary) => Ok(Arc::new(BinaryArray::from_iter(
+//             MaxByteArrayDataPageStatsIterator::new(iterator).flatten(),
+//         ))),
+//         Some(DataType::LargeBinary) => Ok(Arc::new(LargeBinaryArray::from_iter(
+//             MaxByteArrayDataPageStatsIterator::new(iterator).flatten(),
+//         ))),
+//         Some(DataType::Utf8) => {
+//             Ok(Arc::new(StringArray::from_iter(
+//                 MaxByteArrayDataPageStatsIterator::new(iterator)
+//                     .map(|x| {
+//                         x.into_iter().map(|x| {
+//                             x.and_then(|x|{
+//                                 let res = std::str::from_utf8(x.data()).map(|s|s.to_string()).ok();
+//                                 if res.is_none() {
+//                                     log::debug!("Utf8 statistics is a non-UTF8 value, ignoring it.");
+//                                 }
+//                                 res
+//                             })
+//                         })
+//                     })
+//                     .flatten(),
+//             )))
+//         }
+//         Some(DataType::LargeUtf8) => Ok(Arc::new(LargeStringArray::from(
+//             MaxByteArrayDataPageStatsIterator::new(iterator)
+//                 .map(|x| {
+//                     x.into_iter().filter_map(|x| {
+//                         x.and_then(|x|{
+//                 let res = std::str::from_utf8(x.data()).map(|s|s.to_string()).ok();
+//                 if res.is_none(){
+//                     log::debug!("LargeUtf8 statistics is a non-UTF8 value, ignoring it.");
+//                 }res
+//             })
+//                     })
+//                 })
+//                 .flatten()
+//                 .collect::<Vec<_>>(),
+//         ))),
+//         Some(DataType::Dictionary(_, value_type)) => {
+//             max_page_statistics(Some(value_type), iterator)
+//         }
+//         Some(DataType::Timestamp(unit, timezone)) => {
+//             let iter = MaxInt64DataPageStatsIterator::new(iterator).flatten();
+//             Ok(match unit {
+//                 TimeUnit::Second => Arc::new(
+//                     TimestampSecondArray::from_iter(iter)
+//                         .with_timezone_opt(timezone.clone()),
+//                 ),
+//                 TimeUnit::Millisecond => Arc::new(
+//                     TimestampMillisecondArray::from_iter(iter)
+//                         .with_timezone_opt(timezone.clone()),
+//                 ),
+//                 TimeUnit::Microsecond => Arc::new(
+//                     TimestampMicrosecondArray::from_iter(iter)
+//                         .with_timezone_opt(timezone.clone()),
+//                 ),
+//                 TimeUnit::Nanosecond => Arc::new(
+//                     TimestampNanosecondArray::from_iter(iter)
+//                         .with_timezone_opt(timezone.clone()),
+//                 ),
+//             })
+//         }
+//         Some(DataType::Date32) => Ok(Arc::new(Date32Array::from_iter(
+//             MaxInt32DataPageStatsIterator::new(iterator).flatten(),
+//         ))),
+//         Some(DataType::Date64) => Ok(Arc::new(Date64Array::from(
+//             MaxInt32DataPageStatsIterator::new(iterator)
+//                 .map(|x| {
+//                     x.into_iter()
+//                         .filter_map(|x| x.and_then(|x| i64::try_from(x).ok()))
+//                         .map(|x| x * 24 * 60 * 60 * 1000)
+//                 })
+//                 .flatten()
+//                 .collect::<Vec<_>>(),
+//         ))),
+//         Some(DataType::Decimal128(precision, scale)) => Ok(Arc::new(
+//             Decimal128Array::from_iter(
+//                 MaxDecimal128DataPageStatsIterator::new(iterator).flatten(),
+//             )
+//             .with_precision_and_scale(*precision, *scale)?,
+//         )),
+//         Some(DataType::Decimal256(precision, scale)) => Ok(Arc::new(
+//             Decimal256Array::from_iter(
+//                 MaxDecimal256DataPageStatsIterator::new(iterator).flatten(),
+//             )
+//             .with_precision_and_scale(*precision, *scale)?,
+//         )),
+//         Some(DataType::Time32(unit)) => Ok(match unit {
+//             TimeUnit::Second => Arc::new(Time32SecondArray::from_iter(
+//                 MaxInt32DataPageStatsIterator::new(iterator).flatten(),
+//             )),
+//             TimeUnit::Millisecond => Arc::new(Time32MillisecondArray::from_iter(
+//                 MaxInt32DataPageStatsIterator::new(iterator).flatten(),
+//             )),
+//             _ => new_empty_array(&DataType::Time32(unit.clone())),
+//         }),
+//         Some(DataType::Time64(unit)) => Ok(match unit {
+//             TimeUnit::Microsecond => Arc::new(Time64MicrosecondArray::from_iter(
+//                 MaxInt64DataPageStatsIterator::new(iterator).flatten(),
+//             )),
+//             TimeUnit::Nanosecond => Arc::new(Time64NanosecondArray::from_iter(
+//                 MaxInt64DataPageStatsIterator::new(iterator).flatten(),
+//             )),
+//             _ => new_empty_array(&DataType::Time64(unit.clone())),
+//         }),
+//         Some(DataType::FixedSizeBinary(size)) => Ok(Arc::new(
+//             FixedSizeBinaryArray::try_from_iter(
+//                 MaxFixedLenByteArrayDataPageStatsIterator::new(iterator)
+//                     .flat_map(|x| x.into_iter())
+//                     .filter_map(|x| x),
+//             )
+//             .unwrap_or_else(|e| {
+//                 log::debug!("FixedSizeBinary statistics is invalid: {}", e);
+//                 FixedSizeBinaryArray::new(*size, vec![].into(), None)
+//             }),
+//         )),
+//         _ => unimplemented!(),
+//     }
+// }
+
 
 /// Extracts the null count statistics from an iterator
 /// of parquet page [`Index`]'es to an [`ArrayRef`]

--- a/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/statistics.rs
@@ -19,7 +19,7 @@
 
 // TODO: potentially move this to arrow-rs: https://github.com/apache/arrow-rs/issues/4328
 
-use arrow::array::{LargeStringBuilder, StringBuilder};
+use arrow::array::{FixedSizeBinaryBuilder, LargeStringBuilder, StringBuilder};
 use arrow::datatypes::i256;
 use arrow::{array::ArrayRef, datatypes::DataType};
 use arrow_array::{
@@ -435,47 +435,31 @@ macro_rules! get_statistics {
                     builder.append_value(x);
                 }
                 Ok(Arc::new(builder.finish()))
-            }
-            // DataType::FixedSizeBinary(size) => {
-            //     let iterator = MaxFixedLenByteArrayStatsIterator::new($iterator);
-            //     let mut builder = FixedSizeBinaryBuilder::new(*size);
-            //     for x in iterator {
-            //         let Some(x) = x else {
-            //             builder.append_null(); // no statistics value
-            //             continue;
-            //         };
+            },
+            DataType::FixedSizeBinary(size) => {
+                let iterator = [<$stat_type_prefix FixedLenByteArrayStatsIterator>]::new($iterator);
+                let mut builder = FixedSizeBinaryBuilder::new(*size);
+                for x in iterator {
+                    let Some(x) = x else {
+                        builder.append_null(); // no statistics value
+                        continue;
+                    };
 
-            //         // ignore invalid values
-            //         if x.len().try_into() != Ok(*size){
-            //             log::debug!(
-            //                 "FixedSizeBinary({}) statistics is a binary of size {}, ignoring it.",
-            //                 size,
-            //                 x.len(),
-            //             );
-            //             builder.append_null();
-            //             continue;
-            //         }
+                    // ignore invalid values
+                    if x.len().try_into() != Ok(*size){
+                        log::debug!(
+                            "FixedSizeBinary({}) statistics is a binary of size {}, ignoring it.",
+                            size,
+                            x.len(),
+                        );
+                        builder.append_null();
+                        continue;
+                    }
 
-            //         builder.append_value(x).expect("ensure to append successfully here, because size have been checked before");
-            //     }
-            //     Ok(Arc::new(builder.finish()))
-            // }
-            DataType::FixedSizeBinary(size) => Ok(Arc::new(FixedSizeBinaryArray::from(
-                [<$stat_type_prefix FixedLenByteArrayStatsIterator>]::new($iterator).map(|x| {
-                    x.and_then(|x| {
-                        if x.len().try_into() == Ok(*size) {
-                            Some(x)
-                        } else {
-                            log::debug!(
-                                "FixedSizeBinary({}) statistics is a binary of size {}, ignoring it.",
-                                size,
-                                x.len(),
-                            );
-                            None
-                        }
-                    })
-                }).collect::<Vec<_>>(),
-            ))),
+                    builder.append_value(x).expect("ensure to append successfully here, because size have been checked before");
+                }
+                Ok(Arc::new(builder.finish()))
+            },
             DataType::Decimal128(precision, scale) => {
                 let arr = Decimal128Array::from_iter(
                     [<$stat_type_prefix Decimal128StatsIterator>]::new($iterator)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11281 

## Rationale for this change
Improve the stats convert performance as possible.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Use string builder directly to eliminate some tmp `Vec`s and `String`s(for example, Utf8 and LargeUtf case in both row group or page stats).
- Eliminate some unnecessary collect to avoid tmp `Vec` creation

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Test by exist tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
