### PR TITLE
Change `FileSinkConfig.object_store_url` from `ObjectStoreUrl` to `Url`

### DIFF
--- a/datafusion/core/src/datasource/file_format/arrow.rs
+++ b/datafusion/core/src/datasource/file_format/arrow.rs
@@ -267,7 +267,8 @@ impl DataSink for ArrowFileSink {
     ) -> Result<u64> {
         let object_store = context
             .runtime_env()
-            .object_store(&self.config.object_store_url)?;
+            .object_store_registry
+            .get_store(&self.config.object_store_url)?;
 
         let part_col = if !self.config.table_partition_cols.is_empty() {
             Some(self.config.table_partition_cols.clone())

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -718,7 +718,8 @@ impl DataSink for ParquetSink {
 
         let object_store = context
             .runtime_env()
-            .object_store(&self.config.object_store_url)?;
+            .object_store_registry
+            .get_store(&self.config.object_store_url)?;
 
         let parquet_opts = &self.parquet_options;
         let allow_single_file_parallelism =
@@ -2064,7 +2065,7 @@ mod tests {
         let object_store_url = ObjectStoreUrl::local_filesystem();
 
         let file_sink_config = FileSinkConfig {
-            object_store_url: object_store_url.clone(),
+            object_store_url: AsRef::<url::Url>::as_ref(&object_store_url).clone(),
             file_groups: vec![PartitionedFile::new("/tmp".to_string(), 1)],
             table_paths: vec![ListingTableUrl::parse("file:///")?],
             output_schema: schema.clone(),
@@ -2159,7 +2160,7 @@ mod tests {
 
         // set file config to include partitioning on field_a
         let file_sink_config = FileSinkConfig {
-            object_store_url: object_store_url.clone(),
+            object_store_url: AsRef::<url::Url>::as_ref(&object_store_url).clone(),
             file_groups: vec![PartitionedFile::new("/tmp".to_string(), 1)],
             table_paths: vec![ListingTableUrl::parse("file:///")?],
             output_schema: schema.clone(),
@@ -2242,7 +2243,7 @@ mod tests {
             let object_store_url = ObjectStoreUrl::local_filesystem();
 
             let file_sink_config = FileSinkConfig {
-                object_store_url: object_store_url.clone(),
+                object_store_url: AsRef::<url::Url>::as_ref(&object_store_url).clone(),
                 file_groups: vec![PartitionedFile::new("/tmp".to_string(), 1)],
                 table_paths: vec![ListingTableUrl::parse("file:///")?],
                 output_schema: schema.clone(),

--- a/datafusion/core/src/datasource/file_format/write/orchestration.rs
+++ b/datafusion/core/src/datasource/file_format/write/orchestration.rs
@@ -248,7 +248,8 @@ pub(crate) async fn stateless_multipart_put(
 ) -> Result<u64> {
     let object_store = context
         .runtime_env()
-        .object_store(&config.object_store_url)?;
+        .object_store_registry
+        .get_store(&config.object_store_url)?;
 
     let base_output_path = &config.table_paths[0];
     let part_cols = if !config.table_partition_cols.is_empty() {

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -899,7 +899,7 @@ impl TableProvider for ListingTable {
 
         // Sink related option, apart from format
         let config = FileSinkConfig {
-            object_store_url: self.table_paths()[0].object_store(),
+            object_store_url: AsRef::<url::Url>::as_ref(&self.table_paths()[0]).clone(),
             table_paths: self.table_paths().clone(),
             file_groups,
             output_schema: self.schema(),

--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -54,10 +54,7 @@ use super::listing::ListingTableUrl;
 use crate::error::Result;
 use crate::physical_plan::{DisplayAs, DisplayFormatType};
 use crate::{
-    datasource::{
-        listing::{FileRange, PartitionedFile},
-        object_store::ObjectStoreUrl,
-    },
+    datasource::listing::{FileRange, PartitionedFile},
     physical_plan::display::{display_orderings, ProjectSchemaDisplay},
 };
 
@@ -68,12 +65,13 @@ use datafusion_physical_expr::PhysicalSortExpr;
 use futures::StreamExt;
 use log::debug;
 use object_store::{path::Path, GetOptions, GetRange, ObjectMeta, ObjectStore};
+use url::Url;
 
 /// The base configurations to provide when creating a physical plan for
 /// writing to any given file format.
 pub struct FileSinkConfig {
     /// Object store URL, used to get an ObjectStore instance
-    pub object_store_url: ObjectStoreUrl,
+    pub object_store_url: Url,
     /// A vector of [`PartitionedFile`] structs, each representing a file partition
     pub file_groups: Vec<PartitionedFile>,
     /// Vector of partition paths

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -763,7 +763,7 @@ impl DefaultPhysicalPlanner {
             }) => {
                 let input_exec = children.one()?;
                 let parsed_url = ListingTableUrl::parse(output_url)?;
-                let object_store_url = parsed_url.object_store();
+                let object_store_url: &url::Url = parsed_url.as_ref();
 
                 let schema: Schema = (**input.schema()).clone().into();
 
@@ -787,7 +787,7 @@ impl DefaultPhysicalPlanner {
 
                 // Set file sink related options
                 let config = FileSinkConfig {
-                    object_store_url,
+                    object_store_url: object_store_url.clone(),
                     table_paths: vec![parsed_url],
                     file_groups: vec![],
                     output_schema: Arc::new(schema),

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -56,6 +56,7 @@ pbjson = { version = "0.6.0", optional = true }
 prost = "0.12.0"
 serde = { version = "1.0", optional = true }
 serde_json = { workspace = true, optional = true }
+url = { workspace = true }
 
 [dev-dependencies]
 datafusion-functions = { workspace = true, default-features = true }

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -652,8 +652,10 @@ impl TryFrom<&protobuf::FileSinkConfig> for FileSinkConfig {
                 Ok((name.clone(), data_type))
             })
             .collect::<Result<Vec<_>>>()?;
+        let object_store_url = url::Url::parse(&conf.object_store_url)
+            .map_err(|e| DataFusionError::Internal(format!("{e}")))?;
         Ok(Self {
-            object_store_url: ObjectStoreUrl::parse(&conf.object_store_url)?,
+            object_store_url: object_store_url,
             file_groups,
             table_paths,
             output_schema: Arc::new(convert_required!(conf.output_schema)?),

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -91,6 +91,7 @@ use datafusion_proto::physical_plan::{
     AsExecutionPlan, DefaultPhysicalExtensionCodec, PhysicalExtensionCodec,
 };
 use datafusion_proto::protobuf;
+use url::Url;
 
 use crate::cases::{MyAggregateUDF, MyAggregateUdfNode, MyRegexUdf, MyRegexUdfNode};
 
@@ -1044,9 +1045,10 @@ fn roundtrip_json_sink() -> Result<()> {
     let field_b = Field::new("plan", DataType::Utf8, false);
     let schema = Arc::new(Schema::new(vec![field_a, field_b]));
     let input = Arc::new(PlaceholderRowExec::new(schema.clone()));
+    let object_store_url = ObjectStoreUrl::local_filesystem();
 
     let file_sink_config = FileSinkConfig {
-        object_store_url: ObjectStoreUrl::local_filesystem(),
+        object_store_url: AsRef::<Url>::as_ref(&object_store_url).clone(),
         file_groups: vec![PartitionedFile::new("/tmp".to_string(), 1)],
         table_paths: vec![ListingTableUrl::parse("file:///")?],
         output_schema: schema.clone(),
@@ -1080,9 +1082,10 @@ fn roundtrip_csv_sink() -> Result<()> {
     let field_b = Field::new("plan", DataType::Utf8, false);
     let schema = Arc::new(Schema::new(vec![field_a, field_b]));
     let input = Arc::new(PlaceholderRowExec::new(schema.clone()));
+    let object_store_url = ObjectStoreUrl::local_filesystem();
 
     let file_sink_config = FileSinkConfig {
-        object_store_url: ObjectStoreUrl::local_filesystem(),
+        object_store_url: AsRef::<Url>::as_ref(&object_store_url).clone(),
         file_groups: vec![PartitionedFile::new("/tmp".to_string(), 1)],
         table_paths: vec![ListingTableUrl::parse("file:///")?],
         output_schema: schema.clone(),
@@ -1139,9 +1142,10 @@ fn roundtrip_parquet_sink() -> Result<()> {
     let field_b = Field::new("plan", DataType::Utf8, false);
     let schema = Arc::new(Schema::new(vec![field_a, field_b]));
     let input = Arc::new(PlaceholderRowExec::new(schema.clone()));
+    let object_store_url = ObjectStoreUrl::local_filesystem();
 
     let file_sink_config = FileSinkConfig {
-        object_store_url: ObjectStoreUrl::local_filesystem(),
+        object_store_url: AsRef::<Url>::as_ref(&object_store_url).clone(),
         file_groups: vec![PartitionedFile::new("/tmp".to_string(), 1)],
         table_paths: vec![ListingTableUrl::parse("file:///")?],
         output_schema: schema.clone(),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

/

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When using legacy object store URLs, bucket is contained in URL path — first segment, however `ObjectStoreUrl` holds no path segments.  
This effectively prevents usage of `FileSinks` — Arrow/Csv/Parquet/Json, with legacy object store URLs as (correct) `ObjectStore` cannot be obtained from `ObjectStoreRegistry` due to missing bucket segment.

As `ObjectStoreRegistry` already operates with `Urls`, it was natural to change `FileSinkConfig.object_store_url` to an `Url`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- FileSinkConfig `object_store_url` changed from `ObjectStoreUrl` to `Url`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
