### PR TITLE
Do not silently ignore unsupported `CREATE TABLE` and `CREATE VIEW` syntax

### DIFF
--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -544,10 +544,6 @@ impl<'a> DFParser<'a> {
         } else if self.parser.parse_keyword(Keyword::UNBOUNDED) {
             self.parser.expect_keyword(Keyword::EXTERNAL)?;
             self.parse_create_external_table(true)
-        } else if self.parser.parse_keyword(Keyword::TEMPORARY) {
-            Err(ParserError::ParserError(
-                "Creating temporary tables is Unsupported".to_owned(),
-            ))
         } else {
             Ok(Statement::Statement(Box::from(self.parser.parse_create()?)))
         }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -31,12 +31,7 @@ use crate::utils::normalize_ident;
 
 use arrow_schema::{DataType, Fields};
 use datafusion_common::parsers::CompressionTypeVariant;
-use datafusion_common::{
-    exec_err, not_impl_err, plan_datafusion_err, plan_err, schema_err,
-    unqualified_field_not_found, Column, Constraints, DFSchema, DFSchemaRef,
-    DataFusionError, Result, ScalarValue, SchemaError, SchemaReference, TableReference,
-    ToDFSchema,
-};
+use datafusion_common::{exec_err, not_impl_err, plan_datafusion_err, plan_err, schema_err, unqualified_field_not_found, Column, Constraints, DFSchema, DFSchemaRef, DataFusionError, Result, ScalarValue, SchemaError, SchemaReference, TableReference, ToDFSchema};
 use datafusion_expr::dml::CopyTo;
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas_and_ambiguity_check;
 use datafusion_expr::logical_plan::builder::project;
