### PR TITLE
Improve MSRV CI check to print out problems to log

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -588,10 +588,10 @@ jobs:
           cargo msrv --verify --log-target stdout
       - name: Check datafusion-substrait
         working-directory: datafusion/substrait
-        run: cargo msrv --verify --log-target stdout
+        run: cargo msrv --output-format json --log-target stdout verify
       - name: Check datafusion-proto
         working-directory: datafusion/proto
-        run: cargo msrv --verify --log-target stdout
+        run: cargo msrv --output-format json --log-target stdout verify
       - name: Check datafusion-cli
         working-directory: datafusion-cli
-        run: cargo msrv --verify --log-target stdout
+        run: cargo msrv --output-format json --log-target stdout verify

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -570,6 +570,12 @@ jobs:
           # your code or some crate in the dependency tree has a higher MSRV
           # (Min Supported Rust Version) than the one specified in the
           # `rust-version` key of `Cargo.toml`.
+          #
+          # To reproduce: 
+          # 1. Install the version of Rust that is failing. Example: 
+          #    rustup install 1.76.0
+          # 2. Run the command that failed with that version. Example:
+          #    cargo +1.76.0 check -p datafusion
           # 
           # To resolve, either:
           # 1. Change your code to use older Rust features, 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -566,18 +566,26 @@ jobs:
       - name: Check datafusion
         working-directory: datafusion/core
         run: |
-          # If you encounter an error with any of the commands below
-          # it means some crate in your dependency tree has a higher 
-          # MSRV (Min Supported Rust Version) than the one specified 
-          # in the `rust-version` key of `Cargo.toml`. Check your 
-          # dependencies or update the version in `Cargo.toml`
-          cargo msrv verify
+          # If you encounter an error with any of the commands below it means
+          # your code or some crate in the dependency tree has a higher MSRV
+          # (Min Supported Rust Version) than the one specified in the
+          # `rust-version` key of `Cargo.toml`.
+          # 
+          # To resolve, either:
+          # 1. Change your code to use older Rust features, 
+          # 2. Revert dependency update
+          # 3. Update the MSRV version in `Cargo.toml`
+          #
+          # Please see the DataFusion Rust Version Compatibility Policy before
+          # updating Cargo.toml. You may have to update the code instead. 
+          # https://github.com/apache/datafusion/blob/main/README.md#rust-version-compatibility-policy
+          cargo msrv --verify --log-target stdout
       - name: Check datafusion-substrait
         working-directory: datafusion/substrait
-        run: cargo msrv verify
+        run: cargo msrv --verify --log-target stdout
       - name: Check datafusion-proto
         working-directory: datafusion/proto
-        run: cargo msrv verify
+        run: cargo msrv --verify --log-target stdout
       - name: Check datafusion-cli
         working-directory: datafusion-cli
-        run: cargo msrv verify
+        run: cargo msrv --verify --log-target stdout

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -585,7 +585,7 @@ jobs:
           # Please see the DataFusion Rust Version Compatibility Policy before
           # updating Cargo.toml. You may have to update the code instead. 
           # https://github.com/apache/datafusion/blob/main/README.md#rust-version-compatibility-policy
-          cargo msrv --verify --log-target stdout
+          cargo msrv --output-format json --log-target stdout verify
       - name: Check datafusion-substrait
         working-directory: datafusion/substrait
         run: cargo msrv --output-format json --log-target stdout verify


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/11788

## Rationale for this change
When the MSRV CI check fails it does not say what is wrong or offer specific advice on how to fix it. For example:

CI failure: https://github.com/apache/datafusion/actions/runs/10204347289/job/28280296775?pr=11627

Output error:
```
Run # If you encounter an error with any of the commands below
Fetching index
Verifying the Minimum Supported Rust Version (MSRV) for toolchain x86_64-unknown-linux-gnu
Using check command cargo check
   Failed check command cargo check didn't succeed
Crate source was found to be incompatible with its MSRV '1.76.0', as defined in '/__w/datafusion/datafusion/datafusion/core/Cargo.toml'
Error: Process completed with exit code 1.

```

## What changes are included in this PR?

1. Add `--logfile stdout` so errors are printed to the log
2. Update comments in CI check explaining how to fix. 

Here is an example failure with this change: https://github.com/apache/datafusion/actions/runs/10220955214/job/28282400260?pr=11789

While the log is not pretty 🤮  it at least provides enough information to debug:

> (/__w/datafusion/datafusion/datafusion/sql)\n    Checking datafusion-functions v40.0.0 (/__w/datafusion/datafusion/datafusion/functions)\nerror[E0716]: temporary value dropped while borrowed\n   --> datafusion/physical-expr-common/src/aggregate/groups_accumulator/prim_op.rs:167:18\n    |\n151 |         let values = match opt_filter {\n    |             ------ borrow later stored here\n...\n167 |                 &PrimitiveArray::<T>::new(values_buf, nulls_buf).with_data_type(dt)\n    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use\n168 |             }\n    |             - temporary value is freed at the end of this statement\n    |\n    = note: consider using a `let` binding to create a longer lived value\n\nFor more information about this error, try `rustc --explain E0716`.\nerror: could not compile `datafusion-physical-expr-common` (lib) due to 1 previous error\nwarning: build failed, waiting for other jobs to finish...\n" cmd="1.76.0-x86_64-unknown-linux-gnu cargo check"


## Are these changes tested?

Yes (in progress)

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
