### PR TITLE
Fix: Internal error in regexp_replace() for some StringView input

### DIFF
--- a/datafusion/functions/benches/regx.rs
+++ b/datafusion/functions/benches/regx.rs
@@ -18,7 +18,7 @@
 extern crate criterion;
 
 use arrow::array::builder::StringBuilder;
-use arrow::array::{ArrayRef, StringArray};
+use arrow::array::{ArrayRef, AsArray, StringArray};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use datafusion_functions::regex::regexplike::regexp_like;
 use datafusion_functions::regex::regexpmatch::regexp_match;
@@ -123,10 +123,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 regexp_replace::<i32, _, _>(
-                    Arc::clone(&data),
-                    Arc::clone(&regex),
-                    Arc::clone(&replacement),
-                    Some(&Arc::clone(&flags)),
+                    data.as_string::<i32>(),
+                    regex.as_string::<i32>(),
+                    replacement.as_string::<i32>(),
+                    Some(&flags),
                 )
                 .expect("regexp_replace should work on valid values"),
             )

--- a/datafusion/functions/benches/regx.rs
+++ b/datafusion/functions/benches/regx.rs
@@ -122,12 +122,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             black_box(
-                regexp_replace::<i32>(&[
+                regexp_replace::<i32, _, _>(
                     Arc::clone(&data),
                     Arc::clone(&regex),
                     Arc::clone(&replacement),
-                    Arc::clone(&flags),
-                ])
+                    Some(&Arc::clone(&flags)))
                 .expect("regexp_replace should work on valid values"),
             )
         })

--- a/datafusion/functions/benches/regx.rs
+++ b/datafusion/functions/benches/regx.rs
@@ -126,7 +126,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     Arc::clone(&data),
                     Arc::clone(&regex),
                     Arc::clone(&replacement),
-                    Some(&Arc::clone(&flags)))
+                    Some(&Arc::clone(&flags)),
+                )
                 .expect("regexp_replace should work on valid values"),
             )
         })

--- a/datafusion/functions/src/regex/regexpreplace.rs
+++ b/datafusion/functions/src/regex/regexpreplace.rs
@@ -285,9 +285,6 @@ where
 
             Ok(Arc::new(result) as ArrayRef)
         }
-        other => exec_err!(
-            "regexp_replace was called with {other:?} arguments. It requires at least 3 and at most 4."
-        ),
     }
 }
 

--- a/datafusion/functions/src/regex/regexpreplace.rs
+++ b/datafusion/functions/src/regex/regexpreplace.rs
@@ -59,6 +59,7 @@ impl RegexpReplaceFunc {
                     Exact(vec![Utf8, Utf8, Utf8]),
                     Exact(vec![Utf8View, Utf8, Utf8]),
                     Exact(vec![Utf8, Utf8, Utf8, Utf8]),
+                    Exact(vec![Utf8View, Utf8, Utf8, Utf8]),
                 ],
                 Volatility::Immutable,
             ),

--- a/datafusion/functions/src/regex/regexpreplace.rs
+++ b/datafusion/functions/src/regex/regexpreplace.rs
@@ -16,15 +16,15 @@
 // under the License.
 
 //! Regx expressions
-use arrow::array::new_null_array;
 use arrow::array::ArrayAccessor;
 use arrow::array::ArrayDataBuilder;
 use arrow::array::BufferBuilder;
 use arrow::array::GenericStringArray;
 use arrow::array::StringViewBuilder;
+use arrow::array::{new_null_array, ArrayIter, AsArray};
 use arrow::array::{Array, ArrayRef, OffsetSizeTrait};
 use arrow::datatypes::DataType;
-use datafusion_common::cast::as_string_view_array;
+use datafusion_common::cast::{as_string_array, as_string_view_array};
 use datafusion_common::exec_err;
 use datafusion_common::plan_err;
 use datafusion_common::ScalarValue;
