### PR TITLE
Docs: adding explicit mention of test_utils to docs

### DIFF
--- a/docs/source/contributor-guide/testing.md
+++ b/docs/source/contributor-guide/testing.md
@@ -29,7 +29,8 @@ and tries to follow the Rust standard [Testing Organization](https://doc.rust-la
 
 ## Unit tests
 
-Tests for code in an individual module are defined in the same source file with a `test` module, following Rust convention. If you need to perform assertions on RecordBatch you can leverage the `assert_batches_sorted_eq` and `assert_contains` macros provided by the [test_util](https://github.com/apache/datafusion/tree/main/datafusion/common/src/test_util.rs) module.
+Tests for code in an individual module are defined in the same source file with a `test` module, following Rust convention.
+The [test_util](https://github.com/apache/datafusion/tree/main/datafusion/common/src/test_util.rs) module provides useful macros to write unit tests effectively, such as `assert_batches_sorted_eq` and `assert_batches_eq` for RecordBatches and `assert_contains` / `assert_not_contains` which are used extensively in the codebase.
 
 ## sqllogictests Tests
 

--- a/docs/source/contributor-guide/testing.md
+++ b/docs/source/contributor-guide/testing.md
@@ -29,7 +29,7 @@ and tries to follow the Rust standard [Testing Organization](https://doc.rust-la
 
 ## Unit tests
 
-Tests for code in an individual module are defined in the same source file with a `test` module, following Rust convention.
+Tests for code in an individual module are defined in the same source file with a `test` module, following Rust convention. If you need to perform assertions on RecordBatch you can leverage the `assert_batches_sorted_eq` and `assert_contains` macros provided by the [test_util](https://github.com/apache/datafusion/tree/main/datafusion/common/src/test_util.rs) module.
 
 ## sqllogictests Tests
 


### PR DESCRIPTION
Minor improvement of the documentation section for unit tests, probably wrong because the best practice is to use the macro as re-exported from `datafusion_common` or maybe even `datafusion`? 