### PR TITLE
Support `LIMIT` Push-down logical plan optimization for `Extension` nodes

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2557,6 +2557,10 @@ mod tests {
         ) -> Result<Self> {
             unimplemented!("NoOp");
         }
+
+        fn allows_limit_to_inputs(&self) -> bool {
+            false // Disallow limit push-down by default
+        }
     }
 
     #[derive(Debug)]

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2558,7 +2558,7 @@ mod tests {
             unimplemented!("NoOp");
         }
 
-        fn allows_limit_to_inputs(&self) -> bool {
+        fn supports_limit_pushdown(&self) -> bool {
             false // Disallow limit push-down by default
         }
     }

--- a/datafusion/core/tests/user_defined/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined/user_defined_plan.rs
@@ -443,6 +443,10 @@ impl UserDefinedLogicalNodeCore for TopKPlanNode {
             expr: replace_sort_expression(self.expr.clone(), exprs.swap_remove(0)),
         })
     }
+
+    fn allows_limit_to_inputs(&self) -> bool {
+        false // Disallow limit push-down by default
+    }
 }
 
 /// Physical planner for TopK nodes

--- a/datafusion/core/tests/user_defined/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined/user_defined_plan.rs
@@ -444,7 +444,7 @@ impl UserDefinedLogicalNodeCore for TopKPlanNode {
         })
     }
 
-    fn allows_limit_to_inputs(&self) -> bool {
+    fn supports_limit_pushdown(&self) -> bool {
         false // Disallow limit push-down by default
     }
 }

--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -196,9 +196,15 @@ pub trait UserDefinedLogicalNode: fmt::Debug + Send + Sync {
     fn dyn_eq(&self, other: &dyn UserDefinedLogicalNode) -> bool;
     fn dyn_ord(&self, other: &dyn UserDefinedLogicalNode) -> Option<Ordering>;
 
-    /// Indicates to the optimizer if its safe to push a limit down past
-    /// this extension node
-    fn allows_limit_to_inputs(&self) -> bool;
+    /// Returns `true` if a limit can be safely pushed down through this
+    /// `UserDefinedLogicalNode` node.
+    ///
+    /// If this method returns `true`, and the query plan contains a limit at
+    /// the output of this node, DataFusion will push the limit to the input
+    /// of this node.
+    fn supports_limit_pushdown(&self) -> bool {
+        false
+    }
 }
 
 impl Hash for dyn UserDefinedLogicalNode {
@@ -300,9 +306,15 @@ pub trait UserDefinedLogicalNodeCore:
         None
     }
 
-    /// Indicates to the optimizer if its safe to push a limit down past
-    /// this extension node
-    fn allows_limit_to_inputs(&self) -> bool;
+    /// Returns `true` if a limit can be safely pushed down through this
+    /// `UserDefinedLogicalNode` node.
+    ///
+    /// If this method returns `true`, and the query plan contains a limit at
+    /// the output of this node, DataFusion will push the limit to the input
+    /// of this node.
+    fn supports_limit_pushdown(&self) -> bool {
+        false // Disallow limit push-down by default
+    }
 }
 
 /// Automatically derive UserDefinedLogicalNode to `UserDefinedLogicalNode`
@@ -370,8 +382,8 @@ impl<T: UserDefinedLogicalNodeCore> UserDefinedLogicalNode for T {
             .and_then(|other| self.partial_cmp(other))
     }
 
-    fn allows_limit_to_inputs(&self) -> bool {
-        self.allows_limit_to_inputs()
+    fn supports_limit_pushdown(&self) -> bool {
+        self.supports_limit_pushdown()
     }
 }
 

--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -195,6 +195,10 @@ pub trait UserDefinedLogicalNode: fmt::Debug + Send + Sync {
     /// directly because it must remain object safe.
     fn dyn_eq(&self, other: &dyn UserDefinedLogicalNode) -> bool;
     fn dyn_ord(&self, other: &dyn UserDefinedLogicalNode) -> Option<Ordering>;
+
+    /// Indicates to the optimizer if its safe to push a limit down past
+    /// this extension node
+    fn allows_limit_to_inputs(&self) -> bool;
 }
 
 impl Hash for dyn UserDefinedLogicalNode {
@@ -295,6 +299,10 @@ pub trait UserDefinedLogicalNodeCore:
     ) -> Option<Vec<Vec<usize>>> {
         None
     }
