### PR TITLE
Rename aggregation modules, GroupColumn

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/column.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/column.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::aggregates::group_values::group_value_row::{
-    ArrayRowEq, ByteGroupValueBuilder, PrimitiveGroupValueBuilder,
+use crate::aggregates::group_values::group_column::{
+    ByteGroupValueBuilder, GroupColumn, PrimitiveGroupValueBuilder,
 };
 use crate::aggregates::group_values::GroupValues;
 use ahash::RandomState;
@@ -57,7 +57,7 @@ pub struct GroupValuesColumn {
     /// The actual group by values, stored column-wise. Compare from
     /// the left to right, each column is stored as `ArrayRowEq`.
     /// This is shown faster than the row format
-    group_values: Vec<Box<dyn ArrayRowEq>>,
+    group_values: Vec<Box<dyn GroupColumn>>,
 
     /// reused buffer to store hashes
     hashes_buffer: Vec<u64>,
@@ -180,7 +180,7 @@ impl GroupValues for GroupValuesColumn {
                 }
 
                 fn check_row_equal(
-                    array_row: &dyn ArrayRowEq,
+                    array_row: &dyn GroupColumn,
                     lhs_row: usize,
                     array: &ArrayRef,
                     rhs_row: usize,

--- a/datafusion/physical-plan/src/aggregates/group_values/group_column.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/group_column.rs
@@ -43,7 +43,7 @@ use datafusion_physical_expr_common::binary_map::{OutputType, INITIAL_BUFFER_CAP
 /// (similar to various builders in Arrow-rs) that allow for quick comparison to
 /// incoming rows.
 ///
-pub trait ArrayRowEq: Send + Sync {
+pub trait GroupColumn: Send + Sync {
     /// Returns equal if the row stored in this builder at `lhs_row` is equal to
     /// the row in `array` at `rhs_row`
     fn equal_to(&self, lhs_row: usize, array: &ArrayRef, rhs_row: usize) -> bool;
@@ -51,7 +51,7 @@ pub trait ArrayRowEq: Send + Sync {
     fn append_val(&mut self, array: &ArrayRef, row: usize);
     /// Returns the number of rows stored in this builder
     fn len(&self) -> usize;
-    /// Returns the number of bytes used by this [`ArrayRowEq`]
+    /// Returns the number of bytes used by this [`GroupColumn`]
     fn size(&self) -> usize;
     /// Builds a new array from all of the stored rows
     fn build(self: Box<Self>) -> ArrayRef;
@@ -82,7 +82,7 @@ where
     }
 }
 
-impl<T: ArrowPrimitiveType> ArrayRowEq for PrimitiveGroupValueBuilder<T> {
+impl<T: ArrowPrimitiveType> GroupColumn for PrimitiveGroupValueBuilder<T> {
     fn equal_to(&self, lhs_row: usize, array: &ArrayRef, rhs_row: usize) -> bool {
         // non-null fast path
         // both non-null
@@ -225,7 +225,7 @@ where
     }
 }
 
-impl<O> ArrayRowEq for ByteGroupValueBuilder<O>
+impl<O> GroupColumn for ByteGroupValueBuilder<O>
 where
     O: OffsetSizeTrait,
 {
@@ -407,7 +407,7 @@ mod tests {
     use arrow_array::{ArrayRef, StringArray};
     use datafusion_physical_expr::binary_map::OutputType;
 
-    use super::{ArrayRowEq, ByteGroupValueBuilder};
+    use super::{ByteGroupValueBuilder, GroupColumn};
 
     #[test]
     fn test_take_n() {

--- a/datafusion/physical-plan/src/aggregates/group_values/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/mod.rs
@@ -25,9 +25,9 @@ pub(crate) mod primitive;
 use datafusion_expr::EmitTo;
 use primitive::GroupValuesPrimitive;
 
-mod column_wise;
+mod column;
 mod row;
-use column_wise::GroupValuesColumn;
+use column::GroupValuesColumn;
 use row::GroupValuesRows;
 
 mod bytes;
@@ -35,7 +35,7 @@ mod bytes_view;
 use bytes::GroupValuesByes;
 use datafusion_physical_expr::binary_map::OutputType;
 
-mod group_value_row;
+mod group_column;
 
 /// An interning store for group keys
 pub trait GroupValues: Send {


### PR DESCRIPTION
## Which issue does this PR close?
Follow on to https://github.com/apache/datafusion/pull/12269 from @jayzhan211


## Rationale for this change


As I was reviewing the code, the names of the modules don't quite match their contents and aren't consistent with `row.rs`, so I would like to fix that as we begin to work on this code more

Changes:

## What changes are included in this PR?
1. rename modules to match contents and reflect structure.
2. rename `ArrowRowEq` to `GroupColumn` as I think that better reflects what the trait does

## Are these changes tested?
CI tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
