### PR TITLE
Remove `once_cell` crate from dependencies

### DIFF
--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -62,7 +62,6 @@ hashbrown = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true, features = ["use_std"] }
 log = { workspace = true }
-once_cell = "1.18.0"
 parking_lot = { workspace = true }
 pin-project-lite = "^0.2.7"
 rand = { workspace = true }

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -1563,7 +1563,7 @@ pub enum SHJStreamState {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::sync::{LazyLock, Mutex};
 
     use super::*;
     use crate::joins::test_utils::{
@@ -1580,7 +1580,6 @@ mod tests {
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{binary, col, lit, Column};
 
-    use once_cell::sync::Lazy;
     use rstest::*;
 
     const TABLE_SIZE: i32 = 30;
@@ -1589,8 +1588,8 @@ mod tests {
     type TableValue = (Vec<RecordBatch>, Vec<RecordBatch>); // (left, right)
 
     // Cache for storing tables
-    static TABLE_CACHE: Lazy<Mutex<HashMap<TableKey, TableValue>>> =
-        Lazy::new(|| Mutex::new(HashMap::new()));
+    static TABLE_CACHE: LazyLock<Mutex<HashMap<TableKey, TableValue>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
 
     fn get_or_create_table(
         cardinality: (i32, i32),


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

This should be merged after https://github.com/apache/datafusion/pull/12601

When looking at https://github.com/apache/datafusion/pull/12601 I noticed that the `once_cell` crate is still listed as a dependency, but there are no usages of it in the codebase, aside from one test that could move to LazyLock instead.

## What changes are included in this PR?

Remove the unused `once_cell` dependency and replace the usage of it with `LazyLock`.

## Are these changes tested?

Tested by CI

## Are there any user-facing changes?

No
