### PR TITLE
Track parquet writer encoding memory usage on MemoryPool

### DIFF
--- a/datafusion/core/src/test_util/mod.rs
+++ b/datafusion/core/src/test_util/mod.rs
@@ -366,3 +366,39 @@ pub fn register_unbounded_file_with_ordering(
     ctx.register_table(table_name, Arc::new(StreamTable::new(Arc::new(config))))?;
     Ok(())
 }
+
+struct BoundedStream {
+    limit: usize,
+    count: usize,
+    batch: RecordBatch,
+}
+
+impl Stream for BoundedStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if self.count >= self.limit {
+            return Poll::Ready(None);
+        }
+        self.count += 1;
+        Poll::Ready(Some(Ok(self.batch.clone())))
+    }
+}
+
+impl RecordBatchStream for BoundedStream {
+    fn schema(&self) -> SchemaRef {
+        self.batch.schema()
+    }
+}
+
+/// Creates an bounded stream for testing purposes.
+pub fn bounded_stream(batch: RecordBatch, limit: usize) -> SendableRecordBatchStream {
+    Box::pin(BoundedStream {
+        count: 0,
+        limit,
+        batch,
+    })
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11344 

## Rationale for this change

ParquetSink can use non-trivial amounts of memory to buffer rowgroups prior to flush, when executed within a task context. Therefore, this memory usage should be accounted within the task's memory pool.

## What changes are included in this PR?

Ensure memory accounting under three use cases for ParquetSink:
* when non-parallel writes
* when using multiple row-writers
* when using multiple column-writers

How parallelized-write memory tracking works, is [summarized here](https://github.com/apache/datafusion/pull/11345#discussion_r1669599846). I feel like it should be a doc comment, but I wasn't sure where. 🤔 

## Are these changes tested?

Yes

## Are there any user-facing changes?

No