+
+    /// Indicates to the optimizer if its safe to push a limit down past
+    /// this extension node
+    fn allows_limit_to_inputs(&self) -> bool;
 }
 
 /// Automatically derive UserDefinedLogicalNode to `UserDefinedLogicalNode`
@@ -360,6 +368,10 @@ impl<T: UserDefinedLogicalNodeCore> UserDefinedLogicalNode for T {
             .as_any()
             .downcast_ref::<Self>()
             .and_then(|other| self.partial_cmp(other))
+    }
+
+    fn allows_limit_to_inputs(&self) -> bool {
+        self.allows_limit_to_inputs()
     }
 }
 

--- a/datafusion/optimizer/src/analyzer/subquery.rs
+++ b/datafusion/optimizer/src/analyzer/subquery.rs
@@ -386,7 +386,7 @@ mod test {
             })
         }
 
-        fn allows_limit_to_inputs(&self) -> bool {
+        fn supports_limit_pushdown(&self) -> bool {
             false // Disallow limit push-down by default
         }
     }

--- a/datafusion/optimizer/src/analyzer/subquery.rs
+++ b/datafusion/optimizer/src/analyzer/subquery.rs
@@ -385,6 +385,10 @@ mod test {
                 empty_schema: Arc::clone(&self.empty_schema),
             })
         }
+
+        fn allows_limit_to_inputs(&self) -> bool {
+            false // Disallow limit push-down by default
+        }
     }
 
     #[test]

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -895,6 +895,10 @@ mod tests {
             // Since schema is same. Output columns requires their corresponding version in the input columns.
             Some(vec![output_columns.to_vec()])
         }
+
+        fn allows_limit_to_inputs(&self) -> bool {
+            false // Disallow limit push-down by default
+        }
     }
 
     #[derive(Debug, Hash, PartialEq, Eq)]
@@ -990,6 +994,10 @@ mod tests {
                 }
             }
             Some(vec![left_reqs, right_reqs])
+        }
+
+        fn allows_limit_to_inputs(&self) -> bool {
+            false // Disallow limit push-down by default
         }
     }
 

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -896,7 +896,7 @@ mod tests {
             Some(vec![output_columns.to_vec()])
         }
 
-        fn allows_limit_to_inputs(&self) -> bool {
+        fn supports_limit_pushdown(&self) -> bool {
             false // Disallow limit push-down by default
         }
     }
@@ -996,7 +996,7 @@ mod tests {
             Some(vec![left_reqs, right_reqs])
         }
 
-        fn allows_limit_to_inputs(&self) -> bool {
+        fn supports_limit_pushdown(&self) -> bool {
             false // Disallow limit push-down by default
         }
     }

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1499,6 +1499,9 @@ mod tests {
                 schema: Arc::clone(&self.schema),
             })
         }
+        fn allows_limit_to_inputs(&self) -> bool {
+            false // Disallow limit push-down by default
+        }
     }
 
     #[test]

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1499,6 +1499,7 @@ mod tests {
                 schema: Arc::clone(&self.schema),
             })
         }
+
         fn allows_limit_to_inputs(&self) -> bool {
             false // Disallow limit push-down by default
         }

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1500,7 +1500,7 @@ mod tests {
             })
         }
 
-        fn allows_limit_to_inputs(&self) -> bool {
+        fn supports_limit_pushdown(&self) -> bool {
             false // Disallow limit push-down by default
         }
     }

--- a/datafusion/optimizer/src/push_down_limit.rs
+++ b/datafusion/optimizer/src/push_down_limit.rs
@@ -153,6 +153,36 @@ impl OptimizerRule for PushDownLimit {
                 subquery_alias.input = Arc::new(new_limit);
                 Ok(Transformed::yes(LogicalPlan::SubqueryAlias(subquery_alias)))
             }
+            LogicalPlan::Extension(extension_plan) => {
+                if !extension_plan.node.allows_limit_to_inputs() {
+                    // If push down is not allowed, keep the original limit
+                    return original_limit(
+                        skip,
+                        fetch,
+                        LogicalPlan::Extension(extension_plan),
+                    );
+                }
+
+                let new_children = extension_plan
+                    .node
+                    .inputs()
+                    .into_iter()
+                    .map(|child| {
+                        LogicalPlan::Limit(Limit {
+                            skip: 0,
+                            fetch: Some(fetch + skip),
+                            input: Arc::new(child.clone()),
+                        })
+                    })
+                    .collect::<Vec<_>>();
+
+                // Create a new extension node with updated inputs
+                let child_plan = LogicalPlan::Extension(extension_plan);
+                let new_extension =
+                    child_plan.with_new_exprs(child_plan.expressions(), new_children)?;
+
+                transformed_limit(skip, fetch, new_extension)
+            }
             input => original_limit(skip, fetch, input),
         }
     }
