### PR TITLE
Fix: generate_series function support string type

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -572,6 +572,9 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
+        (Date32, _) if matches!(type_from, Date32 | Utf8 | LargeUtf8 | Null) => {
+            Some(type_into.clone())
+        }
         (Timestamp(TimeUnit::Nanosecond, None), _)
             if matches!(
                 type_from,
@@ -580,7 +583,7 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
-        (Interval(_), _) if matches!(type_from, Utf8 | LargeUtf8) => {
+        (Interval(_), _) if matches!(type_from, Utf8 | LargeUtf8 | Null) => {
             Some(type_into.clone())
         }
         // We can go into a Utf8View from a Utf8 or LargeUtf8

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -572,9 +572,6 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
-        (Date32, _) if matches!(type_from, Date32 | Utf8 | LargeUtf8 | Null) => {
-            Some(type_into.clone())
-        }
         (Timestamp(TimeUnit::Nanosecond, None), _)
             if matches!(
                 type_from,
@@ -583,7 +580,7 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
-        (Interval(_), _) if matches!(type_from, Utf8 | LargeUtf8 | Null) => {
+        (Interval(_), _) if matches!(type_from, Utf8 | LargeUtf8) => {
             Some(type_into.clone())
         }
         // We can go into a Utf8View from a Utf8 or LargeUtf8

--- a/datafusion/functions-nested/src/range.rs
+++ b/datafusion/functions-nested/src/range.rs
@@ -65,8 +65,8 @@ impl ScalarUDFImpl for Range {
         &self.signature
     }
 
-    fn coerce_types(&self, _arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        _arg_types
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        arg_types
             .iter()
             .map(|arg_type| match arg_type {
                 Null => Ok(Null),

--- a/datafusion/functions-nested/src/range.rs
+++ b/datafusion/functions-nested/src/range.rs
@@ -315,7 +315,10 @@ fn gen_range_date(args: &[ArrayRef], include_upper: bool) -> Result<ArrayRef> {
     let values_builder = Date32Builder::new();
     let mut list_builder = ListBuilder::new(values_builder);
 
-    if start_array.unwrap().is_null(0) | stop_array.is_null(0) | step_array.unwrap().is_null(0) {
+    if start_array.unwrap().is_null(0)
+        | stop_array.is_null(0)
+        | step_array.unwrap().is_null(0)
+    {
         list_builder.append_null();
         return Ok(Arc::new(list_builder.finish()));
     }

--- a/datafusion/functions-nested/src/range.rs
+++ b/datafusion/functions-nested/src/range.rs
@@ -27,13 +27,11 @@ use arrow_schema::DataType::*;
 use arrow_schema::IntervalUnit::MonthDayNano;
 use datafusion_common::cast::{as_date32_array, as_int64_array, as_interval_mdn_array};
 use datafusion_common::{exec_err, not_impl_datafusion_err, Result};
-use datafusion_expr::{
-    ColumnarValue, ScalarUDFImpl, Signature, Volatility,
-};
+use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
+use itertools::Itertools;
 use std::any::Any;
 use std::iter::from_fn;
 use std::sync::Arc;
-use itertools::Itertools;
 
 make_udf_expr_and_func!(
     Range,
@@ -68,7 +66,8 @@ impl ScalarUDFImpl for Range {
     }
 
     fn coerce_types(&self, _arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        _arg_types.iter()
+        _arg_types
+            .iter()
             .map(|arg_type| match arg_type {
                 Null => Ok(Null),
                 Int8 => Ok(Int64),
@@ -87,7 +86,8 @@ impl ScalarUDFImpl for Range {
                 Utf8View => Ok(Date32),
                 Interval(_) => Ok(Interval(MonthDayNano)),
                 _ => exec_err!("Unsupported DataType"),
-            }).try_collect()
+            })
+            .try_collect()
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
@@ -153,7 +153,8 @@ impl ScalarUDFImpl for GenSeries {
     }
 
     fn coerce_types(&self, _arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        _arg_types.iter()
+        _arg_types
+            .iter()
             .map(|arg_type| match arg_type {
                 Null => Ok(Null),
                 Int8 => Ok(Int64),
@@ -172,7 +173,8 @@ impl ScalarUDFImpl for GenSeries {
                 Utf8View => Ok(Date32),
                 Interval(_) => Ok(Interval(MonthDayNano)),
                 _ => exec_err!("Unsupported DataType"),
-            }).try_collect()
+            })
+            .try_collect()
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5804,7 +5804,7 @@ select generate_series(5),
 ----
 [0, 1, 2, 3, 4, 5] [2, 3, 4, 5] [2, 5, 8] [1, 2, 3, 4, 5] [5, 4, 3, 2, 1] [10, 7, 4] [1992-09-01, 1992-10-01, 1992-11-01, 1992-12-01, 1993-01-01, 1993-02-01, 1993-03-01] [1993-02-01, 1993-01-31, 1993-01-30, 1993-01-29, 1993-01-28, 1993-01-27, 1993-01-26, 1993-01-25, 1993-01-24, 1993-01-23, 1993-01-22, 1993-01-21, 1993-01-20, 1993-01-19, 1993-01-18, 1993-01-17, 1993-01-16, 1993-01-15, 1993-01-14, 1993-01-13, 1993-01-12, 1993-01-11, 1993-01-10, 1993-01-09, 1993-01-08, 1993-01-07, 1993-01-06, 1993-01-05, 1993-01-04, 1993-01-03, 1993-01-02, 1993-01-01] [1989-04-01, 1990-04-01, 1991-04-01, 1992-04-01]
 
-query error DataFusion error: Error during planning: Error during planning: Coercion from \[Timestamp\(Nanosecond, None\), Timestamp\(Nanosecond, None\), Interval\(MonthDayNano\)\]
+query error DataFusion error: Execution error: Cannot generate date range less than 1 day\.
 select generate_series('2021-01-01'::timestamp, '2021-01-02'::timestamp, INTERVAL '1' HOUR);
 
 ## should return NULL

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5804,7 +5804,7 @@ select generate_series(5),
 ----
 [0, 1, 2, 3, 4, 5] [2, 3, 4, 5] [2, 5, 8] [1, 2, 3, 4, 5] [5, 4, 3, 2, 1] [10, 7, 4] [1992-09-01, 1992-10-01, 1992-11-01, 1992-12-01, 1993-01-01, 1993-02-01, 1993-03-01] [1993-02-01, 1993-01-31, 1993-01-30, 1993-01-29, 1993-01-28, 1993-01-27, 1993-01-26, 1993-01-25, 1993-01-24, 1993-01-23, 1993-01-22, 1993-01-21, 1993-01-20, 1993-01-19, 1993-01-18, 1993-01-17, 1993-01-16, 1993-01-15, 1993-01-14, 1993-01-13, 1993-01-12, 1993-01-11, 1993-01-10, 1993-01-09, 1993-01-08, 1993-01-07, 1993-01-06, 1993-01-05, 1993-01-04, 1993-01-03, 1993-01-02, 1993-01-01] [1989-04-01, 1990-04-01, 1991-04-01, 1992-04-01]
 
-query error DataFusion error: Error during planning: Error during planning: Coercion from.*
+query error DataFusion error: Error during planning: Error during planning: Coercion from \[Timestamp\(Nanosecond, None\), Timestamp\(Nanosecond, None\), Interval\(MonthDayNano\)\]
 select generate_series('2021-01-01'::timestamp, '2021-01-02'::timestamp, INTERVAL '1' HOUR);
 
 ## should return NULL

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5936,12 +5936,12 @@ select generate_series(start, '1993-03-01'::date, INTERVAL '1 year') from date_t
 
 
 # https://github.com/apache/datafusion/issues/11922
-query error
-select generate_series(start, '1993-03-01', INTERVAL '1 year') from date_table;
+query ?
+select generate_series(start, DATE '1993-03-01', INTERVAL '1 year') from date_table;
 ----
-DataFusion error: Internal error: could not cast value to arrow_array::array::primitive_array::PrimitiveArray<arrow_array::types::Date32Type>.
-This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
-
+[1992-01-01, 1993-01-01]
+[1993-02-01]
+[1989-04-01, 1990-04-01, 1991-04-01, 1992-04-01]
 
 ## array_except
 

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5804,7 +5804,7 @@ select generate_series(5),
 ----
 [0, 1, 2, 3, 4, 5] [2, 3, 4, 5] [2, 5, 8] [1, 2, 3, 4, 5] [5, 4, 3, 2, 1] [10, 7, 4] [1992-09-01, 1992-10-01, 1992-11-01, 1992-12-01, 1993-01-01, 1993-02-01, 1993-03-01] [1993-02-01, 1993-01-31, 1993-01-30, 1993-01-29, 1993-01-28, 1993-01-27, 1993-01-26, 1993-01-25, 1993-01-24, 1993-01-23, 1993-01-22, 1993-01-21, 1993-01-20, 1993-01-19, 1993-01-18, 1993-01-17, 1993-01-16, 1993-01-15, 1993-01-14, 1993-01-13, 1993-01-12, 1993-01-11, 1993-01-10, 1993-01-09, 1993-01-08, 1993-01-07, 1993-01-06, 1993-01-05, 1993-01-04, 1993-01-03, 1993-01-02, 1993-01-01] [1989-04-01, 1990-04-01, 1991-04-01, 1992-04-01]
 
-query error DataFusion error: Execution error: unsupported type for range. Expected Int64 or Date32, got: Timestamp\(Nanosecond, None\)
+query error DataFusion error: Error during planning: Error during planning: Coercion from.*
 select generate_series('2021-01-01'::timestamp, '2021-01-02'::timestamp, INTERVAL '1' HOUR);
 
 ## should return NULL
@@ -5936,11 +5936,12 @@ select generate_series(start, '1993-03-01'::date, INTERVAL '1 year') from date_t
 
 
 # https://github.com/apache/datafusion/issues/11922
-query error
+query ?
 select generate_series(start, '1993-03-01', INTERVAL '1 year') from date_table;
 ----
-DataFusion error: Internal error: could not cast value to arrow_array::array::primitive_array::PrimitiveArray<arrow_array::types::Date32Type>.
-This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+[1992-01-01, 1993-01-01]
+[1993-02-01]
+[1989-04-01, 1990-04-01, 1991-04-01, 1992-04-01]
 
 
 ## array_except

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5936,12 +5936,12 @@ select generate_series(start, '1993-03-01'::date, INTERVAL '1 year') from date_t
 
 
 # https://github.com/apache/datafusion/issues/11922
-query ?
-select generate_series(start, DATE '1993-03-01', INTERVAL '1 year') from date_table;
+query error
+select generate_series(start, '1993-03-01', INTERVAL '1 year') from date_table;
 ----
-[1992-01-01, 1993-01-01]
-[1993-02-01]
-[1989-04-01, 1990-04-01, 1991-04-01, 1992-04-01]
+DataFusion error: Internal error: could not cast value to arrow_array::array::primitive_array::PrimitiveArray<arrow_array::types::Date32Type>.
+This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+
 
 ## array_except
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11922.

## Rationale for this change
`generate_series` function does not accept string arguments. 
However, the as-is test provide string  arguments.

I think it would be better if the type signature of `generate_series` was changed.
https://github.com/apache/datafusion/blob/main/datafusion/functions-nested/src/range.rs#L129

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Only sqllogictest

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
