### PR TITLE
fix: make `UnKnownColumn`s not equal to others physical exprs

### DIFF
--- a/datafusion/physical-expr/src/expressions/column.rs
+++ b/datafusion/physical-expr/src/expressions/column.rs
@@ -95,10 +95,8 @@ impl PhysicalExpr for UnKnownColumn {
 
 impl PartialEq<dyn Any> for UnKnownColumn {
     fn eq(&self, _other: &dyn Any) -> bool {
-        // The `name` of an `UnKnownColumn` may come from another expression's name, and different expressions
-        // may have the same name.  For example, `t1.a` and `t2.a` both have the same name `a`.
-        // Therefore, we can't determine whether two UnknownColumns are the same only by their names,
-        // so return false for safety.
+        // UnknownColumn is not a valid expression, so it should not be equal to any other expression.
+        // See https://github.com/apache/datafusion/pull/11536
         false
     }
 }

--- a/datafusion/physical-expr/src/expressions/column.rs
+++ b/datafusion/physical-expr/src/expressions/column.rs
@@ -21,7 +21,6 @@ use std::any::Any;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use crate::physical_expr::down_cast_any_ref;
 use crate::PhysicalExpr;
 
 use arrow::{
@@ -95,11 +94,12 @@ impl PhysicalExpr for UnKnownColumn {
 }
 
 impl PartialEq<dyn Any> for UnKnownColumn {
-    fn eq(&self, other: &dyn Any) -> bool {
-        down_cast_any_ref(other)
-            .downcast_ref::<Self>()
-            .map(|x| self == x)
-            .unwrap_or(false)
+    fn eq(&self, _other: &dyn Any) -> bool {
+        // The `name` of an `UnKnownColumn` may come from another expression's name, and different expressions
+        // may have the same name.  For example, `t1.a` and `t2.a` both have the same name `a`.
+        // Therefore, we can't determine whether two UnknownColumns are the same only by their names,
+        // so return false for safety.
+        false
     }
 }
 

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -431,7 +431,12 @@ impl ExecutionPlan for InterleaveExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(InterleaveExec::try_new(children)?))
+        // New children may not be able to interleave; in that case, we fall back to UnionExec.
+        if !can_interleave(children.iter()) {
+            Ok(Arc::new(UnionExec::new(children)))
+        } else {
+            Ok(Arc::new(InterleaveExec::try_new(children)?))
+        }
     }
 
     fn execute(

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -431,12 +431,7 @@ impl ExecutionPlan for InterleaveExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // New children may not be able to interleave; in that case, we fall back to UnionExec.
-        if !can_interleave(children.iter()) {
-            Ok(Arc::new(UnionExec::new(children)))
-        } else {
-            Ok(Arc::new(InterleaveExec::try_new(children)?))
-        }
+        Ok(Arc::new(InterleaveExec::try_new(children)?))
     }
 
     fn execute(

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -431,6 +431,12 @@ impl ExecutionPlan for InterleaveExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        // New children are no longer interleavable, which might be a bug of optimization rewrite.
+        if !can_interleave(children.iter()) {
+            return internal_err!(
+                "Can not create InterleaveExec: new children can not be interleaved"
+            );
+        }
         Ok(Arc::new(InterleaveExec::try_new(children)?))
     }
 

--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -602,3 +602,48 @@ physical_plan
 09)--ProjectionExec: expr=[1 as count, MAX(Int64(10))@0 as n]
 10)----AggregateExec: mode=Single, gby=[], aggr=[MAX(Int64(10))]
 11)------PlaceholderRowExec
+
+
+# Test issue: https://github.com/apache/datafusion/issues/11409
+statement ok
+CREATE TABLE t1(v0 BIGINT, v1 BIGINT, v2 BIGINT, v3 BOOLEAN);
+
+statement ok
+CREATE TABLE t2(v0 DOUBLE);
+
+query I
+INSERT INTO t1(v0, v2, v1) VALUES (-1229445667, -342312412, -1507138076);
+----
+1
+
+query I
+INSERT INTO t1(v0, v1) VALUES (1541512604, -1229445667);
+----
+1
+
+query I
+INSERT INTO t1(v1, v3, v0, v2) VALUES (-1020641465, false, -1493773377, 1751276473);
+----
+1
+
+query I
+INSERT INTO t1(v3) VALUES (true), (true), (false);
+----
+3
+
+query I
+INSERT INTO t2(v0) VALUES (0.28014577292925047);
+----
+1
+
+query II
+SELECT t1.v2, t1.v0 FROM t2 NATURAL JOIN t1
+    UNION ALL
+SELECT t1.v2, t1.v0 FROM t2 NATURAL JOIN t1 WHERE (t1.v2 IS NULL);
+----
+
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11409.

