### PR TITLE
Minor: add err on `create` `temporary` table

### DIFF
--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -544,6 +544,10 @@ impl<'a> DFParser<'a> {
         } else if self.parser.parse_keyword(Keyword::UNBOUNDED) {
             self.parser.expect_keyword(Keyword::EXTERNAL)?;
             self.parse_create_external_table(true)
+        } else if self.parser.parse_keyword(Keyword::TEMPORARY) {
+            Err(ParserError::ParserError(
+                "Creating temporary tables is Unsupported".to_owned(),
+            ))
         } else {
             Ok(Statement::Statement(Box::from(self.parser.parse_create()?)))
         }

--- a/datafusion/sqllogictest/test_files/create_external_table.slt
+++ b/datafusion/sqllogictest/test_files/create_external_table.slt
@@ -95,6 +95,16 @@ STORED AS CSV
 LOCATION 'foo.csv'
 OPTIONS ('format.delimiter' ';', 'format.column_index_truncate_length' '123')
 
+# Creating Temporary tables
+statement error DataFusion error: SQL error: ParserError\("Creating temporary tables is Unsupported"\)
+CREATE TEMPORARY TABLE my_temp_table (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+statement error DataFusion error: SQL error: ParserError\("Creating temporary tables is Unsupported"\)
+CREATE TEMPORARY VIEW my_temp_view AS SELECT id, name FROM my_table;
+
 # Partitioned table on a single file
 query error DataFusion error: Error during planning: Can't create a partitioned table backed by a single file, perhaps the URL is missing a trailing slash\?
 CREATE EXTERNAL TABLE single_file_partition(c1 int)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12363 

## Rationale for this change
Returns an explicit error when attempting to `create` a `temporary` table which is unsupported.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
yes, returns an explicit error.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
