### PR TITLE
[MINOR]:  Use take_arrays in repartition 

### DIFF
--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -1001,7 +1001,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_arrayref_at_indices() -> Result<()> {
+    fn test_take_arrays() -> Result<()> {
         let arrays: Vec<ArrayRef> = vec![
             Arc::new(Float64Array::from(vec![5.0, 7.0, 8.0, 9., 10.])),
             Arc::new(Float64Array::from(vec![2.0, 3.0, 3.0, 4.0, 5.0])),

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -41,7 +41,7 @@ use crate::{DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, Stat
 use arrow::datatypes::{SchemaRef, UInt32Type};
 use arrow::record_batch::RecordBatch;
 use arrow_array::{PrimitiveArray, RecordBatchOptions};
-use datafusion_common::utils::{get_arrayref_at_indices, transpose};
+use datafusion_common::utils::{take_arrays, transpose};
 use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_common_runtime::SpawnedTask;
 use datafusion_execution::memory_pool::MemoryConsumer;
@@ -300,7 +300,7 @@ impl BatchPartitioner {
 
                             // Produce batches based on indices
                             let columns =
-                                get_arrayref_at_indices(batch.columns(), &indices)?;
+                                take_arrays(batch.columns(), &indices)?;
 
                             let mut options = RecordBatchOptions::new();
                             options = options.with_row_count(Some(indices.len()));

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -299,8 +299,7 @@ impl BatchPartitioner {
                             let _timer = partitioner_timer.timer();
 
                             // Produce batches based on indices
-                            let columns =
-                                take_arrays(batch.columns(), &indices)?;
+                            let columns = take_arrays(batch.columns(), &indices)?;
 
                             let mut options = RecordBatchOptions::new();
                             options = options.with_row_count(Some(indices.len()));


### PR DESCRIPTION
## Which issue does this PR close?
Follow #12654 

gently ping @comphead @akurmustafa 

## Rationale for this change
`get_arrayref_at_indices` is no longer exist.

## What changes are included in this PR?
No

## Are these changes tested?
I encountered a compile error on the current main branch. After renaming `get_arrayref_at_indices`, Cargo was able to compile the code for me.

## Are there any user-facing changes?
No