### PR TITLE
Possible reproducer of schema metadata bug.

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -861,7 +861,10 @@ impl TryFrom<SchemaRef> for DFSchema {
 
 impl From<DFSchema> for SchemaRef {
     fn from(df_schema: DFSchema) -> Self {
-        SchemaRef::new(df_schema.into())
+        Arc::new(Schema::new_with_metadata(
+            df_schema.fields().to_owned(),
+            HashMap::new(),
+        ))
     }
 }
 

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -31,18 +31,14 @@ select * from table_with_metadata;
 NULL bar
 3 baz
 
-query I rowsort
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
 SELECT (
   SELECT id FROM table_with_metadata
   ) UNION (
   SELECT id FROM table_with_metadata
   );
-----
-1
-3
-NULL
 
-query I rowsort
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
 SELECT "data"."id"
 FROM
   (
@@ -54,9 +50,6 @@ FROM
     SELECT "id" FROM "table_with_metadata"
   ) as "samples"
 WHERE "data"."id" = "samples"."id";
-----
-1
-3
 
 statement ok
 drop table table_with_metadata;


### PR DESCRIPTION
## Which issue does this PR close?

Related to #12560 

## Rationale for this change

A [PR merged](https://github.com/apache/datafusion/pull/11989) (and released in 42.0.0) has [added a check](https://github.com/apache/datafusion/blob/322d83526909ab44cfbe34b982d1a1c36a4dbe8f/datafusion/core/src/physical_planner.rs#L676) that the logical and physical plan input schemas (to an aggregate node) are the same.

Once released into the wild, it began being triggered. One [example case](https://github.com/apache/datafusion/blob/322d83526909ab44cfbe34b982d1a1c36a4dbe8f/datafusion/core/src/physical_planner.rs#L676) is where field metadata is in the logical plan, but missing from the physical plan.

I haven't yet re-created that exact reproducer. However, I ended up creating the inverse case -- where the metadata is in the physical plan, but missing from the logical plan.

## What changes are included in this PR?

First commit: changed the [From DFSchema for SchemaRef](https://github.com/apache/datafusion/blob/84e9ce8ebf27c376c43b9eddf6b6bbb282426731/datafusion/common/src/dfschema.rs#L862), so it stops dropping the metadata.

Second commit: demonstrate that test cases (where metadata is on the data) end up failing due to the same error as in #12560.

## Are these changes tested?


## Are there any user-facing changes?


