### PR TITLE
Update download page to reflect latest version (v41)

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -407,3 +407,7 @@ Here is an example blog post PR:
 - https://github.com/apache/arrow-site/pull/217
 
 Once the PR is merged, a GitHub action will publish the new blog post to https://arrow.apache.org/blog/.
+
+### Update the version on the download page
+
+Update the version on the [download page](https://datafusion.apache.org/download) to point to the latest release [here](../../docs/source/download.md).

--- a/docs/source/download.md
+++ b/docs/source/download.md
@@ -26,12 +26,12 @@ official Apache DataFusion releases are provided as source artifacts.
 
 ## Releases
 
-The latest source release is [37.0.0][source-link] ([asc][asc-link],
+The latest source release is [41.0.0][source-link] ([asc][asc-link],
 [sha512][sha512-link]).
 
-[source-link]: https://www.apache.org/dyn/closer.lua/arrow/arrow-datafusion-37.0.0/apache-arrow-datafusion-37.0.0.tar.gz?action=download
-[asc-link]: https://downloads.apache.org/arrow/arrow-datafusion-37.0.0/apache-arrow-datafusion-37.0.0.tar.gz.asc
-[sha512-link]: https://downloads.apache.org/arrow/arrow-datafusion-37.0.0/apache-arrow-datafusion-37.0.0.tar.gz.sha512
+[source-link]: https://www.apache.org/dyn/closer.lua/datafusion/datafusion-41.0.0/apache-datafusion-41.0.0.tar.gz?action=download
+[asc-link]: https://downloads.apache.org/datafusion/datafusion-41.0.0/apache-datafusion-41.0.0.tar.gz.asc
+[sha512-link]: https://downloads.apache.org/datafusion/datafusion-41.0.0/apache-datafusion-41.0.0.tar.gz.sha512
 
 For previous releases, please check the [archive](https://archive.apache.org/dist/datafusion/).
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

I found that the download link was incorrect while skimming the DataFusion docs.

## What changes are included in this PR?

Changes the download link to point to the correct location and release.

Also updates the release process with a note to update the download page.

## Are these changes tested?

Not a code change.

## Are there any user-facing changes?

No