### PR TITLE
Remove unnecessary `DFSchema::check_ambiguous_name`

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -406,33 +406,6 @@ impl DFSchema {
         }
     }
 
-    /// Check whether the column reference is ambiguous
-    pub fn check_ambiguous_name(
-        &self,
-        qualifier: Option<&TableReference>,
-        name: &str,
-    ) -> Result<()> {
-        let count = self
-            .iter()
-            .filter(|(field_q, f)| match (field_q, qualifier) {
-                (Some(q1), Some(q2)) => q1.resolved_eq(q2) && f.name() == name,
-                (None, None) => f.name() == name,
-                _ => false,
-            })
-            .take(2)
-            .count();
-        if count > 1 {
-            _schema_err!(SchemaError::AmbiguousReference {
-                field: Column {
-                    relation: None,
-                    name: name.to_string(),
-                },
-            })
-        } else {
-            Ok(())
-        }
-    }
-
     /// Find the qualified field with the given name
     pub fn qualified_field_with_name(
         &self,

--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -126,9 +126,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         ) {
                             match planner_result {
                                 PlannerResult::Planned(expr) => {
-                                    // sanity check on column
-                                    schema
-                                        .check_ambiguous_name(qualifier, field.name())?;
                                     return Ok(expr);
                                 }
                                 PlannerResult::Original(_args) => {}
@@ -139,8 +136,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 }
                 // found matching field with no spare identifier(s)
                 Some((field, qualifier, _nested_names)) => {
-                    // sanity check on column
-                    schema.check_ambiguous_name(qualifier, field.name())?;
                     Ok(Expr::Column(Column::from((qualifier, field))))
                 }
                 None => {
@@ -184,9 +179,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             let s = &ids[0..ids.len()];
                             // safe unwrap as s can never be empty or exceed the bounds
                             let (relation, column_name) = form_identifier(s).unwrap();
-                            // sanity check on column
-                            schema
-                                .check_ambiguous_name(relation.as_ref(), column_name)?;
                             Ok(Expr::Column(Column::new(relation, column_name)))
                         }
                     }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change
`check_ambiguous_name` was introduced for issue #12337 .

After PR #12608, there are no longer duplicate field names in `DFSchema`, so this function is no longer necessary.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
By existing tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No, `check_ambiguous_name` should only be used internally.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
