### PR TITLE
Fix Regex signature types

### DIFF
--- a/datafusion/functions/src/regex/regexplike.rs
+++ b/datafusion/functions/src/regex/regexplike.rs
@@ -48,9 +48,9 @@ impl RegexpLikeFunc {
             signature: Signature::one_of(
                 vec![
                     Exact(vec![Utf8, Utf8]),
-                    Exact(vec![LargeUtf8, Utf8]),
+                    Exact(vec![LargeUtf8, LargeUtf8]),
                     Exact(vec![Utf8, Utf8, Utf8]),
-                    Exact(vec![LargeUtf8, Utf8, Utf8]),
+                    Exact(vec![LargeUtf8, LargeUtf8, LargeUtf8]),
                 ],
                 Volatility::Immutable,
             ),

--- a/datafusion/functions/src/regex/regexpmatch.rs
+++ b/datafusion/functions/src/regex/regexpmatch.rs
@@ -54,9 +54,9 @@ impl RegexpMatchFunc {
                     // If that fails, it proceeds to `(LargeUtf8, Utf8)`.
                     // TODO: Native support Utf8View for regexp_match.
                     Exact(vec![Utf8, Utf8]),
-                    Exact(vec![LargeUtf8, Utf8]),
+                    Exact(vec![LargeUtf8, LargeUtf8]),
                     Exact(vec![Utf8, Utf8, Utf8]),
-                    Exact(vec![LargeUtf8, Utf8, Utf8]),
+                    Exact(vec![LargeUtf8, LargeUtf8, LargeUtf8]),
                 ],
                 Volatility::Immutable,
             ),
@@ -131,7 +131,7 @@ pub fn regexp_match<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             let flags = as_generic_string_array::<T>(&args[2])?;
 
             if flags.iter().any(|s| s == Some("g")) {
-                return plan_err!("regexp_match() does not support the \"global\" option")
+                return plan_err!("regexp_match() does not support the \"global\" option");
             }
 
             regexp::regexp_match(values, regex, Some(flags))

--- a/datafusion/sqllogictest/test_files/regexp.slt
+++ b/datafusion/sqllogictest/test_files/regexp.slt
@@ -174,18 +174,6 @@ select regexp_like('aaa-555', '.*-(\d*)');
 ----
 true
 
-query B
-select regexp_like(arrow_cast('foobar', 'LargeUtf8'), 'b.r');
-----
-true
-
-
-query B
-select regexp_like(arrow_cast('foobar', 'LargeUtf8'), 'B.R', 'i');
-----
-true
-
-
 #
 # regexp_match tests
 #
@@ -280,17 +268,6 @@ query ?
 SELECT regexp_match('(?<=[A-Z]\w )Smith', 'John Smith', 'i');
 ----
 NULL
-
-query ?
-select regexp_match(arrow_cast('foobar', 'LargeUtf8'), 'b.r');
-----
-[bar]
-
-query ?
-select regexp_match(arrow_cast('foobar', 'LargeUtf8'), 'B.R', 'i');
-----
-[bar]
-
 
 # ported test
 query ?

--- a/datafusion/sqllogictest/test_files/regexp.slt
+++ b/datafusion/sqllogictest/test_files/regexp.slt
@@ -174,6 +174,18 @@ select regexp_like('aaa-555', '.*-(\d*)');
 ----
 true
 
+query B
+select regexp_like(arrow_cast('foobar', 'LargeUtf8'), 'b.r');
+----
+true
+
+
+query B
+select regexp_like(arrow_cast('foobar', 'LargeUtf8'), 'B.R', 'i');
+----
+true
+
+
 #
 # regexp_match tests
 #
@@ -268,6 +280,17 @@ query ?
 SELECT regexp_match('(?<=[A-Z]\w )Smith', 'John Smith', 'i');
 ----
 NULL
+
+query ?
+select regexp_match(arrow_cast('foobar', 'LargeUtf8'), 'b.r');
+----
+[bar]
+
+query ?
+select regexp_match(arrow_cast('foobar', 'LargeUtf8'), 'B.R', 'i');
+----
+[bar]
+
 
 # ported test
 query ?

--- a/datafusion/sqllogictest/test_files/string/dictionary_utf8.slt
+++ b/datafusion/sqllogictest/test_files/string/dictionary_utf8.slt
@@ -53,36 +53,6 @@ Xiangpeng datafusion数据融合 false true false true
 Raphael datafusionДатаФусион false false false false
 NULL NULL NULL NULL NULL NULL
 
