### PR TITLE
Minor: allow to build RuntimeEnv from RuntimeConfig

### DIFF
--- a/datafusion/core/tests/fuzz_cases/sort_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_fuzz.rs
@@ -22,7 +22,7 @@ use arrow::{
     compute::SortOptions,
     record_batch::RecordBatch,
 };
-use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+use datafusion::execution::runtime_env::RuntimeConfig;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::memory::MemoryExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
@@ -136,9 +136,9 @@ impl SortTest {
                     .sort_spill_reservation_bytes,
             );
 
-            let runtime_config = RuntimeConfig::new()
-                .with_memory_pool(Arc::new(GreedyMemoryPool::new(pool_size)));
-            let runtime = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
+            let runtime_env = RuntimeConfig::new()
+                .with_memory_pool(Arc::new(GreedyMemoryPool::new(pool_size))).build();
+            let runtime = Arc::new(runtime_env.unwrap());
             SessionContext::new_with_config_rt(session_config, runtime)
         } else {
             SessionContext::new_with_config(session_config)

--- a/datafusion/core/tests/fuzz_cases/sort_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_fuzz.rs
@@ -137,7 +137,8 @@ impl SortTest {
             );
 
             let runtime_env = RuntimeConfig::new()
-                .with_memory_pool(Arc::new(GreedyMemoryPool::new(pool_size))).build();
+                .with_memory_pool(Arc::new(GreedyMemoryPool::new(pool_size)))
+                .build();
             let runtime = Arc::new(runtime_env.unwrap());
             SessionContext::new_with_config_rt(session_config, runtime)
         } else {

--- a/datafusion/execution/src/runtime_env.rs
+++ b/datafusion/execution/src/runtime_env.rs
@@ -228,4 +228,9 @@ impl RuntimeConfig {
     pub fn with_temp_file_path(self, path: impl Into<PathBuf>) -> Self {
         self.with_disk_manager(DiskManagerConfig::new_specified(vec![path.into()]))
     }
+
+    /// Build a `RuntimeEnv` object from the configuration
+    pub fn build(self) -> Result<RuntimeEnv> {
+        RuntimeEnv::new(self)
+    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12137

## Rationale for this change

Allow to create `RuntimeEnv` directly from the config instance.

## What changes are included in this PR?

- New method
- Changed test to cover this change

## Are these changes tested?

To test this change, I've changed one existing test sort_fuzz to use a new API.

## Are there any user-facing changes?

No