### PR TITLE
fix: dont try to coerce list for regex match

### DIFF
--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -1018,7 +1018,6 @@ pub fn like_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataTyp
 /// This is a union of string coercion rules and dictionary coercion rules
 pub fn regex_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     string_coercion(lhs_type, rhs_type)
-        .or_else(|| list_coercion(lhs_type, rhs_type))
         .or_else(|| dictionary_coercion(lhs_type, rhs_type, false))
 }
 

--- a/datafusion/functions/src/regex/regexpmatch.rs
+++ b/datafusion/functions/src/regex/regexpmatch.rs
@@ -36,6 +36,7 @@ use std::sync::Arc;
 pub struct RegexpMatchFunc {
     signature: Signature,
 }
+
 impl Default for RegexpMatchFunc {
     fn default() -> Self {
         Self::new()

--- a/datafusion/sqllogictest/test_files/regexp.slt
+++ b/datafusion/sqllogictest/test_files/regexp.slt
@@ -326,6 +326,8 @@ SELECT 'foo\nbar\nbaz' ~ 'bar';
 true
 
 statement error
+Error during planning: Cannot infer common argument type for regex operation List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata
+: {} }) ~ List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
 select [1,2] ~ [3];
 
 query B

--- a/datafusion/sqllogictest/test_files/regexp.slt
+++ b/datafusion/sqllogictest/test_files/regexp.slt
@@ -325,6 +325,9 @@ SELECT 'foo\nbar\nbaz' ~ 'bar';
 ----
 true
 
+statement error
+select [1,2] ~ [3];
+
 query B
 SELECT 'foo\nbar\nbaz' LIKE '%bar%';
 ----


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11622

## Rationale for this change

Regex match's args will try to be coerced from Lists, but that shouldn't be possible.

List coercion was added in https://github.com/apache/datafusion/pull/10445, but it's not clear to me why.

## What changes are included in this PR?

Remove list coercion, add tests

## Are these changes tested?

yes

## Are there any user-facing changes?

No