### PR TITLE
Extract `CoalesceBatchesStream` to a struct

### DIFF
--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -15,13 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! CoalesceBatchesExec combines small batches into larger batches for more efficient use of
-//! vectorized processing by upstream operators.
+//! [`CoalesceBatchesExec`] combines small batches into larger batches.
 
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 use arrow::array::{AsArray, StringViewBuilder};
 use arrow::compute::concat_batches;
@@ -41,11 +40,43 @@ use super::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use super::{DisplayAs, ExecutionPlanProperties, PlanProperties, Statistics};
 
 /// `CoalesceBatchesExec` combines small batches into larger batches for more
-/// efficient use of vectorized processing by later operators. The operator
-/// works by buffering batches until it collects `target_batch_size` rows. When
-/// only a limited number of rows are necessary (specified by the `fetch`
-/// parameter), the operator will stop buffering and return the final batch
-/// once the number of collected rows reaches the `fetch` value.
+/// efficient use of vectorized processing by later operators.
+///
+/// The operator buffers batches until it collects `target_batch_size` rows and
+/// then emits a single concatenated batch. When only a limited number of rows
+/// are necessary (specified by the `fetch` parameter), the operator will stop
+/// buffering and returns the final batch once the number of collected rows
+/// reaches the `fetch` value.
+///
+/// # Background
+///
+/// Generally speaking, larger RecordBatches are more efficient to process than
+/// smaller record batches (until the CPU cache is exceeded) because there is
+/// fixed processing overhead per batch. This code concatenates multiple small
+/// record batches into larger ones to amortize this overhead.
+///
+/// ```text
+/// ┌────────────────────┐
+/// │    RecordBatch     │
+/// │   num_rows = 23    │
+/// └────────────────────┘                 ┌────────────────────┐
+///                                        │                    │
+/// ┌────────────────────┐     Coalesce    │                    │
+/// │                    │      Batches    │                    │
+/// │    RecordBatch     │                 │                    │
+/// │   num_rows = 50    │  ─ ─ ─ ─ ─ ─ ▶  │                    │
+/// │                    │                 │    RecordBatch     │
+/// │                    │                 │   num_rows = 106   │
+/// └────────────────────┘                 │                    │
+///                                        │                    │
+/// ┌────────────────────┐                 │                    │
+/// │                    │                 │                    │
+/// │    RecordBatch     │                 │                    │
+/// │   num_rows = 33    │                 └────────────────────┘
+/// │                    │
+/// └────────────────────┘
+/// ```
+
 #[derive(Debug)]
 pub struct CoalesceBatchesExec {
     /// The input plan
@@ -166,12 +197,11 @@ impl ExecutionPlan for CoalesceBatchesExec {
     ) -> Result<SendableRecordBatchStream> {
         Ok(Box::pin(CoalesceBatchesStream {
             input: self.input.execute(partition, context)?,
-            schema: self.input.schema(),
-            target_batch_size: self.target_batch_size,
-            fetch: self.fetch,
-            buffer: Vec::new(),
-            buffered_rows: 0,
-            total_rows: 0,
+            coalescer: BatchCoalescer::new(
+                self.input.schema(),
+                self.target_batch_size,
+                self.fetch,
+            ),
             is_closed: false,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
         }))
@@ -196,21 +226,12 @@ impl ExecutionPlan for CoalesceBatchesExec {
     }
 }
 
+/// Stream for [`CoalesceBatchesExec`]. See [`CoalesceBatchesExec`] for more details.
 struct CoalesceBatchesStream {
     /// The input plan
     input: SendableRecordBatchStream,
-    /// The input schema
-    schema: SchemaRef,
-    /// Minimum number of rows for coalesces batches
-    target_batch_size: usize,
-    /// Maximum number of rows to fetch, `None` means fetching all rows
-    fetch: Option<usize>,
-    /// Buffered batches
-    buffer: Vec<RecordBatch>,
-    /// Buffered row count
-    buffered_rows: usize,
-    /// Total number of rows returned
-    total_rows: usize,
+    /// Buffer for combining batches
+    coalescer: BatchCoalescer,
     /// Whether the stream has finished returning all of its data or not
     is_closed: bool,
     /// Execution metrics
@@ -249,75 +270,32 @@ impl CoalesceBatchesStream {
             let input_batch = self.input.poll_next_unpin(cx);
             // records time on drop
             let _timer = cloned_time.timer();
-            match input_batch {
-                Poll::Ready(x) => match x {
-                    Some(Ok(batch)) => {
-                        let batch = gc_string_view_batch(&batch);
-
-                        // Handle fetch limit:
-                        if let Some(fetch) = self.fetch {
-                            if self.total_rows + batch.num_rows() >= fetch {
-                                // We have reached the fetch limit.
-                                let remaining_rows = fetch - self.total_rows;
-                                debug_assert!(remaining_rows > 0);
-
+            match ready!(input_batch) {
+                Some(result) => {
+                    let Ok(input_batch) = result else {
+                        return Poll::Ready(Some(result)); // pass back error
+                    };
+                    // Buffer the batch and either get more input if not enough
+                    // rows yet or output
+                    match self.coalescer.push_batch(input_batch) {
+                        Ok(None) => continue,
+                        res => {
+                            if self.coalescer.limit_reached() {
                                 self.is_closed = true;
-                                self.total_rows = fetch;
-                                // Trim the batch and add to buffered batches:
-                                let batch = batch.slice(0, remaining_rows);
-                                self.buffered_rows += batch.num_rows();
-                                self.buffer.push(batch);
-                                // Combine buffered batches:
-                                let batch = concat_batches(&self.schema, &self.buffer)?;
-                                // Reset the buffer state and return final batch:
-                                self.buffer.clear();
-                                self.buffered_rows = 0;
-                                return Poll::Ready(Some(Ok(batch)));
                             }
-                        }
-                        self.total_rows += batch.num_rows();
-
-                        if batch.num_rows() >= self.target_batch_size
-                            && self.buffer.is_empty()
-                        {
-                            return Poll::Ready(Some(Ok(batch)));
-                        } else if batch.num_rows() == 0 {
-                            // discard empty batches
-                        } else {
-                            // add to the buffered batches
-                            self.buffered_rows += batch.num_rows();
-                            self.buffer.push(batch);
-                            // check to see if we have enough batches yet
-                            if self.buffered_rows >= self.target_batch_size {
-                                // combine the batches and return
-                                let batch = concat_batches(&self.schema, &self.buffer)?;
-                                // reset buffer state
-                                self.buffer.clear();
-                                self.buffered_rows = 0;
-                                // return batch
-                                return Poll::Ready(Some(Ok(batch)));
-                            }
+                            return Poll::Ready(res.transpose());
                         }
                     }
-                    None => {
-                        self.is_closed = true;
-                        // we have reached the end of the input stream but there could still
-                        // be buffered batches
-                        if self.buffer.is_empty() {
-                            return Poll::Ready(None);
-                        } else {
-                            // combine the batches and return
-                            let batch = concat_batches(&self.schema, &self.buffer)?;
-                            // reset buffer state
-                            self.buffer.clear();
-                            self.buffered_rows = 0;
-                            // return batch
-                            return Poll::Ready(Some(Ok(batch)));
-                        }
-                    }
-                    other => return Poll::Ready(other),
-                },
-                Poll::Pending => return Poll::Pending,
+                }
+                None => {
+                    self.is_closed = true;
+                    // we have reached the end of the input stream but there could still
+                    // be buffered batches
+                    return match self.coalescer.finish() {
+                        Ok(None) => Poll::Ready(None),
+                        res => Poll::Ready(res.transpose()),
+                    };
+                }
             }
         }
     }
@@ -325,7 +303,144 @@ impl CoalesceBatchesStream {
 
 impl RecordBatchStream for CoalesceBatchesStream {
     fn schema(&self) -> SchemaRef {
+        self.coalescer.schema()
+    }
+}
+
+/// Concatenate multiple record batches into larger batches
+///
+/// See [`CoalesceBatchesExec`] for more details.
+///
+/// Notes:
+///
+/// 1. The output rows is the same order as the input rows
+///
+/// 2. The output is a sequence of batches, with all but the last being at least
+///    `target_batch_size` rows.
+///
+/// 3. Eventually this may also be able to handle other optimizations such as a
+///    combined filter/coalesce operation.
+#[derive(Debug)]
+struct BatchCoalescer {
+    /// The input schema
+    schema: SchemaRef,
+    /// Minimum number of rows for coalesces batches
+    target_batch_size: usize,
+    /// Total number of rows returned so far
+    total_rows: usize,
+    /// Buffered batches
+    buffer: Vec<RecordBatch>,
+    /// Buffered row count
+    buffered_rows: usize,
+    /// Maximum number of rows to fetch, `None` means fetching all rows
+    fetch: Option<usize>,
+}
+
+impl BatchCoalescer {
+    /// Create a new `BatchCoalescer`
+    ///
+    /// # Arguments
+    /// - `schema` - the schema of the output batches
+    /// - `target_batch_size` - the minimum number of rows for each
+    ///    output batch (until limit reached)
+    /// - `fetch` - the maximum number of rows to fetch, `None` means fetch all rows
+    fn new(schema: SchemaRef, target_batch_size: usize, fetch: Option<usize>) -> Self {
+        Self {
+            schema,
+            target_batch_size,
+            total_rows: 0,
+            buffer: vec![],
+            buffered_rows: 0,
+            fetch,
+        }
+    }
+
+    /// Return the schema of the output batches
+    fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
+    }
+
+    /// Add a batch, returning a batch if the target batch size or limit is reached
+    fn push_batch(&mut self, batch: RecordBatch) -> Result<Option<RecordBatch>> {
+        // discard empty batches
+        if batch.num_rows() == 0 {
+            return Ok(None);
+        }
+
+        // past limit
+        if self.limit_reached() {
+            return Ok(None);
+        }
+
+        let batch = gc_string_view_batch(&batch);
+
+        // Handle fetch limit:
+        if let Some(fetch) = self.fetch {
+            if self.total_rows + batch.num_rows() >= fetch {
+                // We have reached the fetch limit.
+                let remaining_rows = fetch - self.total_rows;
+                debug_assert!(remaining_rows > 0);
+                self.total_rows = fetch;
+                // Trim the batch and add to buffered batches:
+                let batch = batch.slice(0, remaining_rows);
+                self.buffered_rows += batch.num_rows();
+                self.buffer.push(batch);
+                // Combine buffered batches:
+                let batch = concat_batches(&self.schema, &self.buffer)?;
+                // Reset the buffer state and return final batch:
+                self.buffer.clear();
+                self.buffered_rows = 0;
+                return Ok(Some(batch));
+            }
+        }
+        self.total_rows += batch.num_rows();
+
+        // batch itself is already big enough and we have no buffered rows so
+        // return it directly
+        if batch.num_rows() >= self.target_batch_size && self.buffer.is_empty() {
+            return Ok(Some(batch));
+        }
+        // add to the buffered batches
+        self.buffered_rows += batch.num_rows();
+        self.buffer.push(batch);
+        // check to see if we have enough batches yet
+        let batch = if self.buffered_rows >= self.target_batch_size {
+            // combine the batches and return
+            let batch = concat_batches(&self.schema, &self.buffer)?;
+            // reset buffer state
+            self.buffer.clear();
+            self.buffered_rows = 0;
+            // return batch
+            Some(batch)
+        } else {
+            None
+        };
+        Ok(batch)
+    }
+
+    /// Finish the coalescing process, returning all buffered data as a final,
+    /// single batch, if any
+    fn finish(&mut self) -> Result<Option<RecordBatch>> {
+        if self.buffer.is_empty() {
+            Ok(None)
+        } else {
+            // combine the batches and return
+            let batch = concat_batches(&self.schema, &self.buffer)?;
+            // reset buffer state
+            self.buffer.clear();
+            self.buffered_rows = 0;
+            // return batch
+            Ok(Some(batch))
+        }
+    }
+
+    /// returns true if there is a limit and it has been reached
+    pub fn limit_reached(&self) -> bool {
+        if let Some(fetch) = self.fetch {
+            self.total_rows >= fetch
+        } else {
+            false
+        }
     }
 }
 
@@ -400,164 +515,206 @@ fn gc_string_view_batch(batch: &RecordBatch) -> RecordBatch {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow_array::builder::ArrayBuilder;
     use arrow_array::{StringViewArray, UInt32Array};
+    use std::ops::Range;
 
-    use crate::{memory::MemoryExec, repartition::RepartitionExec, Partitioning};
-
-    use super::*;
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_concat_batches() -> Result<()> {
-        let schema = test_schema();
-        let partition = create_vec_batches(&schema, 10);
-        let partitions = vec![partition];
-
-        let output_partitions = coalesce_batches(&schema, partitions, 21, None).await?;
-        assert_eq!(1, output_partitions.len());
-
-        // input is 10 batches x 8 rows (80 rows)
-        // expected output is batches of at least 20 rows (except for the final batch)
-        let batches = &output_partitions[0];
-        assert_eq!(4, batches.len());
-        assert_eq!(24, batches[0].num_rows());
-        assert_eq!(24, batches[1].num_rows());
-        assert_eq!(24, batches[2].num_rows());
-        assert_eq!(8, batches[3].num_rows());
-
-        Ok(())
+    #[test]
+    fn test_coalesce() {
+        let batch = uint32_batch(0..8);
+        Test::new()
+            .with_batches(std::iter::repeat(batch).take(10))
+            // expected output is batches of at least 20 rows (except for the final batch)
+            .with_target_batch_size(21)
+            .with_expected_output_sizes(vec![24, 24, 24, 8])
+            .run()
     }
 
-    #[tokio::test]
-    async fn test_concat_batches_with_fetch_larger_than_input_size() -> Result<()> {
-        let schema = test_schema();
-        let partition = create_vec_batches(&schema, 10);
-        let partitions = vec![partition];
-
-        let output_partitions =
-            coalesce_batches(&schema, partitions, 21, Some(100)).await?;
-        assert_eq!(1, output_partitions.len());
-
-        // input is 10 batches x 8 rows (80 rows) with fetch limit of 100
-        // expected to behave the same as `test_concat_batches`
-        let batches = &output_partitions[0];
-        assert_eq!(4, batches.len());
-        assert_eq!(24, batches[0].num_rows());
-        assert_eq!(24, batches[1].num_rows());
-        assert_eq!(24, batches[2].num_rows());
-        assert_eq!(8, batches[3].num_rows());
-
-        Ok(())
+    #[test]
+    fn test_coalesce_with_fetch_larger_than_input_size() {
+        let batch = uint32_batch(0..8);
+        Test::new()
+            .with_batches(std::iter::repeat(batch).take(10))
+            // input is 10 batches x 8 rows (80 rows) with fetch limit of 100
+            // expected to behave the same as `test_concat_batches`
+            .with_target_batch_size(21)
+            .with_fetch(Some(100))
+            .with_expected_output_sizes(vec![24, 24, 24, 8])
+            .run();
     }
 
-    #[tokio::test]
-    async fn test_concat_batches_with_fetch_less_than_input_size() -> Result<()> {
-        let schema = test_schema();
-        let partition = create_vec_batches(&schema, 10);
-        let partitions = vec![partition];
-
-        let output_partitions =
-            coalesce_batches(&schema, partitions, 21, Some(50)).await?;
-        assert_eq!(1, output_partitions.len());
-
-        // input is 10 batches x 8 rows (80 rows) with fetch limit of 50
-        let batches = &output_partitions[0];
-        assert_eq!(3, batches.len());
-        assert_eq!(24, batches[0].num_rows());
-        assert_eq!(24, batches[1].num_rows());
-        assert_eq!(2, batches[2].num_rows());
-
-        Ok(())
+    #[test]
+    fn test_coalesce_with_fetch_less_than_input_size() {
+        let batch = uint32_batch(0..8);
+        Test::new()
+            .with_batches(std::iter::repeat(batch).take(10))
+            // input is 10 batches x 8 rows (80 rows) with fetch limit of 50
+            .with_target_batch_size(21)
+            .with_fetch(Some(50))
+            .with_expected_output_sizes(vec![24, 24, 2])
+            .run();
     }
 
-    #[tokio::test]
-    async fn test_concat_batches_with_fetch_less_than_target_and_no_remaining_rows(
-    ) -> Result<()> {
-        let schema = test_schema();
-        let partition = create_vec_batches(&schema, 10);
-        let partitions = vec![partition];
-
-        let output_partitions =
-            coalesce_batches(&schema, partitions, 21, Some(48)).await?;
-        assert_eq!(1, output_partitions.len());
-
-        // input is 10 batches x 8 rows (80 rows) with fetch limit of 48
-        let batches = &output_partitions[0];
-        assert_eq!(2, batches.len());
-        assert_eq!(24, batches[0].num_rows());
-        assert_eq!(24, batches[1].num_rows());
-
-        Ok(())
+    #[test]
+    fn test_coalesce_with_fetch_less_than_target_and_no_remaining_rows() {
+        let batch = uint32_batch(0..8);
+        Test::new()
+            .with_batches(std::iter::repeat(batch).take(10))
+            // input is 10 batches x 8 rows (80 rows) with fetch limit of 48
+            .with_target_batch_size(21)
+            .with_fetch(Some(48))
+            .with_expected_output_sizes(vec![24, 24])
+            .run();
     }
 
-    #[tokio::test]
-    async fn test_concat_batches_with_fetch_less_target_batch_size() -> Result<()> {
-        let schema = test_schema();
-        let partition = create_vec_batches(&schema, 10);
-        let partitions = vec![partition];
-
-        let output_partitions =
-            coalesce_batches(&schema, partitions, 21, Some(10)).await?;
-        assert_eq!(1, output_partitions.len());
-
-        // input is 10 batches x 8 rows (80 rows) with fetch limit of 10
-        let batches = &output_partitions[0];
-        assert_eq!(1, batches.len());
-        assert_eq!(10, batches[0].num_rows());
-
-        Ok(())
+    #[test]
+    fn test_coalesce_with_fetch_less_target_batch_size() {
+        let batch = uint32_batch(0..8);
+        Test::new()
+            .with_batches(std::iter::repeat(batch).take(10))
+            // input is 10 batches x 8 rows (80 rows) with fetch limit of 10
+            .with_target_batch_size(21)
+            .with_fetch(Some(10))
+            .with_expected_output_sizes(vec![10])
+            .run();
     }
 
-    fn test_schema() -> Arc<Schema> {
-        Arc::new(Schema::new(vec![Field::new("c0", DataType::UInt32, false)]))
+    #[test]
+    fn test_coalesce_single_large_batch_over_fetch() {
+        let large_batch = uint32_batch(0..100);
+        Test::new()
+            .with_batch(large_batch)
+            .with_target_batch_size(20)
+            .with_fetch(Some(7))
+            .with_expected_output_sizes(vec![7])
+            .run()
     }
 
-    async fn coalesce_batches(
-        schema: &SchemaRef,
-        input_partitions: Vec<Vec<RecordBatch>>,
+    /// Test for [`BatchCoalescer`]
+    ///
+    /// Pushes the input batches to the coalescer and verifies that the resulting
+    /// batches have the expected number of rows and contents.
+    #[derive(Debug, Clone, Default)]
+    struct Test {
+        /// Batches to feed to the coalescer. Tests must have at least one
+        /// schema
+        input_batches: Vec<RecordBatch>,
+        /// Expected output sizes of the resulting batches
+        expected_output_sizes: Vec<usize>,
+        /// target batch size
         target_batch_size: usize,
+        /// Fetch (limit)
         fetch: Option<usize>,
-    ) -> Result<Vec<Vec<RecordBatch>>> {
-        // create physical plan
-        let exec = MemoryExec::try_new(&input_partitions, Arc::clone(schema), None)?;
-        let exec =
-            RepartitionExec::try_new(Arc::new(exec), Partitioning::RoundRobinBatch(1))?;
-        let exec: Arc<dyn ExecutionPlan> = Arc::new(
-            CoalesceBatchesExec::new(Arc::new(exec), target_batch_size).with_fetch(fetch),
-        );
+    }
 
-        // execute and collect results
-        let output_partition_count = exec.output_partitioning().partition_count();
-        let mut output_partitions = Vec::with_capacity(output_partition_count);
-        for i in 0..output_partition_count {
-            // execute this *output* partition and collect all batches
-            let task_ctx = Arc::new(TaskContext::default());
-            let mut stream = exec.execute(i, Arc::clone(&task_ctx))?;
-            let mut batches = vec![];
-            while let Some(result) = stream.next().await {
-                batches.push(result?);
+    impl Test {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        /// Set the target batch size
+        fn with_target_batch_size(mut self, target_batch_size: usize) -> Self {
+            self.target_batch_size = target_batch_size;
+            self
+        }
+
+        /// Set the fetch (limit)
+        fn with_fetch(mut self, fetch: Option<usize>) -> Self {
+            self.fetch = fetch;
+            self
+        }
+
+        /// Extend the input batches with `batch`
+        fn with_batch(mut self, batch: RecordBatch) -> Self {
+            self.input_batches.push(batch);
+            self
+        }
+
+        /// Extends the input batches with `batches`
+        fn with_batches(
+            mut self,
+            batches: impl IntoIterator<Item = RecordBatch>,
+        ) -> Self {
+            self.input_batches.extend(batches);
+            self
+        }
+
+        /// Extends `sizes` to expected output sizes
+        fn with_expected_output_sizes(
+            mut self,
+            sizes: impl IntoIterator<Item = usize>,
+        ) -> Self {
+            self.expected_output_sizes.extend(sizes);
+            self
+        }
+
+        /// Runs the test -- see documentation on [`Test`] for details
+        fn run(self) {
+            let Self {
+                input_batches,
+                target_batch_size,
+                fetch,
+                expected_output_sizes,
+            } = self;
+
+            let schema = input_batches[0].schema();
+
+            // create a single large input batch for output comparison
+            let single_input_batch = concat_batches(&schema, &input_batches).unwrap();
+
+            let mut coalescer = BatchCoalescer::new(schema, target_batch_size, fetch);
+
+            let mut output_batches = vec![];
+            for batch in input_batches {
+                if let Some(batch) = coalescer.push_batch(batch).unwrap() {
+                    output_batches.push(batch);
+                }
             }
-            output_partitions.push(batches);
+            if let Some(batch) = coalescer.finish().unwrap() {
+                output_batches.push(batch);
+            }
+
+            // make sure we got the expected number of output batches and content
+            let mut starting_idx = 0;
+            assert_eq!(expected_output_sizes.len(), output_batches.len());
+            for (i, (expected_size, batch)) in
+                expected_output_sizes.iter().zip(output_batches).enumerate()
+            {
+                assert_eq!(
+                    *expected_size,
+                    batch.num_rows(),
+                    "Unexpected number of rows in Batch {i}"
+                );
+
+                // compare the contents of the batch (using `==` compares the
+                // underlying memory layout too)
+                let expected_batch =
+                    single_input_batch.slice(starting_idx, *expected_size);
+                let batch_strings = batch_to_pretty_strings(&batch);
+                let expected_batch_strings = batch_to_pretty_strings(&expected_batch);
+                let batch_strings = batch_strings.lines().collect::<Vec<_>>();
+                let expected_batch_strings =
+                    expected_batch_strings.lines().collect::<Vec<_>>();
+                assert_eq!(
+                    expected_batch_strings, batch_strings,
+                    "Unexpected content in Batch {i}:\
+                    \n\nExpected:\n{expected_batch_strings:#?}\n\nActual:\n{batch_strings:#?}"
+                );
+                starting_idx += *expected_size;
+            }
         }
-        Ok(output_partitions)
     }
 
-    /// Create vector batches
-    fn create_vec_batches(schema: &Schema, n: usize) -> Vec<RecordBatch> {
-        let batch = create_batch(schema);
-        let mut vec = Vec::with_capacity(n);
-        for _ in 0..n {
-            vec.push(batch.clone());
-        }
-        vec
-    }
+    /// Return a batch of  UInt32 with the specified range
+    fn uint32_batch(range: Range<u32>) -> RecordBatch {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c0", DataType::UInt32, false)]));
 
-    /// Create batch
-    fn create_batch(schema: &Schema) -> RecordBatch {
         RecordBatch::try_new(
-            Arc::new(schema.clone()),
-            vec![Arc::new(UInt32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8]))],
+            Arc::clone(&schema),
+            vec![Arc::new(UInt32Array::from_iter_values(range))],
         )
         .unwrap()
     }
@@ -655,5 +812,10 @@ mod tests {
                 }
             }
         }
+    }
+    fn batch_to_pretty_strings(batch: &RecordBatch) -> String {
+        arrow::util::pretty::pretty_format_batches(&[batch.clone()])
+            .unwrap()
+            .to_string()
     }
 }


### PR DESCRIPTION
Note most of this PR is additional documentation and tests. There is no new functionality

## Which issue does this PR close?

Related to https://github.com/apache/datafusion/issues/9370 
Related to https://github.com/apache/datafusion/issues/7957

## Rationale for this change

1. I want to be able to write tests more easily for PRs like (https://github.com/apache/datafusion/pull/11587)
2. I also harbor plans to improve repartitioning and filtering (to avoid a copy -- see https://github.com/apache/datafusion/issues/7957) this is the first step

As an example of what I hope to do with this, today we have a `FilterExec` which copies all rows that pass the filter into a new `RecordBatch` followed by  `CoalesceBatches` which will likely copy the batch again into a larger set
With a struct like this, I think we have the possibility of the  filter producing the output batch directly, thus skipping
the intermediate copy. See https://github.com/apache/datafusion/issues/7957 and https://github.com/apache/datafusion/issues/7957#issuecomment-2246257591 for details


## What changes are included in this PR?

1. Move the logic for coalescing batches into a struct `CoalesceBatchesExec`
2. Add tests for the new struct
3. Improve documentation

I also happen to think this change makes the code easier to read as it separates
the coalescing logic from the stream handling logic.

## Are these changes tested?
Yes, by existing CI and new unit tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No changes, this is just an internal code reorganization

Benchmark results show now significant changes

<details><summary>Details</summary>
<p>

```
--------------------
Benchmark tpch_sf1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃ main_base ┃ alamb_coalsece_batches_in_struct ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  336.31ms │                         334.12ms │     no change │
│ QQuery 2     │  132.50ms │                         130.44ms │     no change │
│ QQuery 3     │  171.55ms │                         163.97ms │     no change │
│ QQuery 4     │  103.14ms │                         101.11ms │     no change │
│ QQuery 5     │  206.06ms │                         206.75ms │     no change │
│ QQuery 6     │   90.73ms │                          86.85ms │     no change │
│ QQuery 7     │  280.56ms │                         283.90ms │     no change │
│ QQuery 8     │  209.03ms │                         209.75ms │     no change │
│ QQuery 9     │  322.83ms │                         314.44ms │     no change │
│ QQuery 10    │  285.55ms │                         273.64ms │     no change │
│ QQuery 11    │  102.55ms │                         106.14ms │     no change │
│ QQuery 12    │  156.14ms │                         154.16ms │     no change │
│ QQuery 13    │  328.09ms │                         322.20ms │     no change │
│ QQuery 14    │  122.36ms │                         113.86ms │ +1.07x faster │
│ QQuery 15    │  174.65ms │                         171.91ms │     no change │
│ QQuery 16    │   98.16ms │                          98.39ms │     no change │
│ QQuery 17    │  328.06ms │                         322.44ms │     no change │
│ QQuery 18    │  451.03ms │                         438.80ms │     no change │
│ QQuery 19    │  199.06ms │                         200.66ms │     no change │
│ QQuery 20    │  193.02ms │                         198.21ms │     no change │
│ QQuery 21    │  341.11ms │                         343.05ms │     no change │
│ QQuery 22    │   75.44ms │                          71.36ms │ +1.06x faster │
└──────────────┴───────────┴──────────────────────────────────┴───────────────┘

--------------------
Benchmark clickbench_extended.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃ main_base ┃ alamb_coalsece_batches_in_struct ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 0     │ 3921.00ms │                        4013.39ms │     no change │
│ QQuery 1     │ 1620.96ms │                        1561.27ms │     no change │
│ QQuery 2     │ 3379.19ms │                        3177.36ms │ +1.06x faster │
└──────────────┴───────────┴──────────────────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Summary                               ┃           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Total Time (main_base)                          │ 8921.15ms │
│ Total Time (alamb_coalsece_batches_in_struct)   │ 8752.02ms │
│ Average Time (main_base)                        │ 2973.72ms │
│ Average Time (alamb_coalsece_batches_in_struct) │ 2917.34ms │
│ Queries Faster                                  │         1 │
│ Queries Slower                                  │         0 │
│ Queries with No Change                          │         2 │
└─────────────────────────────────────────────────┴───────────┘

--------------------
Benchmark clickbench_1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ Query        ┃  main_base ┃ alamb_coalsece_batches_in_struct ┃       Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ QQuery 0     │     0.82ms │                           0.86ms │ 1.05x slower │
│ QQuery 1     │    98.96ms │                         100.49ms │    no change │
│ QQuery 2     │   206.13ms │                         204.16ms │    no change │
│ QQuery 3     │   201.66ms │                         207.14ms │    no change │
│ QQuery 4     │  2279.50ms │                        2242.69ms │    no change │
│ QQuery 5     │  2032.10ms │                        2095.51ms │    no change │
│ QQuery 6     │    89.81ms │                          87.66ms │    no change │
│ QQuery 7     │   105.83ms │                         106.21ms │    no change │
│ QQuery 8     │  3306.67ms │                        3271.35ms │    no change │
│ QQuery 9     │  2486.23ms │                        2463.97ms │    no change │
│ QQuery 10    │   846.34ms │                         868.00ms │    no change │
│ QQuery 11    │   945.26ms │                         942.57ms │    no change │
│ QQuery 12    │  2201.69ms │                        2183.83ms │    no change │
│ QQuery 13    │  4682.18ms │                        4687.81ms │    no change │
│ QQuery 14    │  2937.50ms │                        2932.22ms │    no change │
│ QQuery 15    │  2494.34ms │                        2476.97ms │    no change │
│ QQuery 16    │  6000.61ms │                        6074.24ms │    no change │
│ QQuery 17    │  5915.76ms │                        5978.01ms │    no change │
│ QQuery 18    │ 12147.41ms │                       12245.43ms │    no change │
│ QQuery 19    │   173.83ms │                         176.01ms │    no change │
│ QQuery 20    │  2772.44ms │                        2732.58ms │    no change │
│ QQuery 21    │  3573.59ms │                        3536.36ms │    no change │
│ QQuery 22    │  9672.75ms │                        9617.31ms │    no change │
│ QQuery 23    │ 22739.93ms │                       22735.77ms │    no change │
│ QQuery 24    │  1426.12ms │                        1417.39ms │    no change │
│ QQuery 25    │  1189.16ms │                        1190.12ms │    no change │
│ QQuery 26    │  1524.24ms │                        1531.46ms │    no change │
│ QQuery 27    │  4069.20ms │                        4061.53ms │    no change │
│ QQuery 28    │ 28517.26ms │                       28507.06ms │    no change │
│ QQuery 29    │  1035.81ms │                        1039.16ms │    no change │
│ QQuery 30    │  2612.55ms │                        2563.26ms │    no change │
│ QQuery 31    │  3328.59ms │                        3301.66ms │    no change │
│ QQuery 32    │ 17443.34ms │                       17993.00ms │    no change │
│ QQuery 33    │  9777.24ms │                        9713.21ms │    no change │
│ QQuery 34    │  9708.11ms │                        9670.55ms │    no change │
│ QQuery 35    │  3859.54ms │                        3874.81ms │    no change │
│ QQuery 36    │   373.39ms │                         360.72ms │    no change │
│ QQuery 37    │   232.22ms │                         234.41ms │    no change │
│ QQuery 38    │   203.17ms │                         202.32ms │    no change │
│ QQuery 39    │  1183.33ms │                        1183.65ms │    no change │
│ QQuery 40    │    96.68ms │                          97.02ms │    no change │
│ QQuery 41    │    86.76ms │                          85.72ms │    no change │
│ QQuery 42    │   105.67ms │                         102.31ms │    no change │
└──────────────┴────────────┴──────────────────────────────────┴──────────────┘
```

</p>
</details> 

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
