### PR TITLE
fix: `collect_columns` quadratic complexity

### DIFF
--- a/datafusion/physical-expr/src/utils/mod.rs
+++ b/datafusion/physical-expr/src/utils/mod.rs
@@ -17,9 +17,10 @@
 
 mod guarantee;
 pub use guarantee::{Guarantee, LiteralGuarantee};
+use hashbrown::HashSet;
 
 use std::borrow::Borrow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::expressions::{BinaryExpr, Column};
@@ -204,9 +205,7 @@ pub fn collect_columns(expr: &Arc<dyn PhysicalExpr>) -> HashSet<Column> {
     let mut columns = HashSet::<Column>::new();
     expr.apply(|expr| {
         if let Some(column) = expr.as_any().downcast_ref::<Column>() {
-            if !columns.iter().any(|c| c.eq(column)) {
-                columns.insert(column.clone());
-            }
+            columns.get_or_insert_owned(column);
         }
         Ok(TreeNodeRecursion::Continue)
     })


### PR DESCRIPTION
## Which issue does this PR close?
\-

## Rationale for this change
Fix accidental $O(n^2)$ in `collect_columns`.

## What changes are included in this PR?
There are the following ways to insert a clone into a hash set:

- **clone before check:** Basically `set.insert(x.clone())`. That's rather expensive if you have a lot of duplicates.
- **iter & clone:** That's what we do right now, but that's in $O(n^2)$.
- **check & insert:** Basically `if !set.contains(x) {set.insert(x.clone())}` That requires two hash probes though.
- **entry-based API:** Sadly the stdlib doesn't really offer any handle/entry-based APIs yet (see https://github.com/rust-lang/rust/issues/60896 ), but `hashbrown` does, so we can use the nice `set.get_or_insert_owned(x)` which will only clone the reference if it doesn't exists yet and only hashes once.

We now use the last approach.

## Are these changes tested?
Functional tests still pass, performance change is only visible for large inputs (like 100+ columns).

## Are there any user-facing changes?
**:warning: Breaking change:** `collect_columns` now returns `hashbrown::HashSet` instead of `std::collections::HashSet`!