### PR TITLE
Provide field and schema metadata missing on distinct aggregations.

### DIFF
--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -237,7 +237,7 @@ impl ExecutionPlan for ProjectionExec {
 
 /// If e is a direct column reference, returns the field level
 /// metadata for that field, if any. Otherwise returns None
-fn get_field_metadata(
+pub(crate) fn get_field_metadata(
     e: &Arc<dyn PhysicalExpr>,
     input_schema: &Schema,
 ) -> Option<HashMap<String, String>> {

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -61,15 +61,19 @@ WHERE "data"."id" = "samples"."id";
 
 
 # Regression test: prevent field metadata loss per https://github.com/apache/datafusion/issues/12687
-statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+query I
 select count(distinct name) from table_with_metadata;
+----
+2
 
 # Regression test: prevent field metadata loss per https://github.com/apache/datafusion/issues/12687
-statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+query I
 select approx_median(distinct id) from table_with_metadata;
+----
+2
 
 # Regression test: prevent field metadata loss per https://github.com/apache/datafusion/issues/12687
-statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+statement ok
 select array_agg(distinct id) from table_with_metadata;
 
 query I

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -58,5 +58,39 @@ WHERE "data"."id" = "samples"."id";
 1
 3
 
+
+
+# Regression test: prevent field metadata loss per https://github.com/apache/datafusion/issues/12687
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+select count(distinct name) from table_with_metadata;
+
+# Regression test: prevent field metadata loss per https://github.com/apache/datafusion/issues/12687
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+select approx_median(distinct id) from table_with_metadata;
+
+# Regression test: prevent field metadata loss per https://github.com/apache/datafusion/issues/12687
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+select array_agg(distinct id) from table_with_metadata;
+
+query I
+select distinct id from table_with_metadata order by id;
+----
+1
+3
+NULL
+
+query I
+select count(id) from table_with_metadata;
+----
+2
+
+query I
+select count(id) cnt from table_with_metadata group by name order by cnt;
+----
+0
+1
+1
+
+
 statement ok
 drop table table_with_metadata;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12687 

## Rationale for this change

A [PR merged](https://github.com/apache/datafusion/pull/11989) (and released in 42.0.0) has [added a check](https://github.com/apache/datafusion/blob/322d83526909ab44cfbe34b982d1a1c36a4dbe8f/datafusion/core/src/physical_planner.rs#L676) that the logical and physical plan input schemas (to an aggregate node) are the same.

Once released into the wild, it began being triggered. One example case is issue #12687 where field metadata is in the logical plan, but missing from the physical plan.

## What changes are included in this PR?

commit 1 = made regression tests, which are failing.
commit 2 = fixed those tests.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No
