### PR TITLE
Fix `plan_to_sql`: Add wildcard projection to SELECT statement if no projection was set

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -140,6 +140,12 @@ impl Unparser<'_> {
             return Ok(*body);
         }
 
+        // If no projection is set, add a wildcard projection to the select 
+        // which will be translated to `SELECT *` in the SQL statement 
+        if !select_builder.already_projected(){
+            select_builder.projection(vec![ast::SelectItem::Wildcard(ast::WildcardAdditionalOptions::default())]);
+        }
+
         let mut twj = select_builder.pop_from().unwrap();
         twj.relation(relation_builder);
         select_builder.push_from(twj);

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -140,10 +140,12 @@ impl Unparser<'_> {
             return Ok(*body);
         }
 
-        // If no projection is set, add a wildcard projection to the select 
-        // which will be translated to `SELECT *` in the SQL statement 
-        if !select_builder.already_projected(){
-            select_builder.projection(vec![ast::SelectItem::Wildcard(ast::WildcardAdditionalOptions::default())]);
+        // If no projection is set, add a wildcard projection to the select
+        // which will be translated to `SELECT *` in the SQL statement
+        if !select_builder.already_projected() {
+            select_builder.projection(vec![ast::SelectItem::Wildcard(
+                ast::WildcardAdditionalOptions::default(),
+            )]);
         }
 
         let mut twj = select_builder.pop_from().unwrap();

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -456,16 +456,19 @@ fn test_table_scan_with_no_projection_in_plan_to_sql() {
         ]);
 
         let plan = table_scan(Some(table_name), &schema, None)
-        .unwrap()
-        .build()
-        .unwrap();
+            .unwrap()
+            .build()
+            .unwrap();
         let sql = plan_to_sql(&plan).unwrap();
         assert_eq!(format!("{}", sql), expected_sql)
     }
 
-    test("catalog.schema.table", "SELECT * FROM catalog.\"schema\".\"table\"");
+    test(
+        "catalog.schema.table",
+        "SELECT * FROM catalog.\"schema\".\"table\"",
+    );
     test("schema.table", "SELECT * FROM \"schema\".\"table\"");
-    test("table","SELECT * FROM \"table\"");
+    test("table", "SELECT * FROM \"table\"");
 }
 
 #[test]

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -448,6 +448,27 @@ fn test_table_references_in_plan_to_sql() {
 }
 
 #[test]
+fn test_table_scan_with_no_projection_in_plan_to_sql() {
+    fn test(table_name: &str, expected_sql: &str) {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, false),
+        ]);
+
+        let plan = table_scan(Some(table_name), &schema, None)
+        .unwrap()
+        .build()
+        .unwrap();
+        let sql = plan_to_sql(&plan).unwrap();
+        assert_eq!(format!("{}", sql), expected_sql)
+    }
+
+    test("catalog.schema.table", "SELECT * FROM catalog.\"schema\".\"table\"");
+    test("schema.table", "SELECT * FROM \"schema\".\"table\"");
+    test("table","SELECT * FROM \"table\"");
+}
+
+#[test]
 fn test_pretty_roundtrip() -> Result<()> {
     let schema = Schema::new(vec![
         Field::new("id", DataType::Utf8, false),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11743.

## Rationale for this change

This PR will check the `select_builder` in the `select_to_sql_expr` after calling the `select_to_sql_recursively` and if no projection is set, it will add a projection with one element set to `ast::SelectItem::Wildcard(ast::WildcardAdditionalOptions::default())`

## What changes are included in this PR?

The changes described above, and some test cases. 

## Are these changes tested?

Yes. 

## Are there any user-facing changes?

I would say no. 
