### PR TITLE
doc: Fix malformed hex string literal in user guide

### DIFF
--- a/docs/source/user-guide/sql/data_types.md
+++ b/docs/source/user-guide/sql/data_types.md
@@ -97,7 +97,7 @@ select arrow_cast(now(), 'Timestamp(Second, None)');
 | `BYTEA`      | `Binary`       |
 
 You can create binary literals using a hex string literal such as
-`X'1234` to create a `Binary` value of two bytes, `0x12` and `0x34`.
+`X'1234'` to create a `Binary` value of two bytes, `0x12` and `0x34`.
 
 ## Unsupported SQL Types
 


### PR DESCRIPTION
## Which issue does this PR close?

None

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

[Data Types](https://datafusion.apache.org/user-guide/sql/data_types.html) shows `X'1234` as an example of a hex string literal, but it's not syntactically valid.

## What changes are included in this PR?

Adds a closing quotation mark to make it valid.

```
$ datafusion-cli

❯ select X'1234;  🤔 Invalid statement: sql parser error: Unterminated string literal at Line: 1, Column 9

❯ select X'1234';
+-----------------+
| Binary("18,52") |
+-----------------+
| 1234            |
+-----------------+
1 row in set. Query took 0.000 seconds.
```

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
