### PR TITLE
Fix : `signum` function bug when `0.0` input

### DIFF
--- a/datafusion/functions/src/math/mod.rs
+++ b/datafusion/functions/src/math/mod.rs
@@ -174,3 +174,67 @@ pub fn functions() -> Vec<Arc<ScalarUDF>> {
         trunc(),
     ]
 }
+
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use arrow::array::{Float32Array, Float64Array};
+    use datafusion_common::cast::{as_float32_array, as_float64_array};
+    use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
+
+    use crate::math::signum::SignumFunc;
+
+    #[test]
+    fn test_signum_f32() {
+        let args = [ColumnarValue::Array(Arc::new(Float32Array::from(vec![-1.0, -0.0, 0.0, 1.0])))];
+
+        let result = SignumFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function signum");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float32_array(&arr)
+                    .expect("failed to convert result to a Float32Array");
+
+                assert_eq!(floats.len(), 4);
+                assert_eq!(floats.value(0), -1.0);
+                assert_eq!(floats.value(1), 0.0);
+                assert_eq!(floats.value(2), 0.0);
+                assert_eq!(floats.value(3), 1.0);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+
+    #[test]
+    fn test_signum_f64() {
+        let args = [
+            ColumnarValue::Array(Arc::new(Float64Array::from(vec![-1.0, -0.0, 0.0, 1.0]))), // base
+        ];
+
+        let result = SignumFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function signum");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float64_array(&arr)
+                    .expect("failed to convert result to a Float32Array");
+
+                assert_eq!(floats.len(), 4);
+                assert_eq!(floats.value(0), -1.0);
+                assert_eq!(floats.value(1), 0.0);
+                assert_eq!(floats.value(2), 0.0);
+                assert_eq!(floats.value(3), 1.0);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+}

--- a/datafusion/functions/src/math/mod.rs
+++ b/datafusion/functions/src/math/mod.rs
@@ -35,8 +35,8 @@ pub mod pi;
 pub mod power;
 pub mod random;
 pub mod round;
-pub mod trunc;
 pub mod signum;
+pub mod trunc;
 
 // Create UDFs
 make_udf_function!(abs::AbsFunc, ABS, abs);
@@ -175,5 +175,3 @@ pub fn functions() -> Vec<Arc<ScalarUDF>> {
         trunc(),
     ]
 }
-
-

--- a/datafusion/functions/src/math/mod.rs
+++ b/datafusion/functions/src/math/mod.rs
@@ -36,6 +36,7 @@ pub mod power;
 pub mod random;
 pub mod round;
 pub mod trunc;
+pub mod signum;
 
 // Create UDFs
 make_udf_function!(abs::AbsFunc, ABS, abs);
@@ -81,7 +82,7 @@ make_math_unary_udf!(
 );
 make_udf_function!(random::RandomFunc, RANDOM, random);
 make_udf_function!(round::RoundFunc, ROUND, round);
-make_math_unary_udf!(SignumFunc, SIGNUM, signum, signum, super::signum_order);
+make_udf_function!(signum::SignumFunc, SIGNUM, signum);
 make_math_unary_udf!(SinFunc, SIN, sin, sin, super::sin_order);
 make_math_unary_udf!(SinhFunc, SINH, sinh, sinh, super::sinh_order);
 make_math_unary_udf!(SqrtFunc, SQRT, sqrt, sqrt, super::sqrt_order);
@@ -176,65 +177,3 @@ pub fn functions() -> Vec<Arc<ScalarUDF>> {
 }
 
 