-# TODO: move it back to `string_query.slt.part` after fixing the issue
-# see detail: https://github.com/apache/datafusion/issues/12664
-query BBBB
-SELECT
-  REGEXP_LIKE(ascii_1, 'an'),
-  REGEXP_LIKE(unicode_1, 'таФ'),
-  REGEXP_LIKE(ascii_1, NULL),
-  REGEXP_LIKE(unicode_1, NULL)
-FROM test_basic_operator;
-----
-false false NULL NULL
-true false NULL NULL
-false true NULL NULL
-NULL NULL NULL NULL
-
-# TODO: move it back to `string_query.slt.part` after fixing the issue
-# see detail: https://github.com/apache/datafusion/issues/12664
-query ????
-SELECT
-  REGEXP_MATCH(ascii_1, 'an'),
-  REGEXP_MATCH(unicode_1, 'таФ'),
-  REGEXP_MATCH(ascii_1, NULL),
-  REGEXP_MATCH(unicode_1, NULL)
-FROM test_basic_operator;
-----
-NULL NULL NULL NULL
-[an] NULL NULL NULL
-NULL [таФ] NULL NULL
-NULL NULL NULL NULL
-
 #
 # common test for string-like functions and operators
 #

--- a/datafusion/sqllogictest/test_files/string/string.slt
+++ b/datafusion/sqllogictest/test_files/string/string.slt
@@ -64,36 +64,6 @@ Raphael datafusionДатаФусион false false false false
 NULL NULL NULL NULL NULL NULL
 
 # TODO: move it back to `string_query.slt.part` after fixing the issue
-# see detail: https://github.com/apache/datafusion/issues/12664
-query BBBB
-SELECT
-  REGEXP_LIKE(ascii_1, 'an'),
-  REGEXP_LIKE(unicode_1, 'таФ'),
-  REGEXP_LIKE(ascii_1, NULL),
-  REGEXP_LIKE(unicode_1, NULL)
-FROM test_basic_operator;
-----
-false false NULL NULL
-true false NULL NULL
-false true NULL NULL
-NULL NULL NULL NULL
-
-# TODO: move it back to `string_query.slt.part` after fixing the issue
-# see detail: https://github.com/apache/datafusion/issues/12664
-query ????
-SELECT
-  REGEXP_MATCH(ascii_1, 'an'),
-  REGEXP_MATCH(unicode_1, 'таФ'),
-  REGEXP_MATCH(ascii_1, NULL),
-  REGEXP_MATCH(unicode_1, NULL)
-FROM test_basic_operator;
-----
-NULL NULL NULL NULL
-[an] NULL NULL NULL
-NULL [таФ] NULL NULL
-NULL NULL NULL NULL
-
-# TODO: move it back to `string_query.slt.part` after fixing the issue
 # see detail: https://github.com/apache/datafusion/issues/12670
 query IIIIII
 SELECT

--- a/datafusion/sqllogictest/test_files/string/string_query.slt.part
+++ b/datafusion/sqllogictest/test_files/string/string_query.slt.part
@@ -856,39 +856,35 @@ NULL NULL
 # Test REGEXP_LIKE
 # --------------------------------------
 
-# TODO: LargeString does not support REGEXP_LIKE. Enable this after fixing the issue
-# see issue: https://github.com/apache/datafusion/issues/12664
-#query BBBB
-#SELECT
-#  REGEXP_LIKE(ascii_1, 'an'),
-#  REGEXP_LIKE(unicode_1, 'таФ'),
-#  REGEXP_LIKE(ascii_1, NULL),
-#  REGEXP_LIKE(unicode_1, NULL)
-#FROM test_basic_operator;
-#----
-#false false NULL NULL
-#true false NULL NULL
-#false true NULL NULL
-#NULL NULL NULL NULL
+query BBBB
+SELECT
+  REGEXP_LIKE(ascii_1, 'an'),
+  REGEXP_LIKE(unicode_1, 'таФ'),
+  REGEXP_LIKE(ascii_1, NULL),
+  REGEXP_LIKE(unicode_1, NULL)
+FROM test_basic_operator;
+----
+false false NULL NULL
+true false NULL NULL
+false true NULL NULL
+NULL NULL NULL NULL
 
 # --------------------------------------
 # Test REGEXP_MATCH
 # --------------------------------------
 
-# TODO: LargeString does not support REGEXP_MATCH. Enable this after fixing the issue
-# see issue: https://github.com/apache/datafusion/issues/12664
-#query ????
-#SELECT
-#  REGEXP_MATCH(ascii_1, 'an'),
-#  REGEXP_MATCH(unicode_1, 'таФ'),
-#  REGEXP_MATCH(ascii_1, NULL),
-#  REGEXP_MATCH(unicode_1, NULL)
-#FROM test_basic_operator;
-#----
-#NULL NULL NULL NULL
-#[an] NULL NULL NULL
-#NULL [таФ] NULL NULL
-#NULL NULL NULL NULL
+query ????
+SELECT
+  REGEXP_MATCH(ascii_1, 'an'),
+  REGEXP_MATCH(unicode_1, 'таФ'),
+  REGEXP_MATCH(ascii_1, NULL),
+  REGEXP_MATCH(unicode_1, NULL)
+FROM test_basic_operator;
+----
+NULL NULL NULL NULL
+[an] NULL NULL NULL
+NULL [таФ] NULL NULL
+NULL NULL NULL NULL
 
 # --------------------------------------
 # Test REPEAT

--- a/datafusion/sqllogictest/test_files/string/string_query.slt.part
+++ b/datafusion/sqllogictest/test_files/string/string_query.slt.part
@@ -856,35 +856,47 @@ NULL NULL
 # Test REGEXP_LIKE
 # --------------------------------------
 
