### PR TITLE
fix: calling `with_column` twice and using a `window` function for the 2nd call returns an error

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -3013,7 +3013,7 @@ mod tests {
 
         assert_eq!(
             "\
-        Projection: t1.c1, t2.c1, Boolean(true) AS new_column\
+        Projection: *, Boolean(true) AS new_column\
         \n  Limit: skip=0, fetch=1\
         \n    Sort: t1.c1 ASC NULLS FIRST\
         \n      Inner Join: t1.c1 = t2.c1\

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -3086,10 +3086,15 @@ mod tests {
             &df_results
         );
 
-        let actual_err = df.clone().with_column("new_column", lit(true)).unwrap_err();
-        let expected_err = "Error during planning: Projections require unique expression names \
-            but the expression \"t1.c1\" at position 0 and \"t1.c1\" at position 1 have the same name. \
-            Consider aliasing (\"AS\") one of them.";
+        // The error now doesn't occur until the `physical` stage.
+        // I assume there's a way to catch this during hte `logical` stage, so please let me know.
+        let df_with_new_column = df
+            .clone()
+            .with_column("new_column", lit(true))
+            .expect("with-column");
+        let actual_err = df_with_new_column.collect().await.unwrap_err();
+
+        let expected_err = "expand_wildcard_rule\ncaused by\nError during planning: Projections require unique expression names but the expression \"t1.c1\" at position 0 and \"t1.c1\" at position 1 have the same name. Consider aliasing (\"AS\") one of them.";
         assert_eq!(actual_err.strip_backtrace(), expected_err);
 
         Ok(())


### PR DESCRIPTION
DRAFT

My first attempt was to convert `with_column` to a sugar API for `df.select(vec![wildcard(), expr.alias(name)])`, which mostly matches my mental model of what the function should do.

There are currently failing test cases surrounding ambiguous and/or "over-write an existing column" use cases. I *suspect* proper use of `WildcardOptions` will let me resolve those.

## Which issue does this PR close?

Closes #12425.

## Rationale for this change

## What changes are included in this PR?

## Are these changes tested?

## Are there any user-facing changes?