### PR TITLE
Fix `Duration` vs `Interval` comparisons and `Interval` as LHS

### DIFF
--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -1123,7 +1123,9 @@ fn temporal_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataTyp
     use arrow::datatypes::TimeUnit::*;
 
     match (lhs_type, rhs_type) {
-        (Interval(_), Interval(_)) => Some(Interval(MonthDayNano)),
+        (Interval(_) | Duration(_), Interval(_) | Duration(_)) => {
+            Some(Interval(MonthDayNano))
+        }
         (Date64, Date32) | (Date32, Date64) => Some(Date64),
         (Timestamp(_, None), Date64) | (Date64, Timestamp(_, None)) => {
             Some(Timestamp(Nanosecond, None))

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -227,6 +227,12 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 let df_op = match op {
                     BinaryOperator::Plus => Operator::Plus,
                     BinaryOperator::Minus => Operator::Minus,
+                    BinaryOperator::Eq => Operator::Eq,
+                    BinaryOperator::NotEq => Operator::NotEq,
+                    BinaryOperator::Gt => Operator::Gt,
+                    BinaryOperator::GtEq => Operator::GtEq,
+                    BinaryOperator::Lt => Operator::Lt,
+                    BinaryOperator::LtEq => Operator::LtEq,
                     _ => {
                         return not_impl_err!("Unsupported interval operator: {op:?}");
                     }

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -3109,6 +3109,43 @@ SELECT * FROM VALUES
 2024-02-01T08:00:00Z
 2023-12-31T23:00:00Z
 
+# interval vs. duration comparison
+query B
+select (now() - now()) < interval '1 seconds';
+----
+true
+
+query B
+select arrow_cast(123, 'Duration(Nanosecond)') < interval '200 nanoseconds';
+----
+true
+
+query B
+select arrow_cast(123, 'Duration(Nanosecond)') < interval '100 nanoseconds';
+----
+false
+
+query B
+select arrow_cast(123, 'Duration(Nanosecond)') < interval '1 seconds';
+----
+true
+
+query B
+select interval '1 seconds' < arrow_cast(123, 'Duration(Nanosecond)')
+----
+false
+
+# interval as LHS
+query B
+select interval '2 seconds' = interval '2 seconds';
+----
+true
+
+query B
+select interval '1 seconds' < interval '2 seconds';
+----
+true
+
 statement ok
 drop table t;
 

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -3116,6 +3116,31 @@ select (now() - now()) < interval '1 seconds';
 true
 
 query B
+select (now() - now()) <= interval '1 seconds';
+----
+true
+
+query B
+select (now() - now()) = interval '0 seconds';
+----
+true
+
+query B
+select (now() - now()) != interval '1 seconds';
+----
+true
+
+query B
+select (now() - now()) > interval '-1 seconds';
+----
+true
+
+query B
+select (now() - now()) >= interval '-1 seconds';
+----
+true
+
+query B
 select arrow_cast(123, 'Duration(Nanosecond)') < interval '200 nanoseconds';
 ----
 true


### PR DESCRIPTION
## Which issue does this PR close?

Close https://github.com/apache/datafusion/issues/11891

## Rationale for this change

We regularly want to allow queries of the form

```sql
SELECT * FROM records WHERE end_timestamp - start_timestamp > interval '2 seconds'
```

Until now that failed with

```
type_coercion: Cannot infer common argument type for comparison operation Duration(Microsecond) > Interval(MonthDayNano)
```

While working on that, I discovered you couldn't compare to an interval with the interval as the left hand side of the operation, so I fixed that too.

## What changes are included in this PR?

* fix `Duration` vs. `Interval` comparison - sense check - is it really as simple as it looks?
* support more operators in machinery to support intervals as the LHF of binary operations
* add tests for both

## Are these changes tested?

Yes

## Are there any user-facing changes?

Should be only the above changes to support SQL.
