### PR TITLE
Introduce `Scalar` type for ColumnarValue

### DIFF
--- a/datafusion-examples/examples/optimizer_rule.rs
+++ b/datafusion-examples/examples/optimizer_rule.rs
@@ -207,7 +207,7 @@ impl ScalarUDFImpl for MyEq {
     fn invoke(&self, _args: &[ColumnarValue]) -> Result<ColumnarValue> {
         // this example simply returns "true" which is not what a real
         // implementation would do.
-        Ok(ColumnarValue::Scalar(ScalarValue::from(true)))
+        Ok(ColumnarValue::from(ScalarValue::from(true)))
     }
 }
 

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -1707,6 +1707,9 @@ impl ScalarValue {
         Self::iter_to_array_of_type(scalars, &data_type)
     }
 
+    /// Same as [`Self::iter_to_array`] but the target `data_type` can be
+    /// manually specified instead of being implicitly derived from the type of
+    /// the first value of the iterator.
     pub fn iter_to_array_of_type(
         scalars: impl IntoIterator<Item = ScalarValue>,
         data_type: &DataType,

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -687,14 +687,16 @@ impl BoolVecBuilder {
             ColumnarValue::Array(array) => {
                 self.combine_array(array.as_boolean());
             }
-            ColumnarValue::Scalar(ScalarValue::Boolean(Some(false))) => {
-                // False means all containers can not pass the predicate
-                self.inner = vec![false; self.inner.len()];
-            }
-            _ => {
-                // Null or true means the rows in container may pass this
-                // conjunct so we can't prune any containers based on that
-            }
+            ColumnarValue::Scalar(scalar) => match scalar.value() {
+                ScalarValue::Boolean(Some(false)) => {
+                    // False means all containers can not pass the predicate
+                    self.inner = vec![false; self.inner.len()];
+                }
+                _ => {
+                    // Null or true means the rows in container may pass this
+                    // conjunct so we can't prune any containers based on that
+                }
+            },
         }
     }
 

