### PR TITLE
Fix: approx_percentile_cont_with_weight Panic

### DIFF
--- a/datafusion/functions-aggregate-common/src/tdigest.rs
+++ b/datafusion/functions-aggregate-common/src/tdigest.rs
@@ -641,15 +641,8 @@ impl TDigest {
             v => panic!("invalid centroids type {v:?}"),
         };
 
-        let mut max = cast_scalar_f64!(&state[3]);
-        let mut min = cast_scalar_f64!(&state[4]);
-
-        if !min.is_finite() {
-            min = f64::NEG_INFINITY;
-        }
-        if !max.is_finite() {
-            max = f64::INFINITY;
-        }
+        let max = cast_scalar_f64!(&state[3]);
+        let min = cast_scalar_f64!(&state[4]);
 
         if min.is_finite() && max.is_finite() {
             assert!(max.total_cmp(&min).is_ge());

--- a/datafusion/functions-aggregate-common/src/tdigest.rs
+++ b/datafusion/functions-aggregate-common/src/tdigest.rs
@@ -647,7 +647,6 @@ impl TDigest {
         if !min.is_finite() {
             min = f64::NEG_INFINITY;
         }
-    
         if !max.is_finite() {
             max = f64::INFINITY;
         }

--- a/datafusion/functions-aggregate-common/src/tdigest.rs
+++ b/datafusion/functions-aggregate-common/src/tdigest.rs
@@ -641,8 +641,16 @@ impl TDigest {
             v => panic!("invalid centroids type {v:?}"),
         };
 
-        let max = cast_scalar_f64!(&state[3]);
-        let min = cast_scalar_f64!(&state[4]);
+        let mut max = cast_scalar_f64!(&state[3]);
+        let mut min = cast_scalar_f64!(&state[4]);
+
+        if !min.is_finite() {
+            min = f64::NEG_INFINITY;
+        }
+    
+        if !max.is_finite() {
+            max = f64::INFINITY;
+        }
 
         assert!(max.total_cmp(&min).is_ge());
 

--- a/datafusion/functions-aggregate-common/src/tdigest.rs
+++ b/datafusion/functions-aggregate-common/src/tdigest.rs
@@ -651,7 +651,9 @@ impl TDigest {
             max = f64::INFINITY;
         }
 
-        assert!(max.total_cmp(&min).is_ge());
+        if min.is_finite() && max.is_finite() {
+            assert!(max.total_cmp(&min).is_ge());
+        }
 
         Self {
             max_size,

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -1398,7 +1398,7 @@ INSERT INTO t1 VALUES (TRUE);
 query R
 SELECT approx_percentile_cont_with_weight('NaN'::DOUBLE, 0, 0) FROM t1 WHERE t1.v1;
 ----
--Infinity
+Infinity
 
 statement ok
 DROP TABLE t1;

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -1385,6 +1385,24 @@ NaN
 statement ok
 DROP TABLE tmp_percentile_cont;
 
+# Test for issue where approx_percentile_cont_with_weight
+
+statement ok
+CREATE TABLE t1(v1 BOOL);
+
+statement ok
+INSERT INTO t1 VALUES (TRUE);
+
+# ISSUE: https://github.com/apache/datafusion/issues/12716
+# This test verifies that approx_percentile_cont_with_weight does not panic when given 'NaN' and returns 'inf'
+query R
+SELECT approx_percentile_cont_with_weight('NaN'::DOUBLE, 0, 0) FROM t1 WHERE t1.v1;
+----
+-Infinity
+
+statement ok
+DROP TABLE t1;
+
 # csv_query_cube_avg
 query TIR
 SELECT c1, c2, AVG(c3) FROM aggregate_test_100 GROUP BY CUBE (c1, c2) ORDER BY c1, c2


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #.
-->

Closes #12716.

## Rationale for this change
Handles case where min/max are infinite or not a number (NaN)
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Checks if min/max values are infinite or NaN + tests
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
