### PR TITLE
Add JOB benchmark dataset (imdb dataset)

### DIFF
--- a/benchmarks/src/bin/imdb.rs
+++ b/benchmarks/src/bin/imdb.rs
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! IMDB binary entrypoint
+
+use datafusion::error::Result;
+use datafusion_benchmarks::imdb;
+use structopt::StructOpt;
+
+#[cfg(all(feature = "snmalloc", feature = "mimalloc"))]
+compile_error!(
+    "feature \"snmalloc\" and feature \"mimalloc\" cannot be enabled at the same time"
+);
+
+#[cfg(feature = "snmalloc")]
+#[global_allocator]
+static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "IMDB", about = "IMDB Dataset Processing.")]
+enum ImdbOpt {
+    Convert(imdb::ConvertOpt),
+}
+
+#[tokio::main]
+pub async fn main() -> Result<()> {
+    env_logger::init();
+    match ImdbOpt::from_args() {
+        ImdbOpt::Convert(opt) => opt.run().await,
+    }
+}

--- a/benchmarks/src/imdb/convert.rs
+++ b/benchmarks/src/imdb/convert.rs
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion::dataframe::DataFrameWriteOptions;
+use datafusion_common::instant::Instant;
+use std::path::PathBuf;
+
+use datafusion::error::Result;
+use datafusion::prelude::*;
+use structopt::StructOpt;
+
+use datafusion::common::not_impl_err;
+
+use super::IMDB_TABLES;
+use super::get_imdb_table_schema;
+
+#[derive(Debug, StructOpt)]
+pub struct ConvertOpt {
+    /// Path to csv files
+    #[structopt(parse(from_os_str), required = true, short = "i", long = "input")]
+    input_path: PathBuf,
+
+    /// Output path
+    #[structopt(parse(from_os_str), required = true, short = "o", long = "output")]
+    output_path: PathBuf,
+
+    /// Output file format: `csv` or `parquet`
+    #[structopt(short = "f", long = "format")]
+    file_format: String,
+
+     /// Batch size when reading CSV or Parquet files
+     #[structopt(short = "s", long = "batch-size", default_value = "8192")]
+     batch_size: usize,
+}
+
+impl ConvertOpt {
+    pub async fn run(self) -> Result<()> {
+
+        let input_path = self.input_path.to_str().unwrap();
+        let output_path = self.output_path.to_str().unwrap();
+
+        for table in IMDB_TABLES {
+            let start = Instant::now();
+            let schema = get_imdb_table_schema(table);
+            
+            let input_path = format!("{input_path}/{table}.csv");
+            let output_path = format!("{output_path}/{table}.parquet");
+            let options = CsvReadOptions::new()
+                .schema(&schema)
+                .has_header(false)
+                .delimiter(b',')
+                .escape(b'\\')
+                .file_extension(".csv");
+
+            let config = SessionConfig::new().with_batch_size(self.batch_size);
+            let ctx = SessionContext::new_with_config(config);
+
+            let mut csv = ctx.read_csv(&input_path, options).await?;
+
+            // Select all apart from the padding column
+            let selection = csv
+                .schema()
+                .iter()
+                .take(schema.fields.len() - 1)
+                .map(Expr::from)
+                .collect();
+
+            csv = csv.select(selection)?;
+
+            println!(
+                "Converting '{}' to {} files in directory '{}'",
+                &input_path, self.file_format, &output_path
+            );
+            match self.file_format.as_str() {
+                "csv" => {
+                    csv.write_csv(
+                        output_path.as_str(),
+                        DataFrameWriteOptions::new(),
+                        None,
+                    ).await?;
+                }
+                "parquet" => {
+                    csv.write_parquet(
+                        output_path.as_str(),
+                        DataFrameWriteOptions::new(),
+                        None,
+                    ).await?;
+                }
+                other => {
+                    return not_impl_err!("Invalid output format: {other}");
+                }
+            }
+            println!("Conversion completed in {} ms", start.elapsed().as_millis());
+        }
+        Ok(())
+    }
+}

