### PR TITLE
fix: throw error on sub-day generate_series increments

### DIFF
--- a/datafusion/functions-nested/src/range.rs
+++ b/datafusion/functions-nested/src/range.rs
@@ -357,7 +357,6 @@ fn gen_range_date(args: &[ArrayRef], include_upper: bool) -> Result<ArrayRef> {
         });
 
         list_builder.append_value(values);
-        list_builder.append(true);
     }
 
     let arr = Arc::new(list_builder.finish());

--- a/datafusion/functions-nested/src/range.rs
+++ b/datafusion/functions-nested/src/range.rs
@@ -166,7 +166,10 @@ impl ScalarUDFImpl for GenSeries {
             Int64 => make_scalar_function(|args| gen_range_inner(args, true))(args),
             Date32 => make_scalar_function(|args| gen_range_date(args, true))(args),
             dt => {
-                exec_err!("unsupported type for range. Expected Int64 or Date32, got: {}", dt)
+                exec_err!(
+                    "unsupported type for range. Expected Int64 or Date32, got: {}",
+                    dt
+                )
             }
         }
     }

--- a/datafusion/functions-nested/src/range.rs
+++ b/datafusion/functions-nested/src/range.rs
@@ -166,7 +166,7 @@ impl ScalarUDFImpl for GenSeries {
             Int64 => make_scalar_function(|args| gen_range_inner(args, true))(args),
             Date32 => make_scalar_function(|args| gen_range_date(args, true))(args),
             dt => {
-                exec_err!("unsupported type for range: {}", dt)
+                exec_err!("unsupported type for range. Expected Int64 or Date32, got: {}", dt)
             }
         }
     }

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5787,6 +5787,9 @@ select range(DATE '1993-03-01', DATE '1989-04-01', INTERVAL '1' YEAR)
 ----
 []
 
+query error DataFusion error: Execution error: Cannot generate date range less than 1 day\.
+select range(DATE '1993-03-01', DATE '1993-03-01', INTERVAL '1' HOUR)
+
 query ?????????
 select generate_series(5),
        generate_series(2, 5),
@@ -5800,6 +5803,9 @@ select generate_series(5),
 ;
 ----
 [0, 1, 2, 3, 4, 5] [2, 3, 4, 5] [2, 5, 8] [1, 2, 3, 4, 5] [5, 4, 3, 2, 1] [10, 7, 4] [1992-09-01, 1992-10-01, 1992-11-01, 1992-12-01, 1993-01-01, 1993-02-01, 1993-03-01] [1993-02-01, 1993-01-31, 1993-01-30, 1993-01-29, 1993-01-28, 1993-01-27, 1993-01-26, 1993-01-25, 1993-01-24, 1993-01-23, 1993-01-22, 1993-01-21, 1993-01-20, 1993-01-19, 1993-01-18, 1993-01-17, 1993-01-16, 1993-01-15, 1993-01-14, 1993-01-13, 1993-01-12, 1993-01-11, 1993-01-10, 1993-01-09, 1993-01-08, 1993-01-07, 1993-01-06, 1993-01-05, 1993-01-04, 1993-01-03, 1993-01-02, 1993-01-01] [1989-04-01, 1990-04-01, 1991-04-01, 1992-04-01]
+
+query error DataFusion error: Execution error: unsupported type for range: Timestamp\(Nanosecond, None\)
+select generate_series('2021-01-01'::timestamp, '2021-01-02'::timestamp, INTERVAL '1' HOUR);
 
 ## should return NULL
 query ?
@@ -5834,6 +5840,9 @@ select generate_series(DATE '1993-03-01', DATE '1989-04-01', INTERVAL '1' YEAR)
 
 query error DataFusion error: Execution error: Cannot generate date range less than 1 day.
 select generate_series(DATE '2000-01-01', DATE '2000-01-03', INTERVAL '1' HOUR)
+
+query error DataFusion error: Execution error: Cannot generate date range less than 1 day.
+select generate_series(DATE '2000-01-01', DATE '2000-01-03', INTERVAL '-1' HOUR)
 
 # Test generate_series with zero step
 query error DataFusion error: Execution error: step can't be 0 for function generate_series\(start \[, stop, step\]\)
@@ -5893,6 +5902,7 @@ select generate_series(NULL)
 ----
 NULL
 