-#[cfg(test)]
-mod test {
-    use std::sync::Arc;
-
-    use arrow::array::{Float32Array, Float64Array};
-    use datafusion_common::cast::{as_float32_array, as_float64_array};
-    use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
-
-    use crate::math::signum::SignumFunc;
-
-    #[test]
-    fn test_signum_f32() {
-        let args = [ColumnarValue::Array(Arc::new(Float32Array::from(vec![-1.0, -0.0, 0.0, 1.0])))];
-
-        let result = SignumFunc::new()
-            .invoke(&args)
-            .expect("failed to initialize function signum");
-
-        match result {
-            ColumnarValue::Array(arr) => {
-                let floats = as_float32_array(&arr)
-                    .expect("failed to convert result to a Float32Array");
-
-                assert_eq!(floats.len(), 4);
-                assert_eq!(floats.value(0), -1.0);
-                assert_eq!(floats.value(1), 0.0);
-                assert_eq!(floats.value(2), 0.0);
-                assert_eq!(floats.value(3), 1.0);
-            }
-            ColumnarValue::Scalar(_) => {
-                panic!("Expected an array value")
-            }
-        }
-    }
-
-    #[test]
-    fn test_signum_f64() {
-        let args = [
-            ColumnarValue::Array(Arc::new(Float64Array::from(vec![-1.0, -0.0, 0.0, 1.0]))), // base
-        ];
-
-        let result = SignumFunc::new()
-            .invoke(&args)
-            .expect("failed to initialize function signum");
-
-        match result {
-            ColumnarValue::Array(arr) => {
-                let floats = as_float64_array(&arr)
-                    .expect("failed to convert result to a Float32Array");
-
-                assert_eq!(floats.len(), 4);
-                assert_eq!(floats.value(0), -1.0);
-                assert_eq!(floats.value(1), 0.0);
-                assert_eq!(floats.value(2), 0.0);
-                assert_eq!(floats.value(3), 1.0);
-            }
-            ColumnarValue::Scalar(_) => {
-                panic!("Expected an array value")
-            }
-        }
-    }
-}

--- a/datafusion/functions/src/math/monotonicity.rs
+++ b/datafusion/functions/src/math/monotonicity.rs
@@ -197,11 +197,6 @@ pub fn radians_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-/// Non-decreasing for all real numbers x.
-pub fn signum_order(input: &[ExprProperties]) -> Result<SortProperties> {
-    Ok(input[0].sort_properties)
-}
-
 /// Non-decreasing on \[0, π\] and then non-increasing on \[π, 2π\].
 /// This pattern repeats periodically with a period of 2π.
 // TODO: Implement ordering rule of the SIN function.

