### PR TITLE
Bump deprecated version of SessionState::new_with_config_rt to 41.0.0

### DIFF
--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -249,7 +249,7 @@ impl Session for SessionState {
 impl SessionState {
     /// Returns new [`SessionState`] using the provided
     /// [`SessionConfig`] and [`RuntimeEnv`].
-    #[deprecated(since = "40.0.0", note = "Use SessionStateBuilder")]
+    #[deprecated(since = "41.0.0", note = "Use SessionStateBuilder")]
     pub fn new_with_config_rt(config: SessionConfig, runtime: Arc<RuntimeEnv>) -> Self {
         SessionStateBuilder::new()
             .with_config(config)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None.

## Rationale for this change

#11403 is not shipped in 40.0.0 but marks `SessionState::new_with_config_rt` as deprecated since `40.0.0`.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Bump deprecated version of `SessionState::new_with_config_rt` to `41.0.0`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

* https://github.com/apache/datafusion/blob/40.0.0/datafusion/core/src/execution/session_state.rs#L178
* https://docs.rs/datafusion/40.0.0/datafusion/execution/session_state/struct.SessionState.html#method.new_with_config_rt

Both code and docs of 40.0.0 don't deprecate `SessionState::new_with_config_rt`.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

It should be considered as a squashed fix to #11403.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
