### PR TITLE
Minor: Change no-statement error message to be clearer

### DIFF
--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -555,7 +555,7 @@ impl SessionState {
         }
         let statement = statements.pop_front().ok_or_else(|| {
             DataFusionError::NotImplemented(
-                "The context requires a statement!".to_string(),
+                "No SQL statements were provided in the query string".to_string(),
             )
         })?;
         Ok(statement)

--- a/datafusion/core/tests/sql/sql_api.rs
+++ b/datafusion/core/tests/sql/sql_api.rs
@@ -136,7 +136,11 @@ async fn multiple_statements_returns_error() {
     let state = ctx.state();
 
     // Give it a string that contains multiple statements
-    let plan_res = state.create_logical_plan("INSERT INTO test (x) VALUES (1); INSERT INTO test (x) VALUES (2)").await;
+    let plan_res = state
+        .create_logical_plan(
+            "INSERT INTO test (x) VALUES (1); INSERT INTO test (x) VALUES (2)",
+        )
+        .await;
     assert_eq!(
         plan_res.unwrap_err().strip_backtrace(),
         "This feature is not implemented: The context currently only supports a single SQL statement"

--- a/datafusion/core/tests/sql/sql_api.rs
+++ b/datafusion/core/tests/sql/sql_api.rs
@@ -114,6 +114,36 @@ async fn unsupported_statement_returns_error() {
 }
 
 #[tokio::test]
+async fn empty_statement_returns_error() {
+    let ctx = SessionContext::new();
+    ctx.sql("CREATE TABLE test (x int)").await.unwrap();
+
+    let state = ctx.state();
+
+    // Give it an empty string which contains no statements
+    let plan_res = state.create_logical_plan("").await;
+    assert_eq!(
+        plan_res.unwrap_err().strip_backtrace(),
+        "This feature is not implemented: No SQL statements were provided in the query string"
+    );
+}
+
+#[tokio::test]
+async fn multiple_statements_returns_error() {
+    let ctx = SessionContext::new();
+    ctx.sql("CREATE TABLE test (x int)").await.unwrap();
+
+    let state = ctx.state();
+
+    // Give it a string that contains multiple statements
+    let plan_res = state.create_logical_plan("INSERT INTO test (x) VALUES (1); INSERT INTO test (x) VALUES (2)").await;
+    assert_eq!(
+        plan_res.unwrap_err().strip_backtrace(),
+        "This feature is not implemented: The context currently only supports a single SQL statement"
+    );
+}
+
+#[tokio::test]
 async fn ddl_can_not_be_planned_by_session_state() {
     let ctx = SessionContext::new();
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11393 .

## Rationale for this change

This is a much clearer error message than previously existed in its place. 

## What changes are included in this PR?

This changes the error message and adds two tests: one to cover this exact use case (of no statements being provided) and another to cover the instance of multiple statements being provided (which returns an error right before the check to see if any statements were provided at all), since there were no tests for that error case.

## Are these changes tested?

Yes, running `cargo test` in the root of the repo produces no failures.

## Are there any user-facing changes?

I think this qualifies as a user-facing change, but I don't think it violates any invariants or changes any use-cases (or anything like that) in a way that would require any documentation changes. I may be wrong, though - clarification on if this qualifies as a 'user-facing change' would be appreciated.
