### PR TITLE
Use qualified aliases to simplify searching DFSchema

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -355,18 +355,7 @@ impl DFSchema {
                 // qualifier and name.
                 (Some(q), Some(field_q)) => q.resolved_eq(field_q) && f.name() == name,
                 // field to lookup is qualified but current field is unqualified.
-                (Some(qq), None) => {
-                    // the original field may now be aliased with a name that matches the
-                    // original qualified name
-                    let column = Column::from_qualified_name(f.name());
-                    match column {
-                        Column {
-                            relation: Some(r),
-                            name: column_name,
-                        } => &r == qq && column_name == name,
-                        _ => false,
-                    }
-                }
+                (Some(_), None) => false,
                 // field to lookup is unqualified, no need to compare qualifier
                 (None, Some(_)) | (None, None) => f.name() == name,
             })

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -22,9 +22,7 @@ use std::sync::Arc;
 use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 
-use datafusion_common::{
-    internal_err, qualified_name, tree_node::Transformed, DataFusionError, Result,
-};
+use datafusion_common::{internal_err, tree_node::Transformed, DataFusionError, Result};
 use datafusion_expr::builder::project;
 use datafusion_expr::{
     col,
@@ -135,7 +133,7 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                 // alias all original group_by exprs
                 let (mut inner_group_exprs, out_group_expr_with_alias): (
                     Vec<Expr>,
-                    Vec<(Expr, Option<String>)>,
+                    Vec<(Expr, _)>,
                 ) = group_expr
                     .into_iter()
                     .enumerate()
@@ -166,10 +164,7 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                             let (qualifier, field) = schema.qualified_field(i);
                             (
                                 group_expr.alias(alias_str.clone()),
-                                (
-                                    col(alias_str),
-                                    Some(qualified_name(qualifier, field.name())),
-                                ),
+                                (col(alias_str), Some((qualifier, field.name()))),
                             )
                         }
                     })
@@ -253,19 +248,17 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                 // - aggr expr
                 let alias_expr: Vec<_> = out_group_expr_with_alias
                     .into_iter()
-                    .map(|(group_expr, original_field)| {
-                        if let Some(name) = original_field {
-                            group_expr.alias(name)
-                        } else {
-                            group_expr
+                    .map(|(group_expr, original_name)| match original_name {
+                        Some((qualifier, name)) => {
+                            group_expr.alias_qualified(qualifier.cloned(), name)
                         }
+                        None => group_expr,
                     })
                     .chain(outer_aggr_exprs.iter().cloned().enumerate().map(
                         |(idx, expr)| {
                             let idx = idx + group_size;
                             let (qualifier, field) = schema.qualified_field(idx);
-                            let name = qualified_name(qualifier, field.name());
-                            expr.alias(name)
+                            expr.alias_qualified(qualifier.cloned(), field.name())
                         },
                     ))
                     .collect();

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -1756,3 +1756,7 @@ SELECT "test.a" FROM (SELECT a AS "test.a" FROM test)
 
 statement ok
 DROP TABLE test;
+
+# Can't reference an unqualified column by a qualified name
+query error DataFusion error: Schema error: No field named t1\.v1\. Valid fields are "t1\.v1"\.
+SELECT t1.v1 FROM (SELECT 1 AS "t1.v1");


### PR DESCRIPTION
## Which issue does this PR close?
N/A.

## Rationale for this change
The following logic was introduced for `single_distinct_to_groupby` in #4050.  
The reason was the lack of alias-with-qualifier, which caused the qualifier to be lost after alias. See [comment](https://github.com/apache/datafusion/pull/4050#discussion_r1011990524)
When searching for a qualified name in DFSchema, we must also check unqualified fields because they may have been aliased and previously had a qualifier. We can now use qualified aliases to avoid this.

https://github.com/apache/datafusion/blob/0243ebd585264852be55822e3504be54e1e0e406/datafusion/common/src/dfschema.rs#L358-L369



## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
By existing tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
