### PR TITLE
Plan `LATERAL` subqueries

### DIFF
--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -3106,7 +3106,7 @@ fn join_on_complex_condition() {
 #[test]
 fn lateral_constant() {
     let sql = "SELECT * FROM j1, LATERAL (SELECT 1) AS j2";
-    let expected = "Projection: j1.j1_id, j1.j1_string, j2.Int64(1)\
+    let expected = "Projection: *\
             \n  CrossJoin:\
             \n    TableScan: j1\
             \n    SubqueryAlias: j2\
@@ -3126,7 +3126,7 @@ fn lateral_comma_join() {
             \n    TableScan: j1\
             \n    SubqueryAlias: j2\
             \n      Subquery:\
-            \n        Projection: j2.j2_id, j2.j2_string\
+            \n        Projection: *\
             \n          Filter: outer_ref(j1.j1_id) < j2.j2_id\
             \n            TableScan: j2";
     quick_test(sql, expected);
@@ -3137,7 +3137,7 @@ fn lateral_comma_join_referencing_join_rhs() {
     let sql = "SELECT * FROM\
             \n  j1 JOIN (j2 JOIN j3 ON(j2_id = j3_id - 2)) ON(j1_id = j2_id),\
             \n  LATERAL (SELECT * FROM j3 WHERE j3_string = j2_string) as j4;";
-    let expected = "Projection: j1.j1_id, j1.j1_string, j2.j2_id, j2.j2_string, j3.j3_id, j3.j3_string, j4.j3_id, j4.j3_string\
+    let expected = "Projection: *\
             \n  CrossJoin:\
             \n    Inner Join:  Filter: j1.j1_id = j2.j2_id\
             \n      TableScan: j1\
@@ -3146,7 +3146,7 @@ fn lateral_comma_join_referencing_join_rhs() {
             \n        TableScan: j3\
             \n    SubqueryAlias: j4\
             \n      Subquery:\
-            \n        Projection: j3.j3_id, j3.j3_string\
+            \n        Projection: *\
             \n          Filter: j3.j3_string = outer_ref(j2.j2_string)\
             \n            TableScan: j3";
     quick_test(sql, expected);
@@ -3161,17 +3161,17 @@ fn lateral_comma_join_with_shadowing() {
                 SELECT * FROM j2 WHERE j1_id = j2_id\
               ) as j2\
             ) as j2;";
-    let expected = "Projection: j1.j1_id, j1.j1_string, j2.j1_id, j2.j1_string, j2.j2_id, j2.j2_string\
+    let expected = "Projection: *\
             \n  CrossJoin:\
             \n    TableScan: j1\
             \n    SubqueryAlias: j2\
             \n      Subquery:\
-            \n        Projection: j1.j1_id, j1.j1_string, j2.j2_id, j2.j2_string\
+            \n        Projection: *\
             \n          CrossJoin:\
             \n            TableScan: j1\
             \n            SubqueryAlias: j2\
             \n              Subquery:\
-            \n                Projection: j2.j2_id, j2.j2_string\
+            \n                Projection: *\
             \n                  Filter: outer_ref(j1.j1_id) = j2.j2_id\
             \n                    TableScan: j2";
     quick_test(sql, expected);
@@ -3187,7 +3187,7 @@ fn lateral_left_join() {
             \n    TableScan: j1\
             \n    SubqueryAlias: j2\
             \n      Subquery:\
-            \n        Projection: j2.j2_id, j2.j2_string\
+            \n        Projection: *\
             \n          Filter: outer_ref(j1.j1_id) < j2.j2_id\
             \n            TableScan: j2";
     quick_test(sql, expected);
@@ -3198,14 +3198,14 @@ fn lateral_nested_left_join() {
     let sql = "SELECT * FROM 
             j1, \
             (j2 LEFT JOIN LATERAL (SELECT * FROM j3 WHERE j1_id + j2_id = j3_id) AS j3 ON(true))";
-    let expected = "Projection: j1.j1_id, j1.j1_string, j2.j2_id, j2.j2_string, j3.j3_id, j3.j3_string\
+    let expected = "Projection: *\
             \n  CrossJoin:\
             \n    TableScan: j1\
             \n    Left Join:  Filter: Boolean(true)\
             \n      TableScan: j2\
             \n      SubqueryAlias: j3\
             \n        Subquery:\
-            \n          Projection: j3.j3_id, j3.j3_string\
+            \n          Projection: *\
             \n            Filter: outer_ref(j1.j1_id) + outer_ref(j2.j2_id) = j3.j3_id\
             \n              TableScan: j3";
     quick_test(sql, expected);

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -3104,6 +3104,101 @@ fn join_on_complex_condition() {
 }
 
 #[test]
+fn lateral_comma_join() {
+    let sql = "SELECT j1_string, j2_string FROM
+            j1, \
+            LATERAL (SELECT * FROM j2 WHERE j1_id < j2_id) AS j2";
+    let expected = "Projection: j1.j1_string, j2.j2_string\
+            \n  CrossJoin:\
+            \n    TableScan: j1\
+            \n    SubqueryAlias: j2\
+            \n      Subquery:\
+            \n        Projection: j2.j2_id, j2.j2_string\
+            \n          Filter: outer_ref(j1.j1_id) < j2.j2_id\
+            \n            TableScan: j2";
+    quick_test(sql, expected);
+}
+
+#[test]
+fn lateral_comma_join_referencing_join_rhs() {
+    let sql = "SELECT * FROM\
+            \n  j1 JOIN (j2 JOIN j3 ON(j2_id = j3_id - 2)) ON(j1_id = j2_id),\
+            \n  LATERAL (SELECT * FROM j3 WHERE j3_string = j2_string) as j4;";
+    let expected = "Projection: j1.j1_id, j1.j1_string, j2.j2_id, j2.j2_string, j3.j3_id, j3.j3_string, j4.j3_id, j4.j3_string\
+            \n  CrossJoin:\
+            \n    Inner Join:  Filter: j1.j1_id = j2.j2_id\
+            \n      TableScan: j1\
+            \n      Inner Join:  Filter: j2.j2_id = j3.j3_id - Int64(2)\
+            \n        TableScan: j2\
+            \n        TableScan: j3\
+            \n    SubqueryAlias: j4\
+            \n      Subquery:\
+            \n        Projection: j3.j3_id, j3.j3_string\
+            \n          Filter: j3.j3_string = outer_ref(j2.j2_string)\
+            \n            TableScan: j3";
+    quick_test(sql, expected);
+}
+
+#[test]
+fn lateral_comma_join_with_shadowing() {
+    // The j1_id on line 3 references the (closest) j1 definition from line 2.
+    let sql = "\
+            SELECT * FROM j1, LATERAL (\
+              SELECT * FROM j1, LATERAL (\
+                SELECT * FROM j2 WHERE j1.j1_id = j2_id\
+              ) as j2\
+            ) as j2;";
+    let expected = "Projection: j1.j1_id, j1.j1_string, j2.j1_id, j2.j1_string, j2.j2_id, j2.j2_string\
+            \n  CrossJoin:\
+            \n    TableScan: j1\
+            \n    SubqueryAlias: j2\
+            \n      Subquery:\
+            \n        Projection: j1.j1_id, j1.j1_string, j2.j2_id, j2.j2_string\
+            \n          CrossJoin:\
+            \n            TableScan: j1\
+            \n            SubqueryAlias: j2\
+            \n              Subquery:\
+            \n                Projection: j2.j2_id, j2.j2_string\
+            \n                  Filter: outer_ref(j1.j1_id) = j2.j2_id\
+            \n                    TableScan: j2";
+    quick_test(sql, expected);
+}
+
+#[test]
+fn lateral_left_join() {
+    let sql = "SELECT j1_string, j2_string FROM \
+            j1 \
+            LEFT JOIN LATERAL (SELECT * FROM j2 WHERE j1_id < j2_id) AS j2 ON(true);";
+    let expected = "Projection: j1.j1_string, j2.j2_string\
+            \n  Left Join:  Filter: Boolean(true)\
+            \n    TableScan: j1\
+            \n    SubqueryAlias: j2\
+            \n      Subquery:\
+            \n        Projection: j2.j2_id, j2.j2_string\
+            \n          Filter: outer_ref(j1.j1_id) < j2.j2_id\
+            \n            TableScan: j2";
+    quick_test(sql, expected);
+}
+
+#[test]
+fn lateral_nested_left_join() {
+    let sql = "SELECT * FROM 
+            j1, \
+            (j2 LEFT JOIN LATERAL (SELECT * FROM j3 WHERE j1_id + j2_id = j3_id) AS j3 ON(true))";
+    let expected = "Projection: j1.j1_id, j1.j1_string, j2.j2_id, j2.j2_string, j3.j3_id, j3.j3_string\
+            \n  CrossJoin:\
+            \n    TableScan: j1\
+            \n    Left Join:  Filter: Boolean(true)\
+            \n      TableScan: j2\
+            \n      SubqueryAlias: j3\
+            \n        Subquery:\
+            \n          Projection: j3.j3_id, j3.j3_string\
+            \n            Filter: outer_ref(j1.j1_id) + outer_ref(j2.j2_id) = j3.j3_id\
+            \n              TableScan: j3";
+    quick_test(sql, expected);
+}
+
+#[test]
 fn hive_aggregate_with_filter() -> Result<()> {
     let dialect = &HiveDialect {};
     let sql = "SELECT sum(age) FILTER (WHERE age > 4) FROM person";

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -3104,6 +3104,19 @@ fn join_on_complex_condition() {
 }
 
 #[test]
+fn lateral_constant() {
+    let sql = "SELECT * FROM j1, LATERAL (SELECT 1) AS j2";
+    let expected = "Projection: j1.j1_id, j1.j1_string, j2.Int64(1)\
+            \n  CrossJoin:\
+            \n    TableScan: j1\
+            \n    SubqueryAlias: j2\
+            \n      Subquery:\
+            \n        Projection: Int64(1)\
+            \n          EmptyRelation";
+    quick_test(sql, expected);
+}
+
+#[test]
 fn lateral_comma_join() {
     let sql = "SELECT j1_string, j2_string FROM
             j1, \
@@ -3145,7 +3158,7 @@ fn lateral_comma_join_with_shadowing() {
     let sql = "\
             SELECT * FROM j1, LATERAL (\
               SELECT * FROM j1, LATERAL (\
-                SELECT * FROM j2 WHERE j1.j1_id = j2_id\
+                SELECT * FROM j2 WHERE j1_id = j2_id\
               ) as j2\
             ) as j2;";
     let expected = "Projection: j1.j1_id, j1.j1_string, j2.j1_id, j2.j1_string, j2.j2_id, j2.j2_string\

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -4044,3 +4044,52 @@ physical_plan
 03)----MemoryExec: partitions=1, partition_sizes=[1]
 04)----SortExec: TopK(fetch=10), expr=[b@1 ASC NULLS LAST], preserve_partitioning=[false]
 05)------MemoryExec: partitions=1, partition_sizes=[1]
+
+
+# Test CROSS JOIN LATERAL syntax (planning)
+query TT
+explain select t1_id, t1_name, i from join_t1 t1 cross join lateral (select * from unnest(generate_series(1, t1_int))) as series(i);
+----
+logical_plan
+01)CrossJoin:
+02)--SubqueryAlias: t1
+03)----TableScan: join_t1 projection=[t1_id, t1_name]
+04)--SubqueryAlias: series
+05)----Subquery:
+06)------Projection: unnest(generate_series(Int64(1),outer_ref(t1.t1_int))) AS i
+07)--------Unnest: lists[unnest(generate_series(Int64(1),outer_ref(t1.t1_int)))] structs[]
+08)----------Projection: generate_series(Int64(1), CAST(outer_ref(t1.t1_int) AS Int64)) AS unnest(generate_series(Int64(1),outer_ref(t1.t1_int)))
+09)------------EmptyRelation
+
+
+# Test CROSS JOIN LATERAL syntax (execution)
+# TODO: https://github.com/apache/datafusion/issues/10048
+query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t1" \}\), name: "t1_int" \}\)
+select t1_id, t1_name, i from join_t1 t1 cross join lateral (select * from unnest(generate_series(1, t1_int))) as series(i);
+
+
+# Test INNER JOIN LATERAL syntax (planning)
+query TT
+explain select t1_id, t1_name, i from join_t1 t2 inner join lateral (select * from unnest(generate_series(1, t1_int))) as series(i) on(t1_id > i);
+----
+logical_plan
+01)Inner Join:  Filter: CAST(t2.t1_id AS Int64) > series.i
+02)--SubqueryAlias: t2
+03)----TableScan: join_t1 projection=[t1_id, t1_name]
+04)--SubqueryAlias: series
+05)----Subquery:
+06)------Projection: unnest(generate_series(Int64(1),outer_ref(t2.t1_int))) AS i
+07)--------Unnest: lists[unnest(generate_series(Int64(1),outer_ref(t2.t1_int)))] structs[]
+08)----------Projection: generate_series(Int64(1), CAST(outer_ref(t2.t1_int) AS Int64)) AS unnest(generate_series(Int64(1),outer_ref(t2.t1_int)))
+09)------------EmptyRelation
+
+
+# Test INNER JOIN LATERAL syntax (execution)
+# TODO: https://github.com/apache/datafusion/issues/10048
+query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t2" \}\), name: "t1_int" \}\)
+select t1_id, t1_name, i from join_t1 t2 inner join lateral (select * from unnest(generate_series(1, t1_int))) as series(i) on(t1_id > i);
+
+
+# Test RIGHT JOIN LATERAL syntax (unsupported)
+query error DataFusion error: This feature is not implemented: LATERAL syntax is not supported for FULL OUTER and RIGHT \[OUTER \| ANTI \| SEMI\] joins
+select t1_id, t1_name, i from join_t1 t1 right join lateral (select * from unnest(generate_series(1, t1_int))) as series(i);


### PR DESCRIPTION
## Which issue does this PR close?

Closes the planning part of #10048. The query from the issue will now fail in the optimization phase similar to #6140.

## Rationale for this change

Adds an unsupported fragment of the SQL syntax.

## What changes are included in this PR?

Extends the planner with support for `LATERAL` subqueries. See the tests added in `sql_integration.rs` for details.

## Are these changes tested?

Yes, I added tests in `sql_integration.rs`.

## Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If we document the supported SQL fragment in the user-facing docs as BNF-style diagrams we might want to adapt those.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

I don't think so.