### PR TITLE
Make HashJoinExec::join_schema public

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -306,7 +306,7 @@ pub struct HashJoinExec {
     pub join_type: JoinType,
     /// The schema after join. Please be careful when using this schema,
     /// if there is a projection, the schema isn't the same as the output schema.
-    join_schema: SchemaRef,
+    pub join_schema: SchemaRef,
     /// Future that consumes left input and builds the hash table
     left_fut: OnceAsync<JoinLeftData>,
     /// Shared the `RandomState` for the hashing algorithm

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -306,7 +306,7 @@ pub struct HashJoinExec {
     pub join_type: JoinType,
     /// The schema after join. Please be careful when using this schema,
     /// if there is a projection, the schema isn't the same as the output schema.
-    pub join_schema: SchemaRef,
+    join_schema: SchemaRef,
     /// Future that consumes left input and builds the hash table
     left_fut: OnceAsync<JoinLeftData>,
     /// Shared the `RandomState` for the hashing algorithm
@@ -413,6 +413,12 @@ impl HashJoinExec {
     /// How the join is performed
     pub fn join_type(&self) -> &JoinType {
         &self.join_type
+    }
+
+    /// The schema after join. Please be careful when using this schema,
+    /// if there is a projection, the schema isn't the same as the output schema.
+    pub fn join_schema(&self) -> &SchemaRef {
+        &self.join_schema
     }
 
     /// The partitioning mode of this hash join


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12806.

## Rationale for this change

It is needed by physical optimizers that want to replace the HashJoin with a different type of join, as they need to replace it with an equivalent projection, but HashJoinExec::projection could not be used to build it because it refers to indices in HashJoinExec::join_schema.

## What changes are included in this PR?

Makes HashJoinExec::join_schema public

## Are these changes tested?

no (should they?)

## Are there any user-facing changes?

new field in the API, already documented