### PR TITLE
feat: Support null safe equals in ExtractEquijoinPredicate

### DIFF
--- a/datafusion/optimizer/src/eliminate_cross_join.rs
+++ b/datafusion/optimizer/src/eliminate_cross_join.rs
@@ -96,6 +96,7 @@ impl OptimizerRule for EliminateCrossJoin {
                 filter.input.as_ref(),
                 LogicalPlan::Join(Join {
                     join_type: JoinType::Inner,
+                    null_equals_null: false,
                     ..
                 }) | LogicalPlan::CrossJoin(_)
             );
@@ -124,6 +125,7 @@ impl OptimizerRule for EliminateCrossJoin {
             plan,
             LogicalPlan::Join(Join {
                 join_type: JoinType::Inner,
+                null_equals_null: false,
                 ..
             })
         ) {
@@ -268,6 +270,7 @@ fn can_flatten_join_inputs(plan: &LogicalPlan) -> bool {
         match child {
             LogicalPlan::Join(Join {
                 join_type: JoinType::Inner,
+                null_equals_null: false,
                 ..
             })
             | LogicalPlan::CrossJoin(_) => {

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -772,6 +772,50 @@ DROP TABLE t1;
 statement ok
 DROP TABLE t2;
 
+# tables for join nulls equals null
+statement ok
+CREATE TABLE IF NOT EXISTS t1(t1_id INT NULL, t1_int INT) AS VALUES
+(11, 1),
+(22, 2),
+(NULL, 3);
+
+statement ok
+CREATE TABLE IF NOT EXISTS t2(t2_id INT NULL, t2_int INT) AS VALUES
+(11, 3),
+(33, 1),
+(NULL, 5),
+(NULL, 6);
+
+
+# IS NOT DISTRINCT can be transformed into equijoin
+query TT
+EXPLAIN SELECT t1_id, t1_int, t2_int FROM t1 JOIN t2 ON t1_id IS NOT DISTINCT from t2_id
+----
+logical_plan
+01)Projection: t1.t1_id, t1.t1_int, t2.t2_int
+02)--Inner Join: t1.t1_id = t2.t2_id
+03)----TableScan: t1 projection=[t1_id, t1_int]
+04)----TableScan: t2 projection=[t2_id, t2_int]
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=8192
+02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@0, t2_id@0)], projection=[t1_id@0, t1_int@1, t2_int@3]
+03)----MemoryExec: partitions=1, partition_sizes=[1]
+04)----MemoryExec: partitions=1, partition_sizes=[1]
+
+query III rowsort
+SELECT t1_id, t1_int, t2_int FROM t1 JOIN t2 ON t1_id IS NOT DISTINCT from t2_id
+----
+11 1 3
+NULL 3 5
+NULL 3 6
+
+
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;
+
 # sort by company name and then by lead name
 statement ok
 CREATE TABLE companies(name VARCHAR, employees INT) AS VALUES ('Jeyork', 150),('Shalk', 350),('ShuttlP', 75)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12299.

## Rationale for this change

Allow more joins to be executed efficiently.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Previously ExtractEquijoinPredicate did not inspect the value of `nulls_equals_null` for the join before extracting equi join predicates, which was likely a possible source of bugs. The new code will respect `null_equals_null` if set (and there is a equi join predicate) and if not it will first try to extra `Operator::Eq` predicates and if none is found it will try to extract `Operator::IsNotDistinctFrom` equi predicates.

Prev

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes, using existing and some new test cases.


<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

For queries using `IS NOT DISTINCT` might have improved query plans.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
