### PR TITLE
test: re-enable window function over parquet with forced collisions

### DIFF
--- a/datafusion/sqllogictest/test_files/parquet.slt
+++ b/datafusion/sqllogictest/test_files/parquet.slt
@@ -251,27 +251,25 @@ SELECT COUNT(*) FROM timestamp_with_tz;
 ----
 131072
 
-# FIXME(#TODO) fails with feature `force_hash_collisions`
-# https://github.com/apache/datafusion/issues/11660
 # Perform the query:
-# query IPT
-# SELECT
-#   count,
-#   LAG(timestamp, 1) OVER (ORDER BY timestamp),
-#   arrow_typeof(LAG(timestamp, 1) OVER (ORDER BY timestamp))
-# FROM timestamp_with_tz
-# LIMIT 10;
-# ----
-# 0 NULL Timestamp(Millisecond, Some("UTC"))
-# 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-# 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-# 4 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-# 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-# 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-# 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-# 14 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-# 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-# 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+query IPT
+SELECT
+  count,
+  LAG(timestamp, 1) OVER (ORDER BY timestamp),
+  arrow_typeof(LAG(timestamp, 1) OVER (ORDER BY timestamp))
+FROM timestamp_with_tz
+LIMIT 10;
+----
+0 NULL Timestamp(Millisecond, Some("UTC"))
+0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+4 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+14 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
 
 # Test config listing_table_ignore_subdirectory:
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11660.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

After several attempts to reproduce the failure locally and in fork CI it still was not reproducing. Also I wasn't able to find any workflow failure related to 1.80 upgrade in PRs and on main. So, trying to just uncomment the test.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Test uncommented.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