@@ -222,6 +217,15 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             } => self.set_variable_to_plan(local, hivevar, &variables, value),
 
             Statement::CreateTable(CreateTable {
+                temporary,
+                external,
+                global,
+                transient,
+                volatile,
+                hive_distribution,
+                hive_formats,
+                file_format,
+                location,
                 query,
                 name,
                 columns,
@@ -230,8 +234,138 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 with_options,
                 if_not_exists,
                 or_replace,
-                ..
+                without_rowid,
+                like,
+                clone,
+                engine,
+                comment,
+                auto_increment_offset,
+                default_charset,
+                collation,
+                on_commit,
+                on_cluster,
+                primary_key,
+                order_by,
+                partition_by,
+                cluster_by,
+                options,
+                strict,
+                copy_grants,
+                enable_schema_evolution,
+                change_tracking,
+                data_retention_time_in_days,
+                max_data_extension_time_in_days,
+                default_ddl_collation,
+                with_aggregation_policy,
+                with_row_access_policy,
+                with_tags,
             }) if table_properties.is_empty() && with_options.is_empty() => {
+                if temporary {
+                    return not_impl_err!("Temporary tables not supported")?;
+                }
+                if external {
+                    return not_impl_err!("External tables not supported")?;
+                }
+                if global.is_some() {
+                    return not_impl_err!("Global tables not supported")?;
+                }
+                if transient {
+                    return not_impl_err!("Transient tables not supported")?;
+                }
+                if volatile {
+                    return not_impl_err!("Volatile tables not supported")?;
+                }
+                if hive_distribution != ast::HiveDistributionStyle::NONE {
+                    return not_impl_err!("Hive distribution not supported: {hive_distribution:?}")?;
+                }
+                if !matches!(hive_formats, Some(ast::HiveFormat {
+                    row_format:None,serde_properties:None,storage: None,location: None,
+                })) {
+                    return not_impl_err!("Hive formats not supported: {hive_formats:?}")?;
+                }
+                if file_format.is_some() {
+                    return not_impl_err!("File format not supported")?;
+                }
+                if location.is_some() {
+                    return not_impl_err!("Location not supported")?;
+                }
+                if without_rowid {
+                    return not_impl_err!("Without rowid not supported")?;
+                }
+                if like.is_some() {
+                    return not_impl_err!("Like not supported")?;
+                }
+                if clone.is_some() {
+                    return not_impl_err!("Clone not supported")?;
+                }
+                if engine.is_some() {
+                    return not_impl_err!("Engine not supported")?;
+                }
+                if comment.is_some() {
+                    return not_impl_err!("Comment not supported")?;
+                }
+                if auto_increment_offset.is_some() {
+                    return not_impl_err!("Auto increment offset not supported")?;
+                }
+                if default_charset.is_some() {
+                    return not_impl_err!("Default charset not supported")?;
+                }
+                if collation.is_some() {
+                    return not_impl_err!("Collation not supported")?;
+                }
+                if on_commit.is_some() {
+                    return not_impl_err!("On commit not supported")?;
+                }
+                if on_cluster.is_some() {
+                    return not_impl_err!("On cluster not supported")?;
+                }
+                if primary_key.is_some() {
+                    return not_impl_err!("Primary key not supported")?;
+                }
+                if order_by.is_some() {
+                    return not_impl_err!("Order by not supported")?;
+                }
+                if partition_by.is_some() {
+                    return not_impl_err!("Partition by not supported")?;
+                }
+                if cluster_by.is_some() {
+                    return not_impl_err!("Cluster by not supported")?;
+                }
+                if options.is_some() {
+                    return not_impl_err!("Options not supported")?;
+                }
+                if strict {
+                    return not_impl_err!("Strict not supported")?;
+                }
+                if copy_grants {
+                    return not_impl_err!("Copy grants not supported")?;
+                }
+                if enable_schema_evolution.is_some() {
+                    return not_impl_err!("Enable schema evolution not supported")?;
+                }
+                if change_tracking.is_some() {
+                    return not_impl_err!("Change tracking not supported")?;
+                }
+                if data_retention_time_in_days.is_some() {
+                    return not_impl_err!("Data retention time in days not supported")?;
+                }
+                if max_data_extension_time_in_days.is_some() {
+                    return not_impl_err!("Max data extension time in days not supported")?;
+                }
+                if default_ddl_collation.is_some() {
+                    return not_impl_err!("Default DDL collation not supported")?;
+                }
+                if with_aggregation_policy.is_some() {
+                    return not_impl_err!("With aggregation policy not supported")?;
+                }
+                if with_row_access_policy.is_some() {
+                    return not_impl_err!("With row access policy not supported")?;
+                }
+                if with_tags.is_some() {
+                    return not_impl_err!("With tags not supported")?;
+                }
+
+
                 // Merge inline constraints and existing constraints
                 let mut all_constraints = constraints;
                 let inline_constraints = calc_inline_constraints_from_columns(&columns);

--- a/datafusion/sqllogictest/test_files/create_external_table.slt
+++ b/datafusion/sqllogictest/test_files/create_external_table.slt
@@ -96,13 +96,13 @@ LOCATION 'foo.csv'
 OPTIONS ('format.delimiter' ';', 'format.column_index_truncate_length' '123')
 
 # Creating Temporary tables
-statement error DataFusion error: SQL error: ParserError\("Creating temporary tables is Unsupported"\)
+statement error DataFusion error: This feature is not implemented: Temporary tables not supported
 CREATE TEMPORARY TABLE my_temp_table (
     id INTEGER PRIMARY KEY,
     name TEXT NOT NULL
 );
 
-statement error DataFusion error: SQL error: ParserError\("Creating temporary tables is Unsupported"\)
+statement error DataFusion error: Error during planning: table 'datafusion\.public\.my_table' not found
 CREATE TEMPORARY VIEW my_temp_view AS SELECT id, name FROM my_table;
 
 # Partitioned table on a single file

--- a/datafusion/sqllogictest/test_files/create_external_table.slt
+++ b/datafusion/sqllogictest/test_files/create_external_table.slt
@@ -102,7 +102,7 @@ CREATE TEMPORARY TABLE my_temp_table (
     name TEXT NOT NULL
 );
 
-statement error DataFusion error: Error during planning: table 'datafusion\.public\.my_table' not found
+statement error DataFusion error: This feature is not implemented: Temporary views not supported
 CREATE TEMPORARY VIEW my_temp_view AS SELECT id, name FROM my_table;
 
 # Partitioned table on a single file


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/12449

## Rationale for this change

@hailelagi fixed the bug for `TEMPORARY` in https://github.com/apache/datafusion/pull/12439 :pray:

While reviewing https://github.com/apache/datafusion/pull/12439 I noticed there are some other clauses that are ignored too

For example the `CLUSTER BY ` clause is totally ignored:

```sql
> create table  foo(x int) cluster by x;
0 row(s) fetched.
Elapsed 0.009 seconds.
```

We should reject this with an explicit error rather than silently ignoring it


## What changes are included in this PR?

Changes:
1. Change sqlparser to error on fields which are currently ignored

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
