### PR TITLE
Use `cargo release` in `bench.sh`

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -34,8 +34,7 @@ COMMAND=
 BENCHMARK=all
 DATAFUSION_DIR=${DATAFUSION_DIR:-$SCRIPT_DIR/..}
 DATA_DIR=${DATA_DIR:-$SCRIPT_DIR/data}
-#CARGO_COMMAND=${CARGO_COMMAND:-"cargo run --release"}
-CARGO_COMMAND=${CARGO_COMMAND:-"cargo run --profile release-nonlto"}  # for faster iterations
+CARGO_COMMAND=${CARGO_COMMAND:-"cargo run --release"}
 PREFER_HASH_JOIN=${PREFER_HASH_JOIN:-true}
 VIRTUAL_ENV=${VIRTUAL_ENV:-$SCRIPT_DIR/venv}
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

As we get into serious benchmarking / optimization mode, ensuring the benchmark results are as close to what is actually run as possible is important. Thus I want to propose using `cargo release` in bench.sh even if that makes the runs take longer. 

Most builds of DataFusion use `cargo <cmd> --release` rather than `cargo <cmd> --profile release-nonlto`

For example, I am not sure why https://github.com/apache/datafusion/pull/11718 shows improvements on some environments and not others. 

## What changes are included in this PR?

1. Change `bench.sh` to use `--release` instead of `--relase-non-lto`

## Are these changes tested?

I am going to run benchmarks on my test rig manually to see if this causes any differences

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