--- a/datafusion/functions/src/math/signum.rs
+++ b/datafusion/functions/src/math/signum.rs
@@ -1,0 +1,192 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Float32Array, Float64Array};
+use arrow::datatypes::DataType;
+use arrow::datatypes::DataType::{Float32, Float64};
+
+use datafusion_common::{DataFusionError, exec_err, not_impl_err, Result};
+use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
+use datafusion_expr::ColumnarValue;
+use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
+
+use crate::utils::make_scalar_function;
+
+#[derive(Debug)]
+pub struct SignumFunc {
+    signature: Signature,
+}
+
+impl Default for SignumFunc {
+    fn default() -> Self {
+        SignumFunc::new()
+    }
+}
+
+impl SignumFunc {
+    pub fn new() -> Self {
+        use DataType::*;
+        Self {
+            signature: Signature::uniform(
+                1,
+                vec![Float64, Float32],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SignumFunc {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "signum"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        match &arg_types[0] {
+            Float32 => Ok(Float32),
+            Float64 => Ok(Float64),
+            _ => not_impl_err!(
+                "Unsupported data type {} for function signum",
+                arg_types[0].to_string()
+            ),
+        }
+    }
+
+    fn output_ordering(
+        &self,
+        input: &[ExprProperties],
+    ) -> Result<SortProperties> {
+        // Non-decreasing for all real numbers x.
+        Ok(input[0].sort_properties)
+    }
+
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
+        make_scalar_function(signum, vec![])(args)
+    }
+}
+
+/// signum SQL function
+pub fn signum(args: &[ArrayRef]) -> Result<ArrayRef> {
+    match args[0].data_type() {
+        Float64 => Ok(Arc::new(make_function_scalar_inputs_return_type!(
+            &args[0],
+            "signum",
+            Float64Array,
+            Float64Array,
+            { |x: f64| { if x == 0_f64 { 0_f64 } else { x.signum() } } }
+        )) as ArrayRef),
+
+        Float32 => Ok(Arc::new(make_function_scalar_inputs_return_type!(
+            &args[0],
+            "signum",
+            Float32Array,
+            Float32Array,
+            { |x: f32| { if x == 0_f32 { 0_f32 } else { x.signum() } } }
+        )) as ArrayRef),
+
+        other => exec_err!("Unsupported data type {other:?} for function signum"),
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use arrow::array::{Float32Array, Float64Array};
+
+    use datafusion_common::cast::{as_float32_array, as_float64_array};
+    use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
+
+    use crate::math::signum::SignumFunc;
+
+    #[test]
+    fn test_signum_f32() {
+        let args = [ColumnarValue::Array(Arc::new(Float32Array::from(
+            vec![-1.0, -0.0, 0.0, 1.0, -0.01, 0.01, f32::NAN, f32::INFINITY, f32::NEG_INFINITY]
+        )))];
+
+        let result = SignumFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function signum");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float32_array(&arr)
+                    .expect("failed to convert result to a Float32Array");
+
+                assert_eq!(floats.len(), 9);
+                assert_eq!(floats.value(0), -1.0);
+                assert_eq!(floats.value(1), 0.0);
+                assert_eq!(floats.value(2), 0.0);
+                assert_eq!(floats.value(3), 1.0);
+                assert_eq!(floats.value(4), -1.0);
+                assert_eq!(floats.value(5), 1.0);
+                assert!(floats.value(6).is_nan());
+                assert_eq!(floats.value(7), 1.0);
+                assert_eq!(floats.value(8), -1.0);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+
+    #[test]
+    fn test_signum_f64() {
+        let args = [
+            ColumnarValue::Array(Arc::new(Float64Array::from(
+                vec![-1.0, -0.0, 0.0, 1.0, -0.01, 0.01, f64::NAN, f64::INFINITY, f64::NEG_INFINITY]
+            )))];
+
+        let result = SignumFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function signum");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float64_array(&arr)
+                    .expect("failed to convert result to a Float32Array");
+
+                assert_eq!(floats.len(), 9);
+                assert_eq!(floats.value(0), -1.0);
+                assert_eq!(floats.value(1), 0.0);
+                assert_eq!(floats.value(2), 0.0);
+                assert_eq!(floats.value(3), 1.0);
+                assert_eq!(floats.value(4), -1.0);
+                assert_eq!(floats.value(5), 1.0);
+                assert!(floats.value(6).is_nan());
+                assert_eq!(floats.value(7), 1.0);
+                assert_eq!(floats.value(8), -1.0);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+}

--- a/datafusion/functions/src/math/signum.rs
+++ b/datafusion/functions/src/math/signum.rs
@@ -22,7 +22,7 @@ use arrow::array::{ArrayRef, Float32Array, Float64Array};
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::{Float32, Float64};
 
-use datafusion_common::{exec_err, not_impl_err, DataFusionError, Result};
+use datafusion_common::{exec_err, DataFusionError, Result};
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
@@ -69,11 +69,7 @@ impl ScalarUDFImpl for SignumFunc {
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         match &arg_types[0] {
             Float32 => Ok(Float32),
-            Float64 => Ok(Float64),
-            _ => not_impl_err!(
-                "Unsupported data type {} for function signum",
-                arg_types[0].to_string()
-            ),
+            _ => Ok(Float64),
         }
     }
 

--- a/datafusion/functions/src/math/signum.rs
+++ b/datafusion/functions/src/math/signum.rs
@@ -22,10 +22,10 @@ use arrow::array::{ArrayRef, Float32Array, Float64Array};
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::{Float32, Float64};
 
-use datafusion_common::{DataFusionError, exec_err, not_impl_err, Result};
-use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
-use datafusion_expr::ColumnarValue;
+use datafusion_common::{exec_err, not_impl_err, DataFusionError, Result};
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
+use datafusion_expr::ColumnarValue;
+use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
 
 use crate::utils::make_scalar_function;
 
@@ -77,10 +77,7 @@ impl ScalarUDFImpl for SignumFunc {
         }
     }
 
-    fn output_ordering(
-        &self,
-        input: &[ExprProperties],
-    ) -> Result<SortProperties> {
+    fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
         // Non-decreasing for all real numbers x.
         Ok(input[0].sort_properties)
     }
@@ -98,7 +95,15 @@ pub fn signum(args: &[ArrayRef]) -> Result<ArrayRef> {
             "signum",
             Float64Array,
             Float64Array,
-            { |x: f64| { if x == 0_f64 { 0_f64 } else { x.signum() } } }
+            {
+                |x: f64| {
+                    if x == 0_f64 {
+                        0_f64
+                    } else {
+                        x.signum()
+                    }
+                }
+            }
         )) as ArrayRef),
 
         Float32 => Ok(Arc::new(make_function_scalar_inputs_return_type!(
@@ -106,13 +111,20 @@ pub fn signum(args: &[ArrayRef]) -> Result<ArrayRef> {
             "signum",
             Float32Array,
             Float32Array,
-            { |x: f32| { if x == 0_f32 { 0_f32 } else { x.signum() } } }
+            {
+                |x: f32| {
+                    if x == 0_f32 {
+                        0_f32
+                    } else {
+                        x.signum()
+                    }
+                }
+            }
         )) as ArrayRef),
 
         other => exec_err!("Unsupported data type {other:?} for function signum"),
     }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -127,9 +139,17 @@ mod test {
 
     #[test]
     fn test_signum_f32() {
-        let args = [ColumnarValue::Array(Arc::new(Float32Array::from(
-            vec![-1.0, -0.0, 0.0, 1.0, -0.01, 0.01, f32::NAN, f32::INFINITY, f32::NEG_INFINITY]
-        )))];
+        let args = [ColumnarValue::Array(Arc::new(Float32Array::from(vec![
+            -1.0,
+            -0.0,
+            0.0,
+            1.0,
+            -0.01,
+            0.01,
+            f32::NAN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+        ])))];
 
         let result = SignumFunc::new()
             .invoke(&args)
@@ -159,10 +179,17 @@ mod test {
 
     #[test]
     fn test_signum_f64() {
-        let args = [
-            ColumnarValue::Array(Arc::new(Float64Array::from(
-                vec![-1.0, -0.0, 0.0, 1.0, -0.01, 0.01, f64::NAN, f64::INFINITY, f64::NEG_INFINITY]
-            )))];
+        let args = [ColumnarValue::Array(Arc::new(Float64Array::from(vec![
+            -1.0,
+            -0.0,
+            0.0,
+            1.0,
+            -0.01,
+            0.01,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ])))];
 
         let result = SignumFunc::new()
             .invoke(&args)

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -794,7 +794,7 @@ select round(column1, column2) from values (3.14, 2), (3.14, 3), (3.14, 21474836
 query RRR rowsort
 select signum(-2), signum(0), signum(2);
 ----
--1 1 1
+-1 0 1
 
 # signum scalar nulls
 query R rowsort


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11557 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. add signum function unit test
2. move `signum_order` function from monotonicity.rs to signum.rs
3. signum function implementation by new code. not `make_udf_function!` macro

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
1. Add some unit tests.
2. datafusion-cli test
```sql
> select signum(-1), signum(1), signum(0), signum(-0.0), signum(0.0), signum(1.0), signum(-1.0)
;
+-------------------+------------------+------------------+---------------------+--------------------+--------------------+---------------------+
| signum(Int64(-1)) | signum(Int64(1)) | signum(Int64(0)) | signum(Float64(-0)) | signum(Float64(0)) | signum(Float64(1)) | signum(Float64(-1)) |
+-------------------+------------------+------------------+---------------------+--------------------+--------------------+---------------------+
| -1.0              | 1.0              | 0.0              | 0.0                 | 0.0                | 1.0                | -1.0                |
+-------------------+------------------+------------------+---------------------+--------------------+--------------------+---------------------+

```

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

no
