### PR TITLE
Minor: cleanup `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,45 +16,11 @@
 # under the License.
 
 apache-rat-*.jar
-arrow-src.tar
-arrow-src.tar.gz
-
-# Compiled source
-*.a
-*.dll
-*.o
-*.py[ocd]
-*.so
-*.so.*
-*.bundle
-*.dylib
-.build_cache_dir
-dependency-reduced-pom.xml
-MANIFEST
-compile_commands.json
-build.ninja
-
-# Generated Visual Studio files
-*.vcxproj
-*.vcxproj.*
-*.sln
-*.iml
 
 # Linux perf sample data
 perf.data
 perf.data.old
 
-cpp/.idea/
-.clangd/
-cpp/.clangd/
-cpp/apidoc/xml/
-docs/example.gz
-docs/example1.dat
-docs/example3.dat
-python/.eggs/
-python/doc/
-# Egg metadata
-*.egg-info
 
 .vscode
 .idea/
@@ -66,16 +32,9 @@ docker_cache
 .*.swp
 .*.swo
 
-site/
-
-# R files
-**/.Rproj.user
-**/*.Rcheck/
-**/.Rhistory
-.Rproj.user
+venv/*
 
 # macOS
-cpp/Brewfile.lock.json
 .DS_Store
 
 # docker volumes used for caching
@@ -89,9 +48,6 @@ Cargo.lock
 rusty-tags.vi
 .history
 .flatbuffers/
-
-.vscode
-venv/*
 
 # apache release artifacts
 dev/dist


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change


While working on https://github.com/apache/datafusion/pull/12034 I noticed a bunch of stuff in .gitignore that was left over from when this code was pulled from the arrow monorepo: https://github.com/apache/arrow/blob/main/.gitignore



## What changes are included in this PR?

Remove the obviously irrelevant parts of .gitignore

I am sure there is more we could remove but this is an improvement already in my mind

## Are these changes tested?
Sort of by CI

## Are there any user-facing changes?
No, this is entirely development process changes

