### PR TITLE
Make PruningPredicate's rewrite public

### DIFF
--- a/datafusion/core/src/physical_optimizer/pruning.rs
+++ b/datafusion/core/src/physical_optimizer/pruning.rs
@@ -502,12 +502,6 @@ impl Default for ConstantUnhandledPredicateHook {
     }
 }
 
-impl ConstantUnhandledPredicateHook {
-    fn new(default: Arc<dyn PhysicalExpr>) -> Self {
-        Self { default }
-    }
-}
-
 impl UnhandledPredicateHook for ConstantUnhandledPredicateHook {
     fn handle(&self, _expr: &Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
         self.default.clone()


### PR DESCRIPTION
Replaces https://github.com/apache/datafusion/pull/12606, https://github.com/apache/datafusion/pull/12835

As per https://github.com/apache/datafusion/pull/12606#issuecomment-2392303014 the plan was to split the rewrite logic from the rest of PruningPredicate. It turns out that was as easy as making a function public, kudos to whoever wrote this originally for organizing it nicely 🥳.