### PR TITLE
Fix compilation on main

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -399,7 +399,7 @@ impl LogicalPlanBuilder {
     /// Apply a filter which is used for a having clause
     pub fn having(self, expr: impl Into<Expr>) -> Result<Self> {
         let expr = normalize_col(expr.into(), &self.plan)?;
-        Filter::try_new_with_having(expr, Arc::new(self.plan))
+        Filter::try_new_with_having(expr, self.plan)
             .map(LogicalPlan::Filter)
             .map(Self::from)
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Compilaton on main is broken due to a  logical merge conflict between https://github.com/apache/datafusion/pull/12040 and https://github.com/apache/datafusion/pull/12046

```
error[E0308]: mismatched types
   --> datafusion/expr/src/logical_plan/builder.rs:402:52
    |
402 |         Filter::try_new_with_having(expr, Arc::new(self.plan))
    |                                           -------- ^^^^^^^^^ expected `LogicalPlan`, found `Arc<LogicalPlan>`
    |                                           |
    |                                           arguments to this function are incorrect
    |
```

## What changes are included in this PR?

Fix compilation by updating API call

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
