### PR TITLE
Fix bug #11698

### DIFF
--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -1321,7 +1321,7 @@ mod tests {
             .map(|i| i.to_string())
             .collect();
         let coll: Vec<_> = schema
-            .all_fields()
+            .flattened_fields()
             .into_iter()
             .map(|i| i.name().to_string())
             .collect();


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11698.

## Rationale for this change

Fix the CI pipeline.

## What changes are included in this PR?

Replaced one call to `Schema::all_fields` with `Schema::flattened_fields`.

## Are these changes tested?

The change is trivial, and I've checked that `Schema::flattened_fields` just calls `Schema::all_fields` internally.

## Are there any user-facing changes?

No.
