### PR TITLE
Support alternate format for Date32 unparsing (TEXT/SQLite)

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -96,6 +96,12 @@ pub trait Dialect: Send + Sync {
 
         ast::DataType::Timestamp(None, tz_info)
     }
+
+    /// The SQL type to use for Arrow Date32 unparsing
+    /// Most dialects use Date, but some, like SQLite require TEXT
+    fn date32_cast_dtype(&self) -> sqlparser::ast::DataType {
+        sqlparser::ast::DataType::Date
+    }
 }
 
 /// `IntervalStyle` to use for unparsing
@@ -206,6 +212,10 @@ impl Dialect for SqliteDialect {
     fn identifier_quote_style(&self, _: &str) -> Option<char> {
         Some('`')
     }
+
+    fn date32_cast_dtype(&self) -> sqlparser::ast::DataType {
+        sqlparser::ast::DataType::Text
+    }
 }
 
 pub struct CustomDialect {
@@ -220,6 +230,7 @@ pub struct CustomDialect {
     int64_cast_dtype: ast::DataType,
     timestamp_cast_dtype: ast::DataType,
     timestamp_tz_cast_dtype: ast::DataType,
+    date32_cast_dtype: sqlparser::ast::DataType,
 }
 
 impl Default for CustomDialect {
@@ -239,6 +250,7 @@ impl Default for CustomDialect {
                 None,
                 TimezoneInfo::WithTimeZone,
             ),
+            date32_cast_dtype: sqlparser::ast::DataType::Date,
         }
     }
 }
@@ -302,6 +314,10 @@ impl Dialect for CustomDialect {
             self.timestamp_cast_dtype.clone()
         }
     }
+
+    fn date32_cast_dtype(&self) -> sqlparser::ast::DataType {
+        self.date32_cast_dtype.clone()
+    }
 }
 
 /// `CustomDialectBuilder` to build `CustomDialect` using builder pattern
@@ -330,6 +346,7 @@ pub struct CustomDialectBuilder {
     int64_cast_dtype: ast::DataType,
     timestamp_cast_dtype: ast::DataType,
     timestamp_tz_cast_dtype: ast::DataType,
+    date32_cast_dtype: ast::DataType,
 }
 
 impl Default for CustomDialectBuilder {
@@ -355,6 +372,7 @@ impl CustomDialectBuilder {
                 None,
                 TimezoneInfo::WithTimeZone,
             ),
+            date32_cast_dtype: sqlparser::ast::DataType::Date,
         }
     }
 
@@ -371,6 +389,7 @@ impl CustomDialectBuilder {
             int64_cast_dtype: self.int64_cast_dtype,
             timestamp_cast_dtype: self.timestamp_cast_dtype,
             timestamp_tz_cast_dtype: self.timestamp_tz_cast_dtype,
+            date32_cast_dtype: self.date32_cast_dtype,
         }
     }
 
@@ -451,6 +470,11 @@ impl CustomDialectBuilder {
     ) -> Self {
         self.timestamp_cast_dtype = timestamp_cast_dtype;
         self.timestamp_tz_cast_dtype = timestamp_tz_cast_dtype;
+        self
+    }
+
+    pub fn with_date32_cast_dtype(mut self, date32_cast_dtype: ast::DataType) -> Self {
+        self.date32_cast_dtype = date32_cast_dtype;
         self
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

PR improves unparser to produce valid CAST SQL for SQLite and Date32

## Rationale for this change

SQLite does not have dedicated DATE type and prefers a text string that is an [ISO 8601 date/time](https://www.sqlite.org/lang_datefunc.html) value:

You can see below that casting to DATE produces invalid value whether casting to TEXT produces a valid one similar to using DATE function.

```sql
SELECT CAST('1995-03-15' AS DATE), DATE('1995-03-15'), CAST('1995-03-15' AS TEXT)
```

![image](https://github.com/user-attachments/assets/a4a69235-0bbb-48af-ad5f-1ef238e93813)

Test query (native)
```sql
SELECT count(o_orderdate) FROM orders 
WHERE `orders`.`o_orderdate`< '1995-03-15'

7286 rows
```

Existing  unparser behavior, producing `'1995-03-15' AS DATE` SQL for SQLite
```sql
SELECT count(o_orderdate) FROM orders 
WHERE `orders`.`o_orderdate`< CAST('1995-03-15' AS DATE)

0 rows
```

Fixed unparser behavior, producing valid `'1995-03-15' AS TEXT` SQL for SQLite
```sql
select count(o_orderdate) from orders 
where `orders`.`o_orderdate` < CAST('1995-03-15' AS TEXT)

7286 rows
```


## What changes are included in this PR?

PR introduces configurable `date32_cast_dtype` dialect parameter that controls whether DATE vs TEXT is used for Date32 unparsing.

## Are these changes tested?

Yes, added unit tests + manual testing

## Are there any user-facing changes?

`CustomDialectBuilder` now supports `with_date32_cast_dtype` that can be used to specify desired type that should be used for Date32 unparsing.
