### PR TITLE
Better multi-column aggregation support with StringView

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/row.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/row.rs
@@ -15,18 +15,40 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use crate::aggregates::group_values::GroupValues;
 use ahash::RandomState;
+use arrow::array::AsArray as _;
 use arrow::compute::cast;
+use arrow::datatypes::UInt32Type;
 use arrow::record_batch::RecordBatch;
 use arrow::row::{RowConverter, Rows, SortField};
-use arrow_array::{Array, ArrayRef};
+use arrow_array::{Array, ArrayRef, StringViewArray};
 use arrow_schema::{DataType, SchemaRef};
-use datafusion_common::hash_utils::create_hashes;
+// use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::{DataFusionError, Result};
-use datafusion_execution::memory_pool::proxy::{RawTableAllocExt, VecAllocExt};
+use datafusion_execution::memory_pool::proxy::RawTableAllocExt;
 use datafusion_expr::EmitTo;
+use datafusion_physical_expr_common::binary_view_map::ArrowBytesViewMap;
 use hashbrown::raw::RawTable;
+use itertools::Itertools;
+
+struct VarLenGroupValues {
+    map: ArrowBytesViewMap<u32>,
+    num_groups: u32,
+}
+
+impl VarLenGroupValues {
+    fn new() -> Self {
+        Self {
+            map: ArrowBytesViewMap::new(
+                datafusion_physical_expr::binary_map::OutputType::Utf8View,
+            ),
+            num_groups: 0,
+        }
+    }
+}
 
 /// A [`GroupValues`] making use of [`Rows`]
 pub struct GroupValuesRows {
@@ -59,11 +81,11 @@ pub struct GroupValuesRows {
     /// [`Row`]: arrow::row::Row
     group_values: Option<Rows>,
 
-    /// reused buffer to store hashes
-    hashes_buffer: Vec<u64>,
-
     /// reused buffer to store rows
     rows_buffer: Rows,
+
+    // variable length column map
+    var_len_map: Vec<VarLenGroupValues>,
 
     /// Random state for creating hashes
     random_state: RandomState,
@@ -71,11 +93,19 @@ pub struct GroupValuesRows {
 
 impl GroupValuesRows {
     pub fn try_new(schema: SchemaRef) -> Result<Self> {
+        let mut var_len_map = Vec::new();
         let row_converter = RowConverter::new(
             schema
                 .fields()
                 .iter()
-                .map(|f| SortField::new(f.data_type().clone()))
+                .map(|f| {
+                    if f.data_type() == &DataType::Utf8View {
+                        var_len_map.push(VarLenGroupValues::new());
+                        SortField::new(DataType::UInt32)
+                    } else {
+                        SortField::new(f.data_type().clone())
+                    }
+                })
                 .collect(),
         )?;
 
@@ -91,20 +121,92 @@ impl GroupValuesRows {
             map,
             map_size: 0,
             group_values: None,
-            hashes_buffer: Default::default(),
             rows_buffer,
+            var_len_map,
             random_state: Default::default(),
         })
+    }
+
+    fn transform_col_to_fixed_len(&mut self, input: &[ArrayRef]) -> Vec<ArrayRef> {
+        let mut cur_var_len_idx = 0;
+        let transformed_cols: Vec<ArrayRef> = input
+            .iter()
+            .map(|c| {
+                if let DataType::Utf8View = c.data_type() {
+                    let mut var_groups = Vec::with_capacity(c.len());
+                    let group_values = &mut self.var_len_map[cur_var_len_idx];
+                    group_values.map.insert_if_new(
+                        c,
+                        |_value| {
+                            let group_idx = group_values.num_groups;
+                            group_values.num_groups += 1;
+                            group_idx
+                        },
+                        |group_idx| {
+                            var_groups.push(group_idx);
+                        },
+                    );
+                    cur_var_len_idx += 1;
+                    std::sync::Arc::new(arrow_array::UInt32Array::from(var_groups))
+                        as ArrayRef
+                } else {
+                    c.clone()
+                }
+            })
+            .collect();
+        transformed_cols
+    }
+
+    fn transform_col_to_var_len(&mut self, output: Vec<ArrayRef>) -> Vec<ArrayRef> {
+        let mut cur_var_len_idx = 0;
+        let output = output
+            .into_iter()
+            .enumerate()
+            .map(|(i, array)| {
+                let data_type = self.schema.field(i).data_type();
+                if data_type == &DataType::Utf8View {
+                    let arr = array.as_primitive::<UInt32Type>();
+                    let mut views = Vec::with_capacity(arr.len());
+
+                    let map_content =
+                        &mut self.var_len_map[cur_var_len_idx].map.take().into_state();
+                    let map_content = map_content.as_string_view();
+
+                    for v in arr.iter() {
+                        if let Some(index) = v {
+                            let value = unsafe {
+                                map_content.views().get_unchecked(index as usize)
+                            };
+                            views.push(*value);
+                        } else {
+                            views.push(0);
+                        }
+                    }
+                    let output_str = unsafe {
+                        StringViewArray::new_unchecked(
+                            views.into(),
+                            map_content.data_buffers().to_vec(),
+                            map_content.nulls().map(|v| v.clone()),
+                        )
+                    };
+                    cur_var_len_idx += 1;
+                    Arc::new(output_str) as ArrayRef
+                } else {
+                    array
+                }
+            })
+            .collect_vec();
+        output
     }
 }
 
 impl GroupValues for GroupValuesRows {
     fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<usize>) -> Result<()> {
-        // Convert the group keys into the row format
+        let transformed_cols: Vec<ArrayRef> = self.transform_col_to_fixed_len(cols);
+
         let group_rows = &mut self.rows_buffer;
         group_rows.clear();
-        self.row_converter.append(group_rows, cols)?;
-        let n_rows = group_rows.num_rows();
+        self.row_converter.append(group_rows, &transformed_cols)?;
 
         let mut group_values = match self.group_values.take() {
             Some(group_values) => group_values,
@@ -114,20 +216,15 @@ impl GroupValues for GroupValuesRows {
         // tracks to which group each of the input rows belongs
         groups.clear();
 
-        // 1.1 Calculate the group keys for the group values
-        let batch_hashes = &mut self.hashes_buffer;
-        batch_hashes.clear();
-        batch_hashes.resize(n_rows, 0);
-        create_hashes(cols, &self.random_state, batch_hashes)?;
-
-        for (row, &hash) in batch_hashes.iter().enumerate() {
+        for row in group_rows.iter() {
+            let hash = self.random_state.hash_one(row.as_ref());
             let entry = self.map.get_mut(hash, |(_hash, group_idx)| {
                 // verify that a group that we are inserting with hash is
                 // actually the same key value as the group in
                 // existing_idx  (aka group_values @ row)
-                group_rows.row(row) == group_values.row(*group_idx)
+                row.as_ref().len() == group_values.row(*group_idx).as_ref().len()
+                    && row == group_values.row(*group_idx)
             });
-
             let group_idx = match entry {
                 // Existing group_index for this group value
                 Some((_hash, group_idx)) => *group_idx,
@@ -135,7 +232,7 @@ impl GroupValues for GroupValuesRows {
                 None => {
                     // Add new entry to aggr_state and save newly created index
                     let group_idx = group_values.num_rows();
-                    group_values.push(group_rows.row(row));
+                    group_values.push(row);
 
                     // for hasher function, use precomputed hash value
                     self.map.insert_accounted(
@@ -160,7 +257,6 @@ impl GroupValues for GroupValuesRows {
             + group_values_size
             + self.map_size
             + self.rows_buffer.size()
-            + self.hashes_buffer.allocated_size()
     }
 
     fn is_empty(&self) -> bool {
@@ -183,33 +279,12 @@ impl GroupValues for GroupValuesRows {
         let mut output = match emit_to {
             EmitTo::All => {
                 let output = self.row_converter.convert_rows(&group_values)?;
+                let output = self.transform_col_to_var_len(output);
                 group_values.clear();
                 output
             }
-            EmitTo::First(n) => {
-                let groups_rows = group_values.iter().take(n);
-                let output = self.row_converter.convert_rows(groups_rows)?;
-                // Clear out first n group keys by copying them to a new Rows.
-                // TODO file some ticket in arrow-rs to make this more efficient?
-                let mut new_group_values = self.row_converter.empty_rows(0, 0);
-                for row in group_values.iter().skip(n) {
-                    new_group_values.push(row);
-                }
-                std::mem::swap(&mut new_group_values, &mut group_values);
-
-                // SAFETY: self.map outlives iterator and is not modified concurrently
-                unsafe {
-                    for bucket in self.map.iter() {
-                        // Decrement group index by n
-                        match bucket.as_ref().1.checked_sub(n) {
-                            // Group index was >= n, shift value down
-                            Some(sub) => bucket.as_mut().1 = sub,
-                            // Group index was < n, so remove from table
-                            None => self.map.erase(bucket),
-                        }
-                    }
-                }
-                output
+            EmitTo::First(_n) => {
+                unimplemented!("Not supported yet!")
             }
         };
 
@@ -240,7 +315,5 @@ impl GroupValues for GroupValuesRows {
         self.map.clear();
         self.map.shrink_to(count, |_| 0); // hasher does not matter since the map is cleared
         self.map_size = self.map.capacity() * std::mem::size_of::<(u64, usize)>();
-        self.hashes_buffer.clear();
-        self.hashes_buffer.shrink_to(count);
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to  #7000.

## Rationale for this change
I get some time to implement the multi-column aggregation with StringView, the implementation is inspired by @jayzhan211 's #10976. 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

However, the performance is mixed, I see almost no performance diff with ClickBench query 18:
```sql
SELECT "UserID", extract(minute FROM to_timestamp_seconds("EventTime")) AS m, "SearchPhrase", COUNT(*) FROM hits GROUP BY "UserID", m, "SearchPhrase" ORDER BY COUNT(*) DESC LIMIT 10;
```
This is becuase the average size of `SearchPhrase` is only 4, meaning the string is always inlined to view and thus not being reused.

However, I made this query (q14, changed `SearchPhrase` to `URL`)
```sql
SELECT "SearchEngineID", "URL", COUNT(*) AS c FROM hits WHERE "URL" <> '' GROUP BY "SearchEngineID", "URL" ORDER BY c DESC LIMIT 10;
```
Without this patch, it takes 7.4s; with this patch, it takes 5.9s, a 20% improvement.


With this patch, the output string will reuse the string values in the buffer, so it is good.
However, when `intern`ing the values, we need to hash twice: (1) the string itself to build `BytesViewMap` (2) the group index - `u32`, which adds overhead.

## What changes are included in this PR?

Things not implemented yet:
- `EmtiTo::First(n)`: I need to think a bit more about how to efficiently reuse the `BytesViewBuilder`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
