### PR TITLE
parquet: Add option to cache file metadata

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -365,6 +365,11 @@ config_namespace! {
         /// multiple parquet files with schemas containing compatible types but different metadata
         pub skip_metadata: bool, default = true
 
+        /// (reading) If true, caches the Parquet file-level metadata so it does not need
+        /// to be parsed on every query. This should typically be true when running more than
+        /// one (short) query on a table.
+        pub cache_metadata: bool, default = false
+
         /// (reading) If specified, the parquet reader will try and fetch the last `size_hint`
         /// bytes of the parquet file optimistically. If not specified, two reads are required:
         /// One read to fetch the 8-byte parquet footer and

--- a/datafusion/common/src/file_options/parquet_writer.rs
+++ b/datafusion/common/src/file_options/parquet_writer.rs
@@ -168,6 +168,7 @@ impl ParquetOptions {
             enable_page_index: _,
             pruning: _,
             skip_metadata: _,
+            cache_metadata: _,
             metadata_size_hint: _,
             pushdown_filters: _,
             reorder_filters: _,

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -60,7 +60,10 @@ use crate::datasource::schema_adapter::{
 pub use access_plan::{ParquetAccessPlan, RowGroupAccess};
 pub use metrics::ParquetFileMetrics;
 use opener::ParquetOpener;
-pub use reader::{DefaultParquetFileReaderFactory, ParquetFileReaderFactory};
+pub use reader::{
+    CachedParquetFileReaderFactory, DefaultParquetFileReaderFactory,
+    ParquetFileReaderFactory,
+};
 pub use row_filter::can_expr_be_pushed_down_with_schemas;
 pub use writer::plan_to_parquet;
 


### PR DESCRIPTION
Inspired by datafusion-examples/examples/advanced_parquet_index.rs

## Which issue does this PR close?

This was an attempt to solve #12547, but did not achieve it, and I am not sure it is the right approach.

## Rationale for this change

On every query on Parquet ables, Datafusion re-opens every file, and parses its metadata. This takes a significant time for short queries (in my use case, there is usually a single hit in the Page Index).

My goal with to make these queries near-instant. Unfortunately, I realized after writing this code that the Page Index still needs to be parsed every time, because file metadata is lost through the `listing` layer (as mentioned in #9964).

So this does spare some (negligible?) time parsing metadata. I'm not sure it's worth the extra complexity, especially in `ParquetFormat`. What do you think?

## What changes are included in this PR?

* Made `ParquetFormat` carry state (it probably deserves a renaming then...)
* Added `CachedParquetFileReaderFactory` as an alternative to `DefaultParquetFileReaderFactory`, and made it usable through a config option

## Are these changes tested?

no

## Are there any user-facing changes?

Added `datafusion.execution.parquet.cache_metadata`