### PR TITLE
refactor: change error type for "no statement"

### DIFF
--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -554,9 +554,7 @@ impl SessionState {
             );
         }
         let statement = statements.pop_front().ok_or_else(|| {
-            DataFusionError::NotImplemented(
-                "No SQL statements were provided in the query string".to_string(),
-            )
+            plan_datafusion_err!("No SQL statements were provided in the query string")
         })?;
         Ok(statement)
     }

--- a/datafusion/core/tests/sql/sql_api.rs
+++ b/datafusion/core/tests/sql/sql_api.rs
@@ -124,7 +124,7 @@ async fn empty_statement_returns_error() {
     let plan_res = state.create_logical_plan("").await;
     assert_eq!(
         plan_res.unwrap_err().strip_backtrace(),
-        "This feature is not implemented: No SQL statements were provided in the query string"
+        "Error during planning: No SQL statements were provided in the query string"
     );
 }
 


### PR DESCRIPTION
## Which issue does this PR close?
Amends #11394 (sorry, I should have reviewed that).

## Rationale for this change
While reporting "not implemented" for "multiple statements" seems reasonable, I think the user should get a plan error (which roughly translates to "invalid argument") if they don't provide any statement. I don't see any reasonable way to support "no statement" ever, hence "not implemented" seems like a wrong promise.

## What changes are included in this PR?
The user now gets a plan error instead of "no implemented" if no statement was provided.

## Are these changes tested?
Adjusted existing test.

## Are there any user-facing changes?
Improved error type. Esp. if the user converts that error type into a gRPG/HTTP error (e.g. IOx does this) then you can expect a more appropriate outcome.