### PR TITLE
Adds `WindowUDFImpl::reverse_expr`trait method + Support for `IGNORE NULLS`

### DIFF
--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -92,7 +92,7 @@ pub use sqlparser;
 pub use table_source::{TableProviderFilterPushDown, TableSource, TableType};
 pub use udaf::{AggregateUDF, AggregateUDFImpl, ReversedUDAF};
 pub use udf::{ScalarUDF, ScalarUDFImpl};
-pub use udwf::{WindowUDF, WindowUDFImpl};
+pub use udwf::{ReversedUDWF, WindowUDF, WindowUDFImpl};
 pub use window_frame::{WindowFrame, WindowFrameBound, WindowFrameUnits};
 
 #[cfg(test)]

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -172,6 +172,10 @@ impl WindowUDF {
     pub fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         self.inner.coerce_types(arg_types)
     }
+
+    pub fn reverse_expr(&self) -> ReversedUDWF {
+        self.inner.reverse_expr()
+    }
 }
 
 impl<F> From<F> for WindowUDF
@@ -351,6 +355,16 @@ pub trait WindowUDFImpl: Debug + Send + Sync {
     fn coerce_types(&self, _arg_types: &[DataType]) -> Result<Vec<DataType>> {
         not_impl_err!("Function {} does not implement coerce_types", self.name())
     }
+
+    fn reverse_expr(&self) -> ReversedUDWF {
+        ReversedUDWF::NotSupported
+    }
+}
+
+pub enum ReversedUDWF {
+    Identical,
+    NotSupported,
+    Reversed(Arc<WindowUDF>),
 }
 
 impl PartialEq for dyn WindowUDFImpl {

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -173,6 +173,10 @@ impl WindowUDF {
         self.inner.coerce_types(arg_types)
     }
 
+    /// Returns the reversed user-defined window function when the
+    /// order of the computation is reversed.
+    ///
+    /// See [`WindowUDFImpl::reverse_expr`] for more details.
     pub fn reverse_expr(&self) -> ReversedUDWF {
         self.inner.reverse_expr()
     }
@@ -356,14 +360,22 @@ pub trait WindowUDFImpl: Debug + Send + Sync {
         not_impl_err!("Function {} does not implement coerce_types", self.name())
     }
 
+    /// Allows customizing the behavior of the user-defined window
+    /// function when it is evaluated in reverse order.
     fn reverse_expr(&self) -> ReversedUDWF {
         ReversedUDWF::NotSupported
     }
 }
 
 pub enum ReversedUDWF {
+    /// The result of evaluating the user-defined window function
+    /// remains identical when reversed.
     Identical,
+    /// A window function which does not support evaluating the result
+    /// in reverse order.
     NotSupported,
+    /// Customize the user-defined window function for evaluating the
+    /// result in reverse order.
     Reversed(Arc<WindowUDF>),
 }
 

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -174,7 +174,7 @@ impl WindowUDF {
     }
 
     /// Returns the reversed user-defined window function when the
-    /// order of the computation is reversed.
+    /// order of evaluation is reversed.
     ///
     /// See [`WindowUDFImpl::reverse_expr`] for more details.
     pub fn reverse_expr(&self) -> ReversedUDWF {

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -356,7 +356,11 @@ struct WindowUDFExpr {
     name: String,
     /// Types of input expressions
     input_types: Vec<DataType>,
+    /// This is set to `true` only if the user-defined window function
+    /// expression supports evaluation in reverse order, and the
+    /// evaluation order is reversed.
     is_reversed: bool,
+    /// Set to `true` if `IGNORE NULLS` is defined, `false` otherwise.
     ignore_nulls: bool,
 }
 

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -130,7 +130,7 @@ pub fn create_window_expr(
         }
         // TODO: Ordering not supported for Window UDFs yet
         WindowFunctionDefinition::WindowUDF(fun) => Arc::new(BuiltInWindowExpr::new(
-            create_udwf_window_expr(fun, args, input_schema, name)?,
+            create_udwf_window_expr(fun, args, input_schema, name, ignore_nulls)?,
             partition_by,
             order_by,
             window_frame,
@@ -329,6 +329,7 @@ fn create_udwf_window_expr(
     args: &[Arc<dyn PhysicalExpr>],
     input_schema: &Schema,
     name: String,
+    ignore_nulls: bool,
 ) -> Result<Arc<dyn BuiltInWindowFunctionExpr>> {
     // need to get the types into an owned vec for some reason
     let input_types: Vec<_> = args
@@ -342,6 +343,7 @@ fn create_udwf_window_expr(
         input_types,
         name,
         is_reversed: false,
+        ignore_nulls,
     }))
 }
 
@@ -355,6 +357,7 @@ struct WindowUDFExpr {
     /// Types of input expressions
     input_types: Vec<DataType>,
     is_reversed: bool,
+    ignore_nulls: bool,
 }
 
 impl BuiltInWindowFunctionExpr for WindowUDFExpr {
@@ -389,6 +392,7 @@ impl BuiltInWindowFunctionExpr for WindowUDFExpr {
                 name: self.name.clone(),
                 input_types: self.input_types.clone(),
                 is_reversed: !self.is_reversed,
+                ignore_nulls: self.ignore_nulls,
             })),
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Part of #8709.
Closes #12661.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

1. So that a user-defined window function can customize the implementation for evaluating results in reverse order, allowing the optimizer to avoid sorting the data.
 2. Check if `IGNORE NULLS` is set.
 3. Easier to review a smaller diff compared to a PR converting an existing built-in window function.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Extends `WindowUDFExpr` with two new state fields for tracking if a window expression is reversed, and if `IGNORE NULLS` is used in the query.
```rust
/// Implements [`BuiltInWindowFunctionExpr`] for [`WindowUDF`]
#[derive(Clone, Debug)]
struct WindowUDFExpr {
    ...,
    /// This is set to `true` only if the user-defined window function
    /// expression supports evaluation in reverse order, and the
    /// evaluation order is reversed.
    is_reversed: bool,
    /// Set to `true` if `IGNORE NULLS` is defined, `false` otherwise.
    ignore_nulls: bool,
}
```
2. Adds a new trait method `WindowUDFImpl::reverse_expr` with a default implementation.
```rust
pub trait WindowUDFImpl: Debug + Send + Sync {

    /// Allows customizing the behavior of the user-defined window
    /// function when it is evaluated in reverse order.
    fn reverse_expr(&self) -> ReversedUDWF {
        ReversedUDWF::NotSupported
    }
}

pub enum ReversedUDWF {
    /// The result of evaluating the user-defined window function
    /// remains identical when reversed.
    Identical,
    /// A window function which does not support evaluating the result
    /// in reverse order.
    NotSupported,
    /// Customize the user-defined window function for evaluating the
    /// result in reverse order.
    Reversed(Arc<WindowUDF>),
}
```
3. Thread `ignore_nulls` when creating user-defined window expressions.
```rust
fn create_udwf_window_expr(
    fun: &Arc<WindowUDF>,
    args: &[Arc<dyn PhysicalExpr>],
    input_schema: &Schema,
    name: String,
    ignore_nulls: bool,  // <-- here
) -> Result<Arc<dyn BuiltInWindowFunctionExpr>> {
   ...
}
```
## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

~~Yes, against existing tests in CI.~~
No.

When built-in functions like `lead`, `lag`, `nth_value` etc. are converted, this API will get tested by existing sqllogictests.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes, this is a breaking API change: `WindowUDFImpl::reverse_expr`