### PR TITLE
Faster `character_length()` string function for ASCII-only case

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -166,3 +166,8 @@ required-features = ["math_expressions"]
 harness = false
 name = "substr"
 required-features = ["unicode_expressions"]
+
+[[bench]]
+harness = false
+name = "character_length"
+required-features = ["unicode_expressions"]

--- a/datafusion/functions/benches/character_length.rs
+++ b/datafusion/functions/benches/character_length.rs
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate criterion;
+
+use arrow::array::{StringArray, StringViewArray};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datafusion_expr::ColumnarValue;
+use rand::distributions::Alphanumeric;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::sync::Arc;
+
+/// gen_arr(4096, 128, 0.1, 0.1, true) will generate a StringViewArray with
+/// 4096 rows, each row containing a string with 128 random characters.
+/// around 10% of the rows are null, around 10% of the rows are non-ASCII.
+fn gen_string_array(
+    n_rows: usize,
+    str_len_chars: usize,
+    null_density: f32,
+    utf8_density: f32,
+    is_string_view: bool, // false -> StringArray, true -> StringViewArray
+) -> Vec<ColumnarValue> {
+    let mut rng = StdRng::seed_from_u64(42);
+    let rng_ref = &mut rng;
+
+    let corpus = "DataFusionДатаФусион数据融合📊🔥"; // includes utf8 encoding with 1~4 bytes
+    let corpus_char_count = corpus.chars().count();
+
+    let mut output_string_vec: Vec<Option<String>> = Vec::with_capacity(n_rows);
+    for _ in 0..n_rows {
+        let rand_num = rng_ref.gen::<f32>(); // [0.0, 1.0)
+        if rand_num < null_density {
+            output_string_vec.push(None);
+        } else if rand_num < null_density + utf8_density {
+            // Generate random UTF8 string
+            let mut generated_string = String::with_capacity(str_len_chars);
+            for _ in 0..str_len_chars {
+                let idx = rng_ref.gen_range(0..corpus_char_count);
+                let char = corpus.chars().nth(idx).unwrap();
+                generated_string.push(char);
+            }
+            output_string_vec.push(Some(generated_string));
+        } else {
+            // Generate random ASCII-only string
+            let value = rng_ref
+                .sample_iter(&Alphanumeric)
+                .take(str_len_chars)
+                .collect();
+            let value = String::from_utf8(value).unwrap();
+            output_string_vec.push(Some(value));
+        }
+    }
+
+    if is_string_view {
+        let string_view_array: StringViewArray = output_string_vec.into_iter().collect();
+        vec![ColumnarValue::Array(Arc::new(string_view_array))]
+    } else {
+        let string_array: StringArray = output_string_vec.clone().into_iter().collect();
+        vec![ColumnarValue::Array(Arc::new(string_array))]
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // All benches are single batch run with 8192 rows
+    let character_length = datafusion_functions::unicode::character_length();
+
+    let n_rows = 8192;
+    for str_len in [8, 32, 128, 4096] {
+        // StringArray ASCII only
+        let args_string_ascii = gen_string_array(n_rows, str_len, 0.1, 0.0, false);
+        c.bench_function(
+            &format!("character_length_StringArray_ascii_str_len_{}", str_len),
+            |b| b.iter(|| black_box(character_length.invoke(&args_string_ascii))),
+        );
+
+        // StringArray UTF8
+        let args_string_utf8 = gen_string_array(n_rows, str_len, 0.1, 0.5, false);
+        c.bench_function(
+            &format!("character_length_StringArray_utf8_str_len_{}", str_len),
+            |b| b.iter(|| black_box(character_length.invoke(&args_string_utf8))),
+        );
+
+        // StringViewArray ASCII only
+        let args_string_view_ascii = gen_string_array(n_rows, str_len, 0.1, 0.0, true);
+        c.bench_function(
+            &format!("character_length_StringViewArray_ascii_str_len_{}", str_len),
+            |b| b.iter(|| black_box(character_length.invoke(&args_string_view_ascii))),
+        );
+
+        // StringViewArray UTF8
+        let args_string_view_utf8 = gen_string_array(n_rows, str_len, 0.1, 0.5, true);
+        c.bench_function(
+            &format!("character_length_StringViewArray_utf8_str_len_{}", str_len),
+            |b| b.iter(|| black_box(character_length.invoke(&args_string_view_utf8))),
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -351,17 +351,28 @@ pub trait StringArrayType<'a>: ArrayAccessor<Item = &'a str> + Sized {
     ///
     /// This iterator iterates returns `Option<&str>` for each item in the array.
     fn iter(&self) -> ArrayIter<Self>;
+
+    /// Check if the array is ASCII only.
+    fn is_ascii(&self) -> bool;
 }
 
 impl<'a, T: OffsetSizeTrait> StringArrayType<'a> for &'a GenericStringArray<T> {
     fn iter(&self) -> ArrayIter<Self> {
         GenericStringArray::<T>::iter(self)
     }
+
+    fn is_ascii(&self) -> bool {
+        GenericStringArray::<T>::is_ascii(self)
+    }
 }
 
 impl<'a> StringArrayType<'a> for &'a StringViewArray {
     fn iter(&self) -> ArrayIter<Self> {
         StringViewArray::iter(self)
+    }
+
+    fn is_ascii(&self) -> bool {
+        StringViewArray::is_ascii(self)
     }
 }
 

--- a/datafusion/functions/src/unicode/character_length.rs
+++ b/datafusion/functions/src/unicode/character_length.rs
@@ -115,13 +115,9 @@ where
         .map(|string| {
             string.map(|string: &str| {
                 if is_array_ascii_only {
-                    T::Native::from_usize(string.len()).expect(
-                        "should not fail as string.len will always return integer",
-                    )
+                    T::Native::usize_as(string.len())
                 } else {
-                    T::Native::from_usize(string.chars().count()).expect(
-                        "should not fail as string.chars will always return integer",
-                    )
+                    T::Native::usize_as(string.chars().count())
                 }
             })
         })


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion/issues/12306

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
See the issue.

This PR wants to show how the change will look like and decide if we should continue with other string functions like `lower()`
Though speed up for `char_length()` is not big, I guess it's because counting character's implementation is also relatively more CPU friendly, but according to Velox's benchmarks we can expect more speed up for string functions like `lower()/upper()`

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Inside `character_length()` first check whether the current string array is ASCII-only, if so directly count bytes instead of decode characters one by one
2. Micro benchmark (first commit is bench only)

Result
```
group                                                  after                                  before
-----                                                  -----                                  ------
character_length_StringArray_ascii_str_len_128         1.00    123.9±7.62µs        ? ?/sec    1.42    175.8±7.33µs        ? ?/sec
character_length_StringArray_ascii_str_len_32          1.00    81.8±12.05µs        ? ?/sec    1.71    139.9±2.66µs        ? ?/sec
character_length_StringArray_ascii_str_len_4096        1.00      3.1±0.03ms        ? ?/sec    1.02      3.1±0.19ms        ? ?/sec
character_length_StringArray_ascii_str_len_8           1.00     66.0±3.38µs        ? ?/sec    1.35     89.0±2.00µs        ? ?/sec
character_length_StringArray_utf8_str_len_128          1.00   313.5±24.58µs        ? ?/sec    1.03   323.0±10.86µs        ? ?/sec
character_length_StringArray_utf8_str_len_32           1.00    236.5±3.47µs        ? ?/sec    1.04    245.8±3.84µs        ? ?/sec
character_length_StringArray_utf8_str_len_4096         1.00      6.0±0.78ms        ? ?/sec    1.03      6.2±1.23ms        ? ?/sec
character_length_StringArray_utf8_str_len_8            1.00    162.5±6.09µs        ? ?/sec    1.03   167.4±13.90µs        ? ?/sec
character_length_StringViewArray_ascii_str_len_128     1.00   143.4±28.39µs        ? ?/sec    1.31   187.4±52.47µs        ? ?/sec
character_length_StringViewArray_ascii_str_len_32      1.00    104.1±6.05µs        ? ?/sec    1.35   140.0±31.13µs        ? ?/sec
character_length_StringViewArray_ascii_str_len_4096    1.00      2.6±0.04ms        ? ?/sec    1.22      3.1±0.27ms        ? ?/sec
character_length_StringViewArray_ascii_str_len_8       1.02     92.9±0.57µs        ? ?/sec    1.00    91.2±22.02µs        ? ?/sec
character_length_StringViewArray_utf8_str_len_128      1.01   323.8±17.53µs        ? ?/sec    1.00    319.0±4.83µs        ? ?/sec
character_length_StringViewArray_utf8_str_len_32       1.02   248.8±29.66µs        ? ?/sec    1.00   244.0±19.25µs        ? ?/sec
character_length_StringViewArray_utf8_str_len_4096     1.00      5.9±0.42ms        ? ?/sec    1.03      6.1±0.43ms        ? ?/sec
character_length_StringViewArray_utf8_str_len_8        1.01    171.9±6.96µs        ? ?/sec    1.00   169.5±10.64µs        ? ?/sec
```

## Are these changes tested?

Current sqllogictest has covered non-ascii case `char_length()` function
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
