### PR TITLE
Keep original SQL for CreateExternalTable

### DIFF
--- a/datafusion-cli/src/helper.rs
+++ b/datafusion-cli/src/helper.rs
@@ -133,7 +133,7 @@ fn is_open_quote_for_location(line: &str, pos: usize) -> bool {
     let mut sql = line[..pos].to_string();
     sql.push('\'');
     if let Ok(stmts) = DFParser::parse_sql(&sql) {
-        if let Some(Statement::CreateExternalTable(_)) = stmts.back() {
+        if let Some(Statement::CreateExternalTable(_, _)) = stmts.back() {
             return true;
         }
     }

--- a/datafusion/core/src/catalog_common/mod.rs
+++ b/datafusion/core/src/catalog_common/mod.rs
@@ -184,7 +184,7 @@ pub fn resolve_table_references(
             DFStatement::Statement(s) => {
                 let _ = s.as_ref().visit(visitor);
             }
-            DFStatement::CreateExternalTable(table) => {
+            DFStatement::CreateExternalTable(table, _) => {
                 visitor
                     .relations
                     .insert(ObjectName(vec![Ident::from(table.name.as_str())]));

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -162,7 +162,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Generate a logical plan from an DataFusion SQL statement
     pub fn statement_to_plan(&self, statement: DFStatement) -> Result<LogicalPlan> {
         match statement {
-            DFStatement::CreateExternalTable(s) => self.external_table_to_plan(s),
+            DFStatement::CreateExternalTable(stmt, sql) => {
+                self.external_table_to_plan(stmt, sql)
+            }
             DFStatement::Statement(s) => self.sql_statement_to_plan(*s),
             DFStatement::CopyTo(s) => self.copy_to_plan(s),
             DFStatement::Explain(ExplainStatement {
@@ -1189,8 +1191,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     fn external_table_to_plan(
         &self,
         statement: CreateExternalTable,
+        sql: Option<String>,
     ) -> Result<LogicalPlan> {
-        let definition = Some(statement.to_string());
+        let definition = sql.or(Some(statement.to_string()));
         let CreateExternalTable {
             name,
             columns,


### PR DESCRIPTION
Currently, the CreateExternalTable::definition field is just a stringfied version of the statement. Its slightly awkward to have the definition not be the same as what a user provided.

## Which issue does this PR close?

Closes #12652

## Rationale for this change

The CreateExternalTable::definition field isn't the same as what was provided to the SQL parser.

## What changes are included in this PR?

This is a first draft at updating the CreateExternalTable::definition value to reflect what was provided.

Heads up, if folks are generally on board with the motivation here, I'm pretty sure we'll want to move the "render SQL between these two token indices" logic to live in the sqlparser crate. Here I've just implemented a less than optimal approach directly in `DFParser` to sketch out that the idea is vaguely possible. If folks are on board with this, I'd be more than happy to split that out and provide a proper implementation in the sqlparser crate that this change could then use.

## Are these changes tested?

Yes-ish. I've updated the sql parser tests to match. Though there are tests in other parts of the project that are now failing after the change that I've not investigated. I'll obviously go chase down all those loose ends if/when there's consensus that this change is wanted at all.

## Are there any user-facing changes?

Yes, though I expect a few requests for changes as I just wrote enough to show that it could work before polishing up into a complete PR.

* `datafusion_sql::parser::Statement::CreateExternalTable` now has an `Option<String>` element.

I'm assuming the public enum change warrants the API change label, so I'll add that. 
