### PR TITLE
Add unhandled hook to PruningPredicate

### DIFF
--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -3466,8 +3466,7 @@ mod tests {
                         left.as_any().downcast_ref::<phys_expr::Column>()
                     {
                         if column.name() == "b" {
-                            if let Some(_) =
-                                right.as_any().downcast_ref::<phys_expr::Literal>()
+                            if right.as_any().downcast_ref::<phys_expr::Literal>().is_some()
                             {
                                 let new_column =
                                     Arc::new(phys_expr::Column::new("c", column.index()))

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -3466,7 +3466,10 @@ mod tests {
                         left.as_any().downcast_ref::<phys_expr::Column>()
                     {
                         if column.name() == "b" {
-                            if right.as_any().downcast_ref::<phys_expr::Literal>().is_some()
+                            if right
+                                .as_any()
+                                .downcast_ref::<phys_expr::Literal>()
+                                .is_some()
                             {
                                 let new_column =
                                     Arc::new(phys_expr::Column::new("c", column.index()))

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -3474,7 +3474,7 @@ mod tests {
                                         as _;
                                 return Arc::new(phys_expr::BinaryExpr::new(
                                     new_column,
-                                    expr.op().clone(),
+                                    *expr.op(),
                                     right.clone(),
                                 ));
                             }

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -3465,21 +3465,18 @@ mod tests {
                     if let Some(column) =
                         left.as_any().downcast_ref::<phys_expr::Column>()
                     {
-                        if column.name() == "b" {
-                            if right
+                        if column.name() == "b" && right
                                 .as_any()
                                 .downcast_ref::<phys_expr::Literal>()
-                                .is_some()
-                            {
-                                let new_column =
-                                    Arc::new(phys_expr::Column::new("c", column.index()))
-                                        as _;
-                                return Arc::new(phys_expr::BinaryExpr::new(
-                                    new_column,
-                                    *expr.op(),
-                                    right.clone(),
-                                ));
-                            }
+                                .is_some() {
+                            let new_column =
+                                Arc::new(phys_expr::Column::new("c", column.index()))
+                                    as _;
+                            return Arc::new(phys_expr::BinaryExpr::new(
+                                new_column,
+                                *expr.op(),
+                                right.clone(),
+                            ));
                         }
                     }
                 }

--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -3465,10 +3465,12 @@ mod tests {
                     if let Some(column) =
                         left.as_any().downcast_ref::<phys_expr::Column>()
                     {
-                        if column.name() == "b" && right
+                        if column.name() == "b"
+                            && right
                                 .as_any()
                                 .downcast_ref::<phys_expr::Literal>()
-                                .is_some() {
+                                .is_some()
+                        {
                             let new_column =
                                 Arc::new(phys_expr::Column::new("c", column.index()))
                                     as _;


### PR DESCRIPTION
I have a secondary index with min/max stats columns that is compatible with PruningPredicate's rewrites.

I now want to add an index for point lookups (I plan on implementing it as a column with distinct array values, but that's a bit of an implementation detail).

The point is that when `PruningPredicate` encounters this column (for which there are no stats, and which it doesn't recognize because I only pass in Fields for which there are stats) it currently returns `true` such that `a_column_with_stats = 123 and a_point_lookup_column = 'abc'` becomes `a_column_with_stats_min <= 123 and a_column_with_stats_max >= 123 and true` (ignoring nulls, maybe simplifying other bits) but I want it to become `a_column_with_stats_min <= 123 and a_column_with_stats_max >= 123 and a_point_lookup_column @> '{abc}'::text[]` or something like that.

I don't think it's reasonable to add APIs to DataFusion for this specific case since it depends on implementation details outside of DataFusion's control, but I also can't easily work around it on my end (I'd have to re-implement all of PruningPredicate). So I'm hoping that adding this hook is acceptable 😄 