### PR TITLE
Fix compilation, change row_number() expr_fn to 0 args

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1710,13 +1710,13 @@ mod tests {
     use datafusion_common::{Constraint, Constraints, ScalarValue};
     use datafusion_common_runtime::SpawnedTask;
     use datafusion_expr::expr::WindowFunction;
-    use datafusion_expr::window_function::row_number;
     use datafusion_expr::{
         cast, create_udf, expr, lit, BuiltInWindowFunction, ExprFunctionExt,
         ScalarFunctionImplementation, Volatility, WindowFrame, WindowFrameBound,
         WindowFrameUnits, WindowFunctionDefinition,
     };
     use datafusion_functions_aggregate::expr_fn::{array_agg, count_distinct};
+    use datafusion_functions_window::expr_fn::row_number;
     use datafusion_physical_expr::expressions::Column;
     use datafusion_physical_plan::{get_plan_string, ExecutionPlanProperties};
     use sqlparser::ast::NullTreatment;

--- a/datafusion/functions-window/src/row_number.rs
+++ b/datafusion/functions-window/src/row_number.rs
@@ -31,8 +31,8 @@ use datafusion_expr::{Expr, PartitionEvaluator, Signature, Volatility, WindowUDF
 
 /// Create a [`WindowFunction`](Expr::WindowFunction) expression for
 /// `row_number` user-defined window function.
-pub fn row_number(args: Vec<Expr>) -> Expr {
-    Expr::WindowFunction(WindowFunction::new(row_number_udwf(), args))
+pub fn row_number() -> Expr {
+    Expr::WindowFunction(WindowFunction::new(row_number_udwf(), vec![]))
 }
 
 /// Singleton instance of `row_number`, ensures the UDWF is only created once.

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -904,7 +904,7 @@ async fn roundtrip_expr_api() -> Result<()> {
             vec![lit(1), lit(2), lit(3)],
             vec![lit(10), lit(20), lit(30)],
         ),
-        row_number(vec![col("a")]),
+        row_number(),
     ];
 
     // ensure expressions created with the expr api can be round tripped


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change

Fix logical conflict between https://github.com/apache/datafusion/pull/12030 and https://github.com/apache/datafusion/pull/12000


## What changes are included in this PR?
1. Update include
2. fix signature of row_number expr_fn to not take arguments

## Are these changes tested?

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
