### PR TITLE
[Minor] Short circuit `ApplyFunctionRewrites` if there are no function rewrites

### DIFF
--- a/datafusion/optimizer/src/analyzer/function_rewrite.rs
+++ b/datafusion/optimizer/src/analyzer/function_rewrite.rs
@@ -85,11 +85,6 @@ impl AnalyzerRule for ApplyFunctionRewrites {
     }
 
     fn analyze(&self, plan: LogicalPlan, options: &ConfigOptions) -> Result<LogicalPlan> {
-        if self.function_rewrites.is_empty() {
-            // No need to walk the plan tree since there's nothing to rewrite
-            return Ok(plan);
-        }
-
         plan.transform_up_with_subqueries(|plan| self.rewrite_plan(plan, options))
             .map(|res| res.data)
     }

--- a/datafusion/optimizer/src/analyzer/function_rewrite.rs
+++ b/datafusion/optimizer/src/analyzer/function_rewrite.rs
@@ -85,6 +85,11 @@ impl AnalyzerRule for ApplyFunctionRewrites {
     }
 
     fn analyze(&self, plan: LogicalPlan, options: &ConfigOptions) -> Result<LogicalPlan> {
+        if self.function_rewrites.is_empty() {
+            // No need to walk the plan tree since there's nothing to rewrite
+            return Ok(plan);
+        }
+
         plan.transform_up_with_subqueries(|plan| self.rewrite_plan(plan, options))
             .map(|res| res.data)
     }

--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -136,9 +136,15 @@ impl Analyzer {
         // Note this is run before all other rules since it rewrites based on
         // the argument types (List or Scalar), and TypeCoercion may cast the
         // argument types from Scalar to List.
-        let expr_to_function: Arc<dyn AnalyzerRule + Send + Sync> =
-            Arc::new(ApplyFunctionRewrites::new(self.function_rewrites.clone()));
-        let rules = std::iter::once(&expr_to_function).chain(self.rules.iter());
+        let expr_to_function: Option<Arc<dyn AnalyzerRule + Send + Sync>> =
+            if self.function_rewrites.is_empty() {
+                None
+            } else {
+                Some(Arc::new(ApplyFunctionRewrites::new(
+                    self.function_rewrites.clone(),
+                )))
+            };
+        let rules = expr_to_function.iter().chain(self.rules.iter());
 
         // TODO add common rule executor for Analyzer and Optimizer
         for rule in rules {

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -176,7 +176,6 @@ EXPLAIN VERBOSE SELECT a, b, c FROM simple_explain_test
 initial_logical_plan
 01)Projection: simple_explain_test.a, simple_explain_test.b, simple_explain_test.c
 02)--TableScan: simple_explain_test
-logical_plan after apply_function_rewrites SAME TEXT AS ABOVE
 logical_plan after inline_table_scan SAME TEXT AS ABOVE
 logical_plan after type_coercion SAME TEXT AS ABOVE
 logical_plan after count_wildcard_rule SAME TEXT AS ABOVE


### PR DESCRIPTION
## Which issue does this PR close?

Relates to #9373 and #9375.

## Rationale for this change

I'm dealing with a situation where we [have deeply nested plans](https://github.com/splitgraph/seafowl/blob/82a9ca4a7da9eed0d17e9fe0f6b3357af8bd97a1/src/frontend/flight/sync/writer.rs#L387-L398), which we want to execute and stream the data into storage (Parquet/Delta), and we're hitting the stack overflow problem observed in the aforementioned issues.

Since this is on a write path we don't really need the analyzer/optimizer rules (I think), which are a part of the problem due to tree node recursion that takes place there. This is not an issue, since those can easily be opted out of via `with_analyzer_rules`/`with_optimizer_rules`. 

However, the tightest bottleneck as per lldb is actually `ApplyFunctionRewrites`, which can't be opted out of, even though after https://github.com/apache/datafusion/pull/11155 it has no rewrite rules by default.

## What changes are included in this PR?

Make `ApplyFunctionRewrites` simply bail out of the plan transformation/rewrite if it has no rules to apply (the default case presently).

## Are these changes tested?

I wanted to add a test that checks for reference equity of the in/out plans but then recalled `AnalyzerRule::analyze` takes ownership of it. 

So the only test is that I see a higher stack overflow threshold with this change.

## Are there any user-facing changes?

None.
