### PR TITLE
Minor: Add getter for logical optimizer rules

### DIFF
--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -1939,16 +1939,19 @@ mod tests {
             .build();
 
         assert_eq!(state.optimizers().len(), 1);
-        
+
         let state = SessionStateBuilder::new()
             .with_optimizer_rule(Arc::new(DummyRule {}))
             .build();
 
-        assert_eq!(state.optimizers().len(), Optimizer::default().rules.len() + 1);
+        assert_eq!(
+            state.optimizers().len(),
+            Optimizer::default().rules.len() + 1
+        );
     }
 
     struct DummyRule {}
-    
+
     impl OptimizerRule for DummyRule {
         fn name(&self) -> &str {
             "dummy_rule"

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -1932,14 +1932,21 @@ mod tests {
 
     #[test]
     fn test_session_state_with_optimizer_rules() {
-        // test building sessions with supplied rules
+        struct DummyRule {}
 
+        impl OptimizerRule for DummyRule {
+            fn name(&self) -> &str {
+                "dummy_rule"
+            }
+        }
+        // test building sessions with fresh set of rules
         let state = SessionStateBuilder::new()
             .with_optimizer_rules(vec![Arc::new(DummyRule {})])
             .build();
 
         assert_eq!(state.optimizers().len(), 1);
 
+        // test adding rules to default recommendations
         let state = SessionStateBuilder::new()
             .with_optimizer_rule(Arc::new(DummyRule {}))
             .build();
@@ -1948,13 +1955,5 @@ mod tests {
             state.optimizers().len(),
             Optimizer::default().rules.len() + 1
         );
-    }
-
-    struct DummyRule {}
-
-    impl OptimizerRule for DummyRule {
-        fn name(&self) -> &str {
-            "dummy_rule"
-        }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

My team and I have been exploring Datafusion's potential to federate our custom sources performantly. Part of that is tuning optimizers depending on our needs. Noticed that there isn't a convenience method in `SessionState` yet that returns logical optimizer rules compared to its physical counterpart. Would be great for our POC work to quickly inspect them outside (and/or alongside) debugger or observer.

## What changes are included in this PR?

Adds a getter method `optimizers()` in `SessionState` in parity to the `physical_optimizers()` counterpart.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, ran new and existing tests. Also manually tested from our existing POC code.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Examples:

```rust
let state = SessionStateBuilder::new()
    .with_optimizer_rules(vec![
        Arc::new(UnwrapCastInComparison::new()),
        Arc::new(SimplifyExpressions::new()),
        Arc::new(OptimizeProjections::new()),
        Arc::new(PushDownFilter::new()),
    ])
    .build();

let optimizer_rules = state.optimizers();
for rule in optimizer_rules {
    println!("Optimizer: {}", rule.name());
}
```
