### PR TITLE
fix: set `null_equals_null` to false when `convert_cross_join_to_inner_join`

### DIFF
--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1127,7 +1127,7 @@ fn convert_cross_join_to_inner_join(cross_join: CrossJoin) -> Result<Join> {
         on: vec![],
         filter: None,
         schema: DFSchemaRef::new(join_schema),
-        null_equals_null: true,
+        null_equals_null: false,
     })
 }
 

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -1109,3 +1109,25 @@ DROP TABLE t0;
 
 statement ok
 DROP TABLE t1;
+
+# Test SQLancer issue: https://github.com/apache/datafusion/issues/11704
+query II
+WITH
+    t1 AS (SELECT NULL::int AS a),
+    t2 AS (SELECT NULL::int AS a)
+SELECT * FROM
+  (SELECT * FROM t1 CROSS JOIN t2)
+WHERE t1.a == t2.a
+  AND t1.a + t2.a IS NULL;
+----
+
+# Similar to above test case, but without the equality predicate
+query II
+WITH
+    t1 AS (SELECT NULL::int AS a),
+    t2 AS (SELECT NULL::int AS a)
+SELECT * FROM
+  (SELECT * FROM t1 CROSS JOIN t2)
+WHERE t1.a + t2.a IS NULL;
+----
+NULL NULL


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11704.

## Rationale for this change
Given an example query:
```sql
CREATE TABLE t1(a INT) AS VALUES(NULL);
CREATE TABLE t2(a INT) AS VALUES(NULL);
SELECT * FROM
  (SELECT * FROM t1 CROSS JOIN t2)
WHERE t1.a == t2.a
  AND t1.a + t2.a IS NULL;
```
The `push_down_filter` rule will convert the cross join into an inner join.
```sh
| initial_logical_plan                | Projection: t1.a, t2.a                                       |
|                                     |   Filter: t1.a = t2.a AND t1.a + t2.a IS NULL                |
|                                     |     Projection: t1.a, t2.a                                   |
|                                     |       CrossJoin:                                             |
|                                     |         TableScan: t1                                        |
|                                     |         TableScan: t2                                        |
| logical_plan after push_down_filter | Projection: t1.a, t2.a                                       |
|                                     |   Projection: t1.a, t2.a                                     |
|                                     |     Inner Join:  Filter: t2.a = t1.a AND t1.a + t2.a IS NULL |
|                                     |       TableScan: t1                                          |
|                                     |       TableScan: t2                                          |
| extract_equijoin_predicate          | Inner Join: t1.a = t2.a Filter: t1.a + t2.a IS NULL          |
|                                     |   TableScan: t1 projection=[a]                               |
|                                     |   TableScan: t2 projection=[a]                               |
```
`null_equals_null` is only valid for equijoins, and when applying the corresponding equality predicate to the cross join, null does not equal null. So we should set `null_equals_null` to false in order to convert the cross join to an equivalent equijoin.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes


## Are there any user-facing changes?
No