### PR TITLE
Replace `OnceLock` with `LazyLock`, update MSRV to 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ homepage = "https://datafusion.apache.org"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/datafusion"
-rust-version = "1.76"
+rust-version = "1.80"
 version = "40.0.0"
 
 [workspace.dependencies]

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 homepage = "https://datafusion.apache.org"
 repository = "https://github.com/apache/datafusion"
 # Specify MSRV here as `cargo msrv` doesn't support workspace version
-rust-version = "1.76"
+rust-version = "1.80"
 readme = "README.md"
 
 [dependencies]

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -30,7 +30,7 @@ authors = { workspace = true }
 # Specify MSRV here as `cargo msrv` doesn't support workspace version and fails with
 # "Unable to find key 'package.rust-version' (or 'package.metadata.msrv') in 'arrow-datafusion/Cargo.toml'"
 # https://github.com/foresterre/cargo-msrv/issues/590
-rust-version = "1.76"
+rust-version = "1.80"
 
 [lints]
 workspace = true

--- a/datafusion/core/tests/parquet/external_access_plan.rs
+++ b/datafusion/core/tests/parquet/external_access_plan.rs
@@ -317,7 +317,7 @@ impl TestFull {
             schema,
             file_name,
             file_size,
-        } = TEST_DATA;
+        } = &*TEST_DATA;
 
         let mut partitioned_file = PartitionedFile::new(file_name, *file_size);
 

--- a/datafusion/functions-aggregate/src/macros.rs
+++ b/datafusion/functions-aggregate/src/macros.rs
@@ -85,18 +85,14 @@ macro_rules! create_func {
             /// Singleton instance of [$UDAF], ensures the UDAF is only created once
             /// named STATIC_$(UDAF). For example `STATIC_FirstValue`
             #[allow(non_upper_case_globals)]
-            static [< STATIC_ $UDAF >]: std::sync::OnceLock<std::sync::Arc<datafusion_expr::AggregateUDF>> =
-            std::sync::OnceLock::new();
+            static [< STATIC_ $UDAF >]: std::sync::LazyLock<std::sync::Arc<datafusion_expr::AggregateUDF>> =
+                std::sync::LazyLock::new(|| {
+                    std::sync::Arc::new(datafusion_expr::AggregateUDF::from($CREATE))
+                });
 
-            /// AggregateFunction that returns a [AggregateUDF] for [$UDAF]
-            ///
-            /// [AggregateUDF]: datafusion_expr::AggregateUDF
+            #[doc = concat!("AggregateFunction that returns a [`AggregateUDF`](datafusion_expr::AggregateUDF) for [`", stringify!($UDAF), "`]")]
             pub fn $AGGREGATE_UDF_FN() -> std::sync::Arc<datafusion_expr::AggregateUDF> {
-                [< STATIC_ $UDAF >]
-                    .get_or_init(|| {
-                        std::sync::Arc::new(datafusion_expr::AggregateUDF::from($CREATE))
-                    })
-                    .clone()
+                [< STATIC_ $UDAF >].clone()
             }
         }
     }

--- a/datafusion/functions-nested/src/macros.rs
+++ b/datafusion/functions-nested/src/macros.rs
@@ -88,19 +88,14 @@ macro_rules! create_func {
             /// Singleton instance of [`$UDF`], ensures the UDF is only created once
             /// named STATIC_$(UDF). For example `STATIC_ArrayToString`
             #[allow(non_upper_case_globals)]
-            static [< STATIC_ $UDF >]: std::sync::OnceLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
-                std::sync::OnceLock::new();
-            /// ScalarFunction that returns a [`ScalarUDF`] for [`$UDF`]
-            ///
-            /// [`ScalarUDF`]: datafusion_expr::ScalarUDF
+            static [< STATIC_ $UDF >]: std::sync::LazyLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
+                std::sync::LazyLock::new(|| {
+                    std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(<$UDF>::new()))
+                });
+
+            #[doc = concat!("ScalarFunction that returns a [`ScalarUDF`](datafusion_expr::ScalarUDF) for [`", stringify!($UDF), "`]")]
             pub fn $SCALAR_UDF_FN() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
-                [< STATIC_ $UDF >]
-                    .get_or_init(|| {
-                        std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
-                            <$UDF>::new(),
-                        ))
-                    })
-                    .clone()
+                [< STATIC_ $UDF >].clone()
             }
         }
     };

