### PR TITLE
allow opt-out of skip partial aggregation feature

### DIFF
--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -200,6 +200,15 @@ impl SessionConfig {
         self
     }
 
+    /// Customize [`skip_partial_aggregation_probe_rows_threshold`]
+    ///
+    /// [`skip_partial_aggregation_probe_rows_threshold`]: datafusion_common::config::ExecutionOptions::skip_partial_aggregation_probe_rows_threshold
+    pub fn with_skip_partial_aggregation_probe_rows_threshold(mut self, n: usize) -> Self {
+        self.options.execution.skip_partial_aggregation_probe_rows_threshold = n;
+        self
+    }
+
+
     /// Insert new [ConfigExtension]
     pub fn with_option_extension<T: ConfigExtension>(mut self, extension: T) -> Self {
         self.options_mut().extensions.insert(extension);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/datafusion/issues/11850

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

For the Comet project, we need to disable the skip partial aggregation feature to avoid incorrect results

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
