### PR TITLE
Fix Possible Congestion Scenario in SPM

### DIFF
--- a/datafusion/core/tests/fuzz_cases/merge_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/merge_fuzz.rs
@@ -285,6 +285,7 @@ impl Stream for CongestedStream {
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
+        println!("asd");
         match self.partition {
             0 => {
                 let cleared = self.congestion_cleared.lock().unwrap();
@@ -347,10 +348,9 @@ async fn test_spm_congestion() -> Result<()> {
         )],
         Arc::new(source),
     );
-    let spm_task =
-        SpawnedTask::spawn(async move { collect(Arc::new(spm), task_ctx).await });
+    let spm_task = SpawnedTask::spawn(collect(Arc::new(spm), task_ctx));
 
-    let result = timeout(Duration::from_secs(10), spm_task.join()).await;
+    let result = timeout(Duration::from_secs(5), spm_task.join()).await;
     match result {
         Ok(Ok(Ok(_batches))) => Ok(()),
         Ok(Ok(Err(e))) => Err(e),

--- a/datafusion/core/tests/fuzz_cases/merge_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/merge_fuzz.rs
@@ -350,7 +350,7 @@ async fn test_spm_congestion() -> Result<()> {
     let spm_task =
         SpawnedTask::spawn(async move { collect(Arc::new(spm), task_ctx).await });
 
-    let result = timeout(Duration::from_secs(1), spm_task.join()).await;
+    let result = timeout(Duration::from_secs(10), spm_task.join()).await;
     match result {
         Ok(Ok(Ok(_batches))) => Ok(()),
         Ok(Ok(Err(e))) => Err(e),

--- a/datafusion/physical-plan/src/sorts/merge.rs
+++ b/datafusion/physical-plan/src/sorts/merge.rs
@@ -190,7 +190,9 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
                 if self.uninitiated_cursors.is_empty() {
                     break;
                 }
-                return Poll::Pending;
+                if return_pending {
+                    return Poll::Pending;
+                }
             }
             self.init_loser_tree();
         }

--- a/datafusion/physical-plan/src/sorts/merge.rs
+++ b/datafusion/physical-plan/src/sorts/merge.rs
@@ -18,19 +18,23 @@
 //! Merge that deals with an arbitrary size of streaming inputs.
 //! This is an order-preserving merge.
 
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{ready, Context, Poll};
+
 use crate::metrics::BaselineMetrics;
 use crate::sorts::builder::BatchBuilder;
 use crate::sorts::cursor::{Cursor, CursorValues};
 use crate::sorts::stream::PartitionedStream;
 use crate::RecordBatchStream;
+
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use datafusion_common::Result;
 use datafusion_execution::memory_pool::MemoryReservation;
+
 use futures::Stream;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{ready, Context, Poll};
+use hashbrown::HashSet;
 
 /// A fallible [`PartitionedStream`] of [`Cursor`] and [`RecordBatch`]
 type CursorStream<C> = Box<dyn PartitionedStream<Output = Result<(C, RecordBatch)>>>;
@@ -97,6 +101,9 @@ pub(crate) struct SortPreservingMergeStream<C: CursorValues> {
 
     /// number of rows produced
     produced: usize,
+
+    /// Cursors which are not initialized yet
+    uninitiated_cursors: HashSet<usize>,
 }
 
 impl<C: CursorValues> SortPreservingMergeStream<C> {
@@ -121,6 +128,7 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
             batch_size,
             fetch,
             produced: 0,
+            uninitiated_cursors: (0..stream_count).collect(),
         }
     }
 
@@ -138,9 +146,13 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
         }
 
         match futures::ready!(self.streams.poll_next(cx, idx)) {
-            None => Poll::Ready(Ok(())),
+            None => {
+                self.uninitiated_cursors.retain(|&x| x != idx);
+                Poll::Ready(Ok(()))
+            }
             Some(Err(e)) => Poll::Ready(Err(e)),
             Some(Ok((cursor, batch))) => {
+                self.uninitiated_cursors.retain(|&x| x != idx);
                 self.cursors[idx] = Some(Cursor::new(cursor));
                 Poll::Ready(self.in_progress.push_batch(idx, batch))
             }
@@ -158,11 +170,27 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
         if self.loser_tree.is_empty() {
             // Ensure all non-exhausted streams have a cursor from which
             // rows can be pulled
-            for i in 0..self.streams.partitions() {
-                if let Err(e) = ready!(self.maybe_poll_stream(cx, i)) {
-                    self.aborted = true;
-                    return Poll::Ready(Some(Err(e)));
+            loop {
+                let mut return_pending = false;
+                let uninitiated_cursors = self.uninitiated_cursors.clone();
+                for i in uninitiated_cursors {
+                    if self.uninitiated_cursors.contains(&i) {
+                        match self.maybe_poll_stream(cx, i) {
+                            Poll::Ready(Err(e)) => {
+                                self.aborted = true;
+                                return Poll::Ready(Some(Err(e)));
+                            }
+                            Poll::Pending => {
+                                return_pending = true;
+                            }
+                            _ => {}
+                        }
+                    }
                 }
+                if self.uninitiated_cursors.is_empty() {
+                    break;
+                }
+                return Poll::Pending;
             }
             self.init_loser_tree();
         }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

During the initialization of cursors of SPM (`SortPreservingMergeExec`), it needs to get `Poll::Ready()` for each partition, to initiate the next partition cursor. We have experienced a scenario in our downstream where SPM is polling 1st partition continuously but never get a `Poll::Ready()`. Those polls get all upstream operator buffers and channels grow. However, if SPM have skipped that partition and tried to initiate other partitions before retry, we did not experience this problem (congestion in partition 1 is cleared once the other partitions are pulled).

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

SPM does not wait initiating the next cursor partition. Instead, it iterates over all partitions continuously whether it is OK or not, until they are all successfully initiated.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, with a unit test. The test depends on a timeout duration to sense deadlock but I could also add a memory usage test.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
