### PR TITLE
Make make_scalar_function() result candidate for inlining, by removing the `Arc`

### DIFF
--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -15,14 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
-
 use arrow::array::ArrayRef;
 use arrow::datatypes::DataType;
 
 use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::function::Hint;
-use datafusion_expr::{ColumnarValue, ScalarFunctionImplementation};
+use datafusion_expr::ColumnarValue;
 
 /// Creates a function to identify the optimal return type of a string function given
 /// the type of its first argument.
@@ -80,11 +78,11 @@ get_optimal_return_type!(utf8_to_int_type, DataType::Int64, DataType::Int32);
 pub(super) fn make_scalar_function<F>(
     inner: F,
     hints: Vec<Hint>,
-) -> ScalarFunctionImplementation
+) -> impl Fn(&[ColumnarValue]) -> Result<ColumnarValue>
 where
-    F: Fn(&[ArrayRef]) -> Result<ArrayRef> + Sync + Send + 'static,
+    F: Fn(&[ArrayRef]) -> Result<ArrayRef>,
 {
-    Arc::new(move |args: &[ColumnarValue]| {
+    move |args: &[ColumnarValue]| {
         // first, identify if any of the arguments is an Array. If yes, store its `len`,
         // as any scalar will need to be converted to an array of len `len`.
         let len = args
@@ -119,7 +117,7 @@ where
         } else {
             result.map(ColumnarValue::Array)
         }
-    })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`make_scalar_function` serves as a template to implement functions, abstracting away processing of scalar values. While it's recommended to implement `ScalarUDFImpl` directly, a few functions still use the `make_scalar_function` helper, perhaps because it reduces code verbosity.

While `make_scalar_function` is a template function, it's not eligible for effective inlining because of the `Arc<Fn>` return type.

This commit removes `Arc` and unlocks inlining. The change impact was
verified manually using `cargo rustc -p datafusion-functions-nested   --
--emit asm -C opt-level=2` and comparing the generated for
`ArrayDistance::invoke` exemplary function that uses
`make_scalar_function`. Only after the changes can
`ArrayDistance::invoke` call the `array_distance_inner` directly.

The change saves some small overhead on each invocation of a UDF, but doesn't improve per-row performance.