--- a/datafusion/expr-common/src/columnar_value.rs
+++ b/datafusion/expr-common/src/columnar_value.rs
@@ -198,7 +198,7 @@ impl ColumnarValue {
             )),
             ColumnarValue::Scalar(scalar) => {
                 // TODO(@notfilippo, logical vs physical): if `scalar.data_type` is *logically equivalent*
-                // to `cast_type` skip the kernel cast and only change the `data_type` of the scalar.
+                // to `cast_type` then skip the kernel cast and only change the `data_type` of the scalar.
 
                 let scalar_array =
                     if cast_type == &DataType::Timestamp(TimeUnit::Nanosecond, None) {

--- a/datafusion/expr-common/src/columnar_value.rs
+++ b/datafusion/expr-common/src/columnar_value.rs
@@ -25,6 +25,8 @@ use datafusion_common::format::DEFAULT_CAST_OPTIONS;
 use datafusion_common::{internal_err, Result, ScalarValue};
 use std::sync::Arc;
 
+use crate::scalar::Scalar;
+
 /// The result of evaluating an expression.
 ///
 /// [`ColumnarValue::Scalar`] represents a single value repeated any number of
@@ -89,7 +91,7 @@ pub enum ColumnarValue {
     /// Array of values
     Array(ArrayRef),
     /// A single value
-    Scalar(ScalarValue),
+    Scalar(Scalar),
 }
 
 impl From<ArrayRef> for ColumnarValue {
@@ -100,14 +102,14 @@ impl From<ArrayRef> for ColumnarValue {
 
 impl From<ScalarValue> for ColumnarValue {
     fn from(value: ScalarValue) -> Self {
-        ColumnarValue::Scalar(value)
+        ColumnarValue::Scalar(value.into())
     }
 }
 
 impl ColumnarValue {
-    pub fn data_type(&self) -> DataType {
+    pub fn data_type(&self) -> &DataType {
         match self {
-            ColumnarValue::Array(array_value) => array_value.data_type().clone(),
+            ColumnarValue::Array(array_value) => array_value.data_type(),
             ColumnarValue::Scalar(scalar_value) => scalar_value.data_type(),
         }
     }
@@ -195,9 +197,12 @@ impl ColumnarValue {
                 kernels::cast::cast_with_options(array, cast_type, &cast_options)?,
             )),
             ColumnarValue::Scalar(scalar) => {
+                // TODO(@notfilippo, logical/physical): this cast in the future should reduce to updating
+                // Scalar's `data_type` to the target `cast_type`.
+
                 let scalar_array =
                     if cast_type == &DataType::Timestamp(TimeUnit::Nanosecond, None) {
-                        if let ScalarValue::Float64(Some(float_ts)) = scalar {
+                        if let ScalarValue::Float64(Some(float_ts)) = scalar.value() {
                             ScalarValue::Int64(Some(
                                 (float_ts * 1_000_000_000_f64).trunc() as i64,
                             ))
@@ -214,7 +219,7 @@ impl ColumnarValue {
                     &cast_options,
                 )?;
                 let cast_scalar = ScalarValue::try_from_array(&cast_array, 0)?;
-                Ok(ColumnarValue::Scalar(cast_scalar))
+                Ok(ColumnarValue::from(cast_scalar))
             }
         }
     }
@@ -250,7 +255,7 @@ mod tests {
             TestCase {
                 input: vec![
                     ColumnarValue::Array(make_array(1, 3)),
-                    ColumnarValue::Scalar(ScalarValue::Int32(Some(100))),
+                    ColumnarValue::from(ScalarValue::Int32(Some(100))),
                 ],
                 expected: vec![
                     make_array(1, 3),
@@ -260,7 +265,7 @@ mod tests {
             // scalar and array
             TestCase {
                 input: vec![
-                    ColumnarValue::Scalar(ScalarValue::Int32(Some(100))),
+                    ColumnarValue::from(ScalarValue::Int32(Some(100))),
                     ColumnarValue::Array(make_array(1, 3)),
                 ],
                 expected: vec![
@@ -271,9 +276,9 @@ mod tests {
             // multiple scalars and array
             TestCase {
                 input: vec![
-                    ColumnarValue::Scalar(ScalarValue::Int32(Some(100))),
+                    ColumnarValue::from(ScalarValue::Int32(Some(100))),
                     ColumnarValue::Array(make_array(1, 3)),
-                    ColumnarValue::Scalar(ScalarValue::Int32(Some(200))),
+                    ColumnarValue::from(ScalarValue::Int32(Some(200))),
                 ],
                 expected: vec![
                     make_array(100, 3), // scalar is expanded
@@ -306,7 +311,7 @@ mod tests {
     fn values_to_arrays_mixed_length_and_scalar() {
         ColumnarValue::values_to_arrays(&[
             ColumnarValue::Array(make_array(1, 3)),
-            ColumnarValue::Scalar(ScalarValue::Int32(Some(100))),
+            ColumnarValue::from(ScalarValue::Int32(Some(100))),
             ColumnarValue::Array(make_array(2, 7)),
         ])
         .unwrap();

--- a/datafusion/expr-common/src/columnar_value.rs
+++ b/datafusion/expr-common/src/columnar_value.rs
@@ -197,6 +197,9 @@ impl ColumnarValue {
                 kernels::cast::cast_with_options(array, cast_type, &cast_options)?,
             )),
             ColumnarValue::Scalar(scalar) => {
+                // TODO(@notfilippo, logical vs physical): if `scalar.data_type` is *logically equivalent*
+                // to `cast_type` skip the kernel cast and only change the `data_type` of the scalar.
+
                 let scalar_array =
                     if cast_type == &DataType::Timestamp(TimeUnit::Nanosecond, None) {
                         if let ScalarValue::Float64(Some(float_ts)) = scalar.value() {

--- a/datafusion/expr-common/src/columnar_value.rs
+++ b/datafusion/expr-common/src/columnar_value.rs
@@ -197,9 +197,6 @@ impl ColumnarValue {
                 kernels::cast::cast_with_options(array, cast_type, &cast_options)?,
             )),
             ColumnarValue::Scalar(scalar) => {
-                // TODO(@notfilippo, logical/physical): this cast in the future should reduce to updating
-                // Scalar's `data_type` to the target `cast_type`.
-
                 let scalar_array =
                     if cast_type == &DataType::Timestamp(TimeUnit::Nanosecond, None) {
                         if let ScalarValue::Float64(Some(float_ts)) = scalar.value() {
@@ -218,8 +215,8 @@ impl ColumnarValue {
                     cast_type,
                     &cast_options,
                 )?;
-                let cast_scalar = ScalarValue::try_from_array(&cast_array, 0)?;
-                Ok(ColumnarValue::from(cast_scalar))
+                let cast_scalar = Scalar::try_from_array(&cast_array, 0)?;
+                Ok(ColumnarValue::Scalar(cast_scalar))
             }
         }
     }

--- a/datafusion/expr-common/src/lib.rs
+++ b/datafusion/expr-common/src/lib.rs
@@ -31,6 +31,7 @@ pub mod columnar_value;
 pub mod groups_accumulator;
 pub mod interval_arithmetic;
 pub mod operator;
+pub mod scalar;
 pub mod signature;
 pub mod sort_properties;
 pub mod type_coercion;

--- a/datafusion/expr-common/src/scalar.rs
+++ b/datafusion/expr-common/src/scalar.rs
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::{
+    array::{Array, ArrayRef},
+    datatypes::DataType,
+};
+use datafusion_common::{exec_err, DataFusionError, Result, ScalarValue};
+
+#[derive(Clone, Debug)]
+pub struct Scalar {
+    value: ScalarValue,
+    data_type: DataType,
+}
+
+impl From<ScalarValue> for Scalar {
+    fn from(value: ScalarValue) -> Self {
+        Self {
+            data_type: value.data_type(),
+            value,
+        }
+    }
+}
+
+impl TryFrom<DataType> for Scalar {
+    type Error = DataFusionError;
+    fn try_from(value: DataType) -> Result<Self> {
+        Ok(Self {
+            value: ScalarValue::try_from(&value)?,
+            data_type: value,
+        })
+    }
+}
+
+impl PartialEq for Scalar {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value)
+    }
+}
+
+impl Scalar {
+    pub fn new(value: ScalarValue, data_type: DataType) -> Self {
+        Self { value, data_type }
+    }
+
+    pub fn try_from_array(array: &dyn Array, index: usize) -> Result<Self> {
+        let value = ScalarValue::try_from_array(array, index)?;
+        Ok(Self::new(value, array.data_type().clone()))
+    }
+
+    #[inline]
+    pub fn value(&self) -> &ScalarValue {
+        &self.value
+    }
+
+    #[inline]
+    pub fn into_value(self) -> ScalarValue {
+        self.value
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    pub fn with_data_type(mut self, data_type: DataType) -> Self {
+        self.data_type = data_type;
+        self
+    }
+
+    #[inline]
+    pub fn to_array_of_size(&self, size: usize) -> Result<ArrayRef> {
+        self.value.to_array_of_size_and_type(size, &self.data_type)
+    }
+
+    #[inline]
+    pub fn to_array(&self) -> Result<ArrayRef> {
+        self.to_array_of_size(1)
+    }
+
+    pub fn to_scalar(&self) -> Result<arrow::array::Scalar<ArrayRef>> {
+        Ok(arrow::array::Scalar::new(self.to_array()?))
+    }
+
+    pub fn iter_to_array(scalars: impl IntoIterator<Item = Scalar>) -> Result<ArrayRef> {
+        let mut scalars = scalars.into_iter().peekable();
+
+        // figure out the type based on the first element
+        let data_type = match scalars.peek() {
+            None => return exec_err!("Empty iterator passed to Scalar::iter_to_array"),
+            Some(sv) => sv.data_type().clone(),
+        };
+
+        ScalarValue::iter_to_array_of_type(scalars.map(|scalar| scalar.value), &data_type)
+    }
+}

--- a/datafusion/expr-common/src/scalar.rs
+++ b/datafusion/expr-common/src/scalar.rs
@@ -102,6 +102,8 @@ impl Scalar {
         })
     }
 
+    /// Converts an iterator of references [`Scalar`] into an [`ArrayRef`]
+    /// corresponding to those values.
     pub fn iter_to_array(scalars: impl IntoIterator<Item = Scalar>) -> Result<ArrayRef> {
         let mut scalars = scalars.into_iter().peekable();
 

--- a/datafusion/expr-common/src/scalar.rs
+++ b/datafusion/expr-common/src/scalar.rs
@@ -19,8 +19,27 @@ use arrow::{
     array::{Array, ArrayRef},
     datatypes::DataType,
 };
-use datafusion_common::{exec_err, Result, ScalarValue};
+use datafusion_common::{exec_err, DataFusionError, Result, ScalarValue};
 
+/// Represents a physical scalar value obtained after evaluating an expression.
+///
+/// Currently [`Scalar`] represents a no-op wrapper around scalar value. This
+/// is due to the fact that the current variants of [`ScalarValue`] correspond
+/// 1:1 with the variants of [`DataType`]. The goal of this type is aid the
+/// process of condensing some of the variants (e.g. [`ScalarValue::LargeUtf8`],
+/// [`ScalarValue::Utf8View`], and [`ScalarValue::Utf8`]) into a single variant
+/// (e.g. [`ScalarValue::Utf8`]). This type achieves this goal by storing the
+/// physical type as [`DataType`] alongside the value represented as
+/// [`ScalarValue`].
+///
+/// [`Scalar`] cannot be constructed directly as not all [`DataType`] variants
+/// can correctly be represented by a [`ScalarValue`] without casting. For more
+/// information see:
+/// - [`Scalar::from`]
+/// - [`Scalar::try_from_array`]
+/// - [`Scalar::new_null_of`]
+///
+/// [`Scalar`] is meant to be stored as a variant of [`crate::columnar_value::ColumnarValue`].
 #[derive(Clone, Debug)]
 pub struct Scalar {
     value: ScalarValue,
@@ -28,11 +47,26 @@ pub struct Scalar {
 }
 
 impl From<ScalarValue> for Scalar {
+    /// Converts a [`ScalarValue`] to a Scalar, resolving the [`DataType`] from
+    /// the value itself.
     fn from(value: ScalarValue) -> Self {
         Self {
             data_type: value.data_type(),
             value,
         }
+    }
+}
+
+impl<T: Array> TryFrom<arrow::array::Scalar<T>> for Scalar {
+    type Error = DataFusionError;
+
+    /// Converts a [`arrow::array::Scalar`] to a Scalar, resolving the
+    /// [`DataType`] from the inner scalar array.
+    ///
+    /// See [`Scalar::try_from_array`].
+    fn try_from(value: arrow::array::Scalar<T>) -> Result<Self> {
+        let array = value.into_inner();
+        Self::try_from_array(&array, 0)
     }
 }
 
@@ -43,16 +77,28 @@ impl PartialEq for Scalar {
 }
 
 impl Scalar {
+    /// Converts a value in `array` at `index` into a Scalar, resolving the
+    /// [`DataType`] from the `array`'s data type.
+    ///
+    /// Once [`ScalarValue`] variants will be condensed, this method will prove
+    /// very useful in order to keep track of the wanted data type (sourced from
+    /// `array`) as the type information might be lost when simply calling
+    /// [`ScalarValue::try_from_array`].
     pub fn try_from_array(array: &dyn Array, index: usize) -> Result<Self> {
         let data_type = array.data_type().clone();
         let value = ScalarValue::try_from_array(array, index)?;
         Ok(Self { value, data_type })
     }
 
-    pub fn new_null_of(value: DataType) -> Result<Self> {
+    /// Creates a null Scalar of the specified `data_type`.
+    ///
+    /// Note that the null `value` stored inside the Scalar might be of a
+    /// logically equivalent type of `data_type`, but the type information
+    /// provided will not be lost as it will be stored alongside the value.
+    pub fn new_null_of(data_type: DataType) -> Result<Self> {
         Ok(Self {
-            value: ScalarValue::try_from(&value)?,
-            data_type: value,
+            value: ScalarValue::try_from(&data_type)?,
+            data_type,
         })
     }
 

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -2530,7 +2530,7 @@ mod test {
             }
 
             fn invoke(&self, _args: &[ColumnarValue]) -> Result<ColumnarValue> {
-                Ok(ColumnarValue::Scalar(ScalarValue::from("a")))
+                Ok(ColumnarValue::from(ScalarValue::from("a")))
             }
         }
         let udf = Arc::new(ScalarUDF::from(TestScalarUDF {

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -71,6 +71,7 @@ pub use datafusion_expr_common::accumulator::Accumulator;
 pub use datafusion_expr_common::columnar_value::ColumnarValue;
 pub use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
 pub use datafusion_expr_common::operator::Operator;
+pub use datafusion_expr_common::scalar::Scalar;
 pub use datafusion_expr_common::signature::{
     ArrayFunctionSignature, Signature, TypeSignature, Volatility, TIMEZONE_WILDCARD,
 };

--- a/datafusion/functions-aggregate/src/approx_percentile_cont.rs
+++ b/datafusion/functions-aggregate/src/approx_percentile_cont.rs
@@ -147,7 +147,7 @@ fn get_scalar_value(expr: &Arc<dyn PhysicalExpr>) -> Result<ScalarValue> {
     let empty_schema = Arc::new(Schema::empty());
     let batch = RecordBatch::new_empty(Arc::clone(&empty_schema));
     if let ColumnarValue::Scalar(s) = expr.evaluate(&batch)? {
-        Ok(s)
+        Ok(s.into_value())
     } else {
         internal_err!("Didn't expect ColumnarValue::Array")
     }

--- a/datafusion/functions-nested/benches/map.rs
+++ b/datafusion/functions-nested/benches/map.rs
@@ -91,8 +91,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             Arc::new(Int32Array::from(values(&mut rng))),
             None,
         );
-        let keys = ColumnarValue::Scalar(ScalarValue::List(Arc::new(key_list)));
-        let values = ColumnarValue::Scalar(ScalarValue::List(Arc::new(value_list)));
+        let keys = ColumnarValue::from(ScalarValue::List(Arc::new(key_list)));
+        let values = ColumnarValue::from(ScalarValue::List(Arc::new(value_list)));
 
         b.iter(|| {
             black_box(

--- a/datafusion/functions-nested/src/array_has.rs
+++ b/datafusion/functions-nested/src/array_has.rs
@@ -106,8 +106,8 @@ impl ScalarUDFImpl for ArrayHas {
             ColumnarValue::Scalar(scalar_needle) => {
                 // Always return null if the second argument is null
                 // i.e. array_has(array, null) -> null
-                if scalar_needle.is_null() {
-                    return Ok(ColumnarValue::Scalar(ScalarValue::Boolean(None)));
+                if scalar_needle.value().is_null() {
+                    return Ok(ColumnarValue::from(ScalarValue::Boolean(None)));
                 }
 
                 // since the needle is a scalar, convert it to an array of size 1
@@ -118,7 +118,7 @@ impl ScalarUDFImpl for ArrayHas {
                 if let ColumnarValue::Scalar(_) = &args[0] {
                     // If both inputs are scalar, keeps output as scalar
                     let scalar_value = ScalarValue::try_from_array(&array, 0)?;
-                    Ok(ColumnarValue::Scalar(scalar_value))
+                    Ok(ColumnarValue::from(scalar_value))
                 } else {
                     Ok(ColumnarValue::Array(array))
                 }

--- a/datafusion/functions-nested/src/map.rs
+++ b/datafusion/functions-nested/src/map.rs
@@ -111,7 +111,7 @@ fn check_unique_keys(array: &dyn Array) -> Result<()> {
 
 fn get_first_array_ref(columnar_value: &ColumnarValue) -> Result<ArrayRef> {
     match columnar_value {
-        ColumnarValue::Scalar(value) => match value {
+        ColumnarValue::Scalar(value) => match value.value() {
             ScalarValue::List(array) => Ok(array.value(0)),
             ScalarValue::LargeList(array) => Ok(array.value(0)),
             ScalarValue::FixedSizeList(array) => Ok(array.value(0)),
@@ -125,7 +125,7 @@ fn make_map_batch_internal(
     keys: ArrayRef,
     values: ArrayRef,
     can_evaluate_to_const: bool,
-    data_type: DataType,
+    data_type: &DataType,
 ) -> Result<ColumnarValue> {
     if keys.len() != values.len() {
         return exec_err!("map requires key and value lists to have the same length");
@@ -172,7 +172,7 @@ fn make_map_batch_internal(
     let map_array = Arc::new(MapArray::from(map_data));
 
     Ok(if can_evaluate_to_const {
-        ColumnarValue::Scalar(ScalarValue::try_from_array(map_array.as_ref(), 0)?)
+        ColumnarValue::from(ScalarValue::try_from_array(map_array.as_ref(), 0)?)
     } else {
         ColumnarValue::Array(map_array)
     })

--- a/datafusion/functions-nested/src/utils.rs
+++ b/datafusion/functions-nested/src/utils.rs
@@ -85,7 +85,7 @@ where
         if is_scalar {
             // If all inputs are scalar, keeps output as scalar
             let result = result.and_then(|arr| ScalarValue::try_from_array(&arr, 0));
-            result.map(ColumnarValue::Scalar)
+            result.map(ColumnarValue::from)
         } else {
             result.map(ColumnarValue::Array)
         }

--- a/datafusion/functions/benches/concat.rs
+++ b/datafusion/functions/benches/concat.rs
@@ -28,7 +28,7 @@ fn create_args(size: usize, str_len: usize) -> Vec<ColumnarValue> {
     let scalar = ScalarValue::Utf8(Some(", ".to_string()));
     vec![
         ColumnarValue::Array(Arc::clone(&array) as ArrayRef),
-        ColumnarValue::Scalar(scalar),
+        ColumnarValue::from(scalar),
         ColumnarValue::Array(array),
     ]
 }

--- a/datafusion/functions/benches/date_bin.rs
+++ b/datafusion/functions/benches/date_bin.rs
@@ -40,7 +40,7 @@ fn timestamps(rng: &mut ThreadRng) -> TimestampSecondArray {
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("date_bin_1000", |b| {
         let mut rng = rand::thread_rng();
-        let interval = ColumnarValue::Scalar(ScalarValue::new_interval_dt(0, 1_000_000));
+        let interval = ColumnarValue::from(ScalarValue::new_interval_dt(0, 1_000_000));
         let timestamps = ColumnarValue::Array(Arc::new(timestamps(&mut rng)) as ArrayRef);
         let udf = date_bin();
 

--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -119,7 +119,7 @@ fn create_args(
     );
     vec![
         ColumnarValue::Array(string_array),
-        ColumnarValue::Scalar(pattern),
+        ColumnarValue::from(pattern),
     ]
 }
 

--- a/datafusion/functions/benches/make_date.rs
+++ b/datafusion/functions/benches/make_date.rs
@@ -72,7 +72,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("make_date_scalar_col_col_1000", |b| {
         let mut rng = rand::thread_rng();
-        let year = ColumnarValue::Scalar(ScalarValue::Int32(Some(2025)));
+        let year = ColumnarValue::from(ScalarValue::Int32(Some(2025)));
         let months = ColumnarValue::Array(Arc::new(months(&mut rng)) as ArrayRef);
         let days = ColumnarValue::Array(Arc::new(days(&mut rng)) as ArrayRef);
 
@@ -87,8 +87,8 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("make_date_scalar_scalar_col_1000", |b| {
         let mut rng = rand::thread_rng();
-        let year = ColumnarValue::Scalar(ScalarValue::Int32(Some(2025)));
-        let month = ColumnarValue::Scalar(ScalarValue::Int32(Some(11)));
+        let year = ColumnarValue::from(ScalarValue::Int32(Some(2025)));
+        let month = ColumnarValue::from(ScalarValue::Int32(Some(11)));
         let days = ColumnarValue::Array(Arc::new(days(&mut rng)) as ArrayRef);
 
         b.iter(|| {
@@ -101,9 +101,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("make_date_scalar_scalar_scalar", |b| {
-        let year = ColumnarValue::Scalar(ScalarValue::Int32(Some(2025)));
-        let month = ColumnarValue::Scalar(ScalarValue::Int32(Some(11)));
-        let day = ColumnarValue::Scalar(ScalarValue::Int32(Some(26)));
+        let year = ColumnarValue::from(ScalarValue::Int32(Some(2025)));
+        let month = ColumnarValue::from(ScalarValue::Int32(Some(11)));
+        let day = ColumnarValue::from(ScalarValue::Int32(Some(26)));
 
         b.iter(|| {
             black_box(

--- a/datafusion/functions/benches/nullif.rs
+++ b/datafusion/functions/benches/nullif.rs
@@ -29,7 +29,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     for size in [1024, 4096, 8192] {
         let array = Arc::new(create_string_array_with_len::<i32>(size, 0.2, 32));
         let args = vec![
-            ColumnarValue::Scalar(ScalarValue::Utf8(Some("abcd".to_string()))),
+            ColumnarValue::from(ScalarValue::Utf8(Some("abcd".to_string()))),
             ColumnarValue::Array(array),
         ];
         c.bench_function(&format!("nullif scalar array: {}", size), |b| {

--- a/datafusion/functions/benches/to_char.rs
+++ b/datafusion/functions/benches/to_char.rs
@@ -98,7 +98,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut rng = rand::thread_rng();
         let data = ColumnarValue::Array(Arc::new(data(&mut rng)) as ArrayRef);
         let patterns =
-            ColumnarValue::Scalar(ScalarValue::Utf8(Some("%Y-%m-%d".to_string())));
+            ColumnarValue::from(ScalarValue::Utf8(Some("%Y-%m-%d".to_string())));
 
         b.iter(|| {
             black_box(
@@ -118,10 +118,9 @@ fn criterion_benchmark(c: &mut Criterion) {
             .and_utc()
             .timestamp_nanos_opt()
             .unwrap();
-        let data = ColumnarValue::Scalar(TimestampNanosecond(Some(timestamp), None));
-        let pattern = ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-            "%d-%m-%Y %H:%M:%S".to_string(),
-        )));
+        let data = ColumnarValue::from(TimestampNanosecond(Some(timestamp), None));
+        let pattern =
+            ColumnarValue::from(ScalarValue::Utf8(Some("%d-%m-%Y %H:%M:%S".to_string())));
 
         b.iter(|| {
             black_box(

--- a/datafusion/functions/src/core/arrowtypeof.rs
+++ b/datafusion/functions/src/core/arrowtypeof.rs
@@ -65,7 +65,7 @@ impl ScalarUDFImpl for ArrowTypeOfFunc {
         }
 
         let input_data_type = args[0].data_type();
-        Ok(ColumnarValue::Scalar(ScalarValue::from(format!(
+        Ok(ColumnarValue::from(ScalarValue::from(format!(
             "{input_data_type}"
         ))))
     }

--- a/datafusion/functions/src/core/coalesce.rs
+++ b/datafusion/functions/src/core/coalesce.rs
@@ -86,7 +86,7 @@ impl ScalarUDFImpl for CoalesceFunc {
 
         if let Some(size) = return_array.next() {
             // start with nulls as default output
-            let mut current_value = new_null_array(&return_type, size);
+            let mut current_value = new_null_array(return_type, size);
             let mut remainder = BooleanArray::from(vec![true; size]);
 
             for arg in args {
@@ -97,7 +97,7 @@ impl ScalarUDFImpl for CoalesceFunc {
                         remainder = and(&remainder, &is_null(array)?)?;
                     }
                     ColumnarValue::Scalar(value) => {
-                        if value.is_null() {
+                        if value.value().is_null() {
                             continue;
                         } else {
                             let last_value = value.to_scalar()?;
@@ -115,7 +115,7 @@ impl ScalarUDFImpl for CoalesceFunc {
             let result = args
                 .iter()
                 .filter_map(|x| match x {
-                    ColumnarValue::Scalar(s) if !s.is_null() => Some(x.clone()),
+                    ColumnarValue::Scalar(s) if !s.value().is_null() => Some(x.clone()),
                     _ => None,
                 })
                 .next()

--- a/datafusion/functions/src/core/getfield.rs
+++ b/datafusion/functions/src/core/getfield.rs
@@ -168,14 +168,14 @@ impl ScalarUDFImpl for GetFieldFunc {
         }
 
         if args[0].data_type().is_null() {
-            return Ok(ColumnarValue::Scalar(ScalarValue::Null));
+            return Ok(ColumnarValue::from(ScalarValue::Null));
         }
 
         let arrays = ColumnarValue::values_to_arrays(args)?;
         let array = Arc::clone(&arrays[0]);
 
         let name = match &args[1] {
-            ColumnarValue::Scalar(name) => name,
+            ColumnarValue::Scalar(name) => name.value(),
             _ => {
                 return exec_err!(
                     "get_field function requires the argument field_name to be a string"
@@ -227,7 +227,7 @@ impl ScalarUDFImpl for GetFieldFunc {
                 "get indexed field is only possible on struct with utf8 indexes. \
                              Tried with {name:?} index"
             ),
-            (DataType::Null, _) => Ok(ColumnarValue::Scalar(ScalarValue::Null)),
+            (DataType::Null, _) => Ok(ColumnarValue::from(ScalarValue::Null)),
             (dt, name) => exec_err!(
                 "get indexed field is only possible on lists with int64 indexes or struct \
                                          with utf8 indexes. Tried {dt:?} with {name:?} index"

--- a/datafusion/functions/src/core/named_struct.rs
+++ b/datafusion/functions/src/core/named_struct.rs
@@ -47,7 +47,10 @@ fn named_struct_expr(args: &[ColumnarValue]) -> Result<ColumnarValue> {
 
             let name_column = &chunk[0];
             let name = match name_column {
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(name_scalar))) => name_scalar,
+                ColumnarValue::Scalar(scalar) => match scalar.value() {
+                    ScalarValue::Utf8(Some(name_scalar)) => name_scalar,
+                _ => return exec_err!("named_struct even arguments must be string literals, got {name_column:?} instead at position {}", i * 2)
+                }
                 _ => return exec_err!("named_struct even arguments must be string literals, got {name_column:?} instead at position {}", i * 2)
             };
 

--- a/datafusion/functions/src/core/nullif.rs
+++ b/datafusion/functions/src/core/nullif.rs
@@ -133,10 +133,10 @@ fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         (ColumnarValue::Scalar(lhs), ColumnarValue::Scalar(rhs)) => {
             let val: ScalarValue = match lhs.eq(rhs) {
                 true => lhs.data_type().try_into()?,
-                false => lhs.clone(),
+                false => lhs.value().clone(),
             };
 
-            Ok(ColumnarValue::Scalar(val))
+            Ok(ColumnarValue::from(val))
         }
     }
 }
@@ -164,7 +164,7 @@ mod tests {
         ]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
+        let lit_array = ColumnarValue::from(ScalarValue::Int32(Some(2i32)));
 
         let result = nullif_func(&[a, lit_array])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -190,7 +190,7 @@ mod tests {
         let a = Int32Array::from(vec![1, 3, 10, 7, 8, 1, 2, 4, 5]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(1i32)));
+        let lit_array = ColumnarValue::from(ScalarValue::Int32(Some(1i32)));
 
         let result = nullif_func(&[a, lit_array])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -215,7 +215,7 @@ mod tests {
         let a = BooleanArray::from(vec![Some(true), Some(false), None]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)));
+        let lit_array = ColumnarValue::from(ScalarValue::Boolean(Some(false)));
 
         let result = nullif_func(&[a, lit_array])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -232,7 +232,7 @@ mod tests {
         let a = StringArray::from(vec![Some("foo"), Some("bar"), None, Some("baz")]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::from("bar"));
+        let lit_array = ColumnarValue::from(ScalarValue::from("bar"));
 
         let result = nullif_func(&[a, lit_array])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -253,7 +253,7 @@ mod tests {
         let a = Int32Array::from(vec![Some(1), Some(2), None, None, Some(3), Some(4)]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
+        let lit_array = ColumnarValue::from(ScalarValue::Int32(Some(2i32)));
 
         let result = nullif_func(&[lit_array, a])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -272,8 +272,8 @@ mod tests {
 
     #[test]
     fn nullif_scalar() -> Result<()> {
-        let a_eq = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
-        let b_eq = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
+        let a_eq = ColumnarValue::from(ScalarValue::Int32(Some(2i32)));
+        let b_eq = ColumnarValue::from(ScalarValue::Int32(Some(2i32)));
 
         let result_eq = nullif_func(&[a_eq, b_eq])?;
         let result_eq = result_eq.into_array(1).expect("Failed to convert to array");
@@ -282,8 +282,8 @@ mod tests {
 
         assert_eq!(expected_eq.as_ref(), result_eq.as_ref());
 
-        let a_neq = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
-        let b_neq = ColumnarValue::Scalar(ScalarValue::Int32(Some(1i32)));
+        let a_neq = ColumnarValue::from(ScalarValue::Int32(Some(2i32)));
+        let b_neq = ColumnarValue::from(ScalarValue::Int32(Some(1i32)));
 
         let result_neq = nullif_func(&[a_neq, b_neq])?;
         let result_neq = result_neq

--- a/datafusion/functions/src/core/nvl.rs
+++ b/datafusion/functions/src/core/nvl.rs
@@ -112,7 +112,7 @@ fn nvl_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         }
         (ColumnarValue::Scalar(lhs), ColumnarValue::Scalar(rhs)) => {
             let mut current_value = lhs;
-            if lhs.is_null() {
+            if lhs.value().is_null() {
                 current_value = rhs;
             }
             return Ok(ColumnarValue::Scalar(current_value.clone()));
@@ -147,7 +147,7 @@ mod tests {
         ]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(6i32)));
+        let lit_array = ColumnarValue::from(ScalarValue::Int32(Some(6i32)));
 
         let result = nvl_func(&[a, lit_array])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -173,7 +173,7 @@ mod tests {
         let a = Int32Array::from(vec![1, 3, 10, 7, 8, 1, 2, 4, 5]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(20i32)));
+        let lit_array = ColumnarValue::from(ScalarValue::Int32(Some(20i32)));
 
         let result = nvl_func(&[a, lit_array])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -198,7 +198,7 @@ mod tests {
         let a = BooleanArray::from(vec![Some(true), Some(false), None]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)));
+        let lit_array = ColumnarValue::from(ScalarValue::Boolean(Some(false)));
 
         let result = nvl_func(&[a, lit_array])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -218,7 +218,7 @@ mod tests {
         let a = StringArray::from(vec![Some("foo"), Some("bar"), None, Some("baz")]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::from("bax"));
+        let lit_array = ColumnarValue::from(ScalarValue::from("bax"));
 
         let result = nvl_func(&[a, lit_array])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -239,7 +239,7 @@ mod tests {
         let a = Int32Array::from(vec![Some(1), Some(2), None, None, Some(3), Some(4)]);
         let a = ColumnarValue::Array(Arc::new(a));
 
-        let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
+        let lit_array = ColumnarValue::from(ScalarValue::Int32(Some(2i32)));
 
         let result = nvl_func(&[lit_array, a])?;
         let result = result.into_array(0).expect("Failed to convert to array");
@@ -258,8 +258,8 @@ mod tests {
 
     #[test]
     fn nvl_scalar() -> Result<()> {
-        let a_null = ColumnarValue::Scalar(ScalarValue::Int32(None));
-        let b_null = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
+        let a_null = ColumnarValue::from(ScalarValue::Int32(None));
+        let b_null = ColumnarValue::from(ScalarValue::Int32(Some(2i32)));
 
         let result_null = nvl_func(&[a_null, b_null])?;
         let result_null = result_null
@@ -270,8 +270,8 @@ mod tests {
 
         assert_eq!(expected_null.as_ref(), result_null.as_ref());
 
-        let a_nnull = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
-        let b_nnull = ColumnarValue::Scalar(ScalarValue::Int32(Some(1i32)));
+        let a_nnull = ColumnarValue::from(ScalarValue::Int32(Some(2i32)));
+        let b_nnull = ColumnarValue::from(ScalarValue::Int32(Some(1i32)));
 
         let result_nnull = nvl_func(&[a_nnull, b_nnull])?;
         let result_nnull = result_nnull

--- a/datafusion/functions/src/core/nvl2.rs
+++ b/datafusion/functions/src/core/nvl2.rs
@@ -126,7 +126,7 @@ fn nvl2_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
                 internal_err!("except Scalar value, but got Array")
             }
             ColumnarValue::Scalar(scalar) => {
-                if scalar.is_null() {
+                if scalar.value().is_null() {
                     current_value = &args[2];
                 }
                 Ok(current_value.clone())

--- a/datafusion/functions/src/core/version.rs
+++ b/datafusion/functions/src/core/version.rs
@@ -76,7 +76,7 @@ impl ScalarUDFImpl for VersionFunc {
             std::env::consts::ARCH,
             std::env::consts::OS,
         );
-        Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(version))))
+        Ok(ColumnarValue::from(ScalarValue::Utf8(Some(version))))
     }
 }
 
@@ -90,7 +90,11 @@ mod test {
         let version_udf = ScalarUDF::from(VersionFunc::new());
         let version = version_udf.invoke_no_args(0).unwrap();
 
-        if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(version))) = version {
+        let ColumnarValue::Scalar(version) = version else {
+            panic!("Expected scalar version")
+        };
+
+        if let ScalarValue::Utf8(Some(version)) = version.value() {
             assert!(version.starts_with("Apache DataFusion"));
         } else {
             panic!("Expected version string");

--- a/datafusion/functions/src/datetime/common.rs
+++ b/datafusion/functions/src/datetime/common.rs
@@ -195,10 +195,10 @@ where
             ))),
             other => exec_err!("Unsupported data type {other:?} for function {name}"),
         },
-        ColumnarValue::Scalar(scalar) => match scalar {
+        ColumnarValue::Scalar(scalar) => match scalar.value() {
             ScalarValue::Utf8(a) | ScalarValue::LargeUtf8(a) => {
                 let result = a.as_ref().map(|x| (op)(x)).transpose()?;
-                Ok(ColumnarValue::Scalar(S::scalar(result)))
+                Ok(ColumnarValue::from(S::scalar(result)))
             }
             other => exec_err!("Unsupported data type {other:?} for function {name}"),
         },
@@ -252,7 +252,7 @@ where
             }
         },
         // if the first argument is a scalar utf8 all arguments are expected to be scalar utf8
-        ColumnarValue::Scalar(scalar) => match scalar {
+        ColumnarValue::Scalar(scalar) => match scalar.value() {
             ScalarValue::Utf8(a) | ScalarValue::LargeUtf8(a) => {
                 let a = a.as_ref();
                 // ASK: Why do we trust `a` to be non-null at this point?
@@ -261,9 +261,11 @@ where
                 let mut ret = None;
 
                 for (pos, v) in args.iter().enumerate().skip(1) {
-                    let ColumnarValue::Scalar(
-                        ScalarValue::Utf8(x) | ScalarValue::LargeUtf8(x),
-                    ) = v
+                    let ColumnarValue::Scalar(v) = v else {
+                        return exec_err!("Expected scalar of data type {v:?} for function {name}, arg # {pos}");
+                    };
+
+                    let (ScalarValue::Utf8(x) | ScalarValue::LargeUtf8(x)) = v.value()
                     else {
                         return exec_err!("Unsupported data type {v:?} for function {name}, arg # {pos}");
                     };
@@ -271,7 +273,7 @@ where
                     if let Some(s) = x {
                         match op(a.as_str(), s.as_str()) {
                             Ok(r) => {
-                                ret = Some(Ok(ColumnarValue::Scalar(S::scalar(Some(
+                                ret = Some(Ok(ColumnarValue::from(S::scalar(Some(
                                     op2(r),
                                 )))));
                                 break;
@@ -328,7 +330,7 @@ where
             ColumnarValue::Array(a) => {
                 Ok(Either::Left(as_generic_string_array::<T>(a.as_ref())?))
             }
-            ColumnarValue::Scalar(s) => match s {
+            ColumnarValue::Scalar(s) => match s.value() {
                 ScalarValue::Utf8(a) | ScalarValue::LargeUtf8(a) => Ok(Either::Right(a)),
                 other => exec_err!(
                     "Unexpected scalar type encountered '{other}' for function '{name}'"

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -140,14 +140,15 @@ impl ScalarUDFImpl for DatePartFunc {
         }
         let (part, array) = (&args[0], &args[1]);
 
-        let part = if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(v))) = part {
-            v
-        } else if let ColumnarValue::Scalar(ScalarValue::Utf8View(Some(v))) = part {
-            v
-        } else {
+        let ColumnarValue::Scalar(part) = part else {
             return exec_err!(
                 "First argument of `DATE_PART` must be non-null scalar Utf8"
             );
+        };
+
+        let part = match part.value() {
+            ScalarValue::Utf8(Some(v)) | ScalarValue::Utf8View(Some(v)) => v,
+            _ => unreachable!(),
         };
 
         let is_scalar = matches!(array, ColumnarValue::Scalar(_));
@@ -192,7 +193,7 @@ impl ScalarUDFImpl for DatePartFunc {
         };
 
         Ok(if is_scalar {
-            ColumnarValue::Scalar(ScalarValue::try_from_array(arr.as_ref(), 0)?)
+            ColumnarValue::from(ScalarValue::try_from_array(arr.as_ref(), 0)?)
         } else {
             ColumnarValue::Array(arr)
         })

--- a/datafusion/functions/src/datetime/date_trunc.rs
+++ b/datafusion/functions/src/datetime/date_trunc.rs
@@ -137,15 +137,15 @@ impl ScalarUDFImpl for DateTruncFunc {
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         let (granularity, array) = (&args[0], &args[1]);
 
-        let granularity = if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(v))) =
-            granularity
-        {
-            v.to_lowercase()
-        } else if let ColumnarValue::Scalar(ScalarValue::Utf8View(Some(v))) = granularity
-        {
-            v.to_lowercase()
-        } else {
+        let ColumnarValue::Scalar(granularity) = granularity else {
             return exec_err!("Granularity of `date_trunc` must be non-null scalar Utf8");
+        };
+
+        let granularity = match granularity.value() {
+            ScalarValue::Utf8(Some(v)) | ScalarValue::Utf8View(Some(v)) => {
+                v.to_lowercase()
+            }
+            _ => unreachable!(),
         };
 
         fn process_array<T: ArrowTimestampType>(
@@ -171,22 +171,30 @@ impl ScalarUDFImpl for DateTruncFunc {
             let parsed_tz = parse_tz(tz_opt)?;
             let value = general_date_trunc(T::UNIT, v, parsed_tz, granularity.as_str())?;
             let value = ScalarValue::new_timestamp::<T>(value, tz_opt.clone());
-            Ok(ColumnarValue::Scalar(value))
+            Ok(ColumnarValue::from(value))
         }
 
         Ok(match array {
-            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(v, tz_opt)) => {
-                process_scalar::<TimestampNanosecondType>(v, granularity, tz_opt)?
-            }
-            ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(v, tz_opt)) => {
-                process_scalar::<TimestampMicrosecondType>(v, granularity, tz_opt)?
-            }
-            ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(v, tz_opt)) => {
-                process_scalar::<TimestampMillisecondType>(v, granularity, tz_opt)?
-            }
-            ColumnarValue::Scalar(ScalarValue::TimestampSecond(v, tz_opt)) => {
-                process_scalar::<TimestampSecondType>(v, granularity, tz_opt)?
-            }
+            ColumnarValue::Scalar(scalar) => match scalar.value() {
+                ScalarValue::TimestampNanosecond(v, tz_opt) => {
+                    process_scalar::<TimestampNanosecondType>(v, granularity, tz_opt)?
+                }
+                ScalarValue::TimestampMicrosecond(v, tz_opt) => {
+                    process_scalar::<TimestampMicrosecondType>(v, granularity, tz_opt)?
+                }
+                ScalarValue::TimestampMillisecond(v, tz_opt) => {
+                    process_scalar::<TimestampMillisecondType>(v, granularity, tz_opt)?
+                }
+                ScalarValue::TimestampSecond(v, tz_opt) => {
+                    process_scalar::<TimestampSecondType>(v, granularity, tz_opt)?
+                }
+                value => {
+                    return exec_err!(
+                    "second argument of `date_trunc` is an unsupported scalar type: {}",
+                    value.data_type()
+                )
+                }
+            },
             ColumnarValue::Array(array) => {
                 let array_type = array.data_type();
                 if let Timestamp(unit, tz_opt) = array_type {
@@ -215,11 +223,6 @@ impl ScalarUDFImpl for DateTruncFunc {
                 } else {
                     return exec_err!("second argument of `date_trunc` is an unsupported array type: {array_type}");
                 }
-            }
-            _ => {
-                return exec_err!(
-                    "second argument of `date_trunc` must be timestamp scalar or array"
-                );
             }
         })
     }
@@ -689,7 +692,7 @@ mod tests {
                 .with_timezone_opt(tz_opt.clone());
             let result = DateTruncFunc::new()
                 .invoke(&[
-                    ColumnarValue::Scalar(ScalarValue::from("day")),
+                    ColumnarValue::from(ScalarValue::from("day")),
                     ColumnarValue::Array(Arc::new(input)),
                 ])
                 .unwrap();
@@ -847,7 +850,7 @@ mod tests {
                 .with_timezone_opt(tz_opt.clone());
             let result = DateTruncFunc::new()
                 .invoke(&[
-                    ColumnarValue::Scalar(ScalarValue::from("hour")),
+                    ColumnarValue::from(ScalarValue::from("hour")),
                     ColumnarValue::Array(Arc::new(input)),
                 ])
                 .unwrap();

--- a/datafusion/functions/src/datetime/make_date.rs
+++ b/datafusion/functions/src/datetime/make_date.rs
@@ -94,7 +94,7 @@ impl ScalarUDFImpl for MakeDateFunc {
             let ColumnarValue::Scalar(s) = col else {
                 return exec_err!("Expected scalar value");
             };
-            let ScalarValue::Int32(Some(i)) = s else {
+            let ScalarValue::Int32(Some(i)) = s.value() else {
                 return exec_err!("Unable to parse date from null/empty value");
             };
             Ok(*i)
@@ -143,7 +143,7 @@ impl ScalarUDFImpl for MakeDateFunc {
                 |days: i32| value = days,
             )?;
 
-            ColumnarValue::Scalar(ScalarValue::Date32(Some(value)))
+            ColumnarValue::from(ScalarValue::Date32(Some(value)))
         };
 
         Ok(value)
@@ -192,44 +192,65 @@ mod tests {
     fn test_make_date() {
         let res = MakeDateFunc::new()
             .invoke(&[
-                ColumnarValue::Scalar(ScalarValue::Int32(Some(2024))),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(1))),
-                ColumnarValue::Scalar(ScalarValue::UInt32(Some(14))),
+                ColumnarValue::from(ScalarValue::Int32(Some(2024))),
+                ColumnarValue::from(ScalarValue::Int64(Some(1))),
+                ColumnarValue::from(ScalarValue::UInt32(Some(14))),
             ])
             .expect("that make_date parsed values without error");
 
-        if let ColumnarValue::Scalar(ScalarValue::Date32(date)) = res {
+        let ColumnarValue::Scalar(scalar) = res else {
+            panic!("Expected a scalar value")
+        };
+
+        if let ScalarValue::Date32(date) = scalar.value() {
             assert_eq!(19736, date.unwrap());
         } else {
-            panic!("Expected a scalar value")
+            panic!(
+                "Expected a Date32 scalar, got {}",
+                scalar.value().data_type()
+            )
         }
 
         let res = MakeDateFunc::new()
             .invoke(&[
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(2024))),
-                ColumnarValue::Scalar(ScalarValue::UInt64(Some(1))),
-                ColumnarValue::Scalar(ScalarValue::UInt32(Some(14))),
+                ColumnarValue::from(ScalarValue::Int64(Some(2024))),
+                ColumnarValue::from(ScalarValue::UInt64(Some(1))),
+                ColumnarValue::from(ScalarValue::UInt32(Some(14))),
             ])
             .expect("that make_date parsed values without error");
 
-        if let ColumnarValue::Scalar(ScalarValue::Date32(date)) = res {
+        let ColumnarValue::Scalar(scalar) = res else {
+            panic!("Expected a scalar value")
+        };
+
+        if let ScalarValue::Date32(date) = scalar.value() {
             assert_eq!(19736, date.unwrap());
         } else {
-            panic!("Expected a scalar value")
+            panic!(
+                "Expected a Date32 scalar, got {}",
+                scalar.value().data_type()
+            )
         }
 
         let res = MakeDateFunc::new()
             .invoke(&[
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some("2024".to_string()))),
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some("1".to_string()))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some("14".to_string()))),
+                ColumnarValue::from(ScalarValue::Utf8(Some("2024".to_string()))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(Some("1".to_string()))),
+                ColumnarValue::from(ScalarValue::Utf8(Some("14".to_string()))),
             ])
             .expect("that make_date parsed values without error");
 
-        if let ColumnarValue::Scalar(ScalarValue::Date32(date)) = res {
+        let ColumnarValue::Scalar(scalar) = res else {
+            panic!("Expected a scalar value")
+        };
+
+        if let ScalarValue::Date32(date) = scalar.value() {
             assert_eq!(19736, date.unwrap());
         } else {
-            panic!("Expected a scalar value")
+            panic!(
+                "Expected a Date32 scalar, got {}",
+                scalar.value().data_type()
+            )
         }
 
         let years = Arc::new((2021..2025).map(Some).collect::<Int64Array>());
@@ -261,7 +282,7 @@ mod tests {
 
         // invalid number of arguments
         let res = MakeDateFunc::new()
-            .invoke(&[ColumnarValue::Scalar(ScalarValue::Int32(Some(1)))]);
+            .invoke(&[ColumnarValue::from(ScalarValue::Int32(Some(1)))]);
         assert_eq!(
             res.err().unwrap().strip_backtrace(),
             "Execution error: make_date function requires 3 arguments, got 1"
@@ -269,9 +290,9 @@ mod tests {
 
         // invalid type
         let res = MakeDateFunc::new().invoke(&[
-            ColumnarValue::Scalar(ScalarValue::IntervalYearMonth(Some(1))),
-            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
-            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+            ColumnarValue::from(ScalarValue::IntervalYearMonth(Some(1))),
+            ColumnarValue::from(ScalarValue::TimestampNanosecond(Some(1), None)),
+            ColumnarValue::from(ScalarValue::TimestampNanosecond(Some(1), None)),
         ]);
         assert_eq!(
             res.err().unwrap().strip_backtrace(),
@@ -280,9 +301,9 @@ mod tests {
 
         // overflow of month
         let res = MakeDateFunc::new().invoke(&[
-            ColumnarValue::Scalar(ScalarValue::Int32(Some(2023))),
-            ColumnarValue::Scalar(ScalarValue::UInt64(Some(u64::MAX))),
-            ColumnarValue::Scalar(ScalarValue::Int32(Some(22))),
+            ColumnarValue::from(ScalarValue::Int32(Some(2023))),
+            ColumnarValue::from(ScalarValue::UInt64(Some(u64::MAX))),
+            ColumnarValue::from(ScalarValue::Int32(Some(22))),
         ]);
         assert_eq!(
             res.err().unwrap().strip_backtrace(),
@@ -291,9 +312,9 @@ mod tests {
 
         // overflow of day
         let res = MakeDateFunc::new().invoke(&[
-            ColumnarValue::Scalar(ScalarValue::Int32(Some(2023))),
-            ColumnarValue::Scalar(ScalarValue::Int32(Some(22))),
-            ColumnarValue::Scalar(ScalarValue::UInt32(Some(u32::MAX))),
+            ColumnarValue::from(ScalarValue::Int32(Some(2023))),
+            ColumnarValue::from(ScalarValue::Int32(Some(22))),
+            ColumnarValue::from(ScalarValue::UInt32(Some(u32::MAX))),
         ]);
         assert_eq!(
             res.err().unwrap().strip_backtrace(),

--- a/datafusion/functions/src/datetime/to_char.rs
+++ b/datafusion/functions/src/datetime/to_char.rs
@@ -115,22 +115,22 @@ impl ScalarUDFImpl for ToCharFunc {
         }
 
         match &args[1] {
-            ColumnarValue::Scalar(ScalarValue::Utf8(None))
-            | ColumnarValue::Scalar(ScalarValue::Null) => {
-                _to_char_scalar(args[0].clone(), None)
-            }
-            // constant format
-            ColumnarValue::Scalar(ScalarValue::Utf8(Some(format))) => {
-                // invoke to_char_scalar with the known string, without converting to array
-                _to_char_scalar(args[0].clone(), Some(format))
-            }
+            ColumnarValue::Scalar(scalar) => match scalar.value() {
+                ScalarValue::Utf8(None) | ScalarValue::Null => {
+                    _to_char_scalar(args[0].clone(), None)
+                }
+                ScalarValue::Utf8(Some(format)) => {
+                    // invoke to_char_scalar with the known string, without converting to array
+                    _to_char_scalar(args[0].clone(), Some(format))
+                }
+                _ => {
+                    exec_err!(
+                        "Format for `to_char` must be non-null Utf8, received {:?}",
+                        args[1].data_type()
+                    )
+                }
+            },
             ColumnarValue::Array(_) => _to_char_array(args),
-            _ => {
-                exec_err!(
-                    "Format for `to_char` must be non-null Utf8, received {:?}",
-                    args[1].data_type()
-                )
-            }
         }
     }
 
@@ -177,13 +177,13 @@ fn _to_char_scalar(
 ) -> Result<ColumnarValue> {
     // it's possible that the expression is a scalar however because
     // of the implementation in arrow-rs we need to convert it to an array
-    let data_type = &expression.data_type();
+    let data_type = expression.data_type().clone();
     let is_scalar_expression = matches!(&expression, ColumnarValue::Scalar(_));
     let array = expression.into_array(1)?;
 
     if format.is_none() {
         if is_scalar_expression {
-            return Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)));
+            return Ok(ColumnarValue::from(ScalarValue::Utf8(None)));
         } else {
             return Ok(ColumnarValue::Array(new_null_array(
                 &DataType::Utf8,
@@ -192,7 +192,7 @@ fn _to_char_scalar(
         }
     }
 
-    let format_options = match _build_format_options(data_type, format) {
+    let format_options = match _build_format_options(&data_type, format) {
         Ok(value) => value,
         Err(value) => return value,
     };
@@ -204,7 +204,7 @@ fn _to_char_scalar(
 
     if let Ok(formatted) = formatted {
         if is_scalar_expression {
-            Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
+            Ok(ColumnarValue::from(ScalarValue::Utf8(Some(
                 formatted.first().unwrap().to_string(),
             ))))
         } else {
@@ -252,10 +252,10 @@ fn _to_char_array(args: &[ColumnarValue]) -> Result<ColumnarValue> {
             results,
         )) as ArrayRef)),
         ColumnarValue::Scalar(_) => match results.first().unwrap() {
-            Some(value) => Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
+            Some(value) => Ok(ColumnarValue::from(ScalarValue::Utf8(Some(
                 value.to_string(),
             )))),
-            None => Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None))),
+            None => Ok(ColumnarValue::from(ScalarValue::Utf8(None))),
         },
     }
 }
@@ -351,13 +351,15 @@ mod tests {
 
         for (value, format, expected) in scalar_data {
             let result = ToCharFunc::new()
-                .invoke(&[ColumnarValue::Scalar(value), ColumnarValue::Scalar(format)])
+                .invoke(&[ColumnarValue::from(value), ColumnarValue::from(format)])
                 .expect("that to_char parsed values without error");
 
-            if let ColumnarValue::Scalar(ScalarValue::Utf8(date)) = result {
-                assert_eq!(expected, date.unwrap());
-            } else {
-                panic!("Expected a scalar value")
+            match result {
+                ColumnarValue::Scalar(scalar) => match scalar.into_value() {
+                    ScalarValue::Utf8(date) => assert_eq!(expected, date.unwrap()),
+                    _ => unreachable!(),
+                },
+                _ => panic!("Expected a scalar value"),
             }
         }
 
@@ -426,15 +428,17 @@ mod tests {
         for (value, format, expected) in scalar_array_data {
             let result = ToCharFunc::new()
                 .invoke(&[
-                    ColumnarValue::Scalar(value),
+                    ColumnarValue::from(value),
                     ColumnarValue::Array(Arc::new(format) as ArrayRef),
                 ])
                 .expect("that to_char parsed values without error");
 
-            if let ColumnarValue::Scalar(ScalarValue::Utf8(date)) = result {
-                assert_eq!(expected, date.unwrap());
-            } else {
-                panic!("Expected a scalar value")
+            match result {
+                ColumnarValue::Scalar(scalar) => match scalar.into_value() {
+                    ScalarValue::Utf8(date) => assert_eq!(expected, date.unwrap()),
+                    _ => unreachable!(),
+                },
+                _ => panic!("Expected a scalar value"),
             }
         }
 
@@ -552,7 +556,7 @@ mod tests {
             let result = ToCharFunc::new()
                 .invoke(&[
                     ColumnarValue::Array(value as ArrayRef),
-                    ColumnarValue::Scalar(format),
+                    ColumnarValue::from(format),
                 ])
                 .expect("that to_char parsed values without error");
 
@@ -585,8 +589,8 @@ mod tests {
         //
 
         // invalid number of arguments
-        let result = ToCharFunc::new()
-            .invoke(&[ColumnarValue::Scalar(ScalarValue::Int32(Some(1)))]);
+        let result =
+            ToCharFunc::new().invoke(&[ColumnarValue::from(ScalarValue::Int32(Some(1)))]);
         assert_eq!(
             result.err().unwrap().strip_backtrace(),
             "Execution error: to_char function requires 2 arguments, got 1"
@@ -594,8 +598,8 @@ mod tests {
 
         // invalid type
         let result = ToCharFunc::new().invoke(&[
-            ColumnarValue::Scalar(ScalarValue::Int32(Some(1))),
-            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(1), None)),
+            ColumnarValue::from(ScalarValue::Int32(Some(1))),
+            ColumnarValue::from(ScalarValue::TimestampNanosecond(Some(1), None)),
         ]);
         assert_eq!(
             result.err().unwrap().strip_backtrace(),

--- a/datafusion/functions/src/datetime/to_date.rs
+++ b/datafusion/functions/src/datetime/to_date.rs
@@ -156,18 +156,22 @@ mod tests {
         for tc in &test_cases {
             let date_scalar = ScalarValue::Utf8(Some(tc.date_str.to_string()));
             let to_date_result =
-                ToDateFunc::new().invoke(&[ColumnarValue::Scalar(date_scalar)]);
+                ToDateFunc::new().invoke(&[ColumnarValue::from(date_scalar)]);
 
             match to_date_result {
-                Ok(ColumnarValue::Scalar(ScalarValue::Date32(date_val))) => {
-                    let expected = Date32Type::parse_formatted(tc.date_str, "%Y-%m-%d");
-                    assert_eq!(
-                        date_val, expected,
-                        "{}: to_date created wrong value",
-                        tc.name
-                    );
-                }
-                _ => panic!("Could not convert '{}' to Date", tc.date_str),
+                Ok(ColumnarValue::Scalar(scalar)) => match scalar.into_value() {
+                    ScalarValue::Date32(date_val) => {
+                        let expected =
+                            Date32Type::parse_formatted(tc.date_str, "%Y-%m-%d");
+                        assert_eq!(
+                            date_val, expected,
+                            "{}: to_date created wrong value",
+                            tc.name
+                        );
+                    }
+                    _ => panic!("Could not convert '{}' to Date", tc.date_str),
+                },
+                _ => unreachable!(),
             }
         }
     }
@@ -226,19 +230,23 @@ mod tests {
             let format_scalar = ScalarValue::Utf8(Some(tc.format_str.to_string()));
 
             let to_date_result = ToDateFunc::new().invoke(&[
-                ColumnarValue::Scalar(formatted_date_scalar),
-                ColumnarValue::Scalar(format_scalar),
+                ColumnarValue::from(formatted_date_scalar),
+                ColumnarValue::from(format_scalar),
             ]);
 
             match to_date_result {
-                Ok(ColumnarValue::Scalar(ScalarValue::Date32(date_val))) => {
-                    let expected = Date32Type::parse_formatted(tc.date_str, "%Y-%m-%d");
-                    assert_eq!(date_val, expected, "{}: to_date created wrong value for date '{}' with format string '{}'", tc.name, tc.formatted_date, tc.format_str);
-                }
-                _ => panic!(
-                    "Could not convert '{}' with format string '{}'to Date",
-                    tc.date_str, tc.format_str
-                ),
+                Ok(ColumnarValue::Scalar(scalar)) => match scalar.into_value() {
+                    ScalarValue::Date32(date_val) => {
+                        let expected =
+                            Date32Type::parse_formatted(tc.date_str, "%Y-%m-%d");
+                        assert_eq!(date_val, expected, "{}: to_date created wrong value for date '{}' with format string '{}'", tc.name, tc.formatted_date, tc.format_str);
+                    }
+                    _ => panic!(
+                        "Could not convert '{}' with format string '{}'to Date",
+                        tc.date_str, tc.format_str
+                    ),
+                },
+                _ => unreachable!(),
             }
         }
     }
@@ -250,20 +258,23 @@ mod tests {
         let format2_scalar = ScalarValue::Utf8(Some("%Y/%m/%d".into()));
 
         let to_date_result = ToDateFunc::new().invoke(&[
-            ColumnarValue::Scalar(formatted_date_scalar),
-            ColumnarValue::Scalar(format1_scalar),
-            ColumnarValue::Scalar(format2_scalar),
+            ColumnarValue::from(formatted_date_scalar),
+            ColumnarValue::from(format1_scalar),
+            ColumnarValue::from(format2_scalar),
         ]);
 
         match to_date_result {
-            Ok(ColumnarValue::Scalar(ScalarValue::Date32(date_val))) => {
-                let expected = Date32Type::parse_formatted("2023-01-31", "%Y-%m-%d");
-                assert_eq!(
-                    date_val, expected,
-                    "to_date created wrong value for date with 2 format strings"
-                );
-            }
-            _ => panic!("Conversion failed",),
+            Ok(ColumnarValue::Scalar(scalar)) => match scalar.into_value() {
+                ScalarValue::Date32(date_val) => {
+                    let expected = Date32Type::parse_formatted("2023-01-31", "%Y-%m-%d");
+                    assert_eq!(
+                        date_val, expected,
+                        "to_date created wrong value for date with 2 format strings"
+                    );
+                }
+                _ => panic!("Conversion failed",),
+            },
+            _ => unreachable!(),
         }
     }
 
@@ -278,14 +289,18 @@ mod tests {
             let formatted_date_scalar = ScalarValue::Utf8(Some(date_str.into()));
 
             let to_date_result =
-                ToDateFunc::new().invoke(&[ColumnarValue::Scalar(formatted_date_scalar)]);
+                ToDateFunc::new().invoke(&[ColumnarValue::from(formatted_date_scalar)]);
 
             match to_date_result {
-                Ok(ColumnarValue::Scalar(ScalarValue::Date32(date_val))) => {
-                    let expected = Date32Type::parse_formatted("2020-09-08", "%Y-%m-%d");
-                    assert_eq!(date_val, expected, "to_date created wrong value");
-                }
-                _ => panic!("Conversion of {} failed", date_str),
+                Ok(ColumnarValue::Scalar(scalar)) => match scalar.into_value() {
+                    ScalarValue::Date32(date_val) => {
+                        let expected =
+                            Date32Type::parse_formatted("2020-09-08", "%Y-%m-%d");
+                        assert_eq!(date_val, expected, "to_date created wrong value");
+                    }
+                    _ => panic!("Conversion of {} failed", date_str),
+                },
+                _ => unreachable!(),
             }
         }
     }
@@ -296,18 +311,21 @@ mod tests {
         let date_scalar = ScalarValue::Utf8(Some(date_str.into()));
 
         let to_date_result =
-            ToDateFunc::new().invoke(&[ColumnarValue::Scalar(date_scalar)]);
+            ToDateFunc::new().invoke(&[ColumnarValue::from(date_scalar)]);
 
         match to_date_result {
-            Ok(ColumnarValue::Scalar(ScalarValue::Date32(date_val))) => {
-                let expected = Date32Type::parse_formatted("2024-12-31", "%Y-%m-%d");
-                assert_eq!(
-                    date_val, expected,
-                    "to_date created wrong value for {}",
-                    date_str
-                );
-            }
-            _ => panic!("Conversion of {} failed", date_str),
+            Ok(ColumnarValue::Scalar(scalar)) => match scalar.into_value() {
+                ScalarValue::Date32(date_val) => {
+                    let expected = Date32Type::parse_formatted("2024-12-31", "%Y-%m-%d");
+                    assert_eq!(
+                        date_val, expected,
+                        "to_date created wrong value for {}",
+                        date_str
+                    );
+                }
+                _ => panic!("Conversion of {} failed", date_str),
+            },
+            _ => unreachable!(),
         }
     }
 
@@ -317,13 +335,15 @@ mod tests {
         let date_scalar = ScalarValue::Utf8(Some(date_str.into()));
 
         let to_date_result =
-            ToDateFunc::new().invoke(&[ColumnarValue::Scalar(date_scalar)]);
+            ToDateFunc::new().invoke(&[ColumnarValue::from(date_scalar)]);
 
-        if let Ok(ColumnarValue::Scalar(ScalarValue::Date32(_))) = to_date_result {
-            panic!(
-                "Conversion of {} succeded, but should have failed, ",
-                date_str
-            );
+        if let Ok(ColumnarValue::Scalar(scalar)) = to_date_result {
+            if let ScalarValue::Date32(_) = scalar.value() {
+                panic!(
+                    "Conversion of {} succeded, but should have failed, ",
+                    date_str
+                )
+            }
         }
     }
 }

--- a/datafusion/functions/src/datetime/to_local_time.rs
+++ b/datafusion/functions/src/datetime/to_local_time.rs
@@ -97,50 +97,48 @@ impl ToLocalTimeFunc {
                 let tz: Tz = timezone.parse()?;
 
                 match time_value {
-                    ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(
-                        Some(ts),
-                        Some(_),
-                    )) => {
-                        let adjusted_ts =
-                            adjust_to_local_time::<TimestampNanosecondType>(*ts, tz)?;
-                        Ok(ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(
-                            Some(adjusted_ts),
-                            None,
-                        )))
-                    }
-                    ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-                        Some(ts),
-                        Some(_),
-                    )) => {
-                        let adjusted_ts =
-                            adjust_to_local_time::<TimestampMicrosecondType>(*ts, tz)?;
-                        Ok(ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-                            Some(adjusted_ts),
-                            None,
-                        )))
-                    }
-                    ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
-                        Some(ts),
-                        Some(_),
-                    )) => {
-                        let adjusted_ts =
-                            adjust_to_local_time::<TimestampMillisecondType>(*ts, tz)?;
-                        Ok(ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
-                            Some(adjusted_ts),
-                            None,
-                        )))
-                    }
-                    ColumnarValue::Scalar(ScalarValue::TimestampSecond(
-                        Some(ts),
-                        Some(_),
-                    )) => {
-                        let adjusted_ts =
-                            adjust_to_local_time::<TimestampSecondType>(*ts, tz)?;
-                        Ok(ColumnarValue::Scalar(ScalarValue::TimestampSecond(
-                            Some(adjusted_ts),
-                            None,
-                        )))
-                    }
+                    ColumnarValue::Scalar(scalar) => match scalar.value() {
+                        ScalarValue::TimestampNanosecond(Some(ts), Some(_)) => {
+                            let adjusted_ts =
+                                adjust_to_local_time::<TimestampNanosecondType>(*ts, tz)?;
+                            Ok(ColumnarValue::from(ScalarValue::TimestampNanosecond(
+                                Some(adjusted_ts),
+                                None,
+                            )))
+                        }
+                        ScalarValue::TimestampMicrosecond(Some(ts), Some(_)) => {
+                            let adjusted_ts = adjust_to_local_time::<
+                                TimestampMicrosecondType,
+                            >(*ts, tz)?;
+                            Ok(ColumnarValue::from(ScalarValue::TimestampMicrosecond(
+                                Some(adjusted_ts),
+                                None,
+                            )))
+                        }
+                        ScalarValue::TimestampMillisecond(Some(ts), Some(_)) => {
+                            let adjusted_ts = adjust_to_local_time::<
+                                TimestampMillisecondType,
+                            >(*ts, tz)?;
+                            Ok(ColumnarValue::from(ScalarValue::TimestampMillisecond(
+                                Some(adjusted_ts),
+                                None,
+                            )))
+                        }
+                        ScalarValue::TimestampSecond(Some(ts), Some(_)) => {
+                            let adjusted_ts =
+                                adjust_to_local_time::<TimestampSecondType>(*ts, tz)?;
+                            Ok(ColumnarValue::from(ScalarValue::TimestampSecond(
+                                Some(adjusted_ts),
+                                None,
+                            )))
+                        }
+                        _ => {
+                            exec_err!(
+                        "to_local_time function requires timestamp argument, got {:?}",
+                        time_value.data_type()
+                    )
+                        }
+                    },
                     ColumnarValue::Array(array) => {
                         fn transform_array<T: ArrowTimestampType>(
                             array: &ArrayRef,
@@ -184,12 +182,6 @@ impl ToLocalTimeFunc {
                                 exec_err!("to_local_time function requires timestamp argument in array, got {:?}", array.data_type())
                             }
                         }
-                    }
-                    _ => {
-                        exec_err!(
-                        "to_local_time function requires timestamp argument, got {:?}",
-                        time_value.data_type()
-                    )
                     }
                 }
             }
@@ -359,7 +351,7 @@ mod tests {
     use arrow::datatypes::{DataType, TimeUnit};
     use chrono::NaiveDateTime;
     use datafusion_common::ScalarValue;
-    use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
+    use datafusion_expr::{ColumnarValue, Scalar, ScalarUDFImpl};
 
     use super::{adjust_to_local_time, ToLocalTimeFunc};
 
@@ -486,11 +478,11 @@ mod tests {
 
     fn test_to_local_time_helper(input: ScalarValue, expected: ScalarValue) {
         let res = ToLocalTimeFunc::new()
-            .invoke(&[ColumnarValue::Scalar(input)])
+            .invoke(&[ColumnarValue::from(input)])
             .unwrap();
         match res {
             ColumnarValue::Scalar(res) => {
-                assert_eq!(res, expected);
+                assert_eq!(res, Scalar::from(expected));
             }
             _ => panic!("unexpected return type"),
         }

--- a/datafusion/functions/src/datetime/to_timestamp.rs
+++ b/datafusion/functions/src/datetime/to_timestamp.rs
@@ -169,7 +169,7 @@ impl ScalarUDFImpl for ToTimestampFunc {
                 args[0].cast_to(&Timestamp(Nanosecond, None), None)
             }
             DataType::Timestamp(_, Some(tz)) => {
-                args[0].cast_to(&Timestamp(Nanosecond, Some(tz)), None)
+                args[0].cast_to(&Timestamp(Nanosecond, Some(Arc::clone(tz))), None)
             }
             DataType::Utf8 => {
                 to_timestamp_impl::<TimestampNanosecondType>(args, "to_timestamp")
@@ -219,7 +219,7 @@ impl ScalarUDFImpl for ToTimestampSecondsFunc {
                 args[0].cast_to(&Timestamp(Second, None), None)
             }
             DataType::Timestamp(_, Some(tz)) => {
-                args[0].cast_to(&Timestamp(Second, Some(tz)), None)
+                args[0].cast_to(&Timestamp(Second, Some(Arc::clone(tz))), None)
             }
             DataType::Utf8 => {
                 to_timestamp_impl::<TimestampSecondType>(args, "to_timestamp_seconds")
@@ -269,7 +269,7 @@ impl ScalarUDFImpl for ToTimestampMillisFunc {
                 args[0].cast_to(&Timestamp(Millisecond, None), None)
             }
             DataType::Timestamp(_, Some(tz)) => {
-                args[0].cast_to(&Timestamp(Millisecond, Some(tz)), None)
+                args[0].cast_to(&Timestamp(Millisecond, Some(Arc::clone(tz))), None)
             }
             DataType::Utf8 => {
                 to_timestamp_impl::<TimestampMillisecondType>(args, "to_timestamp_millis")
@@ -319,7 +319,7 @@ impl ScalarUDFImpl for ToTimestampMicrosFunc {
                 args[0].cast_to(&Timestamp(Microsecond, None), None)
             }
             DataType::Timestamp(_, Some(tz)) => {
-                args[0].cast_to(&Timestamp(Microsecond, Some(tz)), None)
+                args[0].cast_to(&Timestamp(Microsecond, Some(Arc::clone(tz))), None)
             }
             DataType::Utf8 => {
                 to_timestamp_impl::<TimestampMicrosecondType>(args, "to_timestamp_micros")
@@ -369,7 +369,7 @@ impl ScalarUDFImpl for ToTimestampNanosFunc {
                 args[0].cast_to(&Timestamp(Nanosecond, None), None)
             }
             DataType::Timestamp(_, Some(tz)) => {
-                args[0].cast_to(&Timestamp(Nanosecond, Some(tz)), None)
+                args[0].cast_to(&Timestamp(Nanosecond, Some(Arc::clone(tz))), None)
             }
             DataType::Utf8 => {
                 to_timestamp_impl::<TimestampNanosecondType>(args, "to_timestamp_nanos")
@@ -803,7 +803,7 @@ mod tests {
 
         for udf in &udfs {
             for array in arrays {
-                let rt = udf.return_type(&[array.data_type()]).unwrap();
+                let rt = udf.return_type(&[array.data_type().clone()]).unwrap();
                 assert!(matches!(rt, DataType::Timestamp(_, Some(_))));
 
                 let res = udf
@@ -846,7 +846,7 @@ mod tests {
 
         for udf in &udfs {
             for array in arrays {
-                let rt = udf.return_type(&[array.data_type()]).unwrap();
+                let rt = udf.return_type(&[array.data_type().clone()]).unwrap();
                 assert!(matches!(rt, DataType::Timestamp(_, None)));
 
                 let res = udf
@@ -896,9 +896,9 @@ mod tests {
             // test UTF8
             let string_array = [
                 ColumnarValue::Array(Arc::new(data.clone()) as ArrayRef),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%s".to_string()))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%c".to_string()))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%+".to_string()))),
+                ColumnarValue::from(ScalarValue::Utf8(Some("%s".to_string()))),
+                ColumnarValue::from(ScalarValue::Utf8(Some("%c".to_string()))),
+                ColumnarValue::from(ScalarValue::Utf8(Some("%+".to_string()))),
             ];
             let parsed_timestamps = func(&string_array)
                 .expect("that to_timestamp with format args parsed values without error");
@@ -925,9 +925,9 @@ mod tests {
             // test LargeUTF8
             let string_array = [
                 ColumnarValue::Array(Arc::new(data.clone()) as ArrayRef),
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some("%s".to_string()))),
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some("%c".to_string()))),
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some("%+".to_string()))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(Some("%s".to_string()))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(Some("%c".to_string()))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(Some("%+".to_string()))),
             ];
             let parsed_timestamps = func(&string_array)
                 .expect("that to_timestamp with format args parsed values without error");
@@ -959,9 +959,9 @@ mod tests {
             // test other types
             let string_array = [
                 ColumnarValue::Array(Arc::new(data.clone()) as ArrayRef),
-                ColumnarValue::Scalar(ScalarValue::Int32(Some(1))),
-                ColumnarValue::Scalar(ScalarValue::Int32(Some(2))),
-                ColumnarValue::Scalar(ScalarValue::Int32(Some(3))),
+                ColumnarValue::from(ScalarValue::Int32(Some(1))),
+                ColumnarValue::from(ScalarValue::Int32(Some(2))),
+                ColumnarValue::from(ScalarValue::Int32(Some(3))),
             ];
 
             let expected = "Unsupported data type Int32 for function".to_string();

--- a/datafusion/functions/src/encoding/inner.rs
+++ b/datafusion/functions/src/encoding/inner.rs
@@ -174,7 +174,7 @@ fn encode_process(value: &ColumnarValue, encoding: Encoding) -> Result<ColumnarV
             ),
         },
         ColumnarValue::Scalar(scalar) => {
-            match scalar {
+            match scalar.value() {
                 ScalarValue::Utf8(a) => {
                     Ok(encoding.encode_scalar(a.as_ref().map(|s: &String| s.as_bytes())))
                 }
@@ -205,7 +205,7 @@ fn decode_process(value: &ColumnarValue, encoding: Encoding) -> Result<ColumnarV
             ),
         },
         ColumnarValue::Scalar(scalar) => {
-            match scalar {
+            match scalar.value() {
                 ScalarValue::Utf8(a) => {
                     encoding.decode_scalar(a.as_ref().map(|s: &String| s.as_bytes()))
                 }
@@ -266,7 +266,7 @@ macro_rules! decode_to_array {
 
 impl Encoding {
     fn encode_scalar(self, value: Option<&[u8]>) -> ColumnarValue {
-        ColumnarValue::Scalar(match self {
+        ColumnarValue::from(match self {
             Self::Base64 => ScalarValue::Utf8(
                 value.map(|v| general_purpose::STANDARD_NO_PAD.encode(v)),
             ),
@@ -275,7 +275,7 @@ impl Encoding {
     }
 
     fn encode_large_scalar(self, value: Option<&[u8]>) -> ColumnarValue {
-        ColumnarValue::Scalar(match self {
+        ColumnarValue::from(match self {
             Self::Base64 => ScalarValue::LargeUtf8(
                 value.map(|v| general_purpose::STANDARD_NO_PAD.encode(v)),
             ),
@@ -310,7 +310,7 @@ impl Encoding {
     fn decode_scalar(self, value: Option<&[u8]>) -> Result<ColumnarValue> {
         let value = match value {
             Some(value) => value,
-            None => return Ok(ColumnarValue::Scalar(ScalarValue::Binary(None))),
+            None => return Ok(ColumnarValue::from(ScalarValue::Binary(None))),
         };
 
         let out = match self {
@@ -332,13 +332,13 @@ impl Encoding {
             })?,
         };
 
-        Ok(ColumnarValue::Scalar(ScalarValue::Binary(Some(out))))
+        Ok(ColumnarValue::from(ScalarValue::Binary(Some(out))))
     }
 
     fn decode_large_scalar(self, value: Option<&[u8]>) -> Result<ColumnarValue> {
         let value = match value {
             Some(value) => value,
-            None => return Ok(ColumnarValue::Scalar(ScalarValue::LargeBinary(None))),
+            None => return Ok(ColumnarValue::from(ScalarValue::LargeBinary(None))),
         };
 
         let out = match self {
@@ -360,7 +360,7 @@ impl Encoding {
             })?,
         };
 
-        Ok(ColumnarValue::Scalar(ScalarValue::LargeBinary(Some(out))))
+        Ok(ColumnarValue::from(ScalarValue::LargeBinary(Some(out))))
     }
 
     fn decode_binary_array<T>(self, value: &dyn Array) -> Result<ColumnarValue>
@@ -425,7 +425,7 @@ fn encode(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         );
     }
     let encoding = match &args[1] {
-        ColumnarValue::Scalar(scalar) => match scalar {
+        ColumnarValue::Scalar(scalar) => match scalar.value() {
             ScalarValue::Utf8(Some(method)) | ScalarValue::LargeUtf8(Some(method)) => {
                 method.parse::<Encoding>()
             }
@@ -451,7 +451,7 @@ fn decode(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         );
     }
     let encoding = match &args[1] {
-        ColumnarValue::Scalar(scalar) => match scalar {
+        ColumnarValue::Scalar(scalar) => match scalar.value() {
             ScalarValue::Utf8(Some(method)) | ScalarValue::LargeUtf8(Some(method)) => {
                 method.parse::<Encoding>()
             }

--- a/datafusion/functions/src/math/pi.rs
+++ b/datafusion/functions/src/math/pi.rs
@@ -64,7 +64,7 @@ impl ScalarUDFImpl for PiFunc {
     }
 
     fn invoke_no_args(&self, _number_rows: usize) -> Result<ColumnarValue> {
-        Ok(ColumnarValue::Scalar(ScalarValue::Float64(Some(
+        Ok(ColumnarValue::from(ScalarValue::Float64(Some(
             std::f64::consts::PI,
         ))))
     }

--- a/datafusion/functions/src/math/trunc.rs
+++ b/datafusion/functions/src/math/trunc.rs
@@ -115,16 +115,22 @@ fn trunc(args: &[ArrayRef]) -> Result<ArrayRef> {
     //or then invoke the compute_truncate method to process precision
     let num = &args[0];
     let precision = if args.len() == 1 {
-        ColumnarValue::Scalar(Int64(Some(0)))
+        ColumnarValue::from(Int64(Some(0)))
     } else {
-        ColumnarValue::Array(Arc::clone(&args[1]))
+        ColumnarValue::from(Arc::clone(&args[1]))
     };
 
     match args[0].data_type() {
         Float64 => match precision {
-            ColumnarValue::Scalar(Int64(Some(0))) => Ok(Arc::new(
-                make_function_scalar_inputs!(num, "num", Float64Array, { f64::trunc }),
-            ) as ArrayRef),
+            ColumnarValue::Scalar(scalar) => match scalar.value() {
+                Int64(Some(0)) => Ok(Arc::new(make_function_scalar_inputs!(
+                    num,
+                    "num",
+                    Float64Array,
+                    { f64::trunc }
+                )) as ArrayRef),
+                _ => exec_err!("trunc function requires a Int64 scalar for precision"),
+            },
             ColumnarValue::Array(precision) => Ok(Arc::new(make_function_inputs2!(
                 num,
                 precision,
@@ -134,12 +140,17 @@ fn trunc(args: &[ArrayRef]) -> Result<ArrayRef> {
                 Int64Array,
                 { compute_truncate64 }
             )) as ArrayRef),
-            _ => exec_err!("trunc function requires a scalar or array for precision"),
         },
         Float32 => match precision {
-            ColumnarValue::Scalar(Int64(Some(0))) => Ok(Arc::new(
-                make_function_scalar_inputs!(num, "num", Float32Array, { f32::trunc }),
-            ) as ArrayRef),
+            ColumnarValue::Scalar(scalar) => match scalar.value() {
+                Int64(Some(0)) => Ok(Arc::new(make_function_scalar_inputs!(
+                    num,
+                    "num",
+                    Float32Array,
+                    { f32::trunc }
+                )) as ArrayRef),
+                _ => exec_err!("trunc function requires a Int64 scalar for precision"),
+            },
             ColumnarValue::Array(precision) => Ok(Arc::new(make_function_inputs2!(
                 num,
                 precision,
@@ -149,7 +160,6 @@ fn trunc(args: &[ArrayRef]) -> Result<ArrayRef> {
                 Int64Array,
                 { compute_truncate32 }
             )) as ArrayRef),
-            _ => exec_err!("trunc function requires a scalar or array for precision"),
         },
         other => exec_err!("Unsupported data type {other:?} for function trunc"),
     }

--- a/datafusion/functions/src/regex/regexplike.rs
+++ b/datafusion/functions/src/regex/regexplike.rs
@@ -100,7 +100,7 @@ impl ScalarUDFImpl for RegexpLikeFunc {
         if is_scalar {
             // If all inputs are scalar, keeps output as scalar
             let result = result.and_then(|arr| ScalarValue::try_from_array(&arr, 0));
-            result.map(ColumnarValue::Scalar)
+            result.map(ColumnarValue::from)
         } else {
             result.map(ColumnarValue::Array)
         }

--- a/datafusion/functions/src/regex/regexpmatch.rs
+++ b/datafusion/functions/src/regex/regexpmatch.rs
@@ -102,7 +102,7 @@ impl ScalarUDFImpl for RegexpMatchFunc {
         if is_scalar {
             // If all inputs are scalar, keeps output as scalar
             let result = result.and_then(|arr| ScalarValue::try_from_array(&arr, 0));
-            result.map(ColumnarValue::Scalar)
+            result.map(ColumnarValue::from)
         } else {
             result.map(ColumnarValue::Array)
         }

--- a/datafusion/functions/src/regex/regexpreplace.rs
+++ b/datafusion/functions/src/regex/regexpreplace.rs
@@ -118,7 +118,7 @@ impl ScalarUDFImpl for RegexpReplaceFunc {
         if is_scalar {
             // If all inputs are scalar, keeps output as scalar
             let result = result.and_then(|arr| ScalarValue::try_from_array(&arr, 0));
-            result.map(ColumnarValue::Scalar)
+            result.map(ColumnarValue::from)
         } else {
             result.map(ColumnarValue::Array)
         }

--- a/datafusion/functions/src/string/ascii.rs
+++ b/datafusion/functions/src/string/ascii.rs
@@ -122,7 +122,7 @@ mod tests {
         ($INPUT:expr, $EXPECTED:expr) => {
             test_function!(
                 AsciiFunc::new(),
-                &[ColumnarValue::Scalar(ScalarValue::Utf8($INPUT))],
+                &[ColumnarValue::from(ScalarValue::Utf8($INPUT))],
                 $EXPECTED,
                 i32,
                 Int32,
@@ -131,7 +131,7 @@ mod tests {
 
             test_function!(
                 AsciiFunc::new(),
-                &[ColumnarValue::Scalar(ScalarValue::LargeUtf8($INPUT))],
+                &[ColumnarValue::from(ScalarValue::LargeUtf8($INPUT))],
                 $EXPECTED,
                 i32,
                 Int32,
@@ -140,7 +140,7 @@ mod tests {
 
             test_function!(
                 AsciiFunc::new(),
-                &[ColumnarValue::Scalar(ScalarValue::Utf8View($INPUT))],
+                &[ColumnarValue::from(ScalarValue::Utf8View($INPUT))],
                 $EXPECTED,
                 i32,
                 Int32,

--- a/datafusion/functions/src/string/bit_length.rs
+++ b/datafusion/functions/src/string/bit_length.rs
@@ -77,13 +77,13 @@ impl ScalarUDFImpl for BitLengthFunc {
 
         match &args[0] {
             ColumnarValue::Array(v) => Ok(ColumnarValue::Array(bit_length(v.as_ref())?)),
-            ColumnarValue::Scalar(v) => match v {
-                ScalarValue::Utf8(v) => Ok(ColumnarValue::Scalar(ScalarValue::Int32(
+            ColumnarValue::Scalar(v) => match v.value() {
+                ScalarValue::Utf8(v) => Ok(ColumnarValue::from(ScalarValue::Int32(
                     v.as_ref().map(|x| (x.len() * 8) as i32),
                 ))),
-                ScalarValue::LargeUtf8(v) => Ok(ColumnarValue::Scalar(
-                    ScalarValue::Int64(v.as_ref().map(|x| (x.len() * 8) as i64)),
-                )),
+                ScalarValue::LargeUtf8(v) => Ok(ColumnarValue::from(ScalarValue::Int64(
+                    v.as_ref().map(|x| (x.len() * 8) as i64),
+                ))),
                 _ => unreachable!(),
             },
         }

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -230,18 +230,18 @@ where
             }
             other => exec_err!("Unsupported data type {other:?} for function {name}"),
         },
-        ColumnarValue::Scalar(scalar) => match scalar {
+        ColumnarValue::Scalar(scalar) => match scalar.value() {
             ScalarValue::Utf8(a) => {
                 let result = a.as_ref().map(|x| op(x));
-                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(result)))
+                Ok(ColumnarValue::from(ScalarValue::Utf8(result)))
             }
             ScalarValue::LargeUtf8(a) => {
                 let result = a.as_ref().map(|x| op(x));
-                Ok(ColumnarValue::Scalar(ScalarValue::LargeUtf8(result)))
+                Ok(ColumnarValue::from(ScalarValue::LargeUtf8(result)))
             }
             ScalarValue::Utf8View(a) => {
                 let result = a.as_ref().map(|x| op(x));
-                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(result)))
+                Ok(ColumnarValue::from(ScalarValue::Utf8(result)))
             }
             other => exec_err!("Unsupported data type {other:?} for function {name}"),
         },

--- a/datafusion/functions/src/string/contains.rs
+++ b/datafusion/functions/src/string/contains.rs
@@ -209,8 +209,8 @@ mod tests {
         test_function!(
             ContainsFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from("alph")),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from("alph")),
             ],
             Ok(Some(true)),
             bool,
@@ -220,8 +220,8 @@ mod tests {
         test_function!(
             ContainsFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from("dddddd")),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from("dddddd")),
             ],
             Ok(Some(false)),
             bool,
@@ -231,8 +231,8 @@ mod tests {
         test_function!(
             ContainsFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from("pha")),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from("pha")),
             ],
             Ok(Some(true)),
             bool,
@@ -243,10 +243,8 @@ mod tests {
         test_function!(
             ContainsFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
-                    "Apache"
-                )))),
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from("pac")))),
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from("Apache")))),
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from("pac")))),
             ],
             Ok(Some(true)),
             bool,
@@ -256,10 +254,8 @@ mod tests {
         test_function!(
             ContainsFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
-                    "Apache"
-                )))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("ap")))),
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from("Apache")))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("ap")))),
             ],
             Ok(Some(false)),
             bool,
@@ -269,10 +265,8 @@ mod tests {
         test_function!(
             ContainsFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
-                    "Apache"
-                )))),
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from("Apache")))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(Some(String::from(
                     "DataFusion"
                 )))),
             ],

--- a/datafusion/functions/src/string/ends_with.rs
+++ b/datafusion/functions/src/string/ends_with.rs
@@ -111,8 +111,8 @@ mod tests {
         test_function!(
             EndsWithFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from("alph")),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from("alph")),
             ],
             Ok(Some(false)),
             bool,
@@ -122,8 +122,8 @@ mod tests {
         test_function!(
             EndsWithFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from("bet")),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from("bet")),
             ],
             Ok(Some(true)),
             bool,
@@ -133,8 +133,8 @@ mod tests {
         test_function!(
             EndsWithFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
-                ColumnarValue::Scalar(ScalarValue::from("alph")),
+                ColumnarValue::from(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::from("alph")),
             ],
             Ok(None),
             bool,
@@ -144,8 +144,8 @@ mod tests {
         test_function!(
             EndsWithFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::Utf8(None)),
             ],
             Ok(None),
             bool,

--- a/datafusion/functions/src/string/initcap.rs
+++ b/datafusion/functions/src/string/initcap.rs
@@ -137,7 +137,7 @@ mod tests {
     fn test_functions() -> Result<()> {
         test_function!(
             InitcapFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::from("hi THOMAS"))],
+            &[ColumnarValue::from(ScalarValue::from("hi THOMAS"))],
             Ok(Some("Hi Thomas")),
             &str,
             Utf8,
@@ -145,7 +145,7 @@ mod tests {
         );
         test_function!(
             InitcapFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::from(""))],
+            &[ColumnarValue::from(ScalarValue::from(""))],
             Ok(Some("")),
             &str,
             Utf8,
@@ -153,7 +153,7 @@ mod tests {
         );
         test_function!(
             InitcapFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::from(""))],
+            &[ColumnarValue::from(ScalarValue::from(""))],
             Ok(Some("")),
             &str,
             Utf8,
@@ -161,7 +161,7 @@ mod tests {
         );
         test_function!(
             InitcapFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8(None))],
+            &[ColumnarValue::from(ScalarValue::Utf8(None))],
             Ok(None),
             &str,
             Utf8,
@@ -169,7 +169,7 @@ mod tests {
         );
         test_function!(
             InitcapFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8View(Some(
+            &[ColumnarValue::from(ScalarValue::Utf8View(Some(
                 "hi THOMAS".to_string()
             )))],
             Ok(Some("Hi Thomas")),
@@ -179,7 +179,7 @@ mod tests {
         );
         test_function!(
             InitcapFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8View(Some(
+            &[ColumnarValue::from(ScalarValue::Utf8View(Some(
                 "hi THOMAS wIth M0re ThAN 12 ChaRs".to_string()
             )))],
             Ok(Some("Hi Thomas With M0re Than 12 Chars")),
@@ -189,7 +189,7 @@ mod tests {
         );
         test_function!(
             InitcapFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8View(Some(
+            &[ColumnarValue::from(ScalarValue::Utf8View(Some(
                 "".to_string()
             )))],
             Ok(Some("")),
@@ -199,7 +199,7 @@ mod tests {
         );
         test_function!(
             InitcapFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8View(None))],
+            &[ColumnarValue::from(ScalarValue::Utf8View(None))],
             Ok(None),
             &str,
             Utf8,

--- a/datafusion/functions/src/string/octet_length.rs
+++ b/datafusion/functions/src/string/octet_length.rs
@@ -77,16 +77,16 @@ impl ScalarUDFImpl for OctetLengthFunc {
 
         match &args[0] {
             ColumnarValue::Array(v) => Ok(ColumnarValue::Array(length(v.as_ref())?)),
-            ColumnarValue::Scalar(v) => match v {
-                ScalarValue::Utf8(v) => Ok(ColumnarValue::Scalar(ScalarValue::Int32(
+            ColumnarValue::Scalar(v) => match v.value() {
+                ScalarValue::Utf8(v) => Ok(ColumnarValue::from(ScalarValue::Int32(
                     v.as_ref().map(|x| x.len() as i32),
                 ))),
-                ScalarValue::LargeUtf8(v) => Ok(ColumnarValue::Scalar(
-                    ScalarValue::Int64(v.as_ref().map(|x| x.len() as i64)),
-                )),
-                ScalarValue::Utf8View(v) => Ok(ColumnarValue::Scalar(
-                    ScalarValue::Int32(v.as_ref().map(|x| x.len() as i32)),
-                )),
+                ScalarValue::LargeUtf8(v) => Ok(ColumnarValue::from(ScalarValue::Int64(
+                    v.as_ref().map(|x| x.len() as i64),
+                ))),
+                ScalarValue::Utf8View(v) => Ok(ColumnarValue::from(ScalarValue::Int32(
+                    v.as_ref().map(|x| x.len() as i32),
+                ))),
                 _ => unreachable!(),
             },
         }
@@ -111,7 +111,7 @@ mod tests {
     fn test_functions() -> Result<()> {
         test_function!(
             OctetLengthFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Int32(Some(12)))],
+            &[ColumnarValue::from(ScalarValue::Int32(Some(12)))],
             exec_err!(
                 "The OCTET_LENGTH function can only accept strings, but got Int32."
             ),
@@ -133,8 +133,8 @@ mod tests {
         test_function!(
             OctetLengthFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("chars")))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("chars"))))
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("chars")))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("chars"))))
             ],
             exec_err!("octet_length function requires 1 argument, got 2"),
             i32,
@@ -143,9 +143,9 @@ mod tests {
         );
         test_function!(
             OctetLengthFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-                String::from("chars")
-            )))],
+            &[ColumnarValue::from(ScalarValue::Utf8(Some(String::from(
+                "chars"
+            ))))],
             Ok(Some(5)),
             i32,
             Int32,
@@ -153,9 +153,9 @@ mod tests {
         );
         test_function!(
             OctetLengthFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-                String::from("josé")
-            )))],
+            &[ColumnarValue::from(ScalarValue::Utf8(Some(String::from(
+                "josé"
+            ))))],
             Ok(Some(5)),
             i32,
             Int32,
@@ -163,9 +163,9 @@ mod tests {
         );
         test_function!(
             OctetLengthFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-                String::from("")
-            )))],
+            &[ColumnarValue::from(ScalarValue::Utf8(Some(String::from(
+                ""
+            ))))],
             Ok(Some(0)),
             i32,
             Int32,
@@ -173,7 +173,7 @@ mod tests {
         );
         test_function!(
             OctetLengthFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8(None))],
+            &[ColumnarValue::from(ScalarValue::Utf8(None))],
             Ok(None),
             i32,
             Int32,
@@ -181,7 +181,7 @@ mod tests {
         );
         test_function!(
             OctetLengthFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8View(Some(
+            &[ColumnarValue::from(ScalarValue::Utf8View(Some(
                 String::from("joséjoséjoséjosé")
             )))],
             Ok(Some(20)),
@@ -191,7 +191,7 @@ mod tests {
         );
         test_function!(
             OctetLengthFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8View(Some(
+            &[ColumnarValue::from(ScalarValue::Utf8View(Some(
                 String::from("josé")
             )))],
             Ok(Some(5)),
@@ -201,7 +201,7 @@ mod tests {
         );
         test_function!(
             OctetLengthFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8View(Some(
+            &[ColumnarValue::from(ScalarValue::Utf8View(Some(
                 String::from("")
             )))],
             Ok(Some(0)),

--- a/datafusion/functions/src/string/repeat.rs
+++ b/datafusion/functions/src/string/repeat.rs
@@ -147,8 +147,8 @@ mod tests {
         test_function!(
             RepeatFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("Pg")))),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(4))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("Pg")))),
+                ColumnarValue::from(ScalarValue::Int64(Some(4))),
             ],
             Ok(Some("PgPgPgPg")),
             &str,
@@ -158,8 +158,8 @@ mod tests {
         test_function!(
             RepeatFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(4))),
+                ColumnarValue::from(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::Int64(Some(4))),
             ],
             Ok(None),
             &str,
@@ -169,8 +169,8 @@ mod tests {
         test_function!(
             RepeatFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("Pg")))),
-                ColumnarValue::Scalar(ScalarValue::Int64(None)),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("Pg")))),
+                ColumnarValue::from(ScalarValue::Int64(None)),
             ],
             Ok(None),
             &str,
@@ -181,8 +181,8 @@ mod tests {
         test_function!(
             RepeatFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from("Pg")))),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(4))),
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from("Pg")))),
+                ColumnarValue::from(ScalarValue::Int64(Some(4))),
             ],
             Ok(Some("PgPgPgPg")),
             &str,
@@ -192,8 +192,8 @@ mod tests {
         test_function!(
             RepeatFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(None)),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(4))),
+                ColumnarValue::from(ScalarValue::Utf8View(None)),
+                ColumnarValue::from(ScalarValue::Int64(Some(4))),
             ],
             Ok(None),
             &str,
@@ -203,8 +203,8 @@ mod tests {
         test_function!(
             RepeatFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from("Pg")))),
-                ColumnarValue::Scalar(ScalarValue::Int64(None)),
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from("Pg")))),
+                ColumnarValue::from(ScalarValue::Int64(None)),
             ],
             Ok(None),
             &str,

--- a/datafusion/functions/src/string/replace.rs
+++ b/datafusion/functions/src/string/replace.rs
@@ -136,9 +136,9 @@ mod tests {
         test_function!(
             ReplaceFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("aabbdqcbb")))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("bb")))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("ccc")))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("aabbdqcbb")))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("bb")))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("ccc")))),
             ],
             Ok(Some("aacccdqcccc")),
             &str,
@@ -149,11 +149,9 @@ mod tests {
         test_function!(
             ReplaceFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(String::from(
-                    "aabbb"
-                )))),
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(String::from("bbb")))),
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(String::from("cc")))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(Some(String::from("aabbb")))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(Some(String::from("bbb")))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(Some(String::from("cc")))),
             ],
             Ok(Some("aacc")),
             &str,
@@ -164,11 +162,9 @@ mod tests {
         test_function!(
             ReplaceFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
-                    "aabbbcw"
-                )))),
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from("bb")))),
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from("cc")))),
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from("aabbbcw")))),
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from("bb")))),
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from("cc")))),
             ],
             Ok(Some("aaccbcw")),
             &str,

--- a/datafusion/functions/src/string/split_part.rs
+++ b/datafusion/functions/src/string/split_part.rs
@@ -173,7 +173,7 @@ impl ScalarUDFImpl for SplitPartFunc {
         if is_scalar {
             // If all inputs are scalar, keep the output as scalar
             let result = result.and_then(|arr| ScalarValue::try_from_array(&arr, 0));
-            result.map(ColumnarValue::Scalar)
+            result.map(ColumnarValue::from)
         } else {
             result.map(ColumnarValue::Array)
         }
@@ -242,11 +242,11 @@ mod tests {
         test_function!(
             SplitPartFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from(
                     "abc~@~def~@~ghi"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("~@~")))),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(2))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("~@~")))),
+                ColumnarValue::from(ScalarValue::Int64(Some(2))),
             ],
             Ok(Some("def")),
             &str,
@@ -256,11 +256,11 @@ mod tests {
         test_function!(
             SplitPartFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from(
                     "abc~@~def~@~ghi"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("~@~")))),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(20))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("~@~")))),
+                ColumnarValue::from(ScalarValue::Int64(Some(20))),
             ],
             Ok(Some("")),
             &str,
@@ -270,11 +270,11 @@ mod tests {
         test_function!(
             SplitPartFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from(
                     "abc~@~def~@~ghi"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("~@~")))),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(-1))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("~@~")))),
+                ColumnarValue::from(ScalarValue::Int64(Some(-1))),
             ],
             Ok(Some("ghi")),
             &str,
@@ -284,11 +284,11 @@ mod tests {
         test_function!(
             SplitPartFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from(
                     "abc~@~def~@~ghi"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("~@~")))),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(0))),
+                ColumnarValue::from(ScalarValue::Utf8(Some(String::from("~@~")))),
+                ColumnarValue::from(ScalarValue::Int64(Some(0))),
             ],
             exec_err!("field position must not be zero"),
             &str,

--- a/datafusion/functions/src/string/starts_with.rs
+++ b/datafusion/functions/src/string/starts_with.rs
@@ -117,18 +117,18 @@ mod tests {
         .into_iter()
         .flat_map(|(a, b, c)| {
             let utf_8_args = vec![
-                ColumnarValue::Scalar(ScalarValue::Utf8(a.map(|s| s.to_string()))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(b.map(|s| s.to_string()))),
+                ColumnarValue::from(ScalarValue::Utf8(a.map(|s| s.to_string()))),
+                ColumnarValue::from(ScalarValue::Utf8(b.map(|s| s.to_string()))),
             ];
 
             let large_utf_8_args = vec![
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(a.map(|s| s.to_string()))),
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(b.map(|s| s.to_string()))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(a.map(|s| s.to_string()))),
+                ColumnarValue::from(ScalarValue::LargeUtf8(b.map(|s| s.to_string()))),
             ];
 
             let utf_8_view_args = vec![
-                ColumnarValue::Scalar(ScalarValue::Utf8View(a.map(|s| s.to_string()))),
-                ColumnarValue::Scalar(ScalarValue::Utf8View(b.map(|s| s.to_string()))),
+                ColumnarValue::from(ScalarValue::Utf8View(a.map(|s| s.to_string()))),
+                ColumnarValue::from(ScalarValue::Utf8View(b.map(|s| s.to_string()))),
             ];
 
             vec![(utf_8_args, c), (large_utf_8_args, c), (utf_8_view_args, c)]

--- a/datafusion/functions/src/unicode/character_length.rs
+++ b/datafusion/functions/src/unicode/character_length.rs
@@ -139,7 +139,7 @@ mod tests {
         ($INPUT:expr, $EXPECTED:expr) => {
             test_function!(
                 CharacterLengthFunc::new(),
-                &[ColumnarValue::Scalar(ScalarValue::Utf8($INPUT))],
+                &[ColumnarValue::from(ScalarValue::Utf8($INPUT))],
                 $EXPECTED,
                 i32,
                 Int32,
@@ -148,7 +148,7 @@ mod tests {
 
             test_function!(
                 CharacterLengthFunc::new(),
-                &[ColumnarValue::Scalar(ScalarValue::LargeUtf8($INPUT))],
+                &[ColumnarValue::from(ScalarValue::LargeUtf8($INPUT))],
                 $EXPECTED,
                 i64,
                 Int64,
@@ -157,7 +157,7 @@ mod tests {
 
             test_function!(
                 CharacterLengthFunc::new(),
-                &[ColumnarValue::Scalar(ScalarValue::Utf8View($INPUT))],
+                &[ColumnarValue::from(ScalarValue::Utf8View($INPUT))],
                 $EXPECTED,
                 i32,
                 Int32,
@@ -181,7 +181,7 @@ mod tests {
         #[cfg(not(feature = "unicode_expressions"))]
         test_function!(
             CharacterLengthFunc::new(),
-            &[ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("josé"))))],
+            &[ColumnarValue::from(ScalarValue::Utf8(Some(String::from("josé"))))],
             internal_err!(
                 "function character_length requires compilation with feature flag: unicode_expressions."
             ),

--- a/datafusion/functions/src/unicode/left.rs
+++ b/datafusion/functions/src/unicode/left.rs
@@ -153,8 +153,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(Some("ab")),
             &str,
@@ -164,8 +164,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(200i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(200i64)),
             ],
             Ok(Some("abcde")),
             &str,
@@ -175,8 +175,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(-2i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(-2i64)),
             ],
             Ok(Some("abc")),
             &str,
@@ -186,8 +186,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(-200i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(-200i64)),
             ],
             Ok(Some("")),
             &str,
@@ -197,8 +197,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(0i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(0i64)),
             ],
             Ok(Some("")),
             &str,
@@ -208,8 +208,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(None),
             &str,
@@ -219,8 +219,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::Int64(None)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::Int64(None)),
             ],
             Ok(None),
             &str,
@@ -230,8 +230,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("joséésoj")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("joséésoj")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(Some("joséé")),
             &str,
@@ -241,8 +241,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("joséésoj")),
-                ColumnarValue::Scalar(ScalarValue::from(-3i64)),
+                ColumnarValue::from(ScalarValue::from("joséésoj")),
+                ColumnarValue::from(ScalarValue::from(-3i64)),
             ],
             Ok(Some("joséé")),
             &str,
@@ -253,8 +253,8 @@ mod tests {
         test_function!(
             LeftFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             internal_err!(
                 "function left requires compilation with feature flag: unicode_expressions."

--- a/datafusion/functions/src/unicode/lpad.rs
+++ b/datafusion/functions/src/unicode/lpad.rs
@@ -265,8 +265,8 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::Utf8($INPUT)),
-                    ColumnarValue::Scalar($LENGTH)
+                    ColumnarValue::from(ScalarValue::Utf8($INPUT)),
+                    ColumnarValue::from($LENGTH)
                 ],
                 $EXPECTED,
                 &str,
@@ -277,8 +277,8 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::LargeUtf8($INPUT)),
-                    ColumnarValue::Scalar($LENGTH)
+                    ColumnarValue::from(ScalarValue::LargeUtf8($INPUT)),
+                    ColumnarValue::from($LENGTH)
                 ],
                 $EXPECTED,
                 &str,
@@ -289,8 +289,8 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::Utf8View($INPUT)),
-                    ColumnarValue::Scalar($LENGTH)
+                    ColumnarValue::from(ScalarValue::Utf8View($INPUT)),
+                    ColumnarValue::from($LENGTH)
                 ],
                 $EXPECTED,
                 &str,
@@ -304,9 +304,9 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::Utf8($INPUT)),
-                    ColumnarValue::Scalar($LENGTH),
-                    ColumnarValue::Scalar(ScalarValue::Utf8($REPLACE))
+                    ColumnarValue::from(ScalarValue::Utf8($INPUT)),
+                    ColumnarValue::from($LENGTH),
+                    ColumnarValue::from(ScalarValue::Utf8($REPLACE))
                 ],
                 $EXPECTED,
                 &str,
@@ -317,9 +317,9 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::Utf8($INPUT)),
-                    ColumnarValue::Scalar($LENGTH),
-                    ColumnarValue::Scalar(ScalarValue::LargeUtf8($REPLACE))
+                    ColumnarValue::from(ScalarValue::Utf8($INPUT)),
+                    ColumnarValue::from($LENGTH),
+                    ColumnarValue::from(ScalarValue::LargeUtf8($REPLACE))
                 ],
                 $EXPECTED,
                 &str,
@@ -330,9 +330,9 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::Utf8($INPUT)),
-                    ColumnarValue::Scalar($LENGTH),
-                    ColumnarValue::Scalar(ScalarValue::Utf8View($REPLACE))
+                    ColumnarValue::from(ScalarValue::Utf8($INPUT)),
+                    ColumnarValue::from($LENGTH),
+                    ColumnarValue::from(ScalarValue::Utf8View($REPLACE))
                 ],
                 $EXPECTED,
                 &str,
@@ -344,9 +344,9 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::LargeUtf8($INPUT)),
-                    ColumnarValue::Scalar($LENGTH),
-                    ColumnarValue::Scalar(ScalarValue::Utf8($REPLACE))
+                    ColumnarValue::from(ScalarValue::LargeUtf8($INPUT)),
+                    ColumnarValue::from($LENGTH),
+                    ColumnarValue::from(ScalarValue::Utf8($REPLACE))
                 ],
                 $EXPECTED,
                 &str,
@@ -357,9 +357,9 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::LargeUtf8($INPUT)),
-                    ColumnarValue::Scalar($LENGTH),
-                    ColumnarValue::Scalar(ScalarValue::LargeUtf8($REPLACE))
+                    ColumnarValue::from(ScalarValue::LargeUtf8($INPUT)),
+                    ColumnarValue::from($LENGTH),
+                    ColumnarValue::from(ScalarValue::LargeUtf8($REPLACE))
                 ],
                 $EXPECTED,
                 &str,
