### PR TITLE
Fix bug in TopK aggregates

### DIFF
--- a/datafusion/physical-optimizer/src/topk_aggregation.rs
+++ b/datafusion/physical-optimizer/src/topk_aggregation.rs
@@ -119,10 +119,8 @@ impl TopKAggregation {
             } else {
                 // or we continue down through types that don't reduce cardinality
                 match plan.cardinality_effect() {
-                    CardinalityEffect::NoEffect
-                    | CardinalityEffect::IncreaseOrNoEffect => {}
-                    CardinalityEffect::Unknown
-                    | CardinalityEffect::DecreaseOrNoEffect => {
+                    CardinalityEffect::Equal | CardinalityEffect::GreaterEqual => {}
+                    CardinalityEffect::Unknown | CardinalityEffect::LowerEqual => {
                         cardinality_preserved = false;
                     }
                 }

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -47,6 +47,7 @@ use datafusion_physical_expr::{
     PhysicalExpr, PhysicalSortRequirement,
 };
 
+use crate::execution_plan::CardinalityEffect;
 use datafusion_physical_expr::aggregate::AggregateFunctionExpr;
 use itertools::Itertools;
 
@@ -784,6 +785,10 @@ impl ExecutionPlan for AggregateExec {
                 })
             }
         }
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::DecreaseOrNoEffect
     }
 }
 

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -788,7 +788,7 @@ impl ExecutionPlan for AggregateExec {
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::DecreaseOrNoEffect
+        CardinalityEffect::LowerEqual
     }
 }
 

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -202,7 +202,7 @@ impl ExecutionPlan for CoalesceBatchesExec {
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::NoEffect
+        CardinalityEffect::Equal
     }
 }
 

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -34,6 +34,7 @@ use datafusion_common::Result;
 use datafusion_execution::TaskContext;
 
 use crate::coalesce::{BatchCoalescer, CoalescerState};
+use crate::execution_plan::CardinalityEffect;
 use futures::ready;
 use futures::stream::{Stream, StreamExt};
 
@@ -198,6 +199,10 @@ impl ExecutionPlan for CoalesceBatchesExec {
 
     fn fetch(&self) -> Option<usize> {
         self.fetch
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::NoEffect
     }
 }
 

--- a/datafusion/physical-plan/src/coalesce_partitions.rs
+++ b/datafusion/physical-plan/src/coalesce_partitions.rs
@@ -181,7 +181,7 @@ impl ExecutionPlan for CoalescePartitionsExec {
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::NoEffect
+        CardinalityEffect::Equal
     }
 }
 

