### PR TITLE
Support `IS NULL` and `IS NOT NULL` on Unions

### DIFF
--- a/datafusion/physical-expr/src/expressions/is_not_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_not_null.rs
@@ -20,7 +20,6 @@
 use std::hash::{Hash, Hasher};
 use std::{any::Any, sync::Arc};
 
-use crate::expressions::is_null::union_is_null;
 use crate::physical_expr::down_cast_any_ref;
 use crate::PhysicalExpr;
 use arrow::compute;
@@ -122,11 +121,8 @@ pub fn is_not_null(arg: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> 
 }
 
 fn union_is_not_null(union_array: &UnionArray) -> Result<BooleanArray> {
-    union_is_null(union_array).map(|is_null| {
-        compute::not(&is_null)
-            .expect("Failed to compute is not null")
-            .into()
-    })
+    super::is_null::union_is_null(union_array)
+        .map(|is_null| compute::not(&is_null).expect("Failed to compute is not null"))
 }
 
 #[cfg(test)]

--- a/datafusion/physical-expr/src/expressions/is_not_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_not_null.rs
@@ -27,7 +27,6 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
-use arrow_array::{BooleanArray, UnionArray};
 use datafusion_common::Result;
 use datafusion_common::ScalarValue;
 use datafusion_expr::ColumnarValue;
