### PR TITLE
handle 0 and NULL value of NTH_VALUE function

### DIFF
--- a/datafusion/physical-expr/src/window/nth_value.rs
+++ b/datafusion/physical-expr/src/window/nth_value.rs
@@ -30,7 +30,7 @@ use crate::PhysicalExpr;
 use arrow::array::{Array, ArrayRef};
 use arrow::datatypes::{DataType, Field};
 use datafusion_common::Result;
-use datafusion_common::{exec_err, ScalarValue};
+use datafusion_common::ScalarValue;
 use datafusion_expr::window_state::WindowAggState;
 use datafusion_expr::PartitionEvaluator;
 
@@ -86,16 +86,13 @@ impl NthValue {
         n: i64,
         ignore_nulls: bool,
     ) -> Result<Self> {
-        match n {
-            0 => exec_err!("NTH_VALUE expects n to be non-zero"),
-            _ => Ok(Self {
-                name: name.into(),
-                expr,
-                data_type,
-                kind: NthValueKind::Nth(n),
-                ignore_nulls,
-            }),
-        }
+        Ok(Self {
+            name: name.into(),
+            expr,
+            data_type,
+            kind: NthValueKind::Nth(n),
+            ignore_nulls,
+        })
     }
 
     /// Get the NTH_VALUE kind
@@ -188,10 +185,7 @@ impl PartitionEvaluator for NthValueEvaluator {
                         // Negative index represents reverse direction.
                         (n_range >= reverse_index, true)
                     }
-                    Ordering::Equal => {
-                        // The case n = 0 is not valid for the NTH_VALUE function.
-                        unreachable!();
-                    }
+                    Ordering::Equal => (true, false),
                 }
             }
         };
@@ -298,10 +292,7 @@ impl PartitionEvaluator for NthValueEvaluator {
                                 )
                             }
                         }
-                        Ordering::Equal => {
-                            // The case n = 0 is not valid for the NTH_VALUE function.
-                            unreachable!();
-                        }
+                        Ordering::Equal => ScalarValue::try_from(arr.data_type()),
                     }
                 }
             }

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -190,7 +190,7 @@ fn get_signed_integer(value: ScalarValue) -> Result<i64> {
     }
 
     if !value.data_type().is_integer() {
-        return exec_err!("Expected an integer value")
+        return exec_err!("Expected an integer value");
     }
 
     value.cast_to(&DataType::Int64)?.try_into()

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -185,20 +185,30 @@ fn get_scalar_value_from_args(
 }
 
 fn get_signed_integer(value: ScalarValue) -> Result<i64> {
+    if value.is_null() {
+        return Ok(0);
+    }
+
     if !value.data_type().is_integer() {
         return Err(DataFusionError::Execution(
             "Expected an integer value".to_string(),
         ));
     }
+
     value.cast_to(&DataType::Int64)?.try_into()
 }
 
 fn get_unsigned_integer(value: ScalarValue) -> Result<u64> {
+    if value.is_null() {
+        return Ok(0);
+    }
+
     if !value.data_type().is_integer() {
         return Err(DataFusionError::Execution(
             "Expected an integer value".to_string(),
         ));
     }
+
     value.cast_to(&DataType::UInt64)?.try_into()
 }
 

--- a/datafusion/physical-plan/src/windows/mod.rs
+++ b/datafusion/physical-plan/src/windows/mod.rs
@@ -190,9 +190,7 @@ fn get_signed_integer(value: ScalarValue) -> Result<i64> {
     }
 
     if !value.data_type().is_integer() {
-        return Err(DataFusionError::Execution(
-            "Expected an integer value".to_string(),
-        ));
+        return exec_err!("Expected an integer value")
     }
 
     value.cast_to(&DataType::Int64)?.try_into()
@@ -204,9 +202,7 @@ fn get_unsigned_integer(value: ScalarValue) -> Result<u64> {
     }
 
     if !value.data_type().is_integer() {
-        return Err(DataFusionError::Execution(
-            "Expected an integer value".to_string(),
-        ));
+        return exec_err!("Expected an integer value");
     }
 
     value.cast_to(&DataType::UInt64)?.try_into()

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -4894,3 +4894,42 @@ NULL a4 5
 
 statement ok
 drop table t
+
+## test handle NULL and 0 value of nth_value
+statement ok
+CREATE TABLE t(v1 int, v2 int);
+
+statement ok
+INSERT INTO t VALUES (1,1), (1,2),(1,3),(2,1),(2,2);
+
+query II
+SELECT v1, NTH_VALUE(v2, null) OVER (PARTITION BY v1 ORDER BY v2) FROM t;
+----
+1 NULL
+1 NULL
+1 NULL
+2 NULL
+2 NULL
+
+query II
+SELECT v1, NTH_VALUE(v2, v2*null) OVER (PARTITION BY v1 ORDER BY v2) FROM t;
+----
+1 NULL
+1 NULL
+1 NULL
+2 NULL
+2 NULL
+
+query II
+SELECT v1, NTH_VALUE(v2, 0) OVER (PARTITION BY v1 ORDER BY v2) FROM t;
+----
+1 NULL
+1 NULL
+1 NULL
+2 NULL
+2 NULL
+
+statement ok
+DROP TABLE t;
+
+## end test handle NULL and 0 of NTH_VALUE


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12320.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The root cause in #12320 is because `get_signed_integer_value` will return an error on `NULL` or `Int64(NULL)` value. To process the `nth_value` function, it requires the `n` value should be an integer. Therefore, I decided to convert `NULL` value to 0 in `get_signed_integer_value` and implement handler for the `0` case. This will evaluate to NULL value for the `nth_value(v1, NULL)` expression.

Furthermore, it also evaluate the `nth_value(v1, 0)` to NULL instead of generating panic, which match the expected behaviour in duckdb.

## What changes are included in this PR?
[x] Return 0 for NULL value in `get_signed_integer`
[x] Handle nth_value execution when n is 0
[x] Test file updated to test `nth_value(v2, 0)`, `nth_value(v2, NULL)` and `nth_value(v2, v2 * NULL)`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