--- a/datafusion/physical-plan/src/coalesce_partitions.rs
+++ b/datafusion/physical-plan/src/coalesce_partitions.rs
@@ -30,6 +30,7 @@ use super::{
 
 use crate::{DisplayFormatType, ExecutionPlan, Partitioning};
 
+use crate::execution_plan::CardinalityEffect;
 use datafusion_common::{internal_err, Result};
 use datafusion_execution::TaskContext;
 
@@ -177,6 +178,10 @@ impl ExecutionPlan for CoalescePartitionsExec {
 
     fn supports_limit_pushdown(&self) -> bool {
         true
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::NoEffect
     }
 }
 

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -908,7 +908,7 @@ pub fn get_plan_string(plan: &Arc<dyn ExecutionPlan>) -> Vec<String> {
 pub enum CardinalityEffect {
     /// Unknown effect. This is the default
     Unknown,
-    /// The operator is guaranteed to produce exactly one row for 
+    /// The operator is guaranteed to produce exactly one row for
     /// each input row
     Equal,
     /// The operator may produce fewer output rows than it receives input rows

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -416,6 +416,11 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
     fn fetch(&self) -> Option<usize> {
         None
     }
+
+    /// Gets the effect on cardinality, if known
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Unknown
+    }
 }
 
 /// Extension trait provides an easy API to fetch various properties of
@@ -896,6 +901,13 @@ pub fn get_plan_string(plan: &Arc<dyn ExecutionPlan>) -> Vec<String> {
     let formatted = displayable(plan.as_ref()).indent(true).to_string();
     let actual: Vec<&str> = formatted.trim().lines().collect();
     actual.iter().map(|elem| elem.to_string()).collect()
+}
+
+pub enum CardinalityEffect {
+    Unknown,
+    NoEffect,
+    DecreaseOrNoEffect,
+    IncreaseOrNoEffect,
 }
 
 #[cfg(test)]

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -903,10 +903,17 @@ pub fn get_plan_string(plan: &Arc<dyn ExecutionPlan>) -> Vec<String> {
     actual.iter().map(|elem| elem.to_string()).collect()
 }
 
+/// Indicates the effect an execution plan operator will have on the cardinality
+/// of its input stream
 pub enum CardinalityEffect {
+    /// Unknown effect. This is the default
     Unknown,
+    /// The operator is guaranteed to produce exactly one row for 
+    /// each input row
     Equal,
+    /// The operator may produce fewer output rows than it receives input rows
     LowerEqual,
+    /// The operator may produce more output rows than it receives input rows
     GreaterEqual,
 }
 

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -905,9 +905,9 @@ pub fn get_plan_string(plan: &Arc<dyn ExecutionPlan>) -> Vec<String> {
 
 pub enum CardinalityEffect {
     Unknown,
-    NoEffect,
-    DecreaseOrNoEffect,
-    IncreaseOrNoEffect,
+    Equal,
+    LowerEqual,
+    GreaterEqual,
 }
 
 #[cfg(test)]

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -375,7 +375,7 @@ impl ExecutionPlan for FilterExec {
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::DecreaseOrNoEffect
+        CardinalityEffect::LowerEqual
     }
 }
 

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -48,6 +48,7 @@ use datafusion_physical_expr::{
     analyze, split_conjunction, AnalysisContext, ConstExpr, ExprBoundaries, PhysicalExpr,
 };
 
+use crate::execution_plan::CardinalityEffect;
 use futures::stream::{Stream, StreamExt};
 use log::trace;
 
@@ -371,6 +372,10 @@ impl ExecutionPlan for FilterExec {
     /// predicate's selectivity value can be determined for the incoming data.
     fn statistics(&self) -> Result<Statistics> {
         Self::statistics_helper(&self.input, self.predicate(), self.default_selectivity)
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::DecreaseOrNoEffect
     }
 }
 

--- a/datafusion/physical-plan/src/limit.rs
+++ b/datafusion/physical-plan/src/limit.rs
@@ -34,6 +34,7 @@ use arrow::record_batch::RecordBatch;
 use datafusion_common::{internal_err, Result};
 use datafusion_execution::TaskContext;
 
+use crate::execution_plan::CardinalityEffect;
 use futures::stream::{Stream, StreamExt};
 use log::trace;
 
@@ -335,6 +336,10 @@ impl ExecutionPlan for LocalLimitExec {
 
     fn supports_limit_pushdown(&self) -> bool {
         true
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::DecreaseOrNoEffect
     }
 }
 

--- a/datafusion/physical-plan/src/limit.rs
+++ b/datafusion/physical-plan/src/limit.rs
@@ -339,7 +339,7 @@ impl ExecutionPlan for LocalLimitExec {
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::DecreaseOrNoEffect
+        CardinalityEffect::LowerEqual
     }
 }
 

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -236,7 +236,7 @@ impl ExecutionPlan for ProjectionExec {
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::NoEffect
+        CardinalityEffect::Equal
     }
 }
 

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -42,6 +42,7 @@ use datafusion_execution::TaskContext;
 use datafusion_physical_expr::equivalence::ProjectionMapping;
 use datafusion_physical_expr::expressions::Literal;
 
+use crate::execution_plan::CardinalityEffect;
 use futures::stream::{Stream, StreamExt};
 use log::trace;
 
@@ -232,6 +233,10 @@ impl ExecutionPlan for ProjectionExec {
 
     fn supports_limit_pushdown(&self) -> bool {
         true
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::NoEffect
     }
 }
 

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -672,7 +672,7 @@ impl ExecutionPlan for RepartitionExec {
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::NoEffect
+        CardinalityEffect::Equal
     }
 }
 

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -48,6 +48,7 @@ use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::{EquivalenceProperties, PhysicalExpr, PhysicalSortExpr};
 
+use crate::execution_plan::CardinalityEffect;
 use futures::stream::Stream;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use hashbrown::HashMap;
