### PR TITLE
fix: Panic/correctness issue in variance GroupsAccumulator

### DIFF
--- a/datafusion/functions-aggregate/src/variance.rs
+++ b/datafusion/functions-aggregate/src/variance.rs
@@ -470,7 +470,7 @@ impl VarianceGroupsAccumulator {
 
         if let StatsType::Sample = self.stats_type {
             counts.iter_mut().for_each(|count| {
-                *count -= 1;
+                *count = count.saturating_sub(1);
             });
         }
         let nulls = NullBuffer::from_iter(counts.iter().map(|&count| count != 0));

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -567,13 +567,13 @@ set datafusion.sql_parser.dialect = 'Postgres';
 
 # csv_query_stddev_12
 query IR
-SELECT c2, var_samp(c12) FILTER (WHERE c12 > 0.90) FROM aggregate_test_100 GROUP BY c2 ORDER BY c2
+SELECT c2, var_samp(c12) FILTER (WHERE c12 > 0.95) FROM aggregate_test_100 GROUP BY c2 ORDER BY c2
 ----
-1 0.000889240174
-2 0.000785878272
+1 0.000791243479
+2 0.000061521903
 3 NULL
 4 NULL
-5 0.000269544643
+5 NULL
 
 # Restore the default dialect
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12616.

## Rationale for this change

The bug was in the orginal implementation in #12095. This fixes the
issue and modify a test case such that it would have caught it.

Current code panics in debug builds and produces incorrect results in release.


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Use `staturating_sub` instead to correct the behavior.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Modified test case.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No,

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