@@ -370,9 +370,9 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::LargeUtf8($INPUT)),
-                    ColumnarValue::Scalar($LENGTH),
-                    ColumnarValue::Scalar(ScalarValue::Utf8View($REPLACE))
+                    ColumnarValue::from(ScalarValue::LargeUtf8($INPUT)),
+                    ColumnarValue::from($LENGTH),
+                    ColumnarValue::from(ScalarValue::Utf8View($REPLACE))
                 ],
                 $EXPECTED,
                 &str,
@@ -384,9 +384,9 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::Utf8View($INPUT)),
-                    ColumnarValue::Scalar($LENGTH),
-                    ColumnarValue::Scalar(ScalarValue::Utf8($REPLACE))
+                    ColumnarValue::from(ScalarValue::Utf8View($INPUT)),
+                    ColumnarValue::from($LENGTH),
+                    ColumnarValue::from(ScalarValue::Utf8($REPLACE))
                 ],
                 $EXPECTED,
                 &str,
@@ -397,9 +397,9 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::Utf8View($INPUT)),
-                    ColumnarValue::Scalar($LENGTH),
-                    ColumnarValue::Scalar(ScalarValue::LargeUtf8($REPLACE))
+                    ColumnarValue::from(ScalarValue::Utf8View($INPUT)),
+                    ColumnarValue::from($LENGTH),
+                    ColumnarValue::from(ScalarValue::LargeUtf8($REPLACE))
                 ],
                 $EXPECTED,
                 &str,
