### PR TITLE
Make DefaultSchemaAdapterFactory public

### DIFF
--- a/datafusion/core/src/datasource/schema_adapter.rs
+++ b/datafusion/core/src/datasource/schema_adapter.rs
@@ -92,8 +92,10 @@ pub trait SchemaMapper: Debug + Send + Sync {
     ) -> datafusion_common::Result<RecordBatch>;
 }
 
+/// Basic implementation of [`SchemaAdapterFactory`] that maps columns by name
+/// and casts columns to the expected type.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct DefaultSchemaAdapterFactory {}
+pub struct DefaultSchemaAdapterFactory {}
 
 impl SchemaAdapterFactory for DefaultSchemaAdapterFactory {
     fn create(&self, table_schema: SchemaRef) -> Box<dyn SchemaAdapter> {


### PR DESCRIPTION
This seems like a nice self-contained API that would be useful for downstream consumers of DataFusion