### PR TITLE
Provide field and schema metadata missing on cross joins, and union with null fields.

### DIFF
--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -241,16 +241,14 @@ pub fn transform_schema_to_view(schema: &Schema) -> Schema {
         .fields
         .iter()
         .map(|field| match field.data_type() {
-            DataType::Utf8 | DataType::LargeUtf8 => Arc::new(Field::new(
-                field.name(),
-                DataType::Utf8View,
-                field.is_nullable(),
-            )),
-            DataType::Binary | DataType::LargeBinary => Arc::new(Field::new(
-                field.name(),
-                DataType::BinaryView,
-                field.is_nullable(),
-            )),
+            DataType::Utf8 | DataType::LargeUtf8 => Arc::new(
+                Field::new(field.name(), DataType::Utf8View, field.is_nullable())
+                    .with_metadata(field.metadata().to_owned()),
+            ),
+            DataType::Binary | DataType::LargeBinary => Arc::new(
+                Field::new(field.name(), DataType::BinaryView, field.is_nullable())
+                    .with_metadata(field.metadata().to_owned()),
+            ),
             _ => field.clone(),
         })
         .collect();

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -474,7 +474,12 @@ fn union_schema(inputs: &[Arc<dyn ExecutionPlan>]) -> SchemaRef {
                 .iter()
                 .filter_map(|input| {
                     if input.schema().fields().len() > i {
-                        Some(input.schema().field(i).clone())
+                        let field = input.schema().field(i).clone();
+                        let right_hand_metdata =
+                            inputs[1].schema().field(i).metadata().clone();
+                        let mut metadata = field.metadata().clone();
+                        metadata.extend(right_hand_metdata);
+                        Some(field.with_metadata(metadata))
                     } else {
                         None
                     }

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -475,8 +475,12 @@ fn union_schema(inputs: &[Arc<dyn ExecutionPlan>]) -> SchemaRef {
                 .filter_map(|input| {
                     if input.schema().fields().len() > i {
                         let field = input.schema().field(i).clone();
-                        let right_hand_metdata =
-                            inputs[1].schema().field(i).metadata().clone();
+                        let right_hand_metdata = inputs
+                            .get(1)
+                            .map(|right_input| {
+                                right_input.schema().field(i).metadata().clone()
+                            })
+                            .unwrap_or_default();
                         let mut metadata = field.metadata().clone();
                         metadata.extend(right_hand_metdata);
                         Some(field.with_metadata(metadata))

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -314,8 +314,13 @@ pub async fn register_metadata_tables(ctx: &SessionContext) {
         String::from("metadata_key"),
         String::from("the name field"),
     )]));
+    let l_name =
+        Field::new("l_name", DataType::Utf8, true).with_metadata(HashMap::from([(
+            String::from("metadata_key"),
+            String::from("the l_name field"),
+        )]));
 
-    let schema = Schema::new(vec![id, name]).with_metadata(HashMap::from([(
+    let schema = Schema::new(vec![id, name, l_name]).with_metadata(HashMap::from([(
         String::from("metadata_key"),
         String::from("the entire schema"),
     )]));
@@ -325,6 +330,7 @@ pub async fn register_metadata_tables(ctx: &SessionContext) {
         vec![
             Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])) as _,
             Arc::new(StringArray::from(vec![None, Some("bar"), Some("baz")])) as _,
+            Arc::new(StringArray::from(vec![None, Some("l_bar"), Some("l_baz")])) as _,
         ],
     )
     .unwrap();

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -111,11 +111,17 @@ FROM
 6
 
 # Regression test: missing field metadata, from the NULL field on the left side of the union
-statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+query ITT
 (SELECT id, NULL::string as name, l_name FROM "table_with_metadata")
   UNION
 (SELECT id, name, NULL::string as l_name FROM "table_with_metadata")
 ORDER BY id, name, l_name;
+----
+1 NULL NULL
+3 baz NULL
+3 NULL l_baz
+NULL bar NULL
+NULL NULL l_bar
 
 
 

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -98,7 +98,7 @@ select count(id) cnt from table_with_metadata group by name order by cnt;
 
 
 # Regression test: missing schema metadata, when aggregate on cross join
-statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+query I
 SELECT count("data"."id")
 FROM
   (
@@ -107,6 +107,8 @@ FROM
   (
     SELECT "id" FROM "table_with_metadata"
   ) as "samples";
+----
+6
 
 
 statement ok

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -25,7 +25,7 @@
 ## with metadata in SQL.
 
 query IT
-select * from table_with_metadata;
+select id, name from table_with_metadata;
 ----
 1 NULL
 NULL bar
@@ -109,6 +109,14 @@ FROM
   ) as "samples";
 ----
 6
+
+# Regression test: missing field metadata, from the NULL field on the left side of the union
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+(SELECT id, NULL::string as name, l_name FROM "table_with_metadata")
+  UNION
+(SELECT id, name, NULL::string as l_name FROM "table_with_metadata")
+ORDER BY id, name, l_name;
+
 
 
 statement ok

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -96,5 +96,18 @@ select count(id) cnt from table_with_metadata group by name order by cnt;
 1
 
 
+
+# Regression test: missing schema metadata, when aggregate on cross join
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+SELECT count("data"."id")
+FROM
+  (
+   SELECT "id" FROM "table_with_metadata"
+  ) as "data",
+  (
+    SELECT "id" FROM "table_with_metadata"
+  ) as "samples";
+
+
 statement ok
 drop table table_with_metadata;


### PR DESCRIPTION
## Which issue does this PR close?

Related to #12687 
Closes #12734
Closes https://github.com/apache/datafusion/issues/12735

## Rationale for this change

A https://github.com/apache/datafusion/pull/11989 (and released in 42.0.0) has [added a check](https://github.com/apache/datafusion/blob/322d83526909ab44cfbe34b982d1a1c36a4dbe8f/datafusion/core/src/physical_planner.rs#L676) that the logical and physical plan input schemas (to an aggregate node) are the same.

Once released into the wild, it began being triggered. We [previously fixed a use case with distinct aggregations](https://github.com/apache/datafusion/pull/12691). In this PR we fix two additional use cases for cross joins, and union on null fields.

## What changes are included in this PR?

commit 1 = reproducer for cross join bug, where schema metadata is dropped
commit 2 = fix

commit 3 = cleanup PR, since I noticed field metadata is dropped during logical plan creation (so not triggering the added check), for the transformation to view types

commit 4 = reproducer for union bug, where field metadata is dropped
commit 5 = fix


## Are these changes tested?

Yes

## Are there any user-facing changes?
No
