### PR TITLE
benches: add lower benches for stringview

### DIFF
--- a/datafusion/functions/benches/lower.rs
+++ b/datafusion/functions/benches/lower.rs
@@ -17,8 +17,10 @@
 
 extern crate criterion;
 
-use arrow::array::{ArrayRef, StringArray};
-use arrow::util::bench_util::create_string_array_with_len;
+use arrow::array::{ArrayRef, StringArray, StringViewBuilder};
+use arrow::util::bench_util::{
+    create_string_array_with_len, create_string_view_array_with_len,
+};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use datafusion_expr::ColumnarValue;
 use datafusion_functions::string;
@@ -65,6 +67,58 @@ fn create_args3(size: usize) -> Vec<ColumnarValue> {
     vec![ColumnarValue::Array(array)]
 }
 
+/// Create an array of args containing StringViews, where all the values in the
+/// StringViews are ASCII.
+/// * `size` - the length of the StringViews, and
+/// * `str_len` - the length of the strings within the array.
+/// * `null_density` - the density of null values in the array.
+/// * `mixed` - whether the array is mixed between inlined and referenced strings.
+fn create_args4(
+    size: usize,
+    str_len: usize,
+    null_density: f32,
+    mixed: bool,
+) -> Vec<ColumnarValue> {
+    let array = Arc::new(create_string_view_array_with_len(
+        size,
+        null_density,
+        str_len,
+        mixed,
+    ));
+
+    vec![ColumnarValue::Array(array)]
+}
+
+/// Create an array of args containing a StringViewArray, where some of the values in the
+/// array are non-ASCII.
+/// * `size` - the length of the StringArray, and
+/// * `non_ascii_density` - the density of non-ASCII values in the array.
+/// * `null_density` - the density of null values in the array.
+fn create_args5(
+    size: usize,
+    non_ascii_density: f32,
+    null_density: f32,
+) -> Vec<ColumnarValue> {
+    let mut string_view_builder = StringViewBuilder::with_capacity(size);
+    for _ in 0..size {
+        // sample null_density to determine if the value should be null
+        if rand::random::<f32>() < null_density {
+            string_view_builder.append_null();
+            continue;
+        }
+
+        // sample non_ascii_density to determine if the value should be non-ASCII
+        if rand::random::<f32>() < non_ascii_density {
+            string_view_builder.append_value("农历新年农历新年农历新年农历新年农历新年");
+        } else {
+            string_view_builder.append_value("DATAFUSIONDATAFUSIONDATAFUSION");
+        }
+    }
+
+    let array = Arc::new(string_view_builder.finish()) as ArrayRef;
+    vec![ColumnarValue::Array(array)]
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     let lower = string::lower();
     for size in [1024, 4096, 8192] {
@@ -84,6 +138,40 @@ fn criterion_benchmark(c: &mut Criterion) {
             &format!("lower_the_middle_value_is_nonascii: {}", size),
             |b| b.iter(|| black_box(lower.invoke(&args))),
         );
+    }
+
+    let sizes = [4096, 8192];
+    let str_lens = [10, 64, 128];
+    let mixes = [true, false];
+    let null_densities = [0.0f32, 0.1f32];
+
+    for null_density in &null_densities {
+        for &mixed in &mixes {
+            for &str_len in &str_lens {
+                for &size in &sizes {
+                    let args = create_args4(size, str_len, *null_density, mixed);
+                    c.bench_function(
+            &format!("lower_all_values_are_ascii_string_views: size: {}, str_len: {}, null_density: {}, mixed: {}",
+                     size, str_len, null_density, mixed),
+            |b| b.iter(|| black_box(lower.invoke(&args))),
+        );
+
+                    let args = create_args4(size, str_len, *null_density, mixed);
+                    c.bench_function(
+            &format!("lower_all_values_are_ascii_string_views: size: {}, str_len: {}, null_density: {}, mixed: {}",
+                     size, str_len, null_density, mixed),
+            |b| b.iter(|| black_box(lower.invoke(&args))),
+        );
+
+                    let args = create_args5(size, 0.1, *null_density);
+                    c.bench_function(
+            &format!("lower_some_values_are_nonascii_string_views: size: {}, str_len: {}, non_ascii_density: {}, null_density: {}, mixed: {}",
+                     size, str_len, 0.1, null_density, mixed),
+            |b| b.iter(|| black_box(lower.invoke(&args))),
+        );
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Follow up for https://github.com/apache/datafusion/issues/11855.

## Rationale for this change

I updated the impl of upper and lower to support stringview, but didn't update the benchmarks to include stringview cases. This may be useful in the future if certain optimizations can be added.

It does add a number of new cases, so I can trim them if there's general concern about overall benchmark runtime.

## What changes are included in this PR?

Just update the lower benches. I could also update the upper if it's good for completeness, but the lower and upper share 95% of their implementation.

## Are these changes tested?

Yes, ran the benchmarks.

