### PR TITLE
Minor: Rename `RepartitionMetrics::repartition_time` to `RepartitionMetrics::repart_time` to match metric

### DIFF
--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -415,7 +415,7 @@ struct RepartitionMetrics {
     /// Time in nanos to execute child operator and fetch batches
     fetch_time: metrics::Time,
     /// Time in nanos to perform repartitioning
-    repartition_time: metrics::Time,
+    repart_time: metrics::Time,
     /// Time in nanos for sending resulting batches to channels.
     ///
     /// One metric per output partition.
@@ -449,7 +449,7 @@ impl RepartitionMetrics {
 
         Self {
             fetch_time,
-            repartition_time: repart_time,
+            repart_time,
             send_time,
         }
     }
@@ -775,7 +775,7 @@ impl RepartitionExec {
         context: Arc<TaskContext>,
     ) -> Result<()> {
         let mut partitioner =
-            BatchPartitioner::try_new(partitioning, metrics.repartition_time.clone())?;
+            BatchPartitioner::try_new(partitioning, metrics.repart_time.clone())?;
 
         // execute the child operator
         let timer = metrics.fetch_time.timer();


### PR DESCRIPTION
~Draft until https://github.com/apache/datafusion/pull/11440 merges~

## Which issue does this PR close?
None

## Rationale for this change

While reviewing https://github.com/apache/datafusion/pull/11440 from @korowa  it took me a little while to find how the metric was plumbed through. Part of that was that the field name is slightly different

## What changes are included in this PR?

Rename a field to match the metric it tracks

## Are these changes tested?
By existing CI
## Are there any user-facing changes?
No this is entirely internal