### PR TITLE
Fix: `substr()` on StringView column's behavior is inconsistent with the old version

### DIFF
--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -473,11 +473,6 @@ SELECT substr('alphabet', 30)
 (empty)
 
 query T
-SELECT substr('alphabet', CAST(NULL AS int))
-----
-NULL
-
-query T
 SELECT substr('alphabet', 3, 2)
 ----
 ph
@@ -487,21 +482,132 @@ SELECT substr('alphabet', 3, 20)
 ----
 phabet
 
-query T
-SELECT substr('alphabet', CAST(NULL AS int), 20)
+# test range ouside of string length
+query TTTTTTTTTTTT
+SELECT
+    substr('hi🌏', 1, 3),
+    substr('hi🌏', 1, 4),
+    substr('hi🌏', 1, 100),
+    substr('hi🌏', 0, 1),
+    substr('hi🌏', 0, 2),
+    substr('hi🌏', 0, 4),
+    substr('hi🌏', 0, 5),
+    substr('hi🌏', -10, 100),
+    substr('hi🌏', -10, 12),
+    substr('hi🌏', -10, 5),
+    substr('hi🌏', 10, 0),
+    substr('hi🌏', 10, 10);
 ----
-NULL
+hi🌏 hi🌏 hi🌏 (empty) h hi🌏 hi🌏 hi🌏 h (empty) (empty) (empty)
+
+query TTTTTTTTTTTT
+SELECT
+    substr('', 1, 3),
+    substr('', 1, 4),
+    substr('', 1, 100),
+    substr('', 0, 1),
+    substr('', 0, 2),
+    substr('', 0, 4),
+    substr('', 0, 5),
+    substr('', -10, 100),
+    substr('', -10, 12),
+    substr('', -10, 5),
+    substr('', 10, 0),
+    substr('', 10, 10);
+----
+(empty) (empty) (empty) (empty) (empty) (empty) (empty) (empty) (empty) (empty) (empty) (empty)
+
+# Nulls
+query TTTTTTTTTT
+SELECT 
+  substr('alphabet', NULL),
+  substr(NULL, 1),
+  substr(NULL, NULL),
+  substr('alphabet', CAST(NULL AS int), -20),
+  substr('alphabet', 3, CAST(NULL AS int)),
+  substr(NULL, 3, -4),
+  substr(NULL, NULL, 4),
+  substr(NULL, 1, NULL),
+  substr('', NULL, NULL),
+  substr(NULL, NULL, NULL);
+----
+NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL
 
 query T
-SELECT substr('alphabet', 3, CAST(NULL AS int))
+SELECT substr('Hello🌏世界', 5)
 ----
-NULL
+o🌏世界
+
+query T
+SELECT substr('Hello🌏世界', 5, 3)
+----
+o🌏世
+
+statement ok
+create table test_substr (
+    c1 VARCHAR
+) as values ('foo'), ('hello🌏世界'), ('💩'), ('ThisIsAVeryLongASCIIString'), (''), (NULL);
+
+statement ok
+create table test_substr_stringview as
+select c1 as c1, arrow_cast(c1, 'Utf8View') as c1_view from test_substr;
+
+# `substr()` on `StringViewArray`'s implementation operates directly on view's
+# logical pointers, so check it's consistent with `StringArray`
+query BBBBBBBBBBBBBB
+select 
+    substr(c1, 1) = substr(c1_view, 1),
+    substr(c1, 3) = substr(c1_view, 3),
+    substr(c1, 100) = substr(c1_view, 100),
+    substr(c1, -1) = substr(c1_view, -1),
+    substr(c1, 0, 0) = substr(c1_view, 0, 0),
+    substr(c1, -1, 2) = substr(c1_view, -1, 2),
+    substr(c1, -2, 10) = substr(c1_view, -2, 10),
+    substr(c1, -100, 200) = substr(c1_view, -100, 200),
+    substr(c1, -10, 10) = substr(c1_view, -10, 10),
+    substr(c1, -100, 10) = substr(c1_view, -100, 10),
+    substr(c1, 1, 100) = substr(c1_view, 1, 100),
+    substr(c1, 5, 3) = substr(c1_view, 5, 3),
+    substr(c1, 100, 200) = substr(c1_view, 100, 200),
+    substr(c1, 8, 0) = substr(c1_view, 8, 0)
+from test_substr_stringview;
+----
+true true true true true true true true true true true true true true
+true true true true true true true true true true true true true true
+true true true true true true true true true true true true true true
+true true true true true true true true true true true true true true
+true true true true true true true true true true true true true true
+NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL
+
+# Check for non-ASCII strings
+query TT
+select substr(c1_view, 1), substr(c1_view, 5,3) from test_substr_stringview;
+----
+foo (empty)
+hello🌏世界 o🌏世
+💩 (empty)
+ThisIsAVeryLongASCIIString IsA
+(empty) (empty)
+NULL NULL
+
+statement ok
+drop table test_substr;
+
+statement ok
+drop table test_substr_stringview;
+
 
 statement error The SUBSTR function can only accept strings, but got Int64.
 SELECT substr(1, 3)
 
 statement error The SUBSTR function can only accept strings, but got Int64.
 SELECT substr(1, 3, 4)
+
+statement error Execution error: negative substring length not allowed
+select substr(arrow_cast('foo', 'Utf8View'), 1, -1);
+
+statement error Execution error: negative substring length not allowed
+select substr('', 1, -1);
 
 query T
 SELECT translate('12345', '143', 'ax')


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N.A.

## Rationale for this change

Recently native `StringView` type support is implemented on `substr()` string function, but its behaviour is not consistent with the older implementation on `StringArray` string physical column type
The function semantics on the original `StringArray` type is consistent with postgres https://www.postgresql.org/docs/9.1/functions-string.html

The postgres version of `substr(s, start, count)`'s behavior is: `start` is 1-indexed, then we have a maybe out of bounds , and 0-indexed character range `[start-1, start-1+count)` , the valid char range is `[0, s.chars().count())`, and this function will take the intersection of two.

They handle negative start index differently and also handle invalid range differently
```
DataFusion CLI v41.0.0
> select substr('foo', -2,4), substr(arrow_cast('foo', 'Utf8View'), -2, 4);
+----------------------------------------+---------------------------------------------------------------------+
| substr(Utf8("foo"),Int64(-2),Int64(4)) | substr(arrow_cast(Utf8("foo"),Utf8("Utf8View")),Int64(-2),Int64(4)) |
+----------------------------------------+---------------------------------------------------------------------+
| f                                      | foo                                                                 |
+----------------------------------------+---------------------------------------------------------------------+
1 row(s) fetched.
Elapsed 0.104 seconds.

> select substr('', -10, 5)='', substr(arrow_cast('', 'Utf8View'), -10, 5)='';
+-------------------------------------------------+------------------------------------------------------------------------------+
| substr(Utf8(""),Int64(-10),Int64(5)) = Utf8("") | substr(arrow_cast(Utf8(""),Utf8("Utf8View")),Int64(-10),Int64(5)) = Utf8("") |
+-------------------------------------------------+------------------------------------------------------------------------------+
| true                                            |                                                                              |
+-------------------------------------------------+------------------------------------------------------------------------------+
1 row(s) fetched.
Elapsed 0.010 seconds.
```
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

`substr`'s behavior is already consistent with postgres if input is `StringArray`
This PR changes implementation to keep `StringView` version also consistent with postgres
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Added more sqllogictests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
