### PR TITLE
feat: support Map literals in Substrait consumer and producer

### DIFF
--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -741,30 +741,30 @@ mod tests {
         // Row 0
         builder.keys().append_value("key1");
         builder.keys().append_value("key2");
-        builder.values().append_value(10);
-        builder.values().append_value(11);
+        builder.values().append_value(1);
+        builder.values().append_value(2);
         builder.append(true).unwrap();
         // Row 1
         builder.keys().append_value("key1");
         builder.keys().append_value("key2");
-        builder.values().append_value(10);
-        builder.values().append_value(11);
+        builder.values().append_value(1);
+        builder.values().append_value(2);
         builder.append(true).unwrap();
         // Row 2
         builder.keys().append_value("key1");
         builder.keys().append_value("key2");
-        builder.values().append_value(10);
-        builder.values().append_value(12);
+        builder.values().append_value(1);
+        builder.values().append_value(3);
         builder.append(true).unwrap();
         // Row 3
         builder.keys().append_value("key1");
         builder.keys().append_value("key3");
-        builder.values().append_value(10);
-        builder.values().append_value(11);
+        builder.values().append_value(1);
+        builder.values().append_value(2);
         builder.append(true).unwrap();
         // Row 4
         builder.keys().append_value("key1");
-        builder.values().append_value(10);
+        builder.values().append_value(1);
         builder.append(true).unwrap();
         // Row 5
         builder.keys().append_value("key1");
@@ -774,7 +774,7 @@ mod tests {
         builder.append(true).unwrap();
         // Row 7
         builder.keys().append_value("key1");
-        builder.values().append_value(10);
+        builder.values().append_value(1);
         builder.append(false).unwrap();
 
         let array = Arc::new(builder.finish()) as ArrayRef;
@@ -783,8 +783,8 @@ mod tests {
         let mut hashes = vec![0; array.len()];
         create_hashes(&[array], &random_state, &mut hashes).unwrap();
         assert_eq!(hashes[0], hashes[1]); // same value
-        assert_ne!(hashes[0], hashes[2]); // different key
-        assert_ne!(hashes[0], hashes[3]); // different value
+        assert_ne!(hashes[0], hashes[2]); // different value
+        assert_ne!(hashes[0], hashes[3]); // different key
         assert_ne!(hashes[0], hashes[4]); // missing an entry
         assert_ne!(hashes[4], hashes[5]); // filled vs null value
         assert_eq!(hashes[6], hashes[7]); // empty vs null map

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -1773,6 +1773,7 @@ impl ScalarValue {
             }
             DataType::List(_)
             | DataType::LargeList(_)
+            | DataType::Map(_, _)
             | DataType::Struct(_)
             | DataType::Union(_, _) => {
                 let arrays = scalars.map(|s| s.to_array()).collect::<Result<Vec<_>>>()?;
@@ -1841,7 +1842,6 @@ impl ScalarValue {
             | DataType::Time32(TimeUnit::Nanosecond)
             | DataType::Time64(TimeUnit::Second)
             | DataType::Time64(TimeUnit::Millisecond)
-            | DataType::Map(_, _)
             | DataType::RunEndEncoded(_, _)
             | DataType::ListView(_)
             | DataType::LargeListView(_) => {

--- a/datafusion/sqllogictest/test_files/map.slt
+++ b/datafusion/sqllogictest/test_files/map.slt
@@ -302,3 +302,9 @@ SELECT MAP(arrow_cast(make_array('POST', 'HEAD', 'PATCH'), 'LargeList(Utf8)'), a
 {POST: 41, HEAD: 33, PATCH: 30}
 {POST: 41, HEAD: 33, PATCH: 30}
 {POST: 41, HEAD: 33, PATCH: 30}
+
+
+query ?
+VALUES(MAP([], []))
+----
+{}

--- a/datafusion/sqllogictest/test_files/map.slt
+++ b/datafusion/sqllogictest/test_files/map.slt
@@ -305,6 +305,8 @@ SELECT MAP(arrow_cast(make_array('POST', 'HEAD', 'PATCH'), 'LargeList(Utf8)'), a
 
 
 query ?
-VALUES(MAP([], []))
+VALUES (MAP(['a'], [1])), (MAP(['b'], [2])), (MAP(['c', 'a'], [3, 1]))
 ----
-{}
+{a: 1}
+{b: 2}
+{c: 3, a: 1}

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1752,7 +1752,12 @@ fn from_substrait_literal(
                 .iter()
                 .map(|el| {
                     element_name_idx = *name_idx;
-                    from_substrait_literal(el, extensions, dfs_names, &mut element_name_idx)
+                    from_substrait_literal(
+                        el,
+                        extensions,
+                        dfs_names,
+                        &mut element_name_idx,
+                    )
                 })
                 .collect::<Result<Vec<_>>>()?;
             *name_idx = element_name_idx;

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -57,8 +57,10 @@ use datafusion::logical_expr::{expr, Between, JoinConstraint, LogicalPlan, Opera
 use datafusion::prelude::Expr;
 use pbjson_types::Any as ProtoAny;
 use substrait::proto::exchange_rel::{ExchangeKind, RoundRobin, ScatterFields};
+use substrait::proto::expression::literal::map::KeyValue;
 use substrait::proto::expression::literal::{
-    user_defined, IntervalDayToSecond, IntervalYearToMonth, List, Struct, UserDefined,
+    user_defined, IntervalDayToSecond, IntervalYearToMonth, List, Map, Struct,
+    UserDefined,
 };
 use substrait::proto::expression::subquery::InPredicate;
 use substrait::proto::expression::window_function::BoundsType;
@@ -1922,6 +1924,48 @@ fn to_substrait_literal(
             convert_array_to_literal_list(l, extensions)?,
             LARGE_CONTAINER_TYPE_VARIATION_REF,
         ),
+        ScalarValue::Map(m) => {
+            let map = if m.is_empty() || m.value(0).is_empty() {
+                let mt = to_substrait_type(m.data_type(), m.is_nullable(), extensions)?;
+                let mt = match mt {
+                    substrait::proto::Type {
+                        kind: Some(r#type::Kind::Map(mt)),
+                    } => Ok(mt.as_ref().to_owned()),
+                    _ => exec_err!("Unexpected type for a map: {mt:?}"),
+                }?;
+                LiteralType::EmptyMap(mt)
+            } else {
+                let keys = (0..m.keys().len())
+                    .map(|i| {
+                        to_substrait_literal(
+                            &ScalarValue::try_from_array(&m.keys(), i)?,
+                            extensions,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let values = (0..m.values().len())
+                    .map(|i| {
+                        to_substrait_literal(
+                            &ScalarValue::try_from_array(&m.values(), i)?,
+                            extensions,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                let key_values = keys
+                    .into_iter()
+                    .zip(values.into_iter())
+                    .map(|(k, v)| {
+                        Ok(KeyValue {
+                            key: Some(k),
+                            value: Some(v),
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                LiteralType::Map(Map { key_values })
+            };
+            (map, DEFAULT_CONTAINER_TYPE_VARIATION_REF)
+        }
         ScalarValue::Struct(s) => (
             LiteralType::Struct(Struct {
                 fields: s
@@ -1967,7 +2011,7 @@ fn convert_array_to_literal_list<T: OffsetSizeTrait>(
         .collect::<Result<Vec<_>>>()?;
 
     if values.is_empty() {
-        let et = match to_substrait_type(
+        let lt = match to_substrait_type(
             array.data_type(),
             array.is_nullable(),
             extensions,
@@ -1977,7 +2021,7 @@ fn convert_array_to_literal_list<T: OffsetSizeTrait>(
             } => lt.as_ref().to_owned(),
             _ => unreachable!(),
         };
-        Ok(LiteralType::EmptyList(et))
+        Ok(LiteralType::EmptyList(lt))
     } else {
         Ok(LiteralType::List(List { values }))
     }
@@ -2094,7 +2138,9 @@ mod test {
         from_substrait_literal_without_names, from_substrait_type_without_names,
     };
     use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
-    use datafusion::arrow::array::GenericListArray;
+    use datafusion::arrow::array::{
+        GenericListArray, Int64Builder, MapBuilder, StringBuilder,
+    };
     use datafusion::arrow::datatypes::Field;
     use datafusion::common::scalar::ScalarStructBuilder;
     use std::collections::HashMap;
@@ -2159,6 +2205,28 @@ mod test {
                 1,
             ),
         )))?;
+
+        // Null map
+        let mut map_builder =
+            MapBuilder::new(None, StringBuilder::new(), Int64Builder::new());
+        map_builder.append(false)?;
+        round_trip_literal(ScalarValue::Map(Arc::new(map_builder.finish())))?;
+
+        // Empty map
+        let mut map_builder =
+            MapBuilder::new(None, StringBuilder::new(), Int64Builder::new());
+        map_builder.append(true)?;
+        round_trip_literal(ScalarValue::Map(Arc::new(map_builder.finish())))?;
+
+        // Valid map
+        let mut map_builder =
+            MapBuilder::new(None, StringBuilder::new(), Int64Builder::new());
+        map_builder.keys().append_value("key1");
+        map_builder.keys().append_value("key2");
+        map_builder.values().append_value(1);
+        map_builder.values().append_value(2);
+        map_builder.append(true)?;
+        round_trip_literal(ScalarValue::Map(Arc::new(map_builder.finish())))?;
 
         let c0 = Field::new("c0", DataType::Boolean, true);
         let c1 = Field::new("c1", DataType::Int32, true);

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -749,7 +749,7 @@ async fn roundtrip_values() -> Result<()> {
                 [[-213.1, NULL, 5.5, 2.0, 1.0], []], \
                 arrow_cast([1,2,3], 'LargeList(Int64)'), \
                 STRUCT(true, 1 AS int_field, CAST(NULL AS STRING)), \
-                [STRUCT(STRUCT('a' AS string_field) AS struct_field)]\
+                [STRUCT(STRUCT('a' AS string_field) AS struct_field), STRUCT(STRUCT('b' AS string_field) AS struct_field)]\
             ), \
             (NULL, NULL, NULL, NULL, NULL, NULL)",
         "Values: \
@@ -759,7 +759,7 @@ async fn roundtrip_values() -> Result<()> {
                 List([[-213.1, , 5.5, 2.0, 1.0], []]), \
                 LargeList([1, 2, 3]), \
                 Struct({c0:true,int_field:1,c2:}), \
-                List([{struct_field: {string_field: a}}])\
+                List([{struct_field: {string_field: a}}, {struct_field: {string_field: b}}])\
             ), \
             (Int64(NULL), Utf8(NULL), List(), LargeList(), Struct({c0:,int_field:,c2:}), List())",
     true).await


### PR DESCRIPTION
## Which issue does this PR close?

Related to Map epic https://github.com/apache/datafusion/issues/11434

## Rationale for this change

Substrait didn't support Map literals, since we previously didn't have Map ScalarValues. https://github.com/apache/datafusion/pull/11224 implemented ScalarValues (thanks!), so now we can add them into Substrait as well. 

There were also couple gaps left by the implementation that I encountered while testing this, so I fixed those as well.

Also, there was a bug in the from_substrait_literal for lists containing structs, which I realized while implementing the map support.

## What changes are included in this PR?

- Implement Substrait roundtrip support for Map literals, incl. null and empty maps.
- Fix field name handling for Substrait lists containing structs
- Add Map support to `ScalarValue::iter_to_array` and `create_hashes`

## Are these changes tested?

Tested with new roundtrip tests for the Map literals, and unit tests for hashing.
Also an existing UT for list literals is extended to cover the multiple structs values case.


I'd have added a sql roundtrip test for Map as well, but it seems that the `MAP` command turns into a ScalarFunction rather than ScalarValue. Maybe we'd need to run some round of optimizer to fold it, but I wonder why that is different from the `STRUCT` command which does turn into a struct literal?

I.e. doing `roundtrip("VALUES (MAP(['k1', 'k2'], [true, CAST(NULL AS BOOLEAN)]))").await?;` results in `Error: Substrait("Only literal types can be aliased in Virtual Tables, got: ScalarFunction")`, while similar code for STRUCT works fine. 

## Are there any user-facing changes?
