### PR TITLE
Support for SIMILAR TO for physical plan

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -681,6 +681,22 @@ pub fn binary(
     Ok(Arc::new(BinaryExpr::new(lhs, op, rhs)))
 }
 
+/// Create a similar to expression
+pub fn similar_to(
+    negated: bool,
+    case_insensitive: bool,
+    expr: Arc<dyn PhysicalExpr>,
+    pattern: Arc<dyn PhysicalExpr>,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    let binary_op = match (negated, case_insensitive) {
+        (false, false) => Operator::RegexMatch,
+        (false, true) => Operator::RegexIMatch,
+        (true, false) => Operator::RegexNotMatch,
+        (true, true) => Operator::RegexNotIMatch,
+    };
+    Ok(Arc::new(BinaryExpr::new(expr, binary_op, pattern)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -4259,7 +4259,7 @@ mod tests {
             case_insensitive,
             col("a", schema)?,
             col("b", schema)?,
-        );
+        )?;
         let batch =
             RecordBatch::try_new(Arc::clone(schema), vec![Arc::new(a), Arc::new(b)])?;
         let result = op
@@ -4278,7 +4278,7 @@ mod tests {
             Field::new("b", DataType::Utf8, false),
         ]));
 
-        let expected = [true, false].iter().collect();
+        let expected = [Some(true), Some(false)].iter().collect();
         // case-sensitive
         apply_similar_to(
             &schema,

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -42,7 +42,7 @@ pub use crate::window::ntile::Ntile;
 pub use crate::window::rank::{dense_rank, percent_rank, rank, Rank, RankType};
 pub use crate::PhysicalSortExpr;
 
-pub use binary::{binary, BinaryExpr};
+pub use binary::{binary, similar_to, BinaryExpr};
 pub use case::{case, CaseExpr};
 pub use cast::{cast, CastExpr};
 pub use column::{col, with_new_schema, Column};

--- a/datafusion/sqllogictest/test_files/strings.slt
+++ b/datafusion/sqllogictest/test_files/strings.slt
@@ -46,6 +46,51 @@ P1m1e1
 p1m1e1
 p2m1e1
 
+# REGEX
+query T rowsort
+SELECT s FROM test WHERE s ~ 'p[12].*';
+----
+p1
+p1e1
+p1m1e1
+p2
+p2e1
+p2m1e1
+
+# REGEX nocase
+query T rowsort
+SELECT s FROM test WHERE s ~* 'p[12].*';
+----
+P1
+P1e1
+P1m1e1
+p1
+p1e1
+p1m1e1
+p2
+p2e1
+p2m1e1
+
+# SIMILAR TO
+query T rowsort
+SELECT s FROM test WHERE s SIMILAR TO 'p[12].*';
+----
+p1
+p1e1
+p1m1e1
+p2
+p2e1
+p2m1e1
+
+# NOT SIMILAR TO
+query T rowsort
+SELECT s FROM test WHERE s NOT SIMILAR TO 'p[12].*';
+----
+P1
+P1e1
+P1m1e1
+e1
+
 # NOT LIKE
 query T rowsort
 SELECT s FROM test WHERE s NOT LIKE 'p1%';


### PR DESCRIPTION
## Which issue does this PR close?

Add support for SIMILAR TO and NOT SIMILAR TO to the physical plan.

Closes #12155.

## Rationale for this change

Currently, a simple query `select * from t1 where c1 similar to 'x*'` is not supported.

## What changes are included in this PR?

- Support for "SIMILAR TO" family operator in physical plan
- Additional sqllogic tests

The functionality is based on creating a binary expression for `Operator::RegexMatch` and family.

There is an existing `like` module for the LIKE operator. Probably, this functionality can be extracted to a similar `similar_to` module.

## Are these changes tested?

- unit test (for binary operator only)
- sqllogictest integration test
- manual test using `datafusion-cli`
- tested with additional operators for expression and pattern

## Are there any user-facing changes?

No