@@ -75,14 +74,9 @@ impl PhysicalExpr for IsNotNullExpr {
         let arg = self.arg.evaluate(batch)?;
         match arg {
             ColumnarValue::Array(array) => {
-                let bool_array = if let Some(union_array) =
-                    array.as_any().downcast_ref::<UnionArray>()
-                {
-                    union_is_not_null(union_array)?
-                } else {
-                    compute::is_not_null(array.as_ref())?
-                };
-                Ok(ColumnarValue::Array(Arc::new(bool_array)))
+                let is_null = super::is_null::compute_is_null(array)?;
+                let is_not_null = compute::not(&is_null)?;
+                Ok(ColumnarValue::Array(Arc::new(is_not_null)))
             }
             ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::Scalar(
                 ScalarValue::Boolean(Some(!scalar.is_null())),
@@ -120,11 +114,6 @@ pub fn is_not_null(arg: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> 
     Ok(Arc::new(IsNotNullExpr::new(arg)))
 }
 
-fn union_is_not_null(union_array: &UnionArray) -> Result<BooleanArray> {
-    super::is_null::union_is_null(union_array)
-        .map(|is_null| compute::not(&is_null).expect("Failed to compute is not null"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,6 +122,8 @@ mod tests {
         array::{BooleanArray, StringArray},
         datatypes::*,
     };
+    use arrow_array::{Array, Float64Array, Int32Array, UnionArray};
+    use arrow_buffer::ScalarBuffer;
     use datafusion_common::cast::as_boolean_array;
 
     #[test]
@@ -155,5 +146,49 @@ mod tests {
         assert_eq!(expected, result);
 
         Ok(())
+    }
+
+    #[test]
+    fn union_is_not_null_op() {
+        // union of [{A=1}, {A=}, {B=1.1}, {B=1.2}, {B=}]
+        let int_array = Int32Array::from(vec![Some(1), None, None, None, None]);
+        let float_array =
+            Float64Array::from(vec![None, None, Some(1.1), Some(1.2), None]);
+        let type_ids = [0, 0, 1, 1, 1].into_iter().collect::<ScalarBuffer<i8>>();
+
+        let children = vec![Arc::new(int_array) as Arc<dyn Array>, Arc::new(float_array)];
+
+        let union_fields: UnionFields = [
+            (0, Arc::new(Field::new("A", DataType::Int32, true))),
+            (1, Arc::new(Field::new("B", DataType::Float64, true))),
+        ]
+        .into_iter()
+        .collect();
+
+        let array =
+            UnionArray::try_new(union_fields.clone(), type_ids, None, children).unwrap();
+
+        let field = Field::new(
+            "my_union",
+            DataType::Union(union_fields, UnionMode::Sparse),
+            true,
+        );
+
+        let schema = Schema::new(vec![field]);
+        let expr = is_not_null(col("my_union", &schema).unwrap()).unwrap();
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)]).unwrap();
+
+        // expression: "a is not null"
+        let actual = expr
+            .evaluate(&batch)
+            .unwrap()
+            .into_array(batch.num_rows())
+            .expect("Failed to convert to array");
+        let actual = as_boolean_array(&actual).unwrap();
+
+        let expected = &BooleanArray::from(vec![true, false, true, true, false]);
+
+        assert_eq!(expected, actual);
     }
 }

--- a/datafusion/physical-expr/src/expressions/is_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_null.rs
@@ -131,9 +131,7 @@ fn dense_union_is_null(
     let buffer: BooleanBuffer = offsets
         .iter()
         .zip(union_array.type_ids())
-        .map(|(offset, type_id)| {
-            (&child_arrays[*type_id as usize]).value(*offset as usize)
-        })
+        .map(|(offset, type_id)| child_arrays[*type_id as usize].value(*offset as usize))
         .collect();
 
     Ok(BooleanArray::new(buffer, None))

--- a/datafusion/physical-expr/src/expressions/is_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_null.rs
@@ -103,8 +103,8 @@ impl PhysicalExpr for IsNullExpr {
     }
 }
 
-/// workaround https://github.com/apache/arrow-rs/issues/6017,
-/// this can be removed once `arrow::compute::is_null` is fixed
+/// workaround <https://github.com/apache/arrow-rs/issues/6017>,
+/// this can be replaced with a direct call to `arrow::compute::is_null` once it's fixed.
 pub(crate) fn compute_is_null(array: ArrayRef) -> Result<BooleanArray> {
     if let Some(union_array) = array.as_any().downcast_ref::<UnionArray>() {
         if let Some(offsets) = union_array.offsets() {

--- a/datafusion/physical-expr/src/expressions/is_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_null.rs
@@ -25,6 +25,9 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use arrow_array::{Array, BooleanArray, Int8Array, UnionArray};
+use arrow_buffer::{BooleanBuffer, ScalarBuffer};
+use arrow_ord::cmp;
 
 use crate::physical_expr::down_cast_any_ref;
 use crate::PhysicalExpr;
@@ -74,9 +77,16 @@ impl PhysicalExpr for IsNullExpr {
     fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
         let arg = self.arg.evaluate(batch)?;
         match arg {
-            ColumnarValue::Array(array) => Ok(ColumnarValue::Array(Arc::new(
-                compute::is_null(array.as_ref())?,
-            ))),
+            ColumnarValue::Array(array) => {
+                let bool_array = if let Some(union_array) =
+                    array.as_any().downcast_ref::<UnionArray>()
+                {
+                    union_is_null(union_array)?
+                } else {
+                    compute::is_null(array.as_ref())?
+                };
+                Ok(ColumnarValue::Array(Arc::new(bool_array)))
+            }
             ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::Scalar(
                 ScalarValue::Boolean(Some(scalar.is_null())),
             )),
@@ -100,6 +110,51 @@ impl PhysicalExpr for IsNullExpr {
     }
 }
 
+pub(crate) fn union_is_null(union_array: &UnionArray) -> Result<BooleanArray> {
+    if let Some(offsets) = union_array.offsets() {
+        dense_union_is_null(union_array, offsets)
+    } else {
+        sparce_union_is_null(union_array)
+    }
+}
+
+fn dense_union_is_null(
+    union_array: &UnionArray,
+    offsets: &ScalarBuffer<i32>,
+) -> Result<BooleanArray> {
+    let child_arrays = (0..union_array.type_names().len())
+        .map(|type_id| {
+            compute::is_null(&union_array.child(type_id as i8)).map_err(Into::into)
+        })
+        .collect::<Result<Vec<BooleanArray>>>()?;
+
+    let buffer: BooleanBuffer = offsets
+        .iter()
+        .zip(union_array.type_ids())
+        .map(|(offset, type_id)| {
+            (&child_arrays[*type_id as usize]).value(*offset as usize)
+        })
+        .collect();
+
+    Ok(BooleanArray::new(buffer, None))
+}
+
+fn sparce_union_is_null(union_array: &UnionArray) -> Result<BooleanArray> {
+    let type_ids = Int8Array::new(union_array.type_ids().clone(), None);
+
+    let mut union_is_null =
+        BooleanArray::new(BooleanBuffer::new_unset(union_array.len()), None);
+    for type_id in 0..union_array.type_names().len() {
+        let type_id = type_id as i8;
+        let union_is_child = cmp::eq(&type_ids, &Int8Array::new_scalar(type_id))?;
+        let child = union_array.child(type_id);
+        let child_array_is_null = compute::is_null(&child)?;
+        let child_is_null = compute::and(&union_is_child, &child_array_is_null)?;
+        union_is_null = compute::or(&union_is_null, &child_is_null)?;
+    }
+    Ok(union_is_null)
+}
+
 impl PartialEq<dyn Any> for IsNullExpr {
     fn eq(&self, other: &dyn Any) -> bool {
         down_cast_any_ref(other)
@@ -108,6 +163,7 @@ impl PartialEq<dyn Any> for IsNullExpr {
             .unwrap_or(false)
     }
 }
+
 /// Create an IS NULL expression
 pub fn is_null(arg: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> {
     Ok(Arc::new(IsNullExpr::new(arg)))
@@ -121,6 +177,8 @@ mod tests {
         array::{BooleanArray, StringArray},
         datatypes::*,
     };
+    use arrow_array::{Float64Array, Int32Array};
+    use arrow_buffer::ScalarBuffer;
     use datafusion_common::cast::as_boolean_array;
 
     #[test]
@@ -144,5 +202,66 @@ mod tests {
         assert_eq!(expected, result);
 
         Ok(())
+    }
+
+    fn union_fields() -> UnionFields {
+        [
+            (0, Arc::new(Field::new("A", DataType::Int32, true))),
+            (1, Arc::new(Field::new("B", DataType::Float64, true))),
+            (2, Arc::new(Field::new("C", DataType::Utf8, true))),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    #[test]
+    fn sparse_union_is_null() {
+        // union of [{A=1}, {A=}, {B=3.2}, {B=}, {C="a"}, {C=}]
+        let int_array = Int32Array::from(vec![Some(1), None, None, None, None, None]);
+        let float_array =
+            Float64Array::from(vec![None, None, Some(3.2), None, None, None]);
+        let str_array = StringArray::from(vec![None, None, None, None, Some("a"), None]);
+        let type_ids = [0, 0, 1, 1, 2, 2].into_iter().collect::<ScalarBuffer<i8>>();
+
+        let children = vec![
+            Arc::new(int_array) as Arc<dyn Array>,
+            Arc::new(float_array),
+            Arc::new(str_array),
+        ];
+
+        let array =
+            UnionArray::try_new(union_fields(), type_ids, None, children).unwrap();
+
+        let result = union_is_null(&array).unwrap();
+
+        let expected = &BooleanArray::from(vec![false, true, false, true, false, true]);
+        assert_eq!(expected, &result);
+    }
+
+    #[test]
+    fn dense_union_is_null() {
+        // union of [{A=1}, {A=}, {B=3.2}, {B=}, {C="a"}, {C=}]
+        let int_array = Int32Array::from(vec![Some(1), None]);
+        let float_array = Float64Array::from(vec![Some(3.2), None]);
+        let str_array = StringArray::from(vec![Some("a"), None]);
+        let type_ids = [0, 0, 1, 1, 2, 2].into_iter().collect::<ScalarBuffer<i8>>();
+        let offsets = [0, 1, 0, 1, 0, 1]
+            .into_iter()
+            .collect::<ScalarBuffer<i32>>();
+
+        let children = vec![
+            Arc::new(int_array) as Arc<dyn Array>,
+            Arc::new(float_array),
+            Arc::new(str_array),
+        ];
+
+        let array =
+            UnionArray::try_new(union_fields(), type_ids, Some(offsets), children)
+                .unwrap();
+
+        let result = union_is_null(&array).unwrap();
+
+        let expected = &BooleanArray::from(vec![false, true, false, true, false, true]);
+        assert_eq!(expected, &result);
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11162, replaces #11314

## Rationale for this change

See #11162.

## What changes are included in this PR?

* Changes to `is_null` to support correctly support unions
* Changes to `is_not_null` to support correctly support unions
* change to `ScalarValue::is_null`
* tests

## Are these changes tested?

Yes

## Are there any user-facing changes?

Should just be the intended fix.
