### PR TITLE
feat: support UDWFs in Substrait

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1183,10 +1183,10 @@ pub async fn from_substrait_rex(
             let fn_name = substrait_fun_name(fn_name);
 
             // check udwf first, then udaf, then built-in window and aggregate functions
-            let fun = if let Ok(udaf) = ctx.udaf(fn_name) {
-                Ok(WindowFunctionDefinition::AggregateUDF(udaf))
-            } else if let Ok(udwf) = ctx.udwf(fn_name) {
+            let fun = if let Ok(udwf) = ctx.udwf(fn_name) {
                 Ok(WindowFunctionDefinition::WindowUDF(udwf))
+            } else if let Ok(udaf) = ctx.udaf(fn_name) {
+                Ok(WindowFunctionDefinition::AggregateUDF(udaf))
             } else if let Some(fun) = find_df_window_func(fn_name) {
                 Ok(fun)
             } else {

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -23,8 +23,8 @@ use datafusion::arrow::datatypes::{
 };
 use datafusion::common::plan_err;
 use datafusion::common::{
-    not_impl_datafusion_err, not_impl_err, plan_datafusion_err, substrait_datafusion_err,
-    substrait_err, DFSchema, DFSchemaRef,
+    not_impl_err, plan_datafusion_err, substrait_datafusion_err, substrait_err, DFSchema,
+    DFSchemaRef,
 };
 use datafusion::execution::FunctionRegistry;
 use datafusion::logical_expr::expr::{Exists, InSubquery, Sort};
@@ -1182,16 +1182,19 @@ pub async fn from_substrait_rex(
             };
             let fn_name = substrait_fun_name(fn_name);
 
-            // check udaf first, then built-in functions
-            let fun = match ctx.udaf(fn_name) {
-                Ok(udaf) => Ok(WindowFunctionDefinition::AggregateUDF(udaf)),
-                Err(_) => find_df_window_func(fn_name).ok_or_else(|| {
-                    not_impl_datafusion_err!(
-                        "Window function {} is not supported: function anchor = {:?}",
-                        fn_name,
-                        window.function_reference
-                    )
-                }),
+            // check udwf first, then udaf, then built-in window and aggregate functions
+            let fun = if let Ok(udaf) = ctx.udaf(fn_name) {
+                Ok(WindowFunctionDefinition::AggregateUDF(udaf))
+            } else if let Ok(udwf) = ctx.udwf(fn_name) {
+                Ok(WindowFunctionDefinition::WindowUDF(udwf))
+            } else if let Some(fun) = find_df_window_func(fn_name) {
+                Ok(fun)
+            } else {
+                not_impl_err!(
+                    "Window function {} is not supported: function anchor = {:?}",
+                    fn_name,
+                    window.function_reference
+                )
             }?;
 
             let order_by =


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Previously Substrait consumer would, for window functions, look at:
1. UDAFs
2. built-in window functions
3. built-in aggregate functions

That makes it tough to override the built-in window function behavior, as it could only be overridden with a UDAF but some window functions don't fit nicely into aggregates.

## What changes are included in this PR?

This change adds UDWFs at the top, so the consumer will look at:
1. UDWFs
2. UDAFs
3. built-in window functions
4. built-in aggregate functions

This allows us to override any window function as well, and also paves the way for moving DF's built-in window funcs into UDWFs.

## Are these changes tested?

Added a unit test

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
