### PR TITLE
Refactor `SqlToRel::sql_expr_to_logical_expr_internal` to reduce stack size

### DIFF
--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -21,8 +21,8 @@ use datafusion_expr::planner::{
     PlannerResult, RawBinaryExpr, RawDictionaryExpr, RawFieldAccessExpr,
 };
 use sqlparser::ast::{
-    BinaryOperator, CastKind, DictionaryField, Expr as SQLExpr, MapEntry, StructField,
-    Subscript, TrimWhereField, Value,
+    BinaryOperator, CastFormat, CastKind, DataType as SQLDataType, DictionaryField,
+    Expr as SQLExpr, MapEntry, StructField, Subscript, TrimWhereField, Value,
 };
 
 use datafusion_common::{
@@ -174,6 +174,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         schema: &DFSchema,
         planner_context: &mut PlannerContext,
     ) -> Result<Expr> {
+        // NOTE: This function is called recusively, so each match arm body should be as
+        //       small as possible to avoid stack overflows in debug builds. Follow the
+        //       common pattern of extracting into a separate function for non-trivial
+        //       arms.
         match sql {
             SQLExpr::Value(value) => {
                 self.parse_value(value, planner_context.prepare_param_data_types())
@@ -210,91 +214,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
             // <expr>["foo"], <expr>[4] or <expr>[4:5]
             SQLExpr::Subscript { expr, subscript } => {
-                let expr =
-                    self.sql_expr_to_logical_expr(*expr, schema, planner_context)?;
-
-                let field_access = match *subscript {
-                    Subscript::Index { index } => {
-                        // index can be a name, in which case it is a named field access
-                        match index {
-                            SQLExpr::Value(
-                                Value::SingleQuotedString(s)
-                                | Value::DoubleQuotedString(s),
-                            ) => GetFieldAccess::NamedStructField {
-                                name: ScalarValue::from(s),
-                            },
-                            SQLExpr::JsonAccess { .. } => {
-                                return not_impl_err!("JsonAccess");
-                            }
-                            // otherwise treat like a list index
-                            _ => GetFieldAccess::ListIndex {
-                                key: Box::new(self.sql_expr_to_logical_expr(
-                                    index,
-                                    schema,
-                                    planner_context,
-                                )?),
-                            },
-                        }
-                    }
-                    Subscript::Slice {
-                        lower_bound,
-                        upper_bound,
-                        stride,
-                    } => {
-                        // Means access like [:2]
-                        let lower_bound = if let Some(lower_bound) = lower_bound {
-                            self.sql_expr_to_logical_expr(
-                                lower_bound,
-                                schema,
-                                planner_context,
-                            )
-                        } else {
-                            not_impl_err!("Slice subscript requires a lower bound")
-                        }?;
-
-                        // means access like [2:]
-                        let upper_bound = if let Some(upper_bound) = upper_bound {
-                            self.sql_expr_to_logical_expr(
-                                upper_bound,
-                                schema,
-                                planner_context,
-                            )
-                        } else {
-                            not_impl_err!("Slice subscript requires an upper bound")
-                        }?;
-
-                        // stride, default to 1
-                        let stride = if let Some(stride) = stride {
-                            self.sql_expr_to_logical_expr(
-                                stride,
-                                schema,
-                                planner_context,
-                            )?
-                        } else {
-                            lit(1i64)
-                        };
-
-                        GetFieldAccess::ListRange {
-                            start: Box::new(lower_bound),
-                            stop: Box::new(upper_bound),
-                            stride: Box::new(stride),
-                        }
-                    }
-                };
-
-                let mut field_access_expr = RawFieldAccessExpr { expr, field_access };
-                for planner in self.context_provider.get_expr_planners() {
-                    match planner.plan_field_access(field_access_expr, schema)? {
-                        PlannerResult::Planned(expr) => return Ok(expr),
-                        PlannerResult::Original(expr) => {
-                            field_access_expr = expr;
-                        }
-                    }
-                }
-
-                not_impl_err!(
-                    "GetFieldAccess not supported by ExprPlanner: {field_access_expr:?}"
-                )
+                self.sql_subscript_to_expr(*expr, subscript, schema, planner_context)
             }
 
             SQLExpr::CompoundIdentifier(ids) => {
@@ -320,31 +240,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 expr,
                 data_type,
                 format,
-            } => {
-                if let Some(format) = format {
-                    return not_impl_err!("CAST with format is not supported: {format}");
-                }
-
-                let dt = self.convert_data_type(&data_type)?;
-                let expr =
-                    self.sql_expr_to_logical_expr(*expr, schema, planner_context)?;
-
-                // numeric constants are treated as seconds (rather as nanoseconds)
-                // to align with postgres / duckdb semantics
-                let expr = match &dt {
-                    DataType::Timestamp(TimeUnit::Nanosecond, tz)
-                        if expr.get_type(schema)? == DataType::Int64 =>
-                    {
-                        Expr::Cast(Cast::new(
-                            Box::new(expr),
-                            DataType::Timestamp(TimeUnit::Second, tz.clone()),
-                        ))
-                    }
-                    _ => expr,
-                };
-
-                Ok(Expr::Cast(Cast::new(Box::new(expr), dt)))
-            }
+            } => self.sql_cast_to_expr(expr, data_type, format, schema, planner_context),
 
             SQLExpr::Cast {
                 kind: CastKind::TryCast | CastKind::SafeCast,
@@ -1015,6 +911,118 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }
         }
         not_impl_err!("Overlay not supported by ExprPlanner: {overlay_args:?}")
+    }
+
+    fn sql_cast_to_expr(
+        &self,
+        expr: Box<SQLExpr>,
+        data_type: SQLDataType,
+        format: Option<CastFormat>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        if let Some(format) = format {
+            return not_impl_err!("CAST with format is not supported: {format}");
+        }
+
+        let dt = self.convert_data_type(&data_type)?;
+        let expr = self.sql_expr_to_logical_expr(*expr, schema, planner_context)?;
+
+        // numeric constants are treated as seconds (rather as nanoseconds)
+        // to align with postgres / duckdb semantics
+        let expr = match &dt {
+            DataType::Timestamp(TimeUnit::Nanosecond, tz)
+                if expr.get_type(schema)? == DataType::Int64 =>
+            {
+                Expr::Cast(Cast::new(
+                    Box::new(expr),
+                    DataType::Timestamp(TimeUnit::Second, tz.clone()),
+                ))
+            }
+            _ => expr,
+        };
+
+        Ok(Expr::Cast(Cast::new(Box::new(expr), dt)))
+    }
+
+    fn sql_subscript_to_expr(
+        &self,
+        expr: SQLExpr,
+        subscript: Box<Subscript>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let expr = self.sql_expr_to_logical_expr(expr, schema, planner_context)?;
+
+        let field_access = match *subscript {
+            Subscript::Index { index } => {
+                // index can be a name, in which case it is a named field access
+                match index {
+                    SQLExpr::Value(
+                        Value::SingleQuotedString(s) | Value::DoubleQuotedString(s),
+                    ) => GetFieldAccess::NamedStructField {
+                        name: ScalarValue::from(s),
+                    },
+                    SQLExpr::JsonAccess { .. } => {
+                        return not_impl_err!("JsonAccess");
+                    }
+                    // otherwise treat like a list index
+                    _ => GetFieldAccess::ListIndex {
+                        key: Box::new(self.sql_expr_to_logical_expr(
+                            index,
+                            schema,
+                            planner_context,
+                        )?),
+                    },
+                }
+            }
+            Subscript::Slice {
+                lower_bound,
+                upper_bound,
+                stride,
+            } => {
+                // Means access like [:2]
+                let lower_bound = if let Some(lower_bound) = lower_bound {
+                    self.sql_expr_to_logical_expr(lower_bound, schema, planner_context)
+                } else {
+                    not_impl_err!("Slice subscript requires a lower bound")
+                }?;
+
+                // means access like [2:]
+                let upper_bound = if let Some(upper_bound) = upper_bound {
+                    self.sql_expr_to_logical_expr(upper_bound, schema, planner_context)
+                } else {
+                    not_impl_err!("Slice subscript requires an upper bound")
+                }?;
+
+                // stride, default to 1
+                let stride = if let Some(stride) = stride {
+                    self.sql_expr_to_logical_expr(stride, schema, planner_context)?
+                } else {
+                    lit(1i64)
+                };
+
+                GetFieldAccess::ListRange {
+                    start: Box::new(lower_bound),
+                    stop: Box::new(upper_bound),
+                    stride: Box::new(stride),
+                }
+            }
+        };
+
+        let mut field_access_expr = RawFieldAccessExpr { expr, field_access };
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_field_access(field_access_expr, schema)? {
+                PlannerResult::Planned(expr) => return Ok(expr),
+                PlannerResult::Original(expr) => {
+                    field_access_expr = expr;
+                }
+            }
+        }
+
+        not_impl_err!(
+            "GetFieldAccess not supported by ExprPlanner: {field_access_expr:?}"
+        )
     }
 }
 

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -178,6 +178,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         //       small as possible to avoid stack overflows in debug builds. Follow the
         //       common pattern of extracting into a separate function for non-trivial
         //       arms.
