### PR TITLE
Require `Debug` for `PhysicalOptimizerRule`

### DIFF
--- a/datafusion/core/src/physical_optimizer/coalesce_batches.rs
+++ b/datafusion/core/src/physical_optimizer/coalesce_batches.rs
@@ -34,7 +34,7 @@ use datafusion_physical_optimizer::PhysicalOptimizerRule;
 
 /// Optimizer rule that introduces CoalesceBatchesExec to avoid overhead with small batches that
 /// are produced by highly selective filters
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct CoalesceBatches {}
 
 impl CoalesceBatches {

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -176,7 +176,7 @@ use itertools::izip;
 ///
 /// This rule only chooses the exact match and satisfies the Distribution(a, b, c)
 /// by a HashPartition(a, b, c).
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct EnforceDistribution {}
 
 impl EnforceDistribution {

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -298,7 +298,7 @@ fn adjust_input_keys_ordering(
                         right.clone(),
                         new_conditions.0,
                         filter.clone(),
-                        &join_type,
+                        join_type,
                         // TODO: although projection is not used in the join here, because projection pushdown is after enforce_distribution. Maybe we need to handle it later. Same as filter.
                         projection.clone(),
                         PartitionMode::Partitioned,

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -298,7 +298,7 @@ fn adjust_input_keys_ordering(
                         right.clone(),
                         new_conditions.0,
                         filter.clone(),
-                        join_type,
+                        &join_type,
                         // TODO: although projection is not used in the join here, because projection pushdown is after enforce_distribution. Maybe we need to handle it later. Same as filter.
                         projection.clone(),
                         PartitionMode::Partitioned,

--- a/datafusion/core/src/physical_optimizer/enforce_sorting.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_sorting.rs
@@ -72,7 +72,7 @@ use itertools::izip;
 
 /// This rule inspects [`SortExec`]'s in the given physical plan and removes the
 /// ones it can prove unnecessary.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct EnforceSorting {}
 
 impl EnforceSorting {

--- a/datafusion/core/src/physical_optimizer/join_selection.rs
+++ b/datafusion/core/src/physical_optimizer/join_selection.rs
@@ -46,7 +46,7 @@ use datafusion_physical_optimizer::PhysicalOptimizerRule;
 /// The [`JoinSelection`] rule tries to modify a given plan so that it can
 /// accommodate infinite sources and optimize joins in the plan according to
 /// available statistical information, if there is any.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct JoinSelection {}
 
 impl JoinSelection {

--- a/datafusion/core/src/physical_optimizer/optimizer.rs
+++ b/datafusion/core/src/physical_optimizer/optimizer.rs
@@ -35,7 +35,7 @@ use crate::physical_optimizer::sanity_checker::SanityCheckPlan;
 use crate::physical_optimizer::topk_aggregation::TopKAggregation;
 
 /// A rule-based physical optimizer.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PhysicalOptimizer {
     /// All rules to apply
     pub rules: Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>>,

--- a/datafusion/core/src/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/projection_pushdown.rs
@@ -60,7 +60,7 @@ use itertools::Itertools;
 
 /// This rule inspects [`ProjectionExec`]'s in the given physical plan and tries to
 /// remove or swap with its child.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ProjectionPushdown {}
 
 impl ProjectionPushdown {

--- a/datafusion/core/src/physical_optimizer/sanity_checker.rs
+++ b/datafusion/core/src/physical_optimizer/sanity_checker.rs
@@ -41,7 +41,7 @@ use itertools::izip;
 ///    are not satisfied by their children.
 /// 2. Plans that use pipeline-breaking operators on infinite input(s),
 ///    it is impossible to execute such queries (they will never generate output nor finish)
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SanityCheckPlan {}
 
 impl SanityCheckPlan {

--- a/datafusion/core/src/physical_optimizer/update_aggr_exprs.rs
+++ b/datafusion/core/src/physical_optimizer/update_aggr_exprs.rs
@@ -48,7 +48,7 @@ use datafusion_physical_plan::{
 /// This rule analyzes aggregate expressions of type `Beneficial` to see whether
 /// their input ordering requirements are satisfied. If this is the case, the
 /// aggregators are modified to run in a more efficient mode.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct OptimizeAggregateOrder {}
 
 impl OptimizeAggregateOrder {

--- a/datafusion/physical-optimizer/src/aggregate_statistics.rs
+++ b/datafusion/physical-optimizer/src/aggregate_statistics.rs
@@ -33,7 +33,7 @@ use datafusion_physical_plan::placeholder_row::PlaceholderRowExec;
 use datafusion_physical_plan::udaf::AggregateFunctionExpr;
 
 /// Optimizer that uses available statistics for aggregate functions
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AggregateStatistics {}
 
 impl AggregateStatistics {

--- a/datafusion/physical-optimizer/src/combine_partial_final_agg.rs
+++ b/datafusion/physical-optimizer/src/combine_partial_final_agg.rs
@@ -37,7 +37,7 @@ use datafusion_physical_expr::{physical_exprs_equal, PhysicalExpr};
 ///
 /// This rule should be applied after the EnforceDistribution and EnforceSorting rules
 ///
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct CombinePartialFinalAggregate {}
 
 impl CombinePartialFinalAggregate {

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -33,7 +33,7 @@ use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 
 /// This rule inspects [`ExecutionPlan`]'s and pushes down the fetch limit from
 /// the parent to the child if applicable.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct LimitPushdown {}
 
 /// This is a "data class" we use within the [`LimitPushdown`] rule to push

--- a/datafusion/physical-optimizer/src/limited_distinct_aggregation.rs
+++ b/datafusion/physical-optimizer/src/limited_distinct_aggregation.rs
@@ -35,6 +35,7 @@ use itertools::Itertools;
 /// rows in the group to be processed for correctness. Example queries fitting this description are:
 /// - `SELECT distinct l_orderkey FROM lineitem LIMIT 10;`
 /// - `SELECT l_orderkey FROM lineitem GROUP BY l_orderkey LIMIT 10;`
+#[derive(Debug)]
 pub struct LimitedDistinctAggregation {}
 
 impl LimitedDistinctAggregation {

--- a/datafusion/physical-optimizer/src/optimizer.rs
+++ b/datafusion/physical-optimizer/src/optimizer.rs
@@ -20,6 +20,7 @@
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::Result;
 use datafusion_physical_plan::ExecutionPlan;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 /// `PhysicalOptimizerRule` transforms one ['ExecutionPlan'] into another which
@@ -29,7 +30,7 @@ use std::sync::Arc;
 /// `PhysicalOptimizerRule`s.
 ///
 /// [`SessionState::add_physical_optimizer_rule`]: https://docs.rs/datafusion/latest/datafusion/execution/session_state/struct.SessionState.html#method.add_physical_optimizer_rule
-pub trait PhysicalOptimizerRule {
+pub trait PhysicalOptimizerRule: Debug {
     /// Rewrite `plan` to an optimized form
     fn optimize(
         &self,

--- a/datafusion/physical-optimizer/src/topk_aggregation.rs
+++ b/datafusion/physical-optimizer/src/topk_aggregation.rs
@@ -37,6 +37,7 @@ use crate::PhysicalOptimizerRule;
 use itertools::Itertools;
 
 /// An optimizer rule that passes a `limit` hint to aggregations if the whole result is not needed
+#[derive(Debug)]
 pub struct TopKAggregation {}
 
 impl TopKAggregation {


### PR DESCRIPTION
## Which issue does this PR close?
Part of #12555 

## Rationale for this change
Supporting [SessionStateBuilder](https://docs.rs/datafusion/latest/datafusion/execution/session_state/struct.SessionStateBuilder.html) to implement Debug
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
1. Require `Debug` for PhysicalOptimizerRule
2. `#derive` Debug where necessary
~~3. Add a `&` to take a `&JoinType` in `EnforceDistribution` (not sure why this wasn't a `cargo check` error but rust-analyzer showed it and types seem to require it)~~

## Are these changes tested?

By CI and the compiler

## Are there any user-facing changes?

API change for `PhysicalOptimizerRule` which now requires Debug