--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -72,20 +72,16 @@ macro_rules! export_functions {
 macro_rules! make_udf_function {
     ($UDF:ty, $GNAME:ident, $NAME:ident) => {
         /// Singleton instance of the function
-        static $GNAME: std::sync::OnceLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
-            std::sync::OnceLock::new();
+        static $GNAME: std::sync::LazyLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
+            std::sync::LazyLock::new(|| {
+                std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
+                    <$UDF>::new(),
+                ))
+            });
 
-        /// Return a [`ScalarUDF`] for [`$UDF`]
-        ///
-        /// [`ScalarUDF`]: datafusion_expr::ScalarUDF
+        #[doc = concat!("Return a [`ScalarUDF`](datafusion_expr::ScalarUDF) for [`", stringify!($UDF), "`]")]
         pub fn $NAME() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
-            $GNAME
-                .get_or_init(|| {
-                    std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
-                        <$UDF>::new(),
-                    ))
-                })
-                .clone()
+            $GNAME.clone()
         }
     };
 }

--- a/datafusion/physical-expr/src/utils/guarantee.rs
+++ b/datafusion/physical-expr/src/utils/guarantee.rs
@@ -420,7 +420,7 @@ impl<'a> ColOpLit<'a> {
 
 #[cfg(test)]
 mod test {
-    use std::sync::OnceLock;
+    use std::sync::LazyLock;
 
     use super::*;
     use crate::planner::logical2physical;
@@ -835,8 +835,7 @@ mod test {
     /// Tests that analyzing expr results in the expected guarantees
     fn test_analyze(expr: Expr, expected: Vec<LiteralGuarantee>) {
         println!("Begin analyze of {expr}");
-        let schema = schema();
-        let physical_expr = logical2physical(&expr, &schema);
+        let physical_expr = logical2physical(&expr, &SCHEMA);
 
         let actual = LiteralGuarantee::analyze(&physical_expr);
         assert_eq!(
@@ -869,15 +868,10 @@ mod test {
         LiteralGuarantee::try_new(column, Guarantee::NotIn, literals.iter()).unwrap()
     }
 
-    // Schema for testing
-    fn schema() -> SchemaRef {
-        Arc::clone(SCHEMA.get_or_init(|| {
-            Arc::new(Schema::new(vec![
-                Field::new("a", DataType::Utf8, false),
-                Field::new("b", DataType::Int32, false),
-            ]))
-        }))
-    }
-
-    static SCHEMA: OnceLock<SchemaRef> = OnceLock::new();
+    static SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+        Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Utf8, false),
+            Field::new("b", DataType::Int32, false),
+        ]))
+    });
 }

--- a/datafusion/proto-common/Cargo.toml
+++ b/datafusion/proto-common/Cargo.toml
@@ -26,7 +26,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
-rust-version = "1.76"
+rust-version = "1.80"
 
 # Exclude proto files so crates.io consumers don't need protoc
 exclude = ["*.proto"]

--- a/datafusion/proto-common/gen/Cargo.toml
+++ b/datafusion/proto-common/gen/Cargo.toml
@@ -20,7 +20,7 @@ name = "gen-common"
 description = "Code generation for proto"
 version = "0.1.0"
 edition = { workspace = true }
-rust-version = "1.76"
+rust-version = "1.80"
 authors = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -27,7 +27,7 @@ repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
 # Specify MSRV here as `cargo msrv` doesn't support workspace version
-rust-version = "1.76"
+rust-version = "1.80"
 
 # Exclude proto files so crates.io consumers don't need protoc
 exclude = ["*.proto"]

--- a/datafusion/proto/gen/Cargo.toml
+++ b/datafusion/proto/gen/Cargo.toml
@@ -20,7 +20,7 @@ name = "gen"
 description = "Code generation for proto"
 version = "0.1.0"
 edition = { workspace = true }
-rust-version = "1.76"
+rust-version = "1.80"
 authors = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -26,7 +26,7 @@ repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
 # Specify MSRV here as `cargo msrv` doesn't support workspace version
-rust-version = "1.76"
+rust-version = "1.80"
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11687.

## What changes are included in this PR?

- **Updated MSRV to 1.80 where necessary**, which will need review and may warrant holding off merging this for now
- Replaces all uses of `OnceLock` with `LazyLock`
- In many cases, the associated getter function for a lazy static was removed and call sites updated to access the static directly
- In a few macros that made use of `OnceLock`, I fixed the doc comments so that tokens were properly expanded into the text

## Are these changes tested?

I haven't checked that all the modified code is covered by tests, though the changes are pretty trivial. I will do so soon when time permits.

## Are there any user-facing changes?

No, only implementation details have been changed.
