### PR TITLE
Improve unparser MySQL compatibility

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -115,7 +115,7 @@ pub enum IntervalStyle {
 
 /// Datetime subfield extraction style for unparsing
 ///
-/// https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
+/// `<https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT>`
 /// Different DBMSs follow different standards; popular ones are:
 /// date_part('YEAR', date '2001-02-16')
 /// EXTRACT(YEAR from date '2001-02-16')

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -15,9 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
+use arrow_schema::TimeUnit;
 use regex::Regex;
 use sqlparser::{
-    ast::{self, Ident, ObjectName},
+    ast::{self, Ident, ObjectName, TimezoneInfo},
     keywords::ALL_KEYWORDS,
 };
 
@@ -75,6 +78,22 @@ pub trait Dialect: Send + Sync {
     // Most dialects use BigInt, but some, like MySQL, require SIGNED
     fn int64_cast_dtype(&self) -> ast::DataType {
         ast::DataType::BigInt(None)
+    }
+
+    // The SQL type to use for Timestamp casting
+    // Most dialects use Timestamp, but some, like MySQL, require Datetime
+    // Some dialects like Dremio does not support WithTimeZone and requires always Timestamp
+    fn timestamp_cast_dtype(
+        &self,
+        _time_unit: &TimeUnit,
+        tz: &Option<Arc<str>>,
+    ) -> ast::DataType {
+        let tz_info = match tz {
+            Some(_) => TimezoneInfo::WithTimeZone,
+            None => TimezoneInfo::None,
+        };
+
+        ast::DataType::Timestamp(None, tz_info)
     }
 }
 
@@ -167,6 +186,14 @@ impl Dialect for MySqlDialect {
     fn int64_cast_dtype(&self) -> ast::DataType {
         ast::DataType::Custom(ObjectName(vec![Ident::new("SIGNED")]), vec![])
     }
+
+    fn timestamp_cast_dtype(
+        &self,
+        _time_unit: &TimeUnit,
+        _tz: &Option<Arc<str>>,
+    ) -> ast::DataType {
+        ast::DataType::Datetime(None)
+    }
 }
 
 pub struct SqliteDialect {}
@@ -187,6 +214,8 @@ pub struct CustomDialect {
     large_utf8_cast_dtype: ast::DataType,
     date_subfield_extract_style: DateFieldExtractStyle,
     int64_cast_dtype: ast::DataType,
+    timestamp_cast_dtype: ast::DataType,
+    timestamp_cast_dtype_tz: ast::DataType,
 }
 
 impl Default for CustomDialect {
@@ -202,6 +231,11 @@ impl Default for CustomDialect {
             use_char_for_utf8_cast: false,
             date_subfield_extract_style: DateFieldExtractStyle::DatePart,
             int64_cast_dtype: ast::DataType::BigInt(None),
+            timestamp_cast_dtype: ast::DataType::Timestamp(None, TimezoneInfo::None),
+            timestamp_cast_dtype_tz: ast::DataType::Timestamp(
+                None,
+                TimezoneInfo::WithTimeZone,
+            ),
         }
     }
 }
@@ -253,6 +287,18 @@ impl Dialect for CustomDialect {
     fn int64_cast_dtype(&self) -> ast::DataType {
         self.int64_cast_dtype.clone()
     }
+
+    fn timestamp_cast_dtype(
+        &self,
+        _time_unit: &TimeUnit,
+        tz: &Option<Arc<str>>,
+    ) -> ast::DataType {
+        if tz.is_some() {
+            self.timestamp_cast_dtype_tz.clone()
+        } else {
+            self.timestamp_cast_dtype.clone()
+        }
+    }
 }
 
 /// `CustomDialectBuilder` to build `CustomDialect` using builder pattern
@@ -279,6 +325,8 @@ pub struct CustomDialectBuilder {
     large_utf8_cast_dtype: ast::DataType,
     date_subfield_extract_style: DateFieldExtractStyle,
     int64_cast_dtype: ast::DataType,
+    timestamp_cast_dtype: ast::DataType,
+    timestamp_cast_dtype_tz: ast::DataType,
 }
 
 impl Default for CustomDialectBuilder {
@@ -299,6 +347,11 @@ impl CustomDialectBuilder {
             large_utf8_cast_dtype: ast::DataType::Text,
             date_subfield_extract_style: DateFieldExtractStyle::DatePart,
             int64_cast_dtype: ast::DataType::BigInt(None),
+            timestamp_cast_dtype: ast::DataType::Timestamp(None, TimezoneInfo::None),
+            timestamp_cast_dtype_tz: ast::DataType::Timestamp(
+                None,
+                TimezoneInfo::WithTimeZone,
+            ),
         }
     }
 
@@ -313,6 +366,8 @@ impl CustomDialectBuilder {
             large_utf8_cast_dtype: self.large_utf8_cast_dtype,
             date_subfield_extract_style: self.date_subfield_extract_style,
             int64_cast_dtype: self.int64_cast_dtype,
+            timestamp_cast_dtype: self.timestamp_cast_dtype,
+            timestamp_cast_dtype_tz: self.timestamp_cast_dtype_tz,
         }
     }
 
