### PR TITLE
Warn instead of error for unused imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,4 +169,3 @@ large_futures = "warn"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
-unused_imports = "deny"

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -25,6 +25,8 @@
 # This file be run directly:
 # $ ./pre-commit.sh
 
+set -e
+
 function RED() {
 	echo "\033[0;31m$@\033[0m"
 }


### PR DESCRIPTION
## Rationale for this change

It's very frustrating when working on datafusion that unused imports cause scripts and tests to fail at build time, and not run.

Also, while looking in to this, it seems the `pre-commit.sh` script wasn't failing when clippy failed.

This doesn't affect CI where unused imports will still cause failure I believe.

## What changes are included in this PR?

* remove `unused_imports = "deny"` from the root `Cargo.toml`, so the default behaviour of warning occurs
* make `pre-commit.sh` fail if clippy fails

## Are these changes tested?

Manually, yes.

## Are there any user-facing changes?

No.
