### PR TITLE
Minor: Add a test for version() function

### DIFF
--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -250,3 +250,33 @@ async fn test_parameter_invalid_types() -> Result<()> {
 );
     Ok(())
 }
+
+#[tokio::test]
+async fn test_version_function() {
+    let expected_version = format!(
+        "Apache DataFusion {}, {} on {}",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::ARCH,
+        std::env::consts::OS,
+    );
+
+    let ctx = SessionContext::new();
+    let results = ctx
+        .sql("select version()")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // since width of columns varies between platforms, we can't compare directly
+    // so we just check that the version string is present
+
+    // expect a single string column with a single row
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].num_columns(), 1);
+    let version = results[0].column(0).as_string::<i32>();
+    assert_eq!(version.len(), 1);
+
+    assert_eq!(version.value(0), expected_version);
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/12424
Follow on to https://github.com/apache/datafusion/pull/12429

## Rationale for this change

Testing the `version()` function is a bit tricky as the output is platform and version dependent so we didn't put one in https://github.com/apache/datafusion/pull/12429

## What changes are included in this PR?

Add a test for `version()`

## Are these changes tested?

All tests
## Are there any user-facing changes?
No, this is test only

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
