### PR TITLE
Fix depcheck by updating  to cargo `0.81.0`

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,9 +25,11 @@ on:
   push:
     paths:
       - "**/Cargo.toml"
+      - "dev/depcheck"
   pull_request:
     paths:
       - "**/Cargo.toml"
+      - "dev/depcheck"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:

--- a/dev/depcheck/Cargo.toml
+++ b/dev/depcheck/Cargo.toml
@@ -22,4 +22,4 @@ name = "depcheck"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo = "0.78.1"
+cargo = "0.81.0"

--- a/dev/depcheck/src/main.rs
+++ b/dev/depcheck/src/main.rs
@@ -17,13 +17,11 @@
 
 extern crate cargo;
 
-use cargo::CargoResult;
+use cargo::{CargoResult, GlobalContext};
 /// Check for circular dependencies between DataFusion crates
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::Path;
-
-use cargo::util::config::Config;
 
 /// Verifies that there are no circular dependencies between DataFusion crates
 /// (which prevents publishing on crates.io) by parsing the Cargo.toml files and
@@ -31,7 +29,7 @@ use cargo::util::config::Config;
 ///
 /// See https://github.com/apache/datafusion/issues/9278 for more details
 fn main() -> CargoResult<()> {
-    let config = Config::default()?;
+    let global_context = GlobalContext::default()?;
     // This is the path for the depcheck binary
     let path = env::var("CARGO_MANIFEST_DIR").unwrap();
     let root_cargo_toml = Path::new(&path)
@@ -47,7 +45,7 @@ fn main() -> CargoResult<()> {
         "Checking for circular dependencies in {}",
         root_cargo_toml.display()
     );
-    let workspace = cargo::core::Workspace::new(&root_cargo_toml, &config)?;
+    let workspace = cargo::core::Workspace::new(&root_cargo_toml, &global_context)?;
     let (_, resolve) = cargo::ops::resolve_ws(&workspace)?;
 
     let mut package_deps = HashMap::new();


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/11671

## Rationale for this change
Fix https://github.com/apache/datafusion/issues/11671

## What changes are included in this PR?

1. Update to a new version of the cargo crate
2. Update the code for the API change
3. Change dependencies job to trigger on changes to dev/depcheck directory

## Are these changes tested?
I tested them locally

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
