### PR TITLE
Sync rust docs params for CI and dev

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -233,11 +233,7 @@ jobs:
         with:
           rust-version: stable
       - name: Run cargo doc
-        run: |
-          export RUSTDOCFLAGS="-D warnings"
-          cargo doc --document-private-items --no-deps --workspace
-          cd datafusion-cli
-          cargo doc --document-private-items --no-deps
+        run: ci/scripts/rust_docs.sh
 
   linux-wasm-pack:
     name: build with wasm-pack

--- a/ci/scripts/rust_docs.sh
+++ b/ci/scripts/rust_docs.sh
@@ -18,7 +18,7 @@
 # under the License.
 
 set -ex
-export RUSTDOCFLAGS="-D warnings -A rustdoc::private-intra-doc-links"
+export RUSTDOCFLAGS="-D warnings"
 cargo doc --document-private-items --no-deps --workspace
 cd datafusion-cli
 cargo doc --document-private-items --no-deps


### PR DESCRIPTION
Since a4ac0829ecf63b3640315835b1374211dfadd953 commit there was a discrepancy between rust.yml GitHub workflow and the `dev/rust_lint.sh` script behavior. Sync the behaviors. Reuse common script to prevent future discrepancies.
