### PR TITLE
Enhance the formatting for Column

### DIFF
--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -372,7 +372,7 @@ impl FromStr for Column {
 
 impl fmt::Display for Column {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.flat_name())
+        write!(f, "{}", self.quoted_flat_name())
     }
 }
 
@@ -454,5 +454,13 @@ mod tests {
         assert_eq!(err.strip_backtrace(), expected);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_display() {
+        let col = Column::new(Some("t1"), "a");
+        assert_eq!(col.to_string(), "t1.a");
+        let col = Column::new(TableReference::none(), "t1.a");
+        assert_eq!(col.to_string(), r#""t1.a""#);
     }
 }

--- a/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
@@ -388,9 +388,9 @@ async fn udaf_as_window_func() -> Result<()> {
     context.register_udaf(my_acc);
 
     let sql = "SELECT a, MY_ACC(b) OVER(PARTITION BY a) FROM my_table";
-    let expected = r#"Projection: my_table.a, my_acc(my_table.b) PARTITION BY [my_table.a] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-  WindowAggr: windowExpr=[[my_acc(my_table.b) PARTITION BY [my_table.a] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING]]
-    TableScan: my_table"#;
+    let expected = "Projection: my_table.a, \"my_acc(my_table.b) PARTITION BY [my_table.a] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING\"\
+    \n  WindowAggr: windowExpr=[[my_acc(my_table.b) PARTITION BY [my_table.a] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING]]\
+    \n    TableScan: my_table";
 
     let dataframe = context.sql(sql).await.unwrap();
     assert_eq!(format!("{:?}", dataframe.logical_plan()), expected);

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2911,7 +2911,6 @@ mod tests {
     use datafusion_common::{not_impl_err, Constraint, ScalarValue};
 
     use crate::test::function_stub::count;
-    use crate::window_function::row_number;
 
     fn employee_schema() -> Schema {
         Schema::new(vec![

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2754,7 +2754,8 @@ fn calc_func_dependencies_for_project(
             let expr_name = match expr {
                 Expr::Alias(alias) => alias.expr.display_name(),
                 _ => expr.display_name(),
-            }.ok()?;
+            }
+            .ok()?;
             input_fields.iter().position(|item| *item == expr_name)
         })
         .collect::<Vec<_>>();

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -3528,7 +3528,8 @@ digraph {
             .build()
             .unwrap();
 
-        let expected = "Projection: t.\"max(id)\"\n  Filter: t.state = Utf8(\"CO\")\n    TableScan: t";
+        let expected =
+            "Projection: t.max(id)\n  Filter: t.state = Utf8(\"CO\")\n    TableScan: t";
         let actual = format!("{}", plan.display_indent());
         assert_eq!(expected.to_string(), actual);
 

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2752,11 +2752,9 @@ fn calc_func_dependencies_for_project(
         .iter()
         .filter_map(|expr| {
             let expr_name = match expr {
-                Expr::Alias(alias) => {
-                    format!("{}", alias.expr)
-                }
-                _ => format!("{}", expr),
-            };
+                Expr::Alias(alias) => alias.expr.display_name(),
+                _ => expr.display_name(),
+            }.ok()?;
             input_fields.iter().position(|item| *item == expr_name)
         })
         .collect::<Vec<_>>();
@@ -2912,6 +2910,7 @@ mod tests {
     use datafusion_common::{not_impl_err, Constraint, ScalarValue};
 
     use crate::test::function_stub::count;
+    use crate::window_function::row_number;
 
     fn employee_schema() -> Schema {
         Schema::new(vec![


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
No corresponding issue.

## Rationale for this change
Consider the following case:

```rust
let plan = LogicalPlanBuilder::table_scan(Some("t"), &schema, None).unwrap().build().unwrap();
let projection = LogicalPlan::Projection(Projection::try_new(vec![col("t.id"), ident("t.id")], Arc::new(plan)).unwrap());
```

Before this change, if we try to format `Column`, the result is:

```
Projection: t.id, t.id
  TableScan: t
```

We can't distinguish between `col("t.id")` and `ident("t.id")`.

Now, the result will be:

```
Projection: t.id, "t.id"
  TableScan: t
```

This change is beneficial for debugging.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Change the formatting behavior.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
