### PR TITLE
Making avro_to_arrow::schema::to_arrow_schema public

### DIFF
--- a/datafusion/core/src/datasource/avro_to_arrow/mod.rs
+++ b/datafusion/core/src/datasource/avro_to_arrow/mod.rs
@@ -30,6 +30,8 @@ use crate::arrow::datatypes::Schema;
 use crate::error::Result;
 #[cfg(feature = "avro")]
 pub use reader::{Reader, ReaderBuilder};
+#[cfg(feature = "avro")]
+pub use schema::to_arrow_schema;
 use std::io::Read;
 
 #[cfg(feature = "avro")]


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12451

## Rationale for this change

We need schema::to_arrow_schema to be able to use avro_to_arrow module in situations where we are deserializing avro from in memory buffers and not an avro file.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
