### PR TITLE
Sort metrics alphabetically in EXPLAIN ANALYZE output

### DIFF
--- a/datafusion/physical-plan/src/metrics/mod.rs
+++ b/datafusion/physical-plan/src/metrics/mod.rs
@@ -301,8 +301,12 @@ impl MetricsSet {
 
     /// Sort the order of metrics so the "most useful" show up first
     pub fn sorted_for_display(mut self) -> Self {
-        self.metrics
-            .sort_unstable_by_key(|metric| metric.value().display_sort_key());
+        self.metrics.sort_unstable_by_key(|metric| {
+            (
+                metric.value().display_sort_key(),
+                metric.value().name().to_owned(),
+            )
+        });
         self
     }
 
@@ -665,7 +669,9 @@ mod tests {
         MetricBuilder::new(&metrics).end_timestamp(0);
         MetricBuilder::new(&metrics).start_timestamp(0);
         MetricBuilder::new(&metrics).elapsed_compute(0);
+        MetricBuilder::new(&metrics).counter("the_second_counter", 0);
         MetricBuilder::new(&metrics).counter("the_counter", 0);
+        MetricBuilder::new(&metrics).counter("the_third_counter", 0);
         MetricBuilder::new(&metrics).subset_time("the_time", 0);
         MetricBuilder::new(&metrics).output_rows(0);
         let metrics = metrics.clone_inner();
@@ -675,9 +681,9 @@ mod tests {
             n.join(", ")
         }
 
-        assert_eq!("end_timestamp, start_timestamp, elapsed_compute, the_counter, the_time, output_rows", metric_names(&metrics));
+        assert_eq!("end_timestamp, start_timestamp, elapsed_compute, the_second_counter, the_counter, the_third_counter, the_time, output_rows", metric_names(&metrics));
 
         let metrics = metrics.sorted_for_display();
-        assert_eq!("output_rows, elapsed_compute, the_counter, the_time, start_timestamp, end_timestamp", metric_names(&metrics));
+        assert_eq!("output_rows, elapsed_compute, the_counter, the_second_counter, the_third_counter, the_time, start_timestamp, end_timestamp", metric_names(&metrics));
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12567.

## Rationale for this change

From `ParquetExec` metrics, with predicate pushdown enabled:

> metrics=[output_rows=0, elapsed_compute=96ns, row_groups_matched_bloom_filter=0, row_groups_matched_statistics=21050, file_scan_errors=0, **pushdown_rows_matched=0**, row_groups_pruned_statistics=173576, row_groups_pruned_bloom_filter=21050, file_open_errors=0, num_predicate_creation_errors=0, bytes_scanned=25023432248, **pushdown_rows_pruned=0**, page_index_rows_pruned=0, predicate_evaluation_errors=0, page_index_rows_matched=0, time_elapsed_scanning_until_data=16.622753ms, time_elapsed_processing=72.280463608s, pushdown_eval_time=382ns, page_index_eval_time=3.177676ms, time_elapsed_scanning_total=16.661811ms, time_elapsed_opening=102.989073638s]

For example, `pushdown_rows_matched` and `pushdown_rows_pruned` (highlighted in the snippet) are far away from each other, even though they refer to roughly the same thing.

The unstable sort also makes it hard to compare multiple `EXPLAIN ANALYZE` results.

after this change, metrics for the same query look like this:

> metrics=[output_rows=0, elapsed_compute=96ns, bytes_scanned=25023432248, file_open_errors=0, file_scan_errors=0, num_predicate_creation_errors=0, page_index_rows_matched=0, page_index_rows_pruned=0, predicate_evaluation_errors=0, **pushdown_rows_matched=0**, **pushdown_rows_pruned=0**, row_groups_matched_bloom_filter=0, row_groups_matched_statistics=21050, row_groups_pruned_bloom_filter=21050, row_groups_pruned_statistics=173576, page_index_eval_time=2.882359ms, pushdown_eval_time=382ns, time_elapsed_opening=104.629010525s, time_elapsed_processing=73.86660138s, time_elapsed_scanning_total=97.929057ms, time_elapsed_scanning_until_data=97.893962ms]

## What changes are included in this PR?

Refinement of the partial order used in `MetricsSet::sorted_for_display`

## Are these changes tested?

Yes

## Are there any user-facing changes?

More readable output. There doesn't seem to be any snippet in the documentation that needs to be updated to match the new behavior.