### PR TITLE
Trivial: use arrow csv writer's timestamp_tz_format

### DIFF
--- a/datafusion/common/src/file_options/csv_writer.rs
+++ b/datafusion/common/src/file_options/csv_writer.rs
@@ -63,6 +63,9 @@ impl TryFrom<&CsvOptions> for CsvWriterOptions {
         if let Some(v) = &value.timestamp_format {
             builder = builder.with_timestamp_format(v.into())
         }
+        if let Some(v) = &value.timestamp_tz_format {
+            builder = builder.with_timestamp_tz_format(v.into())
+        }
         if let Some(v) = &value.time_format {
             builder = builder.with_time_format(v.into())
         }


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/8640

## What changes are included in this PR?

Just uses the already-existing config field to pass into the respective builder method from arrow-rs

## Are these changes tested?

I'm not actually adding any tests here for the csv writing itself, since I've added some in https://github.com/apache/arrow-rs/pull/5890 and we're just passing the value through

## Are there any user-facing changes?

No. (Well, in some sense, this fixes a sort-of bug as the config field existed but wasn't used here) 
