### PR TITLE
Initial changes to support using udaf min/max for statistics and opti…

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -1321,7 +1321,7 @@ mod tests {
             .map(|i| i.to_string())
             .collect();
         let coll: Vec<_> = schema
-            .all_fields()
+            .flattened_fields()
             .into_iter()
             .map(|i| i.name().to_string())
             .collect();

--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -254,8 +254,8 @@ impl AggregateUDF {
     /// None in all other cases, used in certain optimizations or
     /// or aggregate
     ///
-    pub fn get_minmax_desc(&self) -> Option<bool> {
-        self.inner.get_minmax_desc()
+    pub fn is_descending(&self) -> Option<bool> {
+        self.inner.is_descending()
     }
 }
 
@@ -551,7 +551,7 @@ pub trait AggregateUDFImpl: Debug + Send + Sync {
     ///
     ///
     /// Note: this is used to use special aggregate implementations in certain conditions
-    fn get_minmax_desc(&self) -> Option<bool> {
+    fn is_descending(&self) -> Option<bool> {
         None
     }
 }

--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -249,6 +249,14 @@ impl AggregateUDF {
     pub fn simplify(&self) -> Option<AggregateFunctionSimplification> {
         self.inner.simplify()
     }
+
+    /// Returns true if the function is max, false if the function is min
+    /// None in all other cases, used in certain optimizations or
+    /// or aggregate
+    ///
+    pub fn get_minmax_desc(&self) -> Option<bool> {
+        self.inner.get_minmax_desc()
+    }
 }
 
 impl<F> From<F> for AggregateUDF
@@ -535,6 +543,16 @@ pub trait AggregateUDFImpl: Debug + Send + Sync {
         self.name().hash(hasher);
         self.signature().hash(hasher);
         hasher.finish()
+    }
+
+    /// If this function is max, return true
+    /// if the function is min, return false
+    /// otherwise return None (the default)
+    ///
+    ///
+    /// Note: this is used to use special aggregate implementations in certain conditions
+    fn get_minmax_desc(&self) -> Option<bool> {
+        None
     }
 }
 

--- a/datafusion/physical-expr-common/src/aggregate/mod.rs
+++ b/datafusion/physical-expr-common/src/aggregate/mod.rs
@@ -733,7 +733,7 @@ impl AggregateExpr for AggregateFunctionExpr {
 
     fn get_minmax_desc(&self) -> Option<(Field, bool)> {
         self.fun
-            .get_minmax_desc()
+            .is_descending()
             .and_then(|flag| self.field().ok().map(|f| (f, flag)))
     }
 }

--- a/datafusion/physical-expr-common/src/aggregate/mod.rs
+++ b/datafusion/physical-expr-common/src/aggregate/mod.rs
@@ -730,6 +730,12 @@ impl AggregateExpr for AggregateFunctionExpr {
             }
         }
     }
+
+    fn get_minmax_desc(&self) -> Option<(Field, bool)> {
+        self.fun
+            .get_minmax_desc()
+            .and_then(|flag| self.field().ok().map(|f| (f, flag)))
+    }
 }
 
 impl PartialEq<dyn Any> for AggregateFunctionExpr {


### PR DESCRIPTION
This PR tries to extract some work necessary for #10943. Min and Max are special functions that are used for statistics and optimizations, and they need a special treatment.