### PR TITLE
Increase ByteViewMap block size to 2MB

### DIFF
--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -149,7 +149,7 @@ where
             output_type,
             map: hashbrown::raw::RawTable::with_capacity(INITIAL_MAP_CAPACITY),
             map_size: 0,
-            builder: GenericByteViewBuilder::new(),
+            builder: GenericByteViewBuilder::new().with_block_size(2 * 1024 * 1024),
             random_state: RandomState::new(),
             hashes_buffer: vec![],
             null: None,

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -545,7 +545,7 @@ mod tests {
         // Much larger strings in strings2
         let strings2 = StringViewArray::from(vec![
             "FOO".repeat(1000),
-            "BAR larger than 12 bytes.".repeat(1000),
+            "BAR larger than 12 bytes.".repeat(100_000),
             "more unique.".repeat(1000),
             "more unique2.".repeat(1000),
             "FOO".repeat(3000),


### PR DESCRIPTION
Targets the string-view2 branch

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Increase the default block size from 8KB to 2MB, this significantly improves the aggregation performance with high cardinality.
More details see https://github.com/apache/arrow-rs/issues/6094
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
