### PR TITLE
fix(11397): surface proper errors in ParquetSink

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -893,12 +893,9 @@ async fn send_arrays_to_col_writers(
     let mut next_channel = 0;
     for (array, field) in rb.columns().iter().zip(schema.fields()) {
         for c in compute_leaves(field, array)? {
-            col_array_channels[next_channel]
-                .send(c)
-                .await
-                .map_err(|_| {
-                    DataFusionError::Internal("Unable to send array to writer!".into())
-                })?;
+            // Do not surface error from closed channel.
+            let _ = col_array_channels[next_channel].send(c).await;
+
             next_channel += 1;
         }
     }
@@ -984,11 +981,8 @@ fn spawn_parquet_parallel_serialization_task(
                         &pool,
                     );
 
-                    serialize_tx.send(finalize_rg_task).await.map_err(|_| {
-                        DataFusionError::Internal(
-                            "Unable to send closed RG to concat task!".into(),
-                        )
-                    })?;
+                    // Do not surface error from closed channel.
+                    let _ = serialize_tx.send(finalize_rg_task).await;
 
                     current_rg_rows = 0;
                     rb = rb.slice(rows_left, rb.num_rows() - rows_left);
@@ -1013,11 +1007,8 @@ fn spawn_parquet_parallel_serialization_task(
                 &pool,
             );
 
-            serialize_tx.send(finalize_rg_task).await.map_err(|_| {
-                DataFusionError::Internal(
-                    "Unable to send closed RG to concat task!".into(),
-                )
-            })?;
+            // Do not surface any error here due to closed channel.
+            let _ = serialize_tx.send(finalize_rg_task).await;
         }
 
         Ok(())

--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -340,8 +340,8 @@ async fn oom_parquet_sink() {
             path.to_string_lossy()
         ))
         .with_expected_errors(vec![
-            // TODO: update error handling in ParquetSink
-            "Unable to send array to writer!",
+            "Failed to allocate additional",
+            "for ParquetSink(ArrowColumnWriter)",
         ])
         .with_memory_limit(200_000)
         .run()


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11397 

## Rationale for this change

During the parallel writes in ParquetSink, we spawn a series of parallel tasks and then message pass the outcome from one task to the next. In abstraction:
read_batches => channel => `Vec<col_write_tasks>` => channel => `Vec<serialize_rowgroup_tasks>`

When we encounter an error in one of the `Vec<x_tasks>` we are first surfacing an error on the channel.send() rather than on the task join.

## What changes are included in this PR?

Don't surface the errors on the channel send.
This results in the proper error returned, as can be seen on the updated test.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
