### PR TITLE
Enforce uniqueness of `named_struct` field names

### DIFF
--- a/datafusion/functions/src/core/named_struct.rs
+++ b/datafusion/functions/src/core/named_struct.rs
@@ -57,14 +57,18 @@ fn named_struct_expr(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         .into_iter()
         .unzip();
 
-    // Check to enforce the uniqueness of struct field name
-    let unique_field_names_set = names.iter().collect::<HashSet<_>>();
-
-    if unique_field_names_set.len() != names.len() {
-        return exec_err!("named_struct requires unique field names");
+    {
+        // Check to enforce the uniqueness of struct field name
+        let mut unique_field_names = HashSet::new();
+        for name in names.iter() {
+            if unique_field_names.contains(name) {
+                return exec_err!(
+                    "named_struct requires unique field names. Field {name} is used more than once."
+                );
+            }
+            unique_field_names.insert(name);
+        }
     }
-
-    drop(unique_field_names_set);
 
     let arrays = ColumnarValue::values_to_arrays(&values)?;
 

--- a/datafusion/sqllogictest/test_files/struct.slt
+++ b/datafusion/sqllogictest/test_files/struct.slt
@@ -122,6 +122,10 @@ physical_plan
 query error
 select named_struct();
 
+# error on duplicate field names
+query error
+select named_struct('c0': 1, 'c1': 2, 'c1': 3);
+
 # error on odd number of arguments #1
 query error DataFusion error: Execution error: named_struct requires an even number of arguments, got 1 instead
 select named_struct('a');


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11438

## Rationale for this change


## What changes are included in this PR?
* Added a check for uniqueness of named struct fields
* add sql logic tests

## Are these changes tested?
Tested manually 
```

> select {'A': 1, 'a': 2};
+-----------------------------------------------------+
| named_struct(Utf8("A"),Int64(1),Utf8("a"),Int64(2)) |
+-----------------------------------------------------+
| {A: 1, a: 2}                                        |
+-----------------------------------------------------+
1 row(s) fetched. 
Elapsed 0.007 seconds.


> select {'a': 1, 'b': 2, 'c': 3, 'b': 4};
Execution error: named_struct requires unique field names. Field b is used more than once.
```
& existing test cases.

## Are there any user-facing changes?