@@ -377,6 +432,16 @@ impl CustomDialectBuilder {
 
     pub fn with_int64_cast_dtype(mut self, int64_cast_dtype: ast::DataType) -> Self {
         self.int64_cast_dtype = int64_cast_dtype;
+        self
+    }
+
+    pub fn with_timestamp_cast_dtype(
+        mut self,
+        timestamp_cast_dtype: ast::DataType,
+        timestamp_cast_dtype_tz: ast::DataType,
+    ) -> Self {
+        self.timestamp_cast_dtype = timestamp_cast_dtype;
+        self.timestamp_cast_dtype_tz = timestamp_cast_dtype_tz;
         self
     }
 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1145,7 +1145,7 @@ impl Unparser<'_> {
     }
 
     /// MySQL requires INTERVAL sql to be in the format: INTERVAL 1 YEAR + INTERVAL 1 MONTH + INTERVAL 1 DAY etc
-    /// https://dev.mysql.com/doc/refman/8.4/en/expressions.html#temporal-intervals
+    /// `<https://dev.mysql.com/doc/refman/8.4/en/expressions.html#temporal-intervals>`
     /// Interval sequence can't be wrapped in brackets - (INTERVAL 1 YEAR + INTERVAL 1 MONTH ...) so we need to generate
     /// a single INTERVAL expression so it works correct for interval substraction cases
     /// MySQL supports the DAY_MICROSECOND unit type (format is DAYS HOURS:MINUTES:SECONDS.MICROSECONDS), but it is not supported by sqlparser
@@ -1266,7 +1266,7 @@ impl Unparser<'_> {
             last_field: None,
             fractional_seconds_precision: None,
         };
-        return Ok(ast::Expr::Interval(interval));
+        Ok(ast::Expr::Interval(interval))
     }
 
     fn interval_scalar_to_sql(&self, v: &ScalarValue) -> Result<ast::Expr> {
@@ -1371,14 +1371,10 @@ impl Unparser<'_> {
             },
             IntervalStyle::MySQL => match v {
                 ScalarValue::IntervalYearMonth(Some(v)) => {
-                    return self.interval_to_mysql_expr(v.clone(), 0, 0);
+                    self.interval_to_mysql_expr(*v, 0, 0)
                 }
                 ScalarValue::IntervalDayTime(Some(v)) => {
-                    return self.interval_to_mysql_expr(
-                        0,
-                        v.days,
-                        v.milliseconds as i64 * 1_000,
-                    );
+                    self.interval_to_mysql_expr(0, v.days, v.milliseconds as i64 * 1_000)
                 }
                 ScalarValue::IntervalMonthDayNano(Some(v)) => {
                     if v.nanoseconds % 1_000 != 0 {
@@ -1386,11 +1382,7 @@ impl Unparser<'_> {
                             "Unsupported IntervalMonthDayNano scalar with nanoseconds precision for IntervalStyle::MySQL"
                         );
                     }
-                    return self.interval_to_mysql_expr(
-                        v.months,
-                        v.days,
-                        v.nanoseconds as i64 / 1_000,
-                    );
+                    self.interval_to_mysql_expr(v.months, v.days, v.nanoseconds / 1_000)
                 }
                 _ => not_impl_err!(
                     "Unsupported ScalarValue for Interval conversion: {v:?}"


### PR DESCRIPTION
Please let me know if you prefer me to split this into separate PRs. Combined as the changes are related/follow the same logic and to avoid resolving conflicts after PRs are merged.

## Which issue does this PR close?

PR addresses unparser issues producing invalid sql for MySQL and implements support for `IntervalStyle::MySQL`

####  1. Invalid `CAST(col AS Timestamp)` SQL for MySQL.

MySQL [cast function](https://dev.mysql.com/doc/refman/8.4/en/cast-functions.html#function_cast) does not support Timestamp for CAST and requires DATETIME
> DATETIME[(M)]
Produces a [DATETIME](https://dev.mysql.com/doc/refman/8.4/en/datetime.html) value. If the optional M value is given, it specifies the fractional seconds precision.

Timezone information is correctly handled by MySQL when casting with `DATETIME`.

#### 2. Unsupported `date_part` function to extract Datetime subfield

MySQL does not support **date_part** function so PR introduces configurable option to specify Datetime subfield extraction style for unparsing. Different DBMSs follow different standards; popular ones are:
```sql
date_part('YEAR', date '2001-02-16')
EXTRACT(YEAR from date '2001-02-16')
```
Some DBMSs, like Postgres, support both, whereas others like MySQL, Amazon Athena require EXTRACT.

#### 3. invalid `CAST(col AS BigInt)` SQL for MySQL.

MySQL [cast function](https://dev.mysql.com/doc/refman/8.4/en/cast-functions.html#function_cast) does not support BigInt and requires SIGNED for CAST
> SIGNED [INTEGER]
Produces a signed [BIGINT](https://dev.mysql.com/doc/refman/8.4/en/integer-types.html) value.

Note: sqlparser crate does not have Signed type so we use `ast::DataType::Custom` as a workaround

## Rationale for this change

PRs implements `IntervalStyle::MySQL`  and adds support for alternate formats for Timestamp, Int64, Datetime part unparsing via Dialect customization.

## What changes are included in this PR?

Please see above

## Are these changes tested?

Manual testing + unit test for each modification.

## Are there any user-facing changes?

`CustomDialectBuilder` now supports more options for Dialect customization (Timestamp, Int64 unparsing and Datetime part extraction).
