### PR TITLE
Apply `type_union_resolution` to array and values

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -471,10 +471,16 @@ fn type_union_resolution_coercion(
             let new_value_type = type_union_resolution_coercion(value_type, other_type);
             new_value_type.map(|t| DataType::Dictionary(index_type.clone(), Box::new(t)))
         }
+        (DataType::List(lhs), DataType::List(rhs)) => {
+            let new_item_type =
+                type_union_resolution_coercion(lhs.data_type(), rhs.data_type());
+            new_item_type.map(|t| DataType::List(Arc::new(Field::new("item", t, true))))
+        }
         _ => {
             // numeric coercion is the same as comparison coercion, both find the narrowest type
             // that can accommodate both types
             binary_numeric_coercion(lhs_type, rhs_type)
+                .or_else(|| temporal_coercion_nonstrict_timezone(lhs_type, rhs_type))
                 .or_else(|| string_coercion(lhs_type, rhs_type))
                 .or_else(|| numeric_string_coercion(lhs_type, rhs_type))
         }
@@ -505,22 +511,6 @@ pub fn comparison_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<D
         .or_else(|| string_temporal_coercion(lhs_type, rhs_type))
         .or_else(|| binary_coercion(lhs_type, rhs_type))
         .or_else(|| struct_coercion(lhs_type, rhs_type))
-}
-
-/// Coerce `lhs_type` and `rhs_type` to a common type for `VALUES` expression
-///
-/// For example `VALUES (1, 2), (3.0, 4.0)` where the first row is `Int32` and
-/// the second row is `Float64` will coerce to `Float64`
-///
-pub fn values_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
-    if lhs_type == rhs_type {
-        // same type => equality is possible
-        return Some(lhs_type.clone());
-    }
-    binary_numeric_coercion(lhs_type, rhs_type)
-        .or_else(|| temporal_coercion_nonstrict_timezone(lhs_type, rhs_type))
-        .or_else(|| string_coercion(lhs_type, rhs_type))
-        .or_else(|| binary_coercion(lhs_type, rhs_type))
 }
 
 /// Coerce `lhs_type` and `rhs_type` to a common type for the purposes of a comparison operation

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -35,7 +35,6 @@ use crate::logical_plan::{
     Projection, Repartition, Sort, SubqueryAlias, TableScan, Union, Unnest, Values,
     Window,
 };
