### PR TITLE
[WIP] Support deep schema pruning and projection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+[profile.idea]
+inherits = "dev"
+opt-level = 0
+debug = 2
+split-debuginfo = "packed"
+strip = "none"
+debug-assertions = true
+overflow-checks = false
+incremental = true
+codegen-units = 256
+lto = "off"
+
 [workspace]
 exclude = ["datafusion-cli", "dev/depcheck"]
 members = [

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -64,6 +64,7 @@ paste = "1.0.15"
 pyo3 = { version = "0.21.0", optional = true }
 sqlparser = { workspace = true }
 tokio = { workspace = true }
+log = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/datafusion/common/src/deep.rs
+++ b/datafusion/common/src/deep.rs
@@ -1,0 +1,1008 @@
+use crate::cast::as_map_array;
+use crate::{project_schema, DataFusionError, DFSchemaRef};
+use arrow::compute::{can_cast_types, cast};
+use arrow_array::cast::{
+    as_fixed_size_list_array, as_generic_list_array, as_struct_array,
+};
+use arrow_array::{
+    new_null_array, Array, ArrayRef, FixedSizeListArray, LargeListArray, ListArray,
+    MapArray, RecordBatch, RecordBatchOptions, StructArray,
+};
+use arrow_schema::{DataType, Field, FieldRef, Fields, Schema, SchemaRef};
+use log::{error, trace};
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::sync::Arc;
+
+/// Check whether an Arrow [DataType] is recursive in the sense that we need to
+/// look inside and continue unpacking the data
+/// This is used when creating a schema based on a deep projection
+pub fn data_type_recurs(dt: &DataType) -> bool {
+    match dt {
+        // scalars
+        DataType::Null
+        | DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Float16
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Timestamp(_, _)
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Duration(_)
+        | DataType::Interval(_)
+        | DataType::Binary
+        | DataType::FixedSizeBinary(_)
+        | DataType::LargeBinary
+        | DataType::BinaryView
+        | DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Utf8View
+        | DataType::Decimal128(_, _)
+        | DataType::Decimal256(_, _)
+        | DataType::Dictionary(_, _) => false,
+        // containers
+        DataType::RunEndEncoded(_, val) => data_type_recurs(val.data_type()),
+        DataType::Union(_, _) => true,
+        DataType::List(f) => data_type_recurs(f.data_type()),
+        DataType::ListView(f) => data_type_recurs(f.data_type()),
+        DataType::FixedSizeList(f, _) => data_type_recurs(f.data_type()),
+        DataType::LargeList(f) => data_type_recurs(f.data_type()),
+        DataType::LargeListView(f) => data_type_recurs(f.data_type()),
+        // list of struct
+        DataType::Map(f, _) => true,
+        DataType::Struct(_) => true,
+    }
+}
+
+/// Mutually recursive function with [rewrite_record_batch_field]
+/// Given the source and destination fields, as well as the list of Arrow [Array]s
+/// Returns the modified arrays as well as the modified fields.
+pub fn rewrite_record_batch_fields(
+    dst_fields: &Fields,
+    src_fields: &Fields,
+    arrays: Vec<ArrayRef>,
+    num_rows: usize,
+    fill_missing_source_fields: bool,
+    error_on_missing_source_fields: bool,
+) -> crate::Result<(Vec<ArrayRef>, Vec<FieldRef>)> {
+    let mut out_arrays: Vec<ArrayRef> = vec![];
+    let mut out_fields: Vec<FieldRef> = vec![];
+    for i in 0..dst_fields.len() {
+        let dst_field = dst_fields[i].clone();
+        let dst_name = dst_field.name();
+
+        let src_field_opt = src_fields
+            .iter()
+            .enumerate()
+            .find(|(_idx, b)| b.name() == dst_name);
+
+        // if the field exists in the source
+        if src_field_opt.is_some() {
+            let (src_idx, src_field) = src_field_opt.unwrap();
+            let src_field = src_field.clone();
+            let src_arr = arrays[src_idx].clone();
+            let (tmp_array, tmp_field) = rewrite_record_batch_field(
+                dst_field,
+                src_field,
+                src_arr,
+                num_rows,
+                fill_missing_source_fields,
+                error_on_missing_source_fields,
+            )?;
+            out_arrays.push(tmp_array);
+            out_fields.push(tmp_field);
+        } else {
+            if fill_missing_source_fields {
+                let tmp_array = new_null_array(dst_field.data_type(), num_rows);
+                out_arrays.push(tmp_array);
+                out_fields.push(dst_field);
+            } else if error_on_missing_source_fields {
+                return Err(crate::DataFusionError::Internal(format!(
+                    "field {dst_name} not found in source"
+                )));
+            }
+        }
+    }
+    Ok((out_arrays, out_fields))
+}
+
+/// Mutually recursive function with [rewrite_record_batch_fields]
+/// Rewrites a single field, returns a single modified field and array
+/// If the field can be trivially casted (does not recur, simple data types) - falls back to Arrow functionality
+/// If we have a container like field or struct, the function recurs for the data type inside
+pub fn rewrite_record_batch_field(
+    dst_field: FieldRef,
+    src_field: FieldRef,
+    src_array: ArrayRef,
+    num_rows: usize,
+    fill_missing_source_fields: bool,
+    error_on_missing_source_fields: bool,
+) -> crate::Result<(ArrayRef, FieldRef)> {
+    let arrow_cast_available =
+        can_cast_types(src_field.data_type(), dst_field.data_type());
+    if arrow_cast_available {
+        let casted_array = cast(src_array.as_ref(), dst_field.data_type())?;
+        return Ok((casted_array, dst_field.clone()));
+    }
+    match (src_field.data_type(), dst_field.data_type()) {
+        (DataType::List(src_inner), DataType::List(dst_inner)) => {
+            if data_type_recurs(src_field.data_type()) {
+                let src_array_clone = src_array.clone();
+
+                let src_inner_list_array =
+                    as_generic_list_array::<i32>(src_array_clone.as_ref()).clone();
+                let src_offset_buffer = src_inner_list_array.offsets().clone();
+                let src_nulls = match src_inner_list_array.nulls() {
+                    None => None,
+                    Some(x) => Some(x.clone()),
+                };
+                let (values, field) = rewrite_record_batch_field(
+                    dst_inner.clone(),
+                    src_inner.clone(),
+                    src_inner_list_array.values().clone(),
+                    num_rows,
+                    fill_missing_source_fields,
+                    error_on_missing_source_fields,
+                )?;
+                let nlarr = ListArray::try_new(
+                    field.clone(),
+                    src_offset_buffer,
+                    values,
+                    src_nulls,
+                );
+                let list_field = Arc::new(Field::new(
+                    dst_field.name().clone(),
+                    DataType::List(field.clone()),
+                    dst_field.is_nullable(),
+                ));
+
+                Ok((Arc::new(nlarr.unwrap()), list_field))
+            } else {
+                let casted_array =
+                    cast(src_array.as_ref(), dst_field.data_type())?;
+                return Ok((casted_array, dst_field.clone()));
+            }
+        }
+        (
+            DataType::FixedSizeList(src_inner, src_sz),
+            DataType::FixedSizeList(dst_inner, dst_sz),
+        ) => {
+            if src_sz != dst_sz {
+                // Let Arrow do its thing, it's going to error
+                let casted_array =
+                    cast(src_array.as_ref(), dst_field.data_type())?;
+                return Ok((casted_array, dst_field.clone()));
+            }
+            if data_type_recurs(src_field.data_type()) {
+                let tmp = src_array.clone();
+                let src_inner_list_array =
+                    as_fixed_size_list_array(tmp.as_ref()).clone();
+                let src_nulls = match src_inner_list_array.nulls() {
+                    None => None,
+                    Some(x) => Some(x.clone()),
+                };
+                let (values, field) = rewrite_record_batch_field(
+                    dst_inner.clone(),
+                    src_inner.clone(),
+                    src_inner_list_array.values().clone(),
+                    num_rows,
+                    fill_missing_source_fields,
+                    error_on_missing_source_fields,
+                )?;
+
+                let nlarr = FixedSizeListArray::try_new(
+                    field.clone(),
+                    *dst_sz,
+                    values,
+                    src_nulls,
+                );
+                let list_field = Arc::new(Field::new(
+                    dst_field.name().clone(),
+                    DataType::FixedSizeList(field.clone(), *dst_sz),
+                    dst_field.is_nullable(),
+                ));
+
+                Ok((Arc::new(nlarr.unwrap()), list_field))
+            } else {
+                let casted_array =
+                    cast(src_array.as_ref(), dst_field.data_type())?;
+                return Ok((casted_array, dst_field.clone()));
+            }
+        }
+        (DataType::LargeList(src_inner), DataType::LargeList(dst_inner)) => {
+            if data_type_recurs(src_field.data_type()) {
+                let tmp = src_array.clone();
+                let src_inner_list_array =
+                    as_generic_list_array::<i64>(tmp.as_ref()).clone();
+                let src_offset_buffer = src_inner_list_array.offsets().clone();
+                let src_nulls = match src_inner_list_array.nulls() {
+                    None => None,
+                    Some(x) => Some(x.clone()),
+                };
+                let (values, field) = rewrite_record_batch_field(
+                    dst_inner.clone(),
+                    src_inner.clone(),
+                    src_inner_list_array.values().clone(),
+                    num_rows,
+                    fill_missing_source_fields,
+                    error_on_missing_source_fields,
+                )?;
+
+                let nlarr = LargeListArray::try_new(
+                    field.clone(),
+                    src_offset_buffer,
+                    values,
+                    src_nulls,
+                );
+                let list_field = Arc::new(Field::new(
+                    dst_field.name().clone(),
+                    DataType::LargeList(field.clone()),
+                    dst_field.is_nullable(),
+                ));
+
+                Ok((Arc::new(nlarr.unwrap()), list_field))
+            } else {
+                let casted_array =
+                    cast(src_array.as_ref(), dst_field.data_type())?;
+                return Ok((casted_array, dst_field.clone()));
+            }
+        }
+
+        (DataType::Map(src_inner, _), DataType::Map(dst_inner, dst_ordered)) => {
+            match (src_inner.data_type(), dst_inner.data_type()) {
+                (DataType::Struct(src_inner_f), DataType::Struct(dst_inner_f)) => {
+                    let src_map = as_map_array(src_array.as_ref())?;
+                    let src_nulls = match src_map.nulls() {
+                        None => None,
+                        Some(x) => Some(x.clone()),
+                    };
+                    let src_offset_buffer = src_map.offsets().clone();
+
+                    let (tmp_values_array, tmp_values_field) = rewrite_record_batch_field(
+                        dst_inner_f[1].clone(),
+                        src_inner_f[1].clone(),
+                        src_map.values().clone(),
+                        num_rows,
+                        fill_missing_source_fields,
+                        error_on_missing_source_fields,
+                    )?;
+                    // re-build map from keys and values after recursing only on the values
+                    let entry_struct = StructArray::from(vec![
+                        (dst_inner_f[0].clone(), src_map.keys().clone()),
+                        (tmp_values_field, tmp_values_array),
+                    ]);
+
+                    let struct_field = Arc::new(Field::new(
+                        dst_inner.name().clone(),
+                        entry_struct.data_type().clone(),
+                        false,
+                    ));
+
+                    let out_map = MapArray::try_new(
+                        struct_field.clone(),
+                        src_offset_buffer,
+                        entry_struct,
+                        src_nulls,
+                        *dst_ordered,
+                    )?;
+                    let map_field = Arc::new(Field::new(
+                        dst_field.name().clone(),
+                        DataType::Map(struct_field.clone(), *dst_ordered),
+                        dst_field.is_nullable(),
+                    ));
+
+                    Ok((Arc::new(out_map), map_field))
+                }
+                _ => unreachable!(), // unreachable
+            }
+        }
+
+        (DataType::Struct(src_inner), DataType::Struct(dst_inner)) => {
+            let src_struct_array = as_struct_array(src_array.as_ref());
+            let src_nulls = match src_struct_array.nulls() {
+                None => None,
+                Some(x) => Some(x.clone()),
+            };
+            let src_columns = src_struct_array
+                .columns()
+                .iter()
+                .map(|a| a.clone())
+                .collect::<Vec<_>>();
+            let (dst_columns, dst_fields) = rewrite_record_batch_fields(
+                dst_inner,
+                src_inner,
+                src_columns,
+                num_rows,
+                fill_missing_source_fields,
+                error_on_missing_source_fields,
+            )?;
+            let struct_array =
+                StructArray::try_new(dst_inner.clone(), dst_columns, src_nulls)
+                    .map_err(|ae| DataFusionError::from(ae))?;
+            let struct_field = Field::new_struct(
+                dst_field.name(),
+                dst_fields,
+                dst_field.is_nullable(),
+            );
+            Ok((Arc::new(struct_array), Arc::new(struct_field)))
+        }
+        _ => {
+            Err(DataFusionError::Internal(format!(
+                "Could not remap field src type={}, dst type={}",
+                src_field.data_type(), dst_field.data_type()
+            )))
+        }
+    }
+}
+
+/// Rewrites a record batch with a source schema to match a destination schema
+pub fn try_rewrite_record_batch(
+    src: SchemaRef,
+    src_record_batch: RecordBatch,
+    dst: SchemaRef,
+    fill_missing_source_fields: bool,
+    error_on_missing_source_fields: bool,
+) -> crate::Result<RecordBatch> {
+
+    let num_rows = src_record_batch.num_rows();
+    let (final_columns, final_fields) = rewrite_record_batch_fields(
+        dst.fields(),
+        src.fields(),
+        src_record_batch.columns().into(),
+        num_rows,
+        fill_missing_source_fields,
+        error_on_missing_source_fields,
+    )?;
+
+    let options = RecordBatchOptions::new().with_row_count(Some(num_rows));
+    let schema = Arc::new(Schema::new(final_fields));
+    let record_batch =
+        RecordBatch::try_new_with_options(schema, final_columns, &options)?;
+    Ok(record_batch)
+}
+
+/// Rewrites a record batch with a source schema to match a destination schema
+/// The destination schema is further filtered using the mappings
+pub fn try_rewrite_record_batch_with_mappings(
+    src: SchemaRef,
+    src_record_batch: RecordBatch,
+    dst: SchemaRef,
+    mappings: Vec<Option<usize>>,
+) -> crate::Result<RecordBatch> {
+    let src_record_batch_cols = src_record_batch.columns().to_vec();
+    let num_rows = src_record_batch.num_rows();
+    let field_vecs = dst.fields()
+        .iter()
+        .zip(mappings)
+        .map(|(field, src_idx)| match src_idx {
+            Some(batch_idx) => {
+                let arr = src_record_batch_cols[batch_idx].clone();
+                let src_field = Arc::new(src.field(batch_idx).clone());
+                rewrite_record_batch_field(field.clone(), src_field, arr, num_rows, true, false)
+            },
+            None => Ok((new_null_array(field.data_type(), num_rows), field.clone())),
+        })
+        .collect::<crate::Result<Vec<(_, _)>, _>>()?;
+
+    let mut final_columns: Vec<ArrayRef> = vec![];
+    let mut final_fields: Vec<FieldRef> = vec![];
+    for (a, f) in field_vecs {
+        final_columns.push(a);
+        final_fields.push(f);
+    }
+
+    let options = RecordBatchOptions::new().with_row_count(Some(num_rows));
+    let schema = Arc::new(Schema::new(final_fields));
+    let record_batch =
+        RecordBatch::try_new_with_options(schema, final_columns, &options)?;
+    Ok(record_batch)
+}
+
+/// Mutually recursive with [can_rewrite_field]
+/// checks whether we can rewrite a source [Fields] object to a destination one
+/// the missing fields in the source behavior can be changed with the [`fill_missing_source_field`]
+/// parameter.
+pub fn can_rewrite_fields(
+    dst_fields: &Fields,
+    src_fields: &Fields,
+    fill_missing_source_fields: bool,
+) -> bool {
+    let mut out = true;
+    for i in 0..dst_fields.len() {
+        let dst_field = dst_fields[i].clone();
+        let dst_name = dst_field.name();
+
+        let src_field_opt = src_fields
+            .iter()
+            .enumerate()
+            .find(|(_idx, b)| b.name() == dst_name);
+
+        // if the field exists in the source
+        if src_field_opt.is_some() {
+            let (_src_idx, src_field) = src_field_opt.unwrap();
+            let src_field = src_field.clone();
+            let can_cast =
+                can_rewrite_field(dst_field, src_field, fill_missing_source_fields);
+            out = out && can_cast;
+        } else {
+            out = out && fill_missing_source_fields;
+        }
+    }
+    out
+}
+
+/// Mutually recursive with [can_rewrite_fielda]
+/// checks whether we can rewrite a source [FieldRef] object to a destination one
+/// the missing fields in the source behavior can be changed with the [`fill_missing_source_field`]
+/// parameter.
+pub fn can_rewrite_field(
+    dst_field: FieldRef,
+    src_field: FieldRef,
+    fill_missing_source_fields: bool,
+) -> bool {
+    let can_cast_by_arrow = !data_type_recurs(dst_field.data_type())
+        && !data_type_recurs(src_field.data_type());
+    if can_cast_by_arrow {
+        return can_cast_types(src_field.data_type(), dst_field.data_type());
+    }
+    match (src_field.data_type(), dst_field.data_type()) {
+        (DataType::List(src_inner), DataType::List(dst_inner))
+        | (DataType::List(src_inner), DataType::LargeList(dst_inner))
+        | (DataType::LargeList(src_inner), DataType::LargeList(dst_inner)) => {
+            if data_type_recurs(src_inner.data_type())
+                && data_type_recurs(dst_inner.data_type())
+            {
+                return can_rewrite_field(
+                    dst_inner.clone(),
+                    src_inner.clone(),
+                    fill_missing_source_fields,
+                );
+            } else {
+                return can_cast_types(src_inner.data_type(), dst_inner.data_type());
+            }
+        }
+        (
+            DataType::FixedSizeList(src_inner, src_sz),
+            DataType::FixedSizeList(dst_inner, dst_sz),
+        ) => {
+            if src_sz != dst_sz {
+                return false;
+            }
+            if data_type_recurs(src_inner.data_type())
+                && data_type_recurs(dst_inner.data_type())
+            {
+                return can_rewrite_field(
+                    dst_inner.clone(),
+                    src_inner.clone(),
+                    fill_missing_source_fields,
+                );
+            } else {
+                return can_cast_types(src_inner.data_type(), dst_inner.data_type());
+            }
+        }
+        (DataType::Map(src_inner, _), DataType::Map(dst_inner, _)) => {
+            return match (src_inner.data_type(), dst_inner.data_type()) {
+                (DataType::Struct(src_inner_f), DataType::Struct(dst_inner_f)) => {
+                    can_rewrite_field(
+                        dst_inner_f[1].clone(),
+                        src_inner_f[1].clone(),
+                        fill_missing_source_fields,
+                    )
+                }
+                _ => false
+            }
+        }
+        (DataType::Struct(src_inner), DataType::Struct(dst_inner)) => {
+            return can_rewrite_fields(dst_inner, src_inner, fill_missing_source_fields);
+        }
+        (_src, _dest) => {
+            error!(
+                target: "deep",
+                "  can_rewrite_field: Unhandled src dest field: src {}={:?}, dst {}={:?}",
+                src_field.name(),
+                src_field.data_type(),
+                dst_field.name(),
+                dst_field.data_type()
+            );
+            false
+        },
+    }
+}
+
+/// Deep projections are represented using a HashMap<usize, Vec<String>>
+/// for backwards compatibility (current projections are represented using a [`Vec<usize>`]
+/// Currently, deep projections are represented (even if there's some duplicated information as a
+/// [`HashMap<usize, Vec<String>>`]
+/// the key is the source field id of the top-level field
+/// the value is a list of "paths" inside the top-level field
+/// Examples:
+///   Scalar fields - no representations of paths inside the field possible
+///   List<Scalar> fields - same thing
+///   List<Struct<id, name, address>> - possible paths may be "*.id", "*.name", "*.address"
+///   List<Map<String, Map<String, Struct<id, name, address>>>
+///     - possible paths may be "*.*", "*.*.*.id", "*.*.*.name", "*.*.*.address"
+pub fn has_deep_projection(possible: Option<&HashMap<usize, Vec<String>>>) -> bool {
+    if possible.is_none() {
+        return false;
+    }
+    let tmp = possible.unwrap();
+    !(tmp.is_empty() || tmp.iter().all(|(k, v)| v.len() == 0))
+}
+
+/// Combines the current projection (numeric indices of top-level columns) with
+/// the deep projection - "paths" inside a top-level column
+pub fn splat_columns(
+    src: SchemaRef,
+    projection: &Vec<usize>,
+    projection_deep: &HashMap<usize, Vec<String>>,
+) -> Vec<String> {
+    let mut out: Vec<String> = vec![];
+    for pi in projection.iter() {
+        let f = src.field(*pi);
+        match projection_deep.get(pi) {
+            None => {
+                out.push(f.name().to_owned());
+            }
+            Some(rests) => {
+                if rests.len() > 0 {
+                    for rest in rests.iter() {
+                        match f.data_type() {
+                            _ => out.push(format!("{}.{}", f.name(), rest)),
+                        }
+                    }
+                } else {
+                    out.push(f.name().to_owned());
+                }
+            }
+        }
+    }
+    out
+}
+
+pub fn try_rewrite_schema_opt(
+    src: SchemaRef,
+    projection_opt: Option<&Vec<usize>>,
+    projection_deep_opt: Option<&HashMap<usize, Vec<String>>>,
+) -> crate::Result<SchemaRef> {
+    match projection_opt {
+        None => Ok(src),
+        Some(projection) => match projection_deep_opt {
+            None => project_schema(&src, projection_opt),
+            Some(projection_deep) => Ok(rewrite_schema(src, projection, projection_deep)),
+        },
+    }
+}
+
+pub fn rewrite_field_projection(
+    src: SchemaRef,
+    projected_field_idx: usize,
+    projection_deep: &HashMap<usize, Vec<String>>,
+) -> FieldRef {
+    let original_field = Arc::new(src.field(projected_field_idx).clone());
+    let single_field_schema = Arc::new(Schema::new(vec![original_field]));
+    // rewrite projection, deep projection to use 0
+    let projected_vec = vec![0];
+    let mut projected_deep_vec = HashMap::new();
+    let empty_vec: Vec<String> = vec![];
+    projected_deep_vec.insert(
+        0 as usize,
+        projection_deep
+            .get(&projected_field_idx)
+            .unwrap_or(&empty_vec)
+            .clone(),
+    );
+
+    let rewritten_single_field_schema =
+        rewrite_schema(single_field_schema, &projected_vec, &projected_deep_vec);
+    Arc::new(rewritten_single_field_schema.field(0).clone())
+}
+
+fn make_path(parent: &String, name: &str) -> String {
+    if parent == "" {
+        return name.to_owned();
+    } else {
+        return format!("{}.{}", parent, name);
+    }
+}
+
+fn path_prefix_exists(filters: &Vec<String>, path: &String) -> bool {
+    filters.iter().any(|f| {
+        let tmp = f.find(path);
+        tmp.is_some() && tmp.unwrap() == 0
+    })
+}
+
+fn path_included(filters: &Vec<String>, path: &String) -> bool {
+    filters.iter().any(|f| {
+        let tmp = path.find(f);
+        tmp.is_some() && tmp.unwrap() == 0
+    })
+}
+
+pub fn fix_possible_field_accesses(schema: &DFSchemaRef, field_idx: usize, rest: &Vec<String>) -> crate::Result<Vec<String>> {
+    let mut field = Arc::new(schema.field(field_idx).clone());
+    let mut rest_idx = 0 as usize;
+    let mut out = rest.clone();
+    while rest_idx < out.len() {
+        let (fix_non_star_access, should_continue, new_field) = match field.data_type() {
+            DataType::Null  | DataType::Boolean  | DataType::Int8  | DataType::Int16  | DataType::Int32  |
+            DataType::Int64  | DataType::UInt8  | DataType::UInt16  | DataType::UInt32  | DataType::UInt64  |
+            DataType::Float16  | DataType::Float32  | DataType::Float64  | DataType::Timestamp(_, _)  |
+            DataType::Date32  | DataType::Date64  | DataType::Time32(_)  | DataType::Time64(_)  | DataType::Duration(_)  |
+            DataType::Interval(_)  | DataType::Binary  | DataType::FixedSizeBinary(_)  |
+            DataType::LargeBinary  | DataType::BinaryView  | DataType::Utf8  | DataType::LargeUtf8  | DataType::Utf8View |
+            DataType::Dictionary(_, _) | DataType::Decimal128(_, _) | DataType::Decimal256(_, _) |
+            DataType::RunEndEncoded(_, _)=> {
+                (false, false, None)
+            }
+            DataType::Union(_, _) => {
+                // FIXME @HStack
+                // don't know what to do here
+                (false, false, None)
+            }
+            DataType::List(inner) | DataType::ListView(inner) |
+            DataType::FixedSizeList(inner, _) | DataType::LargeList(inner) |
+            DataType::LargeListView(inner) => {
+                let new_field = inner.clone();
+                (true, true, Some(new_field))
+            }
+            DataType::Struct(inner_struct) => {
+                let mut new_field: Option<FieldRef> = None;
+                for f in inner_struct.iter() {
+                    if f.name() == &out[rest_idx] {
+                        new_field = Some(f.clone());
+                    }
+                }
+                (false, true, new_field)
+            }
+            DataType::Map(inner_map, _) => {
+                let mut new_field: Option<FieldRef> = None;
+                match inner_map.data_type() {
+                    DataType::Struct(inner_map_struct) => {
+                        new_field = Some(inner_map_struct[1].clone());
+                    }
+                    _ => {
+                        return Err(DataFusionError::Internal(String::from("Invalid inner map type")));
+                    }
+                }
+                (true, true, new_field)
+            }
+        };
+        if fix_non_star_access && rest[rest_idx] != "*" {
+            out[rest_idx] = "*".to_string();
+        }
+        if !should_continue {
+            break;
+        }
+        field = new_field.unwrap();
+        rest_idx += 1;
+    }
+    Ok(out)
+}
+
+pub fn rewrite_schema(
+    src: SchemaRef,
+    projection: &Vec<usize>,
+    projection_deep: &HashMap<usize, Vec<String>>,
+) -> SchemaRef {
+    fn rewrite_schema_fields(
+        parent: String,
+        src_fields: &Fields,
+        filters: &Vec<String>,
+    ) -> Vec<FieldRef> {
+        let mut out_fields: Vec<FieldRef> = vec![];
+        for i in 0..src_fields.len() {
+            let src_field = src_fields[i].clone();
+            let src_field_path = make_path(&parent, src_field.name());
+
+            let field_path_included = path_included(filters, &src_field_path); //filters.contains(&src_field_path);
+            if field_path_included {
+                out_fields.push(src_field.clone());
+            } else {
+                if data_type_recurs(src_field.data_type())
+                    && path_prefix_exists(filters, &src_field_path)
+                {
+                    match rewrite_schema_field(parent.clone(), src_field, filters) {
+                        None => {}
+                        Some(f) => out_fields.push(f),
+                    }
+                }
+            }
+        }
+        out_fields
+    }
+
+    fn rewrite_schema_field(
+        parent: String,
+        src_field: FieldRef,
+        filters: &Vec<String>,
+    ) -> Option<FieldRef> {
+        let src_field_name = src_field.name();
+        // FIXME: @HStack
+        //  if we already navigated to this field and the accessor is "*"
+        //  that means we don't care about the field name
+        //  RETEST THIS for lists
+        let src_field_path = if parent.len() > 0 && parent.chars().last().unwrap() == '*' as char {
+            parent.clone()
+        } else {
+            make_path(&parent, src_field_name)
+        };
+        trace!(target:"deep", "rewrite field: {} = {} ({:?})", src_field_name, src_field_path, filters);
+
+        let field_path_included = path_included(filters, &src_field_path); //filters.contains(&src_field_path);
+        if field_path_included {
+            trace!(target:"deep", "  return {} directly ", src_field_path);
+            return Some(src_field.clone());
+        } else {
+            if data_type_recurs(src_field.data_type())
+                && path_prefix_exists(filters, &src_field_path)
+            {
+                let out = match src_field.data_type() {
+                    DataType::List(src_inner) => {
+                        rewrite_schema_field(
+                            make_path(&src_field_path, "*"),
+                            src_inner.clone(),
+                            filters,
+                        )
+                        .map(|inner| {
+                            trace!(target:"deep", "return new list {} = {:#?}", src_field_name.clone(), inner.clone());
+                            Arc::new(Field::new_list(
+                                src_field.name(),
+                                inner,
+                                src_field.is_nullable(),
+                            ))
+                        })
+                    }
+                    DataType::FixedSizeList(src_inner, src_sz) => rewrite_schema_field(
+                        make_path(&src_field_path, "*"),
+                        src_inner.clone(),
+                        filters,
+                    )
+                    .map(|inner| {
+                        Arc::new(Field::new_fixed_size_list(
+                            src_field.name(),
+                            inner,
+                            *src_sz,
+                            src_field.is_nullable(),
+                        ))
+                    }),
+                    DataType::LargeList(src_inner) => rewrite_schema_field(
+                        make_path(&src_field_path, "*"),
+                        src_inner.clone(),
+                        filters,
+                    )
+                    .map(|inner| {
+                        Arc::new(Field::new_large_list(
+                            src_field.name(),
+                            inner,
+                            src_field.is_nullable(),
+                        ))
+                    }),
+
+                    DataType::Map(map_entry, map_sorted) => {
+                        if let DataType::Struct(map_entry_fields) = map_entry.data_type()
+                        {
+                            let map_key_field = map_entry_fields.get(0).unwrap();
+                            let map_value_field = map_entry_fields.get(1).unwrap();
+                            rewrite_schema_field(
+                                make_path(&src_field_path, "*"),
+                                map_value_field.clone(),
+                                filters,
+                            )
+                            .map(|inner| {
+                                Arc::new(Field::new_map(
+                                    src_field_name,
+                                    map_entry.name().clone(),
+                                    map_key_field.clone(),
+                                    inner,
+                                    *map_sorted,
+                                    src_field.is_nullable(),
+                                ))
+                            })
+                        } else {
+                            panic!("Invalid internal field map: expected struct, but got {}", map_entry.data_type());
+                        }
+                    }
+
+                    DataType::Struct(src_inner) => {
+                        let dst_fields =
+                            rewrite_schema_fields(src_field_path.clone(), src_inner, filters);
+                        trace!(target:"deep", "for struct: {} {} = {:#?}", src_field_name, src_field_path.clone(), dst_fields);
+                        if dst_fields.len() > 0 {
+                            Some(Arc::new(Field::new_struct(
+                                src_field.name(),
+                                dst_fields,
+                                src_field.is_nullable(),
+                            )))
+                        } else {
+                            None
+                        }
+                    }
+                    x => {
+                        panic!("Unhandled data type: {:#?}", x);
+                    }
+                };
+                out
+            } else {
+                None
+            }
+        }
+    }
+
+    let actual_projection = if projection.len() == 0 {
+        (0..src.fields().len()).collect()
+    } else {
+        projection.clone()
+    };
+    let splatted = splat_columns(src.clone(), &actual_projection, &projection_deep);
+
+    // trace!(target:"deep", "rewrite_schema source: {:#?}", src);
+    trace!(target:"deep", "rewrite_schema splatted: {:?} {:?} = {:?}", &actual_projection, &projection_deep, splatted);
+    let mut dst_fields: Vec<FieldRef> = vec![];
+    for pi in actual_projection.iter() {
+        let src_field = src.field(*pi);
+        trace!(target:"deep", "rewrite_schema at field {}", src_field.name());
+        let foutopt =
+            rewrite_schema_field("".to_string(), Arc::new(src_field.clone()), &splatted);
+        match foutopt {
+            None => {}
+            Some(fout) => {
+                dst_fields.push(fout.clone());
+            }
+        }
+    }
+
+    // let dst_fields = rewrite_fields("".to_string(), src.clone().fields(), &splatted);
+    // trace!(target:"deep", "rewrite_schema dst: {:#?}", dst_fields);
+
+    let output = if dst_fields.len() > 0 {
+        Arc::new(Schema::new_with_metadata(dst_fields, src.metadata.clone()))
+    } else {
+        src.clone()
+    };
+
+    return output;
+}
+
+pub fn debug_to_file(name: &str, contents: &str) {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(name)
+        .unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::deep::can_rewrite_fields;
+    use arrow_schema::{DataType, Field, Fields, Schema, TimeUnit};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_cast() -> crate::error::Result<()> {
+        // source, destination, is_fill_dependent
+        let cases = vec![
+            (
+                Arc::new(Schema::new(vec![Field::new("i1", DataType::Int32, true)])),
+                Arc::new(Schema::new(vec![Field::new("i1", DataType::Int8, true)])),
+                false,
+                true,
+            ),
+            (
+                Arc::new(Schema::new(vec![Field::new("i1", DataType::Int32, true)])),
+                Arc::new(Schema::new(vec![Field::new(
+                    "i1",
+                    DataType::Struct(Fields::from(vec![Field::new(
+                        "s1",
+                        DataType::Utf8,
+                        true,
+                    )])),
+                    true,
+                )])),
+                false,
+                false,
+            ),
+            (
+                Arc::new(Schema::new(vec![Field::new(
+                    "l1",
+                    DataType::List(Arc::new(Field::new(
+                        "s1",
+                        DataType::Struct(Fields::from(vec![
+                            Field::new("s1extra1", DataType::Utf8, true),
+                            Field::new("s1extra2", DataType::Utf8, true),
+                            Field::new("s1i2", DataType::Int32, true),
+                            Field::new("s1s1", DataType::Utf8, true),
+                            Field::new(
+                                "s1m1",
+                                DataType::Map(
+                                    Arc::new(Field::new(
+                                        "entries",
+                                        DataType::Struct(Fields::from(vec![
+                                            Field::new("key", DataType::Utf8, false),
+                                            Field::new("value", DataType::Utf8, false),
+                                        ])),
+                                        true,
+                                    )),
+                                    false,
+                                ),
+                                true,
+                            ),
+                            Field::new(
+                                "s1l1",
+                                DataType::List(Arc::new(Field::new(
+                                    "s1l1i1",
+                                    DataType::Int32,
+                                    true,
+                                ))),
+                                true,
+                            ),
+                        ])),
+                        true,
+                    ))),
+                    true,
+                )])),
+                Arc::new(Schema::new(vec![Field::new(
+                    "l1",
+                    DataType::List(Arc::new(Field::new(
+                        "s1",
+                        DataType::Struct(Fields::from(vec![
+                            Field::new("s1s1", DataType::Utf8, true),
+                            Field::new("s1i2", DataType::Int32, true),
+                            Field::new(
+                                "s1m1",
+                                DataType::Map(
+                                    Arc::new(Field::new(
+                                        "entries",
+                                        DataType::Struct(Fields::from(vec![
+                                            Field::new("key", DataType::Utf8, false),
+                                            Field::new("value", DataType::Utf8, false),
+                                        ])),
+                                        true,
+                                    )),
+                                    false,
+                                ),
+                                true,
+                            ),
+                            Field::new(
+                                "s1l1",
+                                DataType::List(Arc::new(Field::new(
+                                    "s1l1i1",
+                                    DataType::Date32,
+                                    true,
+                                ))),
+                                true,
+                            ),
+                            // extra field
+                            Field::new("s1ts1", DataType::Time32(TimeUnit::Second), true),
+                        ])),
+                        true,
+                    ))),
+                    true,
+                )])),
+                true,
+                true,
+            ),
+        ];
+        for (from, to, can_fill, res) in cases.iter() {
+            assert_eq!(
+                can_rewrite_fields(from.fields(), to.fields(), *can_fill),
+                *res,
+                "Wrong result"
+            );
+        }
+        Ok(())
+    }
+}

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -44,6 +44,7 @@ pub mod stats;
 pub mod test_util;
 pub mod tree_node;
 pub mod utils;
+pub mod deep;
 
 /// Reexport arrow crate
 pub use arrow;

--- a/datafusion/core/src/datasource/mod.rs
+++ b/datafusion/core/src/datasource/mod.rs
@@ -31,6 +31,7 @@ pub mod memory;
 pub mod physical_plan;
 pub mod provider;
 pub mod schema_adapter;
+pub mod schema_adapter_deep;
 mod statistics;
 pub mod stream;
 pub mod streaming;

--- a/datafusion/core/src/datasource/schema_adapter.rs
+++ b/datafusion/core/src/datasource/schema_adapter.rs
@@ -27,6 +27,7 @@ use arrow_schema::{Schema, SchemaRef};
 use datafusion_common::plan_err;
 use std::fmt::Debug;
 use std::sync::Arc;
+use crate::datasource::schema_adapter_deep::NestedSchemaAdapter;
 
 /// Factory for creating [`SchemaAdapter`]
 ///
@@ -99,7 +100,9 @@ pub struct DefaultSchemaAdapterFactory {}
 
 impl SchemaAdapterFactory for DefaultSchemaAdapterFactory {
     fn create(&self, table_schema: SchemaRef) -> Box<dyn SchemaAdapter> {
-        Box::new(DefaultSchemaAdapter { table_schema })
+        // FIX Deep schema mapping
+        Box::new(NestedSchemaAdapter { table_schema })
+        // Box::new(DefaultSchemaAdapter { table_schema })
     }
 }
 

--- a/datafusion/core/src/datasource/schema_adapter_deep.rs
+++ b/datafusion/core/src/datasource/schema_adapter_deep.rs
@@ -69,7 +69,7 @@ impl SchemaAdapter for NestedSchemaAdapter {
             if let Some((table_idx, table_field)) =
                 self.table_schema.fields().find(file_field.name())
             {
-                match can_rewrite_field(table_field.clone(), file_field.clone(), false) {
+                match can_rewrite_field(table_field.clone(), file_field.clone(), true) {
                     true => {
                         field_mappings[table_idx] = Some(projection.len());
                         projection.push(file_idx);
@@ -582,8 +582,8 @@ mod tests {
             .sql(
                 r#"
             select
-                get_field(struct1, 'tags') as tags,
-                get_field(array_element(list_struct, 0), 'int32') as f2
+                struct1['tags'] as tags,
+                list_struct[0]['int32'] as f2
             from
                 tbl;
         "#,

--- a/datafusion/core/src/datasource/schema_adapter_deep.rs
+++ b/datafusion/core/src/datasource/schema_adapter_deep.rs
@@ -1,0 +1,658 @@
+use crate::datasource::schema_adapter::{SchemaAdapter, SchemaMapper};
+use arrow_array::RecordBatch;
+use arrow_schema::{Fields, Schema, SchemaRef};
+use datafusion_common::deep::{can_rewrite_field, try_rewrite_record_batch, try_rewrite_record_batch_with_mappings};
+use datafusion_common::plan_err;
+use std::sync::Arc;
+use log::trace;
+
+impl NestedSchemaAdapter {
+    fn map_schema_nested(
+        &self,
+        fields: &Fields,
+    ) -> datafusion_common::Result<(Arc<NestedSchemaMapping>, Vec<usize>)> {
+        let mut projection = Vec::with_capacity(fields.len());
+        let mut field_mappings = vec![None; self.table_schema.fields().len()];
+
+        // start from the destination fields
+        for (table_idx, table_field) in self.table_schema.fields.iter().enumerate() {
+            // if the file exists in the source, check if we can rewrite it to the destination,
+            // and add it to the projections
+            if let Some((file_idx, file_field)) = fields.find(table_field.name()) {
+                if can_rewrite_field(table_field.clone(), file_field.clone(), true) {
+                    field_mappings[table_idx] = Some(projection.len());
+                    projection.push(file_idx);
+                } else {
+                    return plan_err!(
+                        "Cannot cast file schema field {} of type {:?} to table schema field of type {:?}",
+                        file_field.name(),
+                        file_field.data_type(),
+                        table_field.data_type()
+                    );
+                }
+            }
+        }
+        Ok((
+            Arc::new(NestedSchemaMapping {
+                table_schema: self.table_schema.clone(),
+                field_mappings
+            }),
+            projection,
+        ))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct NestedSchemaAdapter {
+    /// Schema for the table
+    pub table_schema: SchemaRef,
+}
+
+impl SchemaAdapter for NestedSchemaAdapter {
+    fn map_column_index(&self, index: usize, file_schema: &Schema) -> Option<usize> {
+        let field = self.table_schema.field(index);
+        Some(file_schema.fields.find(field.name())?.0)
+    }
+
+    fn map_schema(
+        &self,
+        file_schema: &Schema,
+    ) -> datafusion_common::Result<(Arc<dyn SchemaMapper>, Vec<usize>)> {
+        // self.map_schema_nested(file_schema.fields())
+        //     .map(|(s, v)| (s as Arc<dyn SchemaMapper>, v))
+        trace!(target: "deep", "map_schema:  file_schema: {:#?}", file_schema);
+        trace!(target: "deep", "map_schema: table_schema: {:#?}", self.table_schema);
+        let mut projection = Vec::with_capacity(file_schema.fields().len());
+        let mut field_mappings = vec![None; self.table_schema.fields().len()];
+
+        for (file_idx, file_field) in file_schema.fields.iter().enumerate() {
+            if let Some((table_idx, table_field)) =
+                self.table_schema.fields().find(file_field.name())
+            {
+                match can_rewrite_field(table_field.clone(), file_field.clone(), false) {
+                    true => {
+                        field_mappings[table_idx] = Some(projection.len());
+                        projection.push(file_idx);
+                    }
+                    false => {
+                        return plan_err!(
+                            "Cannot cast file schema field {} of type {:?} to table schema field of type {:?}",
+                            file_field.name(),
+                            file_field.data_type(),
+                            table_field.data_type()
+                        )
+                    }
+                }
+            }
+        }
+
+        Ok((
+            Arc::new(NestedSchemaMapping {
+                table_schema: self.table_schema.clone(),
+                field_mappings,
+            }),
+            projection,
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub struct NestedSchemaMapping {
+    table_schema: SchemaRef,
+    field_mappings: Vec<Option<usize>>,
+}
+
+impl SchemaMapper for NestedSchemaMapping {
+    fn map_batch(&self, batch: RecordBatch) -> datafusion_common::Result<RecordBatch> {
+        let record_batch = try_rewrite_record_batch_with_mappings(
+            batch.schema(),
+            batch,
+            self.table_schema.clone(),
+            // FIXME: @HStack ADR: will this break delta tests ?
+            // There are some cases
+            self.field_mappings.clone(),
+        )?;
+        Ok(record_batch)
+    }
+
+    fn map_partial_batch(
+        &self,
+        batch: RecordBatch,
+    ) -> datafusion_common::Result<RecordBatch> {
+        try_rewrite_record_batch(
+            batch.schema().clone(),
+            batch,
+            self.table_schema.clone(),
+            false,
+            false,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dataframe::DataFrame;
+    use crate::datasource::MemTable;
+    use crate::prelude::SessionContext;
+    use arrow_array::builder::{
+        ArrayBuilder, BooleanBuilder, GenericStringBuilder, Int32Builder, ListBuilder,
+        StringBuilder, StructBuilder, UInt32Builder,
+    };
+    use arrow_array::{BooleanArray, RecordBatch, StringArray, StructArray, UInt32Array};
+    use arrow_schema::{DataType, Field, Fields, Schema, TimeUnit};
+    use datafusion_common::deep::{
+        rewrite_schema, try_rewrite_record_batch,
+    };
+    use datafusion_optimizer::optimize_projections::OptimizeProjections;
+    use datafusion_optimizer::{Optimizer, OptimizerContext};
+    use datafusion_physical_plan::get_plan_string;
+    use log::info;
+    use parquet::arrow::parquet_to_arrow_schema;
+    use parquet::schema::parser::parse_message_type;
+    use parquet::schema::types::SchemaDescriptor;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use arrow::util::pretty::print_batches;
+
+    #[tokio::test]
+    async fn test_rewrite_schema() -> crate::error::Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("i1", DataType::Int32, true),
+            Field::new(
+                "l1",
+                DataType::List(Arc::new(Field::new(
+                    "s1",
+                    DataType::Struct(Fields::from(vec![
+                        Field::new("s1s1", DataType::Utf8, true),
+                        Field::new("s1i2", DataType::Int32, true),
+                        Field::new(
+                            "s1m1",
+                            DataType::Map(
+                                Arc::new(Field::new(
+                                    "entries",
+                                    DataType::Struct(Fields::from(vec![
+                                        Field::new("key", DataType::Utf8, false),
+                                        Field::new("value", DataType::Utf8, false),
+                                    ])),
+                                    true,
+                                )),
+                                false,
+                            ),
+                            true,
+                        ),
+                        Field::new(
+                            "s1l1",
+                            DataType::List(Arc::new(Field::new(
+                                "s1l1i1",
+                                DataType::Date32,
+                                true,
+                            ))),
+                            true,
+                        ),
+                        // extra field
+                        Field::new("s1ts1", DataType::Time32(TimeUnit::Second), true),
+                    ])),
+                    true,
+                ))),
+                true,
+            ),
+        ]));
+        let out = rewrite_schema(
+            schema,
+            &vec![1],
+            &HashMap::from([
+                (0, vec![]),
+                (1, vec!["*.s1s1".to_string(), "*.s1l1".to_string()]),
+            ]),
+        );
+        // info!("out: {:#?}", out);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_rewrite() -> crate::error::Result<()> {
+        let _ = env_logger::try_init();
+
+        let message_type = "
+        message schema {
+            REQUIRED INT32 int1;
+            OPTIONAL INT32 int2;
+            REQUIRED BYTE_ARRAY str1 (UTF8);
+            OPTIONAL GROUP stringlist1 (LIST) {
+                repeated group list {
+                    optional BYTE_ARRAY element (UTF8);
+                }
+            }
+            OPTIONAL group map1 (MAP) {
+                REPEATED group map {
+                  REQUIRED binary str (UTF8);
+                  REQUIRED int32 num;
+                }
+            }
+            OPTIONAL GROUP array_of_arrays (LIST) {
+                REPEATED GROUP list {
+                    REQUIRED GROUP element (LIST) {
+                        REPEATED GROUP list {
+                            REQUIRED INT32 element;
+                        }
+                    }
+                }
+            }
+            REQUIRED GROUP array_of_struct (LIST) {
+                REPEATED GROUP struct {
+                    REQUIRED BOOLEAN bools;
+                    REQUIRED INT32 uint32 (INTEGER(32,false));
+                    REQUIRED GROUP   int32 (LIST) {
+                        REPEATED GROUP list {
+                            OPTIONAL INT32 element;
+                        }
+                    }
+                }
+            }
+        }
+        ";
+        let message_type = r#"
+            message schema {
+                REQUIRED GROUP struct {
+                    REQUIRED BINARY name (UTF8);
+                    REQUIRED BOOLEAN bools;
+                    REQUIRED INT32 uint32 (INTEGER(32,false));
+                    REQUIRED GROUP tags (LIST) {
+                        REPEATED GROUP tags {
+                            OPTIONAL BINARY tag (UTF8);
+                        }
+                    }
+                }
+            }
+        "#;
+        let parquet_schema = parse_message_type(message_type)
+            .map(|t| Arc::new(SchemaDescriptor::new(Arc::new(t))))
+            .unwrap();
+
+        let arrow_schema =
+            Arc::new(parquet_to_arrow_schema(parquet_schema.as_ref(), None).unwrap());
+        // println!("schema: {:#?}", arrow_schema);
+        let (_idx, ffield) = arrow_schema.fields().find("struct").unwrap();
+        let struct_field = ffield.clone();
+        let struct_fields = match struct_field.data_type() {
+            DataType::Struct(fields) => Some(fields),
+            _ => None,
+        }
+        .unwrap();
+        println!("struct fields: {:#?}", struct_fields);
+
+        let elem_builder: GenericStringBuilder<i32> = GenericStringBuilder::new();
+        let mut expected_builder = ListBuilder::new(elem_builder).with_field(Field::new(
+            "tag",
+            DataType::Utf8,
+            true,
+        ));
+        expected_builder.values().append_value("foo");
+        expected_builder.values().append_value("bar");
+        expected_builder.append(true);
+        expected_builder.values().append_value("bar");
+        expected_builder.values().append_value("foo");
+        expected_builder.append(true);
+        let expected = expected_builder.finish();
+        let struct_column = StructArray::new(
+            struct_fields.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["name1", "name2"])),
+                Arc::new(BooleanArray::from(vec![true, false])),
+                Arc::new(UInt32Array::from(vec![1, 2])),
+                Arc::new(expected),
+            ],
+            None,
+        );
+        let record_batch =
+            RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(struct_column)])
+                .unwrap();
+        // println!("rb: {:#?}", record_batch);
+
+        let message_type = r#"
+            message schema {
+                REQUIRED GROUP struct {
+                    REQUIRED GROUP tags (LIST) {
+                        REPEATED GROUP tags {
+                            OPTIONAL BINARY tag (UTF8);
+                        }
+                    }
+                }
+            }
+        "#;
+        let parquet_schema_2 = parse_message_type(message_type)
+            .map(|t| Arc::new(SchemaDescriptor::new(Arc::new(t))))
+            .unwrap();
+        let arrow_schema_2 =
+            Arc::new(parquet_to_arrow_schema(parquet_schema_2.as_ref(), None).unwrap());
+        println!("arrow_schema_2: {:#?}", arrow_schema_2);
+        let new_rb = try_rewrite_record_batch(
+            arrow_schema.clone(),
+            record_batch,
+            arrow_schema_2.clone(),
+            true,
+            false,
+        )
+        .unwrap();
+        println!("new_rb: {:#?}", new_rb);
+
+        Ok(())
+    }
+
+    pub fn logical_plan_str(dataframe: &DataFrame) -> String {
+        let cl = dataframe.clone();
+        let op = cl.into_optimized_plan().unwrap();
+        format!("{}", op.display_indent())
+    }
+
+    pub async fn physical_plan_str(dataframe: &DataFrame) -> String {
+        let cl = dataframe.clone();
+        let pp = cl.create_physical_plan().await.unwrap();
+        get_plan_string(&pp).join("\n")
+    }
+
+    #[tokio::test]
+    async fn test_deep_schema() -> crate::error::Result<()> {
+        let _ = env_logger::try_init();
+
+        let message_type = r#"
+            message schema {
+                REQUIRED INT32 id;
+                REQUIRED GROUP struct1 {
+                    REQUIRED BINARY name (UTF8);
+                    REQUIRED BOOLEAN bools;
+                    REQUIRED INT32 uint32 (INTEGER(32,false));
+                    REQUIRED GROUP tags (LIST) {
+                        REPEATED GROUP tags {
+                            OPTIONAL BINARY tag (UTF8);
+                        }
+                    }
+                }
+                OPTIONAL GROUP list_struct (LIST) {
+                    REPEATED GROUP struct {
+                        REQUIRED BOOLEAN bools;
+                        REQUIRED INT32 uint32 (INTEGER(32,false));
+                        REQUIRED GROUP int32 (LIST) {
+                            REPEATED GROUP list {
+                                OPTIONAL INT32 element;
+                            }
+                        }
+                    }
+                }
+                OPTIONAL GROUP struct_list {
+                    REQUIRED BOOLEAN bools;
+                    REQUIRED INT32 uint32 (INTEGER(32,false));
+                    REQUIRED GROUP products (LIST) {
+                        REPEATED GROUP product {
+                            OPTIONAL INT32 qty;
+                            OPTIONAL binary name(utf8);
+                        }
+                    }
+                }
+            }
+        "#;
+        let parquet_schema = parse_message_type(message_type)
+            .map(|t| Arc::new(SchemaDescriptor::new(Arc::new(t))))
+            .unwrap();
+        {}
+        // return Ok(());
+
+        let complete_schema =
+            Arc::new(parquet_to_arrow_schema(parquet_schema.as_ref(), None).unwrap());
+        // info!("schema: {:#?}", complete_schema.clone());
+        // {
+        //     let kk = generate_leaf_paths(
+        //         complete_schema,
+        //         parquet_schema.as_ref(),
+        //         &vec![1, 2],
+        //         &HashMap::from([
+        //             (1 as usize, vec!["name".to_string(), "tags".to_string()])
+        //         ])
+        //     );
+        //     info!("kk: {:#?}", kk);
+        // }
+        // return Ok(());
+
+        let ctx = SessionContext::new();
+
+        let schema_fields = complete_schema.fields().clone();
+        let mut row_builder = StructBuilder::from_fields(schema_fields, 1);
+
+        // field 0
+        let f0_builder = row_builder.field_builder::<Int32Builder>(0).unwrap();
+        f0_builder.append_value(1);
+        let f0_arr = f0_builder.finish();
+
+        // field 1
+        let f1_builder = row_builder.field_builder::<StructBuilder>(1).unwrap();
+
+        // tbl.struct.name
+        {
+            let f1_name_builder = f1_builder.field_builder::<StringBuilder>(0).unwrap();
+            f1_name_builder.append_value("n1");
+        }
+        // tbl.struct.bools
+        {
+            let f1_bools_builder = f1_builder.field_builder::<BooleanBuilder>(1).unwrap();
+            f1_bools_builder.append_value(true);
+        }
+        // tbl.struct.uint32
+        let f1_uint32_builder = f1_builder.field_builder::<UInt32Builder>(2).unwrap();
+        f1_uint32_builder.append_value(1);
+        // tbl.struct.tags
+        let f1_tags_list_builder = f1_builder
+            .field_builder::<ListBuilder<Box<dyn ArrayBuilder>>>(3)
+            .unwrap();
+        let f1_tags_item_builder = f1_tags_list_builder
+            .values()
+            .as_any_mut()
+            .downcast_mut::<StringBuilder>()
+            .unwrap();
+        f1_tags_item_builder.append_value("t1");
+        f1_tags_item_builder.append_value("t2");
+        f1_tags_list_builder.append(true);
+
+        f1_builder.append(true);
+
+        let f1_arr = f1_builder.finish();
+        // field 2
+        // make_array(
+        //     named_struct(
+        //         'bools', false,
+        //         'uint32', 5,
+        //         'int32', make_array(10, 20)
+        //     )
+        // ),
+        let f2_builder = row_builder
+            .field_builder::<ListBuilder<Box<dyn ArrayBuilder>>>(2)
+            .unwrap();
+        let f2_item_builder = f2_builder
+            .values()
+            .as_any_mut()
+            .downcast_mut::<StructBuilder>()
+            .unwrap();
+
+        //tbl.list_struct[].bools
+        let f2_item_bools_builder =
+            f2_item_builder.field_builder::<BooleanBuilder>(0).unwrap();
+        f2_item_bools_builder.append_value(true);
+        // tbl.list_struct[].uint32
+        let f2_item_uint32_builder =
+            f2_item_builder.field_builder::<UInt32Builder>(1).unwrap();
+        f2_item_uint32_builder.append_value(5);
+        // tbl.list_struct[].uint32
+        let f2_item_int32_list_builder = f2_item_builder
+            .field_builder::<ListBuilder<Box<dyn ArrayBuilder>>>(2)
+            .unwrap();
+        let f2_item_int32_item_builder = f2_item_int32_list_builder
+            .values()
+            .as_any_mut()
+            .downcast_mut::<Int32Builder>()
+            .unwrap();
+        f2_item_int32_item_builder.append_values(&[10, 20], &[true, true]);
+        f2_item_int32_list_builder.append(true);
+
+        f2_item_builder.append(true);
+
+        f2_builder.append(true);
+
+        let f2_arr = f2_builder.finish();
+
+        // field 3
+        // named_struct(
+        //     'bools', true,
+        //     'uint32', 5,
+        //     'products', make_array(
+        //         named_struct(
+        //             'qty', 1,
+        //             'name', 'product1'
+        //         ),
+        //         named_struct(
+        //             'qty', 2,
+        //             'name', 'product2'
+        //         )
+        //     )
+        // )
+        let f3_builder = row_builder.field_builder::<StructBuilder>(3).unwrap();
+        // tbl.named_struct.bools
+        let f3_bools_builder = f3_builder.field_builder::<BooleanBuilder>(0).unwrap();
+        f3_bools_builder.append_value(true);
+        // tbl.named_struct.uint32
+        let f3_uint32_builder = f3_builder.field_builder::<UInt32Builder>(1).unwrap();
+        f3_uint32_builder.append_value(5);
+        // tbl.named_struct.uint32
+        let f3_products_builder = f3_builder
+            .field_builder::<ListBuilder<Box<dyn ArrayBuilder>>>(2)
+            .unwrap();
+        {
+            let f3_field_products_item_builder = f3_products_builder
+                .values()
+                .as_any_mut()
+                .downcast_mut::<StructBuilder>()
+                .unwrap();
+            let qty_builder = f3_field_products_item_builder
+                .field_builder::<Int32Builder>(0)
+                .unwrap();
+            qty_builder.append_value(1);
+            let name_builder = f3_field_products_item_builder
+                .field_builder::<StringBuilder>(1)
+                .unwrap();
+            name_builder.append_value("product1");
+
+            f3_field_products_item_builder.append(true);
+
+            let f3_field_products_item_builder = f3_products_builder
+                .values()
+                .as_any_mut()
+                .downcast_mut::<StructBuilder>()
+                .unwrap();
+            let qty_builder = f3_field_products_item_builder
+                .field_builder::<Int32Builder>(0)
+                .unwrap();
+            qty_builder.append_value(1);
+            let name_builder = f3_field_products_item_builder
+                .field_builder::<StringBuilder>(1)
+                .unwrap();
+            name_builder.append_value("product1");
+            f3_field_products_item_builder.append(true);
+        }
+        f3_products_builder.append(true);
+        f3_builder.append(true);
+
+        let f3_arr = f3_builder.finish();
+
+        let row = StructArray::new(
+            complete_schema.fields.clone(),
+            vec![
+                // 1
+                Arc::new(f0_arr),
+                Arc::new(f1_arr),
+                Arc::new(f2_arr),
+                Arc::new(f3_arr),
+            ],
+            None,
+        );
+        let initial_table = Arc::new(MemTable::try_new(
+            complete_schema.clone(),
+            vec![vec![RecordBatch::from(row)]],
+        )?);
+
+        ctx.register_table("tbl", initial_table.clone()).unwrap();
+        let df = ctx
+            .sql(
+                r#"
+            select
+                get_field(struct1, 'tags') as tags,
+                get_field(array_element(list_struct, 0), 'int32') as f2
+            from
+                tbl;
+        "#,
+            )
+            .await
+            .unwrap();
+
+        let df_plan = df.clone().logical_plan().clone();
+        // info!("df_plan: {:?}", df_plan);
+
+        let optimizer = Optimizer::with_rules(vec![Arc::new(OptimizeProjections::new())]);
+        let optimized_plan =
+            optimizer.optimize(df_plan, &OptimizerContext::new(), |_, _| {})?;
+        info!("df_plan: {:?}", optimized_plan);
+
+        info!("logical = {}", logical_plan_str(&df));
+        info!("physical = {}", physical_plan_str(&df).await);
+        df.show().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_deep_schema_2() -> crate::error::Result<()> {
+        let _ = env_logger::try_init();
+        let ctx = SessionContext::new();
+
+        let dfr = ctx
+            .sql(
+                r#"
+            create external table
+                test
+            stored as parquet
+            location '/Users/adragomi/work/arrow/benchmark/profile_export_prod_delta/part-00001-1b493913-ef97-4da6-9f8c-da1506b378f1-c000.snappy.parquet'
+        "#,
+            )
+            .await
+            .unwrap();
+
+        let df = ctx
+            .sql(
+                r#"
+                select
+                    _change_type
+                from test
+                limit 10
+        "#,
+            )
+            .await
+            .unwrap();
+
+        let df_plan = df.clone().logical_plan().clone();
+        // info!("df_plan: {:?}", df_plan);
+
+        let optimizer = Optimizer::with_rules(vec![Arc::new(OptimizeProjections::new())]);
+        let optimized_plan =
+            optimizer.optimize(df_plan, &OptimizerContext::new(), |_, _| {})?;
+        info!("df_plan: {:?}", optimized_plan);
+
+        // info!("logical = {}", logical_plan_str(&df));
+        // info!("physical = {}", physical_plan_str(&df).await);
+        // df.show().await?;
+        let results = df
+            .collect()
+            .await?;
+        print_batches(results.as_slice());
+        info!("results: {}", results.len());
+
+        Ok(())
+    }
+
+
+}

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -441,6 +441,7 @@ impl DefaultPhysicalPlanner {
             LogicalPlan::TableScan(TableScan {
                 source,
                 projection,
+                projection_deep,
                 filters,
                 fetch,
                 ..
@@ -451,7 +452,7 @@ impl DefaultPhysicalPlanner {
                 // referred to in the query
                 let filters = unnormalize_cols(filters.iter().cloned());
                 source
-                    .scan(session_state, projection.as_ref(), &filters, *fetch)
+                    .scan_deep(session_state, projection.as_ref(), projection_deep.as_ref(), &filters, *fetch)
                     .await?
             }
             LogicalPlan::Values(Values { values, schema }) => {

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -52,6 +52,7 @@ serde_json = { workspace = true }
 sqlparser = { workspace = true }
 strum = { version = "0.26.1", features = ["derive"] }
 strum_macros = "0.26.0"
+log = "0.4.21"
 
 [dev-dependencies]
 ctor = { workspace = true }

--- a/datafusion/expr/src/logical_plan/tree_node.rs
+++ b/datafusion/expr/src/logical_plan/tree_node.rs
@@ -691,9 +691,11 @@ impl LogicalPlan {
                 table_name,
                 source,
                 projection,
+                projection_deep,
                 projected_schema,
                 filters,
                 fetch,
+                ..
             }) => filters
                 .into_iter()
                 .map_until_stop_and_collect(f)?
@@ -702,6 +704,7 @@ impl LogicalPlan {
                         table_name,
                         source,
                         projection,
+                        projection_deep,
                         projected_schema,
                         filters,
                         fetch,

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -46,6 +46,9 @@ chrono = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
 datafusion-physical-expr = { workspace = true }
+datafusion-functions = { workspace = true }
+datafusion-functions-nested = { workspace = true }
+datafusion-functions-aggregate = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -850,7 +850,7 @@ mod tests {
         logical_plan::{builder::LogicalPlanBuilder, table_scan},
         not, try_cast, when, BinaryExpr, Expr, Extension, Like, LogicalPlan, Operator,
         Projection, UserDefinedLogicalNodeCore, WindowFunctionDefinition,
-        Literal, 
+        Literal,
     };
     use crate::optimize_projections::required_indices_deep::expr_to_deep_columns;
 

--- a/datafusion/optimizer/src/optimize_projections/required_indices_deep.rs
+++ b/datafusion/optimizer/src/optimize_projections/required_indices_deep.rs
@@ -1,0 +1,144 @@
+use std::collections::{HashMap, VecDeque};
+use std::fmt::Debug;
+use std::hash::Hash;
+use datafusion_common::{Column, ScalarValue};
+use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion_expr::Expr;
+
+// pub fn append_column(acc: &mut HashMap<Column, Vec<String>>, column: &Column, rest: Vec<String>) {
+//     info!("APPEND: {:?} = {:?}", column, rest);
+//     match acc.get_mut(column) {
+//         None => {
+//             let column_clone = column.clone();
+//             if rest.len() > 0 {
+//                 acc.insert(column_clone, vec![rest.join(".")]);
+//             } else {
+//                 acc.insert(column_clone, vec![]);
+//             }
+//         }
+//         Some(cc) => {
+//             if rest.len() > 0 {
+//                 cc.push(rest.join("."));
+//             }
+//         }
+//     }
+// }
+
+pub fn append_column<T>(acc: &mut HashMap<T, Vec<String>>, column: &T, rest: Vec<String>)
+where T: Debug + Clone + Eq + Hash {
+    match acc.get_mut(column) {
+        None => {
+            let column_clone = column.clone();
+            if rest.len() > 0 {
+                acc.insert(column_clone, vec![rest.join(".")]);
+            } else {
+                acc.insert(column_clone, vec![]);
+            }
+        }
+        Some(cc) => {
+            if cc.len() == 0 {
+                // we already had this column in full
+            } else {
+                if rest.len() > 0 {
+                    cc.push(rest.join("."));
+                } else {
+                    // we are getting the entire column, and we already had something
+                    // we should delete everything
+                    cc.clear();
+                }
+            }
+        }
+    }
+}
+
+pub fn expr_to_deep_columns(expr: &Expr) -> HashMap<Column, Vec<String>> {
+    let mut accum: HashMap<Column, Vec<String>> = HashMap::new();
+    let mut field_accum: VecDeque<String> = VecDeque::new();
+    let mut in_make_struct_call: bool = false;
+    let _ = expr.apply(|expr| {
+        match expr {
+            Expr::Column(qc) => {
+                // @HStack FIXME: ADR: we should have a test case
+                // ignore deep columns if we have a in_make_struct_call
+                // case: struct(a, b, c)['col'] - we were getting 'col' in the accum stack
+                // FIXME Will this work for struct(get_field(a, 'substruct'))['col'] ?????
+                if in_make_struct_call {
+                    field_accum.clear()
+                }
+                // at the end, unwind the field_accum and push all to accum
+                let mut tmp: Vec<String> = vec![];
+                // if we did't just save a "*" - which means the entire column
+                if !(field_accum.len() == 1 && field_accum.get(0).unwrap() == "*") {
+                    for f in field_accum.iter().rev() {
+                        tmp.push(f.to_owned());
+                    }
+                }
+                field_accum.clear();
+                append_column::<Column>(&mut accum, qc, tmp);
+            }
+            Expr::ScalarFunction(sf) => {
+                // TODO what about maps ? what's the operator
+                match sf.name() {
+                    "get_field" => {
+                        // get field, append the second argument to the stack and continue
+                        let literal_expr: String = match sf.args[1].clone() {
+                            Expr::Literal(lit_expr) => match lit_expr {
+                                ScalarValue::Utf8(str) => str.unwrap(),
+                                _ => panic!()
+                            }
+                            _ => {panic!()}
+                        };
+                        field_accum.push_back(literal_expr);
+                    }
+                    "array_element" => {
+                        // We don't have the schema, but when splatting the column, we need to actually push the list inner field name here
+                        field_accum.push_back("*".to_owned());
+                    }
+                    "struct" => {
+                        in_make_struct_call = true;
+                    }
+                    _ => {}
+                }
+
+            }
+            // Use explicit pattern match instead of a default
+            // implementation, so that in the future if someone adds
+            // new Expr types, they will check here as well
+            Expr::Unnest(_)
+            | Expr::ScalarVariable(_, _)
+            | Expr::Alias(_)
+            | Expr::Literal(_)
+            | Expr::BinaryExpr { .. }
+            | Expr::Like { .. }
+            | Expr::SimilarTo { .. }
+            | Expr::Not(_)
+            | Expr::IsNotNull(_)
+            | Expr::IsNull(_)
+            | Expr::IsTrue(_)
+            | Expr::IsFalse(_)
+            | Expr::IsUnknown(_)
+            | Expr::IsNotTrue(_)
+            | Expr::IsNotFalse(_)
+            | Expr::IsNotUnknown(_)
+            | Expr::Negative(_)
+            | Expr::Between { .. }
+            | Expr::Case { .. }
+            | Expr::Cast { .. }
+            | Expr::TryCast { .. }
+            | Expr::Sort { .. }
+            | Expr::WindowFunction { .. }
+            | Expr::AggregateFunction { .. }
+            | Expr::GroupingSet(_)
+            | Expr::InList { .. }
+            | Expr::Exists { .. }
+            | Expr::InSubquery(_)
+            | Expr::ScalarSubquery(_)
+            | Expr::Wildcard { .. }
+            | Expr::Placeholder(_)
+            | Expr::OuterReferenceColumn { .. } => {}
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+        .map(|_| ());
+    accum
+}

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -2442,6 +2442,7 @@ mod tests {
                 (*test_provider.schema()).clone(),
             )?),
             projection: None,
+            projection_deep: None,
             source: Arc::new(test_provider),
             fetch: None,
         });
@@ -2514,6 +2515,7 @@ mod tests {
                 (*test_provider.schema()).clone(),
             )?),
             projection: Some(vec![0]),
+            projection_deep: Some(HashMap::new()),
             source: Arc::new(test_provider),
             fetch: None,
         });
@@ -2543,6 +2545,7 @@ mod tests {
                 (*test_provider.schema()).clone(),
             )?),
             projection: Some(vec![0]),
+            projection_deep: Some(HashMap::new()),
             source: Arc::new(test_provider),
             fetch: None,
         });

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -932,6 +932,8 @@ message FileScanExecConf {
   repeated FileGroup file_groups = 1;
   datafusion_common.Schema schema = 2;
   repeated uint32 projection = 4;
+  // FIXME somewhat abusively using ProjectionColumns to serialize map<u32, vec<string>>
+  map<uint32, ProjectionColumns> projection_deep = 20;
   ScanLimit limit = 5;
   datafusion_common.Statistics statistics = 6;
   repeated string table_partition_cols = 7;

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -5151,6 +5151,9 @@ impl serde::Serialize for FileScanExecConf {
         if !self.projection.is_empty() {
             len += 1;
         }
+        if !self.projection_deep.is_empty() {
+            len += 1;
+        }
         if self.limit.is_some() {
             len += 1;
         }
@@ -5175,6 +5178,9 @@ impl serde::Serialize for FileScanExecConf {
         }
         if !self.projection.is_empty() {
             struct_ser.serialize_field("projection", &self.projection)?;
+        }
+        if !self.projection_deep.is_empty() {
+            struct_ser.serialize_field("projectionDeep", &self.projection_deep)?;
         }
         if let Some(v) = self.limit.as_ref() {
             struct_ser.serialize_field("limit", v)?;
@@ -5205,6 +5211,8 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
             "fileGroups",
             "schema",
             "projection",
+            "projection_deep",
+            "projectionDeep",
             "limit",
             "statistics",
             "table_partition_cols",
@@ -5220,6 +5228,7 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
             FileGroups,
             Schema,
             Projection,
+            ProjectionDeep,
             Limit,
             Statistics,
             TablePartitionCols,
@@ -5249,6 +5258,7 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
                             "fileGroups" | "file_groups" => Ok(GeneratedField::FileGroups),
                             "schema" => Ok(GeneratedField::Schema),
                             "projection" => Ok(GeneratedField::Projection),
+                            "projectionDeep" | "projection_deep" => Ok(GeneratedField::ProjectionDeep),
                             "limit" => Ok(GeneratedField::Limit),
                             "statistics" => Ok(GeneratedField::Statistics),
                             "tablePartitionCols" | "table_partition_cols" => Ok(GeneratedField::TablePartitionCols),
@@ -5276,6 +5286,7 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
                 let mut file_groups__ = None;
                 let mut schema__ = None;
                 let mut projection__ = None;
+                let mut projection_deep__ = None;
                 let mut limit__ = None;
                 let mut statistics__ = None;
                 let mut table_partition_cols__ = None;
@@ -5303,6 +5314,15 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
                                 Some(map_.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
+                        }
+                        GeneratedField::ProjectionDeep => {
+                            if projection_deep__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("projectionDeep"));
+                            }
+                            projection_deep__ = Some(
+                                map_.next_value::<std::collections::HashMap<::pbjson::private::NumberDeserialize<u32>, _>>()?
+                                    .into_iter().map(|(k,v)| (k.0, v)).collect()
+                            );
                         }
                         GeneratedField::Limit => {
                             if limit__.is_some() {
@@ -5340,6 +5360,7 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
                     file_groups: file_groups__.unwrap_or_default(),
                     schema: schema__,
                     projection: projection__.unwrap_or_default(),
+                    projection_deep: projection_deep__.unwrap_or_default(),
                     limit: limit__,
                     statistics: statistics__,
                     table_partition_cols: table_partition_cols__.unwrap_or_default(),

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1491,6 +1491,9 @@ pub struct FileScanExecConf {
     pub schema: ::core::option::Option<super::datafusion_common::Schema>,
     #[prost(uint32, repeated, tag = "4")]
     pub projection: ::prost::alloc::vec::Vec<u32>,
+    /// FIXME abusively using projection columns to serialize map<u32, vec<string>>
+    #[prost(map = "uint32, message", tag = "20")]
+    pub projection_deep: ::std::collections::HashMap<u32, ProjectionColumns>,
     #[prost(message, optional, tag = "5")]
     pub limit: ::core::option::Option<ScanLimit>,
     #[prost(message, optional, tag = "6")]

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -16,6 +16,7 @@
 // under the License.language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 #[cfg(feature = "parquet")]
@@ -43,7 +44,7 @@ use datafusion_expr::WindowFrame;
 
 use crate::protobuf::{
     self, physical_aggregate_expr_node, physical_window_expr_node, PhysicalSortExprNode,
-    PhysicalSortExprNodeCollection,
+    PhysicalSortExprNodeCollection, ProjectionColumns
 };
 
 use super::PhysicalExtensionCodec;
@@ -592,6 +593,13 @@ pub fn serialize_file_scan_config(
             .unwrap_or(&vec![])
             .iter()
             .map(|n| *n as u32)
+            .collect(),
+        projection_deep: conf
+            .projection_deep
+            .as_ref()
+            .unwrap_or(&HashMap::new())
+            .iter()
+            .map(|(n, v)| (*n as u32, ProjectionColumns { columns: v.clone() }))
             .collect(),
         schema: Some(schema.as_ref().try_into()?),
         table_partition_cols: conf

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -668,6 +668,7 @@ fn roundtrip_parquet_exec_with_pruning_predicate() -> Result<()> {
             ]))),
         },
         projection: None,
+        projection_deep: None, 
         limit: None,
         table_partition_cols: vec![],
         output_ordering: vec![],
@@ -699,6 +700,7 @@ async fn roundtrip_parquet_exec_with_table_partition_cols() -> Result<()> {
         statistics: Statistics::new_unknown(&schema),
         file_schema: schema,
         projection: Some(vec![0, 1]),
+        projection_deep: None,
         limit: None,
         table_partition_cols: vec![Field::new(
             "part".to_string(),
@@ -732,6 +734,7 @@ fn roundtrip_parquet_exec_with_custom_predicate_expr() -> Result<()> {
             ]))),
         },
         projection: None,
+        projection_deep: None,
         limit: None,
         table_partition_cols: vec![],
         output_ordering: vec![],


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11745

## What changes are included in this PR?

This PR is currently opened as a discussion support for this feature. 

1. We need a way to add the deep projection. This is currently represented (for ease of merging etc) as an extra parameter, `projection_deep` added after a `projection` parameter before. This parameter needs to be propagated all the way down to the physical data source, in our case parquet. 

The representation of the deep projection is a `HashMap<usize, Vec<String>>`. The key represents the index of the top level column, while the `Vec<String>` is a list of "paths". Each path represents a way to navigate inside a deep field separated by dots, like `top_level_struct.subfield1.*.subfield2`. 

**Current problems / questions**

* Duplicated information - for ease of merging, at the moment, we have both the `projection` and `projection_deep` parameters, even though we could only pass the second one, that has in the keys the information currently in projection
* Untyped representation for path - maybe we need a better / safer way to represent the deep projections ? due to unfamiliarity and ease of development, currently it's just a String, but maybe we need to have it represented as a typed thing ? 

3. We have a set of functions that can: rewrite schemas and record batches from an input to an output schema, rewrite an input schema to a (potentially) much smaller output schema that contains ONLY the necessary columns. This is the first patch in the PR (). These functions can be tested in isolation we need to add more unit tests, etc. 

**Current problems / questions**

* We have a lot of seemingly duplicated code that recurses through schemas. We tried making it more generic, but it was pretty complicated, so for the moment there is some duplication in the code, and not really sure how to make it better
* Deep Schema test cases - creating deep schemas in code is very verbose, so we don't have enough test cases. One way would be to use pre-generated parquet files created with other tools and use those for the schema. 

4. We need to detect the deep projections from the input logical plan, that means navigating the expressions, down to the columns and transforming index and field access expressions to a map `field[0]["some_sub_field"]["other_sub_field"] -> 0: Vec<String>{"*.some_sub_field.other_sub_field"}`

**Current problems / questions**

* Uniform field accesses need 2 accesses through the fields: 
    * At the moment, we recurse through the input expressions like `a["b"]["c"]` to compute a path like `b.c`, or `*.c`, or `b.*`.  The `["b"]` could mean either a map access or a substruct access, same for the c
    * So, we go through the paths twice - once we create them and after that we iterate them again, WITH the input schems so we can detect map accesses and replace actual field names that are actual map or list accesses with `*` - so we also introduce a magic string here :(
* Implementing a new `scan_deep` function in the TableProvider
    * We can get rid of this. It's done this way for now, so that we don't break existing TableProvider implementations 

6. We need to push these through the physical layer and finally implement the reading in the parquet layer. 

**Current problems / questions**

* Named field in map key value or list element
    * In the parquet schema, a list has a field inside it with a specific name. However, we don't have this name anywhere, except at the parquet layer. The arrow reader as far as we can tell loads these and replaces the names with standard names  ("element"  in the list case, "key_value.key", "key_value".value). BUT, if the arrow loader behavior changes, this functionality will break. At the moment we detect these hardcoded names and we replace them with a wildcard "*" that signifies that we don't care about this name. We also do this in the INPUT paths, because we don't have these actual names at that level. 

## Are these changes tested?

A version of this is tested on top of Datafusion-40, the rebase on main has not been tested. The PR is opened as a discussion support, but the patch applied mostly cleanly apart from some refactorings in data fucion

## Are there any user-facing changes?

Possible API change for implementers of `TableProvider`