### PR TITLE
changed statistics to arc(statistics)  #11885

### DIFF
--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -1,5 +1,5 @@
 // Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
+// or more contributor lpub statistics: Option<Arc<Statistics>>,icense agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file
 // to you under the Apache License, Version 2.0 (the
@@ -78,7 +78,7 @@ pub struct PartitionedFile {
     ///
     /// DataFusion relies on these statistics for planning (in particular to sort file groups),
     /// so if they are incorrect, incorrect answers may result.
-    pub statistics: Option<Arc<Statistics>>,
+    
     /// An optional field for user defined per object metadata
     pub extensions: Option<Arc<dyn std::any::Any + Send + Sync>>,
 }

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -78,7 +78,7 @@ pub struct PartitionedFile {
     ///
     /// DataFusion relies on these statistics for planning (in particular to sort file groups),
     /// so if they are incorrect, incorrect answers may result.
-    pub statistics: Option<Arc(Statistics)>,
+    pub statistics: Option<Arc<Statistics>>,
     /// An optional field for user defined per object metadata
     pub extensions: Option<Arc<dyn std::any::Any + Send + Sync>>,
 }

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -78,7 +78,7 @@ pub struct PartitionedFile {
     ///
     /// DataFusion relies on these statistics for planning (in particular to sort file groups),
     /// so if they are incorrect, incorrect answers may result.
-    pub statistics: Option<Statistics>,
+    pub statistics: Option<Arc(Statistics)>,
     /// An optional field for user defined per object metadata
     pub extensions: Option<Arc<dyn std::any::Any + Send + Sync>>,
 }


### PR DESCRIPTION
Closes #11885 .

Change `PartitionedFile. statistics` datatype to  `Option<Arc<Statistics>>`

```rust 
Option<Arc<Statistics>> 
```

In Rust, Option<Arc<Statistics>> is a type that combines two powerful features of the language: optional values and thread-safe reference counting. This type is commonly used in concurrent programming to manage shared ownership of data with optionality. Here’s a breakdown of each component:

Option
Option is an enum that represents either a value (Some) or the absence of a value (None). It is used to handle cases where a value may or may not be present

Arc
Arc stands for "Atomic Reference Counted" and is a thread-safe version of Rc (Reference Counted). It allows multiple ownership of data across threads. Arc is used when you need to share immutable data safely between threads.

Combining Option and Arc
When you combine Option with Arc, you get a type that can either hold a reference-counted value or be empty. This is useful when you want to represent an optional shared resource.

