### PR TITLE
Skeleton `concat_elements` implementation for StringViewArray

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary/kernels.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels.rs
@@ -27,7 +27,33 @@ use arrow::datatypes::DataType;
 use datafusion_common::internal_err;
 use datafusion_common::{Result, ScalarValue};
 
+use arrow_schema::ArrowError;
 use std::sync::Arc;
+
+/// Returns the elementwise concatenation of a [`StringViewArary`].
+///
+/// An index of the resulting [`StringViewArray`] is null if any of
+/// `StringViewArary` are null at that location.
+///
+/// ```text
+/// e.g:
+///
+///   ["Hello"] + ["World"] = ["HelloWorld"]
+///
+///   ["a", "b"] + [None, "c"] = [None, "bc"]
+/// ```
+///
+/// An error will be returned if `left` and `right` have different lengths
+///
+/// TODO: port this upstream to arrow-rs (TODO FILE TICKET AND REFERENCE HERE)
+pub fn concat_elements_utf8view(
+    _left: &StringViewArray,
+    _right: &StringViewArray,
+) -> std::result::Result<StringViewArray, ArrowError> {
+    Err(ArrowError::NotYetImplemented(
+        "concat_elements_utf8view".into(),
+    ))
+}
 
 /// Downcasts $LEFT and $RIGHT to $ARRAY_TYPE and then calls $KERNEL($LEFT, $RIGHT)
 macro_rules! call_bitwise_kernel {


### PR DESCRIPTION
## Which issue does this PR close?

related to https://github.com/apache/datafusion/issues/11766

## Rationale for this change

I was trying to write up how to wire up concat_elements for StringView for @dharanad  on https://github.com/apache/datafusion/issues/11766 and I decided it would be easier to make a PR with a template

## What changes are included in this PR?

1. Wire up concat elements into binary.rs for StringViewArray
2. Remove some unecessary macro indirection

## Are these changes tested?
N/A
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