@@ -410,9 +410,9 @@ mod tests {
             test_function!(
                 LPadFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::Utf8View($INPUT)),
-                    ColumnarValue::Scalar($LENGTH),
-                    ColumnarValue::Scalar(ScalarValue::Utf8View($REPLACE))
+                    ColumnarValue::from(ScalarValue::Utf8View($INPUT)),
+                    ColumnarValue::from($LENGTH),
+                    ColumnarValue::from(ScalarValue::Utf8View($REPLACE))
                 ],
                 $EXPECTED,
                 &str,

--- a/datafusion/functions/src/unicode/reverse.rs
+++ b/datafusion/functions/src/unicode/reverse.rs
@@ -117,7 +117,7 @@ mod tests {
         ($INPUT:expr, $EXPECTED:expr) => {
             test_function!(
                 ReverseFunc::new(),
-                &[ColumnarValue::Scalar(ScalarValue::Utf8($INPUT))],
+                &[ColumnarValue::from(ScalarValue::Utf8($INPUT))],
                 $EXPECTED,
                 &str,
                 Utf8,
@@ -126,7 +126,7 @@ mod tests {
 
             test_function!(
                 ReverseFunc::new(),
-                &[ColumnarValue::Scalar(ScalarValue::LargeUtf8($INPUT))],
+                &[ColumnarValue::from(ScalarValue::LargeUtf8($INPUT))],
                 $EXPECTED,
                 &str,
                 LargeUtf8,
@@ -135,7 +135,7 @@ mod tests {
 
             test_function!(
                 ReverseFunc::new(),
-                &[ColumnarValue::Scalar(ScalarValue::Utf8View($INPUT))],
+                &[ColumnarValue::from(ScalarValue::Utf8View($INPUT))],
                 $EXPECTED,
                 &str,
                 Utf8,

--- a/datafusion/functions/src/unicode/right.rs
+++ b/datafusion/functions/src/unicode/right.rs
@@ -156,8 +156,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(Some("de")),
             &str,
@@ -167,8 +167,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(200i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(200i64)),
             ],
             Ok(Some("abcde")),
             &str,
@@ -178,8 +178,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(-2i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(-2i64)),
             ],
             Ok(Some("cde")),
             &str,
@@ -189,8 +189,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(-200i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(-200i64)),
             ],
             Ok(Some("")),
             &str,
@@ -200,8 +200,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(0i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(0i64)),
             ],
             Ok(Some("")),
             &str,
@@ -211,8 +211,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(None),
             &str,
@@ -222,8 +222,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::Int64(None)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::Int64(None)),
             ],
             Ok(None),
             &str,
@@ -233,8 +233,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("joséésoj")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("joséésoj")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(Some("éésoj")),
             &str,
@@ -244,8 +244,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("joséésoj")),
-                ColumnarValue::Scalar(ScalarValue::from(-3i64)),
+                ColumnarValue::from(ScalarValue::from("joséésoj")),
+                ColumnarValue::from(ScalarValue::from(-3i64)),
             ],
             Ok(Some("éésoj")),
             &str,
