### PR TITLE
Minor: Fix project website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@
 [discord-badge]: https://img.shields.io/discord/885562378132000778.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.com/invite/Qw5gKqHxUM
 
-[Website](https://github.com/apache/datafusion) |
-[Guides](https://github.com/apache/datafusion/tree/main/docs) |
+[Website](https://datafusion.apache.org/) |
 [API Docs](https://docs.rs/datafusion/latest/datafusion/) |
 [Chat](https://discord.com/channels/885562378132000778/885562378132000781)
 
-<img src="./docs/source/_static/images/2x_bgwhite_original.png" width="512" alt="logo"/>
+<a href="https://datafusion.apache.org/">
+  <img src="./docs/source/_static/images/2x_bgwhite_original.png" width="512" alt="logo"/>
+</a>
 
 Apache DataFusion is a very fast, extensible query engine for building high-quality data-centric systems in
 [Rust](http://rustlang.org), using the [Apache Arrow](https://arrow.apache.org)


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

While working on https://github.com/apache/datafusion/pull/12418 I noticed that the top most links on https://github.com/apache/datafusion currently were wonky

<img width="911" alt="Screenshot 2024-09-10 at 9 32 38 AM" src="https://github.com/user-attachments/assets/45b7b776-5ff3-4bdd-a614-234b26f3cadd">


1. The project website just linked to the github url
2. the "guides" link linked to the doc source which doesn't seem all that useful

## What changes are included in this PR?
1. Fix project website link to point at https://datafusion.apache.org/
2. Remove guide link (they are on the main project website link)

## Are these changes tested?
I tested manually. You can see the rendered version here: https://github.com/alamb/datafusion/tree/alamb/self_referential_site?tab=readme-ov-file

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Only docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
