### PR TITLE
physical-plan: Cast nested group values back to dictionary if necessary

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/row.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/row.rs
@@ -20,13 +20,14 @@ use ahash::RandomState;
 use arrow::compute::cast;
 use arrow::record_batch::RecordBatch;
 use arrow::row::{RowConverter, Rows, SortField};
-use arrow_array::{Array, ArrayRef};
+use arrow_array::{Array, ArrayRef, ListArray, StructArray};
 use arrow_schema::{DataType, SchemaRef};
 use datafusion_common::hash_utils::create_hashes;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::Result;
 use datafusion_execution::memory_pool::proxy::{RawTableAllocExt, VecAllocExt};
 use datafusion_expr::EmitTo;
 use hashbrown::raw::RawTable;
+use std::sync::Arc;
 
 /// A [`GroupValues`] making use of [`Rows`]
 pub struct GroupValuesRows {
@@ -221,15 +222,10 @@ impl GroupValues for GroupValuesRows {
         // TODO: Materialize dictionaries in group keys (#7647)
         for (field, array) in self.schema.fields.iter().zip(&mut output) {
             let expected = field.data_type();
-            if let DataType::Dictionary(_, v) = expected {
-                let actual = array.data_type();
-                if v.as_ref() != actual {
-                    return Err(DataFusionError::Internal(format!(
-                        "Converted group rows expected dictionary of {v} got {actual}"
-                    )));
-                }
-                *array = cast(array.as_ref(), expected)?;
-            }
+            *array = dictionary_encode_if_necessary(
+                Arc::<dyn arrow_array::Array>::clone(array),
+                expected,
+            )?;
         }
 
         self.group_values = Some(group_values);
@@ -247,5 +243,47 @@ impl GroupValues for GroupValuesRows {
         self.map_size = self.map.capacity() * std::mem::size_of::<(u64, usize)>();
         self.hashes_buffer.clear();
         self.hashes_buffer.shrink_to(count);
+    }
+}
+
+fn dictionary_encode_if_necessary(
+    array: ArrayRef,
+    expected: &DataType,
+) -> Result<ArrayRef> {
+    match (expected, array.data_type()) {
+        (DataType::Struct(expected_fields), _) => {
+            let struct_array = array.as_any().downcast_ref::<StructArray>().unwrap();
+            let arrays = expected_fields
+                .iter()
+                .zip(struct_array.columns())
+                .map(|(expected_field, column)| {
+                    dictionary_encode_if_necessary(
+                        Arc::<dyn arrow_array::Array>::clone(column),
+                        expected_field.data_type(),
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            Ok(Arc::new(StructArray::try_new(
+                expected_fields.clone(),
+                arrays,
+                struct_array.nulls().cloned(),
+            )?))
+        }
+        (DataType::List(expected_field), &DataType::List(_)) => {
+            let list = array.as_any().downcast_ref::<ListArray>().unwrap();
+
+            Ok(Arc::new(ListArray::try_new(
+                Arc::<arrow_schema::Field>::clone(expected_field),
+                list.offsets().clone(),
+                dictionary_encode_if_necessary(
+                    Arc::<dyn arrow_array::Array>::clone(list.values()),
+                    expected_field.data_type(),
+                )?,
+                list.nulls().cloned(),
+            )?))
+        }
+        (DataType::Dictionary(_, _), _) => Ok(cast(array.as_ref(), expected)?),
+        (_, _) => Ok(Arc::<dyn arrow_array::Array>::clone(&array)),
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/12542

## Rationale for this change

Non-nested arrays were already being dictionary encoded again if the input was dictionary encoded, so this just replicates that behavior for structs and lists.

## What changes are included in this PR?

1) Check whether there are any nested dictionaries to encode.
2) Encode arrays that have nested dictionaries appropriately.

Note this may not be conclusive, I've only included lists and structs since those are the cases/types that I need and that I'm most familiar with. I think it'd be nice to get these changes in though and handle any further cases in separate PRs.

## Are these changes tested?

Yes, added a unit test that tests precisely the scenario that led me to opening the issue.

## Are there any user-facing changes?

No, only a bug fix. If the queries didn't panic before it could have been a change in behavior, but since all queries of this sort panicked before it's purely a bug fix.

@alamb @tustvold @andygrove 