### PR TITLE
Minor: Add link to blog to main DataFusion website

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,6 +69,7 @@ See the `developer’s guide`_ for contributing and `communication`_ for getting
    GitHub and Issue Tracker <https://github.com/apache/datafusion>
    crates.io <https://crates.io/crates/datafusion>
    API Docs <https://docs.rs/datafusion/latest/datafusion/>
+   Blog <https://datafusion.apache.org/blog/>
    Code of conduct <https://github.com/apache/datafusion/blob/main/CODE_OF_CONDUCT.md>
    Download <download>
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #9602 

## Rationale for this change

If we are going to have a blog we should make it easier for people to find it

## What changes are included in this PR?

Add a link to the blog from the website:


## Are these changes tested?

I tested this manually locally

<img width="1452" alt="Screenshot 2024-07-09 at 8 03 02 AM" src="https://github.com/apache/datafusion/assets/490673/dd04b6d5-65b3-4c3d-a1f5-a0a929f51f2d">


## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