@@ -668,6 +669,10 @@ impl ExecutionPlan for RepartitionExec {
 
     fn statistics(&self) -> Result<Statistics> {
         self.input.statistics()
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::NoEffect
     }
 }
 

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -975,7 +975,7 @@ impl ExecutionPlan for SortExec {
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::NoEffect
+        CardinalityEffect::Equal
     }
 }
 

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -975,7 +975,11 @@ impl ExecutionPlan for SortExec {
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::Equal
+        if self.fetch.is_none() {
+            CardinalityEffect::Equal
+        } else {
+            CardinalityEffect::LowerEqual
+        }
     }
 }
 

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -55,6 +55,7 @@ use datafusion_execution::TaskContext;
 use datafusion_physical_expr::LexOrdering;
 use datafusion_physical_expr_common::sort_expr::PhysicalSortRequirement;
 
+use crate::execution_plan::CardinalityEffect;
 use futures::{StreamExt, TryStreamExt};
 use log::{debug, trace};
 
@@ -971,6 +972,10 @@ impl ExecutionPlan for SortExec {
 
     fn fetch(&self) -> Option<usize> {
         self.fetch
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::NoEffect
     }
 }
 

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -53,6 +53,12 @@ physical_plan
 07)------------AggregateExec: mode=Partial, gby=[trace_id@0 as trace_id], aggr=[max(traces.timestamp)]
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
+query TI
+select * from (select tid, MAX(timestamp) mts from traces t group by tid) where tid != 'a' order by mts desc limit 3;
+----
+c 4
+b 3
+NULL 0
 
 query TI
 select trace_id, MAX(timestamp) from traces group by trace_id order by MAX(timestamp) desc limit 4;

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -94,6 +94,12 @@ c 1 2
 statement ok
 set datafusion.optimizer.enable_topk_aggregation = true;
 
+query TI
+select * from (select trace_id, MAX(timestamp) max_ts from traces t group by trace_id) where trace_id != 'b' order by max_ts desc limit 3;
+----
+c 4
+a 1
+
 query TT
 explain select trace_id, MAX(timestamp) from traces group by trace_id order by MAX(timestamp) desc limit 4;
 ----

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -57,8 +57,7 @@ query TI
 select * from (select trace_id, MAX(timestamp) max_ts from traces t group by trace_id) where trace_id != 'a' order by max_ts desc limit 3;
 ----
 c 4
-b 3
-NULL 0
+a 1
 
 query TI
 select trace_id, MAX(timestamp) from traces group by trace_id order by MAX(timestamp) desc limit 4;

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -95,7 +95,7 @@ statement ok
 set datafusion.optimizer.enable_topk_aggregation = true;
 
 query TI
-select * from (select trace_id, MAX(timestamp) max_ts from traces t group by trace_id) where trace_id != 'b' order by max_ts desc limit 3;
+select * from (select trace_id, MAX(timestamp) max_ts from traces t group by trace_id) where max_ts != 3 order by max_ts desc limit 2;
 ----
 c 4
 a 1

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -54,7 +54,7 @@ physical_plan
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query TI
-select * from (select trace_id, MAX(timestamp) max_ts from traces t group by trace_id) where trace_id != 'a' order by max_ts desc limit 3;
+select * from (select trace_id, MAX(timestamp) max_ts from traces t group by trace_id) where trace_id != 'b' order by max_ts desc limit 3;
 ----
 c 4
 a 1

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -54,7 +54,7 @@ physical_plan
 08)--------------MemoryExec: partitions=1, partition_sizes=[1]
 
 query TI
-select * from (select tid, MAX(timestamp) mts from traces t group by tid) where tid != 'a' order by mts desc limit 3;
+select * from (select trace_id, MAX(timestamp) max_ts from traces t group by trace_id) where trace_id != 'a' order by max_ts desc limit 3;
 ----
 c 4
 b 3


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12748.

## Rationale for this change

We don't want bugs.

## What changes are included in this PR?

1. Push down agg limits past projections so we can observe the bug
2. Fix the bug

## Are these changes tested?

Yes

## Are there any user-facing changes?

1. queries that weren't optimized should now be optimized
2. queries that are optimized should return correct results