### PR TITLE
tests: enable fuzz for filtered anti-semi NLJoin

### DIFF
--- a/datafusion/core/tests/fuzz_cases/join_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/join_fuzz.rs
@@ -125,6 +125,8 @@ async fn test_left_join_1k() {
 }
 
 #[tokio::test]
+// flaky for HjSmj case
+// https://github.com/apache/datafusion/issues/12359
 async fn test_left_join_1k_filtered() {
     JoinFuzzTestCase::new(
         make_staggered_batches(1000),
@@ -132,7 +134,7 @@ async fn test_left_join_1k_filtered() {
         JoinType::Left,
         Some(Box::new(col_lt_col_filter)),
     )
-    .run_test(&[JoinTestType::HjSmj, JoinTestType::NljHj], false)
+    .run_test(&[JoinTestType::NljHj], false)
     .await
 }
 
@@ -149,6 +151,8 @@ async fn test_right_join_1k() {
 }
 
 #[tokio::test]
+// flaky for HjSmj case
+// https://github.com/apache/datafusion/issues/12359
 async fn test_right_join_1k_filtered() {
     JoinFuzzTestCase::new(
         make_staggered_batches(1000),
@@ -156,7 +160,7 @@ async fn test_right_join_1k_filtered() {
         JoinType::Right,
         Some(Box::new(col_lt_col_filter)),
     )
-    .run_test(&[JoinTestType::HjSmj, JoinTestType::NljHj], false)
+    .run_test(&[JoinTestType::NljHj], false)
     .await
 }
 
@@ -173,6 +177,8 @@ async fn test_full_join_1k() {
 }
 
 #[tokio::test]
+// flaky for HjSmj case
+// https://github.com/apache/datafusion/issues/12359
 async fn test_full_join_1k_filtered() {
     JoinFuzzTestCase::new(
         make_staggered_batches(1000),
@@ -180,7 +186,7 @@ async fn test_full_join_1k_filtered() {
         JoinType::Full,
         Some(Box::new(col_lt_col_filter)),
     )
-    .run_test(&[JoinTestType::HjSmj, JoinTestType::NljHj], false)
+    .run_test(&[JoinTestType::NljHj], false)
     .await
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11537.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It turned out to be not a NLJoin issue, but fuzz tests -- during NLjoin construction, join filter was completely ignored, and all NLjoin tests were running with only equijoin conditions in filter.

In the same time filtered inner/left/right/full join fuzz tests were passing even without the filter -- the reason is that they've been using `less_than_100_join_filter`, which always returns True, as generation of input data for column, used in this filter, always returns values less than 100 -- `make_staggered_batches` comment:
```
/// two sorted int32 columns 'a', 'b' ranged from 0..99 as join columns
```
so it seems to be more useful to place `col_lt_col_filter` in all tests, since it has non 100% selectivity.

Finally, after replacing filter in all test cases, some of HjSmj tests turned out to be flaky, so they are temporarily disabled, until #12359 fix.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- NLJoin construction in fuzz tests now takes into account join_filter, and constructs composite filter as a union of join_filter and equijoin conditions, all fuzz tests are enabled for NljHj case
- all `_filtered` test cases now use `col_lt_col_filter`
- some `_filtered` testcases disabled for SortMergeJoin due to their flakiness

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No, it's related exclusively to the tests

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