+<<<<<<< HEAD
 # Test generate_series with a table of values
 statement ok
 CREATE TABLE date_table(
@@ -5934,6 +5944,8 @@ DataFusion error: Internal error: could not cast value to arrow_array::array::pr
 This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
 
 
+=======
+>>>>>>> f05f2903c (Add a few more tests)
 ## array_except
 
 statement ok

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5804,7 +5804,7 @@ select generate_series(5),
 ----
 [0, 1, 2, 3, 4, 5] [2, 3, 4, 5] [2, 5, 8] [1, 2, 3, 4, 5] [5, 4, 3, 2, 1] [10, 7, 4] [1992-09-01, 1992-10-01, 1992-11-01, 1992-12-01, 1993-01-01, 1993-02-01, 1993-03-01] [1993-02-01, 1993-01-31, 1993-01-30, 1993-01-29, 1993-01-28, 1993-01-27, 1993-01-26, 1993-01-25, 1993-01-24, 1993-01-23, 1993-01-22, 1993-01-21, 1993-01-20, 1993-01-19, 1993-01-18, 1993-01-17, 1993-01-16, 1993-01-15, 1993-01-14, 1993-01-13, 1993-01-12, 1993-01-11, 1993-01-10, 1993-01-09, 1993-01-08, 1993-01-07, 1993-01-06, 1993-01-05, 1993-01-04, 1993-01-03, 1993-01-02, 1993-01-01] [1989-04-01, 1990-04-01, 1991-04-01, 1992-04-01]
 
-query error DataFusion error: Execution error: unsupported type for range: Timestamp\(Nanosecond, None\)
+query error DataFusion error: Execution error: unsupported type for range. Expected Int64 or Date32, got: Timestamp\(Nanosecond, None\)
 select generate_series('2021-01-01'::timestamp, '2021-01-02'::timestamp, INTERVAL '1' HOUR);
 
 ## should return NULL

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5902,7 +5902,6 @@ select generate_series(NULL)
 ----
 NULL
 
-<<<<<<< HEAD
 # Test generate_series with a table of values
 statement ok
 CREATE TABLE date_table(
@@ -5944,8 +5943,6 @@ DataFusion error: Internal error: could not cast value to arrow_array::array::pr
 This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
 
 
-=======
->>>>>>> f05f2903c (Add a few more tests)
 ## array_except
 
 statement ok

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1971,7 +1971,7 @@ select array_slice(arrow_cast(make_array(1, 2, 3, 4, 5), 'LargeList(Int64)'), co
 # `from` may be larger than `to` and `stride` is positive
 query ????
 select array_slice(a, -1, 2, 1), array_slice(a, -1, 2),
-       array_slice(a, 3, 2, 1), array_slice(a, 3, 2) 
+       array_slice(a, 3, 2, 1), array_slice(a, 3, 2)
   from (values ([1.0, 2.0, 3.0, 3.0]), ([4.0, 5.0, 3.0]), ([6.0])) t(a);
 ----
 [] [] [] []
@@ -5711,7 +5711,7 @@ select
 
 # Test range for other edge cases
 query ????????
-select 
+select
   range(9223372036854775807, 9223372036854775807, -1) as c1,
   range(9223372036854775807, 9223372036854775806, -1) as c2,
   range(9223372036854775807, 9223372036854775807, 1) as c3,
@@ -5832,6 +5832,9 @@ select generate_series(DATE '1993-03-01', DATE '1989-04-01', INTERVAL '1' YEAR)
 ----
 []
 
+query error DataFusion error: Execution error: Cannot generate date range less than 1 day.
+select generate_series(DATE '2000-01-01', DATE '2000-01-03', INTERVAL '1' HOUR)
+
 # Test generate_series with zero step
 query error DataFusion error: Execution error: step can't be 0 for function generate_series\(start \[, stop, step\]\)
 select generate_series(1, 1, 0);
@@ -5849,7 +5852,7 @@ select
 
 # Test generate_series for other edge cases
 query ????
-select 
+select
   generate_series(9223372036854775807, 9223372036854775807, -1) as c1,
   generate_series(9223372036854775807, 9223372036854775807, 1) as c2,
   generate_series(-9223372036854775808, -9223372036854775808, -1) as c3,


### PR DESCRIPTION
## Which issue does this PR close?

closes #11823

## Rationale for this change

Currently, when trying to generate a series of dates with increments less than a day, the query will hang due to loss of precision (the step size becomes 0 relative to the Date32).

## What changes are included in this PR?

* Raise an error if attempting increment by less than a day
* Refactor to use a `ListBuilder`
* A few minor quick-fixes

## Are these changes tested?

Yes, added a test.

## Are there any user-facing changes?

Minor in that queries will now error when they would've hung forever.
