### PR TITLE
fix parquet infer statistics for BinaryView types

### DIFF
--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -268,7 +268,9 @@ pub(crate) fn coerce_file_schema_to_view_type(
         .iter()
         .map(|f| {
             let dt = f.data_type();
-            if dt.equals_datatype(&DataType::Utf8View) {
+            if dt.equals_datatype(&DataType::Utf8View)
+                || dt.equals_datatype(&DataType::BinaryView)
+            {
                 transform = true;
             }
             (f.name(), dt)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
Currently if the file/stats format is in `BinaryArray` and we attempt to coerce it into `BinaryViewArray`, the stats will be NULL because type mismatch.

This PR fix it.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Related to #12092 and #6906

In particular, consider this query (simplified Q21 from clickbench):
```sql
SELECT MIN("URL") FROM hits;
```

Datafusion is able to [compeletely remove](https://github.com/apache/datafusion/blob/main/datafusion/physical-optimizer/src/aggregate_statistics.rs#L64) `ParquetExec` based on the statistics, as shown in the physical plan below:

```
Q21: SELECT MIN("URL") FROM hits;
=== Optimized logical plan ===
Aggregate: groupBy=[[]], aggr=[[min(hits.URL)]]
  TableScan: hits projection=[URL]

=== Physical plan with metrics ===
ProjectionExec: expr=[ as min(hits.URL)], metrics=[output_rows=1, elapsed_compute=6.662µs]
  PlaceholderRowExec, metrics=[]
```

Without proper statistics, we will need to scan the entire column, which explains the slowdown.


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
