### PR TITLE
Support StringView for binary operators

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -986,7 +986,10 @@ fn string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType>
 
 /// This will be deprecated when binary operators native support
 /// for Utf8View (use `string_coercion` instead).
-fn regex_comparison_string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
+fn regex_comparison_string_coercion(
+    lhs_type: &DataType,
+    rhs_type: &DataType,
+) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
     match (lhs_type, rhs_type) {
         // If Utf8View is in any side, we coerce to Utf8.

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -984,6 +984,23 @@ fn string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType>
     }
 }
 
+/// This will be deprecated when binary operators native support
+/// for Utf8View (use `string_coercion` instead).
+fn regex_comparison_string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
+    use arrow::datatypes::DataType::*;
+    match (lhs_type, rhs_type) {
+        // If Utf8View is in any side, we coerce to Utf8.
+        (Utf8View, Utf8View | Utf8 | LargeUtf8) | (Utf8 | LargeUtf8, Utf8View) => {
+            Some(Utf8)
+        }
+        // Then, if LargeUtf8 is in any side, we coerce to LargeUtf8.
+        (LargeUtf8, Utf8 | LargeUtf8) | (Utf8, LargeUtf8) => Some(LargeUtf8),
+        // Utf8 coerces to Utf8
+        (Utf8, Utf8) => Some(Utf8),
+        _ => None,
+    }
+}
+
 fn numeric_string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
     match (lhs_type, rhs_type) {
@@ -1072,10 +1089,10 @@ fn regex_null_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataT
     }
 }
 
-/// coercion rules for regular expression comparison operations.
+/// Coercion rules for regular expression comparison operations.
 /// This is a union of string coercion rules and dictionary coercion rules
 pub fn regex_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
-    string_coercion(lhs_type, rhs_type)
+    regex_comparison_string_coercion(lhs_type, rhs_type)
         .or_else(|| dictionary_comparison_coercion(lhs_type, rhs_type, false))
         .or_else(|| regex_null_coercion(lhs_type, rhs_type))
 }

--- a/datafusion/functions/benches/repeat.rs
+++ b/datafusion/functions/benches/repeat.rs
@@ -67,7 +67,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, repeat_times, true);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_string_view [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -76,7 +76,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, repeat_times, false);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -85,7 +85,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i64>(size, 32, repeat_times, false);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_large_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -103,7 +103,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, repeat_times, true);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_string_view [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -112,7 +112,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, repeat_times, false);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -121,7 +121,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i64>(size, 32, repeat_times, false);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_large_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),

--- a/datafusion/functions/benches/substr.rs
+++ b/datafusion/functions/benches/substr.rs
@@ -106,19 +106,19 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args_without_count::<i32>(size, len, true, true);
         group.bench_function(
-            &format!("substr_string_view [size={}, strlen={}]", size, len),
+            format!("substr_string_view [size={}, strlen={}]", size, len),
             |b| b.iter(|| black_box(substr.invoke(&args))),
         );
 
         let args = create_args_without_count::<i32>(size, len, false, false);
         group.bench_function(
-            &format!("substr_string [size={}, strlen={}]", size, len),
+            format!("substr_string [size={}, strlen={}]", size, len),
             |b| b.iter(|| black_box(substr.invoke(&args))),
         );
 
         let args = create_args_without_count::<i64>(size, len, true, false);
         group.bench_function(
-            &format!("substr_large_string [size={}, strlen={}]", size, len),
+            format!("substr_large_string [size={}, strlen={}]", size, len),
             |b| b.iter(|| black_box(substr.invoke(&args))),
         );
 
