### PR TITLE
Minor: add test for panic propagation

### DIFF
--- a/datafusion/common-runtime/src/common.rs
+++ b/datafusion/common-runtime/src/common.rs
@@ -108,4 +108,14 @@ mod tests {
             Err(e) if e.is_cancelled()
         ));
     }
+
+    #[tokio::test]
+    #[should_panic(expected = "foo")]
+    async fn panic_resume() {
+        // this should panic w/o an `unwrap`
+        SpawnedTask::spawn(async { panic!("foo") })
+            .join_unwind()
+            .await
+            .ok();
+    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/datafusion/pull/12086

## Rationale for this change

@crepererum  suggested a  test for an existing panic propagation features here https://github.com/apache/datafusion/pull/12086#discussion_r1728587048

## What changes are included in this PR?

Add test

## Are these changes tested?

Only tests
## Are there any user-facing changes?
Only tests

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
