### PR TITLE
make unparser `Dialect` trait `Send` + `Sync`

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -27,7 +27,7 @@ use sqlparser::keywords::ALL_KEYWORDS;
 ///
 /// See <https://github.com/sqlparser-rs/sqlparser-rs/pull/1170>
 /// See also the discussion in <https://github.com/apache/datafusion/pull/10625>
-pub trait Dialect {
+pub trait Dialect: Send + Sync {
     /// Return the character used to quote identifiers.
     fn identifier_quote_style(&self, _identifier: &str) -> Option<char>;
 


### PR DESCRIPTION
## Which issue does this PR close?

This makes unparser trait `Dialect` easier to work within DataFusion context for federated queries (datafusion-federation).

## Rationale for this change

In federated query context, that could be use cases that a dialect needs to be specified for table providers targeting protocol like flight, odbc because the underlying DBMS may have different sql dialect. Without Send + Sync, it can be tricky to pass the config of dialect down into table provider scan/execute method, etc. 

In current design, the dialect is mostly an empty struct so it's safe to change so. The alternative is to pass a `fn` which create a `Arc<dyn Dialect>` around which doesn't look great.

Thoughts?

## What changes are included in this PR?

Make Unparser Dialect to be Send + Sync

## Are these changes tested?

n/a. I don't think it needs one.

## Are there any user-facing changes?

n/a