### PR TITLE
feat: Error when a SHOW command is passed in with an accompanying non-existant variable

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1146,6 +1146,19 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             // we could introduce alias in OptionDefinition if this string matching thing grows
             format!("{base_query} WHERE name = 'datafusion.execution.time_zone'")
         } else {
+            // These values are what are used to make the information_schema table, so we just
+            // check here, before actually planning or executing the query, if it would produce no
+            // results, and error preemptively if it would (for a better UX)
+            let is_valid_variable = self.context_provider
+                .options()
+                .entries()
+                .iter()
+                .any(|opt| opt.key == variable);
+
+            if !is_valid_variable {
+                return plan_err!("'{variable}' is not a variable which can be viewed with 'SHOW'")
+            }
+
             format!("{base_query} WHERE name = '{variable}'")
         };
 

--- a/datafusion/sqllogictest/test_files/information_schema.slt
+++ b/datafusion/sqllogictest/test_files/information_schema.slt
@@ -368,9 +368,18 @@ datafusion.execution.time_zone +00:00 The default time zone Some functions, e.g.
 
 
 # show empty verbose
-query TTT
+statement error
 SHOW VERBOSE
 ----
+DataFusion error: Error during planning: '' is not a variable which can be viewed with 'SHOW'
+
+
+# show nonsense verbose
+statement error
+SHOW NONSENSE VERBOSE
+----
+DataFusion error: Error during planning: 'nonsense' is not a variable which can be viewed with 'SHOW'
+
 
 # information_schema_describe_table
 
@@ -506,10 +515,11 @@ SHOW columns from datafusion.public.t2
 
 
 # show_non_existing_variable
-# FIXME
-# currently we cannot know whether a variable exists, this will output 0 row instead
-statement ok
+statement error
 SHOW SOMETHING_UNKNOWN;
+----
+DataFusion error: Error during planning: 'something_unknown' is not a variable which can be viewed with 'SHOW'
+
 
 statement ok
 DROP TABLE t;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11529 

## Rationale for this change
This is a very simple implementation for the change suggested in #11529, and is easy to review and comprehend.

## What changes are included in this PR?
This causes datafusion to return an error when someone attempts to execute a command that contains a `SHOW` statement whose variable does not exist in the `information_schema.df_settings` table. This provides a better UX for the user, as they get told exactly what's going on (with a clear error) when they execute this command, instead of getting an empty table as the result (which was happening previously).

## Are these changes tested?

Yes - Additions were made to the sqllogictest tests to cover the use case addressed here.

## Are there any user-facing changes?

I think this counts as a user-facing change - it would be easy to rely on the behavior of "SHOW <variable> will return an empty result if <variable> doesn't exist" and so it's very possible someone does rely on that. 

I'd be happy to update documentation if that's necessary with this change, though I'm somewhat uncertain as to whether this warrants that - the previous behavior wasn't specified in docs, so I don't know if it is necessary here. It probably couldn't hurt, I think.
