### PR TITLE
test: check record count and types in parquet window test

### DIFF
--- a/datafusion/sqllogictest/test_files/parquet.slt
+++ b/datafusion/sqllogictest/test_files/parquet.slt
@@ -251,7 +251,7 @@ SELECT COUNT(*) FROM timestamp_with_tz;
 ----
 131072
 
-# Perform the query asserting that output timestamp columns will contain TZ
+# Ensure that output timestamp columns preserve the timezone from the input
 # and output record count will match input file record count
 query TPI
 SELECT arrow_typeof(lag_timestamp),

--- a/datafusion/sqllogictest/test_files/parquet.slt
+++ b/datafusion/sqllogictest/test_files/parquet.slt
@@ -251,25 +251,21 @@ SELECT COUNT(*) FROM timestamp_with_tz;
 ----
 131072
 
-# Perform the query:
-query IPT
-SELECT
-  count,
-  LAG(timestamp, 1) OVER (ORDER BY timestamp),
-  arrow_typeof(LAG(timestamp, 1) OVER (ORDER BY timestamp))
-FROM timestamp_with_tz
-LIMIT 10;
+# Perform the query asserting that output timestamp columns will contain TZ
+# and output record count will match input file record count
+query TPI
+SELECT arrow_typeof(lag_timestamp),
+       MIN(lag_timestamp),
+       COUNT(1)
+FROM (
+  SELECT
+    count,
+    LAG(timestamp, 1) OVER (ORDER BY timestamp) AS lag_timestamp
+  FROM timestamp_with_tz
+) t
+GROUP BY 1
 ----
-0 NULL Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-4 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-14 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+Timestamp(Millisecond, Some("UTC")) 2014-08-27T14:00:00Z 131072
 
 # Test config listing_table_ignore_subdirectory:
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12185 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The test output is not deterministic due to absence of sorting and bunch of duplicates in input data, and according to the commit [history](https://github.com/apache/datafusion/pull/8560/files#diff-302c60bdcb660ff15df18c07385f977c64cfa6aee4c50ea8d1cbd15700ae51b4L167) it was not intended to check the output data, but was introduced in order to check that timestamp with timezones are not losing timezones while passing through query pipeline ([original PR link](https://github.com/apache/datafusion/pull/5481)).

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The test behavior is rolled back to the one before porting to sqllogictests -- it now is checking output timestamp type (must contain tz), minimum output timestamp value (suppose it may be important) and total count of output records (not necessary, but may be helpful in case of debugging potential issues with this test).

Test comment also updated as it was suggested in [comment](https://github.com/apache/datafusion/pull/11939#discussion_r1715517265) to previous PR

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
