### PR TITLE
API  from `ParquetExec` to `ParquetExecBuilder`

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -501,6 +501,8 @@ impl ParquetExec {
     /// Convert this `ParquetExec` into a builder for modification
     pub fn into_builder(self) -> ParquetExecBuilder {
         // list out fields so it is clear what is being dropped
+        // (note the fields which are dropped are re-created as part of calling
+        // `build` on the builder)
         let Self {
             base_config,
             projected_statistics: _,

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -179,8 +179,8 @@ pub use writer::plan_to_parquet;
 /// # fn parquet_exec() -> ParquetExec { unimplemented!() }
 /// // Split a single ParquetExec into multiple ParquetExecs, one for each file
 /// let exec = parquet_exec();
-/// let exiting_file_groups = &exec.base_config().file_groups;
-/// let new_execs = exiting_file_groups
+/// let existing_file_groups = &exec.base_config().file_groups;
+/// let new_execs = existing_file_groups
 ///   .iter()
 ///   .map(|file_group| {
 ///     // create a new exec by copying the existing exec into a builder
@@ -500,7 +500,7 @@ impl ParquetExec {
 
     /// Convert this `ParquetExec` into a builder for modification
     pub fn into_builder(self) -> ParquetExecBuilder {
-        // list out fileds so it is clear what is being dropped
+        // list out fields so it is clear what is being dropped
         let Self {
             base_config,
             projected_statistics: _,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/12737
Closes https://github.com/apache/datafusion/pull/12726

## Rationale for this change

See https://github.com/apache/datafusion/issues/12737 for rationale (basically many times we manipulate a `ParquetExec` downstream we end up needing to create a builder from an existing `ParquetExec`



## What changes are included in this PR?

Changes:
1. Add `ParquetExec::into_builder()` method
2. Add docs with examples of usage
3. Update some existing code to use it

## Are these changes tested?
Yes

## Are there any user-facing changes?
New API and Docs