### PR TITLE
Check window functions by str for with_column

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1472,7 +1472,11 @@ impl DataFrame {
                     Some(new_column.clone())
                 } else {
                     let e = col(Column::from((qualifier, field)));
-                    window_fn_str.as_ref().filter(|s| *s == &e.to_string()).is_none().then_some(e)
+                    window_fn_str
+                        .as_ref()
+                        .filter(|s| *s == &e.to_string())
+                        .is_none()
+                        .then_some(e)
                 }
             })
             .collect();

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1472,14 +1472,7 @@ impl DataFrame {
                     Some(new_column.clone())
                 } else {
                     let e = col(Column::from((qualifier, field)));
-                    let match_window_fn = window_fn_str
-                        .as_ref()
-                        .map(|s| s == &e.to_string())
-                        .unwrap_or(false);
-                    match match_window_fn {
-                        true => None,
-                        false => Some(e),
-                    }
+                    window_fn_str.as_ref().filter(|s| *s == &e.to_string()).is_none().then_some(e)
                 }
             })
             .collect();

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -2974,7 +2974,8 @@ mod tests {
         Ok(())
     }
 
-    // Test issue: https://github.com/apache/datafusion/issues/11982
+    // Test issues: https://github.com/apache/datafusion/issues/11982
+    // and https://github.com/apache/datafusion/issues/12425
     // Window function was creating unwanted projection when using with_column() method.
     #[tokio::test]
     async fn test_window_function_with_column() -> Result<()> {
@@ -2986,8 +2987,7 @@ mod tests {
         // This first `with_column` results in a column without a `qualifier`
         let df_impl = df_impl.with_column("s", col("c2") + col("c3"))?;
 
-        // This second `with_column` then assigns `"r"` alias to the above column and the window function
-        // Should create an additional column with alias 'r' that has window func results
+        // This second `with_column` should only alias `func` as `"r"`
         let df = df_impl.with_column("r", func)?.limit(0, Some(2))?;
 
         df.clone().show().await?;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12425 

## Rationale for this change

The current implementation regresses when you have multiple columns without a qualifier and the new with_column is a window function. This is because the loop is checking for any field to not have a qualifier.

## What changes are included in this PR?

Check the display name of the expr in the schema matches that of the window function that was added.

## Are these changes tested?

Updated unit test

## Are there any user-facing changes?

None