### PR TITLE
Improve comments on target user and unify intro summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,28 @@
 
 <img src="./docs/source/_static/images/2x_bgwhite_original.png" width="512" alt="logo"/>
 
-Apache DataFusion is a very fast, extensible query engine for building high-quality data-centric systems in
-[Rust](http://rustlang.org), using the [Apache Arrow](https://arrow.apache.org)
-in-memory format. [Python Bindings](https://github.com/apache/datafusion-python) are also available. DataFusion offers SQL and Dataframe APIs, excellent [performance](https://benchmark.clickhouse.com/), built-in support for CSV, Parquet, JSON, and Avro, extensive customization, and a great community.
+DataFusion is an extensible query engine written in [Rust] that
+uses [Apache Arrow] as its in-memory format. DataFusion's target users are
+developers building fast and feature rich database and analytic systems,
+customized to particular workloads. See [use cases] for examples.
+
+"Out of the box," DataFusion offers [SQL] and [`Dataframe`] APIs,
+excellent [performance], built-in support for CSV, Parquet, JSON, and Avro,
+extensive customization, and a great community.
+[Python Bindings] are also available.
+
+DataFusion features a full query planner, a columnar, streaming, multi-threaded,
+vectorized execution engine, and partitioned data sources. You can
+customize DataFusion at almost all points including additional data sources,
+query languages, functions, custom operators and more.
+See the [Architecture] section for more details.
+
+[rust]: http://rustlang.org
+[apache arrow]: https://arrow.apache.org
+[use cases]: https://datafusion.apache.org/user-guide/introduction.html#use-cases
+[python bindings]: https://github.com/apache/datafusion-python
+[performance]: https://benchmark.clickhouse.com/
+[architecture]: https://datafusion.apache.org/contributor-guide/architecture.html
 
 Here are links to some important information
 

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -17,24 +17,28 @@
 #![warn(missing_docs, clippy::needless_borrow)]
 
 //! [DataFusion] is an extensible query engine written in Rust that
-//! uses [Apache Arrow] as its in-memory format. DataFusion help developers
-//! build fast and feature rich database and analytic systems, customized to
-//! particular workloads. See [use cases] for examples
+//! uses [Apache Arrow] as its in-memory format. DataFusion's target users are
+//! developers building fast and feature rich database and analytic systems,
+//! customized to particular workloads. See [use cases] for examples.
 //!
-//! "Out of the box," DataFusion quickly runs complex [SQL] and
-//! [`DataFrame`] queries using a full-featured query planner, a columnar,
-//! streaming, multi-threaded, vectorized execution engine, and partitioned data
-//! sources (Parquet, CSV, JSON, and Avro).
+//! "Out of the box," DataFusion offers [SQL] and [`Dataframe`] APIs,
+//! excellent [performance], built-in support for CSV, Parquet, JSON, and Avro,
+//! extensive customization, and a great community.
+//! [Python Bindings] are also available.
 //!
-//! DataFusion is designed for easy customization such as
-//! additional data sources, query languages, functions, custom
-//! operators and more. See the [Architecture] section for more details.
+//! DataFusion features a full query planner, a columnar, streaming, multi-threaded,
+//! vectorized execution engine, and partitioned data  sources. You can
+//! customize DataFusion at almost all points including additional data sources,
+//! query languages, functions, custom operators and more.
+//! See the [Architecture] section below for more details.
 //!
 //! [DataFusion]: https://datafusion.apache.org/
 //! [Apache Arrow]: https://arrow.apache.org
 //! [use cases]: https://datafusion.apache.org/user-guide/introduction.html#use-cases
 //! [SQL]: https://datafusion.apache.org/user-guide/sql/index.html
 //! [`DataFrame`]: dataframe::DataFrame
+//! [performance]: https://benchmark.clickhouse.com/
+//! [Python Bindings]: https://github.com/apache/datafusion-python
 //! [Architecture]: #architecture
 //!
 //! # Examples

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,14 +32,23 @@ Apache DataFusion
      <a class="github-button" href="https://github.com/apache/datafusion/fork" data-size="large" data-show-count="true" aria-label="Fork apache/datafusion on GitHub">Fork</a>
   </p>
 
-DataFusion is a very fast, extensible query engine for building high-quality data-centric systems in
-`Rust <http://rustlang.org>`_, using the `Apache Arrow <https://arrow.apache.org>`_
-in-memory format.
 
-DataFusion offers SQL and Dataframe APIs, excellent
-`performance <https://benchmark.clickhouse.com>`_, built-in support for
-CSV, Parquet, JSON, and Avro, extensive customization, and a great
-community.
+DataFusion is an extensible query engine written in `Rust <http://rustlang.org>`_ that
+uses `Apache Arrow <https://arrow.apache.org>`_ as its in-memory format. DataFusion's target users are
+developers building fast and feature rich database and analytic systems,
+customized to particular workloads. See `use cases <https://datafusion.apache.org/user-guide/introduction.html#use-cases>`_ for examples.
+
+"Out of the box," DataFusion offers `SQL <https://datafusion.apache.org/user-guide/sql/index.html>`_
+and `Dataframe <https://docs.rs/datafusion/latest/datafusion/dataframe/struct.DataFrame.html>`_ APIs,
+excellent `performance <https://benchmark.clickhouse.com/>`_, built-in support for CSV, Parquet, JSON, and Avro,
+extensive customization, and a great community.
+`Python Bindings <https://github.com/apache/datafusion-python>`_ are also available.
+
+DataFusion features a full query planner, a columnar, streaming, multi-threaded,
+vectorized execution engine, and partitioned data sources. You can
+customize DataFusion at almost all points including additional data sources,
+query languages, functions, custom operators and more.
+See the `Architecture <https://datafusion.apache.org/contributor-guide/architecture.html>`_ section for more details.
 
 To get started, see
 


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/datafusion/issues/12357


## Rationale for this change

Inspired by @phillipleblanc's comment on https://github.com/apache/datafusion/issues/12357#issuecomment-2335401127 let's make it clearer that  DataFusion is targeted at people building other systems

While I was working on this, it also became clear the DataFusion summary / intro had diverged so I unified it again

## What changes are included in this PR?

Changes:
1. Clarify that DataFusion is targeted at people building other systems
2. Ensure that the readme, user guide and library .rs are all in sync

## Are these changes tested?
By CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No functional change, only doc changes
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
