### PR TITLE
Move PruningPredicate to physical-optimizer crate

### DIFF
--- a/datafusion/core/src/physical_optimizer/mod.rs
+++ b/datafusion/core/src/physical_optimizer/mod.rs
@@ -29,7 +29,6 @@ pub mod join_selection;
 pub mod limited_distinct_aggregation;
 pub mod optimizer;
 pub mod projection_pushdown;
-pub mod pruning;
 pub mod replace_with_order_preserving_variants;
 pub mod sanity_checker;
 #[cfg(test)]

--- a/datafusion/expr-common/Cargo.toml
+++ b/datafusion/expr-common/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "datafusion-expr-common"
-description = "Logical plan and expression representation for DataFusion query engine"
+description = "Common types and traits for plan and expression representation for DataFusion query engine"
 keywords = ["datafusion", "logical", "plan", "expressions"]
 readme = "README.md"
 version = { workspace = true }

--- a/datafusion/expr-common/src/lib.rs
+++ b/datafusion/expr-common/src/lib.rs
@@ -38,5 +38,3 @@ pub mod operator;
 pub mod signature;
 pub mod sort_properties;
 pub mod type_coercion;
-
-pub use operator::Operator;

--- a/datafusion/expr-common/src/lib.rs
+++ b/datafusion/expr-common/src/lib.rs
@@ -17,9 +17,13 @@
 
 //! Logical Expr types and traits for [DataFusion]
 //!
-//! This crate contains types and traits that are used by both Logical and Physical expressions.
-//! They are kept in their own crate to avoid physical expressions depending on logical expressions.
-//!  
+//! This crate contains types and traits that are used by both Logical and
+//! Physical expressions. They are kept in their own crate to avoid physical
+//! expressions depending on logical expressions.
+//!
+//! Note this crate is not intended to have substantial logic itself, but rather
+//! to provide a common set of types and traits that can be used by both logical
+//! and physical expressions.
 //!
 //! [DataFusion]: <https://crates.io/crates/datafusion>
 
@@ -34,3 +38,5 @@ pub mod operator;
 pub mod signature;
 pub mod sort_properties;
 pub mod type_coercion;
+
+pub use operator::Operator;

--- a/datafusion/physical-optimizer/Cargo.toml
+++ b/datafusion/physical-optimizer/Cargo.toml
@@ -32,7 +32,10 @@ rust-version = { workspace = true }
 workspace = true
 
 [dependencies]
+arrow = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-execution = { workspace = true }
+datafusion-expr-common = { workspace = true }
 datafusion-physical-expr = { workspace = true }
 datafusion-physical-plan = { workspace = true }
+log = { workspace = true }

--- a/datafusion/physical-optimizer/src/lib.rs
+++ b/datafusion/physical-optimizer/src/lib.rs
@@ -23,3 +23,5 @@ mod optimizer;
 pub mod output_requirements;
 
 pub use optimizer::PhysicalOptimizerRule;
+
+pub mod pruning;


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/11502

## Rationale for this change

We are trying to break up pieces the `datafusion` crate into smaller pieces for faster compile time and better modularity. Part of this is the physical optimizer

## What changes are included in this PR?

Move `PruningPredicate` into the physical optimizer crate

## Are these changes tested?

Yes, by existing CI

## Are there any user-facing changes?

No, there are backwards compatible `pub use` that mean no user change are required