### PR TITLE
Minor: add `ListingOptions::with_file_extension_opt`

### DIFF
--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -245,6 +245,7 @@ impl ListingOptions {
 
     /// Set file extension on [`ListingOptions`] and returns self.
     ///
+    /// # Example
     /// ```
     /// # use std::sync::Arc;
     /// # use datafusion::prelude::SessionContext;
@@ -261,6 +262,33 @@ impl ListingOptions {
         self.file_extension = file_extension.into();
         self
     }
+
+    /// Optionally set file extension on [`ListingOptions`] and returns self.
+    ///
+    /// If `file_extension` is `None`, the file extension will not be changed
+    ///
+    /// # Example
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use datafusion::prelude::SessionContext;
+    /// # use datafusion::datasource::{listing::ListingOptions, file_format::parquet::ParquetFormat};
+    /// let extension = Some(".parquet");
+    /// let listing_options = ListingOptions::new(Arc::new(
+    ///     ParquetFormat::default()
+    ///   ))
+    ///   .with_file_extension_opt(extension);
+    ///
+    /// assert_eq!(listing_options.file_extension, ".parquet");
+    /// ```
+    pub fn with_file_extension_opt<S>(mut self, file_extension: Option<S>) -> Self
+    where S: Into<String>
+    {
+        if let Some(file_extension) = file_extension {
+            self.file_extension = file_extension.into();
+        }
+        self
+    }
+
 
     /// Set `table partition columns` on [`ListingOptions`] and returns self.
     ///

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -281,14 +281,14 @@ impl ListingOptions {
     /// assert_eq!(listing_options.file_extension, ".parquet");
     /// ```
     pub fn with_file_extension_opt<S>(mut self, file_extension: Option<S>) -> Self
-    where S: Into<String>
+    where
+        S: Into<String>,
     {
         if let Some(file_extension) = file_extension {
             self.file_extension = file_extension.into();
         }
         self
     }
-
 
     /// Set `table partition columns` on [`ListingOptions`] and returns self.
     ///


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/datafusion/issues/12378

## Rationale for this change

While working with @waruto210  on https://github.com/apache/datafusion/pull/12417, we noticed this API would make the code easier to work with. 

## What changes are included in this PR?
Add `ListingOptions::with_file_extension_opt`

## Are these changes tested?
Yes, by doc test example that is run in CI


## Are there any user-facing changes?

New API, no breaking changes

