### PR TITLE
feat(substrait): add intersect support to consumer

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -887,6 +887,17 @@ pub async fn from_substrait_rel(
                         not_impl_err!("Union relation requires at least one input")
                     }
                 }
+                set_rel::SetOp::IntersectionPrimary => {
+                    if set.inputs.len() == 2 {
+                        LogicalPlanBuilder::intersect(
+                            from_substrait_rel(ctx, &set.inputs[0], extensions).await?,
+                            from_substrait_rel(ctx, &set.inputs[1], extensions).await?,
+                            false,
+                        )
+                    } else {
+                        not_impl_err!("Primary Intersect relation with more than two inputs isn't supported")
+                    }
+                }
                 _ => not_impl_err!("Unsupported set operator: {set_op:?}"),
             },
             Err(e) => not_impl_err!("Invalid set operation type {}: {e}", set.op),

--- a/datafusion/substrait/tests/testdata/test_plans/intersect.substrait.json
+++ b/datafusion/substrait/tests/testdata/test_plans/intersect.substrait.json
@@ -1,0 +1,118 @@
+{
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "set": {
+            "inputs": [
+              {
+                "project": {
+                  "common": {
+                    "emit": {
+                      "outputMapping": [
+                        1
+                      ]
+                    }
+                  },
+                  "input": {
+                    "read": {
+                      "common": {
+                        "direct": {}
+                      },
+                      "baseSchema": {
+                        "names": [
+                          "a"
+                        ],
+                        "struct": {
+                          "types": [
+                            {
+                              "i64": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            }
+                          ],
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "namedTable": {
+                        "names": [
+                          "data"
+                        ]
+                      }
+                    }
+                  },
+                  "expressions": [
+                    {
+                      "selection": {
+                        "directReference": {
+                          "structField": {}
+                        },
+                        "rootReference": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "project": {
+                  "common": {
+                    "emit": {
+                      "outputMapping": [
+                        1
+                      ]
+                    }
+                  },
+                  "input": {
+                    "read": {
+                      "common": {
+                        "direct": {}
+                      },
+                      "baseSchema": {
+                        "names": [
+                          "a"
+                        ],
+                        "struct": {
+                          "types": [
+                            {
+                              "i64": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            }
+                          ],
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "namedTable": {
+                        "names": [
+                          "data2"
+                        ]
+                      }
+                    }
+                  },
+                  "expressions": [
+                    {
+                      "selection": {
+                        "directReference": {
+                          "structField": {}
+                        },
+                        "rootReference": {}
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "op": "SET_OP_INTERSECTION_PRIMARY"
+          }
+        },
+        "names": [
+          "a"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 54,
+    "producer": "subframe"
+  }
+}


### PR DESCRIPTION
## What changes are included in this PR?

Adds support for intersect (primary) set operation to substrait consumer. 

## Are these changes tested?

Intersect can't be round-tripped (at least not easily) because DF has no explicit logical plan node for the op, rather splits it into lower level operations. That's why the test is comparing DF plans produced by an externally written substrait plan and equivalent datafusion sql query.

## Are there any user-facing changes?

yes, a new feature