### PR TITLE
Add a `version()` UDF

### DIFF
--- a/datafusion/functions/src/core/mod.rs
+++ b/datafusion/functions/src/core/mod.rs
@@ -31,6 +31,7 @@ pub mod nvl;
 pub mod nvl2;
 pub mod planner;
 pub mod r#struct;
+pub mod version;
 
 // create UDFs
 make_udf_function!(arrow_cast::ArrowCastFunc, ARROW_CAST, arrow_cast);
@@ -42,6 +43,7 @@ make_udf_function!(r#struct::StructFunc, STRUCT, r#struct);
 make_udf_function!(named_struct::NamedStructFunc, NAMED_STRUCT, named_struct);
 make_udf_function!(getfield::GetFieldFunc, GET_FIELD, get_field);
 make_udf_function!(coalesce::CoalesceFunc, COALESCE, coalesce);
+make_udf_function!(version::Version, VERSION, version);
 
 pub mod expr_fn {
     use datafusion_expr::{Expr, Literal};
@@ -104,5 +106,6 @@ pub fn functions() -> Vec<Arc<ScalarUDF>> {
         // calls to `get_field`
         get_field(),
         coalesce(),
+        version(),
     ]
 }

--- a/datafusion/functions/src/core/mod.rs
+++ b/datafusion/functions/src/core/mod.rs
@@ -43,7 +43,7 @@ make_udf_function!(r#struct::StructFunc, STRUCT, r#struct);
 make_udf_function!(named_struct::NamedStructFunc, NAMED_STRUCT, named_struct);
 make_udf_function!(getfield::GetFieldFunc, GET_FIELD, get_field);
 make_udf_function!(coalesce::CoalesceFunc, COALESCE, coalesce);
-make_udf_function!(version::Version, VERSION, version);
+make_udf_function!(version::VersionFunc, VERSION, version);
 
 pub mod expr_fn {
     use datafusion_expr::{Expr, Literal};

--- a/datafusion/functions/src/core/version.rs
+++ b/datafusion/functions/src/core/version.rs
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`VersionFunc`]: Implementation of the `version` function.
+
+use std::any::Any;
+
+use arrow::datatypes::DataType;
+use datafusion_common::{not_impl_err, plan_err, Result, ScalarValue};
+use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
+
+#[derive(Debug)]
+pub struct Version {
+    signature: Signature,
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Version {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for Version {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "version"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, args: &[DataType]) -> Result<DataType> {
+        if args.is_empty() {
+            Ok(DataType::Utf8)
+        } else {
+            plan_err!("version expects no arguments")
+        }
+    }
+
+    fn invoke(&self, _: &[ColumnarValue]) -> Result<ColumnarValue> {
+        not_impl_err!("version does not take any arguments")
+    }
+
+    fn invoke_no_args(&self, _: usize) -> Result<ColumnarValue> {
+        // TODO it would be great to add rust version and arrow version,
+        // but that requires a `build.rs` script and/or adding a version const to arrow-rs
+        let version = format!(
+            "DataFusion {}, {} on {}",
+            env!("CARGO_PKG_VERSION"),
+            std::env::consts::ARCH,
+            std::env::consts::OS,
+        );
+        Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(version))))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use datafusion_expr::ScalarUDF;
+
+    #[tokio::test]
+    async fn test_version_udf() {
+        let version_udf = ScalarUDF::from(Version::new());
+        let version = version_udf.invoke_no_args(0).unwrap();
+
+        if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(version))) = version {
+            assert!(version.starts_with("DataFusion"));
+        } else {
+            panic!("Expected version string");
+        }
+    }
+}

--- a/datafusion/functions/src/core/version.rs
+++ b/datafusion/functions/src/core/version.rs
@@ -71,7 +71,7 @@ impl ScalarUDFImpl for Version {
         // TODO it would be great to add rust version and arrow version,
         // but that requires a `build.rs` script and/or adding a version const to arrow-rs
         let version = format!(
-            "DataFusion {}, {} on {}",
+            "Apache DataFusion {}, {} on {}",
             env!("CARGO_PKG_VERSION"),
             std::env::consts::ARCH,
             std::env::consts::OS,
@@ -91,7 +91,7 @@ mod test {
         let version = version_udf.invoke_no_args(0).unwrap();
 
         if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(version))) = version {
-            assert!(version.starts_with("DataFusion"));
+            assert!(version.starts_with("Apache DataFusion"));
         } else {
             panic!("Expected version string");
         }

--- a/datafusion/functions/src/core/version.rs
+++ b/datafusion/functions/src/core/version.rs
@@ -24,17 +24,17 @@ use datafusion_common::{not_impl_err, plan_err, Result, ScalarValue};
 use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 
 #[derive(Debug)]
-pub struct Version {
+pub struct VersionFunc {
     signature: Signature,
 }
 
-impl Default for Version {
+impl Default for VersionFunc {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Version {
+impl VersionFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::exact(vec![], Volatility::Immutable),
@@ -42,7 +42,7 @@ impl Version {
     }
 }
 
-impl ScalarUDFImpl for Version {
+impl ScalarUDFImpl for VersionFunc {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -87,7 +87,7 @@ mod test {
 
     #[tokio::test]
     async fn test_version_udf() {
-        let version_udf = ScalarUDF::from(Version::new());
+        let version_udf = ScalarUDF::from(VersionFunc::new());
         let version = version_udf.invoke_no_args(0).unwrap();
 
         if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(version))) = version {

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -3917,6 +3917,7 @@ sha512(expression)
 
 - [arrow_cast](#arrow_cast)
 - [arrow_typeof](#arrow_typeof)
+- [version](#version)
 
 ### `arrow_cast`
 
@@ -3974,4 +3975,23 @@ arrow_typeof(expression)
 | Utf8                      | Int64                  |
 +---------------------------+------------------------+
 1 row in set. Query took 0.001 seconds.
+```
+
+### `version`
+
+Returns the version of DataFusion.
+
+```
+version()
+```
+
+#### Example
+
+```
+> select version();
++--------------------------------------------+
+| version()                                  |
++--------------------------------------------+
+| Apache DataFusion 41.0.0, aarch64 on macos |
++--------------------------------------------+
 ```


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12424

## Rationale for this change

Pretty self explanatory — it's use to know what version of a database you're using. 

## What changes are included in this PR?

Adds a `version()` UDF.

Usage:

```bash
cargo run --manifest-path datafusion-cli/Cargo.toml
```

```sql
select version();
+--------------------------------------------+
| version()                                  |
+--------------------------------------------+
| Apache DataFusion 41.0.0, aarch64 on macos |
+--------------------------------------------+
1 row(s) fetched. 
Elapsed 0.018 seconds.
```

I'd like to add:
* Rustc version, but that would require a build script or another dependency
* Arrow-rs version, but would require a new export from arrow-rs, equivalent to `datafusion::DATAFUSION_VERSION`

## Are these changes tested?

yes

## Are there any user-facing changes?

Just one new UDF.