### PR TITLE
Throw `not_impl_error` for `approx_percentile_cont` parameters validation 

### DIFF
--- a/datafusion/functions-aggregate/src/approx_percentile_cont.rs
+++ b/datafusion/functions-aggregate/src/approx_percentile_cont.rs
@@ -154,19 +154,20 @@ fn get_scalar_value(expr: &Arc<dyn PhysicalExpr>) -> Result<ScalarValue> {
 }
 
 fn validate_input_percentile_expr(expr: &Arc<dyn PhysicalExpr>) -> Result<f64> {
-    let percentile = match get_scalar_value(expr)? {
-        ScalarValue::Float32(Some(value)) => {
+    let percentile = match get_scalar_value(expr).ok() {
+        Some(ScalarValue::Float32(Some(value))) => {
             value as f64
         }
-        ScalarValue::Float64(Some(value)) => {
+        Some(ScalarValue::Float64(Some(value))) => {
             value
         }
-        sv => {
+        Some(sv) => {
             return not_impl_err!(
                 "Percentile value for 'APPROX_PERCENTILE_CONT' must be Float32 or Float64 literal (got data type {})",
                 sv.data_type()
             )
-        }
+        },
+        None => return not_impl_err!("Percentile value for 'APPROX_PERCENTILE_CONT' must be a literal"),
     };
 
     // Ensure the percentile is between 0 and 1.
@@ -179,21 +180,22 @@ fn validate_input_percentile_expr(expr: &Arc<dyn PhysicalExpr>) -> Result<f64> {
 }
 
 fn validate_input_max_size_expr(expr: &Arc<dyn PhysicalExpr>) -> Result<usize> {
-    let max_size = match get_scalar_value(expr)? {
-        ScalarValue::UInt8(Some(q)) => q as usize,
-        ScalarValue::UInt16(Some(q)) => q as usize,
-        ScalarValue::UInt32(Some(q)) => q as usize,
-        ScalarValue::UInt64(Some(q)) => q as usize,
-        ScalarValue::Int32(Some(q)) if q > 0 => q as usize,
-        ScalarValue::Int64(Some(q)) if q > 0 => q as usize,
-        ScalarValue::Int16(Some(q)) if q > 0 => q as usize,
-        ScalarValue::Int8(Some(q)) if q > 0 => q as usize,
-        sv => {
+    let max_size = match get_scalar_value(expr).ok() {
+        Some(ScalarValue::UInt8(Some(q))) => q as usize,
+        Some(ScalarValue::UInt16(Some(q))) => q as usize,
+        Some(ScalarValue::UInt32(Some(q))) => q as usize,
+        Some(ScalarValue::UInt64(Some(q))) => q as usize,
+        Some(ScalarValue::Int32(Some(q))) if q > 0 => q as usize,
+        Some(ScalarValue::Int64(Some(q))) if q > 0 => q as usize,
+        Some(ScalarValue::Int16(Some(q))) if q > 0 => q as usize,
+        Some(ScalarValue::Int8(Some(q))) if q > 0 => q as usize,
+        Some(sv) => {
             return not_impl_err!(
                 "Tdigest max_size value for 'APPROX_PERCENTILE_CONT' must be UInt > 0 literal (got data type {}).",
                 sv.data_type()
             )
-        }
+        },
+        None => return not_impl_err!("Tdigest max_size value for 'APPROX_PERCENTILE_CONT' must be a literal"),
     };
 
     Ok(max_size)

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -98,6 +98,12 @@ SELECT approx_percentile_cont(c3, 0.95, 111.1) FROM aggregate_test_100
 statement error DataFusion error: Error during planning: Error during planning: Coercion from \[Float64, Float64, Float64\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont(c12, 0.95, 111.1) FROM aggregate_test_100
 
+statement error DataFusion error: This feature is not implemented: Percentile value for 'APPROX_PERCENTILE_CONT' must be a literal
+SELECT approx_percentile_cont(c12, c12) FROM aggregate_test_100
+
+statement error DataFusion error: This feature is not implemented: Tdigest max_size value for 'APPROX_PERCENTILE_CONT' must be a literal
+SELECT approx_percentile_cont(c12, 0.95, c5) FROM aggregate_test_100
+
 # array agg can use order by
 query ?
 SELECT array_agg(c13 ORDER BY c13)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12012 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
If the `percentile` or `t-digest` is invalid for `approx_percentile_cont`, throw `no_impl_err` with a readable message instead of `internal_error`.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