@@ -256,8 +256,8 @@ mod tests {
         test_function!(
             RightFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abcde")),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from("abcde")),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             internal_err!(
                 "function right requires compilation with feature flag: unicode_expressions."

--- a/datafusion/functions/src/unicode/rpad.rs
+++ b/datafusion/functions/src/unicode/rpad.rs
@@ -281,8 +281,8 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("josé")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("josé")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(Some("josé ")),
             &str,
@@ -292,8 +292,8 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("hi")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("hi")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(Some("hi   ")),
             &str,
@@ -303,8 +303,8 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("hi")),
-                ColumnarValue::Scalar(ScalarValue::from(0i64)),
+                ColumnarValue::from(ScalarValue::from("hi")),
+                ColumnarValue::from(ScalarValue::from(0i64)),
             ],
             Ok(Some("")),
             &str,
@@ -314,8 +314,8 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("hi")),
-                ColumnarValue::Scalar(ScalarValue::Int64(None)),
+                ColumnarValue::from(ScalarValue::from("hi")),
+                ColumnarValue::from(ScalarValue::Int64(None)),
             ],
             Ok(None),
             &str,
@@ -325,8 +325,8 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(None),
             &str,
@@ -336,9 +336,9 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("hi")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
-                ColumnarValue::Scalar(ScalarValue::from("xy")),
+                ColumnarValue::from(ScalarValue::from("hi")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("xy")),
             ],
             Ok(Some("hixyx")),
             &str,
