### PR TITLE
Minor: Reuse `NamePreserver` in `SimplifyExpressions`

### DIFF
--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -297,6 +297,8 @@ impl NamePreserver {
     /// Create a new NamePreserver for rewriting the `expr` that is part of the specified plan
     pub fn new(plan: &LogicalPlan) -> Self {
         Self {
+            // The schema of Filter and Join nodes comes from their inputs rather than their output expressions,
+            // so there is no need to use aliases to preserve expression names.
             use_alias: !matches!(plan, LogicalPlan::Filter(_) | LogicalPlan::Join(_)),
         }
     }

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -27,6 +27,7 @@ use datafusion_expr::simplify::SimplifyContext;
 use datafusion_expr::utils::merge_schema;
 
 use crate::optimizer::ApplyOrder;
+use crate::utils::NamePreserver;
 use crate::{OptimizerConfig, OptimizerRule};
 
 use super::ExprSimplifier;
@@ -119,18 +120,13 @@ impl SimplifyExpressions {
             simplifier
         };
 
-        // the output schema of a filter or join is the input schema. Thus they
-        // can't handle aliased expressions
-        let use_alias = !matches!(plan, LogicalPlan::Filter(_) | LogicalPlan::Join(_));
+        // Preserve expression names to avoid changing the schema of the plan.
+        let name_preserver = NamePreserver::new(&plan);
         plan.map_expressions(|e| {
-            let new_e = if use_alias {
-                // TODO: unify with `rewrite_preserving_name`
-                let original_name = e.name_for_alias()?;
-                simplifier.simplify(e)?.alias_if_changed(original_name)
-            } else {
-                simplifier.simplify(e)
-            }?;
-
+            let original_name = name_preserver.save(&e)?;
+            let new_e = simplifier
+                .simplify(e)
+                .and_then(|expr| original_name.restore(expr))?;
             // TODO it would be nice to have a way to know if the expression was simplified
             // or not. For now conservatively return Transformed::yes
             Ok(Transformed::yes(new_e))


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change
The code for preserving expr names here is the same as  `NamePreserver` so `NamePreserver` can be reused directly.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. By existing tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
