### PR TITLE
Confirming UDF aliases are serialized correctly 

### DIFF
--- a/datafusion/proto/tests/cases/mod.rs
+++ b/datafusion/proto/tests/cases/mod.rs
@@ -34,12 +34,17 @@ struct MyRegexUdf {
     signature: Signature,
     // regex as original string
     pattern: String,
+    aliases: Vec<String>,
 }
 
 impl MyRegexUdf {
     fn new(pattern: String) -> Self {
         let signature = Signature::exact(vec![DataType::Utf8], Volatility::Immutable);
-        Self { signature, pattern }
+        Self {
+            signature,
+            pattern,
+            aliases: vec!["aggregate_udf_alias".to_string()],
+        }
     }
 }
 
@@ -66,6 +71,9 @@ impl ScalarUDFImpl for MyRegexUdf {
         _args: &[ColumnarValue],
     ) -> datafusion_common::Result<ColumnarValue> {
         unimplemented!()
+    }
+    fn aliases(&self) -> &[String] {
+        &self.aliases
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

I had created https://github.com/apache/datafusion/issues/11595 which I had created when working on  https://github.com/apache/datafusion/pull/11013 

When I was using `create_aggregate_expr`, aliases for max_udaf wouldn't be serialized, as indicated in #11595 . However, using the `AggregateExprBuilder` solved the problem, so the issue was probably in `create_aggregate_expr` , which by the way has been removed from the codebase, so we need to update the contributors how-to
https://github.com/apache/datafusion/blob/main/docs/source/contributor-guide/howtos.md?plain=1#L62