### PR TITLE
parquet: Add finer metrics on operations covered by `time_elapsed_opening`

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
@@ -45,6 +45,10 @@ pub struct ParquetFileMetrics {
     pub pushdown_rows_matched: Count,
     /// Total time spent evaluating row-level pushdown filters
     pub row_pushdown_eval_time: Time,
+    /// Total time spent evaluating row group-level statistics filters
+    pub statistics_eval_time: Time,
+    /// Total time spent evaluating row group Bloom Filters
+    pub bloom_filter_eval_time: Time,
     /// Total rows filtered out by parquet page index
     pub page_index_rows_pruned: Count,
     /// Total rows passed through the parquet page index
@@ -94,6 +98,13 @@ impl ParquetFileMetrics {
         let row_pushdown_eval_time = MetricBuilder::new(metrics)
             .with_new_label("filename", filename.to_string())
             .subset_time("row_pushdown_eval_time", partition);
+        let statistics_eval_time = MetricBuilder::new(metrics)
+            .with_new_label("filename", filename.to_string())
+            .subset_time("statistics_eval_time", partition);
+        let bloom_filter_eval_time = MetricBuilder::new(metrics)
+            .with_new_label("filename", filename.to_string())
+            .subset_time("bloom_filter_eval_time", partition);
+
         let page_index_rows_pruned = MetricBuilder::new(metrics)
             .with_new_label("filename", filename.to_string())
             .counter("page_index_rows_pruned", partition);
@@ -117,6 +128,8 @@ impl ParquetFileMetrics {
             row_pushdown_eval_time,
             page_index_rows_pruned,
             page_index_rows_matched,
+            statistics_eval_time,
+            bloom_filter_eval_time,
             page_index_eval_time,
         }
     }

--- a/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
@@ -55,6 +55,8 @@ pub struct ParquetFileMetrics {
     pub page_index_rows_matched: Count,
     /// Total time spent evaluating parquet page index filters
     pub page_index_eval_time: Time,
+    /// Total time spent reading and parsing metadata from the footer
+    pub metadata_load_time: Time,
 }
 
 impl ParquetFileMetrics {
@@ -116,6 +118,10 @@ impl ParquetFileMetrics {
             .with_new_label("filename", filename.to_string())
             .subset_time("page_index_eval_time", partition);
 
+        let metadata_load_time = MetricBuilder::new(metrics)
+            .with_new_label("filename", filename.to_string())
+            .subset_time("metadata_load_time", partition);
+
         Self {
             predicate_evaluation_errors,
             row_groups_matched_bloom_filter,
@@ -131,6 +137,7 @@ impl ParquetFileMetrics {
             statistics_eval_time,
             bloom_filter_eval_time,
             page_index_eval_time,
+            metadata_load_time,
         }
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/metrics.rs
@@ -43,8 +43,8 @@ pub struct ParquetFileMetrics {
     pub pushdown_rows_pruned: Count,
     /// Total rows passed predicates pushed into parquet scan
     pub pushdown_rows_matched: Count,
-    /// Total time spent evaluating pushdown filters
-    pub pushdown_eval_time: Time,
+    /// Total time spent evaluating row-level pushdown filters
+    pub row_pushdown_eval_time: Time,
     /// Total rows filtered out by parquet page index
     pub page_index_rows_pruned: Count,
     /// Total rows passed through the parquet page index
@@ -91,9 +91,9 @@ impl ParquetFileMetrics {
             .with_new_label("filename", filename.to_string())
             .counter("pushdown_rows_matched", partition);
 
-        let pushdown_eval_time = MetricBuilder::new(metrics)
+        let row_pushdown_eval_time = MetricBuilder::new(metrics)
             .with_new_label("filename", filename.to_string())
-            .subset_time("pushdown_eval_time", partition);
+            .subset_time("row_pushdown_eval_time", partition);
         let page_index_rows_pruned = MetricBuilder::new(metrics)
             .with_new_label("filename", filename.to_string())
             .counter("page_index_rows_pruned", partition);
@@ -114,7 +114,7 @@ impl ParquetFileMetrics {
             bytes_scanned,
             pushdown_rows_pruned,
             pushdown_rows_matched,
-            pushdown_eval_time,
+            row_pushdown_eval_time,
             page_index_rows_pruned,
             page_index_rows_matched,
             page_index_eval_time,

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -1862,7 +1862,7 @@ mod tests {
         assert_eq!(get_value(&metrics, "pushdown_rows_pruned"), 5);
         assert_eq!(get_value(&metrics, "pushdown_rows_matched"), 2);
         assert!(
-            get_value(&metrics, "pushdown_eval_time") > 0,
+            get_value(&metrics, "row_pushdown_eval_time") > 0,
             "no eval time in metrics: {metrics:#?}"
         );
     }

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -1863,7 +1863,15 @@ mod tests {
         assert_eq!(get_value(&metrics, "pushdown_rows_matched"), 2);
         assert!(
             get_value(&metrics, "row_pushdown_eval_time") > 0,
-            "no eval time in metrics: {metrics:#?}"
+            "no pushdown eval time in metrics: {metrics:#?}"
+        );
+        assert!(
+            get_value(&metrics, "statistics_eval_time") > 0,
+            "no statistics eval time in metrics: {metrics:#?}"
+        );
+        assert!(
+            get_value(&metrics, "bloom_filter_eval_time") > 0,
+            "no Bloom Filter eval time in metrics: {metrics:#?}"
         );
     }
 

--- a/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
@@ -118,6 +118,7 @@ impl FileOpener for ParquetOpener {
         Ok(Box::pin(async move {
             let options = ArrowReaderOptions::new().with_page_index(enable_page_index);
 
+            let mut metadata_timer = file_metrics.metadata_load_time.timer();
             let metadata =
                 ArrowReaderMetadata::load_async(&mut reader, options.clone()).await?;
             let mut schema = metadata.schema().clone();
@@ -132,6 +133,8 @@ impl FileOpener for ParquetOpener {
                 .with_schema(schema.clone());
             let metadata =
                 ArrowReaderMetadata::try_new(metadata.metadata().clone(), options)?;
+
+            metadata_timer.stop();
 
             let mut builder =
                 ParquetRecordBatchStreamBuilder::new_with_metadata(reader, metadata);

--- a/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
@@ -190,7 +190,6 @@ impl FileOpener for ParquetOpener {
             }
             // If there is a predicate that can be evaluated against the metadata
             if let Some(predicate) = predicate.as_ref() {
-                let mut timer = file_metrics.statistics_eval_time.timer();
                 row_groups.prune_by_statistics(
                     &file_schema,
                     builder.parquet_schema(),
@@ -198,10 +197,8 @@ impl FileOpener for ParquetOpener {
                     predicate,
                     &file_metrics,
                 );
-                timer.stop();
 
                 if enable_bloom_filter && !row_groups.is_empty() {
-                    let mut timer = file_metrics.bloom_filter_eval_time.timer();
                     row_groups
                         .prune_by_bloom_filters(
                             &file_schema,
@@ -210,7 +207,6 @@ impl FileOpener for ParquetOpener {
                             &file_metrics,
                         )
                         .await;
-                    timer.stop();
                 }
             }
 

--- a/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
@@ -187,6 +187,7 @@ impl FileOpener for ParquetOpener {
             }
             // If there is a predicate that can be evaluated against the metadata
             if let Some(predicate) = predicate.as_ref() {
+                let mut timer = file_metrics.statistics_eval_time.timer();
                 row_groups.prune_by_statistics(
                     &file_schema,
                     builder.parquet_schema(),
@@ -194,8 +195,10 @@ impl FileOpener for ParquetOpener {
                     predicate,
                     &file_metrics,
                 );
+                timer.stop();
 
                 if enable_bloom_filter && !row_groups.is_empty() {
+                    let mut timer = file_metrics.bloom_filter_eval_time.timer();
                     row_groups
                         .prune_by_bloom_filters(
                             &file_schema,
@@ -204,6 +207,7 @@ impl FileOpener for ParquetOpener {
                             &file_metrics,
                         )
                         .await;
+                    timer.stop();
                 }
             }
 

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_filter.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_filter.rs
@@ -531,7 +531,7 @@ pub fn build_row_filter(
 ) -> Result<Option<RowFilter>> {
     let rows_pruned = &file_metrics.pushdown_rows_pruned;
     let rows_matched = &file_metrics.pushdown_rows_matched;
-    let time = &file_metrics.pushdown_eval_time;
+    let time = &file_metrics.row_pushdown_eval_time;
 
     // Split into conjuncts:
     // `a = 1 AND b = 2 AND c = 3` -> [`a = 1`, `b = 2`, `c = 3`]

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_group_filter.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_group_filter.rs
@@ -109,6 +109,9 @@ impl RowGroupAccessPlanFilter {
         predicate: &PruningPredicate,
         metrics: &ParquetFileMetrics,
     ) {
+        // scoped timer updates on drop
+        let _timer_guard = metrics.statistics_eval_time.timer();
+
         assert_eq!(groups.len(), self.access_plan.len());
         // Indexes of row groups still to scan
         let row_group_indexes = self.access_plan.row_group_indexes();
@@ -158,6 +161,9 @@ impl RowGroupAccessPlanFilter {
         predicate: &PruningPredicate,
         metrics: &ParquetFileMetrics,
     ) {
+        // scoped timer updates on drop
+        let _timer_guard = metrics.bloom_filter_eval_time.timer();
+
         assert_eq!(builder.metadata().num_row_groups(), self.access_plan.len());
         for idx in 0..self.access_plan.len() {
             if !self.access_plan.should_scan(idx) {

--- a/docs/source/user-guide/explain-usage.md
+++ b/docs/source/user-guide/explain-usage.md
@@ -235,7 +235,9 @@ When predicate pushdown is enabled, `ParquetExec` gains the following metrics:
 - `pushdown_rows_pruned`: rows that were tested by any of the above filtered, and did not pass one of them (this should be sum of `page_index_rows_matched`, `row_groups_pruned_bloom_filter`, and `row_groups_pruned_statistics`)
 - `predicate_evaluation_errors`: number of times evaluating the filter expression failed (expected to be zero in normal operation)
 - `num_predicate_creation_errors`: number of errors creating predicates (expected to be zero in normal operation)
-- `pushdown_eval_time`: time spent evaluating these filters
+- `bloom_filter_eval_time`: time spent parsing and evaluating Bloom Filters
+- `statistics_eval_time`: time spent parsing and evaluating row group-level statistics
+- `row_pushdown_eval_time`: time spent evaluating row-level filters
 - `page_index_eval_time`: time required to evaluate the page index filters
 
 ## Partitions and Execution


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12584.

## Rationale for this change

This allows both Datafusion developers and users to better measure the impact of their optimizations. For example, I am working on #12547 (caching the page index), and my patch makes these metrics go from:

> statistics_eval_time=775.283531ms, row_pushdown_eval_time=191ns, time_elapsed_scanning_until_data=16.463873ms, time_elapsed_processing=401.16043928s, **time_elapsed_opening=473.912060225s**, page_index_eval_time=24.19564ms, **metadata_load_time=410.282903954s**, bloom_filter_eval_time=62.038167937s, time_elapsed_scanning_total=16.516948ms

to 

> row_pushdown_eval_time=191ns, time_elapsed_scanning_until_data=1.143893882s, time_elapsed_processing=34.501308377s, **time_elapsed_opening=67.214927741s**, page_index_eval_time=32.002383ms, **metadata_load_time=3.411246ms**, bloom_filter_eval_time=66.495163165s, statistics_eval_time=1.255058963s, time_elapsed_scanning_total=1.143978104s

which shows it reduced `metadata_load_time` and `time_elapsed_opening` with little impact to the others.

## What changes are included in this PR?

1. Add  `metadata_load_time`
2. Add`statistics_eval_time` and `bloom_filter_eval_time`
3.  Rename `pushdown_eval_time` to `row_pushdown_eval_time`, because statistics and eval time are pushdown filters too

## Are these changes tested?

Not really. There is no unit tests, but it works in datafusion-cli and as a library

## Are there any user-facing changes?

Renamed a metric, and added two others, visible in `EXPLAIN ANALYZE`.