@@ -258,15 +288,239 @@ fn push_down_join(mut join: Join, limit: usize) -> Transformed<Join> {
 
 #[cfg(test)]
 mod test {
+    use std::cmp::Ordering;
+    use std::fmt::{Debug, Formatter};
     use std::vec;
 
     use super::*;
     use crate::test::*;
-    use datafusion_expr::{col, exists, logical_plan::builder::LogicalPlanBuilder};
+
+    use datafusion_common::DFSchemaRef;
+    use datafusion_expr::{
+        col, exists, logical_plan::builder::LogicalPlanBuilder, Expr, Extension,
+        UserDefinedLogicalNodeCore,
+    };
     use datafusion_functions_aggregate::expr_fn::max;
 
     fn assert_optimized_plan_equal(plan: LogicalPlan, expected: &str) -> Result<()> {
         assert_optimized_plan_eq(Arc::new(PushDownLimit::new()), plan, expected)
+    }
+
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    pub struct NoopPlan {
+        input: Vec<LogicalPlan>,
+        schema: DFSchemaRef,
+    }
+
+    // Manual implementation needed because of `schema` field. Comparison excludes this field.
+    impl PartialOrd for NoopPlan {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            self.input.partial_cmp(&other.input)
+        }
+    }
+
+    impl UserDefinedLogicalNodeCore for NoopPlan {
+        fn name(&self) -> &str {
+            "NoopPlan"
+        }
+
+        fn inputs(&self) -> Vec<&LogicalPlan> {
+            self.input.iter().collect()
+        }
+
+        fn schema(&self) -> &DFSchemaRef {
+            &self.schema
+        }
+
+        fn expressions(&self) -> Vec<Expr> {
+            self.input
+                .iter()
+                .flat_map(|child| child.expressions())
+                .collect()
+        }
+
+        fn fmt_for_explain(&self, f: &mut Formatter) -> std::fmt::Result {
+            write!(f, "NoopPlan")
+        }
+
+        fn with_exprs_and_inputs(
+            &self,
+            _exprs: Vec<Expr>,
+            inputs: Vec<LogicalPlan>,
+        ) -> Result<Self> {
+            Ok(Self {
+                input: inputs,
+                schema: Arc::clone(&self.schema),
+            })
+        }
+
+        fn allows_limit_to_inputs(&self) -> bool {
+            true // Allow limit push-down
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct NoLimitNoopPlan {
+        input: Vec<LogicalPlan>,
+        schema: DFSchemaRef,
+    }
+
+    // Manual implementation needed because of `schema` field. Comparison excludes this field.
+    impl PartialOrd for NoLimitNoopPlan {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            self.input.partial_cmp(&other.input)
+        }
+    }
+
+    impl UserDefinedLogicalNodeCore for NoLimitNoopPlan {
+        fn name(&self) -> &str {
+            "NoLimitNoopPlan"
+        }
+
+        fn inputs(&self) -> Vec<&LogicalPlan> {
+            self.input.iter().collect()
+        }
+
+        fn schema(&self) -> &DFSchemaRef {
+            &self.schema
+        }
+
+        fn expressions(&self) -> Vec<Expr> {
+            self.input
+                .iter()
+                .flat_map(|child| child.expressions())
+                .collect()
+        }
+
+        fn fmt_for_explain(&self, f: &mut Formatter) -> std::fmt::Result {
+            write!(f, "NoLimitNoopPlan")
+        }
+
+        fn with_exprs_and_inputs(
+            &self,
+            _exprs: Vec<Expr>,
+            inputs: Vec<LogicalPlan>,
+        ) -> Result<Self> {
+            Ok(Self {
+                input: inputs,
+                schema: Arc::clone(&self.schema),
+            })
+        }
+
+        fn allows_limit_to_inputs(&self) -> bool {
+            false // Disallow limit push-down by default
+        }
+    }
+    #[test]
+    fn limit_pushdown_basic() -> Result<()> {
+        let table_scan = test_table_scan()?;
+        let noop_plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(NoopPlan {
+                input: vec![table_scan.clone()],
+                schema: Arc::clone(table_scan.schema()),
+            }),
+        });
+
+        let plan = LogicalPlanBuilder::from(noop_plan)
+            .limit(0, Some(1000))?
+            .build()?;
+
+        let expected = "Limit: skip=0, fetch=1000\
+        \n  NoopPlan\
+        \n    Limit: skip=0, fetch=1000\
+        \n      TableScan: test, fetch=1000";
+
+        assert_optimized_plan_equal(plan, expected)
+    }
+
+    #[test]
+    fn limit_pushdown_with_skip() -> Result<()> {
+        let table_scan = test_table_scan()?;
+        let noop_plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(NoopPlan {
+                input: vec![table_scan.clone()],
+                schema: Arc::clone(table_scan.schema()),
+            }),
+        });
+
+        let plan = LogicalPlanBuilder::from(noop_plan)
+            .limit(10, Some(1000))?
+            .build()?;
+
+        let expected = "Limit: skip=10, fetch=1000\
+        \n  NoopPlan\
+        \n    Limit: skip=0, fetch=1010\
+        \n      TableScan: test, fetch=1010";
+
+        assert_optimized_plan_equal(plan, expected)
+    }
+
+    #[test]
+    fn limit_pushdown_multiple_limits() -> Result<()> {
+        let table_scan = test_table_scan()?;
+        let noop_plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(NoopPlan {
+                input: vec![table_scan.clone()],
+                schema: Arc::clone(table_scan.schema()),
+            }),
+        });
+
+        let plan = LogicalPlanBuilder::from(noop_plan)
+            .limit(10, Some(1000))?
+            .limit(20, Some(500))?
+            .build()?;
+
+        let expected = "Limit: skip=30, fetch=500\
+        \n  NoopPlan\
+        \n    Limit: skip=0, fetch=530\
+        \n      TableScan: test, fetch=530";
+
+        assert_optimized_plan_equal(plan, expected)
+    }
+
+    #[test]
+    fn limit_pushdown_multiple_inputs() -> Result<()> {
+        let table_scan = test_table_scan()?;
+        let noop_plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(NoopPlan {
+                input: vec![table_scan.clone(), table_scan.clone()],
+                schema: Arc::clone(table_scan.schema()),
+            }),
+        });
+
+        let plan = LogicalPlanBuilder::from(noop_plan)
+            .limit(0, Some(1000))?
+            .build()?;
+
+        let expected = "Limit: skip=0, fetch=1000\
+        \n  NoopPlan\
+        \n    Limit: skip=0, fetch=1000\
+        \n      TableScan: test, fetch=1000\
+        \n    Limit: skip=0, fetch=1000\
+        \n      TableScan: test, fetch=1000";
+
+        assert_optimized_plan_equal(plan, expected)
+    }
+
+    #[test]
+    fn limit_pushdown_disallowed_noop_plan() -> Result<()> {
+        let table_scan = test_table_scan()?;
+        let no_limit_noop_plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(NoLimitNoopPlan {
+                input: vec![table_scan.clone()],
+                schema: Arc::clone(table_scan.schema()),
+            }),
+        });
+
+        let plan = LogicalPlanBuilder::from(no_limit_noop_plan)
+            .limit(0, Some(1000))?
+            .build()?;
+
+        let expected = "Limit: skip=0, fetch=1000\
+        \n  NoLimitNoopPlan\
+        \n    TableScan: test";
+
+        assert_optimized_plan_equal(plan, expected)
     }
 
     #[test]

