### PR TITLE
fix: When consuming Substrait, temporarily rename clashing duplicate columns

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -410,14 +410,11 @@ pub async fn from_substrait_rel(
                         from_substrait_rex(ctx, e, input.clone().schema(), extensions)
                             .await?;
                     // if the expression is WindowFunction, wrap in a Window relation
-                    match &*x {
-                        Expr::WindowFunction(_) => {
-                            // Adding the same expression here and in the project below
-                            // works because the project's builder uses columnize_expr(..)
-                            // to transform it into a column reference
-                            input = input.window(vec![x.as_ref().clone()])?
-                        }
-                        _ => {}
+                    if let Expr::WindowFunction(_) = x.as_ref() {
+                        // Adding the same expression here and in the project below
+                        // works because the project's builder uses columnize_expr(..)
+                        // to transform it into a column reference
+                        input = input.window(vec![x.as_ref().clone()])?
                     }
                     // Ensure the expression has a unique display name, so that project's
                     // validate_unique_names doesn't fail

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -59,7 +59,7 @@ use datafusion::{
     prelude::{Column, SessionContext},
     scalar::ScalarValue,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use substrait::proto::exchange_rel::ExchangeKind;
@@ -403,6 +403,7 @@ pub async fn from_substrait_rel(
                 let mut input = LogicalPlanBuilder::from(
                     from_substrait_rel(ctx, input, extensions).await?,
                 );
+                let mut names: HashSet<String> = HashSet::new();
                 let mut exprs: Vec<Expr> = vec![];
                 for e in &p.expressions {
                     let x =
@@ -411,11 +412,28 @@ pub async fn from_substrait_rel(
                     // if the expression is WindowFunction, wrap in a Window relation
                     match &*x {
                         Expr::WindowFunction(_) => {
+                            // Adding the same expression here and in the project below
+                            // works because the project's builder uses columnize_expr(..)
+                            // to transform it into a column reference
                             input = input.window(vec![x.as_ref().clone()])?
                         }
                         _ => {}
                     }
-                    exprs.push(x.as_ref().clone());
+                    // Ensure the expression has a unique display name, so that project's
+                    // validate_unique_names doesn't fail
+                    let name = x.display_name()?;
+                    let mut new_name = name.clone();
+                    let mut i = 0;
+                    while names.contains(&new_name) {
+                        new_name = format!("{}__temp__{}", name, i);
+                        i += 1;
+                    }
+                    names.insert(new_name.clone());
+                    if new_name != name {
+                        exprs.push(x.as_ref().clone().alias(new_name.clone()));
+                    } else {
+                        exprs.push(x.as_ref().clone());
+                    }
                 }
                 input.project(exprs)?.build()
             } else {

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -409,17 +409,13 @@ pub async fn from_substrait_rel(
                         from_substrait_rex(ctx, e, input.clone().schema(), extensions)
                             .await?;
                     // if the expression is WindowFunction, wrap in a Window relation
-                    //   before returning and do not add to list of this Projection's expression list
-                    // otherwise, add expression to the Projection's expression list
                     match &*x {
                         Expr::WindowFunction(_) => {
-                            input = input.window(vec![x.as_ref().clone()])?;
-                            exprs.push(x.as_ref().clone());
+                            input = input.window(vec![x.as_ref().clone()])?
                         }
-                        _ => {
-                            exprs.push(x.as_ref().clone());
-                        }
+                        _ => {}
                     }
+                    exprs.push(x.as_ref().clone());
                 }
                 input.project(exprs)?.build()
             } else {

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -751,6 +751,22 @@ async fn roundtrip_values_duplicate_column_join() -> Result<()> {
     .await
 }
 
+#[tokio::test]
+async fn duplicate_column() -> Result<()> {
+    // Substrait does not keep column names (aliases) in the plan, rather it operates on column indices
+    // only. DataFusion however, is strict about not having duplicate column names appear in the plan.
+    // This test confirms that we generate aliases for columns in the plan which would otherwise have
+    // colliding names.
+    assert_expected_plan(
+        "SELECT a + 1 as sum_a, a + 1 as sum_a_2 FROM data",
+        "Projection: data.a + Int64(1) AS sum_a, data.a + Int64(1) AS data.a + Int64(1)_0 AS sum_a_2\
+            \n  Projection: data.a + Int64(1)\
+            \n    TableScan: data projection=[a]",
+        true,
+    )
+    .await
+}
+
 /// Construct a plan that cast columns. Only those SQL types are supported for now.
 #[tokio::test]
 async fn new_test_grammar() -> Result<()> {

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -759,7 +759,7 @@ async fn duplicate_column() -> Result<()> {
     // colliding names.
     assert_expected_plan(
         "SELECT a + 1 as sum_a, a + 1 as sum_a_2 FROM data",
-        "Projection: data.a + Int64(1) AS sum_a, data.a + Int64(1) AS data.a + Int64(1)_0 AS sum_a_2\
+        "Projection: data.a + Int64(1) AS sum_a, data.a + Int64(1) AS data.a + Int64(1)__temp__0 AS sum_a_2\
             \n  Projection: data.a + Int64(1)\
             \n    TableScan: data projection=[a]",
         true,


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/datafusion/issues/10815, and follows up from https://github.com/apache/datafusion/pull/11049#issuecomment-2185795038. There may still be some cases left uncovered, but this does handle some more.

Closes #.

## Rationale for this change

As DF requires column name uniqueness while Substrait doesn't care about names at all (apart from first & last levels of the plan), that causes clashes in the intermediate nodes that prevent DF from executing plans. 

A simple example of a plan that would not work is:
```
SELECT a + 1 as sum_a, a + 1 as sum_a_2 FROM data
```

This fails as Substrait consumer first creates a project to add the columns, and only then creates the final project (or modifies the existing project) to rename them. But when the first project is created, it has two identical expressions without aliases, meaning their names are collide and `validate_unique_names()` fails.

## What changes are included in this PR?

When consuming Substrait `Project`s, rename expressions as required to prevent duplicates.

## Are these changes tested?

Added unit test + existing tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
