### PR TITLE
Register get_field by default

### DIFF
--- a/datafusion/functions/src/core/mod.rs
+++ b/datafusion/functions/src/core/mod.rs
@@ -94,6 +94,7 @@ pub fn functions() -> Vec<Arc<ScalarUDF>> {
         nvl2(),
         arrow_typeof(),
         named_struct(),
+        get_field(),
         coalesce(),
     ]
 }

--- a/datafusion/sqllogictest/test_files/struct.slt
+++ b/datafusion/sqllogictest/test_files/struct.slt
@@ -72,6 +72,14 @@ select struct(a, b, c)['c1'] from values;
 2.2
 3.3
 
+# explicit invocation of get_field
+query R
+select get_field(struct(a, b, c), 'c1') from values;
+----
+1.1
+2.2
+3.3
+
 # struct scalar function #1
 query ?
 select struct(1, 3.14, 'e');


### PR DESCRIPTION
This makes sense in principle, as all other core udfs are register by default in the context.

It also has a practical use, which is executing logical plans that have field access already de-sugared into get_field invocations.

## Are these changes tested?

Yes

## Are there any user-facing changes?

This is technically user-facing, though there aren't a lot of use cases for actually calling `get_field`.