### PR TITLE
Fix NestedLoopJoin performance regression

### DIFF
--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -656,7 +656,7 @@ fn join_left_and_right_batch(
         build_join_indices(left_batch, right_batch, filter, indices_cache).map_err(
             |e| {
                 exec_datafusion_err!(
-                    "Fail to build join indices in NestedLoopJoinExec, error:{e}"
+                    "Fail to build join indices in NestedLoopJoinExec, error: {e}"
                 )
             },
         )?;

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -2136,10 +2136,10 @@ FROM (select t1_id from join_t1 where join_t1.t1_id > 22) as join_t1
 RIGHT JOIN (select t2_id from join_t2 where join_t2.t2_id > 11) as join_t2
         ON join_t1.t1_id < join_t2.t2_id
 ----
-NULL 22
 33 44
 33 55
 44 55
+NULL 22
 
 #####
 # Configuration teardown


### PR DESCRIPTION
## Which issue does this PR close?
Closes #12528.

## Rationale for this change

Iterating over the right rows instead of the left while calling `build_join_indices` increased the number of calls to `apply_join_filter_to_indices` in cases where the right table has more rows (which applies to most common use cases). Building the indices inside `build_join_indices` helps reduce the number of calls to `apply_join_filter_to_indices`

The same indices are created inside `build_join_indices` every time with an expensive operation so it makes sense to cache them.

## What changes are included in this PR?

This PR builds the indices in one go inside `build_join_indices`, removing the outer iteration, and reduces the number of calls to `apply_join_filter_to_indices` to 1 per `join_left_and_right_batch` call.

Also adds caching for join indices.

## Are these changes tested?

Tested with the following query using TPCH data (SF=1)
```
EXPLAIN ANALYZE SELECT count(1) FROM nation n JOIN lineitem li ON n.n_nationkey < li.l_orderkey;
```

| x | join time | percent change |
|--|----------|----------------|
|before regression|9.421251914s| 0% |
|after regression|51.073303629s| +442.11% |
|fix without cache|10.450086252s| +10.92% |
|fix with cache|7.390388154s| -21.56% |

## Are there any user-facing changes?

Only performance changes.
