### PR TITLE
Minor: Update string tests for strpos

### DIFF
--- a/datafusion/sqllogictest/test_files/string/large_string.slt
+++ b/datafusion/sqllogictest/test_files/string/large_string.slt
@@ -72,23 +72,6 @@ false false
 false true
 NULL NULL
 
-# TODO: move it back to `string_query.slt.part` after fixing the issue
-# see detail: https://github.com/apache/datafusion/issues/12670
-query IIIIII
-SELECT
-  STRPOS(ascii_1, 'e'),
-  STRPOS(ascii_1, 'ang'),
-  STRPOS(ascii_1, NULL),
-  STRPOS(unicode_1, 'и'),
-  STRPOS(unicode_1, 'ион'),
-  STRPOS(unicode_1, NULL)
-FROM test_basic_operator;
-----
-5 0 NULL 0 0 NULL
-7 3 NULL 0 0 NULL
-6 0 NULL 18 18 NULL
-NULL NULL NULL NULL NULL NULL
-
 #
 # common test for string-like functions and operators
 #

--- a/datafusion/sqllogictest/test_files/string/string.slt
+++ b/datafusion/sqllogictest/test_files/string/string.slt
@@ -63,23 +63,6 @@ Xiangpeng datafusion数据融合 false true false true
 Raphael datafusionДатаФусион false false false false
 NULL NULL NULL NULL NULL NULL
 
-# TODO: move it back to `string_query.slt.part` after fixing the issue
-# see detail: https://github.com/apache/datafusion/issues/12670
-query IIIIII
-SELECT
-  STRPOS(ascii_1, 'e'),
-  STRPOS(ascii_1, 'ang'),
-  STRPOS(ascii_1, NULL),
-  STRPOS(unicode_1, 'и'),
-  STRPOS(unicode_1, 'ион'),
-  STRPOS(unicode_1, NULL)
-FROM test_basic_operator;
-----
-5 0 NULL 0 0 NULL
-7 3 NULL 0 0 NULL
-6 0 NULL 18 18 NULL
-NULL NULL NULL NULL NULL NULL
-
 #
 # common test for string-like functions and operators
 #

--- a/datafusion/sqllogictest/test_files/string/string_query.slt.part
+++ b/datafusion/sqllogictest/test_files/string/string_query.slt.part
@@ -951,22 +951,20 @@ NULL NULL
 # Test STRPOS
 # --------------------------------------
 
-# TODO: DictionaryString does not support STRPOS. Enable this after fixing the issue
-# see issue: https://github.com/apache/datafusion/issues/12670
-#query IIIIII
-#SELECT
-#  STRPOS(ascii_1, 'e'),
-#  STRPOS(ascii_1, 'ang'),
-#  STRPOS(ascii_1, NULL),
-#  STRPOS(unicode_1, 'и'),
-#  STRPOS(unicode_1, 'ион'),
-#  STRPOS(unicode_1, NULL)
-#FROM test_basic_operator;
-#----
-#5 0 NULL 0 0 NULL
-#7 3 NULL 0 0 NULL
-#6 0 NULL 18 18 NULL
-#NULL NULL NULL NULL NULL NULL
+query IIIIII
+SELECT
+  STRPOS(ascii_1, 'e'),
+  STRPOS(ascii_1, 'ang'),
+  STRPOS(ascii_1, NULL),
+  STRPOS(unicode_1, 'и'),
+  STRPOS(unicode_1, 'ион'),
+  STRPOS(unicode_1, NULL)
+FROM test_basic_operator;
+----
+5 0 NULL 0 0 NULL
+7 3 NULL 0 0 NULL
+6 0 NULL 18 18 NULL
+NULL NULL NULL NULL NULL NULL
 
 # --------------------------------------
 # Test SUBSTR_INDEX

--- a/datafusion/sqllogictest/test_files/string/string_view.slt
+++ b/datafusion/sqllogictest/test_files/string/string_view.slt
@@ -50,23 +50,6 @@ false false
 false true
 NULL NULL
 
-# TODO: move it back to `string_query.slt.part` after fixing the issue
-# see detail: https://github.com/apache/datafusion/issues/12670
-query IIIIII
-SELECT
-  STRPOS(ascii_1, 'e'),
-  STRPOS(ascii_1, 'ang'),
-  STRPOS(ascii_1, NULL),
-  STRPOS(unicode_1, 'и'),
-  STRPOS(unicode_1, 'ион'),
-  STRPOS(unicode_1, NULL)
-FROM test_basic_operator;
-----
-5 0 NULL 0 0 NULL
-7 3 NULL 0 0 NULL
-6 0 NULL 18 18 NULL
-NULL NULL NULL NULL NULL NULL
-
 #
 # common test for string-like functions and operators
 #


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/datafusion/pull/12712

## Rationale for this change

Now that  https://github.com/apache/datafusion/issues/12670  is fixed (thanks @findepi !), we should update the tests to reflect this and keep the string implementations in sync as @goldmedal  suggests: https://github.com/apache/datafusion/pull/12712#issuecomment-2388357130

## What changes are included in this PR?

Remove the workaround in string tests to make sure all implementations are consistent

## Are these changes tested?

Only tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