@@ -348,9 +348,9 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("hi")),
-                ColumnarValue::Scalar(ScalarValue::from(21i64)),
-                ColumnarValue::Scalar(ScalarValue::from("abcdef")),
+                ColumnarValue::from(ScalarValue::from("hi")),
+                ColumnarValue::from(ScalarValue::from(21i64)),
+                ColumnarValue::from(ScalarValue::from("abcdef")),
             ],
             Ok(Some("hiabcdefabcdefabcdefa")),
             &str,
@@ -360,9 +360,9 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("hi")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
-                ColumnarValue::Scalar(ScalarValue::from(" ")),
+                ColumnarValue::from(ScalarValue::from("hi")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from(" ")),
             ],
             Ok(Some("hi   ")),
             &str,
@@ -372,9 +372,9 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("hi")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
-                ColumnarValue::Scalar(ScalarValue::from("")),
+                ColumnarValue::from(ScalarValue::from("hi")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("")),
             ],
             Ok(Some("hi")),
             &str,
@@ -384,9 +384,9 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
-                ColumnarValue::Scalar(ScalarValue::from("xy")),
+                ColumnarValue::from(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("xy")),
             ],
             Ok(None),
             &str,
@@ -396,9 +396,9 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("hi")),
-                ColumnarValue::Scalar(ScalarValue::Int64(None)),
-                ColumnarValue::Scalar(ScalarValue::from("xy")),
+                ColumnarValue::from(ScalarValue::from("hi")),
+                ColumnarValue::from(ScalarValue::Int64(None)),
+                ColumnarValue::from(ScalarValue::from("xy")),
             ],
             Ok(None),
             &str,
