### PR TITLE
Macro for creating record batch from literal slice

### DIFF
--- a/datafusion/common/src/test_util.rs
+++ b/datafusion/common/src/test_util.rs
@@ -327,15 +327,12 @@ macro_rules! create_array {
 ///
 /// Example:
 /// ```
+/// use datafusion_common::{create_batch, create_array};
 /// let batch = create_batch!(
 ///     ("a", Int32, vec![1, 2, 3]),
 ///     ("b", Float64, vec![Some(4.0), None, Some(5.0)]),
 ///     ("c", Utf8, vec!["alpha", "beta", "gamma"])
-/// )?;
-///
-/// let ctx = SessionContext::new();
-///
-/// df = ctx.read_batch(batch)?;
+/// );
 /// ```
 #[macro_export]
 macro_rules! create_batch {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #12574

## Rationale for this change

This macro allows for easy creation of a record batch, useful for prototype and unit testing. A user requested this feature.

## What changes are included in this PR?

Adds a macro to create a record batch. For example, the following creates a record batch with three arrays, a non nullable Int32, a nullable Float64, and a non nullable String.

```
let batch = create_batch!(
    ("a", Int32, vec![1, 2, 3]),
    ("b", Float64, vec![Some(4.0), None, Some(5.0)]),
    ("c", Utf8, vec!["alpha", "beta", "gamma"])
)?;

let ctx = SessionContext::new();

ctx.read_batch(batch)?.show().await
```

Yields:
```
+---+-----+-------+
| a | b   | c     |
+---+-----+-------+
| 1 | 4.0 | alpha |
| 2 |     | beta  |
| 3 | 5.0 | gamma |
+---+-----+-------+
```

## Are these changes tested?

Tested both in the provided unit test and locally.

## Are there any user-facing changes?

No