### PR TITLE
Add was_valid parameter to NullState callbacks

### DIFF
--- a/datafusion-examples/examples/advanced_udaf.rs
+++ b/datafusion-examples/examples/advanced_udaf.rs
@@ -288,10 +288,9 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
             values,
             opt_filter,
             total_num_groups,
-            |group_index, new_value| {
+            |group_index, _, new_value| {
                 let prod = &mut self.prods[group_index];
                 *prod = prod.mul_wrapping(new_value);
-
                 self.counts[group_index] += 1;
             },
         );
@@ -318,7 +317,7 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
             partial_counts,
             opt_filter,
             total_num_groups,
-            |group_index, partial_count| {
+            |group_index, _, partial_count| {
                 self.counts[group_index] += partial_count;
             },
         );
@@ -330,7 +329,7 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
             partial_prods,
             opt_filter,
             total_num_groups,
-            |group_index, new_value: <Float64Type as ArrowPrimitiveType>::Native| {
+            |group_index, _, new_value| {
                 let prod = &mut self.prods[group_index];
                 *prod = prod.mul_wrapping(new_value);
             },

--- a/datafusion/functions-aggregate/src/average.rs
+++ b/datafusion/functions-aggregate/src/average.rs
@@ -450,10 +450,9 @@ where
             values,
             opt_filter,
             total_num_groups,
-            |group_index, new_value| {
+            |group_index, _, new_value| {
                 let sum = &mut self.sums[group_index];
                 *sum = sum.add_wrapping(new_value);
-
                 self.counts[group_index] += 1;
             },
         );
@@ -533,7 +532,7 @@ where
             partial_counts,
             opt_filter,
             total_num_groups,
-            |group_index, partial_count| {
+            |group_index, _, partial_count| {
                 self.counts[group_index] += partial_count;
             },
         );
@@ -545,7 +544,7 @@ where
             partial_sums,
             opt_filter,
             total_num_groups,
-            |group_index, new_value: <T as ArrowPrimitiveType>::Native| {
+            |group_index, _, new_value: <T as ArrowPrimitiveType>::Native| {
                 let sum = &mut self.sums[group_index];
                 *sum = sum.add_wrapping(new_value);
             },

--- a/datafusion/physical-expr-common/src/aggregate/groups_accumulator/accumulate.rs
+++ b/datafusion/physical-expr-common/src/aggregate/groups_accumulator/accumulate.rs
@@ -324,18 +324,6 @@ impl NullState {
         }
     }
 
-    /// Check if the accumulated value for the group at the given `index` is valid,
-    /// meaning that there was at least one value passing the filter for this group.
-    pub fn is_valid(&self, index: usize) -> bool {
-        self.seen_values.get_bit(index)
-    }
-
-    /// Check if the accumulated value for the group at the given `index` is `null`,
-    /// meaning that no values passing the filter were seen yet for this group.
-    pub fn is_null(&self, index: usize) -> bool {
-        !self.is_valid(index)
-    }
-
     /// Creates the a [`NullBuffer`] representing which group_indices
     /// should have null values (because they never saw any values)
     /// for the `emit_to` rows.
@@ -840,12 +828,9 @@ mod test {
 
             // Validate the final buffer (one value per group)
             let expected_null_buffer = mock.expected_null_buffer(total_num_groups);
-            for (i, expected) in expected_null_buffer.iter().enumerate() {
-                assert_eq!(expected, null_state.is_valid(i));
-                assert_eq!(!expected, null_state.is_null(i))
-            }
 
             let null_buffer = null_state.build(EmitTo::All);
+
             assert_eq!(null_buffer, expected_null_buffer);
         }
     }

--- a/datafusion/physical-expr-common/src/aggregate/groups_accumulator/accumulate.rs
+++ b/datafusion/physical-expr-common/src/aggregate/groups_accumulator/accumulate.rs
@@ -324,6 +324,18 @@ impl NullState {
         }
     }
 
+    /// Check if the accumulated value for the group at the given `index` is valid,
+    /// meaning that there was at least one value passing the filter for this group.
+    pub fn is_valid(&self, index: usize) -> bool {
+        self.seen_values.get_bit(index)
+    }
+
+    /// Check if the accumulated value for the group at the given `index` is `null`,
+    /// meaning that no values passing the filter were seen yet for this group.
+    pub fn is_null(&self, index: usize) -> bool {
+        !self.is_valid(index)
+    }
+
     /// Creates the a [`NullBuffer`] representing which group_indices
     /// should have null values (because they never saw any values)
     /// for the `emit_to` rows.
@@ -828,9 +840,12 @@ mod test {
 
             // Validate the final buffer (one value per group)
             let expected_null_buffer = mock.expected_null_buffer(total_num_groups);
+            for (i, expected) in expected_null_buffer.iter().enumerate() {
+                assert_eq!(expected, null_state.is_valid(i));
+                assert_eq!(!expected, null_state.is_null(i))
+            }
 
             let null_buffer = null_state.build(EmitTo::All);
-
             assert_eq!(null_buffer, expected_null_buffer);
         }
     }

--- a/datafusion/physical-expr-common/src/aggregate/groups_accumulator/bool_op.rs
+++ b/datafusion/physical-expr-common/src/aggregate/groups_accumulator/bool_op.rs
@@ -86,10 +86,14 @@ where
             values,
             opt_filter,
             total_num_groups,
-            |group_index, new_value| {
-                let current_value = self.values.get_bit(group_index);
-                let value = (self.bool_fn)(current_value, new_value);
-                self.values.set_bit(group_index, value);
+            |group_index, was_valid, new_value| {
+                if was_valid {
+                    let current_value = self.values.get_bit(group_index);
+                    let value = (self.bool_fn)(current_value, new_value);
+                    self.values.set_bit(group_index, value)
+                } else {
+                    self.values.set_bit(group_index, new_value)
+                }
             },
         );
 

--- a/datafusion/physical-expr-common/src/aggregate/groups_accumulator/prim_op.rs
+++ b/datafusion/physical-expr-common/src/aggregate/groups_accumulator/prim_op.rs
@@ -102,9 +102,13 @@ where
             values,
             opt_filter,
             total_num_groups,
-            |group_index, new_value| {
-                let value = &mut self.values[group_index];
-                (self.prim_fn)(value, new_value);
+            |group_index, was_valid, new_value| {
+                if was_valid {
+                    let value = &mut self.values[group_index];
+                    (self.prim_fn)(value, new_value)
+                } else {
+                    self.values[group_index] = new_value
+                }
             },
         );
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11591.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Provide more flexibility for implementing `GroupsAccumulator` which often make use of `NullState`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add `was_valid` parameter to `NullState` callbacks. In this way implementations can handle nulls differently.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, extended existing tests.

## Are there any user-facing changes?

Yes, changes the signatures of `NullState::accumulate` and `NullState::accumulate_boolean`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
