### PR TITLE
fix concat dictionary(int32, utf8) bug

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -936,6 +936,9 @@ fn string_concat_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<Da
         (LargeUtf8, from_type) | (from_type, LargeUtf8) => {
             string_concat_internal_coercion(from_type, &LargeUtf8)
         }
+        (Dictionary(_, lhs_value_type), Dictionary(_, rhs_value_type)) => {
+            string_coercion(&lhs_value_type, &rhs_value_type).or(None)
+        }
         _ => None,
     })
 }

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -937,7 +937,7 @@ fn string_concat_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<Da
             string_concat_internal_coercion(from_type, &LargeUtf8)
         }
         (Dictionary(_, lhs_value_type), Dictionary(_, rhs_value_type)) => {
-            string_coercion(&lhs_value_type, &rhs_value_type).or(None)
+            string_coercion(lhs_value_type, rhs_value_type).or(None)
         }
         _ => None,
     })

--- a/datafusion/sqllogictest/test_files/type_coercion.slt
+++ b/datafusion/sqllogictest/test_files/type_coercion.slt
@@ -50,6 +50,35 @@ select interval '1 month' - '2023-05-01'::date;
 query error DataFusion error: Error during planning: Cannot coerce arithmetic expression Interval\(MonthDayNano\) \- Timestamp\(Nanosecond, None\) to valid types
 SELECT interval '1 month' - '2023-05-01 12:30:00'::timestamp;
 
+# dictionary(int32, utf8) -> utf8
+query T
+select arrow_cast('foo', 'Dictionary(Int32, Utf8)') || arrow_cast('bar', 'Dictionary(Int32, Utf8)');
+----
+foobar
+
+# dictionary(int32, largeUtf8) -> largeUtf8
+query T
+select arrow_cast('foo', 'Dictionary(Int32, LargeUtf8)') || arrow_cast('bar', 'Dictionary(Int32, LargeUtf8)');
+----
+foobar
+
+####################################
+## Concat column dictionary test  ##
+####################################
+statement ok
+create table t as values (arrow_cast('foo', 'Dictionary(Int32, Utf8)'), arrow_cast('bar', 'Dictionary(Int32, Utf8)'));
+
+query T
+select column1 || column2 from t;
+----
+foobar
+
+statement ok
+DROP TABLE t
+
+#######################################
+## Concat column dictionary test end ##
+#######################################
 
 ####################################
 ## Test type coercion with UNIONs ##


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12101 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Before this change, query to concat 2 dictionary columns will return error. This PR is to add support for concat dictionary columns in `string_concat_coercion` function.

## What changes are included in this PR?

- [x] Add handler for `string_concat_cocercion` where `lhs` and `rhs` are Dictionary. 
- [x] Update the sqllogictest to match the expectaion. There should be no error when concat columns or values of type Dictionary(int32, utf8) <!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
- [x] The sqllogictest is updated to match the expectation query results.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
