### PR TITLE
Fix: upper case qualifier wildcard bug

### DIFF
--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -27,7 +27,7 @@ use sqlparser::ast::{
 
 use datafusion_common::{
     internal_datafusion_err, internal_err, not_impl_err, plan_err, DFSchema, Result,
-    ScalarValue, TableReference,
+    ScalarValue,
 };
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::expr::{InList, WildcardOptions};
@@ -562,7 +562,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 options: WildcardOptions::default(),
             }),
             SQLExpr::QualifiedWildcard(object_name) => Ok(Expr::Wildcard {
-                qualifier: Some(TableReference::from(object_name.to_string())),
+                qualifier: Some(self.object_name_to_table_reference(object_name)?),
                 options: WildcardOptions::default(),
             }),
             SQLExpr::Tuple(values) => self.parse_tuple(schema, planner_context, values),

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -18,9 +18,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::planner::{
-    idents_to_table_reference, ContextProvider, PlannerContext, SqlToRel,
-};
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 use crate::utils::{
     check_columns_satisfy_exprs, extract_aliases, rebase_expr, resolve_aliases_to_exprs,
     resolve_columns, resolve_positions_to_exprs, transform_bottom_unnests,
@@ -590,7 +588,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }
             SelectItem::QualifiedWildcard(object_name, options) => {
                 Self::check_wildcard_options(&options)?;
-                let qualifier = idents_to_table_reference(object_name.0, false)?;
+                let qualifier = self.object_name_to_table_reference(object_name)?;
                 let planned_options = self.plan_wildcard_options(
                     plan,
                     empty_from,

--- a/datafusion/sqllogictest/test_files/wildcard.slt
+++ b/datafusion/sqllogictest/test_files/wildcard.slt
@@ -108,6 +108,31 @@ SELECT t1.*, tb2.* FROM t1 JOIN t2 tb2 ON t2_id = t1_id ORDER BY t1_id
 statement error Error during planning: Invalid qualifier agg
 SELECT agg.* FROM aggregate_simple ORDER BY c1
 
+# select_upper_case_qualified_wildcard
+query ITI
+SELECT PUBLIC.t1.* FROM PUBLIC.t1
+----
+11 a 1
+22 b 2
+33 c 3
+44 d 4
+
+query ITI
+SELECT PUBLIC.t1.* FROM public.t1
+----
+11 a 1
+22 b 2
+33 c 3
+44 d 4
+
+query ITI
+SELECT public.t1.* FROM PUBLIC.t1
+----
+11 a 1
+22 b 2
+33 c 3
+44 d 4
+
 ########
 # Clean up after the test
 ########


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/12427

## Rationale for this change

In order for the following query to work properly:
```sql
SELECT PUBLIC.t1.* FROM PUBLIC.t1
```

## What changes are included in this PR?

Modify some `SqlToRel` functions: 
- `sql_select_to_rex`
- `sql_expr_to_logical_expr_internal`

Using the `object_name_to_table_reference` function, to be consistent with `create_relation`.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