-query BBBB
+query BBBBBBBB
 SELECT
+  -- without flags
   REGEXP_LIKE(ascii_1, 'an'),
   REGEXP_LIKE(unicode_1, 'таФ'),
   REGEXP_LIKE(ascii_1, NULL),
-  REGEXP_LIKE(unicode_1, NULL)
-FROM test_basic_operator;
+  REGEXP_LIKE(unicode_1, NULL),
+  -- with flags
+  REGEXP_LIKE(ascii_1, 'AN', 'i'),
+  REGEXP_LIKE(unicode_1, 'ТаФ', 'i'),
+  REGEXP_LIKE(ascii_1, NULL, 'i'),
+  REGEXP_LIKE(unicode_1, NULL, 'i')
+  FROM test_basic_operator;
 ----
-false false NULL NULL
-true false NULL NULL
-false true NULL NULL
-NULL NULL NULL NULL
+false false NULL NULL true false NULL NULL
+true false NULL NULL true false NULL NULL
+false true NULL NULL false true NULL NULL
+NULL NULL NULL NULL NULL NULL NULL NULL
 
 # --------------------------------------
 # Test REGEXP_MATCH
 # --------------------------------------
 
-query ????
+query ????????
 SELECT
+  -- without flags
   REGEXP_MATCH(ascii_1, 'an'),
-  REGEXP_MATCH(unicode_1, 'таФ'),
+  REGEXP_MATCH(unicode_1, 'ТаФ'),
   REGEXP_MATCH(ascii_1, NULL),
-  REGEXP_MATCH(unicode_1, NULL)
+  REGEXP_MATCH(unicode_1, NULL),
+  -- with flags
+  REGEXP_MATCH(ascii_1, 'AN', 'i'),
+  REGEXP_MATCH(unicode_1, 'таФ', 'i'),
+  REGEXP_MATCH(ascii_1, NULL, 'i'),
+  REGEXP_MATCH(unicode_1, NULL, 'i')
 FROM test_basic_operator;
 ----
-NULL NULL NULL NULL
-[an] NULL NULL NULL
-NULL [таФ] NULL NULL
-NULL NULL NULL NULL
+NULL NULL NULL NULL [An] NULL NULL NULL
+[an] NULL NULL NULL [an] NULL NULL NULL
+NULL NULL NULL NULL NULL [таФ] NULL NULL
+NULL NULL NULL NULL NULL NULL NULL NULL
 
 # --------------------------------------
 # Test REPEAT

--- a/datafusion/sqllogictest/test_files/string/string_view.slt
+++ b/datafusion/sqllogictest/test_files/string/string_view.slt
@@ -51,36 +51,6 @@ false true
 NULL NULL
 
 # TODO: move it back to `string_query.slt.part` after fixing the issue
-# see detail: https://github.com/apache/datafusion/issues/12664
-query BBBB
-SELECT
-  REGEXP_LIKE(ascii_1, 'an'),
-  REGEXP_LIKE(unicode_1, 'таФ'),
-  REGEXP_LIKE(ascii_1, NULL),
-  REGEXP_LIKE(unicode_1, NULL)
-FROM test_basic_operator;
-----
-false false NULL NULL
-true false NULL NULL
-false true NULL NULL
-NULL NULL NULL NULL
-
-# TODO: move it back to `string_query.slt.part` after fixing the issue
-# see detail: https://github.com/apache/datafusion/issues/12664
-query ????
-SELECT
-  REGEXP_MATCH(ascii_1, 'an'),
-  REGEXP_MATCH(unicode_1, 'таФ'),
-  REGEXP_MATCH(ascii_1, NULL),
-  REGEXP_MATCH(unicode_1, NULL)
-FROM test_basic_operator;
-----
-NULL NULL NULL NULL
-[an] NULL NULL NULL
-NULL [таФ] NULL NULL
-NULL NULL NULL NULL
-
-# TODO: move it back to `string_query.slt.part` after fixing the issue
 # see detail: https://github.com/apache/datafusion/issues/12670
 query IIIIII
 SELECT


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12664.

## Rationale for this change

As pointed out in the original issue, `REGEX_MATCH` and `REGEX_LIKE` fail if the first argument is `LargeUtf8` but the second (or third) argument is `Utf8`. We were performing `as_generic_string_array::<i64>` on `&GenericStringArray<i32>`, which caused the issue.

## What changes are included in this PR?

Regex Match implementation in Apache Arrow requires the input and patterns [to have the same type](https://github.com/apache/arrow-rs/blob/3293a8c2f9062fca93bee2210d540a1d25155bf5/arrow-string/src/regexp.rs#L409), and the flags [to have the same type as well](https://github.com/apache/arrow-rs/blob/3293a8c2f9062fca93bee2210d540a1d25155bf5/arrow-string/src/regexp.rs#L430). I have reflected this change in the function signatures. 

## Are these changes tested?

Yes, by `string_query.slt.part`

## Are there any user-facing changes?

No, only a bugfix.