--- a/benchmarks/src/imdb/mod.rs
+++ b/benchmarks/src/imdb/mod.rs
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmark derived from IMDB dataset.
+
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+mod convert;
+pub use convert::ConvertOpt;
+
+// we have 21 tables in the IMDB dataset
+pub const IMDB_TABLES: &[&str] = &[
+    "aka_name", "aka_title", "cast_info", "char_name", "comp_cast_type",
+    "company_name", "company_type", "complete_cast", "info_type", "keyword",
+    "kind_type", "link_type", "movie_companies", "movie_info_idx", "movie_keyword",
+    "movie_link", "name", "role_type", "title", "movie_info", "person_info",
+];
+
+/// Get the schema for the IMDB dataset tables
+/// see benchmarks/data/imdb/schematext.sql
+pub fn get_imdb_table_schema(table: &str) -> Schema {
+    match table {
+        "aka_name" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("person_id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("imdb_index", DataType::Utf8, true),
+            Field::new("name_pcode_cf", DataType::Utf8, true),
+            Field::new("name_pcode_nf", DataType::Utf8, true),
+            Field::new("surname_pcode", DataType::Utf8, true),
+            Field::new("md5sum", DataType::Utf8, true),
+        ]),
+        "aka_title" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("movie_id", DataType::Int32, false),
+            Field::new("title", DataType::Utf8, true),
+            Field::new("imdb_index", DataType::Utf8, true),
+            Field::new("kind_id", DataType::Int32, false),
+            Field::new("production_year", DataType::Int32, true),
+            Field::new("phonetic_code", DataType::Utf8, true),
+            Field::new("episode_of_id", DataType::Int32, true),
+            Field::new("season_nr", DataType::Int32, true),
+            Field::new("episode_nr", DataType::Int32, true),
+            Field::new("note", DataType::Utf8, true),
+            Field::new("md5sum", DataType::Utf8, true),
+        ]),
+        "cast_info" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("person_id", DataType::Int32, false),
+            Field::new("movie_id", DataType::Int32, false),
+            Field::new("person_role_id", DataType::Int32, true),
+            Field::new("note", DataType::Utf8, true),
+            Field::new("nr_order", DataType::Int32, true),
+            Field::new("role_id", DataType::Int32, false),
+        ]),
+        "char_name" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("imdb_index", DataType::Utf8, true),
+            Field::new("imdb_id", DataType::Int32, true),
+            Field::new("name_pcode_nf", DataType::Utf8, true),
+            Field::new("surname_pcode", DataType::Utf8, true),
+            Field::new("md5sum", DataType::Utf8, true),
+        ]),
+        "comp_cast_type" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("kind", DataType::Utf8, false),
+        ]),
+        "company_name" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("country_code", DataType::Utf8, true),
+            Field::new("imdb_id", DataType::Int32, true),
+            Field::new("name_pcode_nf", DataType::Utf8, true),
+            Field::new("name_pcode_sf", DataType::Utf8, true),
+            Field::new("md5sum", DataType::Utf8, true),
+        ]),
+        "company_type" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("kind", DataType::Utf8, true),
+        ]),
+        "complete_cast" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("movie_id", DataType::Int32, true),
+            Field::new("subject_id", DataType::Int32, false),
+            Field::new("status_id", DataType::Int32, false),
+        ]),
+        "info_type" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("info", DataType::Utf8, false),
+        ]),
+        "keyword" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("keyword", DataType::Utf8, false),
+            Field::new("phonetic_code", DataType::Utf8, true),
+        ]),
+        "kind_type" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("kind", DataType::Utf8, true),
+        ]),
+        "link_type" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("link", DataType::Utf8, false),
+        ]),
+        "movie_companies" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("movie_id", DataType::Int32, false),
+            Field::new("company_id", DataType::Int32, false),
+            Field::new("company_type_id", DataType::Int32, false),
+            Field::new("note", DataType::Utf8, true),
+        ]),
+        "movie_info_idx" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("movie_id", DataType::Int32, false),
+            Field::new("info_type_id", DataType::Int32, false),
+            Field::new("info", DataType::Utf8, false),
+            Field::new("note", DataType::Utf8, true),
+        ]),
+        "movie_keyword" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("movie_id", DataType::Int32, false),
+            Field::new("keyword_id", DataType::Int32, false),
+        ]),
+        "movie_link" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("movie_id", DataType::Int32, false),
+            Field::new("linked_movie_id", DataType::Int32, false),
+            Field::new("link_type_id", DataType::Int32, false),
+        ]),
+        "name" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("imdb_index", DataType::Utf8, true),
+            Field::new("imdb_id", DataType::Int32, true),
+            Field::new("gender", DataType::Utf8, true),
+            Field::new("name_pcode_cf", DataType::Utf8, true),
+            Field::new("name_pcode_nf", DataType::Utf8, true),
+            Field::new("surname_pcode", DataType::Utf8, true),
+            Field::new("md5sum", DataType::Utf8, true),
+        ]),
+        "role_type" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("role", DataType::Utf8, false),
+        ]),
+        "title" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("title", DataType::Utf8, false),
+            Field::new("imdb_index", DataType::Utf8, true),
+            Field::new("kind_id", DataType::Int32, false),
+            Field::new("production_year", DataType::Int32, true),
+            Field::new("imdb_id", DataType::Int32, true),
+            Field::new("phonetic_code", DataType::Utf8, true),
+            Field::new("episode_of_id", DataType::Int32, true),
+            Field::new("season_nr", DataType::Int32, true),
+            Field::new("episode_nr", DataType::Int32, true),
+            Field::new("series_years", DataType::Utf8, true),
+            Field::new("md5sum", DataType::Utf8, true),
+        ]),
+        "movie_info" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("movie_id", DataType::Int32, false),
+            Field::new("info_type_id", DataType::Int32, false),
+            Field::new("info", DataType::Utf8, false),
+            Field::new("note", DataType::Utf8, true),
+        ]),
+        "person_info" => Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("person_id", DataType::Int32, false),
+            Field::new("info_type_id", DataType::Int32, false),
+            Field::new("info", DataType::Utf8, false),
+            Field::new("note", DataType::Utf8, true),
+        ]),
+        _ => unimplemented!("Schema for table {} is not implemented", table),
+    }
+}

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -20,5 +20,6 @@ pub mod clickbench;
 pub mod parquet_filter;
 pub mod sort;
 pub mod tpch;
+pub mod imdb;
 mod util;
 pub use util::*;


### PR DESCRIPTION
## Which issue does this PR close?

Partial Closes [#12311](https://github.com/apache/datafusion/issues/12311)

## Rationale for this change
Add imdb dataset for the JOB benchmarking

## What changes are included in this PR?
Download the the dataset and convert it to parquet files.

## Are these changes tested?
Just like running to generate tpch dataset:
`./bench.sh data tpch`

run:
`./bench.sh data imdb`

## Are there any user-facing changes?
no
