### PR TITLE
Pass scalar to `eq` inside `nullif` 

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -115,6 +115,7 @@ required-features = ["datetime_expressions"]
 [[bench]]
 harness = false
 name = "nullif"
+required-features = ["core_expressions"]
 
 [[bench]]
 harness = false

--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -114,6 +114,10 @@ required-features = ["datetime_expressions"]
 
 [[bench]]
 harness = false
+name = "nullif"
+
+[[bench]]
+harness = false
 name = "date_bin"
 required-features = ["datetime_expressions"]
 

--- a/datafusion/functions/benches/nullif.rs
+++ b/datafusion/functions/benches/nullif.rs
@@ -33,7 +33,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ColumnarValue::Array(array),
         ];
         c.bench_function(&format!("nullif scalar array: {}", size), |b| {
-            b.iter(|| black_box(nullif.invoke(&args)))
+            b.iter(|| black_box(nullif.invoke(&args).unwrap()))
         });
     }
 }

--- a/datafusion/functions/benches/nullif.rs
+++ b/datafusion/functions/benches/nullif.rs
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate criterion;
+
+use arrow::util::bench_util::create_string_array_with_len;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datafusion_common::ScalarValue;
+use datafusion_expr::ColumnarValue;
+use datafusion_functions::core::nullif;
+use std::sync::Arc;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let nullif = nullif();
+    for size in [1024, 4096, 8192] {
+        let array = Arc::new(create_string_array_with_len::<i32>(size, 0.2, 32));
+        let args = vec![
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some("abcd".to_string()))),
+            ColumnarValue::Array(array),
+        ];
+        c.bench_function(&format!("nullif scalar array: {}", size), |b| {
+            b.iter(|| black_box(nullif.invoke(&args)))
+        });
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/functions/src/core/nullif.rs
+++ b/datafusion/functions/src/core/nullif.rs
@@ -124,7 +124,7 @@ fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
             let lhs_s = lhs.to_scalar()?;
             let lhs_a = lhs.to_array_of_size(rhs.len())?;
             let array = nullif(
-                // nullif in arrow-select dodes not support Datum, so we need to convert to array
+                // nullif in arrow-select does not support Datum, so we need to convert to array
                 lhs_a.as_ref(),
                 &eq(&lhs_s, &rhs)?,
             )?;

--- a/datafusion/functions/src/core/nullif.rs
+++ b/datafusion/functions/src/core/nullif.rs
@@ -15,11 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::datatypes::DataType;
+use arrow::{array::Datum, datatypes::DataType};
 use datafusion_common::{exec_err, Result};
 use datafusion_expr::ColumnarValue;
 
-use arrow::array::Array;
 use arrow::compute::kernels::cmp::eq;
 use arrow::compute::kernels::nullif::nullif;
 use datafusion_common::ScalarValue;
@@ -122,8 +121,8 @@ fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
             Ok(ColumnarValue::Array(array))
         }
         (ColumnarValue::Scalar(lhs), ColumnarValue::Array(rhs)) => {
-            let lhs = lhs.to_array_of_size(rhs.len())?;
-            let array = nullif(&lhs, &eq(&lhs, &rhs)?)?;
+            let lhs = lhs.to_scalar()?;
+            let array = nullif(lhs.get().0, &eq(&lhs, &rhs)?)?;
             Ok(ColumnarValue::Array(array))
         }
         (ColumnarValue::Scalar(lhs), ColumnarValue::Scalar(rhs)) => {

--- a/datafusion/functions/src/core/nullif.rs
+++ b/datafusion/functions/src/core/nullif.rs
@@ -122,9 +122,10 @@ fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         }
         (ColumnarValue::Scalar(lhs), ColumnarValue::Array(rhs)) => {
             let lhs_s = lhs.to_scalar()?;
+            let lhs_a = lhs.to_array_of_size(rhs.len())?;
             let array = nullif(
                 // nullif in arrow-select dodes not support Datum, so we need to convert to array
-                lhs.to_array_of_size(rhs.len())?.as_ref(),
+                lhs_a.as_ref(),
                 &eq(&lhs_s, &rhs)?,
             )?;
             Ok(ColumnarValue::Array(array))


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`eq` used inside the `nullif` has a performance specialization for scalar, but it was not used, as we never passed a `Scalar` into it.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add benchmark for nullif
- Convert ScalarValue to Scalar, instead of Array of size 1

```cargo bench --bench nullif --features "core_expressions" -- --baseline=before
nullif scalar array: 1024
                        time:   [5.3127 µs 5.3305 µs 5.3526 µs]
                        change: [-1.2396% -0.9171% -0.5696%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  9 (9.00%) high mild
  4 (4.00%) high severe

nullif scalar array: 4096
                        time:   [16.483 µs 16.577 µs 16.675 µs]
                        change: [-4.6029% -3.9615% -3.1831%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

nullif scalar array: 8192
                        time:   [31.442 µs 31.527 µs 31.620 µs]
                        change: [-4.6155% -4.3827% -4.1375%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
```

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
