### PR TITLE
Minor: add documentation note about `NullState`

### DIFF
--- a/datafusion/expr-common/src/groups_accumulator.rs
+++ b/datafusion/expr-common/src/groups_accumulator.rs
@@ -90,6 +90,11 @@ impl EmitTo {
 /// faster for queries with many group values.  See the [Aggregating Millions of
 /// Groups Fast blog] for more background.
 ///
+/// [`NullState`] can help keep the state for groups that have not seen any
+/// values and produce the correct output for those groups.
+///
+/// [`NullState`]: https://docs.rs/datafusion/latest/datafusion/physical_expr/struct.NullState.html
+///
 /// # Details
 /// Each group is assigned a `group_index` by the hash table and each
 /// accumulator manages the specific state, one per `group_index`.
@@ -117,6 +122,11 @@ pub trait GroupsAccumulator: Send {
     ///
     /// Note that subsequent calls to update_batch may have larger
     /// total_num_groups as new groups are seen.
+    ///
+    /// See [`NullState`] tp help keep the state for groups that have not seen any
+    /// values and produce the correct output for those groups.
+    ///
+    /// [`NullState`]: https://docs.rs/datafusion/latest/datafusion/physical_expr/struct.NullState.html
     fn update_batch(
         &mut self,
         values: &[ArrayRef],

--- a/datafusion/expr-common/src/groups_accumulator.rs
+++ b/datafusion/expr-common/src/groups_accumulator.rs
@@ -123,7 +123,7 @@ pub trait GroupsAccumulator: Send {
     /// Note that subsequent calls to update_batch may have larger
     /// total_num_groups as new groups are seen.
     ///
-    /// See [`NullState`] tp help keep the state for groups that have not seen any
+    /// See [`NullState`] to help keep the state for groups that have not seen any
     /// values and produce the correct output for those groups.
     ///
     /// [`NullState`]: https://docs.rs/datafusion/latest/datafusion/physical_expr/struct.NullState.html

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -17,21 +17,6 @@
 //! [`Max`] and [`MaxAccumulator`] accumulator for the `max` function
 //! [`Min`] and [`MinAccumulator`] accumulator for the `min` function
 
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 use arrow::array::{
     ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Date64Array,
     Decimal128Array, Decimal256Array, Float16Array, Float32Array, Float64Array,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

While working on https://github.com/apache/datafusion/issues/6906 with @devanbenz  it was not always clear that much of the complexity related to null handling in `GroupsAccumulator` can be handled by `NullState`

## What changes are included in this PR?

1. Add a note with reference to NullState in the `GroupsAccumulator` comments
2. Drive by remove a partial copy of the apache license

## Are these changes tested?
Yes, by CI
## Are there any user-facing changes?

Just documentation