### PR TITLE
Define current arrow_cast behavior for BinaryView

### DIFF
--- a/datafusion/sqllogictest/test_files/arrow_typeof.slt
+++ b/datafusion/sqllogictest/test_files/arrow_typeof.slt
@@ -102,7 +102,7 @@ query error Error unrecognized word: unknown
 SELECT arrow_cast('1', 'unknown')
 
 # Round Trip tests:
-query TTTTTTTTTTTTTTTTTTTTTTTT
+query TTTTTTTTTTTTTTTTTTTTTTTTT
 SELECT
   arrow_typeof(arrow_cast(1, 'Int8')) as col_i8,
   arrow_typeof(arrow_cast(1, 'Int16')) as col_i16,
@@ -117,6 +117,7 @@ SELECT
   arrow_typeof(arrow_cast(1, 'Float64')) as col_f64,
   arrow_typeof(arrow_cast('foo', 'Utf8')) as col_utf8,
   arrow_typeof(arrow_cast('foo', 'LargeUtf8')) as col_large_utf8,
+  arrow_typeof(arrow_cast('foo', 'Utf8View')) as col_utf8_view,
   arrow_typeof(arrow_cast('foo', 'Binary')) as col_binary,
   arrow_typeof(arrow_cast('foo', 'LargeBinary')) as col_large_binary,
   arrow_typeof(arrow_cast(to_timestamp('2020-01-02 01:01:11.1234567890Z'), 'Timestamp(Second, None)')) as col_ts_s,
@@ -129,7 +130,7 @@ SELECT
   arrow_typeof(arrow_cast(to_timestamp('2020-01-02 01:01:11.1234567890Z'), 'Timestamp(Nanosecond, Some("+08:00"))')) as col_tstz_ns,
   arrow_typeof(arrow_cast('foo', 'Dictionary(Int32, Utf8)')) as col_dict
 ----
-Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64 Float16 Float32 Float64 Utf8 LargeUtf8 Binary LargeBinary Timestamp(Second, None) Timestamp(Millisecond, None) Timestamp(Microsecond, None) Timestamp(Nanosecond, None) Timestamp(Second, Some("+08:00")) Timestamp(Millisecond, Some("+08:00")) Timestamp(Microsecond, Some("+08:00")) Timestamp(Nanosecond, Some("+08:00")) Dictionary(Int32, Utf8)
+Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64 Float16 Float32 Float64 Utf8 LargeUtf8 Utf8View Binary LargeBinary Timestamp(Second, None) Timestamp(Millisecond, None) Timestamp(Microsecond, None) Timestamp(Nanosecond, None) Timestamp(Second, Some("+08:00")) Timestamp(Millisecond, Some("+08:00")) Timestamp(Microsecond, Some("+08:00")) Timestamp(Nanosecond, Some("+08:00")) Dictionary(Int32, Utf8)
 
 
 
@@ -211,21 +212,23 @@ statement ok
 create table foo as select
   arrow_cast('foo', 'Utf8') as col_utf8,
   arrow_cast('foo', 'LargeUtf8') as col_large_utf8,
+  arrow_cast('foo', 'Utf8View') as col_utf8_view,
   arrow_cast('foo', 'Binary') as col_binary,
   arrow_cast('foo', 'LargeBinary') as col_large_binary
 ;
 
 ## Ensure each column in the table has the expected type
 
-query TTTT
+query TTTTT
 SELECT
   arrow_typeof(col_utf8),
   arrow_typeof(col_large_utf8),
+  arrow_typeof(col_utf8_view),
   arrow_typeof(col_binary),
   arrow_typeof(col_large_binary)
   FROM foo;
 ----
-Utf8 LargeUtf8 Binary LargeBinary
+Utf8 LargeUtf8 Utf8View Binary LargeBinary
 
 
 statement ok
@@ -427,6 +430,7 @@ select arrow_cast('MyAwesomeString', 'Utf8View'), arrow_typeof(arrow_cast('MyAwe
 ----
 MyAwesomeString Utf8View
 
-# Fails until we update arrow-rs with support for https://github.com/apache/arrow-rs/pull/5894
-query error DataFusion error: SQL error: ParserError\("Expected: an SQL statement, found: arrow_cast"\)
-arrow_cast('MyAwesomeString', 'BinaryView'), arrow_typeof(arrow_cast('MyAwesomeString', 'BinaryView'))
+# Fails until we update to use the arrow-cast release with support for casting utf8 types to BinaryView
+# refer to merge commit https://github.com/apache/arrow-rs/commit/4bd737dab2aa17aca200259347909d48ed793ba1
+query error DataFusion error: This feature is not implemented: Unsupported CAST from Utf8 to BinaryView
+select arrow_cast('MyAwesomeString', 'BinaryView'), arrow_typeof(arrow_cast('MyAwesomeString', 'BinaryView'))


### PR DESCRIPTION
## Which issue does this PR close?

Follow up to [observation made on this PR](https://github.com/apache/datafusion/pull/12199#discussion_r1733416035).

## Rationale for this change

Test coverage for current behavior of `arrow_cast` with Utf8View and BinaryView types.

The change needed is already in upstream arrow-cast, but not in the current release used in datafusion.

## What changes are included in this PR?

Only test changes. No code changes.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
