### PR TITLE
FIx VALUES tuples type casts

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -130,6 +130,8 @@ pub struct PlannerContext {
     /// Data types for numbered parameters ($1, $2, etc), if supplied
     /// in `PREPARE` statement
     prepare_param_data_types: Arc<Vec<DataType>>,
+    /// Column types for VALUES tuples during an INSERT.
+    values_column_data_types: Arc<Vec<DataType>>,
     /// Map of CTE name to logical plan of the WITH clause.
     /// Use `Arc<LogicalPlan>` to allow cheap cloning
     ctes: HashMap<String, Arc<LogicalPlan>>,
@@ -151,6 +153,7 @@ impl PlannerContext {
     pub fn new() -> Self {
         Self {
             prepare_param_data_types: Arc::new(vec![]),
+            values_column_data_types: Arc::new(vec![]),
             ctes: HashMap::new(),
             outer_query_schema: None,
             outer_from_schema: None,
@@ -163,6 +166,14 @@ impl PlannerContext {
         prepare_param_data_types: Vec<DataType>,
     ) -> Self {
         self.prepare_param_data_types = prepare_param_data_types.into();
+        self
+    }
+
+    pub fn with_values_column_data_types(
+        mut self,
+        values_column_data_types: Vec<DataType>,
+    ) -> Self {
+        self.values_column_data_types = values_column_data_types.into();
         self
     }
 
@@ -207,6 +218,11 @@ impl PlannerContext {
     /// Return the types of parameters (`$1`, `$2`, etc) if known
     pub fn prepare_param_data_types(&self) -> &[DataType] {
         &self.prepare_param_data_types
+    }
+
+    /// Return the types of columns in VALUES tuples if known
+    pub fn values_column_data_types(&self) -> &[DataType] {
+        &self.values_column_data_types
     }
 
     /// returns true if there is a Common Table Expression (CTE) /

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1468,10 +1468,15 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }
         }
         let prepare_param_data_types = prepare_param_data_types.into_values().collect();
+        let values_column_data_types = fields
+            .iter()
+            .map(|f| f.data_type().clone())
+            .collect::<Vec<_>>();
 
         // Projection
-        let mut planner_context =
-            PlannerContext::new().with_prepare_param_data_types(prepare_param_data_types);
+        let mut planner_context = PlannerContext::new()
+            .with_prepare_param_data_types(prepare_param_data_types)
+            .with_values_column_data_types(values_column_data_types);
         let source = self.query_to_plan(*source, &mut planner_context)?;
         if fields.len() != source.schema().fields().len() {
             plan_err!("Column count doesn't match insert query!")?;

--- a/datafusion/sql/src/values.rs
+++ b/datafusion/sql/src/values.rs
@@ -41,6 +41,11 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     .collect::<Result<Vec<_>>>()
             })
             .collect::<Result<Vec<_>>>()?;
-        LogicalPlanBuilder::values(values)?.build()
+        let column_types = planner_context.values_column_data_types();
+        if column_types.is_empty() {
+            LogicalPlanBuilder::values(values)?.build()
+        } else {
+            LogicalPlanBuilder::values_with_types(values, column_types)?.build()
+        }
     }
 }

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -3195,7 +3195,7 @@ fn lateral_left_join() {
 
 #[test]
 fn lateral_nested_left_join() {
-    let sql = "SELECT * FROM 
+    let sql = "SELECT * FROM
             j1, \
             (j2 LEFT JOIN LATERAL (SELECT * FROM j3 WHERE j1_id + j2_id = j3_id) AS j3 ON(true))";
     let expected = "Projection: *\

--- a/datafusion/sqllogictest/test_files/insert.slt
+++ b/datafusion/sqllogictest/test_files/insert.slt
@@ -433,3 +433,17 @@ drop table test_column_defaults
 
 statement error DataFusion error: Error during planning: Column reference is not allowed in the DEFAULT expression : Schema error: No field named a.
 create table test_column_defaults(a int, b int default a+1)
+
+# test value casting
+statement ok
+create table test_column_insert_cast(
+  a BIGINT UNSIGNED
+);
+
+query I
+insert into test_column_insert_cast(a) values (0), (12775823699315690233);
+----
+2
+
+statement ok
+drop table test_column_insert_cast

--- a/datafusion/sqllogictest/test_files/insert.slt
+++ b/datafusion/sqllogictest/test_files/insert.slt
@@ -255,7 +255,7 @@ insert into table_without_values(id, id) values(3, 3);
 statement error Arrow error: Cast error: Cannot cast string 'zoo' to value of Int64 type
 insert into table_without_values(name, id) values(4, 'zoo');
 
-statement error Error during planning: Column count doesn't match insert query!
+statement error Error during planning: Values list does not match the provided number of data types: got 2 values but expected 1
 insert into table_without_values(id) values(4, 'zoo');
 
 # insert NULL values for the missing column (name)

--- a/datafusion/sqllogictest/test_files/insert_to_external.slt
+++ b/datafusion/sqllogictest/test_files/insert_to_external.slt
@@ -500,7 +500,7 @@ insert into table_without_values(id, id) values(3, 3);
 statement error Arrow error: Cast error: Cannot cast string 'zoo' to value of Int64 type
 insert into table_without_values(name, id) values(4, 'zoo');
 
-statement error Error during planning: Column count doesn't match insert query!
+statement error Error during planning: Values list does not match the provided number of data types: got 2 values but expected 1
 insert into table_without_values(id) values(4, 'zoo');
 
 # insert NULL values for the missing column (name)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12103

## Rationale for this change

The general idea here is to provide the target schema fields to the logical plan builder so that it can avoid the need to guess on VALUES tuple column types.

## What changes are included in this PR?

This updates the SQL planner to accept a list of column data types for VALUE tuple columns which are then used to inform the logical plan builder which types each column should be cast to.

## Are these changes tested?

I've added a test in the sqllogictests crate showing the behavior is fixed. I suspect there will be a request for more tests, but I am uncertain on where they should be placed. I did attempt to try and add a test to the sql crate's tests, but AFAICT those are all stateless which means more specific tests should probably live in the expr crate. However, I wasn't able to find an obviously place to add tests for these changes.

## Are there any user-facing changes?

Some queries that would have previously failed, will no longer fail.
