### PR TITLE
re-export PartitionEvaluatorArgs from datafusion_expr::function

### DIFF
--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -28,6 +28,7 @@ pub use datafusion_functions_aggregate_common::accumulator::{
 };
 
 pub use datafusion_functions_window_common::field::WindowUDFFieldArgs;
+pub use datafusion_functions_window_common::partition::PartitionEvaluatorArgs;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Hint {


### PR DESCRIPTION
This is needed to implement the WindowUDF trait.

## Which issue does this PR close?

Closes #12877.

## Rationale for this change

`PartitionEvaluatorArgs` is needed to implement `WindowUDF`, but is not currently re-exported.

## What changes are included in this PR?

`PartitionEvaluatorArgs` is re-exported in `datafusion_expr::function`.

I placed it here because that is where`WindowUDFFieldArgs` is re-exported.

## Are these changes tested?
N/A

## Are there any user-facing changes?

Not from any released version.