--- a/datafusion/optimizer/src/push_down_limit.rs
+++ b/datafusion/optimizer/src/push_down_limit.rs
@@ -153,16 +153,15 @@ impl OptimizerRule for PushDownLimit {
                 subquery_alias.input = Arc::new(new_limit);
                 Ok(Transformed::yes(LogicalPlan::SubqueryAlias(subquery_alias)))
             }
-            LogicalPlan::Extension(extension_plan) => {
-                if !extension_plan.node.allows_limit_to_inputs() {
-                    // If push down is not allowed, keep the original limit
-                    return original_limit(
-                        skip,
-                        fetch,
-                        LogicalPlan::Extension(extension_plan),
-                    );
-                }
-
+            LogicalPlan::Extension(extension_plan)
+                if !extension_plan.node.allows_limit_to_inputs() =>
+            {
+                // If push down is not allowed, keep the original limit
+                original_limit(skip, fetch, LogicalPlan::Extension(extension_plan))
+            }
+            LogicalPlan::Extension(extension_plan)
+                if extension_plan.node.allows_limit_to_inputs() =>
+            {
                 let new_children = extension_plan
                     .node
                     .inputs()

--- a/datafusion/optimizer/src/push_down_limit.rs
+++ b/datafusion/optimizer/src/push_down_limit.rs
@@ -154,13 +154,7 @@ impl OptimizerRule for PushDownLimit {
                 Ok(Transformed::yes(LogicalPlan::SubqueryAlias(subquery_alias)))
             }
             LogicalPlan::Extension(extension_plan)
-                if !extension_plan.node.allows_limit_to_inputs() =>
-            {
-                // If push down is not allowed, keep the original limit
-                original_limit(skip, fetch, LogicalPlan::Extension(extension_plan))
-            }
-            LogicalPlan::Extension(extension_plan)
-                if extension_plan.node.allows_limit_to_inputs() =>
+                if extension_plan.node.supports_limit_pushdown() =>
             {
                 let new_children = extension_plan
                     .node
@@ -353,7 +347,7 @@ mod test {
             })
         }
 
-        fn allows_limit_to_inputs(&self) -> bool {
+        fn supports_limit_pushdown(&self) -> bool {
             true // Allow limit push-down
         }
     }
@@ -406,7 +400,7 @@ mod test {
             })
         }
 
