### PR TITLE
Fix bug when pushing projection under joins

### DIFF
--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -1024,17 +1024,17 @@ statement ok
 CREATE TABLE t2 (v1 BOOLEAN) AS VALUES (false), (true);
 
 query BB
-SELECT t2.v1, t1.v1 FROM t0, t1, t2 WHERE t2.v1 IS DISTINCT FROM t0.v1;
+SELECT t2.v1, t1.v1 FROM t0, t1, t2 WHERE t2.v1 IS DISTINCT FROM t0.v1 ORDER BY 1,2;
 ----
-true false
-true NULL
-true false
+false false
 false false
 false NULL
-false false
+true false
+true false
+true false
 true false
 true NULL
-true false
+true NULL
 
 statement ok
 DROP TABLE t0;

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -986,3 +986,61 @@ DROP TABLE employees
 
 statement ok
 DROP TABLE department
+
+
+# Test issue: https://github.com/apache/datafusion/issues/11269
+statement ok
+CREATE TABLE t1 (v0 BIGINT) AS VALUES (-503661263);
+
+statement ok
+CREATE TABLE t2 (v0 DOUBLE) AS VALUES (-1.663563947387);
+
+statement ok
+CREATE TABLE t3 (v0 DOUBLE) AS VALUES (0.05112015193508901);
+
+query RR
+SELECT t3.v0, t2.v0 FROM t1,t2,t3 WHERE t3.v0 >= t1.v0;
+----
+0.051120151935 -1.663563947387
+
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;
+
+statement ok
+DROP TABLE t3;
+
+
+# Test issue: https://github.com/apache/datafusion/issues/11275
+statement ok
+CREATE TABLE t0 (v1 BOOLEAN) AS VALUES (false), (null);
+
+statement ok
+CREATE TABLE t1 (v1 BOOLEAN) AS VALUES (false), (null), (false);
+
+statement ok
+CREATE TABLE t2 (v1 BOOLEAN) AS VALUES (false), (true);
+
+query BB
+SELECT t2.v1, t1.v1 FROM t0, t1, t2 WHERE t2.v1 IS DISTINCT FROM t0.v1;
+----
+true false
+true NULL
+true false
+false false
+false NULL
+false false
+true false
+true NULL
+true false
+
+statement ok
+DROP TABLE t0;
+
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11269.
Closes #11275.

## Rationale for this change
The bug occurs at the [`new_indices_for_join_filter`](https://github.com/apache/datafusion/blob/f5e114e4f754c81d332f5105dd0242ab13f29a51/datafusion/core/src/physical_optimizer/projection_pushdown.rs#L1219) function within the `ProjectionPushdown` rule.
It uses the column name to search for the join filter's columns from `projection_exprs`.


https://github.com/apache/datafusion/blob/f5e114e4f754c81d332f5105dd0242ab13f29a51/datafusion/core/src/physical_optimizer/projection_pushdown.rs#L1218-L1220

The problem is that different columns may have the same names, leading to incorrect column matching and generating erroneous physical plans.

## What changes are included in this PR?
Use column index for matching.

## Are these changes tested?
Yes

## Are there any user-facing changes?
No