@@ -133,7 +133,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args_with_count::<i32>(size, len, count, true);
         group.bench_function(
-            &format!(
+            format!(
                 "substr_string_view [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
@@ -142,7 +142,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args_with_count::<i32>(size, len, count, false);
         group.bench_function(
-            &format!(
+            format!(
                 "substr_string [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
@@ -151,7 +151,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args_with_count::<i64>(size, len, count, false);
         group.bench_function(
-            &format!(
+            format!(
                 "substr_large_string [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
@@ -169,7 +169,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args_with_count::<i32>(size, len, count, true);
         group.bench_function(
-            &format!(
+            format!(
                 "substr_string_view [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
@@ -178,7 +178,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args_with_count::<i32>(size, len, count, false);
         group.bench_function(
-            &format!(
+            format!(
                 "substr_string [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
@@ -187,7 +187,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args_with_count::<i64>(size, len, count, false);
         group.bench_function(
-            &format!(
+            format!(
                 "substr_large_string [size={}, count={}, strlen={}]",
                 size, count, len,
             ),

--- a/datafusion/functions/src/regex/regexpmatch.rs
+++ b/datafusion/functions/src/regex/regexpmatch.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Regx expressions
+//! Regex expressions
 use arrow::array::{Array, ArrayRef, OffsetSizeTrait};
 use arrow::compute::kernels::regexp;
 use arrow::datatypes::DataType;
@@ -49,6 +49,10 @@ impl RegexpMatchFunc {
         Self {
             signature: Signature::one_of(
                 vec![
+                    // Planner attempts coercion to the target type starting with the most preferred candidate.
+                    // For example, given input `(Utf8View, Utf8)`, it first tries coercing to `(Utf8, Utf8)`.
+                    // If that fails, it proceeds to `(LargeUtf8, Utf8)`.
+                    // TODO: Native support Utf8View for regexp_match.
                     Exact(vec![Utf8, Utf8]),
                     Exact(vec![LargeUtf8, Utf8]),
                     Exact(vec![Utf8, Utf8, Utf8]),

--- a/datafusion/sqllogictest/test_files/string_view.slt
+++ b/datafusion/sqllogictest/test_files/string_view.slt
@@ -1226,42 +1226,82 @@ NULL NULL NULL
 # `~` operator (regex match)
 query TT
 EXPLAIN SELECT
-  column1_utf8view ~ 'foo' AS c1
+  column1_utf8view ~ 'an' AS c1
 FROM test;
 ----
 logical_plan
-01)Projection: CAST(test.column1_utf8view AS Utf8) LIKE Utf8("%foo%") AS c1
+01)Projection: CAST(test.column1_utf8view AS Utf8) LIKE Utf8("%an%") AS c1
 02)--TableScan: test projection=[column1_utf8view]
+
+query B
+SELECT
+  column1_utf8view ~ 'an' AS c1
+FROM test;
+----
+false
+true
+false
+NULL
 
 # `~*` operator (regex match case-insensitive)
 query TT
 EXPLAIN SELECT
-  column1_utf8view ~* 'foo' AS c1
+  column1_utf8view ~* '^a.{3}e' AS c1
 FROM test;
 ----
 logical_plan
-01)Projection: CAST(test.column1_utf8view AS Utf8) ILIKE Utf8("%foo%") AS c1
+01)Projection: CAST(test.column1_utf8view AS Utf8) ~* Utf8("^a.{3}e") AS c1
 02)--TableScan: test projection=[column1_utf8view]
+
+query B
+SELECT
+  column1_utf8view ~* '^a.{3}e' AS c1
+FROM test;
+----
+true
+false
+false
+NULL
 
 # `!~~` operator (not like match)
 query TT
 EXPLAIN SELECT
-  column1_utf8view !~~ 'an' AS c1
+  column1_utf8view !~~ 'xia_g%g' AS c1
 FROM test;
 ----
 logical_plan
-01)Projection: CAST(test.column1_utf8view AS Utf8) !~~ Utf8("an") AS c1
+01)Projection: CAST(test.column1_utf8view AS Utf8) !~~ Utf8("xia_g%g") AS c1
 02)--TableScan: test projection=[column1_utf8view]
+
+query B
+SELECT
+  column1_utf8view !~~ 'xia_g%g' AS c1
+FROM test;
+----
+true
+true
+true
+NULL
 
 # `!~~*` operator (not like match case-insensitive)
 query TT
 EXPLAIN SELECT
-  column1_utf8view !~~* 'an' AS c1
+  column1_utf8view !~~* 'xia_g%g' AS c1
 FROM test;
 ----
 logical_plan
-01)Projection: CAST(test.column1_utf8view AS Utf8) !~~* Utf8("an") AS c1
+01)Projection: CAST(test.column1_utf8view AS Utf8) !~~* Utf8("xia_g%g") AS c1
 02)--TableScan: test projection=[column1_utf8view]
+
+query B
+SELECT
+  column1_utf8view !~~* 'xia_g%g' AS c1
+FROM test;
+----
+true
+false
+true
+NULL
 
 statement ok
 drop table test;

--- a/datafusion/sqllogictest/test_files/string_view.slt
+++ b/datafusion/sqllogictest/test_files/string_view.slt
@@ -1040,7 +1040,6 @@ Rap  (empty) Raph
 NULL NULL    NULL
 
 ## Ensure no casts for RPAD
-## TODO file ticket
 query TT
 EXPLAIN SELECT
   RPAD(column1_utf8view, 1) as c1,
@@ -1070,7 +1069,6 @@ logical_plan
 02)--TableScan: test projection=[column1_utf8view, column2_utf8view]
 
 ## Ensure no casts for SPLIT_PART
-## TODO file ticket
 query TT
 EXPLAIN SELECT
   SPLIT_PART(column1_utf8view, 'f', 1) as c1,
@@ -1082,7 +1080,6 @@ logical_plan
 02)--TableScan: test projection=[column1_utf8view]
 
 ## Ensure no casts for STRPOS
-## TODO file ticket
 query TT
 EXPLAIN SELECT
   STRPOS(column1_utf8view, 'f') as c,
@@ -1094,7 +1091,6 @@ logical_plan
 02)--TableScan: test projection=[column1_utf8view, column2_utf8view]
 
 ## Ensure no casts for SUBSTR
-## TODO file ticket
 query TT
 EXPLAIN SELECT
   SUBSTR(column1_utf8view, 1) as c,
@@ -1224,6 +1220,48 @@ AndrewAndrew AndrewAndrew AndrewAndrew
 XiangpengXiangpeng XiangpengXiangpeng XiangpengXiangpeng
 RaphaelRaphael RaphaelRaphael RaphaelRaphael
 NULL NULL NULL
+
+## Ensure no casts for binary operators
+## TODO: https://github.com/apache/datafusion/issues/12180
+# `~` operator (regex match)
+query TT
+EXPLAIN SELECT
+  column1_utf8view ~ 'foo' AS c1
+FROM test;
+----
+logical_plan
+01)Projection: CAST(test.column1_utf8view AS Utf8) LIKE Utf8("%foo%") AS c1
+02)--TableScan: test projection=[column1_utf8view]
+
+# `~*` operator (regex match case-insensitive)
+query TT
+EXPLAIN SELECT
+  column1_utf8view ~* 'foo' AS c1
+FROM test;
+----
+logical_plan
+01)Projection: CAST(test.column1_utf8view AS Utf8) ILIKE Utf8("%foo%") AS c1
+02)--TableScan: test projection=[column1_utf8view]
+
+# `!~~` operator (not like match)
+query TT
+EXPLAIN SELECT
+  column1_utf8view !~~ 'an' AS c1
+FROM test;
+----
+logical_plan
+01)Projection: CAST(test.column1_utf8view AS Utf8) !~~ Utf8("an") AS c1
+02)--TableScan: test projection=[column1_utf8view]
+
+# `!~~*` operator (not like match case-insensitive)
+query TT
+EXPLAIN SELECT
+  column1_utf8view !~~* 'an' AS c1
+FROM test;
+----
+logical_plan
+01)Projection: CAST(test.column1_utf8view AS Utf8) !~~* Utf8("an") AS c1
+02)--TableScan: test projection=[column1_utf8view]
 
 statement ok
 drop table test;


### PR DESCRIPTION
## Which issue does this PR close?
Part of #12180.
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

## Rationale for this change
Support StringView for binary operators like `~`, `!~`, etc.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
If Utf8View is in any side of binary operators, we COERCE to Utf8. This behaviour will remain until native StringView support is implemented.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
