### PR TITLE
Support List type coercion for CASE-WHEN-THEN expression

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1026,7 +1026,15 @@ fn list_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
         (LargeList(_), LargeList(_)) => Some(lhs_type.clone()),
         (List(_), FixedSizeList(_, _)) => Some(lhs_type.clone()),
         (FixedSizeList(_, _), List(_)) => Some(rhs_type.clone()),
-        (FixedSizeList(_, _), FixedSizeList(_, _)) => Some(lhs_type.clone()),
+        // Coerce to the left side FixedSizeList type if the list lengths are the same,
+        // otherwise coerce to list with the left type for dynamic length
+        (FixedSizeList(lf, ls), FixedSizeList(_, rs)) => {
+            if ls == rs {
+                Some(lhs_type.clone())
+            } else {
+                Some(List(Arc::clone(lf)))
+            }
+        }
         (LargeList(_), FixedSizeList(_, _)) => Some(lhs_type.clone()),
         (FixedSizeList(_, _), LargeList(_)) => Some(rhs_type.clone()),
         _ => None,

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1816,10 +1816,14 @@ mod test {
         let inner_field = Arc::new(Field::new("item", DataType::Int64, true));
         let schema = Arc::new(DFSchema::from_unqualified_fields(
             vec![
-                Field::new("large_list", DataType::LargeList(inner_field.clone()), true),
+                Field::new(
+                    "large_list",
+                    DataType::LargeList(Arc::clone(&inner_field)),
+                    true,
+                ),
                 Field::new(
                     "fixed_list",
-                    DataType::FixedSizeList(inner_field.clone(), 3),
+                    DataType::FixedSizeList(Arc::clone(&inner_field), 3),
                     true,
                 ),
                 Field::new("list", DataType::List(inner_field), true),
@@ -1906,10 +1910,14 @@ mod test {
         let schema = Arc::new(DFSchema::from_unqualified_fields(
             vec![
                 Field::new("boolean", DataType::Boolean, true),
-                Field::new("large_list", DataType::LargeList(inner_field.clone()), true),
+                Field::new(
+                    "large_list",
+                    DataType::LargeList(Arc::clone(&inner_field)),
+                    true,
+                ),
                 Field::new(
                     "fixed_list",
-                    DataType::FixedSizeList(inner_field.clone(), 3),
+                    DataType::FixedSizeList(Arc::clone(&inner_field), 3),
                     true,
                 ),
                 Field::new("list", DataType::List(inner_field), true),

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -24,7 +24,6 @@ use crate::physical_expr::down_cast_any_ref;
 use crate::PhysicalExpr;
 
 use arrow::array::*;
-use arrow::compute::kernels::cmp::eq;
 use arrow::compute::kernels::zip::zip;
 use arrow::compute::{and, and_not, is_null, not, nullif, or, prep_null_mask_filter};
 use arrow::datatypes::{DataType, Schema};
@@ -33,6 +32,7 @@ use datafusion_common::{exec_err, internal_err, DataFusionError, Result, ScalarV
 use datafusion_expr::ColumnarValue;
 
 use super::{Column, Literal};
+use datafusion_physical_expr_common::datum::compare_with_eq;
 use itertools::Itertools;
 
 type WhenThen = (Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>);
@@ -204,7 +204,13 @@ impl CaseExpr {
                 .evaluate_selection(batch, &remainder)?;
             let when_value = when_value.into_array(batch.num_rows())?;
             // build boolean array representing which rows match the "when" value
-            let when_match = eq(&when_value, &base_value)?;
+            let when_match = compare_with_eq(
+                &when_value,
+                &base_value,
+                // The types of case and when expressions will be coerced to match.
+                // We only need to check if the base_value is nested.
+                base_value.data_type().is_nested(),
+            )?;
             // Treat nulls as false
             let when_match = match when_match.null_count() {
                 0 => Cow::Borrowed(&when_match),

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -146,6 +146,11 @@ SELECT CASE 1 WHEN 1 THEN arrow_cast([1,2,3], 'LargeList(Int64)') WHEN 2 THEN ar
 ----
 [1, 2, 3]
 
+query ?
+SELECT CASE 1 WHEN 1 THEN arrow_cast([1, 2], 'FixedSizeList(2, Int64)') WHEN 2 THEN arrow_cast(['1', '2', '3'], 'FixedSizeList(3, Utf8)') ELSE null END;
+----
+[1, 2]
+
 query error DataFusion error: type_coercion
 SELECT CASE 1 WHEN 1 THEN [1,2,3] WHEN 2 THEN 'test' ELSE null END;
 

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -108,3 +108,54 @@ SELECT CASE WHEN false THEN 1 ELSE 0 END FROM foo
 0
 0
 0
+
+# List(Utf8) will be casted to List(Int64)
+query ?
+SELECT CASE 1 WHEN 1 THEN ['1', '2', '3'] WHEN 2 THEN [1, 2, 3] ELSE null END;
+----
+[1, 2, 3]
+
+query ?
+SELECT CASE 1 WHEN 1 THEN [[1,2], [2,4]] WHEN 2 THEN [['1','2'], ['2','4']] ELSE null END;
+----
+[[1, 2], [2, 4]]
+
+query ?
+SELECT CASE 1 WHEN 1 THEN [1,2,3] WHEN 2 THEN arrow_cast([1,2,3], 'LargeList(Int64)') ELSE null END;
+----
+[1, 2, 3]
+
+query ?
+SELECT CASE 1 WHEN 1 THEN [[1,2], [2,4]] WHEN 2 THEN arrow_cast([[1,2], [2,4]], 'LargeList(LargeList(Int64))') ELSE null END;
+----
+[[1, 2], [2, 4]]
+
+query ?
+SELECT CASE 1 WHEN 1 THEN [1,2,3] WHEN 2 THEN arrow_cast(['1','2','3'], 'LargeList(Utf8)') ELSE null END;
+----
+[1, 2, 3]
+
+query ?
+SELECT CASE 1 WHEN 1 THEN [[1,2], [2,4]] WHEN 2 THEN arrow_cast([['1','2'], ['2','4']], 'LargeList(LargeList(Utf8))') ELSE null END;
+----
+[[1, 2], [2, 4]]
+
+query ?
+SELECT CASE 1 WHEN 1 THEN arrow_cast([1,2,3], 'LargeList(Int64)') WHEN 2 THEN arrow_cast(['1','2','3'], 'LargeList(Utf8)') ELSE null END;
+----
+[1, 2, 3]
+
+
+# TODO: got arrow nested comparison error. Enable this test after the issue is fixed
+# External error: query failed: DataFusion error: Arrow error: Invalid argument error: Nested comparison: LargeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) == LargeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) (hint: use make_comparator instead)
+#query I
+#SELECT CASE [1,2,3] WHEN arrow_cast([1,2,3], 'LargeList(Int64)') THEN 1 ELSE 0 END;
+#----
+#1
+
+# TODO: got arrow nested comparison error Enable this test after the issue is fixed
+# External error: query failed: DataFusion error: Arrow error: Invalid argument error: Nested comparison: LargeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) == LargeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) (hint: use make_comparator instead)
+#query I
+#SELECT CASE arrow_cast([1,2,3], 'LargeList(Int64)') WHEN [1,2,3] THEN 1 ELSE 0 END;
+#----
+#1

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -109,6 +109,7 @@ SELECT CASE WHEN false THEN 1 ELSE 0 END FROM foo
 0
 0
 
+# test then value type coercion
 # List(Utf8) will be casted to List(Int64)
 query ?
 SELECT CASE 1 WHEN 1 THEN ['1', '2', '3'] WHEN 2 THEN [1, 2, 3] ELSE null END;
@@ -145,17 +146,29 @@ SELECT CASE 1 WHEN 1 THEN arrow_cast([1,2,3], 'LargeList(Int64)') WHEN 2 THEN ar
 ----
 [1, 2, 3]
 
+query error DataFusion error: type_coercion
+SELECT CASE 1 WHEN 1 THEN [1,2,3] WHEN 2 THEN 'test' ELSE null END;
 
-# TODO: got arrow nested comparison error. Enable this test after the issue is fixed
-# External error: query failed: DataFusion error: Arrow error: Invalid argument error: Nested comparison: LargeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) == LargeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) (hint: use make_comparator instead)
-#query I
-#SELECT CASE [1,2,3] WHEN arrow_cast([1,2,3], 'LargeList(Int64)') THEN 1 ELSE 0 END;
-#----
-#1
+# test case when type coercion
+query I
+SELECT CASE [1,2,3] WHEN arrow_cast([1,2,3], 'LargeList(Int64)') THEN 1 ELSE 0 END;
+----
+1
 
-# TODO: got arrow nested comparison error Enable this test after the issue is fixed
-# External error: query failed: DataFusion error: Arrow error: Invalid argument error: Nested comparison: LargeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) == LargeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) (hint: use make_comparator instead)
-#query I
-#SELECT CASE arrow_cast([1,2,3], 'LargeList(Int64)') WHEN [1,2,3] THEN 1 ELSE 0 END;
-#----
-#1
+query I
+SELECT CASE [1,2,3] WHEN arrow_cast(['1','2','3'], 'LargeList(Int64)') THEN 1 ELSE 0 END;
+----
+1
+
+query I
+SELECT CASE arrow_cast([1,2,3], 'LargeList(Int64)') WHEN [1,2,3] THEN 1 ELSE 0 END;
+----
+1
+
+query I
+SELECT CASE [[1,2],[2,4]] WHEN arrow_cast([[1,2],[2,4]], 'LargeList(LargeList(Int64))') THEN 1 ELSE 0 END;
+----
+1
+
+query error DataFusion error: type_coercion
+SELECT CASE [1,2,3] WHEN 'test' THEN 1 ELSE 0 END;

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -122,22 +122,22 @@ SELECT CASE 1 WHEN 1 THEN [[1,2], [2,4]] WHEN 2 THEN [['1','2'], ['2','4']] ELSE
 [[1, 2], [2, 4]]
 
 query ?
-SELECT CASE 1 WHEN 1 THEN [1,2,3] WHEN 2 THEN arrow_cast([1,2,3], 'LargeList(Int64)') ELSE null END;
+SELECT CASE 1 WHEN 1 THEN [1,2,3] WHEN 2 THEN arrow_cast([1,2,3], 'LargeList(Int64)') WHEN 3 THEN arrow_cast([1,2,3], 'FixedSizeList(3, Int32)') ELSE null END;
 ----
 [1, 2, 3]
 
 query ?
-SELECT CASE 1 WHEN 1 THEN [[1,2], [2,4]] WHEN 2 THEN arrow_cast([[1,2], [2,4]], 'LargeList(LargeList(Int64))') ELSE null END;
+SELECT CASE 1 WHEN 1 THEN [[1,2], [2,4]] WHEN 2 THEN arrow_cast([[1,2], [2,4]], 'LargeList(LargeList(Int64))') WHEN 3 THEN arrow_cast([[1,2], [2,4]], 'FixedSizeList(2, FixedSizeList(2, Int32))') ELSE null END;
 ----
 [[1, 2], [2, 4]]
 
 query ?
-SELECT CASE 1 WHEN 1 THEN [1,2,3] WHEN 2 THEN arrow_cast(['1','2','3'], 'LargeList(Utf8)') ELSE null END;
+SELECT CASE 1 WHEN 1 THEN [1,2,3] WHEN 2 THEN arrow_cast(['1','2','3'], 'LargeList(Utf8)') WHEN 3 THEN arrow_cast(['1','2','3'], 'FixedSizeList(3, Utf8)') ELSE null END;
 ----
 [1, 2, 3]
 
 query ?
-SELECT CASE 1 WHEN 1 THEN [[1,2], [2,4]] WHEN 2 THEN arrow_cast([['1','2'], ['2','4']], 'LargeList(LargeList(Utf8))') ELSE null END;
+SELECT CASE 1 WHEN 1 THEN [[1,2], [2,4]] WHEN 2 THEN arrow_cast([['1','2'], ['2','4']], 'LargeList(LargeList(Utf8))') WHEN 3 THEN arrow_cast([['1','2'], ['2','4']], 'FixedSizeList(2, FixedSizeList(2, Utf8))') ELSE null END;
 ----
 [[1, 2], [2, 4]]
 
@@ -170,5 +170,30 @@ SELECT CASE [[1,2],[2,4]] WHEN arrow_cast([[1,2],[2,4]], 'LargeList(LargeList(In
 ----
 1
 
+query I
+SELECT CASE arrow_cast([1,2,3], 'FixedSizeList(3, Int64)') WHEN [1,2,3] THEN 1 ELSE 0 END;
+----
+1
+
 query error DataFusion error: type_coercion
 SELECT CASE [1,2,3] WHEN 'test' THEN 1 ELSE 0 END;
+
+query I
+SELECT CASE arrow_cast([1,2], 'FixedSizeList(2, Int64)') WHEN arrow_cast([1,2,3], 'FixedSizeList(3, Int64)') THEN 1 ELSE 0 END;
+----
+0
+
+query I
+SELECT CASE arrow_cast([1,2], 'FixedSizeList(2, Int64)') WHEN arrow_cast(['1','2','3'], 'FixedSizeList(3, Utf8)') THEN 1 ELSE 0 END;
+----
+0
+
+query I
+SELECT CASE arrow_cast(['1','2'], 'FixedSizeList(2, Utf8)') WHEN arrow_cast([1,2,3], 'FixedSizeList(3, Int64)') THEN 1 ELSE 0 END;
+----
+0
+
+query I
+SELECT CASE arrow_cast([1,2,3], 'FixedSizeList(3, Int64)') WHEN arrow_cast([1,2,3], 'FixedSizeList(3, Int64)') THEN 1 ELSE 0 END;
+----
+1


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12370.

## Rationale for this change
The rule for the List type is to choose the wider type (LargeList > List > FixedSizeList) as the target type.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- The type coercion rule for List type comparison.
- Support to coerce the list type for `then` expressions
- Support to compare nested type for `case-when` expression
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
