### PR TITLE
Fix AvroReader: Add union resolving for nested struct arrays

### DIFF
--- a/datafusion/core/src/datasource/avro_to_arrow/arrow_array_reader.rs
+++ b/datafusion/core/src/datasource/avro_to_arrow/arrow_array_reader.rs
@@ -1729,7 +1729,7 @@ mod test {
         ];
         assert_batches_eq!(expected, &[batch]);
     }
-    
+
     #[test]
     fn test_avro_iterator() {
         let reader = build_reader("alltypes_plain.avro", 5);

--- a/datafusion/core/src/datasource/avro_to_arrow/arrow_array_reader.rs
+++ b/datafusion/core/src/datasource/avro_to_arrow/arrow_array_reader.rs
@@ -1644,82 +1644,83 @@ mod test {
     }
 
     #[test]
-    fn test_avro_nullable_struct() {
+    fn test_avro_nullable_struct_array() {
         let schema = apache_avro::Schema::parse_str(
             r#"
             {
-                "type": "record",
-                "name": "r1",
-                "fields": [
+              "type": "record",
+              "name": "r1",
+              "fields": [
+                {
+                  "name": "col1",
+                  "type": [
+                    "null",
                     {
-                        "name": "col1",
-                        "type": [
-                            "null",
-                            {
-                                "type": "record",
-                                "name": "r2",
-                                "fields": [
-                                    {
-                                        "name": "col2",
-                                        "type": ["null", "string"]
-                                    }
-                                ]
-                            }
-                        ],
-                        "default": null
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "null",
+                                {
+                                    "type": "record",
+                                    "name": "Item",
+                                    "fields": [
+                                        {
+                                            "name": "id",
+                                            "type": "long"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
                     }
-                ]
+                  ],
+                  "default": null
+                }
+              ]
             }"#,
         )
         .unwrap();
-        let r1 = apache_avro::to_value(serde_json::json!({ "col1": null }))
+        let jv1 = serde_json::json!({
+            "col1": [
+                {
+                    "id": 234
+                }
+            ]
+        });
+        let r1 = apache_avro::to_value(jv1)
             .unwrap()
             .resolve(&schema)
             .unwrap();
-        let r2 = apache_avro::to_value(serde_json::json!({
-            "col1": {
-                "col2": "hello"
-            }
-        }))
-        .unwrap()
-        .resolve(&schema)
-        .unwrap();
-        let r3 = apache_avro::to_value(serde_json::json!({
-            "col1": {
-                "col2": null
-            }
-        }))
-        .unwrap()
-        .resolve(&schema)
-        .unwrap();
+        let r2 = apache_avro::to_value(serde_json::json!({ "col1": null }))
+            .unwrap()
+            .resolve(&schema)
+            .unwrap();
 
         let mut w = apache_avro::Writer::new(&schema, vec![]);
         w.append(r1).unwrap();
         w.append(r2).unwrap();
-        w.append(r3).unwrap();
         let bytes = w.into_inner().unwrap();
 
         let mut reader = ReaderBuilder::new()
             .read_schema()
-            .with_batch_size(3)
+            .with_batch_size(2)
             .build(std::io::Cursor::new(bytes))
             .unwrap();
         let batch = reader.next().unwrap().unwrap();
-        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 1);
 
         let expected = [
-            "+---------------+",
-            "| col1          |",
-            "+---------------+",
-            "|               |",
-            "| {col2: hello} |",
-            "| {col2: }      |",
-            "+---------------+",
+            "+-------------+",
+            "| col1        |",
+            "+-------------+",
+            "| [{id: 234}] |",
+            "|             |",
+            "+-------------+",
         ];
         assert_batches_eq!(expected, &[batch]);
     }
-
+    
     #[test]
     fn test_avro_iterator() {
         let reader = build_reader("alltypes_plain.avro", 5);

--- a/datafusion/core/src/datasource/avro_to_arrow/arrow_array_reader.rs
+++ b/datafusion/core/src/datasource/avro_to_arrow/arrow_array_reader.rs
@@ -573,7 +573,7 @@ impl<'a, R: Read> AvroArrowArrayReader<'a, R> {
                 // extract list values, with non-lists converted to Value::Null
                 let array_item_count = rows
                     .iter()
-                    .map(|row| match row {
+                    .map(|row| match maybe_resolve_union(row) {
                         Value::Array(values) => values.len(),
                         _ => 1,
                     })


### PR DESCRIPTION
## Which issue does this PR close?

Resolves #12682




## What changes are included in this PR?
Nullable values are passed as unions and this requires a resolving of the union to have the correct null_buffer size.

## Are these changes tested?
Added a new test for this issue
