### PR TITLE
Minor: add "clickbench extended" queries to slt tests

### DIFF
--- a/benchmarks/queries/clickbench/README.md
+++ b/benchmarks/queries/clickbench/README.md
@@ -14,7 +14,7 @@ ClickBench is focused on aggregation and filtering performance (though it has no
 
 The "extended" queries are not part of the official ClickBench benchmark.
 Instead they are used to test other DataFusion features that are not covered by
-the standard benchmark  Each description below is for the corresponding line in
+the standard benchmark. Each description below is for the corresponding line in
 `extended.sql` (line 1 is `Q0`, line 2 is `Q1`, etc.)
 
 ### Q0: Data Exploration

--- a/datafusion/sqllogictest/test_files/clickbench.slt
+++ b/datafusion/sqllogictest/test_files/clickbench.slt
@@ -274,5 +274,23 @@ query PI
 SELECT DATE_TRUNC('minute', to_timestamp_seconds("EventTime")) AS M, COUNT(*) AS PageViews FROM hits WHERE "CounterID" = 62 AND "EventDate"::INT::DATE >= '2013-07-14' AND "EventDate"::INT::DATE <= '2013-07-15' AND "IsRefresh" = 0 AND "DontCountHits" = 0 GROUP BY DATE_TRUNC('minute', to_timestamp_seconds("EventTime")) ORDER BY DATE_TRUNC('minute', M) LIMIT 10 OFFSET 1000;
 ----
 
+# Clickbench "Extended" queries that test count distinct
+
+query III
+SELECT COUNT(DISTINCT "SearchPhrase"), COUNT(DISTINCT "MobilePhone"), COUNT(DISTINCT "MobilePhoneModel") FROM hits;
+----
+1 1 1
+
+query III
+SELECT COUNT(DISTINCT "HitColor"), COUNT(DISTINCT "BrowserCountry"), COUNT(DISTINCT "BrowserLanguage")  FROM hits;
+----
+1 1 1
+
+query TIIII
+SELECT "BrowserCountry",  COUNT(DISTINCT "SocialNetwork"), COUNT(DISTINCT "HitColor"), COUNT(DISTINCT "BrowserLanguage"), COUNT(DISTINCT "SocialAction") FROM hits GROUP BY 1 ORDER BY 2 DESC LIMIT 10;
+----
+� 1 1 1 1
+
+
 statement ok
 drop table hits;


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/datafusion/pull/11723


## Rationale for this change

While working to enable `StringView` by default I hit an error running the [ClickBench "extended" queries](https://github.com/apache/datafusion/blob/feb9100432d453f19d40428265d2aa9a9f942d5d/benchmarks/queries/clickbench/README.md#extended-queries):

```
 Finished `release` profile [optimized] target(s) in 0.77s
     Running `/home/alamb/arrow-datafusion2/target/release/dfbench clickbench --iterations 5 --path /home/alamb/arrow-datafusion/benchmarks/data/hits.par\
quet --queries-path /home/alamb/arrow-datafusion/benchmarks/queries/clickbench/extended.sql -o /home/alamb/arrow-datafusion/benchmarks/results/alamb_stri\
ng_view_default/clickbench_extended.json`
Running benchmarks with the following options: RunOpt { query: None, common: CommonOpt { iterations: 5, partitions: None, batch_size: 8192, debug: false \
}, path: "/home/alamb/arrow-datafusion/benchmarks/data/hits.parquet", queries_path: "/home/alamb/arrow-datafusion/benchmarks/queries/clickbench/extended.\
sql", output_path: Some("/home/alamb/arrow-datafusion/benchmarks/results/alamb_string_view_default/clickbench_extended.json") }
Q0: SELECT COUNT(DISTINCT "SearchPhrase"), COUNT(DISTINCT "MobilePhone"), COUNT(DISTINCT "MobilePhoneModel") FROM hits;
thread 'tokio-runtime-worker' panicked at datafusion/physical-expr-common/src/binary_view_map.rs:220:18:
internal error: entered unreachable code: Utf8/Binary should use `ArrowBytesSet`
```

## What changes are included in this PR?

1. adds unit test coverage for those queries to slt benchmarks
1. Drive by typo fix in README

## Are these changes tested?

All tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