@@ -408,9 +408,9 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("hi")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::from("hi")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::Utf8(None)),
             ],
             Ok(None),
             &str,
@@ -420,9 +420,9 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("josé")),
-                ColumnarValue::Scalar(ScalarValue::from(10i64)),
-                ColumnarValue::Scalar(ScalarValue::from("xy")),
+                ColumnarValue::from(ScalarValue::from("josé")),
+                ColumnarValue::from(ScalarValue::from(10i64)),
+                ColumnarValue::from(ScalarValue::from("xy")),
             ],
             Ok(Some("joséxyxyxy")),
             &str,
@@ -432,9 +432,9 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("josé")),
-                ColumnarValue::Scalar(ScalarValue::from(10i64)),
-                ColumnarValue::Scalar(ScalarValue::from("éñ")),
+                ColumnarValue::from(ScalarValue::from("josé")),
+                ColumnarValue::from(ScalarValue::from(10i64)),
+                ColumnarValue::from(ScalarValue::from("éñ")),
             ],
             Ok(Some("josééñéñéñ")),
             &str,
@@ -445,8 +445,8 @@ mod tests {
         test_function!(
             RPadFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("josé")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("josé")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             internal_err!(
                 "function rpad requires compilation with feature flag: unicode_expressions."

--- a/datafusion/functions/src/unicode/strpos.rs
+++ b/datafusion/functions/src/unicode/strpos.rs
@@ -199,8 +199,8 @@ mod tests {
             test_function!(
                 StrposFunc::new(),
                 &[
-                    ColumnarValue::Scalar(ScalarValue::$t1(Some($lhs.to_owned()))),
-                    ColumnarValue::Scalar(ScalarValue::$t2(Some($rhs.to_owned()))),
+                    ColumnarValue::from(ScalarValue::$t1(Some($lhs.to_owned()))),
+                    ColumnarValue::from(ScalarValue::$t2(Some($rhs.to_owned()))),
                 ],
                 Ok(Some($result)),
                 $t3,

--- a/datafusion/functions/src/unicode/substr.rs
+++ b/datafusion/functions/src/unicode/substr.rs
@@ -456,8 +456,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(None)),
-                ColumnarValue::Scalar(ScalarValue::from(1i64)),
+                ColumnarValue::from(ScalarValue::Utf8View(None)),
+                ColumnarValue::from(ScalarValue::from(1i64)),
             ],
             Ok(None),
             &str,
@@ -467,10 +467,10 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from(
                     "alphabet"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::from(0i64)),
+                ColumnarValue::from(ScalarValue::from(0i64)),
             ],
             Ok(Some("alphabet")),
             &str,
@@ -480,11 +480,11 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from(
                     "this és longer than 12B"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(Some(" é")),
             &str,
@@ -494,10 +494,10 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from(
                     "this is longer than 12B"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(Some(" is longer than 12B")),
             &str,
@@ -507,10 +507,10 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from(
                     "joséésoj"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(Some("ésoj")),
             &str,
@@ -520,11 +520,11 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from(
                     "alphabet"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::from(3i64)),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from(3i64)),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(Some("ph")),
             &str,
@@ -534,11 +534,11 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
+                ColumnarValue::from(ScalarValue::Utf8View(Some(String::from(
                     "alphabet"
                 )))),
-                ColumnarValue::Scalar(ScalarValue::from(3i64)),
-                ColumnarValue::Scalar(ScalarValue::from(20i64)),
+                ColumnarValue::from(ScalarValue::from(3i64)),
+                ColumnarValue::from(ScalarValue::from(20i64)),
             ],
             Ok(Some("phabet")),
             &str,
@@ -548,8 +548,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(0i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(0i64)),
             ],
             Ok(Some("alphabet")),
             &str,
@@ -559,8 +559,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("joséésoj")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("joséésoj")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(Some("ésoj")),
             &str,
@@ -570,8 +570,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("joséésoj")),
-                ColumnarValue::Scalar(ScalarValue::from(-5i64)),
+                ColumnarValue::from(ScalarValue::from("joséésoj")),
+                ColumnarValue::from(ScalarValue::from(-5i64)),
             ],
             Ok(Some("joséésoj")),
             &str,
@@ -581,8 +581,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(1i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(1i64)),
             ],
             Ok(Some("alphabet")),
             &str,
@@ -592,8 +592,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(Some("lphabet")),
             &str,
@@ -603,8 +603,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(3i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(3i64)),
             ],
             Ok(Some("phabet")),
             &str,
@@ -614,8 +614,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(-3i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(-3i64)),
             ],
             Ok(Some("alphabet")),
             &str,
@@ -625,8 +625,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(30i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(30i64)),
             ],
             Ok(Some("")),
             &str,
@@ -636,8 +636,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::Int64(None)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::Int64(None)),
             ],
             Ok(None),
             &str,
@@ -647,9 +647,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(3i64)),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(3i64)),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(Some("ph")),
             &str,
@@ -659,9 +659,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(3i64)),
-                ColumnarValue::Scalar(ScalarValue::from(20i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(3i64)),
+                ColumnarValue::from(ScalarValue::from(20i64)),
             ],
             Ok(Some("phabet")),
             &str,
@@ -671,9 +671,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(0i64)),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(0i64)),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(Some("alph")),
             &str,
@@ -684,9 +684,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(-5i64)),
-                ColumnarValue::Scalar(ScalarValue::from(10i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(-5i64)),
+                ColumnarValue::from(ScalarValue::from(10i64)),
             ],
             Ok(Some("alph")),
             &str,
@@ -697,9 +697,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(-5i64)),
-                ColumnarValue::Scalar(ScalarValue::from(4i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(-5i64)),
+                ColumnarValue::from(ScalarValue::from(4i64)),
             ],
             Ok(Some("")),
             &str,
@@ -710,9 +710,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(-5i64)),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(-5i64)),
+                ColumnarValue::from(ScalarValue::from(5i64)),
             ],
             Ok(Some("")),
             &str,
@@ -722,9 +722,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::Int64(None)),
-                ColumnarValue::Scalar(ScalarValue::from(20i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::Int64(None)),
+                ColumnarValue::from(ScalarValue::from(20i64)),
             ],
             Ok(None),
             &str,
@@ -734,9 +734,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(3i64)),
-                ColumnarValue::Scalar(ScalarValue::Int64(None)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(3i64)),
+                ColumnarValue::from(ScalarValue::Int64(None)),
             ],
             Ok(None),
             &str,
@@ -746,9 +746,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(1i64)),
-                ColumnarValue::Scalar(ScalarValue::from(-1i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(1i64)),
+                ColumnarValue::from(ScalarValue::from(-1i64)),
             ],
             exec_err!("negative substring length not allowed: substr(<str>, 1, -1)"),
             &str,
@@ -758,9 +758,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("joséésoj")),
-                ColumnarValue::Scalar(ScalarValue::from(5i64)),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from("joséésoj")),
+                ColumnarValue::from(ScalarValue::from(5i64)),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(Some("és")),
             &str,
@@ -771,8 +771,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("alphabet")),
-                ColumnarValue::Scalar(ScalarValue::from(0i64)),
+                ColumnarValue::from(ScalarValue::from("alphabet")),
+                ColumnarValue::from(ScalarValue::from(0i64)),
             ],
             internal_err!(
                 "function substr requires compilation with feature flag: unicode_expressions."
@@ -784,8 +784,8 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("abc")),
-                ColumnarValue::Scalar(ScalarValue::from(-9223372036854775808i64)),
+                ColumnarValue::from(ScalarValue::from("abc")),
+                ColumnarValue::from(ScalarValue::from(-9223372036854775808i64)),
             ],
             Ok(Some("abc")),
             &str,
@@ -795,9 +795,9 @@ mod tests {
         test_function!(
             SubstrFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("overflow")),
-                ColumnarValue::Scalar(ScalarValue::from(-9223372036854775808i64)),
-                ColumnarValue::Scalar(ScalarValue::from(1i64)),
+                ColumnarValue::from(ScalarValue::from("overflow")),
+                ColumnarValue::from(ScalarValue::from(-9223372036854775808i64)),
+                ColumnarValue::from(ScalarValue::from(1i64)),
             ],
             exec_err!("negative overflow when calculating skip value"),
             &str,

