### PR TITLE
Minor: Add example for configuring SessionContext

### DIFF
--- a/datafusion/core/src/execution/mod.rs
+++ b/datafusion/core/src/execution/mod.rs
@@ -19,6 +19,8 @@
 
 pub mod context;
 pub mod session_state;
+pub use session_state::{SessionState, SessionStateBuilder};
+
 mod session_state_defaults;
 
 pub use session_state_defaults::SessionStateDefaults;


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

While working on the reprpoducer for https://github.com/apache/datafusion/issues/12136 I knew there was a nice builder API added by @Omega359 in #11403 but I couldn't find it quickly in the docs

## What changes are included in this PR?
1. Add new doc example
1. There is a new `pub use` for `SessionStateBuilder`
2. There is a `From` impl for SessionState to make the example nicer

## Are these changes tested?
yes, by doc CI

## Are there any user-facing changes?
Yes, the changes are user facing

here is what the new docs look like


![Screenshot 2024-08-23 at 2 57 34 PM](https://github.com/user-attachments/assets/481ad7e3-a05a-413c-a3fa-056558fd6434)
