### PR TITLE
Unify CI and pre-commit hook settings for clippy

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -57,13 +57,7 @@ fi
 # 1. cargo clippy
 
 echo -e "$(GREEN INFO): cargo clippy ..."
-
-# Cargo clippy always return exit code 0, and `tee` doesn't work.
-# So let's just run cargo clippy.
-cargo clippy --all-targets --workspace --features avro,pyarrow -- -D warnings
-pushd datafusion-cli
-cargo clippy --all-targets --all-features -- -D warnings
-popd
+./ci/scripts/rust_clippy.sh
 echo -e "$(GREEN INFO): cargo clippy done"
 
 # 2. cargo fmt: format with nightly and stable.


### PR DESCRIPTION
pre-commit hook runs clippy and CI scripts run clippy too. The commands are and should be the same. Let's define them once.
