### PR TITLE
Update async-trait in CLI and catalog crates

### DIFF
--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -31,7 +31,7 @@ readme = "README.md"
 
 [dependencies]
 arrow = { version = "52.2.0" }
-async-trait = "0.1.41"
+async-trait = "0.1.73"
 aws-config = "0.55"
 aws-credential-types = "0.55"
 clap = { version = "3", features = ["derive", "cargo"] }

--- a/datafusion/catalog/Cargo.toml
+++ b/datafusion/catalog/Cargo.toml
@@ -28,7 +28,7 @@ version.workspace = true
 
 [dependencies]
 arrow-schema = { workspace = true }
-async-trait = "0.1.41"
+async-trait = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-execution = { workspace = true }
 datafusion-expr = { workspace = true }


### PR DESCRIPTION
Update async-trait version in CLI and catalog crates and pin to the version defined in the root Cargo file where possible.
