### PR TITLE
Make SessionContext::enable_url_table consume self

### DIFF
--- a/datafusion-examples/examples/external_dependency/query-aws-s3.rs
+++ b/datafusion-examples/examples/external_dependency/query-aws-s3.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
     df.show().await?;
 
     // dynamic query by the file path
-    ctx.enable_url_table();
+    let ctx = ctx.enable_url_table();
     let df = ctx
         .sql(format!(r#"SELECT * FROM '{}' LIMIT 10"#, &path).as_str())
         .await?;


### PR DESCRIPTION
## Which issue does this PR close?

Fixes https://github.com/apache/datafusion/issues/12551


## Rationale for this change

As described on https://github.com/apache/datafusion/issues/12551 the current non consuming API was confusing and caused silently ignored bugs


## What changes are included in this PR?
1. Make SessionContext::enable_url_table consume self
2. Fix bug in example use
3. Add an "into_builder" API to SessionContext to make it easier to work with the builder pattern
4. Update documentation 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
