### PR TITLE
GC `StringViewArray` in `CoalesceBatchesStream`

### DIFF
--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -351,7 +351,7 @@ fn gc_string_view_batch(batch: &RecordBatch) -> RecordBatch {
 
                 let gc_string = builder.finish();
 
-                debug_assert_eq!(gc_string.data_buffers().len(), 1);
+                debug_assert!(gc_string.data_buffers().len() <= 1); // buffer count can be 0 if the `ideal_buffer_size` is 0
 
                 Arc::new(gc_string)
             } else {

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -471,7 +471,6 @@ mod tests {
         let gc_array = do_gc(array.clone());
         compare_string_array_values(&array, &gc_array);
         assert_eq!(array.data_buffers().len(), 5);
-        // TODO this is failing now (it always compacts)
         assert_eq!(array.data_buffers().len(), gc_array.data_buffers().len()); // no compaction
     }
 

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -294,7 +294,7 @@ pub fn concat_batches(
     arrow::compute::concat_batches(schema, batches)
 }
 
-/// [`StringViewArray`] reference to the raw parquet decoded buffer, which reduces copy but prevents those buffer from being released.
+/// `StringViewArray` reference to the raw parquet decoded buffer, which reduces copy but prevents those buffer from being released.
 /// When `StringViewArray`'s cardinality significantly drops (e.g., after `FilterExec` or `HashJoinExec` or many others),
 /// we should consider consolidating it so that we can release the buffer to reduce memory usage and improve string locality for better performance.
 fn gc_string_view_batch(batch: &RecordBatch) -> RecordBatch {

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -244,10 +244,10 @@ impl CoalesceBatchesStream {
 
                                         Arc::new(gc_string)
                                     } else {
-                                        c.clone()
+                                        Arc::clone(c)
                                     }
                                 } else {
-                                    c.clone()
+                                    Arc::clone(c)
                                 }
                             })
                             .collect();


### PR DESCRIPTION
(targets `string-view2` branch)

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of  #10918

## Rationale for this change

`StringViewArray` reference to the raw parquet decoded buffer, which reduces copy but prevents those buffer from being released.
When `StringViewArray`'s cardinality significantly drops (e.g., after `FilterExec` or `HashJoinExec` or many others), we should consider consolidating it so that we can release the buffer to reduce memory usage and improve string locality for better performance.

The current heuristic is to GC `StringViewArray` in `CoalesceBatchesStream` and use larger block size to reduce buffer count (see https://github.com/apache/arrow-rs/issues/6094)
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