-use crate::type_coercion::binary::values_coercion;
 use crate::utils::{
     can_hash, columnize_expr, compare_sort_expr, expr_to_columns,
     find_valid_equijoin_key_pair, group_window_expr_by_sort_keys,
@@ -53,6 +52,7 @@ use datafusion_common::{
     plan_err, Column, DFSchema, DFSchemaRef, DataFusionError, Result, ScalarValue,
     TableReference, ToDFSchema, UnnestOptions,
 };
+use datafusion_expr_common::type_coercion::binary::type_union_resolution;
 
 use super::dml::InsertOp;
 use super::plan::{ColumnUnnestList, ColumnUnnestType};
@@ -209,7 +209,9 @@ impl LogicalPlanBuilder {
                 }
                 if let Some(prev_type) = common_type {
                     // get common type of each column values.
-                    let Some(new_type) = values_coercion(&data_type, &prev_type) else {
+                    let data_tyeps = vec![prev_type.clone(), data_type.clone()];
+                    let Some(new_type) = type_union_resolution(&data_tyeps) else {
+                        println!("data_tyeps: {:?}", data_tyeps);
                         return plan_err!("Inconsistent data type across values list at row {i} column {j}. Was {prev_type} but found {data_type}");
                     };
                     common_type = Some(new_type);

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -209,9 +209,8 @@ impl LogicalPlanBuilder {
                 }
                 if let Some(prev_type) = common_type {
                     // get common type of each column values.
-                    let data_tyeps = vec![prev_type.clone(), data_type.clone()];
-                    let Some(new_type) = type_union_resolution(&data_tyeps) else {
-                        println!("data_tyeps: {:?}", data_tyeps);
+                    let data_types = vec![prev_type.clone(), data_type.clone()];
+                    let Some(new_type) = type_union_resolution(&data_types) else {
                         return plan_err!("Inconsistent data type across values list at row {i} column {j}. Was {prev_type} but found {data_type}");
                     };
                     common_type = Some(new_type);

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -167,6 +167,20 @@ pub fn data_types(
     try_coerce_types(valid_types, current_types, &signature.type_signature)
 }
 
+fn is_well_supported_signature(type_signature: &TypeSignature) -> bool {
+    if let TypeSignature::OneOf(signatures) = type_signature {
+        return signatures.iter().all(is_well_supported_signature);
+    }
+
+    matches!(
+        type_signature,
+        TypeSignature::UserDefined
+            | TypeSignature::Numeric(_)
+            | TypeSignature::Coercible(_)
+            | TypeSignature::Any(_)
+    )
+}
+
 fn try_coerce_types(
     valid_types: Vec<Vec<DataType>>,
     current_types: &[DataType],
@@ -175,14 +189,7 @@ fn try_coerce_types(
     let mut valid_types = valid_types;
 
     // Well-supported signature that returns exact valid types.
-    if !valid_types.is_empty()
-        && matches!(
-            type_signature,
-            TypeSignature::UserDefined
-                | TypeSignature::Numeric(_)
-                | TypeSignature::Coercible(_)
-        )
-    {
+    if !valid_types.is_empty() && is_well_supported_signature(type_signature) {
         // exact valid types
         assert_eq!(valid_types.len(), 1);
         let valid_types = valid_types.swap_remove(0);

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -6595,7 +6595,7 @@ select make_array(1, 2.0, null, 3)
 query ?
 select make_array(1.0, '2', null)
 ----
-[1.0, 2, ]
+[1.0, 2.0, ]
 
 ### FixedSizeListArray
 

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -128,5 +128,5 @@ from aggregate_test_100
 order by c9
 
 
-statement error Inconsistent data type across values list at row 1 column 0. Was Int64 but found Utf8
+query error DataFusion error: Arrow error: Cast error: Cannot cast string 'foo' to value of Int64 type
 create table foo as values (1), ('foo');

--- a/datafusion/sqllogictest/test_files/map.slt
+++ b/datafusion/sqllogictest/test_files/map.slt
@@ -148,17 +148,16 @@ SELECT MAKE_MAP([1,2], ['a', 'b'], [3,4], ['b']);
 {[1, 2]: [a, b], [3, 4]: [b]}
 
 query ?
-SELECT MAKE_MAP('POST', 41, 'HEAD', 'ab', 'PATCH', 30);
+SELECT MAKE_MAP('POST', 41, 'HEAD', 53, 'PATCH', 30);
 ----
-{POST: 41, HEAD: ab, PATCH: 30}
+{POST: 41, HEAD: 53, PATCH: 30}
 
+query error DataFusion error: Arrow error: Cast error: Cannot cast string 'ab' to value of Int64 type
+SELECT MAKE_MAP('POST', 41, 'HEAD', 'ab', 'PATCH', 30);
+
+# Map keys can not be NULL
 query error
 SELECT MAKE_MAP('POST', 41, 'HEAD', 33, null, 30);
-
-query ?
-SELECT MAKE_MAP('POST', 41, 'HEAD', 'ab', 'PATCH', 30);
-----
-{POST: 41, HEAD: ab, PATCH: 30}
 
 query ?
 SELECT MAKE_MAP()
@@ -517,9 +516,12 @@ query error
 SELECT MAP {'a': MAP {1:'a', 2:'b', 3:'c'}, 'b': MAP {2:'c', 4:'d'} }[NULL];
 
 query ?
-SELECT MAP { 'a': 1, 2: 3 };
+SELECT MAP { 'a': 1, 'b': 3 };
 ----
-{a: 1, 2: 3}
+{a: 1, b: 3}
+
+query error DataFusion error: Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
+SELECT MAP { 'a': 1, 2: 3 };
 
 # TODO(https://github.com/apache/datafusion/issues/11785): fix accessing map with non-string key
 # query ?
@@ -610,9 +612,12 @@ select map_extract(column1, 1), map_extract(column1, 5), map_extract(column1, 7)
 # Tests for map_keys
 
 query ?
-SELECT map_keys(MAP { 'a': 1, 2: 3 });
+SELECT map_keys(MAP { 'a': 1, 'b': 3 });
 ----
-[a, 2]
+[a, b]
+
+query error DataFusion error: Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
+SELECT map_keys(MAP { 'a': 1, 2: 3 });
 
 query ?
 SELECT map_keys(MAP {'a':1, 'b':2, 'c':3 }) FROM t;
@@ -657,8 +662,11 @@ SELECT map_keys(column1) from map_array_table_1;
 
 # Tests for map_values
 
-query ?
+query error DataFusion error: Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
 SELECT map_values(MAP { 'a': 1, 2: 3 });
+
+query ?
+SELECT map_values(MAP { 'a': 1, 'b': 3 });
 ----
 [1, 3]
 

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -348,8 +348,11 @@ VALUES (1),()
 statement error DataFusion error: Error during planning: Inconsistent data length across values list: got 2 values in row 1 but expected 1
 VALUES (1),(1,2)
 
-statement error DataFusion error: Error during planning: Inconsistent data type across values list at row 1 column 0
+query I
 VALUES (1),('2')
+----
+1
+2
 
 query R
 VALUES (1),(2.0)
@@ -357,8 +360,11 @@ VALUES (1),(2.0)
 1
 2
 
-statement error DataFusion error: Error during planning: Inconsistent data type across values list at row 1 column 1
+query II
 VALUES (1,2), (1,'2')
+----
+1 2
+1 2
 
 query IT
 VALUES (1,'a'),(NULL,'b'),(3,'c')


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

* Main: Follow on https://github.com/apache/datafusion/pull/10268. Apply `type_union_resolution ` to Array and Values coercion

* Cleanup: Remove `coerce_arguments_for_fun` and move the coercion logic to `coerce_types`. So does the null to i64 conversion.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