@@ -187,27 +187,34 @@ fn regex_replace_posix_groups(replacement: &str) -> String {
 /// # Ok(())
 /// # }
 /// ```
-pub fn regexp_replace<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn regexp_replace<'a, T: OffsetSizeTrait, V, B>(
+    string_array: V,
+    pattern_array: B,
+    replacement_array: B,
+    flags: Option<&ArrayRef>,
+) -> Result<ArrayRef>
+where
+    V: ArrayAccessor<Item = &'a str>,
+    B: ArrayAccessor<Item = &'a str>,
+{
     // Default implementation for regexp_replace, assumes all args are arrays
     // and args is a sequence of 3 or 4 elements.
 
     // creating Regex is expensive so create hashmap for memoization
     let mut patterns: HashMap<String, Regex> = HashMap::new();
 
-    match args.len() {
-        3 => {
-            let string_array = as_generic_string_array::<T>(&args[0])?;
-            let pattern_array = as_generic_string_array::<T>(&args[1])?;
-            let replacement_array = as_generic_string_array::<T>(&args[2])?;
+    let string_array_iter = ArrayIter::new(string_array);
+    let pattern_array_iter = ArrayIter::new(pattern_array);
+    let replacement_array_iter = ArrayIter::new(replacement_array);
 
-            let result = string_array
-            .iter()
-            .zip(pattern_array.iter())
-            .zip(replacement_array.iter())
+    match flags {
+        None => {
+            let result = string_array_iter
+            .zip(pattern_array_iter)
+            .zip(replacement_array_iter)
             .map(|((string, pattern), replacement)| match (string, pattern, replacement) {
                 (Some(string), Some(pattern), Some(replacement)) => {
                     let replacement = regex_replace_posix_groups(replacement);
-
                     // if patterns hashmap already has regexp then use else create and return
                     let re = match patterns.get(pattern) {
                         Some(re) => Ok(re),
@@ -230,16 +237,12 @@ pub fn regexp_replace<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
 
             Ok(Arc::new(result) as ArrayRef)
         }
-        4 => {
-            let string_array = as_generic_string_array::<T>(&args[0])?;
-            let pattern_array = as_generic_string_array::<T>(&args[1])?;
-            let replacement_array = as_generic_string_array::<T>(&args[2])?;
-            let flags_array = as_generic_string_array::<T>(&args[3])?;
+        Some(flags) => {
+            let flags_array = as_generic_string_array::<T>(flags)?;
 
-            let result = string_array
-            .iter()
-            .zip(pattern_array.iter())
-            .zip(replacement_array.iter())
+            let result = string_array_iter
+            .zip(pattern_array_iter)
+            .zip(replacement_array_iter)
             .zip(flags_array.iter())
             .map(|(((string, pattern), replacement), flags)| match (string, pattern, replacement, flags) {
                 (Some(string), Some(pattern), Some(replacement), Some(flags)) => {
@@ -283,7 +286,7 @@ pub fn regexp_replace<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
             Ok(Arc::new(result) as ArrayRef)
         }
         other => exec_err!(
-            "regexp_replace was called with {other} arguments. It requires at least 3 and at most 4."
+            "regexp_replace was called with {other:?} arguments. It requires at least 3 and at most 4."
         ),
     }
 }
@@ -496,7 +499,69 @@ pub fn specialize_regexp_replace<T: OffsetSizeTrait>(
                 .iter()
                 .map(|arg| arg.clone().into_array(inferred_length))
                 .collect::<Result<Vec<_>>>()?;
-            regexp_replace::<T>(&args)
+
+            match args[0].data_type() {
+                DataType::Utf8View => {
+                    let string_array = args[0].as_string_view();
+                    let pattern_array = args[1].as_string::<i32>();
+                    let replacement_array = args[2].as_string::<i32>();
+                    let regexp_replace_result = regexp_replace::<i32, _, _>(
+                        string_array,
+                        pattern_array,
+                        replacement_array,
+                        args.get(3),
+                    )?;
+
+                    if regexp_replace_result.data_type() == &DataType::Utf8 {
+                        let string_view_array =
+                            as_string_array(&regexp_replace_result)?.to_owned();
+
+                        let mut builder =
+                            StringViewBuilder::with_capacity(string_view_array.len())
+                                .with_block_size(1024 * 1024 * 2);
+
+                        for val in string_view_array.iter() {
+                            if let Some(val) = val {
+                                builder.append_value(val);
+                            } else {
+                                builder.append_null();
+                            }
+                        }
+
+                        let result = builder.finish();
+                        Ok(Arc::new(result) as ArrayRef)
+                    } else {
+                        Ok(regexp_replace_result)
+                    }
+                }
+                DataType::Utf8 => {
+                    let string_array = args[0].as_string::<i32>();
+                    let pattern_array = args[1].as_string::<i32>();
+                    let replacement_array = args[2].as_string::<i32>();
+                    regexp_replace::<i32, _, _>(
+                        string_array,
+                        pattern_array,
+                        replacement_array,
+                        args.get(3),
+                    )
+                }
+                DataType::LargeUtf8 => {
+                    let string_array = args[0].as_string::<i64>();
+                    let pattern_array = args[1].as_string::<i64>();
+                    let replacement_array = args[2].as_string::<i64>();
+                    regexp_replace::<i64, _, _>(
+                        string_array,
+                        pattern_array,
+                        replacement_array,
+                        args.get(3),
+                    )
+                }
+                other => {
+                    exec_err!(
+                        "Unsupported data type {other:?} for function regex_replace"
+                    )
+                }
+            }
         }
     }
 }

--- a/datafusion/sqllogictest/test_files/string_view.slt
+++ b/datafusion/sqllogictest/test_files/string_view.slt
@@ -473,10 +473,32 @@ Xiangpfng
 Raphafl
 NULL
 
+# Should run REGEXP_REPLACE with Scalar value for utf8view with flag
+query T
+SELECT
+  REGEXP_REPLACE(column1_utf8view, 'e', 'f', 'i') AS k
+FROM test;
+----
+Andrfw
+Xiangpfng
+Raphafl
+NULL
+
 # Should run REGEXP_REPLACE with Scalar value for utf8
 query T
 SELECT
   REGEXP_REPLACE(column1_utf8, 'e', 'f') AS k
+FROM test;
+----
+Andrfw
+Xiangpfng
+Raphafl
+NULL
+
+# Should run REGEXP_REPLACE with Scalar value for utf8 with flag
+query T
+SELECT
+  REGEXP_REPLACE(column1_utf8, 'e', 'f', 'i') AS k
 FROM test;
 ----
 Andrfw
@@ -495,10 +517,32 @@ Xiangpeng
 Raphael
 NULL
 
+# Should run REGEXP_REPLACE with ScalarArray value for utf8view with flag
+query T
+SELECT
+  REGEXP_REPLACE(column1_utf8view, lower(column1_utf8view), 'bar', 'g') AS k
+FROM test;
+----
+Andrew
+Xiangpeng
+Raphael
+NULL
+
 # Should run REGEXP_REPLACE with ScalarArray value for utf8
 query T
 SELECT
   REGEXP_REPLACE(column1_utf8, lower(column1_utf8), 'bar') AS k
+FROM test;
+----
+Andrew
+Xiangpeng
+Raphael
+NULL
+
+# Should run REGEXP_REPLACE with ScalarArray value for utf8 with flag
+query T
+SELECT
+  REGEXP_REPLACE(column1_utf8, lower(column1_utf8), 'bar', 'g') AS k
 FROM test;
 ----
 Andrew

--- a/datafusion/sqllogictest/test_files/string_view.slt
+++ b/datafusion/sqllogictest/test_files/string_view.slt
@@ -460,6 +460,52 @@ Xiangpeng
 Raphael
 NULL
 
+### Test REGEXP_REPLACE
+
+# Should run REGEXP_REPLACE with Scalar value for utf8view
+query T
+SELECT
+  REGEXP_REPLACE(column1_utf8view, 'e', 'f') AS k
+FROM test;
+----
+Andrfw
+Xiangpfng
+Raphafl
+NULL
+
+# Should run REGEXP_REPLACE with Scalar value for utf8
+query T
+SELECT
+  REGEXP_REPLACE(column1_utf8, 'e', 'f') AS k
+FROM test;
+----
+Andrfw
+Xiangpfng
+Raphafl
+NULL
+
+# Should run REGEXP_REPLACE with ScalarArray value for utf8view
+query T
+SELECT
+  REGEXP_REPLACE(column1_utf8view, lower(column1_utf8view), 'bar') AS k
+FROM test;
+----
+Andrew
+Xiangpeng
+Raphael
+NULL
+
+# Should run REGEXP_REPLACE with ScalarArray value for utf8
+query T
+SELECT
+  REGEXP_REPLACE(column1_utf8, lower(column1_utf8), 'bar') AS k
+FROM test;
+----
+Andrew
+Xiangpeng
+Raphael
+NULL
+
 ### Initcap
 
 query TT


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12150 & closes #11912 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Currently the StringView data type cannot be cast to`as_generic_string_array`. The changes here resolve that: https://github.com/apache/datafusion/pull/12203/files#diff-0007996e12eb1b2e63363974424f13330f85a7fc48e0c55381f8a30a0f372931R206

Another point of issue was in the `return_type` match statement when using a function within the query on `Utf8View` that appears to be returning a ScalarArray of `StringArray` 

For example:

```
SELECT
  REGEXP_REPLACE(column1_utf8view, lower(column1_utf8view), 'bar') AS k
FROM test;
```

`lower(column1_utf8view)` would return a `StringArray` instead of a `StringViewArray` which would cause the result of  the query to return a `StringArray`. For now I am implementing a conversion step https://github.com/apache/datafusion/pull/12203/files#diff-0007996e12eb1b2e63363974424f13330f85a7fc48e0c55381f8a30a0f372931R516 to coerce the return value in to being a StringView as required by the signatures.

I think this is okay. Would love to work on optimizing/making this code better if possible though. For now this appears to be the path forward for the error I was seeing. 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
