### PR TITLE
Support creating tables via SQL with `FixedSizeList` column (e.g. `a int[3]`)

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -387,11 +387,25 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
     pub(crate) fn convert_data_type(&self, sql_type: &SQLDataType) -> Result<DataType> {
         match sql_type {
-            SQLDataType::Array(ArrayElemTypeDef::AngleBracket(inner_sql_type))
-            | SQLDataType::Array(ArrayElemTypeDef::SquareBracket(inner_sql_type, _)) => {
+            SQLDataType::Array(ArrayElemTypeDef::AngleBracket(inner_sql_type)) => {
                 // Arrays may be multi-dimensional.
                 let inner_data_type = self.convert_data_type(inner_sql_type)?;
                 Ok(DataType::new_list(inner_data_type, true))
+            }
+            SQLDataType::Array(ArrayElemTypeDef::SquareBracket(
+                inner_sql_type,
+                maybe_array_size,
+            )) => {
+                let inner_data_type = self.convert_data_type(inner_sql_type)?;
+                if let Some(array_size) = maybe_array_size {
+                    Ok(DataType::new_fixed_size_list(
+                        inner_data_type,
+                        *array_size as i32,
+                        true,
+                    ))
+                } else {
+                    Ok(DataType::new_list(inner_data_type, true))
+                }
             }
             SQLDataType::Array(ArrayElemTypeDef::None) => {
                 not_impl_err!("Arrays with unspecified type is not supported")

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -7097,6 +7097,19 @@ select array_has(a, 1) from values_all_empty;
 false
 false
 
+# Test create table with fixed sized array
+statement ok
+create table fixed_size_col_table (a int[3]) as values ([1,2,3]), ([4,5,6]);
+
+query T
+select arrow_typeof(a) from fixed_size_col_table;
+----
+FixedSizeList(Field { name: "item", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, 3)
+FixedSizeList(Field { name: "item", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, 3)
+
+statement error
+create table varying_fixed_size_col_table (a int[3]) as values ([1,2,3]), ([4,5]);
+
 ### Delete tables
 
 statement ok
@@ -7272,3 +7285,7 @@ drop table test_create_array_table;
 
 statement ok
 drop table values_all_empty;
+
+statement ok
+drop table fixed_size_col_table;
+


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10303.

## Rationale for this change

See #10303. 
To make it possible to create a table with a fixed size list column without resorting to casting.

## What changes are included in this PR?

Enable SQL query planner to convert the SQL data type Array(ArrayElemTypeDef::SquareBracket) to a FixedSizeList.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
