### PR TITLE
Implement SHOW FUNCTIONS

### DIFF
--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -62,6 +62,7 @@ pub mod explain_analyze;
 pub mod joins;
 mod path_partition;
 pub mod select;
+pub mod show;
 mod sql_api;
 
 async fn register_aggregate_csv_by_sql(ctx: &SessionContext) {

--- a/datafusion/core/tests/sql/show.rs
+++ b/datafusion/core/tests/sql/show.rs
@@ -22,7 +22,6 @@ use std::collections::HashSet;
 async fn test_show_functions() {
     let ctx = SessionContext::new();
     let result = execute(&ctx, "SHOW FUNCTIONS").await;
-    println!("{:?}", result);
     assert!(!result.is_empty(), "result is empty");
     let names: HashSet<String> = result
         .into_iter()

--- a/datafusion/core/tests/sql/show.rs
+++ b/datafusion/core/tests/sql/show.rs
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::*;
+use std::collections::HashSet;
+
+#[tokio::test]
+async fn test_show_functions() {
+    let ctx = SessionContext::new();
+    let result = execute(&ctx, "SHOW FUNCTIONS").await;
+    println!("{:?}", result);
+    assert!(!result.is_empty(), "result is empty");
+    let names: HashSet<String> = result
+        .into_iter()
+        .map(|mut row| {
+            assert_eq!(row.len(), 1);
+            row.remove(0)
+        })
+        .collect();
+    [
+        "array_distinct",
+        "to_unixtime",
+        "covar_pop",
+        "max",
+        "concat",
+    ]
+    .into_iter()
+    .for_each(|name| {
+        assert!(names.contains(name), "{} not found in {:?}", name, names);
+    });
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/12144

## Rationale for this change

see https://github.com/apache/datafusion/issues/12144

> I as a user would want to see a list of available functions


## What changes are included in this PR?

Support for `Statement::ShowFunctions` by converting it directly to VALUES.
Filters are not supported. The syntax for filters is subject to https://github.com/sqlparser-rs/sqlparser-rs/issues/1399

## Are these changes tested?

Yes

## Are there any user-facing changes?

Support for the SHOW FUNCTIONS statement.