### PR TITLE
Minor: fix giuthub action labeler rules

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -17,11 +17,11 @@
 
 development-process:
 - changed-files:
-  - any-glob-to-any-file: ['dev/**.*', '.github/**.*', 'ci/**.*', '.asf.yaml']
+  - any-glob-to-any-file: ['dev/**/*', '.github/**/*', 'ci/**/*', '.asf.yaml']
 
 documentation:
 - changed-files:
-  - any-glob-to-any-file: ['docs/**.*', 'README.md', './**/README.md', 'DEVELOPERS.md', 'datafusion/docs/**.*']
+  - any-glob-to-any-file: ['docs/**/*', 'README.md', './**/README.md', 'DEVELOPERS.md', 'datafusion/docs/**/*']
 
 sql:
 - changed-files:


### PR DESCRIPTION
## Which issue does this PR close?


## Rationale for this change

The automatic labeler job doesn't seem to work for documentation changes or development process

(for example, this PR modifies files in `.github` but is not automatically labeled)


## What changes are included in this PR?
Change labeler markdown syntax to be consistent

## Are these changes tested?
No, I didn't test them. I figure we can make another PR if this doesn't work

## Are there any user-facing changes?

No, this should be a dev process only change