### PR TITLE
fix: fixes trig function order by

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -1063,7 +1063,6 @@ impl ScalarValue {
 
     /// Create an one value in the given type.
     pub fn new_one(datatype: &DataType) -> Result<ScalarValue> {
-        assert!(datatype.is_primitive());
         Ok(match datatype {
             DataType::Int8 => ScalarValue::Int8(Some(1)),
             DataType::Int16 => ScalarValue::Int16(Some(1)),
@@ -1086,7 +1085,6 @@ impl ScalarValue {
 
     /// Create a negative one value in the given type.
     pub fn new_negative_one(datatype: &DataType) -> Result<ScalarValue> {
-        assert!(datatype.is_primitive());
         Ok(match datatype {
             DataType::Int8 | DataType::UInt8 => ScalarValue::Int8(Some(-1)),
             DataType::Int16 | DataType::UInt16 => ScalarValue::Int16(Some(-1)),
@@ -1104,7 +1102,6 @@ impl ScalarValue {
     }
 
     pub fn new_ten(datatype: &DataType) -> Result<ScalarValue> {
-        assert!(datatype.is_primitive());
         Ok(match datatype {
             DataType::Int8 => ScalarValue::Int8(Some(10)),
             DataType::Int16 => ScalarValue::Int16(Some(10)),

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1982,3 +1982,34 @@ query I
 select strpos('joséésoj', arrow_cast(null, 'Utf8'));
 ----
 NULL
+
+statement ok
+CREATE TABLE t1 (v1 int) AS VALUES (1), (2), (3);
+
+query I
+SELECT * FROM t1 ORDER BY ACOS(SIN(v1));
+----
+2
+1
+3
+
+query I
+SELECT * FROM t1 ORDER BY ACOSH(SIN(v1));
+----
+1
+2
+3
+
+query I
+SELECT * FROM t1 ORDER BY ASIN(SIN(v1));
+----
+3
+1
+2
+
+query I
+SELECT * FROM t1 ORDER BY ATANH(SIN(v1));
+----
+3
+1
+2

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -2013,3 +2013,6 @@ SELECT * FROM t1 ORDER BY ATANH(SIN(v1));
 3
 1
 2
+
+statement ok
+drop table t1;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11552

## Rationale for this change

The `assert!(datatype.is_primitive());` is getting hit in `new_negative_one`, but as far as I can tell isn't needed. There's a match statement right below that handles the datatype.

Without the assert these functions seem to work properly. That said, I'm a little confused why it's working exactly. The datatypes coming through are `Datatype::Null` which caused the assertion error but seemingly isn't causing errors in the match statement.

I'm also working on a branch https://github.com/apache/datafusion/compare/main...tshauck:arrow-datafusion:add-unary-udf-bounds?expand=1 that I think is a more complete way to solve this problem because currently unary functions don't report their bounds which I think is what ordering relies on to get its data type and means nested trig functions can work for ordering.

## What changes are included in this PR?

Removed `datatype.is_primative()` asserts where the datatype is immediately matched on. I think it'd generally be better to handle unexpected datatypes that way for the error propagation vs asserting, which can lead to panics at query time.

## Are these changes tested?

I added tests from the ticket that were reported as panicking.

## Are there any user-facing changes?

No