### PR TITLE
Fix invalid ref in UserDefinedLogicalNodeCore doc

### DIFF
--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -212,7 +212,7 @@ impl Eq for dyn UserDefinedLogicalNode {}
 /// This trait facilitates implementation of the [`UserDefinedLogicalNode`].
 ///
 /// See the example in
-/// [user_defined_plan.rs](<https://github.com/apache/datafusion/blob/main/datafusion/core/tests/user_defined/user_defined_plan.rs>)
+/// [user_defined_plan.rs](https://github.com/apache/datafusion/blob/main/datafusion/core/tests/user_defined/user_defined_plan.rs)
 /// file for an example of how to use this extension API.
 pub trait UserDefinedLogicalNodeCore:
     fmt::Debug + Eq + Hash + Sized + Send + Sync + 'static

--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -212,8 +212,8 @@ impl Eq for dyn UserDefinedLogicalNode {}
 /// This trait facilitates implementation of the [`UserDefinedLogicalNode`].
 ///
 /// See the example in
-/// [user_defined_plan.rs](../../tests/user_defined_plan.rs) for an
-/// example of how to use this extension API.
+/// [user_defined_plan.rs](<https://github.com/apache/datafusion/blob/main/datafusion/core/tests/user_defined/user_defined_plan.rs>)
+/// file for an example of how to use this extension API.
 pub trait UserDefinedLogicalNodeCore:
     fmt::Debug + Eq + Hash + Sized + Send + Sync + 'static
 {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/12280

## Rationale for this change
One of the links in `datafusion::logical_expr::UserDefinedLogicalNodeCore`  [doc](https://docs.rs/datafusion/latest/datafusion/logical_expr/trait.UserDefinedLogicalNodeCore.html) throws an invalid resource 
![image](https://github.com/user-attachments/assets/669e769d-270d-4867-aee9-eccd82e31bf5)




## What changes are included in this PR?

Referring to the file in a different module is abit tricky to I chose to refer to a remote Github file instead
## Are these changes tested?
Its a doc change so no test is needed (I think)

## Are there any user-facing changes?
Yes. It will change the API doc


