### PR TITLE
fix: Do not skip partial aggregates in case where there are no aggregate expressions

### DIFF
--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -463,11 +463,13 @@ impl GroupedHashAggregateStream {
         // - aggregation mode is Partial
         // - input is not ordered by GROUP BY expressions,
         //   since Final mode expects unique group values as its input
+        // - there is at least one accumulator
         // - all accumulators support input batch to intermediate
         //   aggregate state conversion
         // - there is only one GROUP BY expressions set
         let skip_aggregation_probe = if agg.mode == AggregateMode::Partial
             && matches!(group_ordering, GroupOrdering::None)
+            && !accumulators.is_empty()
             && accumulators
                 .iter()
                 .all(|acc| acc.supports_convert_to_state())

--- a/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
+++ b/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
@@ -56,6 +56,28 @@ set datafusion.execution.batch_size = 1;
 statement ok
 set datafusion.sql_parser.dialect = 'Postgres';
 
+# Regression test for https://github.com/apache/datafusion/issues/11850
+# Loosely based on TPC-DS q97
+query IIIIII
+WITH left AS (
+  SELECT c1 as l1, c2 as l2, c3 as l3, c4 as l4
+  FROM aggregate_test_100
+  GROUP BY 1, 2, 3, 4),
+right AS (
+  SELECT c1 as r1, c2 as r2, c3 as r3, c4 as r4
+  FROM aggregate_test_100
+  GROUP BY 1, 2, 3, 4)
+SELECT
+  SUM(l2), sum(l3), sum(l4),
+  sum(r2), sum(r3), sum(r4) FROM left
+FULL OUTER JOIN right
+ON left.l1 = right.r1
+AND left.l2 = right.r2
+AND left.l3 = right.r3
+AND left.l4 = right.r4;
+----
+285 781 231997 285 781 231997
+
 # Grouping by unique fields allows to check all accumulators
 query ITIIII
 SELECT c5, c1,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/11850

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

For an aggregate with grouping expressions but no aggregate expressions, we should not produce duplicate rows in the output.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I am working on adding a test

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
