### PR TITLE
Compare schema as logically equivalent to workaround disappearing metadata

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -69,7 +69,7 @@ use arrow_array::RecordBatch;
 use datafusion_common::display::ToStringifiedPlan;
 use datafusion_common::{
     exec_err, internal_datafusion_err, internal_err, not_impl_err, plan_err, DFSchema,
-    ScalarValue,
+    ScalarValue, SchemaExt,
 };
 use datafusion_expr::dml::CopyTo;
 use datafusion_expr::expr::{
@@ -673,7 +673,9 @@ impl DefaultPhysicalPlanner {
                 let physical_input_schema_from_logical: Arc<Schema> =
                     logical_input_schema.as_ref().clone().into();
 
-                if physical_input_schema != physical_input_schema_from_logical {
+                if !physical_input_schema.logically_equivalent_names_and_types(
+                    &physical_input_schema_from_logical,
+                ) {
                     return internal_err!("Physical input schema should be the same as the one converted from logical input schema.");
                 }
 


### PR DESCRIPTION
## Which issue does this PR close?

This works around some problems noted in #12560. It is not a full fix, but just unblocks some other work for me.

## Rationale for this change

This check that is being done (which I am changing) only exists to make sure the schema are logically equivalent - if they are different in the metadata of the fields that they contain, that doesn't affect how they are used later on. So it's more 'correct' to just compare them logically as opposed to fully. Comparing them fully does have the benefit of catching issues with lossy transformations between schema (which is probably what is happening in my case to lose the metadata that I mentioned in #12560), but I think that's a benefit that we can get again once we've figured out where metadata is disappearing.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No