### PR TITLE
make `Debug` for `MemoryExec` prettier

### DIFF
--- a/datafusion/physical-plan/src/memory.rs
+++ b/datafusion/physical-plan/src/memory.rs
@@ -56,13 +56,12 @@ pub struct MemoryExec {
 
 impl fmt::Debug for MemoryExec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "partitions: [...]")?;
-        write!(f, "schema: {:?}", self.projected_schema)?;
-        write!(f, "projection: {:?}", self.projection)?;
-        if let Some(sort_info) = &self.sort_information.first() {
-            write!(f, ", output_ordering: {:?}", sort_info)?;
-        }
-        Ok(())
+        f.debug_struct("MemoryExec")
+            .field("partitions", &"[...]")
+            .field("schema", &self.schema)
+            .field("projection", &self.projection)
+            .field("sort_information", &self.sort_information)
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

While working with `MemoryExec`, I noticed it's output is pretty ugly, especially with `dbg!` where I'd expect output across multiple lines.

I don't necessarily agree with the subset of fields included, but I didn't change it.

## Rationale for this change

Make `MemoryExec` easy to understand.

## What changes are included in this PR?

Change the impl of `fmt::Debug` for `MemoryExec` to use the standard `debug_struct` approach

## Are these changes tested?

No, `Debug` implementations generally aren't. I ran it locally.

## Are there any user-facing changes?

no