+        // 
+        // See https://github.com/apache/datafusion/pull/12384 for more context
         match sql {
             SQLExpr::Value(value) => {
                 self.parse_value(value, planner_context.prepare_param_data_types())

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -240,7 +240,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 expr,
                 data_type,
                 format,
-            } => self.sql_cast_to_expr(expr, data_type, format, schema, planner_context),
+            } => self.sql_cast_to_expr(*expr, data_type, format, schema, planner_context),
 
             SQLExpr::Cast {
                 kind: CastKind::TryCast | CastKind::SafeCast,
@@ -915,7 +915,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     fn sql_cast_to_expr(
         &self,
-        expr: Box<SQLExpr>,
+        expr: SQLExpr,
         data_type: SQLDataType,
         format: Option<CastFormat>,
         schema: &DFSchema,
@@ -926,7 +926,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
 
         let dt = self.convert_data_type(&data_type)?;
-        let expr = self.sql_expr_to_logical_expr(*expr, schema, planner_context)?;
+        let expr = self.sql_expr_to_logical_expr(expr, schema, planner_context)?;
 
         // numeric constants are treated as seconds (rather as nanoseconds)
         // to align with postgres / duckdb semantics

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -178,7 +178,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         //       small as possible to avoid stack overflows in debug builds. Follow the
         //       common pattern of extracting into a separate function for non-trivial
         //       arms.
-        // 
+        //
         // See https://github.com/apache/datafusion/pull/12384 for more context
         match sql {
             SQLExpr::Value(value) => {

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -177,9 +177,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // NOTE: This function is called recusively, so each match arm body should be as
         //       small as possible to avoid stack overflows in debug builds. Follow the
         //       common pattern of extracting into a separate function for non-trivial
-        //       arms.
-        //
-        // See https://github.com/apache/datafusion/pull/12384 for more context
+        //       arms. See https://github.com/apache/datafusion/pull/12384 for more context.
         match sql {
             SQLExpr::Value(value) => {
                 self.parse_value(value, planner_context.prepare_param_data_types())

--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -30,11 +30,9 @@ use datafusion_common_runtime::SpawnedTask;
 
 const TEST_DIRECTORY: &str = "test_files/";
 const PG_COMPAT_FILE_PREFIX: &str = "pg_compat_";
-const STACK_SIZE: usize = 2 * 1024 * 1024 + 512 * 1024; // 2.5 MBs, the default 2 MBs is currently too small
 
 pub fn main() -> Result<()> {
     tokio::runtime::Builder::new_multi_thread()
-        .thread_stack_size(STACK_SIZE)
         .enable_all()
         .build()
         .unwrap()


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11499

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Cause for stack overflow was familiar to #9962, so after some LLDB debugging was able to identify that `SqlToRel::sql_expr_to_logical_expr_internal` was being recursively called with a chunky frame size (appox 70000 bytes), and seemed to be the most frequent frame in the backtrace with the largest size. Applied fix similar to #9962 where large arms are split into functions to reduce the size of the main function.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Refactor `SqlToRel::sql_expr_to_logical_expr_internal` to split larger arms into separate functions.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, existing sqllogictest (with stack size modifier removed so back to default 2MB)

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
