### PR TITLE
Improve benchmark for ltrim

### DIFF
--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -63,7 +63,7 @@ pub fn create_string_array_and_characters(
     //   - 10% rows will be `None`
     //   - Other 90% will be strings with same `remaining_len` lengths
     // We will build the string array on it later.
-    let string_iter = (0..size).into_iter().map(|_| {
+    let string_iter = (0..size).map(|_| {
         if rng.gen::<f32>() < 0.1 {
             None
         } else {

--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -37,7 +37,6 @@ pub enum StringArrayType {
 
 pub fn create_string_array_and_characters(
     size: usize,
-    characters: &str,
     trimmed: &str,
     remaining_len: usize,
     string_array_type: StringArrayType,
@@ -93,7 +92,6 @@ fn create_args(
 ) -> Vec<ColumnarValue> {
     let (string_array, pattern) = create_string_array_and_characters(
         size,
-        characters,
         trimmed,
         remaining_len,
         string_array_type,

--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -37,6 +37,7 @@ pub enum StringArrayType {
 
 pub fn create_string_array_and_characters(
     size: usize,
+    characters: &str,
     trimmed: &str,
     remaining_len: usize,
     string_array_type: StringArrayType,
@@ -58,15 +59,15 @@ pub fn create_string_array_and_characters(
     match string_array_type {
         StringArrayType::Utf8View => (
             Arc::new(string_iter.collect::<StringViewArray>()),
-            ScalarValue::Utf8View(Some(trimmed.to_string())),
+            ScalarValue::Utf8View(Some(characters.to_string())),
         ),
         StringArrayType::Utf8 => (
             Arc::new(string_iter.collect::<StringArray>()),
-            ScalarValue::Utf8(Some(trimmed.to_string())),
+            ScalarValue::Utf8(Some(characters.to_string())),
         ),
         StringArrayType::LargeUtf8 => (
             Arc::new(string_iter.collect::<LargeStringArray>()),
-            ScalarValue::LargeUtf8(Some(trimmed.to_string())),
+            ScalarValue::LargeUtf8(Some(characters.to_string())),
         ),
     }
 }
@@ -92,6 +93,7 @@ fn create_args(
 ) -> Vec<ColumnarValue> {
     let (string_array, pattern) = create_string_array_and_characters(
         size,
+        characters,
         trimmed,
         remaining_len,
         string_array_type,

--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -118,8 +118,9 @@ fn create_args(
     ]
 }
 
-fn run_with_string_type<'a, M: Measurement>(
-    group: &mut BenchmarkGroup<'a, M>,
+#[allow(clippy::too_many_arguments)]
+fn run_with_string_type<M: Measurement>(
+    group: &mut BenchmarkGroup<'_, M>,
     ltrim: &ScalarUDF,
     size: usize,
     len: usize,
@@ -128,7 +129,7 @@ fn run_with_string_type<'a, M: Measurement>(
     remaining_len: usize,
     string_type: StringArrayType,
 ) {
-    let args = create_args(size, &characters, &trimmed, remaining_len, string_type);
+    let args = create_args(size, characters, trimmed, remaining_len, string_type);
     group.bench_function(
         format!(
             "{string_type} [size={size}, len_before={len}, len_after={remaining_len}]",
@@ -137,6 +138,7 @@ fn run_with_string_type<'a, M: Measurement>(
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_one_group(
     c: &mut Criterion,
     group_name: &str,
@@ -189,8 +191,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             &string_types,
             size,
             len,
-            &characters,
-            &trimmed,
+            characters,
+            trimmed,
             remaining_len,
         );
 
@@ -205,8 +207,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             &string_types,
             size,
             len,
-            &characters,
-            &trimmed,
+            characters,
+            trimmed,
             remaining_len,
         );
 
@@ -221,7 +223,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             &string_types,
             size,
             len,
-            &characters,
+            characters,
             &trimmed,
             remaining_len,
         );

--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -49,6 +49,7 @@ impl fmt::Display for StringArrayType {
     }
 }
 
+/// returns an array of strings, and `characters` as a ScalarValue
 pub fn create_string_array_and_characters(
     size: usize,
     characters: &str,

--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -17,32 +17,164 @@
 
 extern crate criterion;
 
-use arrow::array::{ArrayRef, StringArray};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use arrow::{
+    array::{ArrayRef, LargeStringArray, StringArray, StringViewArray},
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
 use datafusion_common::ScalarValue;
 use datafusion_expr::ColumnarValue;
 use datafusion_functions::string;
+use rand::{distributions::Alphanumeric, rngs::StdRng, Rng, SeedableRng};
 use std::sync::Arc;
 
-fn create_args(size: usize, characters: &str) -> Vec<ColumnarValue> {
-    let iter =
-        std::iter::repeat(format!("{}datafusion{}", characters, characters)).take(size);
-    let array = Arc::new(StringArray::from_iter_values(iter)) as ArrayRef;
+pub fn seedable_rng() -> StdRng {
+    StdRng::seed_from_u64(42)
+}
+
+pub enum StringArrayType {
+    Utf8View,
+    Utf8,
+    LargeUtf8,
+}
+
+pub fn create_prefixed_string_array_and_pattern(
+    size: usize,
+    prefix: &str,
+    generated_len: usize,
+    string_array_type: StringArrayType,
+) -> (ArrayRef, ScalarValue) {
+    let rng = &mut seedable_rng();
+
+    let lens = vec![generated_len; size];
+    let string_iter = lens.into_iter().map(|len| {
+        if rng.gen::<f32>() < 0.1 {
+            None
+        } else {
+            let mut value = prefix.as_bytes().to_vec();
+            let generated = rng.sample_iter(&Alphanumeric).take(len);
+            value.extend(generated);
+            Some(String::from_utf8(value).unwrap())
+        }
+    });
+
+    match string_array_type {
+        StringArrayType::Utf8View => (
+            Arc::new(string_iter.collect::<StringViewArray>()),
+            ScalarValue::Utf8View(Some(prefix.to_string())),
+        ),
+        StringArrayType::Utf8 => (
+            Arc::new(string_iter.collect::<StringArray>()),
+            ScalarValue::Utf8(Some(prefix.to_string())),
+        ),
+        StringArrayType::LargeUtf8 => (
+            Arc::new(string_iter.collect::<LargeStringArray>()),
+            ScalarValue::LargeUtf8(Some(prefix.to_string())),
+        ),
+    }
+}
+
+fn create_args(
+    size: usize,
+    characters: &str,
+    generated_len: usize,
+    string_array_type: StringArrayType,
+) -> Vec<ColumnarValue> {
+    let (string_array, pattern) = create_prefixed_string_array_and_pattern(
+        size,
+        characters,
+        generated_len,
+        string_array_type,
+    );
     vec![
-        ColumnarValue::Array(array),
-        ColumnarValue::Scalar(ScalarValue::Utf8(Some(characters.to_string()))),
+        ColumnarValue::Array(string_array),
+        ColumnarValue::Scalar(pattern),
     ]
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
     let ltrim = string::ltrim();
-    for char in ["\"", "Header:"] {
-        for size in [1024, 4096, 8192] {
-            let args = create_args(size, char);
-            c.bench_function(&format!("ltrim {}: {}", char, size), |b| {
-                b.iter(|| black_box(ltrim.invoke(&args)))
-            });
-        }
+    let prefix = ",!()";
+    for size in [1024, 4096, 8192] {
+        // len=12, prefix=4, len_after_ltrim=8
+        let len = 12;
+        let len_exclude_prefix = len - prefix.len();
+        let mut group = c.benchmark_group("INPUT LEN <= 12");
+        group.sampling_mode(SamplingMode::Flat);
+        group.sample_size(10);
+
+        let args = create_args(size, &prefix, len_exclude_prefix, StringArrayType::Utf8View);
+        group.bench_function(
+            format!("ltrim_string_view [size={}, strlen={}]", size, len),
+            |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        );
+
+        let args = create_args(size, &prefix, len_exclude_prefix, StringArrayType::Utf8);
+        group.bench_function(
+            format!("ltrim_string [size={}, strlen={}]", size, len),
+            |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        );
+
+        let args = create_args(size, &prefix, len_exclude_prefix, StringArrayType::LargeUtf8);
+        group.bench_function(
+            format!("ltrim_large_string [size={}, strlen={}]", size, len),
+            |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        );
+
+        group.finish();
+
+        // len=64, prefix=4, len_after_ltrim=60
+        let len = 64;
+        let len_exclude_prefix = len - prefix.len();
+        let mut group = c.benchmark_group("INPUT LEN > 12, OUTPUT LEN > 12");
+        group.sampling_mode(SamplingMode::Flat);
+        group.sample_size(10);
+
+        let args = create_args(size, &prefix, len_exclude_prefix, StringArrayType::Utf8View);
+        group.bench_function(
+            format!("ltrim_string_view [size={}, strlen={}]", size, len),
+            |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        );
+
+        let args = create_args(size, &prefix, len_exclude_prefix, StringArrayType::Utf8);
+        group.bench_function(
+            format!("ltrim_string [size={}, strlen={}]", size, len),
+            |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        );
+
+        let args = create_args(size, &prefix, len_exclude_prefix, StringArrayType::LargeUtf8);
+        group.bench_function(
+            format!("ltrim_large_string [size={}, strlen={}]", size, len),
+            |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        );
+
+        group.finish();
+
+        // len=15, prefix=4, len_after_ltrim=11
+        let len = 15;
+        let len_exclude_prefix = len - prefix.len();
+        let mut group = c.benchmark_group("INPUT LEN > 12, OUTPUT LEN <= 12");
+        group.sampling_mode(SamplingMode::Flat);
+        group.sample_size(10);
+
+        let args = create_args(size, &prefix, len_exclude_prefix, StringArrayType::Utf8View);
+        group.bench_function(
+            format!("ltrim_string_view [size={}, strlen={}]", size, len),
+            |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        );
+
+        let args = create_args(size, &prefix, len_exclude_prefix, StringArrayType::Utf8);
+        group.bench_function(
+            format!("ltrim_string [size={}, strlen={}]", size, len),
+            |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        );
+
+        let args = create_args(size, &prefix, len_exclude_prefix, StringArrayType::LargeUtf8);
+        group.bench_function(
+            format!("ltrim_large_string [size={}, strlen={}]", size, len),
+            |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        );
+
+        group.finish();
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #12387 

## Rationale for this change
We need a benchmark to see the improvements of the new string view trim introduced in #12395 .

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Improve the ltrim benchmark, so that we can use it to see the improvements of the new string view trim.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Test manually.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