## Rationale for this change

~~After certain optimizations such as `ProjectionPushdown`, the children of `InterleaveExec` can no longer meet the interleave [condition](https://github.com/apache/datafusion/blob/b19744968770c4ab426d065dec3cc5147534e87a/datafusion/physical-plan/src/union.rs#L363) because their output_partitioning becomes inconsistent.~~
~~Perhaps in this situation,  we could consider falling back to `UnionExec` from `InterleaveExec` instead of throwing an error.~~

### Update
We determine that union inputs can interleave when they have the same hash partition spec.
https://github.com/apache/datafusion/blob/12d82c427d6c37f7884a508707ccd3058a446908/datafusion/physical-plan/src/union.rs#L499
But this may be incorrect if the expressions in the partition spec contain [UnKnownColumn](https://github.com/apache/datafusion/blob/12d82c427d6c37f7884a508707ccd3058a446908/datafusion/physical-expr/src/expressions/column.rs#L35).

When the partitioning expression no longer appears in the plan's output, for example, if the projection expressions in `ProjectionExec` no longer include it, this expression is converted into an `UnknownColumn`, using `expr::to_string()` as its name. This expression comes from the child of current plan. It is invalid for the current plan and shouldn't be used for evaluation or making decisions against the current plan.
https://github.com/apache/datafusion/blob/12d82c427d6c37f7884a508707ccd3058a446908/datafusion/physical-plan/src/projection.rs#L138


Even if two UnknownColumns have the same name, their source expressions might not be the same.
For example, in issue #11409, the partition expressions of both inputs of `InterleaveExec` are `UnKnownColumn { name: "v0@0" }`, which corresponds to a `Column` expression named v0 with index 0. However, this `Column` expression references the output of the child plan of these inputs, and their corresponding source expressions are `CAST(t1.v0 AS Float64)` and `t2.v0`, respectively.

```sh
# InterleaveExec Input-0
ProjectionExec: expr=[v2@2 as v2, v0@1 as v0], schema=[v2:Int64;N, v0:Int64;N], O=Hash([UnKnownColumn { name: "v0@0" }], 2)
  ProjectionExec: expr=[v0@0 as v0, v0@1 as v0, v2@2 as v2], schema=[v0:Float64;N, v0:Int64;N, v2:Int64;N], O=Hash([Column { name: "v0", index: 0 }], 2)
    HashJoinExec: mode=Partitioned, join_type=Inner, on=[(v0@0, CAST(t1.v0 AS Float64)@2)], schema=[v0:Float64;N, v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=Hash([Column { name: "CAST(t1.v0 AS Float64)", index: 3 }], 2)
      RepartitionExec: partitioning=Hash([v0@0], 2), input_partitions=1, schema=[v0:Float64;N], O=Hash([Column { name: "v0", index: 0 }], 2)
        MemoryExec: partitions=1, partition_sizes=[1], schema=[v0:Float64;N], O=UnknownPartitioning(1)
      RepartitionExec: partitioning=Hash([CAST(t1.v0 AS Float64)@2], 2), input_partitions=1, schema=[v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=Hash([Column { name: "CAST(t1.v0 AS Float64)", index: 2 }], 2)
        ProjectionExec: expr=[v0@0 as v0, v2@1 as v2, CAST(v0@0 AS Float64) as CAST(t1.v0 AS Float64)], schema=[v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=UnknownPartitioning(1)
          MemoryExec: partitions=1, partition_sizes=[4], schema=[v0:Int64;N, v2:Int64;N], O=UnknownPartitioning(1)

# InterleaveExec Input-1
ProjectionExec: expr=[v2@2 as v2, v0@1 as v0], schema=[v2:Int64;N, v0:Int64;N], O=Hash([UnKnownColumn { name: "v0@0" }], 2)
  ProjectionExec: expr=[v0@0 as v0, v0@1 as v0, v2@2 as v2], schema=[v0:Float64;N, v0:Int64;N, v2:Int64;N], O=Hash([Column { name: "v0", index: 0 }], 2)
    ProjectionExec: expr=[v0@3 as v0, v0@0 as v0, v2@1 as v2, CAST(t1.v0 AS Float64)@2 as CAST(t1.v0 AS Float64)], schema=[v0:Float64;N, v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=Hash([Column { name: "v0", index: 0 }], 2)
      HashJoinExec: mode=Partitioned, join_type=Inner, on=[(CAST(t1.v0 AS Float64)@2, v0@0)], schema=[v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N, v0:Float64;N], O=Hash([Column { name: "v0", index: 3 }], 2)
        RepartitionExec: partitioning=Hash([CAST(t1.v0 AS Float64)@2], 2), input_partitions=2, schema=[v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=Hash([Column { name: "CAST(t1.v0 AS Float64)", index: 2 }], 2)
          ProjectionExec: expr=[v0@0 as v0, v2@1 as v2, CAST(v0@0 AS Float64) as CAST(t1.v0 AS Float64)], schema=[v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=RoundRobinBatch(2)
            RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1, schema=[v0:Int64;N, v2:Int64;N], O=RoundRobinBatch(2)
              FilterExec: v2@1 IS NULL, schema=[v0:Int64;N, v2:Int64;N], O=UnknownPartitioning(1)
                MemoryExec: partitions=1, partition_sizes=[4], schema=[v0:Int64;N, v2:Int64;N], O=UnknownPartitioning(1)
        RepartitionExec: partitioning=Hash([v0@0], 2), input_partitions=1, schema=[v0:Float64;N], O=Hash([Column { name: "v0", index: 0 }], 2)
          MemoryExec: partitions=1, partition_sizes=[1], schema=[v0:Float64;N], O=UnknownPartitioning(1)
```

After `ProjectionPushdown` creates new ProjectionExec, it performs some degree of restoration on the UnKnownColumn, they become different and no longer meet the interleave condition.
```sh
# New InterleaveExec Input-0:
ProjectionExec: expr=[v2@1 as v2, v0@0 as v0], schema=[v2:Int64;N, v0:Int64;N], O=Hash([UnKnownColumn { name: "CAST(t1.v0 AS Float64)@3" }], 2)
  HashJoinExec: mode=Partitioned, join_type=Inner, on=[(v0@0, CAST(t1.v0 AS Float64)@2)], projection=[v0@1, v2@2], schema=[v0:Int64;N, v2:Int64;N], O=Hash([UnKnownColumn { name: "CAST(t1.v0 AS Float64)@3" }], 2)
    RepartitionExec: partitioning=Hash([v0@0], 2), input_partitions=1, schema=[v0:Float64;N], O=Hash([Column { name: "v0", index: 0 }], 2)
      MemoryExec: partitions=1, partition_sizes=[1], schema=[v0:Float64;N], O=UnknownPartitioning(1)
    RepartitionExec: partitioning=Hash([CAST(t1.v0 AS Float64)@2], 2), input_partitions=1, schema=[v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=Hash([Column { name: "CAST(t1.v0 AS Float64)", index: 2 }], 2)
      ProjectionExec: expr=[v0@0 as v0, v2@1 as v2, CAST(v0@0 AS Float64) as CAST(t1.v0 AS Float64)], schema=[v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=UnknownPartitioning(1)
        MemoryExec: partitions=1, partition_sizes=[4], schema=[v0:Int64;N, v2:Int64;N], O=UnknownPartitioning(1)

# New InterleaveExec Input-1:
ProjectionExec: expr=[v2@1 as v2, v0@0 as v0], schema=[v2:Int64;N, v0:Int64;N], O=Hash([UnKnownColumn { name: "v0@3" }], 2)
  HashJoinExec: mode=Partitioned, join_type=Inner, on=[(CAST(t1.v0 AS Float64)@2, v0@0)], projection=[v0@0, v2@1], schema=[v0:Int64;N, v2:Int64;N], O=Hash([UnKnownColumn { name: "v0@3" }], 2)
    RepartitionExec: partitioning=Hash([CAST(t1.v0 AS Float64)@2], 2), input_partitions=2, schema=[v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=Hash([Column { name: "CAST(t1.v0 AS Float64)", index: 2 }], 2)
      ProjectionExec: expr=[v0@0 as v0, v2@1 as v2, CAST(v0@0 AS Float64) as CAST(t1.v0 AS Float64)], schema=[v0:Int64;N, v2:Int64;N, CAST(t1.v0 AS Float64):Float64;N], O=RoundRobinBatch(2)
        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1, schema=[v0:Int64;N, v2:Int64;N], O=RoundRobinBatch(2)
          FilterExec: v2@1 IS NULL, schema=[v0:Int64;N, v2:Int64;N], O=UnknownPartitioning(1)
            MemoryExec: partitions=1, partition_sizes=[4], schema=[v0:Int64;N, v2:Int64;N], O=UnknownPartitioning(1)
    RepartitionExec: partitioning=Hash([v0@0], 2), input_partitions=1, schema=[v0:Float64;N], O=Hash([Column { name: "v0", index: 0 }], 2)
      MemoryExec: partitions=1, partition_sizes=[1], schema=[v0:Float64;N], O=UnknownPartitioning(1)
```


## What changes are included in this PR?


## Are these changes tested?
Yes

## Are there any user-facing changes?
No
