### PR TITLE
Minor: add example to of assert_batches_eq

### DIFF
--- a/datafusion/common/src/test_util.rs
+++ b/datafusion/common/src/test_util.rs
@@ -29,6 +29,27 @@ use std::{error::Error, path::PathBuf};
 /// Expects to be called about like this:
 ///
 /// `assert_batch_eq!(expected_lines: &[&str], batches: &[RecordBatch])`
+///
+/// # Example
+/// ```
+/// # use std::sync::Arc;
+/// # use arrow::record_batch::RecordBatch;
+/// # use arrow_array::{ArrayRef, Int32Array};
+/// # use datafusion_common::assert_batches_eq;
+/// let col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2]));
+///  let batch = RecordBatch::try_from_iter([("column", col)]).unwrap();
+/// // Expected output is a vec of strings
+/// let expected = vec![
+///     "+--------+",
+///     "| column |",
+///     "+--------+",
+///     "| 1      |",
+///     "| 2      |",
+///     "+--------+",
+/// ];
+/// // compare the formatted output of the record batch with the expected output
+/// assert_batches_eq!(expected, &[batch]);
+/// ```
 #[macro_export]
 macro_rules! assert_batches_eq {
     ($EXPECTED_LINES: expr, $CHUNKS: expr) => {
@@ -56,8 +77,7 @@ macro_rules! assert_batches_eq {
 /// vector of strings in a way that order does not matter.
 /// This is a macro so errors appear on the correct line
 ///
-/// Designed so that failure output can be directly copy/pasted
-/// into the test code as expected results.
+/// See [`assert_batches_eq`] for more details and example.
 ///
 /// Expects to be called about like this:
 ///


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change
While reviewing https://github.com/datafusion-contrib/datafusion-functions-extra/pull/2 from @dmitrybugakov  I realized there is no doc example of how to use this macro

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Add doc example
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes by doc ci
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Only docs, no functional changes
