### PR TITLE
Add benchmark for  STDDEV and VAR to Clickbench extended

### DIFF
--- a/benchmarks/queries/clickbench/README.md
+++ b/benchmarks/queries/clickbench/README.md
@@ -58,6 +58,21 @@ LIMIT 10;
 ```
 
 
+### Q3: What is the income distribution for users in specific regions
+
+**Question**: "What regions and social networks have the highest variance of parameter price 
+
+**Important Query Properties**: STDDEV and VAR aggregation functions, GROUP BY multiple small ints
+
+```sql
+SELECT "SocialSourceNetworkID", "RegionID", COUNT(*), AVG("Age"), AVG("ParamPrice"), STDDEV("ParamPrice") as s, VAR("ParamPrice") 
+FROM 'hits.parquet' 
+GROUP BY "SocialSourceNetworkID", "RegionID"  
+HAVING s IS NOT NULL
+ORDER BY s DESC 
+LIMIT 10;
+```
+
 ## Data Notes
 
 Here are some interesting statistics about the data used in the queries

--- a/benchmarks/queries/clickbench/extended.sql
+++ b/benchmarks/queries/clickbench/extended.sql
@@ -1,3 +1,4 @@
 SELECT COUNT(DISTINCT "SearchPhrase"), COUNT(DISTINCT "MobilePhone"), COUNT(DISTINCT "MobilePhoneModel") FROM hits;
 SELECT COUNT(DISTINCT "HitColor"), COUNT(DISTINCT "BrowserCountry"), COUNT(DISTINCT "BrowserLanguage")  FROM hits;
 SELECT "BrowserCountry",  COUNT(DISTINCT "SocialNetwork"), COUNT(DISTINCT "HitColor"), COUNT(DISTINCT "BrowserLanguage"), COUNT(DISTINCT "SocialAction") FROM hits GROUP BY 1 ORDER BY 2 DESC LIMIT 10;
+SELECT "SocialSourceNetworkID", "RegionID", COUNT(*), AVG("Age"), AVG("ParamPrice"), STDDEV("ParamPrice") as s, VAR("ParamPrice")  FROM hits GROUP BY "SocialSourceNetworkID", "RegionID" HAVING s IS NOT NULL ORDER BY s DESC LIMIT 10;


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/12094

## Rationale for this change

@ejbyfeldt's great PR to improve STDDEV and VAR https://github.com/apache/datafusion/pull/12095 did not  had not improve any existing benchmarks. I think it would be good to add one. 

## What changes are included in this PR?
Add a query to the "extended" clickbench queries (that we use to benchmark datafusion) that has stddev and var


## Are these changes tested?
I tested it manually like this:


```shell
./bench.sh run clickbench_extended
```

```
Q0: SELECT COUNT(DISTINCT "SearchPhrase"), COUNT(DISTINCT "MobilePhone"), COUNT(DISTINCT "MobilePhoneModel") FROM hits;
Query 0 iteration 0 took 788.3 ms and returned 1 rows
Query 0 iteration 1 took 723.0 ms and returned 1 rows
Query 0 iteration 2 took 722.1 ms and returned 1 rows
Query 0 iteration 3 took 741.7 ms and returned 1 rows
Query 0 iteration 4 took 744.6 ms and returned 1 rows
Q1: SELECT COUNT(DISTINCT "HitColor"), COUNT(DISTINCT "BrowserCountry"), COUNT(DISTINCT "BrowserLanguage")  FROM hits;
Query 1 iteration 0 took 285.5 ms and returned 1 rows
Query 1 iteration 1 took 256.2 ms and returned 1 rows
Query 1 iteration 2 took 262.2 ms and returned 1 rows
Query 1 iteration 3 took 266.6 ms and returned 1 rows
Query 1 iteration 4 took 277.7 ms and returned 1 rows
Q2: SELECT "BrowserCountry",  COUNT(DISTINCT "SocialNetwork"), COUNT(DISTINCT "HitColor"), COUNT(DISTINCT "BrowserLanguage"), COUNT(DISTINCT "SocialAction") FROM hits GROUP BY 1 ORDER BY 2 DESC LIMIT 10;
Query 2 iteration 0 took 549.7 ms and returned 10 rows
Query 2 iteration 1 took 540.9 ms and returned 10 rows
Query 2 iteration 2 took 611.5 ms and returned 10 rows
Query 2 iteration 3 took 552.7 ms and returned 10 rows
Query 2 iteration 4 took 566.2 ms and returned 10 rows
Q3: SELECT "SocialSourceNetworkID", "RegionID", COUNT(*), AVG("Age"), AVG("ParamPrice"), STDDEV("ParamPrice") as s, VAR("ParamPrice")  FROM hits GROUP BY "SocialSourceNetworkID", "RegionID" HAVING s IS NOT NULL ORDER BY s DESC LIMIT 10;
Query 3 iteration 0 took 419.4 ms and returned 10 rows
Query 3 iteration 1 took 423.5 ms and returned 10 rows
Query 3 iteration 2 took 410.4 ms and returned 10 rows
Query 3 iteration 3 took 402.7 ms and returned 10 rows
Query 3 iteration 4 took 408.4 ms and returned 10 rows
Done
```

## Are there any user-facing changes?

No this is an internal benchmark script