### PR TITLE
Fixes missing `nth_value` UDAF expr function 

### DIFF
--- a/datafusion/functions-aggregate/src/lib.rs
+++ b/datafusion/functions-aggregate/src/lib.rs
@@ -113,6 +113,7 @@ pub mod expr_fn {
     pub use super::median::median;
     pub use super::min_max::max;
     pub use super::min_max::min;
+    pub use super::nth_value::nth_value;
     pub use super::regr::regr_avgx;
     pub use super::regr::regr_avgy;
     pub use super::regr::regr_count;

--- a/datafusion/functions-aggregate/src/nth_value.rs
+++ b/datafusion/functions-aggregate/src/nth_value.rs
@@ -30,19 +30,33 @@ use datafusion_common::{exec_err, internal_err, not_impl_err, Result, ScalarValu
 use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
-    Accumulator, AggregateUDFImpl, ReversedUDAF, Signature, Volatility,
+    lit, Accumulator, AggregateUDFImpl, ExprFunctionExt, ReversedUDAF, Signature,
+    SortExpr, Volatility,
 };
 use datafusion_functions_aggregate_common::merge_arrays::merge_ordered_arrays;
 use datafusion_functions_aggregate_common::utils::ordering_fields;
 use datafusion_physical_expr::expressions::Literal;
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
 
-make_udaf_expr_and_func!(
-    NthValueAgg,
-    nth_value,
-    "Returns the nth value in a group of values.",
-    nth_value_udaf
-);
+create_func!(NthValueAgg, nth_value_udaf);
+
+/// Returns the nth value in a group of values.
+pub fn nth_value(
+    expr: datafusion_expr::Expr,
+    n: i64,
+    order_by: Option<Vec<SortExpr>>,
+) -> datafusion_expr::Expr {
+    let args = vec![expr, lit(n)];
+    if let Some(order_by) = order_by {
+        nth_value_udaf()
+            .call(args)
+            .order_by(order_by)
+            .build()
+            .unwrap()
+    } else {
+        nth_value_udaf().call(args)
+    }
+}
 
 /// Expression for a `NTH_VALUE(... ORDER BY ..., ...)` aggregation. In a multi
 /// partition setting, partial aggregations are computed for every partition,

--- a/datafusion/functions-aggregate/src/nth_value.rs
+++ b/datafusion/functions-aggregate/src/nth_value.rs
@@ -44,10 +44,10 @@ create_func!(NthValueAgg, nth_value_udaf);
 pub fn nth_value(
     expr: datafusion_expr::Expr,
     n: i64,
-    order_by: Option<Vec<SortExpr>>,
+    order_by: Vec<SortExpr>,
 ) -> datafusion_expr::Expr {
     let args = vec![expr, lit(n)];
-    if let Some(order_by) = order_by {
+    if !order_by.is_empty() {
         nth_value_udaf()
             .call(args)
             .order_by(order_by)

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -71,6 +71,7 @@ use datafusion_expr::{
 use datafusion_functions_aggregate::average::avg_udaf;
 use datafusion_functions_aggregate::expr_fn::{
     approx_distinct, array_agg, avg, bit_and, bit_or, bit_xor, bool_and, bool_or, corr,
+    nth_value,
 };
 use datafusion_functions_aggregate::string_agg::string_agg;
 use datafusion_proto::bytes::{
@@ -903,6 +904,24 @@ async fn roundtrip_expr_api() -> Result<()> {
             vec![lit(10), lit(20), lit(30)],
         ),
         row_number(),
+        nth_value(col("b"), 1, None),
+        nth_value(
+            col("b"),
+            1,
+            Some(vec![
+                col("a").sort(false, false),
+                col("b").sort(true, false),
+            ]),
+        ),
+        nth_value(col("b"), -1, None),
+        nth_value(
+            col("b"),
+            -1,
+            Some(vec![
+                col("a").sort(false, false),
+                col("b").sort(true, false),
+            ]),
+        ),
     ];
 
     // ensure expressions created with the expr api can be round tripped

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -904,23 +904,17 @@ async fn roundtrip_expr_api() -> Result<()> {
             vec![lit(10), lit(20), lit(30)],
         ),
         row_number(),
-        nth_value(col("b"), 1, None),
+        nth_value(col("b"), 1, vec![]),
         nth_value(
             col("b"),
             1,
-            Some(vec![
-                col("a").sort(false, false),
-                col("b").sort(true, false),
-            ]),
+            vec![col("a").sort(false, false), col("b").sort(true, false)],
         ),
-        nth_value(col("b"), -1, None),
+        nth_value(col("b"), -1, vec![]),
         nth_value(
             col("b"),
             -1,
-            Some(vec![
-                col("a").sort(false, false),
-                col("b").sort(true, false),
-            ]),
+            vec![col("a").sort(false, false), col("b").sort(true, false)],
         ),
     ];
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12278.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Same as #12278.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The API in v40 is:
```rust
pub fn nth_value(args: Vec<Expr>) -> Expr
``` 

A better API would be this:
```rust
pub fn nth_value(
        expr: Expr,
        n: i64,
        order_by: Option<Vec<SortExpr>>
) -> Expr
```

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. Logical roundtrip tests, both with and without order by expression.

## Are there any user-facing changes?

Yes, this is a breaking change of user-facing API.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
