### PR TITLE
Minor: simplify SQL number parsing and add a comment about unused

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -519,6 +519,10 @@ macro_rules! make_error {
                 }
             }
 
+
+            // Note: Certain macros are used in this  crate, but not all.
+            // This macro generates a use or all of them in case they are needed
+            // so we allow unused code to avoid warnings when they are not used
             #[doc(hidden)]
             #[allow(unused)]
             pub use $NAME_ERR as [<_ $NAME_ERR>];

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -519,12 +519,7 @@ impl<'a> DFParser<'a> {
             Token::SingleQuotedString(s) => Ok(Value::SingleQuotedString(s)),
             Token::DoubleQuotedString(s) => Ok(Value::DoubleQuotedString(s)),
             Token::EscapedStringLiteral(s) => Ok(Value::EscapedStringLiteral(s)),
-            Token::Number(ref n, l) => match n.parse() {
-                Ok(n) => Ok(Value::Number(n, l)),
-                // The tokenizer should have ensured `n` is an integer
-                // so this should not be possible
-                Err(e) => match e {},
-            },
+            Token::Number(n, l) => Ok(Value::Number(n, l)),
             _ => self.parser.expected("string or numeric value", next_token),
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/datafusion/pull/11958

## Rationale for this change

In discussion with @itsjunetime on https://github.com/apache/datafusion/pull/11958 I saw 2 improvements

## What changes are included in this PR?
1. Simplify number parsing (there is no need to `parse` a string
2. Add comment explaining the use of `allow(unused)`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
By CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