-        fn allows_limit_to_inputs(&self) -> bool {
+        fn supports_limit_pushdown(&self) -> bool {
             false // Disallow limit push-down by default
         }
     }

--- a/datafusion/optimizer/src/test/user_defined.rs
+++ b/datafusion/optimizer/src/test/user_defined.rs
@@ -77,7 +77,7 @@ impl UserDefinedLogicalNodeCore for TestUserDefinedPlanNode {
         })
     }
 
-    fn allows_limit_to_inputs(&self) -> bool {
+    fn supports_limit_pushdown(&self) -> bool {
         false // Disallow limit push-down by default
     }
 }

--- a/datafusion/optimizer/src/test/user_defined.rs
+++ b/datafusion/optimizer/src/test/user_defined.rs
@@ -76,4 +76,8 @@ impl UserDefinedLogicalNodeCore for TestUserDefinedPlanNode {
             input: inputs.swap_remove(0),
         })
     }
+
+    fn allows_limit_to_inputs(&self) -> bool {
+        false // Disallow limit push-down by default
+    }
 }

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -1060,6 +1060,10 @@ impl UserDefinedLogicalNodeCore for TopKPlanNode {
             expr: exprs.swap_remove(0),
         })
     }
+
+    fn allows_limit_to_inputs(&self) -> bool {
+        false // Disallow limit push-down by default
+    }
 }
 
 #[derive(Debug)]

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -1061,7 +1061,7 @@ impl UserDefinedLogicalNodeCore for TopKPlanNode {
         })
     }
 
-    fn allows_limit_to_inputs(&self) -> bool {
+    fn supports_limit_pushdown(&self) -> bool {
         false // Disallow limit push-down by default
     }
 }

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -149,6 +149,10 @@ impl UserDefinedLogicalNode for MockUserDefinedLogicalPlan {
     fn dyn_ord(&self, _: &dyn UserDefinedLogicalNode) -> Option<Ordering> {
         unimplemented!()
     }
+
+    fn allows_limit_to_inputs(&self) -> bool {
+        false // Disallow limit push-down by default
+    }
 }
 
 impl MockUserDefinedLogicalPlan {

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -150,7 +150,7 @@ impl UserDefinedLogicalNode for MockUserDefinedLogicalPlan {
         unimplemented!()
     }
 
-    fn allows_limit_to_inputs(&self) -> bool {
+    fn supports_limit_pushdown(&self) -> bool {
         false // Disallow limit push-down by default
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12679.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

As per issue depicted.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Modify `UserDefinedLogicalNodeCore`/`UserDefinedLogicalNode` traits to check if its safe to push the limit to the children or not, via `allows_limit_to_inputs`, and also update the related interfaces.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, I've add several tests in `datafusion/optimizer/src/push_down_limit.rs`. Please correct me if it's wrong cases or needs more tests.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No user-facing changes.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

But, interface changed in `UserDefinedLogicalNodeCore`/`UserDefinedLogicalNode` traits.
