### PR TITLE
Minor: Consolidate specificataion doc sections

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -134,19 +134,3 @@ The good thing about open code and open development is that any issues in one ch
 
 Pull requests will be marked with a `stale` label after 60 days of inactivity and then closed 7 days after that.
 Commenting on the PR will remove the `stale` label.
-
-## Specifications
-
-We formalize some DataFusion semantics and behaviors through specification
-documents. These specifications are useful to be used as references to help
-resolve ambiguities during development or code reviews.
-
-You are also welcome to propose changes to existing specifications or create
-new specifications as you see fit.
-
-Here is the list current active specifications:
-
-- [Output field name semantic](https://datafusion.apache.org/contributor-guide/specification/output-field-name-semantic.html)
-- [Invariants](https://datafusion.apache.org/contributor-guide/specification/invariants.html)
-
-All specifications are stored in the `docs/source/specification` folder.

--- a/docs/source/contributor-guide/specification/index.rst
+++ b/docs/source/contributor-guide/specification/index.rst
@@ -18,6 +18,16 @@
 Specifications
 ==============
 
+We formalize some DataFusion semantics and behaviors through specification
+documents. These specifications are useful to be used as references to help
+resolve ambiguities during development or code reviews.
+
+You are also welcome to propose changes to existing specifications or create
+new specifications as you see fit. All specifications are stored in the
+`docs/source/specification` folder. Here is the list current active
+specifications:
+
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

It is strange to have the specifications intro text on a different page than the actual specifications

## What changes are included in this PR?

Move the content closer to the specifications

## Are these changes tested?
Doc CI

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
