### PR TITLE
Add binary_view to string_view coercion

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1052,12 +1052,16 @@ fn binary_to_string_coercion(
     match (lhs_type, rhs_type) {
         (Binary, Utf8) => Some(Utf8),
         (Binary, LargeUtf8) => Some(LargeUtf8),
+        (BinaryView, Utf8) => Some(Utf8View),
+        (BinaryView, LargeUtf8) => Some(LargeUtf8),
         (LargeBinary, Utf8) => Some(LargeUtf8),
         (LargeBinary, LargeUtf8) => Some(LargeUtf8),
         (Utf8, Binary) => Some(Utf8),
         (Utf8, LargeBinary) => Some(LargeUtf8),
+        (Utf8, BinaryView) => Some(Utf8View),
         (LargeUtf8, Binary) => Some(LargeUtf8),
         (LargeUtf8, LargeBinary) => Some(LargeUtf8),
+        (LargeUtf8, BinaryView) => Some(LargeUtf8),
         _ => None,
     }
 }

--- a/datafusion/sqllogictest/test_files/binary_view.slt
+++ b/datafusion/sqllogictest/test_files/binary_view.slt
@@ -200,3 +200,18 @@ NULL R NULL NULL NULL NULL
 
 statement ok
 drop table test;
+
+statement ok
+create table bv as values 
+(
+  arrow_cast('one', 'BinaryView'), 
+  arrow_cast('two', 'BinaryView')
+);
+
+query B
+select column1 like 'o%' from bv;
+----
+true
+
+statement ok
+drop table bv;


### PR DESCRIPTION
## Which issue does this PR close?
Closes #12500

## Rationale for this change
a step forward to enable reading StringViewArray by default from Parquet 

## What changes are included in this PR?
add binary_view to  string_view coercion

## Are these changes tested?
yes , add a slt test case 

I also test manually 
change `benchmarks/src/clickbench.rs` , make **force_view_types = true**

```rust
config
    .options_mut()
    .execution
    .parquet
    .schema_force_view_types = true
```

```sh 
cargo build 


cargo run --bin dfbench -- clickbench --iterations 1  \
--path data/hits_partitioned \
--queries-path queries/clickbench/queries.sql  \
-o ./clickbench_partitioned.json
``` 

all 43 query completed.

## Are there any user-facing changes?
No, since force_view_type default is still false. 
 