### PR TITLE
Add datafusion_typeof function

### DIFF
--- a/datafusion/functions/src/core/dftypeof.rs
+++ b/datafusion/functions/src/core/dftypeof.rs
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::DataType;
+use datafusion_common::{exec_err, Result};
+use datafusion_expr::ColumnarValue;
+use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
+use std::any::Any;
+
+#[derive(Debug)]
+pub struct DataFusionTypeOfFunc {
+    signature: Signature,
+}
+
+impl Default for DataFusionTypeOfFunc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DataFusionTypeOfFunc {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for DataFusionTypeOfFunc {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "datafusion_typeof"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke(&self, _args: &[ColumnarValue]) -> Result<ColumnarValue> {
+        exec_err!("{} need to be evaluated during planning", self.name())
+    }
+}

--- a/datafusion/functions/src/core/mod.rs
+++ b/datafusion/functions/src/core/mod.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 pub mod arrow_cast;
 pub mod arrowtypeof;
 pub mod coalesce;
+pub mod dftypeof;
 pub mod expr_ext;
 pub mod getfield;
 pub mod named_struct;
@@ -38,6 +39,7 @@ make_udf_function!(nullif::NullIfFunc, NULLIF, nullif);
 make_udf_function!(nvl::NVLFunc, NVL, nvl);
 make_udf_function!(nvl2::NVL2Func, NVL2, nvl2);
 make_udf_function!(arrowtypeof::ArrowTypeOfFunc, ARROWTYPEOF, arrow_typeof);
+make_udf_function!(dftypeof::DataFusionTypeOfFunc, DFTYPEOF, datafusion_typeof);
 make_udf_function!(r#struct::StructFunc, STRUCT, r#struct);
 make_udf_function!(named_struct::NamedStructFunc, NAMED_STRUCT, named_struct);
 make_udf_function!(getfield::GetFieldFunc, GET_FIELD, get_field);
@@ -67,6 +69,10 @@ pub mod expr_fn {
         "Returns the Arrow type of the input expression.",
         arg1
     ),(
+        datafusion_typeof,
+        "Returns the DataFusion type of the input expression.",
+        arg1
+    ),(
         r#struct,
         "Returns a struct with the given arguments",
         args,
@@ -94,6 +100,7 @@ pub fn functions() -> Vec<Arc<ScalarUDF>> {
         nvl(),
         nvl2(),
         arrow_typeof(),
+        datafusion_typeof(),
         named_struct(),
         // Note: most users invoke `get_field` indirectly via field access
         // syntax like `my_struct_col['field_name']`, which results in a call to


### PR DESCRIPTION
Add a function similar to arrow_typeof, for inspecting logical type as seen by DataFusion.
