### PR TITLE
Reduce code duplication in `PrimitiveGroupValueBuilder` with const generics

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/column.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/column.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 use crate::aggregates::group_values::group_column::{
-    ByteGroupValueBuilder, GroupColumn, NonNullPrimitiveGroupValueBuilder,
-    PrimitiveGroupValueBuilder,
+    ByteGroupValueBuilder, GroupColumn, PrimitiveGroupValueBuilder,
 };
 use crate::aggregates::group_values::GroupValues;
 use ahash::RandomState;
@@ -135,10 +134,10 @@ impl GroupValuesColumn {
 macro_rules! instantiate_primitive {
     ($v:expr, $nullable:expr, $t:ty) => {
         if $nullable {
-            let b = PrimitiveGroupValueBuilder::<$t>::new();
+            let b = PrimitiveGroupValueBuilder::<$t, true>::new();
             $v.push(Box::new(b) as _)
         } else {
-            let b = NonNullPrimitiveGroupValueBuilder::<$t>::new();
+            let b = PrimitiveGroupValueBuilder::<$t, false>::new();
             $v.push(Box::new(b) as _)
         }
     };

--- a/datafusion/physical-plan/src/aggregates/group_values/column.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/column.rs
@@ -123,8 +123,7 @@ impl GroupValuesColumn {
     }
 }
 
-/// instantiates a [`PrimitiveGroupValueBuilder`] or
-/// [`NonNullPrimitiveGroupValueBuilder`]  and pushes it into $v
+/// instantiates a [`PrimitiveGroupValueBuilder`] and pushes it into $v
 ///
 /// Arguments:
 /// `$v`: the vector to push the new builder into


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/12680

## Rationale for this change

As suggested by @Dandandan in https://github.com/apache/datafusion/pull/12623#discussion_r1781444375

We can avoid some duplication using const generics


## What changes are included in this PR?
Use const generics rather than manually copied implementation to avoid duplication

## Are these changes tested?
Existing tests

Benchmark results (realistically no change)

```

--------------------
Benchmark clickbench_partitioned.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃  main_base ┃ alamb_const_generics ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 0     │     2.33ms │               2.35ms │     no change │
│ QQuery 1     │    39.78ms │              39.59ms │     no change │
│ QQuery 2     │    96.34ms │              94.54ms │     no change │
│ QQuery 3     │   101.26ms │              99.68ms │     no change │
│ QQuery 4     │   959.40ms │             947.20ms │     no change │
│ QQuery 5     │  1020.38ms │             978.00ms │     no change │
│ QQuery 6     │    38.62ms │              37.51ms │     no change │
│ QQuery 7     │    44.39ms │              42.64ms │     no change │
│ QQuery 8     │  1400.51ms │            1398.48ms │     no change │
│ QQuery 9     │  1363.52ms │            1368.17ms │     no change │
│ QQuery 10    │   342.83ms │             340.86ms │     no change │
│ QQuery 11    │   408.33ms │             392.02ms │     no change │
│ QQuery 12    │  1117.87ms │            1105.94ms │     no change │
│ QQuery 13    │  1739.30ms │            1581.60ms │ +1.10x faster │
│ QQuery 14    │  1247.71ms │            1231.13ms │     no change │
│ QQuery 15    │  1103.67ms │            1091.41ms │     no change │
│ QQuery 16    │  2582.17ms │            2557.17ms │     no change │
│ QQuery 17    │  2383.87ms │            2355.80ms │     no change │
│ QQuery 18    │  5050.04ms │            5020.26ms │     no change │
│ QQuery 19    │    90.09ms │              90.89ms │     no change │
│ QQuery 20    │  1759.27ms │            1705.88ms │     no change │
│ QQuery 21    │  2044.93ms │            2047.11ms │     no change │
│ QQuery 22    │  5213.13ms │            5298.98ms │     no change │
│ QQuery 23    │ 10465.59ms │           10432.59ms │     no change │
│ QQuery 24    │   591.28ms │             589.29ms │     no change │
│ QQuery 25    │   505.03ms │             501.48ms │     no change │
│ QQuery 26    │   666.67ms │             673.24ms │     no change │
│ QQuery 27    │  2601.17ms │            2540.99ms │     no change │
│ QQuery 28    │ 15707.24ms │           15803.38ms │     no change │
│ QQuery 29    │   535.88ms │             510.83ms │     no change │
│ QQuery 30    │  1069.92ms │            1060.51ms │     no change │
│ QQuery 31    │  1130.40ms │            1096.60ms │     no change │
│ QQuery 32    │  4358.23ms │            4227.61ms │     no change │
│ QQuery 33    │  5258.28ms │            5203.47ms │     no change │
│ QQuery 34    │  5312.52ms │            5122.04ms │     no change │
│ QQuery 35    │  1878.08ms │            1938.79ms │     no change │
│ QQuery 36    │   269.17ms │             284.63ms │  1.06x slower │
│ QQuery 37    │   125.44ms │             122.05ms │     no change │
│ QQuery 38    │   148.92ms │             149.30ms │     no change │
│ QQuery 39    │   815.86ms │             792.99ms │     no change │
│ QQuery 40    │    58.71ms │              62.70ms │  1.07x slower │
│ QQuery 41    │    51.31ms │              50.35ms │     no change │
│ QQuery 42    │    65.18ms │              66.51ms │     no change │
└──────────────┴────────────┴──────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Benchmark Summary                   ┃            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Total Time (main_base)              │ 81764.63ms │
│ Total Time (alamb_const_generics)   │ 81056.59ms │
│ Average Time (main_base)            │  1901.50ms │
│ Average Time (alamb_const_generics) │  1885.04ms │
│ Queries Faster                      │          1 │
│ Queries Slower                      │          2 │
│ Queries with No Change              │         40 │
└─────────────────────────────────────┴────────────┘

--------------------
Benchmark tpch_sf1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃ main_base ┃ alamb_const_generics ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  215.38ms │             214.87ms │     no change │
│ QQuery 2     │  125.69ms │             125.53ms │     no change │
│ QQuery 3     │  121.55ms │             126.54ms │     no change │
│ QQuery 4     │   88.61ms │              87.80ms │     no change │
│ QQuery 5     │  164.86ms │             155.86ms │ +1.06x faster │
│ QQuery 6     │   45.12ms │              54.28ms │  1.20x slower │
│ QQuery 7     │  203.91ms │             202.43ms │     no change │
│ QQuery 8     │  156.03ms │             155.67ms │     no change │
│ QQuery 9     │  264.78ms │             246.68ms │ +1.07x faster │
│ QQuery 10    │  226.96ms │             233.71ms │     no change │
│ QQuery 11    │   97.97ms │              93.36ms │     no change │
│ QQuery 12    │  130.49ms │             134.57ms │     no change │
│ QQuery 13    │  231.24ms │             234.30ms │     no change │
│ QQuery 14    │   73.01ms │              91.28ms │  1.25x slower │
│ QQuery 15    │  120.21ms │             110.97ms │ +1.08x faster │
│ QQuery 16    │   81.80ms │              79.43ms │     no change │
│ QQuery 17    │  211.91ms │             230.44ms │  1.09x slower │
│ QQuery 18    │  331.86ms │             323.65ms │     no change │
│ QQuery 19    │  129.89ms │             138.49ms │  1.07x slower │
│ QQuery 20    │  127.16ms │             135.33ms │  1.06x slower │
│ QQuery 21    │  278.43ms │             291.61ms │     no change │
│ QQuery 22    │   69.00ms │              65.52ms │ +1.05x faster │
└──────────────┴───────────┴──────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Summary                   ┃           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Total Time (main_base)              │ 3495.84ms │
│ Total Time (alamb_const_generics)   │ 3532.31ms │
│ Average Time (main_base)            │  158.90ms │
│ Average Time (alamb_const_generics) │  160.56ms │
│ Queries Faster                      │         4 │
│ Queries Slower                      │         5 │
│ Queries with No Change              │        13 │
└─────────────────────────────────────┴───────────┘
```
## Are there any user-facing changes?

No