### PR TITLE
Replace some usages of `Expr::to_field` with `Expr::qualified_name`

### DIFF
--- a/datafusion/expr/src/expr_rewriter/order_by.rs
+++ b/datafusion/expr/src/expr_rewriter/order_by.rs
@@ -19,7 +19,7 @@
 
 use crate::expr::Alias;
 use crate::expr_rewriter::normalize_col;
-use crate::{expr::Sort, Cast, Expr, ExprSchemable, LogicalPlan, TryCast};
+use crate::{expr::Sort, Cast, Expr, LogicalPlan, TryCast};
 
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::{Column, Result};
@@ -77,11 +77,8 @@ fn rewrite_in_terms_of_projection(
     expr.transform(|expr| {
         // search for unnormalized names first such as "c1" (such as aliases)
         if let Some(found) = proj_exprs.iter().find(|a| (**a) == expr) {
-            let col = Expr::Column(
-                found
-                    .to_field(input.schema())
-                    .map(|(qualifier, field)| Column::new(qualifier, field.name()))?,
-            );
+            let (qualifier, field_name) = found.qualified_name();
+            let col = Expr::Column(Column::new(qualifier, field_name));
             return Ok(Transformed::yes(col));
         }
 


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change

These usages only require the expression's qualifier and field name. The `to_field` function constructs a `Field` that includes unnecessary information like data type, metadata, etc., which incurs higher overhead.

https://github.com/apache/datafusion/blob/f514e12ec4b73a4e6a417c5756152dd1ddceac10/datafusion/expr/src/expr_schema.rs#L461-L471

## What changes are included in this PR?



## Are these changes tested?
Yes. By existing tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
