### PR TITLE
Preserve the order of right table in NestedLoopJoinExec

### DIFF
--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -239,6 +239,18 @@ impl NestedLoopJoinExec {
         PlanProperties::new(eq_properties, output_partitioning, mode)
     }
 
+    /// Returns a vector indicating whether the left and right inputs maintain their order.
+    /// The first element corresponds to the left input, and the second to the right.
+    ///
+    /// The left (build-side) input's order may change, but the right (probe-side) input's
+    /// order is maintained for INNER, RIGHT, RIGHT ANTI, and RIGHT SEMI joins.
+    ///
+    /// Maintaining the right input's order helps optimize the nodes down the pipeline
+    /// (See [`ExecutionPlan::maintains_input_order`]).
+    ///
+    /// This is a separate method because it is also called when computing properties, before
+    /// a [`NestedLoopJoinExec`] is created. It also takes [`JoinType`] as an argument, as
+    /// opposed to `Self`, for the same reason.
     fn maintains_input_order(join_type: JoinType) -> Vec<bool> {
         vec![
             false,

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -1170,7 +1170,7 @@ mod tests {
             .await?;
 
         // Make sure that the order of the right side is maintained
-        let mut prev_values = (i32::MIN, i32::MIN, i32::MIN);
+        let mut prev_values = [i32::MIN, i32::MIN, i32::MIN];
 
         for (batch_index, batch) in batches.iter().enumerate() {
             let right_column_indices = match join_type {
@@ -1190,37 +1190,22 @@ mod tests {
                 .collect();
 
             for row in 0..batch.num_rows() {
-                let current_values = (
+                let current_values = [
                     columns[0].value(row),
                     columns[1].value(row),
                     columns[2].value(row),
-                );
-
+                ];
                 assert!(
-                    current_values.0 >= prev_values.0,
-                    "batch_index: {} row: {} current.0: {}, prev.0: {}",
+                    current_values
+                        .into_iter()
+                        .zip(prev_values)
+                        .all(|(current, prev)| current >= prev),
+                    "batch_index: {} row: {} current: {:?}, prev: {:?}",
                     batch_index,
                     row,
-                    current_values.0,
-                    prev_values.0
+                    current_values,
+                    prev_values
                 );
-                assert!(
-                    current_values.1 >= prev_values.1,
-                    "batch_index: {} row: {} current.1: {}, prev.1: {}",
-                    batch_index,
-                    row,
-                    current_values.1,
-                    prev_values.1
-                );
-                assert!(
-                    current_values.2 >= prev_values.2,
-                    "batch_index: {} row: {} current.2: {}, prev.2: {}",
-                    batch_index,
-                    row,
-                    current_values.2,
-                    prev_values.2
-                );
-
                 prev_values = current_values;
             }
         }

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -838,10 +838,10 @@ LEFT JOIN department AS d
 ON (e.name = 'Alice' OR e.name = 'Bob');
 ----
 1 Alice HR
-2 Bob HR
 1 Alice Engineering
-2 Bob Engineering
 1 Alice Sales
+2 Bob HR
+2 Bob Engineering
 2 Bob Sales
 3 Carol NULL
 
@@ -853,10 +853,10 @@ RIGHT JOIN employees AS e
 ON (e.name = 'Alice' OR e.name = 'Bob');
 ----
 1 Alice HR
-2 Bob HR
 1 Alice Engineering
-2 Bob Engineering
 1 Alice Sales
+2 Bob HR
+2 Bob Engineering
 2 Bob Sales
 3 Carol NULL
 
@@ -868,10 +868,10 @@ FULL JOIN employees AS e
 ON (e.name = 'Alice' OR e.name = 'Bob');
 ----
 1 Alice HR
-2 Bob HR
 1 Alice Engineering
-2 Bob Engineering
 1 Alice Sales
+2 Bob HR
+2 Bob Engineering
 2 Bob Sales
 3 Carol NULL
 

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -2136,10 +2136,10 @@ FROM (select t1_id from join_t1 where join_t1.t1_id > 22) as join_t1
 RIGHT JOIN (select t2_id from join_t2 where join_t2.t2_id > 11) as join_t2
         ON join_t1.t1_id < join_t2.t2_id
 ----
+NULL 22
 33 44
 33 55
 44 55
-NULL 22
 
 #####
 # Configuration teardown


### PR DESCRIPTION
## Which issue does this PR close?

Closes #11332.

## Rationale for this change

See the linked issue.

## What changes are included in this PR?

`NestedLoopJoinExec` now preserves the order of the right table for `Inner`, `Right`, `RightAnti` and `RightSemi` join types.

## Are these changes tested?

Tested with `join_maintains_right_order` and relevant SQL logic tests

## Are there any user-facing changes?

This PR changes the output ordering of some queries with `JOIN`, as reflected in SQL logic tests. The output values and the API remain unchanged.