### PR TITLE
Minor: avoid a clone in type coercion

### DIFF
--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -84,7 +84,7 @@ impl AnalyzerRule for TypeCoercion {
 /// Assumes that children have already been optimized
 fn analyze_internal(
     external_schema: &DFSchema,
-    mut plan: LogicalPlan,
+    plan: LogicalPlan,
 ) -> Result<Transformed<LogicalPlan>> {
     // get schema representing all available input fields. This is used for data type
     // resolution only, so order does not matter here
@@ -103,15 +103,13 @@ fn analyze_internal(
     // select t2.c2 from t1 where t1.c1 in (select t2.c1 from t2 where t2.c2=t1.c3)
     schema.merge(external_schema);
 
-    if let LogicalPlan::Filter(filter) = &mut plan {
-        if let Ok(new_predicate) = filter
-            .predicate
-            .clone()
-            .cast_to(&DataType::Boolean, filter.input.schema())
-        {
-            filter.predicate = new_predicate;
-        }
-    }
+    // Coerce filter predicates to boolean (handles `WHERE NULL`)
+    let plan = if let LogicalPlan::Filter(mut filter) = plan {
+        filter.predicate = filter.predicate.cast_to(&DataType::Boolean, &schema)?;
+        LogicalPlan::Filter(filter)
+    } else {
+        plan
+    };
 
     let mut expr_rewrite = TypeCoercionRewriter::new(&schema);
 

--- a/datafusion/sqllogictest/test_files/misc.slt
+++ b/datafusion/sqllogictest/test_files/misc.slt
@@ -31,7 +31,7 @@ select 1 where NULL
 ----
 
 # Where clause does not accept non boolean and has nice error message
-query Cannot create filter with non\-boolean predicate 'Utf8\("foo"\)' returning Utf8
+query error Cannot create filter with non\-boolean predicate 'Utf8\("foo"\)' returning Utf8
 select 1 where 'foo'
 
 query I

--- a/datafusion/sqllogictest/test_files/misc.slt
+++ b/datafusion/sqllogictest/test_files/misc.slt
@@ -30,6 +30,10 @@ query I
 select 1 where NULL
 ----
 
+# Where clause does not accept non boolean and has nice error message
+query Cannot create filter with non\-boolean predicate 'Utf8\("foo"\)' returning Utf8
+select 1 where 'foo'
+
 query I
 select 1 where NULL and 1 = 1
 ----


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/datafusion/pull/11491 from  @xinlifoobar


## Rationale for this change

While reviewing https://github.com/apache/datafusion/pull/11491  I found a way to remove the clone of predicate in the type coercion pass


## What changes are included in this PR?

1. Remove a clone
2. Add a test for the nice error message on non boolean predicates

## Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