--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -213,9 +213,9 @@ mod tests {
         test_function!(
             SubstrIndexFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
-                ColumnarValue::Scalar(ScalarValue::from(".")),
-                ColumnarValue::Scalar(ScalarValue::from(1i64)),
+                ColumnarValue::from(ScalarValue::from("www.apache.org")),
+                ColumnarValue::from(ScalarValue::from(".")),
+                ColumnarValue::from(ScalarValue::from(1i64)),
             ],
             Ok(Some("www")),
             &str,
@@ -225,9 +225,9 @@ mod tests {
         test_function!(
             SubstrIndexFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
-                ColumnarValue::Scalar(ScalarValue::from(".")),
-                ColumnarValue::Scalar(ScalarValue::from(2i64)),
+                ColumnarValue::from(ScalarValue::from("www.apache.org")),
+                ColumnarValue::from(ScalarValue::from(".")),
+                ColumnarValue::from(ScalarValue::from(2i64)),
             ],
             Ok(Some("www.apache")),
             &str,
@@ -237,9 +237,9 @@ mod tests {
         test_function!(
             SubstrIndexFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
-                ColumnarValue::Scalar(ScalarValue::from(".")),
-                ColumnarValue::Scalar(ScalarValue::from(-2i64)),
+                ColumnarValue::from(ScalarValue::from("www.apache.org")),
+                ColumnarValue::from(ScalarValue::from(".")),
+                ColumnarValue::from(ScalarValue::from(-2i64)),
             ],
             Ok(Some("apache.org")),
             &str,
@@ -249,9 +249,9 @@ mod tests {
         test_function!(
             SubstrIndexFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
-                ColumnarValue::Scalar(ScalarValue::from(".")),
-                ColumnarValue::Scalar(ScalarValue::from(-1i64)),
+                ColumnarValue::from(ScalarValue::from("www.apache.org")),
+                ColumnarValue::from(ScalarValue::from(".")),
+                ColumnarValue::from(ScalarValue::from(-1i64)),
             ],
             Ok(Some("org")),
             &str,
@@ -261,9 +261,9 @@ mod tests {
         test_function!(
             SubstrIndexFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
-                ColumnarValue::Scalar(ScalarValue::from(".")),
-                ColumnarValue::Scalar(ScalarValue::from(0i64)),
+                ColumnarValue::from(ScalarValue::from("www.apache.org")),
+                ColumnarValue::from(ScalarValue::from(".")),
+                ColumnarValue::from(ScalarValue::from(0i64)),
             ],
             Ok(Some("")),
             &str,
@@ -273,9 +273,9 @@ mod tests {
         test_function!(
             SubstrIndexFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("")),
-                ColumnarValue::Scalar(ScalarValue::from(".")),
-                ColumnarValue::Scalar(ScalarValue::from(1i64)),
+                ColumnarValue::from(ScalarValue::from("")),
+                ColumnarValue::from(ScalarValue::from(".")),
+                ColumnarValue::from(ScalarValue::from(1i64)),
             ],
             Ok(Some("")),
             &str,
@@ -285,9 +285,9 @@ mod tests {
         test_function!(
             SubstrIndexFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("www.apache.org")),
-                ColumnarValue::Scalar(ScalarValue::from("")),
-                ColumnarValue::Scalar(ScalarValue::from(1i64)),
+                ColumnarValue::from(ScalarValue::from("www.apache.org")),
+                ColumnarValue::from(ScalarValue::from("")),
+                ColumnarValue::from(ScalarValue::from(1i64)),
             ],
             Ok(Some("")),
             &str,

--- a/datafusion/functions/src/unicode/translate.rs
+++ b/datafusion/functions/src/unicode/translate.rs
@@ -171,9 +171,9 @@ mod tests {
         test_function!(
             TranslateFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("12345")),
-                ColumnarValue::Scalar(ScalarValue::from("143")),
-                ColumnarValue::Scalar(ScalarValue::from("ax"))
+                ColumnarValue::from(ScalarValue::from("12345")),
+                ColumnarValue::from(ScalarValue::from("143")),
+                ColumnarValue::from(ScalarValue::from("ax"))
             ],
             Ok(Some("a2x5")),
             &str,
@@ -183,9 +183,9 @@ mod tests {
         test_function!(
             TranslateFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
-                ColumnarValue::Scalar(ScalarValue::from("143")),
-                ColumnarValue::Scalar(ScalarValue::from("ax"))
+                ColumnarValue::from(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::from("143")),
+                ColumnarValue::from(ScalarValue::from("ax"))
             ],
             Ok(None),
             &str,
@@ -195,9 +195,9 @@ mod tests {
         test_function!(
             TranslateFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("12345")),
-                ColumnarValue::Scalar(ScalarValue::Utf8(None)),
-                ColumnarValue::Scalar(ScalarValue::from("ax"))
+                ColumnarValue::from(ScalarValue::from("12345")),
+                ColumnarValue::from(ScalarValue::Utf8(None)),
+                ColumnarValue::from(ScalarValue::from("ax"))
             ],
             Ok(None),
             &str,
@@ -207,9 +207,9 @@ mod tests {
         test_function!(
             TranslateFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("12345")),
-                ColumnarValue::Scalar(ScalarValue::from("143")),
-                ColumnarValue::Scalar(ScalarValue::Utf8(None))
+                ColumnarValue::from(ScalarValue::from("12345")),
+                ColumnarValue::from(ScalarValue::from("143")),
+                ColumnarValue::from(ScalarValue::Utf8(None))
             ],
             Ok(None),
             &str,
@@ -219,9 +219,9 @@ mod tests {
         test_function!(
             TranslateFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("é2íñ5")),
-                ColumnarValue::Scalar(ScalarValue::from("éñí")),
-                ColumnarValue::Scalar(ScalarValue::from("óü")),
+                ColumnarValue::from(ScalarValue::from("é2íñ5")),
+                ColumnarValue::from(ScalarValue::from("éñí")),
+                ColumnarValue::from(ScalarValue::from("óü")),
             ],
             Ok(Some("ó2ü5")),
             &str,
@@ -232,9 +232,9 @@ mod tests {
         test_function!(
             TranslateFunc::new(),
             &[
-                ColumnarValue::Scalar(ScalarValue::from("12345")),
-                ColumnarValue::Scalar(ScalarValue::from("143")),
-                ColumnarValue::Scalar(ScalarValue::from("ax")),
+                ColumnarValue::from(ScalarValue::from("12345")),
+                ColumnarValue::from(ScalarValue::from("143")),
+                ColumnarValue::from(ScalarValue::from("ax")),
             ],
             internal_err!(
                 "function translate requires compilation with feature flag: unicode_expressions."

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -113,7 +113,7 @@ where
         if is_scalar {
             // If all inputs are scalar, keeps output as scalar
             let result = result.and_then(|arr| ScalarValue::try_from_array(&arr, 0));
-            result.map(ColumnarValue::Scalar)
+            result.map(ColumnarValue::from)
         } else {
             result.map(ColumnarValue::Array)
         }
@@ -133,7 +133,7 @@ pub mod test {
             let expected: Result<Option<$EXPECTED_TYPE>> = $EXPECTED;
             let func = $FUNC;
 
-            let type_array = $ARGS.iter().map(|arg| arg.data_type()).collect::<Vec<_>>();
+            let type_array = $ARGS.iter().map(|arg| arg.data_type().clone()).collect::<Vec<_>>();
             let return_type = func.return_type(&type_array);
 
             match expected {

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1238,7 +1238,7 @@ mod test {
         }
 
         fn invoke(&self, _args: &[ColumnarValue]) -> Result<ColumnarValue> {
-            Ok(ColumnarValue::Scalar(ScalarValue::from("a")))
+            Ok(ColumnarValue::from(ScalarValue::from("a")))
         }
     }
 

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -3047,7 +3047,7 @@ Projection: a, b
         }
 
         fn invoke(&self, _args: &[ColumnarValue]) -> Result<ColumnarValue> {
-            Ok(ColumnarValue::Scalar(ScalarValue::from(1)))
+            Ok(ColumnarValue::from(ScalarValue::from(1)))
         }
     }
 

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -670,7 +670,7 @@ impl<'a> ConstEvaluator<'a> {
             }
             ColumnarValue::Scalar(s) => {
                 // TODO: support the optimization for `Map` type after support impl hash for it
-                if matches!(&s, ScalarValue::Map(_)) {
+                if matches!(&s.value(), ScalarValue::Map(_)) {
                     ConstSimplifyResult::SimplifyRuntimeError(
                         DataFusionError::NotImplemented(
                             "Const evaluate for Map type is still not supported"
@@ -679,7 +679,7 @@ impl<'a> ConstEvaluator<'a> {
                         expr,
                     )
                 } else {
-                    ConstSimplifyResult::Simplified(s)
+                    ConstSimplifyResult::Simplified(s.into_value())
                 }
             }
         }

--- a/datafusion/physical-expr-common/src/datum.rs
+++ b/datafusion/physical-expr-common/src/datum.rs
@@ -21,10 +21,11 @@ use arrow::buffer::NullBuffer;
 use arrow::compute::SortOptions;
 use arrow::error::ArrowError;
 use datafusion_common::DataFusionError;
+use datafusion_common::Result;
 use datafusion_common::{arrow_datafusion_err, internal_err};
-use datafusion_common::{Result, ScalarValue};
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use datafusion_expr_common::operator::Operator;
+use datafusion_expr_common::scalar::Scalar;
 use std::sync::Arc;
 
 /// Applies a binary [`Datum`] kernel `f` to `lhs` and `rhs`
@@ -47,7 +48,7 @@ pub fn apply(
         ),
         (ColumnarValue::Scalar(left), ColumnarValue::Scalar(right)) => {
             let array = f(&left.to_scalar()?, &right.to_scalar()?)?;
-            let scalar = ScalarValue::try_from_array(array.as_ref(), 0)?;
+            let scalar = Scalar::try_from_array(array.as_ref(), 0)?;
             Ok(ColumnarValue::Scalar(scalar))
         }
     }

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -223,12 +223,10 @@ impl CaseExpr {
                 .evaluate_selection(batch, &when_match)?;
 
             current_value = match then_value {
-                ColumnarValue::Scalar(ScalarValue::Null) => {
-                    nullif(current_value.as_ref(), &when_match)?
-                }
-                ColumnarValue::Scalar(then_value) => {
-                    zip(&when_match, &then_value.to_scalar()?, &current_value)?
-                }
+                ColumnarValue::Scalar(scalar) => match scalar.value() {
+                    ScalarValue::Null => nullif(current_value.as_ref(), &when_match)?,
+                    _ => zip(&when_match, &scalar.to_scalar()?, &current_value)?,
+                },
                 ColumnarValue::Array(then_value) => {
                     zip(&when_match, &then_value, &current_value)?
                 }
@@ -294,12 +292,10 @@ impl CaseExpr {
                 .evaluate_selection(batch, &when_value)?;
 
             current_value = match then_value {
-                ColumnarValue::Scalar(ScalarValue::Null) => {
-                    nullif(current_value.as_ref(), &when_value)?
-                }
-                ColumnarValue::Scalar(then_value) => {
-                    zip(&when_value, &then_value.to_scalar()?, &current_value)?
-                }
+                ColumnarValue::Scalar(scalar) => match scalar.value() {
+                    ScalarValue::Null => nullif(current_value.as_ref(), &when_value)?,
+                    _ => zip(&when_value, &scalar.to_scalar()?, &current_value)?,
+                },
                 ColumnarValue::Array(then_value) => {
                     zip(&when_value, &then_value, &current_value)?
                 }

--- a/datafusion/physical-expr/src/expressions/is_not_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_not_null.rs
@@ -76,8 +76,8 @@ impl PhysicalExpr for IsNotNullExpr {
                 let is_not_null = super::is_null::compute_is_not_null(array)?;
                 Ok(ColumnarValue::Array(Arc::new(is_not_null)))
             }
-            ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::Scalar(
-                ScalarValue::Boolean(Some(!scalar.is_null())),
+            ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::from(
+                ScalarValue::Boolean(Some(!scalar.value().is_null())),
             )),
         }
     }

--- a/datafusion/physical-expr/src/expressions/is_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_null.rs
@@ -80,8 +80,8 @@ impl PhysicalExpr for IsNullExpr {
             ColumnarValue::Array(array) => {
                 Ok(ColumnarValue::Array(Arc::new(compute_is_null(array)?)))
             }
-            ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::Scalar(
-                ScalarValue::Boolean(Some(scalar.is_null())),
+            ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::from(
+                ScalarValue::Boolean(Some(scalar.value().is_null())),
             )),
         }
     }

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -72,7 +72,7 @@ impl PhysicalExpr for Literal {
     }
 
     fn evaluate(&self, _batch: &RecordBatch) -> Result<ColumnarValue> {
-        Ok(ColumnarValue::Scalar(self.value.clone()))
+        Ok(ColumnarValue::from(self.value.clone()))
     }
 
     fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {

--- a/datafusion/physical-expr/src/expressions/negative.rs
+++ b/datafusion/physical-expr/src/expressions/negative.rs
@@ -84,7 +84,7 @@ impl PhysicalExpr for NegativeExpr {
                 Ok(ColumnarValue::Array(result))
             }
             ColumnarValue::Scalar(scalar) => {
-                Ok(ColumnarValue::Scalar((scalar.arithmetic_negate())?))
+                Ok(ColumnarValue::from((scalar.value().arithmetic_negate())?))
             }
         }
     }

--- a/datafusion/physical-expr/src/expressions/not.rs
+++ b/datafusion/physical-expr/src/expressions/not.rs
@@ -78,13 +78,11 @@ impl PhysicalExpr for NotExpr {
                 )))
             }
             ColumnarValue::Scalar(scalar) => {
-                if scalar.is_null() {
-                    return Ok(ColumnarValue::Scalar(ScalarValue::Boolean(None)));
+                if scalar.value().is_null() {
+                    return Ok(ColumnarValue::from(ScalarValue::Boolean(None)));
                 }
-                let bool_value: bool = scalar.try_into()?;
-                Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(
-                    !bool_value,
-                ))))
+                let bool_value: bool = scalar.into_value().try_into()?;
+                Ok(ColumnarValue::from(ScalarValue::Boolean(Some(!bool_value))))
             }
         }
     }

--- a/datafusion/physical-expr/src/expressions/try_cast.rs
+++ b/datafusion/physical-expr/src/expressions/try_cast.rs
@@ -92,7 +92,7 @@ impl PhysicalExpr for TryCastExpr {
                 let array = scalar.to_array()?;
                 let cast_array = cast_with_options(&array, &self.cast_type, &options)?;
                 let cast_scalar = ScalarValue::try_from_array(&cast_array, 0)?;
-                Ok(ColumnarValue::Scalar(cast_scalar))
+                Ok(ColumnarValue::from(cast_scalar))
             }
         }
     }

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -27,7 +27,7 @@ pub use datafusion_common::hash_utils;
 pub use datafusion_common::utils::project_schema;
 pub use datafusion_common::{internal_err, ColumnStatistics, Statistics};
 pub use datafusion_execution::{RecordBatchStream, SendableRecordBatchStream};
-pub use datafusion_expr::{Accumulator, ColumnarValue};
+pub use datafusion_expr::{Accumulator, ColumnarValue, Scalar};
 pub use datafusion_physical_expr::window::WindowExpr;
 use datafusion_physical_expr::PhysicalSortExpr;
 pub use datafusion_physical_expr::{

--- a/datafusion/physical-plan/src/values.rs
+++ b/datafusion/physical-plan/src/values.rs
@@ -26,12 +26,12 @@ use super::{
 };
 use crate::{
     memory::MemoryStream, ColumnarValue, DisplayFormatType, ExecutionPlan, Partitioning,
-    PhysicalExpr,
+    PhysicalExpr, Scalar,
 };
 
 use arrow::datatypes::{Schema, SchemaRef};
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
-use datafusion_common::{internal_err, plan_err, Result, ScalarValue};
+use datafusion_common::{internal_err, plan_err, Result};
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::EquivalenceProperties;
 
@@ -74,7 +74,7 @@ impl ValuesExec {
                         match r {
                             Ok(ColumnarValue::Scalar(scalar)) => Ok(scalar),
                             Ok(ColumnarValue::Array(a)) if a.len() == 1 => {
-                                ScalarValue::try_from_array(&a, 0)
+                                Scalar::try_from_array(&a, 0)
                             }
                             Ok(ColumnarValue::Array(a)) => {
                                 plan_err!(
@@ -85,7 +85,7 @@ impl ValuesExec {
                         }
                     })
                     .collect::<Result<Vec<_>>>()
-                    .and_then(ScalarValue::iter_to_array)
+                    .and_then(Scalar::iter_to_array)
             })
             .collect::<Result<Vec<_>>>()?;
         let batch = RecordBatch::try_new_with_options(
@@ -219,6 +219,7 @@ mod tests {
     use crate::test::{self, make_partition};
 
     use arrow_schema::{DataType, Field};
+    use datafusion_common::ScalarValue;
 
     #[tokio::test]
     async fn values_empty_case() -> Result<()> {


### PR DESCRIPTION
This PR represents the first step originating from experiment #11978, which itself stems from the broad objective described in proposal #11513.

---

## Rationale for this change

This change introduces the knowledge of `Scalar` type which identifies the physical representation of a scalar value. `Scalar` will replace `ScalarValue` in the `ColumnarValue` enum. This is done in order to allow, in future PRs, to remove some redundant variants of `ScalarValue` and transition to logical representation of scalar values in datafusion.

## Design rationale

The new `Scalar` type embeds both a `ScalarValue` and a `DataType`. While the type information might seem redundant considering the current implementation `ScalarValue` it will be beneficial once we start to remove redundant variants (such as replacing `ScalarValue::Utf8View` and `ScalarValue::LargeUtf8` while keeping `ScalarValue::Utf8`) in order to keep track of the represented type during physical execution.

### Alternatives considered: [`arrow::array::Scalar`](https://docs.rs/arrow/latest/arrow/array/struct.Scalar.html)

Arrow's array crate provides a `Scalar` type which implements Datum and which holds a reference to a `len() = 1` arrow array. While this type fully identifies the physical representation of a scalar value it falls short when considering the overhead of copying a fully rendered ArrayRef instead of primitives types.

This possibility was also already discussed here: https://github.com/apache/datafusion/issues/7353#issuecomment-1739664804.

## What changes are included in this PR?

- Introduced the `Scalar` struct
- Replaced `ScalarValue` with `Scalar` in `ColumnarValue`'s Scalar variant
- Adapted existing code to the Scalar variant change

## Are these changes tested?

This change should be a no-op as it doesn't include any behavioural change. The existing test suite is sufficient to verify this change.

## TODO

- [ ] rustdoc on new types and functions
