### PR TITLE
return absent stats when filters are pushed down

### DIFF
--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -819,6 +819,20 @@ impl TableProvider for ListingTable {
             .map(|col| Ok(self.table_schema.field_with_name(&col.0)?.clone()))
             .collect::<Result<Vec<_>>>()?;
 
+        // If the filters can be resolved using only partition cols, there is no need to
+        // pushdown it to TableScan, otherwise, `unhandled` pruning predicates will be generated
+        let table_partition_col_names = table_partition_cols
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>();
+        let filters = filters
+            .iter()
+            .filter(|filter| {
+                !expr_applicable_for_cols(&table_partition_col_names, filter)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
         let filters = conjunction(filters.to_vec())
             .map(|expr| -> Result<_> {
                 // NOTE: Use the table schema (NOT file schema) here because `expr` may contain references to partition columns.

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -743,6 +743,7 @@ impl ExecutionPlan for ParquetExec {
     fn statistics(&self) -> Result<Statistics> {
         // When filters are pushed down, we have no way of knowing the exact statistics.
         // Note that pruning predicate is also a kind of filter pushdown.
+        // (bloom filters use `pruning_predicate` too)
         let stats = if self.pruning_predicate.is_some()
             || self.page_pruning_predicate.is_some()
             || (self.predicate.is_some() && self.pushdown_filters())

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -747,7 +747,7 @@ impl ExecutionPlan for ParquetExec {
             || self.page_pruning_predicate.is_some()
             || (self.predicate.is_some() && self.pushdown_filters())
         {
-            Statistics::new_unknown(&self.schema())
+            self.projected_statistics.clone().to_inexact()
         } else {
             self.projected_statistics.clone()
         };

--- a/datafusion/core/tests/parquet/file_statistics.rs
+++ b/datafusion/core/tests/parquet/file_statistics.rs
@@ -27,7 +27,6 @@ use datafusion::datasource::TableProvider;
 use datafusion::execution::context::SessionState;
 use datafusion::prelude::SessionContext;
 use datafusion_common::stats::Precision;
-use datafusion_common::{Column, ScalarValue};
 use datafusion_execution::cache::cache_manager::CacheManagerConfig;
 use datafusion_execution::cache::cache_unit;
 use datafusion_execution::cache::cache_unit::{
@@ -37,7 +36,7 @@ use datafusion_execution::config::SessionConfig;
 use datafusion_execution::runtime_env::RuntimeEnvBuilder;
 
 use datafusion::execution::session_state::SessionStateBuilder;
-use datafusion_expr::{BinaryExpr, Expr};
+use datafusion_expr::{col, lit, Expr};
 use tempfile::tempdir;
 
 #[tokio::test]
@@ -54,11 +53,7 @@ async fn check_stats_precision_with_filter_pushdown() {
     assert_eq!(exec.statistics().unwrap().num_rows, Precision::Exact(8));
 
     // Scan with filter pushdown, stats are inexact
-    let filter = Expr::BinaryExpr(BinaryExpr {
-        left: Box::new(Expr::Column(Column::from_name("id"))),
-        op: datafusion_expr::Operator::And,
-        right: Box::new(Expr::Literal(ScalarValue::UInt64(Some(1)))),
-    });
+    let filter = Expr::gt(col("id"), lit(1));
 
     let exec = table.scan(&state, None, &[filter], None).await.unwrap();
     assert_eq!(exec.statistics().unwrap().num_rows, Precision::Inexact(8));

--- a/datafusion/core/tests/parquet/file_statistics.rs
+++ b/datafusion/core/tests/parquet/file_statistics.rs
@@ -27,6 +27,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::execution::context::SessionState;
 use datafusion::prelude::SessionContext;
 use datafusion_common::stats::Precision;
+use datafusion_common::{Column, ScalarValue};
 use datafusion_execution::cache::cache_manager::CacheManagerConfig;
 use datafusion_execution::cache::cache_unit;
 use datafusion_execution::cache::cache_unit::{
@@ -36,7 +37,32 @@ use datafusion_execution::config::SessionConfig;
 use datafusion_execution::runtime_env::RuntimeEnvBuilder;
 
 use datafusion::execution::session_state::SessionStateBuilder;
+use datafusion_expr::{BinaryExpr, Expr};
 use tempfile::tempdir;
+
+#[tokio::test]
+async fn check_stats_precision_with_filter_pushdown() {
+    let testdata = datafusion::test_util::parquet_test_data();
+    let filename = format!("{}/{}", testdata, "alltypes_plain.parquet");
+    let table_path = ListingTableUrl::parse(filename).unwrap();
+
+    let opt = ListingOptions::new(Arc::new(ParquetFormat::default()));
+    let table = get_listing_table(&table_path, None, &opt).await;
+    let (_, _, state) = get_cache_runtime_state();
+    // Scan without filter, stats are exact
+    let exec = table.scan(&state, None, &[], None).await.unwrap();
+    assert_eq!(exec.statistics().unwrap().num_rows, Precision::Exact(8));
+
+    // Scan with filter pushdown, stats are inexact
+    let filter = Expr::BinaryExpr(BinaryExpr {
+        left: Box::new(Expr::Column(Column::from_name("id"))),
+        op: datafusion_expr::Operator::And,
+        right: Box::new(Expr::Literal(ScalarValue::UInt64(Some(1)))),
+    });
+
+    let exec = table.scan(&state, None, &[filter], None).await.unwrap();
+    assert_eq!(exec.statistics().unwrap().num_rows, Precision::Inexact(8));
+}
 
 #[tokio::test]
 async fn load_table_stats_with_session_level_cache() {

--- a/datafusion/core/tests/sql/path_partition.rs
+++ b/datafusion/core/tests/sql/path_partition.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::DataType;
 use datafusion::datasource::listing::ListingTableUrl;
+use datafusion::datasource::physical_plan::ParquetExec;
 use datafusion::{
     assert_batches_sorted_eq,
     datasource::{
@@ -36,6 +37,7 @@ use datafusion::{
     prelude::SessionContext,
     test_util::{self, arrow_test_data, parquet_test_data},
 };
+use datafusion_catalog::TableProvider;
 use datafusion_common::stats::Precision;
 use datafusion_common::ScalarValue;
 use datafusion_execution::config::SessionConfig;
@@ -43,6 +45,9 @@ use datafusion_execution::config::SessionConfig;
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
+use datafusion_expr::{col, lit, Expr, Operator};
+use datafusion_physical_expr::expressions::{BinaryExpr, Column, Literal};
+use datafusion_physical_expr::PhysicalExpr;
 use futures::stream::{self, BoxStream};
 use object_store::{
     path::Path, GetOptions, GetResult, GetResultPayload, ListResult, ObjectMeta,
@@ -50,6 +55,52 @@ use object_store::{
 };
 use object_store::{Attributes, MultipartUpload, PutMultipartOpts, PutPayload};
 use url::Url;
+
+#[tokio::test]
+async fn parquet_partition_pruning_filter() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let table = create_partitioned_alltypes_parquet_table(
+        &ctx,
+        &[
+            "year=2021/month=09/day=09/file.parquet",
+            "year=2021/month=10/day=09/file.parquet",
+            "year=2021/month=10/day=28/file.parquet",
+        ],
+        &[
+            ("year", DataType::Int32),
+            ("month", DataType::Int32),
+            ("day", DataType::Int32),
+        ],
+        "mirror:///",
+        "alltypes_plain.parquet",
+    )
+    .await;
+
+    // The first three filters can be resolved using only the partition columns.
+    let filters = [
+        Expr::eq(col("year"), lit(2021)),
+        Expr::eq(col("month"), lit(10)),
+        Expr::eq(col("day"), lit(28)),
+        Expr::gt(col("id"), lit(1)),
+    ];
+    let exec = table.scan(&ctx.state(), None, &filters, None).await?;
+    let parquet_exec = exec.as_any().downcast_ref::<ParquetExec>().unwrap();
+    let pred = parquet_exec.predicate().unwrap();
+    // Only the last filter should be pushdown to TableScan
+    let expected = Arc::new(BinaryExpr::new(
+        Arc::new(Column::new_with_schema("id", &exec.schema()).unwrap()),
+        Operator::Gt,
+        Arc::new(Literal::new(ScalarValue::Int32(Some(1)))),
+    ));
+
+    assert!(pred.as_any().is::<BinaryExpr>());
+    let pred = pred.as_any().downcast_ref::<BinaryExpr>().unwrap();
+
+    assert_eq!(pred, expected.as_any());
+
+    Ok(())
+}
 
 #[tokio::test]
 async fn parquet_distinct_partition_col() -> Result<()> {
@@ -563,6 +614,25 @@ async fn register_partitioned_alltypes_parquet(
     table_path: &str,
     source_file: &str,
 ) {
+    let table = create_partitioned_alltypes_parquet_table(
+        ctx,
+        store_paths,
+        partition_cols,
+        table_path,
+        source_file,
+    )
+    .await;
+    ctx.register_table("t", table)
+        .expect("registering listing table failed");
+}
+
+async fn create_partitioned_alltypes_parquet_table(
+    ctx: &SessionContext,
+    store_paths: &[&str],
+    partition_cols: &[(&str, DataType)],
+    table_path: &str,
+    source_file: &str,
+) -> Arc<dyn TableProvider> {
     let testdata = parquet_test_data();
     let parquet_file_path = format!("{testdata}/{source_file}");
     let url = Url::parse("mirror://").unwrap();
@@ -591,11 +661,7 @@ async fn register_partitioned_alltypes_parquet(
     let config = ListingTableConfig::new(table_path)
         .with_listing_options(options)
         .with_schema(file_schema);
-
-    let table = ListingTable::try_new(config).unwrap();
-
-    ctx.register_table("t", Arc::new(table))
-        .expect("registering listing table failed");
+    Arc::new(ListingTable::try_new(config).unwrap())
 }
 
 #[derive(Debug)]

--- a/datafusion/core/tests/sql/path_partition.rs
+++ b/datafusion/core/tests/sql/path_partition.rs
@@ -493,21 +493,6 @@ async fn parquet_statistics() -> Result<()> {
     // TODO assert partition column stats once implemented (#1186)
     assert_eq!(stat_cols[1], ColumnStatistics::new_unknown());
 
-    //// WITH Filter PushDown to [`ParquetExec`] ////
-    let dataframe = ctx
-        .sql("SELECT mycol, year FROM t WHERE mycol='value'")
-        .await?;
-    let physical_plan = dataframe.create_physical_plan().await?;
-    let schema = physical_plan.schema();
-    assert_eq!(schema.fields().len(), 2);
-
-    let stat_cols = physical_plan.statistics()?.column_statistics;
-    assert_eq!(stat_cols.len(), 2);
-    // stats for the first col are absent due to filter pushdown
-    assert_eq!(stat_cols[0].null_count, Precision::Absent);
-    // TODO assert partition column stats once implemented (#1186)
-    assert_eq!(stat_cols[1], ColumnStatistics::new_unknown());
-
     Ok(())
 }
 

--- a/datafusion/core/tests/sql/path_partition.rs
+++ b/datafusion/core/tests/sql/path_partition.rs
@@ -491,7 +491,22 @@ async fn parquet_statistics() -> Result<()> {
     // stats for the first col are read from the parquet file
     assert_eq!(stat_cols[0].null_count, Precision::Exact(1));
     // TODO assert partition column stats once implemented (#1186)
-    assert_eq!(stat_cols[1], ColumnStatistics::new_unknown(),);
+    assert_eq!(stat_cols[1], ColumnStatistics::new_unknown());
+
+    //// WITH Filter PushDown to [`ParquetExec`] ////
+    let dataframe = ctx
+        .sql("SELECT mycol, year FROM t WHERE mycol='value'")
+        .await?;
+    let physical_plan = dataframe.create_physical_plan().await?;
+    let schema = physical_plan.schema();
+    assert_eq!(schema.fields().len(), 2);
+
+    let stat_cols = physical_plan.statistics()?.column_statistics;
+    assert_eq!(stat_cols.len(), 2);
+    // stats for the first col are absent due to filter pushdown
+    assert_eq!(stat_cols[0].null_count, Precision::Absent);
+    // TODO assert partition column stats once implemented (#1186)
+    assert_eq!(stat_cols[1], ColumnStatistics::new_unknown());
 
     Ok(())
 }

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -379,6 +379,9 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
     /// Returns statistics for this `ExecutionPlan` node. If statistics are not
     /// available, should return [`Statistics::new_unknown`] (the default), not
     /// an error.
+    ///
+    /// For TableScan executors, which supports filter pushdown, special attention
+    /// needs to be paid to whether the stats returned by this method are exact or not
     fn statistics(&self) -> Result<Statistics> {
         Ok(Statistics::new_unknown(&self.schema()))
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12416.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Fix the bug mentioned in #12416.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Unlike what was mentioned in #12416, I chose to return absent stats because it's hard to know the selectivity of the filters, and also, for filters that can be resolved using only partition cols, there's no need to pushdown them to the TableScanExec, which would otherwise produce useless `unhandled` pruning predicate.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
