### PR TITLE
Feature/ffi initial implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "datafusion/expr",
     "datafusion/expr-common",
     "datafusion/execution",
+    "datafusion/ffi",
     "datafusion/functions",
     "datafusion/functions-aggregate",
     "datafusion/functions-aggregate-common",
@@ -99,6 +100,7 @@ datafusion-common-runtime = { path = "datafusion/common-runtime", version = "42.
 datafusion-execution = { path = "datafusion/execution", version = "42.0.0" }
 datafusion-expr = { path = "datafusion/expr", version = "42.0.0" }
 datafusion-expr-common = { path = "datafusion/expr-common", version = "42.0.0" }
+datafusion-ffi = { path = "datafusion/ffi", version = "42.0.0" }
 datafusion-functions = { path = "datafusion/functions", version = "42.0.0" }
 datafusion-functions-aggregate = { path = "datafusion/functions-aggregate", version = "42.0.0" }
 datafusion-functions-aggregate-common = { path = "datafusion/functions-aggregate-common", version = "42.0.0" }

--- a/datafusion/ffi/Cargo.toml
+++ b/datafusion/ffi/Cargo.toml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "datafusion-ffi"
+description = "Foreign Function Interface implementation for DataFusion"
+readme = "README.md"
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+# Specify MSRV here as `cargo msrv` doesn't support workspace version
+rust-version = "1.76"
+
+[lints]
+workspace = true
+
+[lib]
+name = "datafusion_ffi"
+path = "src/lib.rs"
+
+[dependencies]
+arrow = { workspace = true, features = ["ffi"] }
+datafusion = { workspace = true, default-features = true }
+datafusion-proto = { workspace = true }
+futures = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+prost = { workspace = true }

--- a/datafusion/ffi/README.md
+++ b/datafusion/ffi/README.md
@@ -1,0 +1,28 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# `datafusion-ffi`: Apache DataFusion Foreign Function Interface
+
+This crate contains code to allow interoperability of Apache [DataFusion]
+with functions from other languages using a stable interface.
+
+See [API Docs] for details and examples.
+
+[datafusion]: https://datafusion.apache.org
+[api docs]: http://docs.rs/datafusion-ffi/latest

--- a/datafusion/ffi/src/execution_plan.rs
+++ b/datafusion/ffi/src/execution_plan.rs
@@ -157,17 +157,17 @@ unsafe extern "C" fn clone_fn_wrapper(plan: *const FFI_ExecutionPlan) -> FFI_Exe
 // This struct exists on the consumer side (datafusion-python, for example) and not
 // in the provider's side.
 #[derive(Debug)]
-pub struct ExportedExecutionPlan {
+pub struct ForeignExecutionPlan {
     name: String,
     plan: Box<FFI_ExecutionPlan>,
     properties: PlanProperties,
     children: Vec<Arc<dyn ExecutionPlan>>,
 }
 
-unsafe impl Send for ExportedExecutionPlan {}
-unsafe impl Sync for ExportedExecutionPlan {}
+unsafe impl Send for ForeignExecutionPlan {}
+unsafe impl Sync for ForeignExecutionPlan {}
 
-impl DisplayAs for ExportedExecutionPlan {
+impl DisplayAs for ForeignExecutionPlan {
     fn fmt_as(
         &self,
         _t: datafusion::physical_plan::DisplayFormatType,
@@ -219,7 +219,7 @@ impl Drop for FFI_ExecutionPlan {
     }
 }
 
-impl ExportedExecutionPlan {
+impl ForeignExecutionPlan {
     /// Takes ownership of a FFI_ExecutionPlan
     ///
     /// # Safety
@@ -265,7 +265,7 @@ impl ExportedExecutionPlan {
                 .into_iter()
                 .map(|child| {
 
-                    let child_plan = ExportedExecutionPlan::new(child);
+                    let child_plan = ForeignExecutionPlan::new(child);
 
                     child_plan.map(|c| Arc::new(c) as Arc<dyn ExecutionPlan>)
                 })
@@ -292,7 +292,7 @@ impl Clone for FFI_ExecutionPlan {
     }
 }
 
-impl ExecutionPlan for ExportedExecutionPlan {
+impl ExecutionPlan for ForeignExecutionPlan {
     fn name(&self) -> &str {
         &self.name
     }
@@ -316,7 +316,7 @@ impl ExecutionPlan for ExportedExecutionPlan {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(ExportedExecutionPlan {
+        Ok(Arc::new(ForeignExecutionPlan {
             plan: self.plan.clone(),
             name: self.name.clone(),
             children,

--- a/datafusion/ffi/src/execution_plan.rs
+++ b/datafusion/ffi/src/execution_plan.rs
@@ -1,0 +1,573 @@
+use std::{
+    ffi::{c_char, c_void, CString},
+    pin::Pin,
+    ptr::null_mut,
+    slice,
+    sync::Arc,
+};
+
+use arrow::{datatypes::Schema, ffi::FFI_ArrowSchema, ffi_stream::FFI_ArrowArrayStream};
+use datafusion::{
+    error::DataFusionError,
+    execution::{SendableRecordBatchStream, TaskContext},
+    physical_plan::{DisplayAs, ExecutionMode, ExecutionPlan, PlanProperties},
+};
+use datafusion::{error::Result, physical_expr::EquivalenceProperties, prelude::SessionContext};
+use datafusion_proto::{
+    physical_plan::{
+        from_proto::{parse_physical_sort_exprs, parse_protobuf_partitioning},
+        to_proto::{serialize_partitioning, serialize_physical_sort_exprs},
+        DefaultPhysicalExtensionCodec,
+    },
+    protobuf::{Partitioning, PhysicalSortExprNodeCollection},
+};
+use prost::Message;
+
+use super::record_batch_stream::{record_batch_to_arrow_stream, ConsumerRecordBatchStream};
+
+#[repr(C)]
+#[derive(Debug)]
+#[allow(missing_docs)]
+#[allow(non_camel_case_types)]
+pub struct FFI_ExecutionPlan {
+    pub properties:
+        Option<unsafe extern "C" fn(plan: *const FFI_ExecutionPlan) -> FFI_PlanProperties>,
+    pub children: Option<
+        unsafe extern "C" fn(
+            plan: *const FFI_ExecutionPlan,
+            num_children: &mut usize,
+            err_code: &mut i32,
+        ) -> *mut *const FFI_ExecutionPlan,
+    >,
+    pub name: unsafe extern "C" fn(plan: *const FFI_ExecutionPlan) -> *const c_char,
+
+    pub execute: unsafe extern "C" fn(
+        plan: *const FFI_ExecutionPlan,
+        partition: usize,
+        err_code: &mut i32,
+    ) -> FFI_ArrowArrayStream,
+
+    pub private_data: *mut c_void,
+}
+
+pub struct ExecutionPlanPrivateData {
+    pub plan: Arc<dyn ExecutionPlan + Send>,
+    pub last_error: Option<CString>,
+    pub children: Vec<*const FFI_ExecutionPlan>,
+    pub context: Arc<TaskContext>,
+}
+
+unsafe extern "C" fn properties_fn_wrapper(plan: *const FFI_ExecutionPlan) -> FFI_PlanProperties {
+    let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+    let properties = (*private_data).plan.properties();
+    properties.clone().into()
+}
+
+unsafe extern "C" fn children_fn_wrapper(
+    plan: *const FFI_ExecutionPlan,
+    num_children: &mut usize,
+    err_code: &mut i32,
+) -> *mut *const FFI_ExecutionPlan {
+    let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+
+    *num_children = (*private_data).children.len();
+    *err_code = 0;
+
+    let mut children: Vec<_> = (*private_data).children.to_owned();
+    let children_ptr = children.as_mut_ptr();
+
+    std::mem::forget(children);
+
+    children_ptr
+}
+
+unsafe extern "C" fn execute_fn_wrapper(
+    plan: *const FFI_ExecutionPlan,
+    partition: usize,
+    err_code: &mut i32,
+) -> FFI_ArrowArrayStream {
+    let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+
+    let record_batch_stream = match (*private_data)
+        .plan
+        .execute(partition, (*private_data).context.clone())
+    {
+        Ok(rbs) => rbs,
+        Err(_e) => {
+            *err_code = 1;
+            return FFI_ArrowArrayStream::empty();
+        }
+    };
+
+    record_batch_to_arrow_stream(record_batch_stream)
+}
+unsafe extern "C" fn name_fn_wrapper(plan: *const FFI_ExecutionPlan) -> *const c_char {
+    let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+
+    let name = (*private_data).plan.name();
+
+    CString::new(name)
+        .unwrap_or(CString::new("unable to parse execution plan name").unwrap())
+        .into_raw()
+}
+
+// Since the trait ExecutionPlan requires borrowed values, we wrap our FFI.
+// This struct exists on the consumer side (datafusion-python, for example) and not
+// in the provider's side.
+#[derive(Debug)]
+pub struct ExportedExecutionPlan {
+    name: String,
+    plan: *const FFI_ExecutionPlan,
+    properties: PlanProperties,
+    children: Vec<Arc<dyn ExecutionPlan>>,
+}
+
+unsafe impl Send for ExportedExecutionPlan {}
+unsafe impl Sync for ExportedExecutionPlan {}
+
+impl DisplayAs for ExportedExecutionPlan {
+    fn fmt_as(
+        &self,
+        _t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(
+            f,
+            "FFI_ExecutionPlan(number_of_children={})",
+            self.children.len(),
+        )
+    }
+}
+
+impl FFI_ExecutionPlan {
+    /// This function is called on the provider's side.
+    pub fn new(plan: Arc<dyn ExecutionPlan + Send>, context: Arc<TaskContext>) -> Self {
+        let children = plan
+            .children()
+            .into_iter()
+            .map(|child| Box::new(FFI_ExecutionPlan::new(child.clone(), context.clone())))
+            .map(|child| Box::into_raw(child) as *const FFI_ExecutionPlan)
+            .collect();
+        println!("children collected");
+
+        let private_data = Box::new(ExecutionPlanPrivateData {
+            plan,
+            children,
+            context,
+            last_error: None,
+        });
+        println!("generated private data, ready to return");
+
+        Self {
+            properties: Some(properties_fn_wrapper),
+            children: Some(children_fn_wrapper),
+            name: name_fn_wrapper,
+            execute: execute_fn_wrapper,
+            private_data: Box::into_raw(private_data) as *mut c_void,
+        }
+    }
+
+    // pub fn empty() -> Self {
+    //     Self {
+    //         properties: None,
+    //         children: None,
+    //         private_data: std::ptr::null_mut(),
+    //     }
+    // }
+}
+
+impl ExportedExecutionPlan {
+    /// Wrap a FFI Execution Plan
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the pointer provided points to a valid implementation
+    /// of FFI_ExecutionPlan
+    pub unsafe fn new(plan: *const FFI_ExecutionPlan) -> Result<Self> {
+        let name_fn = (*plan).name;
+        let name_cstr = name_fn(plan);
+        let name = CString::from_raw(name_cstr as *mut c_char)
+            .to_str()
+            .unwrap_or("Unable to parse FFI_ExecutionPlan name")
+            .to_string();
+
+        println!("entered ExportedExecutionPlan::new");
+        let properties = unsafe {
+            let properties_fn = (*plan).properties.ok_or(DataFusionError::NotImplemented(
+                "properties not implemented on FFI_ExecutionPlan".to_string(),
+            ))?;
+            println!("About to call properties fn");
+            properties_fn(plan).try_into()?
+        };
+
+        println!("created properties");
+        let children = unsafe {
+            let children_fn = (*plan).children.ok_or(DataFusionError::NotImplemented(
+                "children not implemented on FFI_ExecutionPlan".to_string(),
+            ))?;
+            let mut num_children = 0;
+            let mut err_code = 0;
+            let children_ptr = children_fn(plan, &mut num_children, &mut err_code);
+
+            println!(
+                "We called the FFI function children so the provider told us we have {} children",
+                num_children
+            );
+
+            if err_code != 0 {
+                return Err(DataFusionError::Plan(
+                    "Error getting children for FFI_ExecutionPlan".to_string(),
+                ));
+            }
+
+            let ffi_vec = Vec::from_raw_parts(children_ptr, num_children, num_children);
+            let maybe_children: Result<Vec<_>> = ffi_vec
+                .into_iter()
+                .map(|child| {
+                    println!("Ok, we are about to examine a child ffi_executionplan");
+                    if let Some(props_fn) = (*child).properties {
+                        println!("We do have properties on the child ");
+                        let child_props = props_fn(child);
+                        println!("Child schema {:?}", child_props.schema);
+                    }
+
+                    let child_plan = ExportedExecutionPlan::new(child);
+
+                    child_plan.map(|c| Arc::new(c) as Arc<dyn ExecutionPlan>)
+                })
+                .collect();
+            println!("finsihed maybe children");
+
+            maybe_children?
+        };
+
+        println!("About to return ExportedExecurtionPlan");
+
+        Ok(Self {
+            name,
+            plan,
+            properties,
+            children,
+        })
+    }
+}
+
+impl ExecutionPlan for ExportedExecutionPlan {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        self.children
+            .iter()
+            .map(|p| p as &Arc<dyn ExecutionPlan>)
+            .collect()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(ExportedExecutionPlan {
+            plan: self.plan,
+            name: self.name.clone(),
+            children,
+            properties: self.properties.clone(),
+        }))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<datafusion::execution::TaskContext>,
+    ) -> datafusion::error::Result<datafusion::execution::SendableRecordBatchStream> {
+        unsafe {
+            let execute_fn = (*self.plan).execute;
+            let mut err_code = 0;
+            let arrow_stream = execute_fn(self.plan, partition, &mut err_code);
+
+            match err_code {
+                0 => ConsumerRecordBatchStream::try_from(arrow_stream)
+                    .map(|v| Pin::new(Box::new(v)) as SendableRecordBatchStream),
+                _ => Err(DataFusionError::Execution(
+                    "Error occurred during FFI call to FFI_ExecutionPlan execute.".to_string(),
+                )),
+            }
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+#[allow(missing_docs)]
+#[allow(non_camel_case_types)]
+pub struct FFI_PlanProperties {
+    // Returns protobuf serialized bytes of the partitioning
+    pub output_partitioning: Option<
+        unsafe extern "C" fn(
+            plan: *const FFI_PlanProperties,
+            buffer_size: &mut usize,
+            buffer_bytes: &mut *mut u8,
+        ) -> i32,
+    >,
+
+    pub execution_mode:
+        Option<unsafe extern "C" fn(plan: *const FFI_PlanProperties) -> FFI_ExecutionMode>,
+
+    // PhysicalSortExprNodeCollection proto
+    pub output_ordering: Option<
+        unsafe extern "C" fn(
+            plan: *const FFI_PlanProperties,
+            buffer_size: &mut usize,
+            buffer_bytes: &mut *mut u8,
+        ) -> i32,
+    >,
+
+    pub schema: Option<unsafe extern "C" fn(plan: *const FFI_PlanProperties) -> FFI_ArrowSchema>,
+
+    pub private_data: *mut c_void,
+}
+
+unsafe extern "C" fn output_partitioning_fn_wrapper(
+    properties: *const FFI_PlanProperties,
+    buffer_size: &mut usize,
+    buffer_bytes: &mut *mut u8,
+) -> i32 {
+    // let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+    // let properties = (*private_data).plan.properties();
+    // properties.clone().into()
+    let private_data = (*properties).private_data as *const PlanProperties;
+    let partitioning = (*private_data).output_partitioning();
+
+    let codec = DefaultPhysicalExtensionCodec {};
+    let partitioning_data = match serialize_partitioning(partitioning, &codec) {
+        Ok(p) => p,
+        Err(_) => return 1,
+    };
+
+    let mut partition_bytes = partitioning_data.encode_to_vec();
+    *buffer_size = partition_bytes.len();
+    *buffer_bytes = partition_bytes.as_mut_ptr();
+
+    std::mem::forget(partition_bytes);
+
+    0
+}
+
+unsafe extern "C" fn execution_mode_fn_wrapper(
+    properties: *const FFI_PlanProperties,
+) -> FFI_ExecutionMode {
+    // let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+    // let properties = (*private_data).plan.properties();
+    // properties.clone().into()
+    let private_data = (*properties).private_data as *const PlanProperties;
+    let execution_mode = (*private_data).execution_mode();
+
+    execution_mode.into()
+}
+
+unsafe extern "C" fn output_ordering_fn_wrapper(
+    properties: *const FFI_PlanProperties,
+    buffer_size: &mut usize,
+    buffer_bytes: &mut *mut u8,
+) -> i32 {
+    // let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+    // let properties = (*private_data).plan.properties();
+    // properties.clone().into()
+    let private_data = (*properties).private_data as *const PlanProperties;
+    let output_ordering = match (*private_data).output_ordering() {
+        Some(o) => o,
+        None => {
+            *buffer_size = 0;
+            return 0;
+        }
+    }
+    .to_owned();
+
+    let codec = DefaultPhysicalExtensionCodec {};
+    let physical_sort_expr_nodes = match serialize_physical_sort_exprs(output_ordering, &codec) {
+        Ok(p) => p,
+        Err(_) => return 1,
+    };
+
+    let ordering_data = PhysicalSortExprNodeCollection {
+        physical_sort_expr_nodes,
+    };
+
+    let mut ordering_bytes = ordering_data.encode_to_vec();
+    *buffer_size = ordering_bytes.len();
+    *buffer_bytes = ordering_bytes.as_mut_ptr();
+    std::mem::forget(ordering_bytes);
+
+    0
+}
+
+// pub schema: Option<unsafe extern "C" fn(plan: *const FFI_PlanProperties) -> FFI_ArrowSchema>,
+unsafe extern "C" fn schema_fn_wrapper(properties: *const FFI_PlanProperties) -> FFI_ArrowSchema {
+    let private_data = (*properties).private_data as *const PlanProperties;
+    let schema = (*private_data).eq_properties.schema();
+
+    // This does silently fail because TableProvider does not return a result
+    // so we expect it to always pass. Maybe some logging should be added.
+    FFI_ArrowSchema::try_from(schema.as_ref()).unwrap_or(FFI_ArrowSchema::empty())
+}
+
+impl From<PlanProperties> for FFI_PlanProperties {
+    fn from(value: PlanProperties) -> Self {
+        let private_data = Box::new(value);
+
+        Self {
+            output_partitioning: Some(output_partitioning_fn_wrapper),
+            execution_mode: Some(execution_mode_fn_wrapper),
+            output_ordering: Some(output_ordering_fn_wrapper),
+            schema: Some(schema_fn_wrapper),
+            private_data: Box::into_raw(private_data) as *mut c_void,
+        }
+    }
+}
+
+// /// Creates a new [`FFI_TableProvider`].
+// pub fn new(provider: Box<dyn TableProvider + Send>) -> Self {
+//     let private_data = Box::new(ProviderPrivateData {
+//         provider,
+//         last_error: None,
+//     });
+
+//     Self {
+//         version: 2,
+//         schema: Some(provider_schema),
+//         scan: Some(provider_scan),
+//         private_data: Box::into_raw(private_data) as *mut c_void,
+//     }
+// }
+
+impl TryFrom<FFI_PlanProperties> for PlanProperties {
+    type Error = DataFusionError;
+
+    fn try_from(value: FFI_PlanProperties) -> std::result::Result<Self, Self::Error> {
+        unsafe {
+            let schema_fn = value.schema.ok_or(DataFusionError::NotImplemented(
+                "schema() not implemented on FFI_PlanProperties".to_string(),
+            ))?;
+            let ffi_schema = schema_fn(&value);
+            let schema: Schema = (&ffi_schema).try_into()?;
+
+            let ordering_fn = value
+                .output_ordering
+                .ok_or(DataFusionError::NotImplemented(
+                    "output_ordering() not implemented on FFI_PlanProperties".to_string(),
+                ))?;
+            let mut buff_size = 0;
+            let mut buff = null_mut();
+            if ordering_fn(&value, &mut buff_size, &mut buff) != 0 {
+                return Err(DataFusionError::Plan(
+                    "Error occurred during FFI call to output_ordering in FFI_PlanProperties"
+                        .to_string(),
+                ));
+            }
+
+            // TODO we will need to get these, but unsure if it happesn on the provider or consumer right now.
+            let default_ctx = SessionContext::new();
+            let codex = DefaultPhysicalExtensionCodec {};
+
+            let orderings = match buff_size == 0 {
+                true => None,
+                false => {
+                    let data = slice::from_raw_parts(buff, buff_size);
+
+                    let proto_output_ordering = PhysicalSortExprNodeCollection::decode(data)
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+                    Some(parse_physical_sort_exprs(
+                        &proto_output_ordering.physical_sort_expr_nodes,
+                        &default_ctx,
+                        &schema,
+                        &codex,
+                    )?)
+                }
+            };
+
+            let partitioning_fn =
+                value
+                    .output_partitioning
+                    .ok_or(DataFusionError::NotImplemented(
+                        "output_partitioning() not implemented on FFI_PlanProperties".to_string(),
+                    ))?;
+            if partitioning_fn(&value, &mut buff_size, &mut buff) != 0 {
+                return Err(DataFusionError::Plan(
+                    "Error occurred during FFI call to output_partitioning in FFI_PlanProperties"
+                        .to_string(),
+                ));
+            }
+            let data = slice::from_raw_parts(buff, buff_size);
+
+            let proto_partitioning =
+                Partitioning::decode(data).map_err(|e| DataFusionError::External(Box::new(e)))?;
+            // TODO: Validate this unwrap is safe.
+            let partitioning = parse_protobuf_partitioning(
+                Some(&proto_partitioning),
+                &default_ctx,
+                &schema,
+                &codex,
+            )?
+            .unwrap();
+
+            let execution_mode_fn = value.execution_mode.ok_or(DataFusionError::NotImplemented(
+                "execution_mode() not implemented on FFI_PlanProperties".to_string(),
+            ))?;
+            let execution_mode = execution_mode_fn(&value).into();
+
+            let eq_properties = match orderings {
+                Some(ordering) => {
+                    EquivalenceProperties::new_with_orderings(Arc::new(schema), &[ordering])
+                }
+                None => EquivalenceProperties::new(Arc::new(schema)),
+            };
+
+            Ok(Self::new(eq_properties, partitioning, execution_mode))
+        }
+    }
+    // fn from(value: FFI_PlanProperties) -> Self {
+    //     let schema = self.schema()
+
+    //     let equiv_prop = EquivalenceProperties::new_with_orderings(schema, orderings);
+    // }
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum FFI_ExecutionMode {
+    Bounded,
+
+    Unbounded,
+
+    PipelineBreaking,
+}
+
+impl From<ExecutionMode> for FFI_ExecutionMode {
+    fn from(value: ExecutionMode) -> Self {
+        match value {
+            ExecutionMode::Bounded => FFI_ExecutionMode::Bounded,
+            ExecutionMode::Unbounded => FFI_ExecutionMode::Unbounded,
+            ExecutionMode::PipelineBreaking => FFI_ExecutionMode::PipelineBreaking,
+        }
+    }
+}
+
+impl From<FFI_ExecutionMode> for ExecutionMode {
+    fn from(value: FFI_ExecutionMode) -> Self {
+        match value {
+            FFI_ExecutionMode::Bounded => ExecutionMode::Bounded,
+            FFI_ExecutionMode::Unbounded => ExecutionMode::Unbounded,
+            FFI_ExecutionMode::PipelineBreaking => ExecutionMode::PipelineBreaking,
+        }
+    }
+}

--- a/datafusion/ffi/src/execution_plan.rs
+++ b/datafusion/ffi/src/execution_plan.rs
@@ -1,29 +1,18 @@
 use std::{
     ffi::{c_char, c_void, CString},
     pin::Pin,
-    ptr::null_mut,
-    slice,
     sync::Arc,
 };
 
-use arrow::{datatypes::Schema, ffi::FFI_ArrowSchema, ffi_stream::FFI_ArrowArrayStream};
+use arrow::ffi_stream::FFI_ArrowArrayStream;
 use datafusion::{
     error::DataFusionError,
     execution::{SendableRecordBatchStream, TaskContext},
-    physical_plan::{DisplayAs, ExecutionMode, ExecutionPlan, PlanProperties},
+    physical_plan::{DisplayAs, ExecutionPlan, PlanProperties},
 };
-use datafusion::{
-    error::Result, physical_expr::EquivalenceProperties, prelude::SessionContext,
-};
-use datafusion_proto::{
-    physical_plan::{
-        from_proto::{parse_physical_sort_exprs, parse_protobuf_partitioning},
-        to_proto::{serialize_partitioning, serialize_physical_sort_exprs},
-        DefaultPhysicalExtensionCodec,
-    },
-    protobuf::{Partitioning, PhysicalSortExprNodeCollection},
-};
-use prost::Message;
+use datafusion::error::Result;
+
+use crate::plan_properties::FFI_PlanProperties;
 
 use super::record_batch_stream::{
     record_batch_to_arrow_stream, ConsumerRecordBatchStream,
@@ -97,7 +86,7 @@ unsafe extern "C" fn execute_fn_wrapper(
 
     let record_batch_stream = match (*private_data)
         .plan
-        .execute(partition, (*private_data).context.clone())
+        .execute(partition, Arc::clone(&(*private_data).context))
     {
         Ok(rbs) => rbs,
         Err(_e) => {
@@ -148,14 +137,13 @@ impl DisplayAs for ExportedExecutionPlan {
 
 impl FFI_ExecutionPlan {
     /// This function is called on the provider's side.
-    pub fn new(plan: Arc<dyn ExecutionPlan + Send>, context: Arc<TaskContext>) -> Self {
+    pub fn new(plan: Arc<dyn ExecutionPlan>, context: Arc<TaskContext>) -> Self {
         let children = plan
             .children()
             .into_iter()
-            .map(|child| Box::new(FFI_ExecutionPlan::new(child.clone(), context.clone())))
+            .map(|child| Box::new(FFI_ExecutionPlan::new(Arc::clone(child), Arc::clone(&context))))
             .map(|child| Box::into_raw(child) as *const FFI_ExecutionPlan)
             .collect();
-        println!("children collected");
 
         let private_data = Box::new(ExecutionPlanPrivateData {
             plan,
@@ -163,7 +151,6 @@ impl FFI_ExecutionPlan {
             context,
             last_error: None,
         });
-        println!("generated private data, ready to return");
 
         Self {
             properties: Some(properties_fn_wrapper),
@@ -198,17 +185,14 @@ impl ExportedExecutionPlan {
             .unwrap_or("Unable to parse FFI_ExecutionPlan name")
             .to_string();
 
-        println!("entered ExportedExecutionPlan::new");
         let properties = unsafe {
             let properties_fn =
                 (*plan).properties.ok_or(DataFusionError::NotImplemented(
                     "properties not implemented on FFI_ExecutionPlan".to_string(),
                 ))?;
-            println!("About to call properties fn");
             properties_fn(plan).try_into()?
         };
 
-        println!("created properties");
         let children = unsafe {
             let children_fn = (*plan).children.ok_or(DataFusionError::NotImplemented(
                 "children not implemented on FFI_ExecutionPlan".to_string(),
@@ -216,11 +200,6 @@ impl ExportedExecutionPlan {
             let mut num_children = 0;
             let mut err_code = 0;
             let children_ptr = children_fn(plan, &mut num_children, &mut err_code);
-
-            println!(
-                "We called the FFI function children so the provider told us we have {} children",
-                num_children
-            );
 
             if err_code != 0 {
                 return Err(DataFusionError::Plan(
@@ -232,24 +211,15 @@ impl ExportedExecutionPlan {
             let maybe_children: Result<Vec<_>> = ffi_vec
                 .into_iter()
                 .map(|child| {
-                    println!("Ok, we are about to examine a child ffi_executionplan");
-                    if let Some(props_fn) = (*child).properties {
-                        println!("We do have properties on the child ");
-                        let child_props = props_fn(child);
-                        println!("Child schema {:?}", child_props.schema);
-                    }
 
                     let child_plan = ExportedExecutionPlan::new(child);
 
                     child_plan.map(|c| Arc::new(c) as Arc<dyn ExecutionPlan>)
                 })
                 .collect();
-            println!("finsihed maybe children");
 
             maybe_children?
         };
-
-        println!("About to return ExportedExecurtionPlan");
 
         Ok(Self {
             name,
@@ -310,284 +280,6 @@ impl ExecutionPlan for ExportedExecutionPlan {
                         .to_string(),
                 )),
             }
-        }
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-#[allow(missing_docs)]
-#[allow(non_camel_case_types)]
-pub struct FFI_PlanProperties {
-    // Returns protobuf serialized bytes of the partitioning
-    pub output_partitioning: Option<
-        unsafe extern "C" fn(
-            plan: *const FFI_PlanProperties,
-            buffer_size: &mut usize,
-            buffer_bytes: &mut *mut u8,
-        ) -> i32,
-    >,
-
-    pub execution_mode: Option<
-        unsafe extern "C" fn(plan: *const FFI_PlanProperties) -> FFI_ExecutionMode,
-    >,
-
-    // PhysicalSortExprNodeCollection proto
-    pub output_ordering: Option<
-        unsafe extern "C" fn(
-            plan: *const FFI_PlanProperties,
-            buffer_size: &mut usize,
-            buffer_bytes: &mut *mut u8,
-        ) -> i32,
-    >,
-
-    pub schema:
-        Option<unsafe extern "C" fn(plan: *const FFI_PlanProperties) -> FFI_ArrowSchema>,
-
-    pub private_data: *mut c_void,
-}
-
-unsafe extern "C" fn output_partitioning_fn_wrapper(
-    properties: *const FFI_PlanProperties,
-    buffer_size: &mut usize,
-    buffer_bytes: &mut *mut u8,
-) -> i32 {
-    // let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
-    // let properties = (*private_data).plan.properties();
-    // properties.clone().into()
-    let private_data = (*properties).private_data as *const PlanProperties;
-    let partitioning = (*private_data).output_partitioning();
-
-    let codec = DefaultPhysicalExtensionCodec {};
-    let partitioning_data = match serialize_partitioning(partitioning, &codec) {
-        Ok(p) => p,
-        Err(_) => return 1,
-    };
-
-    let mut partition_bytes = partitioning_data.encode_to_vec();
-    *buffer_size = partition_bytes.len();
-    *buffer_bytes = partition_bytes.as_mut_ptr();
-
-    std::mem::forget(partition_bytes);
-
-    0
-}
-
-unsafe extern "C" fn execution_mode_fn_wrapper(
-    properties: *const FFI_PlanProperties,
-) -> FFI_ExecutionMode {
-    // let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
-    // let properties = (*private_data).plan.properties();
-    // properties.clone().into()
-    let private_data = (*properties).private_data as *const PlanProperties;
-    let execution_mode = (*private_data).execution_mode();
-
-    execution_mode.into()
-}
-
-unsafe extern "C" fn output_ordering_fn_wrapper(
-    properties: *const FFI_PlanProperties,
-    buffer_size: &mut usize,
-    buffer_bytes: &mut *mut u8,
-) -> i32 {
-    // let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
-    // let properties = (*private_data).plan.properties();
-    // properties.clone().into()
-    let private_data = (*properties).private_data as *const PlanProperties;
-    let output_ordering = match (*private_data).output_ordering() {
-        Some(o) => o,
-        None => {
-            *buffer_size = 0;
-            return 0;
-        }
-    }
-    .to_owned();
-
-    let codec = DefaultPhysicalExtensionCodec {};
-    let physical_sort_expr_nodes =
-        match serialize_physical_sort_exprs(output_ordering, &codec) {
-            Ok(p) => p,
-            Err(_) => return 1,
-        };
-
-    let ordering_data = PhysicalSortExprNodeCollection {
-        physical_sort_expr_nodes,
-    };
-
-    let mut ordering_bytes = ordering_data.encode_to_vec();
-    *buffer_size = ordering_bytes.len();
-    *buffer_bytes = ordering_bytes.as_mut_ptr();
-    std::mem::forget(ordering_bytes);
-
-    0
-}
-
-// pub schema: Option<unsafe extern "C" fn(plan: *const FFI_PlanProperties) -> FFI_ArrowSchema>,
-unsafe extern "C" fn schema_fn_wrapper(
-    properties: *const FFI_PlanProperties,
-) -> FFI_ArrowSchema {
-    let private_data = (*properties).private_data as *const PlanProperties;
-    let schema = (*private_data).eq_properties.schema();
-
-    // This does silently fail because TableProvider does not return a result
-    // so we expect it to always pass. Maybe some logging should be added.
-    FFI_ArrowSchema::try_from(schema.as_ref()).unwrap_or(FFI_ArrowSchema::empty())
-}
-
-impl From<PlanProperties> for FFI_PlanProperties {
-    fn from(value: PlanProperties) -> Self {
-        let private_data = Box::new(value);
-
-        Self {
-            output_partitioning: Some(output_partitioning_fn_wrapper),
-            execution_mode: Some(execution_mode_fn_wrapper),
-            output_ordering: Some(output_ordering_fn_wrapper),
-            schema: Some(schema_fn_wrapper),
-            private_data: Box::into_raw(private_data) as *mut c_void,
-        }
-    }
-}
-
-// /// Creates a new [`FFI_TableProvider`].
-// pub fn new(provider: Box<dyn TableProvider + Send>) -> Self {
-//     let private_data = Box::new(ProviderPrivateData {
-//         provider,
-//         last_error: None,
-//     });
-
-//     Self {
-//         version: 2,
-//         schema: Some(provider_schema),
-//         scan: Some(provider_scan),
-//         private_data: Box::into_raw(private_data) as *mut c_void,
-//     }
-// }
-
-impl TryFrom<FFI_PlanProperties> for PlanProperties {
-    type Error = DataFusionError;
-
-    fn try_from(value: FFI_PlanProperties) -> std::result::Result<Self, Self::Error> {
-        unsafe {
-            let schema_fn = value.schema.ok_or(DataFusionError::NotImplemented(
-                "schema() not implemented on FFI_PlanProperties".to_string(),
-            ))?;
-            let ffi_schema = schema_fn(&value);
-            let schema: Schema = (&ffi_schema).try_into()?;
-
-            let ordering_fn =
-                value
-                    .output_ordering
-                    .ok_or(DataFusionError::NotImplemented(
-                        "output_ordering() not implemented on FFI_PlanProperties"
-                            .to_string(),
-                    ))?;
-            let mut buff_size = 0;
-            let mut buff = null_mut();
-            if ordering_fn(&value, &mut buff_size, &mut buff) != 0 {
-                return Err(DataFusionError::Plan(
-                    "Error occurred during FFI call to output_ordering in FFI_PlanProperties"
-                        .to_string(),
-                ));
-            }
-
-            // TODO we will need to get these, but unsure if it happesn on the provider or consumer right now.
-            let default_ctx = SessionContext::new();
-            let codex = DefaultPhysicalExtensionCodec {};
-
-            let orderings = match buff_size == 0 {
-                true => None,
-                false => {
-                    let data = slice::from_raw_parts(buff, buff_size);
-
-                    let proto_output_ordering =
-                        PhysicalSortExprNodeCollection::decode(data)
-                            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-
-                    Some(parse_physical_sort_exprs(
-                        &proto_output_ordering.physical_sort_expr_nodes,
-                        &default_ctx,
-                        &schema,
-                        &codex,
-                    )?)
-                }
-            };
-
-            let partitioning_fn =
-                value
-                    .output_partitioning
-                    .ok_or(DataFusionError::NotImplemented(
-                        "output_partitioning() not implemented on FFI_PlanProperties"
-                            .to_string(),
-                    ))?;
-            if partitioning_fn(&value, &mut buff_size, &mut buff) != 0 {
-                return Err(DataFusionError::Plan(
-                    "Error occurred during FFI call to output_partitioning in FFI_PlanProperties"
-                        .to_string(),
-                ));
-            }
-            let data = slice::from_raw_parts(buff, buff_size);
-
-            let proto_partitioning = Partitioning::decode(data)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
-            // TODO: Validate this unwrap is safe.
-            let partitioning = parse_protobuf_partitioning(
-                Some(&proto_partitioning),
-                &default_ctx,
-                &schema,
-                &codex,
-            )?
-            .unwrap();
-
-            let execution_mode_fn =
-                value.execution_mode.ok_or(DataFusionError::NotImplemented(
-                    "execution_mode() not implemented on FFI_PlanProperties".to_string(),
-                ))?;
-            let execution_mode = execution_mode_fn(&value).into();
-
-            let eq_properties = match orderings {
-                Some(ordering) => EquivalenceProperties::new_with_orderings(
-                    Arc::new(schema),
-                    &[ordering],
-                ),
-                None => EquivalenceProperties::new(Arc::new(schema)),
-            };
-
-            Ok(Self::new(eq_properties, partitioning, execution_mode))
-        }
-    }
-    // fn from(value: FFI_PlanProperties) -> Self {
-    //     let schema = self.schema()
-
-    //     let equiv_prop = EquivalenceProperties::new_with_orderings(schema, orderings);
-    // }
-}
-
-#[repr(C)]
-#[allow(non_camel_case_types)]
-pub enum FFI_ExecutionMode {
-    Bounded,
-
-    Unbounded,
-
-    PipelineBreaking,
-}
-
-impl From<ExecutionMode> for FFI_ExecutionMode {
-    fn from(value: ExecutionMode) -> Self {
-        match value {
-            ExecutionMode::Bounded => FFI_ExecutionMode::Bounded,
-            ExecutionMode::Unbounded => FFI_ExecutionMode::Unbounded,
-            ExecutionMode::PipelineBreaking => FFI_ExecutionMode::PipelineBreaking,
-        }
-    }
-}
-
-impl From<FFI_ExecutionMode> for ExecutionMode {
-    fn from(value: FFI_ExecutionMode) -> Self {
-        match value {
-            FFI_ExecutionMode::Bounded => ExecutionMode::Bounded,
-            FFI_ExecutionMode::Unbounded => ExecutionMode::Unbounded,
-            FFI_ExecutionMode::PipelineBreaking => ExecutionMode::PipelineBreaking,
         }
     }
 }

--- a/datafusion/ffi/src/lib.rs
+++ b/datafusion/ffi/src/lib.rs
@@ -18,6 +18,7 @@
 #![deny(clippy::clone_on_ref_ptr)]
 
 pub mod execution_plan;
+pub mod plan_properties;
 pub mod record_batch_stream;
 pub mod session_config;
 pub mod table_provider;

--- a/datafusion/ffi/src/lib.rs
+++ b/datafusion/ffi/src/lib.rs
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// Make cheap clones clear: https://github.com/apache/datafusion/issues/11143
+#![deny(clippy::clone_on_ref_ptr)]
+
+pub mod execution_plan;
+pub mod record_batch_stream;
+pub mod session_config;
+pub mod table_provider;
+
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md", readme_example_test);

--- a/datafusion/ffi/src/lib.rs
+++ b/datafusion/ffi/src/lib.rs
@@ -21,6 +21,7 @@ pub mod execution_plan;
 pub mod record_batch_stream;
 pub mod session_config;
 pub mod table_provider;
+pub mod table_source;
 
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md", readme_example_test);

--- a/datafusion/ffi/src/plan_properties.rs
+++ b/datafusion/ffi/src/plan_properties.rs
@@ -1,4 +1,21 @@
-use std::{ffi::c_void, ptr::null_mut, slice, sync::Arc};
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{ffi::c_void, ptr::null_mut, sync::Arc};
 
 use arrow::ffi::FFI_ArrowSchema;
 use datafusion::{error::DataFusionError, physical_expr::EquivalenceProperties, physical_plan::{ExecutionMode, PlanProperties}, prelude::SessionContext};
@@ -231,10 +248,10 @@ impl TryFrom<FFI_PlanProperties> for PlanProperties {
             let orderings = match buff_size == 0 {
                 true => None,
                 false => {
-                    let data = slice::from_raw_parts(buff, buff_size);
+                    let data = Vec::from_raw_parts(buff, buff_size, buff_size);
 
                     let proto_output_ordering =
-                        PhysicalSortExprNodeCollection::decode(data)
+                        PhysicalSortExprNodeCollection::decode(data.as_ref())
                             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
                     Some(parse_physical_sort_exprs(
@@ -259,9 +276,9 @@ impl TryFrom<FFI_PlanProperties> for PlanProperties {
                         .to_string(),
                 ));
             }
-            let data = slice::from_raw_parts(buff, buff_size);
+            let data = Vec::from_raw_parts(buff, buff_size, buff_size);
 
-            let proto_partitioning = Partitioning::decode(data)
+            let proto_partitioning = Partitioning::decode(data.as_ref())
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
             // TODO: Validate this unwrap is safe.
             let partitioning = parse_protobuf_partitioning(

--- a/datafusion/ffi/src/plan_properties.rs
+++ b/datafusion/ffi/src/plan_properties.rs
@@ -173,6 +173,15 @@ unsafe extern "C" fn release_fn_wrapper(props: *mut FFI_PlanProperties) {
 }
 
 
+impl Drop for FFI_PlanProperties {
+    fn drop(&mut self) {
+        match self.release {
+            None => (),
+            Some(release) => unsafe { release(self) },
+        };
+    }
+}
+
 impl From<PlanProperties> for FFI_PlanProperties {
     fn from(value: PlanProperties) -> Self {
         let private_data = Box::new(value);

--- a/datafusion/ffi/src/plan_properties.rs
+++ b/datafusion/ffi/src/plan_properties.rs
@@ -1,0 +1,265 @@
+use std::{ffi::c_void, ptr::null_mut, slice, sync::Arc};
+
+use arrow::ffi::FFI_ArrowSchema;
+use datafusion::{error::DataFusionError, physical_expr::EquivalenceProperties, physical_plan::{ExecutionMode, PlanProperties}, prelude::SessionContext};
+use datafusion_proto::{physical_plan::{from_proto::{parse_physical_sort_exprs, parse_protobuf_partitioning}, to_proto::{serialize_partitioning, serialize_physical_sort_exprs}, DefaultPhysicalExtensionCodec}, protobuf::{Partitioning, PhysicalSortExprNodeCollection}};
+use prost::Message;
+
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum FFI_ExecutionMode {
+    Bounded,
+
+    Unbounded,
+
+    PipelineBreaking,
+}
+
+impl From<ExecutionMode> for FFI_ExecutionMode {
+    fn from(value: ExecutionMode) -> Self {
+        match value {
+            ExecutionMode::Bounded => FFI_ExecutionMode::Bounded,
+            ExecutionMode::Unbounded => FFI_ExecutionMode::Unbounded,
+            ExecutionMode::PipelineBreaking => FFI_ExecutionMode::PipelineBreaking,
+        }
+    }
+}
+
+impl From<FFI_ExecutionMode> for ExecutionMode {
+    fn from(value: FFI_ExecutionMode) -> Self {
+        match value {
+            FFI_ExecutionMode::Bounded => ExecutionMode::Bounded,
+            FFI_ExecutionMode::Unbounded => ExecutionMode::Unbounded,
+            FFI_ExecutionMode::PipelineBreaking => ExecutionMode::PipelineBreaking,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+#[allow(missing_docs)]
+#[allow(non_camel_case_types)]
+pub struct FFI_PlanProperties {
+    // Returns protobuf serialized bytes of the partitioning
+    pub output_partitioning: Option<
+        unsafe extern "C" fn(
+            plan: *const FFI_PlanProperties,
+            buffer_size: &mut usize,
+            buffer_bytes: &mut *mut u8,
+        ) -> i32,
+    >,
+
+    pub execution_mode: Option<
+        unsafe extern "C" fn(plan: *const FFI_PlanProperties) -> FFI_ExecutionMode,
+    >,
+
+    // PhysicalSortExprNodeCollection proto
+    pub output_ordering: Option<
+        unsafe extern "C" fn(
+            plan: *const FFI_PlanProperties,
+            buffer_size: &mut usize,
+            buffer_bytes: &mut *mut u8,
+        ) -> i32,
+    >,
+
+    pub schema:
+        Option<unsafe extern "C" fn(plan: *const FFI_PlanProperties) -> FFI_ArrowSchema>,
+
+    pub private_data: *mut c_void,
+}
+
+unsafe extern "C" fn output_partitioning_fn_wrapper(
+    properties: *const FFI_PlanProperties,
+    buffer_size: &mut usize,
+    buffer_bytes: &mut *mut u8,
+) -> i32 {
+    // let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+    // let properties = (*private_data).plan.properties();
+    // properties.clone().into()
+    let private_data = (*properties).private_data as *const PlanProperties;
+    let partitioning = (*private_data).output_partitioning();
+
+    let codec = DefaultPhysicalExtensionCodec {};
+    let partitioning_data = match serialize_partitioning(partitioning, &codec) {
+        Ok(p) => p,
+        Err(_) => return 1,
+    };
+
+    let mut partition_bytes = partitioning_data.encode_to_vec();
+    *buffer_size = partition_bytes.len();
+    *buffer_bytes = partition_bytes.as_mut_ptr();
+
+    std::mem::forget(partition_bytes);
+
+    0
+}
+
+unsafe extern "C" fn execution_mode_fn_wrapper(
+    properties: *const FFI_PlanProperties,
+) -> FFI_ExecutionMode {
+    // let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+    // let properties = (*private_data).plan.properties();
+    // properties.clone().into()
+    let private_data = (*properties).private_data as *const PlanProperties;
+    let execution_mode = (*private_data).execution_mode();
+
+    execution_mode.into()
+}
+
+unsafe extern "C" fn output_ordering_fn_wrapper(
+    properties: *const FFI_PlanProperties,
+    buffer_size: &mut usize,
+    buffer_bytes: &mut *mut u8,
+) -> i32 {
+    // let private_data = (*plan).private_data as *const ExecutionPlanPrivateData;
+    // let properties = (*private_data).plan.properties();
+    // properties.clone().into()
+    let private_data = (*properties).private_data as *const PlanProperties;
+    let output_ordering = match (*private_data).output_ordering() {
+        Some(o) => o,
+        None => {
+            *buffer_size = 0;
+            return 0;
+        }
+    }
+    .to_owned();
+
+    let codec = DefaultPhysicalExtensionCodec {};
+    let physical_sort_expr_nodes =
+        match serialize_physical_sort_exprs(output_ordering, &codec) {
+            Ok(p) => p,
+            Err(_) => return 1,
+        };
+
+    let ordering_data = PhysicalSortExprNodeCollection {
+        physical_sort_expr_nodes,
+    };
+
+    let mut ordering_bytes = ordering_data.encode_to_vec();
+    *buffer_size = ordering_bytes.len();
+    *buffer_bytes = ordering_bytes.as_mut_ptr();
+    std::mem::forget(ordering_bytes);
+
+    0
+}
+
+// pub schema: Option<unsafe extern "C" fn(plan: *const FFI_PlanProperties) -> FFI_ArrowSchema>,
+unsafe extern "C" fn schema_fn_wrapper(
+    properties: *const FFI_PlanProperties,
+) -> FFI_ArrowSchema {
+    let private_data = (*properties).private_data as *const PlanProperties;
+    let schema = (*private_data).eq_properties.schema();
+
+    // This does silently fail because TableProvider does not return a result
+    // so we expect it to always pass. Maybe some logging should be added.
+    FFI_ArrowSchema::try_from(schema.as_ref()).unwrap_or(FFI_ArrowSchema::empty())
+}
+
+impl From<PlanProperties> for FFI_PlanProperties {
+    fn from(value: PlanProperties) -> Self {
+        let private_data = Box::new(value);
+
+        Self {
+            output_partitioning: Some(output_partitioning_fn_wrapper),
+            execution_mode: Some(execution_mode_fn_wrapper),
+            output_ordering: Some(output_ordering_fn_wrapper),
+            schema: Some(schema_fn_wrapper),
+            private_data: Box::into_raw(private_data) as *mut c_void,
+        }
+    }
+}
+
+impl TryFrom<FFI_PlanProperties> for PlanProperties {
+    type Error = DataFusionError;
+
+    fn try_from(value: FFI_PlanProperties) -> std::result::Result<Self, Self::Error> {
+        unsafe {
+            let schema_fn = value.schema.ok_or(DataFusionError::NotImplemented(
+                "schema() not implemented on FFI_PlanProperties".to_string(),
+            ))?;
+            let ffi_schema = schema_fn(&value);
+            let schema = (&ffi_schema).try_into()?;
+
+            let ordering_fn =
+                value
+                    .output_ordering
+                    .ok_or(DataFusionError::NotImplemented(
+                        "output_ordering() not implemented on FFI_PlanProperties"
+                            .to_string(),
+                    ))?;
+            let mut buff_size = 0;
+            let mut buff = null_mut();
+            if ordering_fn(&value, &mut buff_size, &mut buff) != 0 {
+                return Err(DataFusionError::Plan(
+                    "Error occurred during FFI call to output_ordering in FFI_PlanProperties"
+                        .to_string(),
+                ));
+            }
+
+            // TODO we will need to get these, but unsure if it happesn on the provider or consumer right now.
+            let default_ctx = SessionContext::new();
+            let codex = DefaultPhysicalExtensionCodec {};
+
+            let orderings = match buff_size == 0 {
+                true => None,
+                false => {
+                    let data = slice::from_raw_parts(buff, buff_size);
+
+                    let proto_output_ordering =
+                        PhysicalSortExprNodeCollection::decode(data)
+                            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+                    Some(parse_physical_sort_exprs(
+                        &proto_output_ordering.physical_sort_expr_nodes,
+                        &default_ctx,
+                        &schema,
+                        &codex,
+                    )?)
+                }
+            };
+
+            let partitioning_fn =
+                value
+                    .output_partitioning
+                    .ok_or(DataFusionError::NotImplemented(
+                        "output_partitioning() not implemented on FFI_PlanProperties"
+                            .to_string(),
+                    ))?;
+            if partitioning_fn(&value, &mut buff_size, &mut buff) != 0 {
+                return Err(DataFusionError::Plan(
+                    "Error occurred during FFI call to output_partitioning in FFI_PlanProperties"
+                        .to_string(),
+                ));
+            }
+            let data = slice::from_raw_parts(buff, buff_size);
+
+            let proto_partitioning = Partitioning::decode(data)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            // TODO: Validate this unwrap is safe.
+            let partitioning = parse_protobuf_partitioning(
+                Some(&proto_partitioning),
+                &default_ctx,
+                &schema,
+                &codex,
+            )?
+            .unwrap();
+
+            let execution_mode_fn =
+                value.execution_mode.ok_or(DataFusionError::NotImplemented(
+                    "execution_mode() not implemented on FFI_PlanProperties".to_string(),
+                ))?;
+            let execution_mode = execution_mode_fn(&value).into();
+
+            let eq_properties = match orderings {
+                Some(ordering) => EquivalenceProperties::new_with_orderings(
+                    Arc::new(schema),
+                    &[ordering],
+                ),
+                None => EquivalenceProperties::new(Arc::new(schema)),
+            };
+
+            Ok(Self::new(eq_properties, partitioning, execution_mode))
+        }
+    }
+}

--- a/datafusion/ffi/src/record_batch_stream.rs
+++ b/datafusion/ffi/src/record_batch_stream.rs
@@ -1,0 +1,182 @@
+use std::{
+    ffi::{c_char, c_int, c_void, CString},
+    ptr::addr_of,
+};
+
+use arrow::{
+    array::StructArray,
+    ffi::{FFI_ArrowArray, FFI_ArrowSchema},
+    ffi_stream::FFI_ArrowArrayStream,
+};
+use arrow::{
+    array::{Array, RecordBatch, RecordBatchReader},
+    ffi_stream::ArrowArrayStreamReader,
+};
+use datafusion::error::Result;
+use datafusion::{
+    error::DataFusionError,
+    execution::{RecordBatchStream, SendableRecordBatchStream},
+};
+use futures::{executor::block_on, Stream, TryStreamExt};
+
+pub fn record_batch_to_arrow_stream(stream: SendableRecordBatchStream) -> FFI_ArrowArrayStream {
+    let private_data = Box::new(RecoredBatchStreamPrivateData {
+        stream,
+        last_error: None,
+    });
+
+    FFI_ArrowArrayStream {
+        get_schema: Some(get_schema),
+        get_next: Some(get_next),
+        get_last_error: Some(get_last_error),
+        release: Some(release_stream),
+        private_data: Box::into_raw(private_data) as *mut c_void,
+    }
+}
+
+struct RecoredBatchStreamPrivateData {
+    stream: SendableRecordBatchStream,
+    last_error: Option<CString>,
+}
+
+// callback used to drop [FFI_ArrowArrayStream] when it is exported.
+unsafe extern "C" fn release_stream(stream: *mut FFI_ArrowArrayStream) {
+    if stream.is_null() {
+        return;
+    }
+    let stream = &mut *stream;
+
+    stream.get_schema = None;
+    stream.get_next = None;
+    stream.get_last_error = None;
+
+    let private_data = Box::from_raw(stream.private_data as *mut RecoredBatchStreamPrivateData);
+    drop(private_data);
+
+    stream.release = None;
+}
+
+// The callback used to get array schema
+unsafe extern "C" fn get_schema(
+    stream: *mut FFI_ArrowArrayStream,
+    schema: *mut FFI_ArrowSchema,
+) -> c_int {
+    ExportedRecordBatchStream { stream }.get_schema(schema)
+}
+
+// The callback used to get next array
+unsafe extern "C" fn get_next(
+    stream: *mut FFI_ArrowArrayStream,
+    array: *mut FFI_ArrowArray,
+) -> c_int {
+    ExportedRecordBatchStream { stream }.get_next(array)
+}
+
+// The callback used to get the error from last operation on the `FFI_ArrowArrayStream`
+unsafe extern "C" fn get_last_error(stream: *mut FFI_ArrowArrayStream) -> *const c_char {
+    let mut ffi_stream = ExportedRecordBatchStream { stream };
+    // The consumer should not take ownership of this string, we should return
+    // a const pointer to it.
+    match ffi_stream.get_last_error() {
+        Some(err_string) => err_string.as_ptr(),
+        None => std::ptr::null(),
+    }
+}
+
+struct ExportedRecordBatchStream {
+    stream: *mut FFI_ArrowArrayStream,
+}
+
+impl ExportedRecordBatchStream {
+    fn get_private_data(&mut self) -> &mut RecoredBatchStreamPrivateData {
+        unsafe { &mut *((*self.stream).private_data as *mut RecoredBatchStreamPrivateData) }
+    }
+
+    pub fn get_schema(&mut self, out: *mut FFI_ArrowSchema) -> i32 {
+        let private_data = self.get_private_data();
+        let stream = &private_data.stream;
+
+        let schema = FFI_ArrowSchema::try_from(stream.schema().as_ref());
+
+        match schema {
+            Ok(schema) => {
+                unsafe { std::ptr::copy(addr_of!(schema), out, 1) };
+                std::mem::forget(schema);
+                0
+            }
+            Err(ref err) => {
+                private_data.last_error = Some(
+                    CString::new(err.to_string()).expect("Error string has a null byte in it."),
+                );
+                1
+            }
+        }
+    }
+
+    pub fn get_next(&mut self, out: *mut FFI_ArrowArray) -> i32 {
+        let private_data = self.get_private_data();
+
+        let maybe_batch = block_on(private_data.stream.try_next());
+
+        match maybe_batch {
+            Ok(None) => {
+                // Marks ArrowArray released to indicate reaching the end of stream.
+                unsafe { std::ptr::write(out, FFI_ArrowArray::empty()) }
+                0
+            }
+            Ok(Some(batch)) => {
+                let struct_array = StructArray::from(batch);
+                let array = FFI_ArrowArray::new(&struct_array.to_data());
+
+                unsafe { std::ptr::write_unaligned(out, array) };
+                0
+            }
+            Err(err) => {
+                private_data.last_error = Some(
+                    CString::new(err.to_string()).expect("Error string has a null byte in it."),
+                );
+                1
+            }
+        }
+    }
+
+    pub fn get_last_error(&mut self) -> Option<&CString> {
+        self.get_private_data().last_error.as_ref()
+    }
+}
+
+pub struct ConsumerRecordBatchStream {
+    reader: ArrowArrayStreamReader,
+}
+
+impl TryFrom<FFI_ArrowArrayStream> for ConsumerRecordBatchStream {
+    type Error = DataFusionError;
+
+    fn try_from(value: FFI_ArrowArrayStream) -> std::result::Result<Self, Self::Error> {
+        let reader = ArrowArrayStreamReader::try_new(value)?;
+
+        Ok(Self { reader })
+    }
+}
+
+impl RecordBatchStream for ConsumerRecordBatchStream {
+    fn schema(&self) -> arrow::datatypes::SchemaRef {
+        self.reader.schema()
+    }
+}
+
+impl Stream for ConsumerRecordBatchStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let batch = self
+            .reader
+            .next()
+            .map(|v| v.map_err(|e| DataFusionError::ArrowError(e, None)));
+
+        std::task::Poll::Ready(batch)
+    }
+}

--- a/datafusion/ffi/src/record_batch_stream.rs
+++ b/datafusion/ffi/src/record_batch_stream.rs
@@ -19,7 +19,9 @@ use datafusion::{
 };
 use futures::{executor::block_on, Stream, TryStreamExt};
 
-pub fn record_batch_to_arrow_stream(stream: SendableRecordBatchStream) -> FFI_ArrowArrayStream {
+pub fn record_batch_to_arrow_stream(
+    stream: SendableRecordBatchStream,
+) -> FFI_ArrowArrayStream {
     let private_data = Box::new(RecoredBatchStreamPrivateData {
         stream,
         last_error: None,
@@ -50,7 +52,8 @@ unsafe extern "C" fn release_stream(stream: *mut FFI_ArrowArrayStream) {
     stream.get_next = None;
     stream.get_last_error = None;
 
-    let private_data = Box::from_raw(stream.private_data as *mut RecoredBatchStreamPrivateData);
+    let private_data =
+        Box::from_raw(stream.private_data as *mut RecoredBatchStreamPrivateData);
     drop(private_data);
 
     stream.release = None;
@@ -89,7 +92,9 @@ struct ExportedRecordBatchStream {
 
 impl ExportedRecordBatchStream {
     fn get_private_data(&mut self) -> &mut RecoredBatchStreamPrivateData {
-        unsafe { &mut *((*self.stream).private_data as *mut RecoredBatchStreamPrivateData) }
+        unsafe {
+            &mut *((*self.stream).private_data as *mut RecoredBatchStreamPrivateData)
+        }
     }
 
     pub fn get_schema(&mut self, out: *mut FFI_ArrowSchema) -> i32 {
@@ -106,7 +111,8 @@ impl ExportedRecordBatchStream {
             }
             Err(ref err) => {
                 private_data.last_error = Some(
-                    CString::new(err.to_string()).expect("Error string has a null byte in it."),
+                    CString::new(err.to_string())
+                        .expect("Error string has a null byte in it."),
                 );
                 1
             }
@@ -133,7 +139,8 @@ impl ExportedRecordBatchStream {
             }
             Err(err) => {
                 private_data.last_error = Some(
-                    CString::new(err.to_string()).expect("Error string has a null byte in it."),
+                    CString::new(err.to_string())
+                        .expect("Error string has a null byte in it."),
                 );
                 1
             }

--- a/datafusion/ffi/src/record_batch_stream.rs
+++ b/datafusion/ffi/src/record_batch_stream.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::{
     ffi::{c_char, c_int, c_void, CString},
     ptr::addr_of,

--- a/datafusion/ffi/src/session_config.rs
+++ b/datafusion/ffi/src/session_config.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::ffi::c_void;
 
 use datafusion::{catalog::Session, prelude::SessionConfig};

--- a/datafusion/ffi/src/session_config.rs
+++ b/datafusion/ffi/src/session_config.rs
@@ -1,0 +1,48 @@
+use std::{
+    ffi::{c_void, CString},
+};
+
+use datafusion::{catalog::Session, prelude::SessionConfig};
+
+#[repr(C)]
+#[derive(Debug)]
+#[allow(missing_docs)]
+#[allow(non_camel_case_types)]
+pub struct FFI_SessionConfig {
+    pub version: i64,
+
+    pub private_data: *mut c_void,
+}
+
+unsafe impl Send for FFI_SessionConfig {}
+
+pub struct SessionConfigPrivateData {
+    pub config: SessionConfig,
+    pub last_error: Option<CString>,
+}
+
+struct ExportedSessionConfig {
+    session: *mut FFI_SessionConfig,
+}
+
+impl ExportedSessionConfig {
+    fn get_private_data(&mut self) -> &mut SessionConfigPrivateData {
+        unsafe { &mut *((*self.session).private_data as *mut SessionConfigPrivateData) }
+    }
+}
+
+impl FFI_SessionConfig {
+    /// Creates a new [`FFI_TableProvider`].
+    pub fn new(session: &dyn Session) -> Self {
+        let config = session.config().clone();
+        let private_data = Box::new(SessionConfigPrivateData {
+            config,
+            last_error: None,
+        });
+
+        Self {
+            version: 2,
+            private_data: Box::into_raw(private_data) as *mut c_void,
+        }
+    }
+}

--- a/datafusion/ffi/src/session_config.rs
+++ b/datafusion/ffi/src/session_config.rs
@@ -15,20 +15,48 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::ffi::c_void;
+use std::{
+    collections::HashMap,
+    ffi::{c_char, c_uint, c_void, CStr, CString},
+    ptr::null_mut,
+    slice,
+};
 
-use datafusion::{catalog::Session, prelude::SessionConfig};
+use datafusion::error::Result;
+use datafusion::{error::DataFusionError, prelude::SessionConfig};
 
 #[repr(C)]
 #[derive(Debug)]
 #[allow(missing_docs)]
 #[allow(non_camel_case_types)]
 pub struct FFI_SessionConfig {
+    pub config_options: Option<
+        unsafe extern "C" fn(
+            config: *const FFI_SessionConfig,
+            num_options: &mut c_uint,
+            keys: &mut *const *const c_char,
+            values: &mut *const *const c_char,
+        ) -> (),
+    >,
+
     pub private_data: *mut c_void,
     pub release: Option<unsafe extern "C" fn(arg: *mut Self)>,
 }
 
 unsafe impl Send for FFI_SessionConfig {}
+
+unsafe extern "C" fn config_options_fn_wrapper(
+    config: *const FFI_SessionConfig,
+    num_options: &mut c_uint,
+    keys: &mut *const *const c_char,
+    values: &mut *const *const c_char,
+) {
+    let private_data = (*config).private_data as *mut SessionConfigPrivateData;
+
+    *num_options = (*private_data).config_keys.len() as c_uint;
+    *keys = (*private_data).config_keys.as_ptr();
+    *values = (*private_data).config_values.as_ptr();
+}
 
 unsafe extern "C" fn release_fn_wrapper(config: *mut FFI_SessionConfig) {
     if config.is_null() {
@@ -36,38 +64,53 @@ unsafe extern "C" fn release_fn_wrapper(config: *mut FFI_SessionConfig) {
     }
     let config = &mut *config;
 
-    let private_data = Box::from_raw(config.private_data as *mut SessionConfigPrivateData);
+    let mut private_data =
+        Box::from_raw(config.private_data as *mut SessionConfigPrivateData);
+    let _removed_keys: Vec<_> = private_data
+        .config_keys
+        .drain(..)
+        .map(|key| CString::from_raw(key as *mut c_char))
+        .collect();
+    let _removed_values: Vec<_> = private_data
+        .config_values
+        .drain(..)
+        .map(|key| CString::from_raw(key as *mut c_char))
+        .collect();
+
     drop(private_data);
 
     config.release = None;
 }
 
-
 struct SessionConfigPrivateData {
-    pub config: SessionConfig,
-}
-
-pub struct ExportedSessionConfig(pub *const FFI_SessionConfig);
-
-impl ExportedSessionConfig {
-    fn get_private_data(&self) -> &SessionConfigPrivateData {
-        unsafe { &*((*self.0).private_data as *const SessionConfigPrivateData) }
-    }
-
-    pub fn session_config(&self) -> &SessionConfig {
-        &self.get_private_data().config
-    }
+    pub config_keys: Vec<*const c_char>,
+    pub config_values: Vec<*const c_char>,
 }
 
 impl FFI_SessionConfig {
     /// Creates a new [`FFI_SessionConfig`].
-    pub fn new(session: &dyn Session) -> Self {
-        let config = session.config().clone();
+    pub fn new(session: &SessionConfig) -> Self {
+        let mut config_keys = Vec::new();
+        let mut config_values = Vec::new();
+        for config_entry in session.options().entries() {
+            if let Some(value) = config_entry.value {
+                let key_cstr = CString::new(config_entry.key).unwrap_or_default();
+                let key_ptr = key_cstr.into_raw() as *const c_char;
+                config_keys.push(key_ptr);
+
+                config_values
+                    .push(CString::new(value).unwrap_or_default().into_raw()
+                        as *const c_char);
+            }
+        }
+
         let private_data = Box::new(SessionConfigPrivateData {
-            config,
+            config_keys,
+            config_values,
         });
 
         Self {
+            config_options: Some(config_options_fn_wrapper),
             private_data: Box::into_raw(private_data) as *mut c_void,
             release: Some(release_fn_wrapper),
         }
@@ -80,5 +123,82 @@ impl Drop for FFI_SessionConfig {
             None => (),
             Some(release) => unsafe { release(self) },
         };
+    }
+}
+
+pub struct ForeignSessionConfig(pub SessionConfig);
+
+impl ForeignSessionConfig {
+    /// Create a session config object from a foreign provider.
+    ///
+    /// # Safety
+    ///
+    /// This function will dereference the provided config pointer and will
+    /// access it's unsafe methods. It is the provider's responsibility that
+    /// this pointer and it's internal functions remain valid for the lifetime
+    /// of the returned struct.
+    pub unsafe fn new(config: *const FFI_SessionConfig) -> Result<Self> {
+        let (keys, values) = unsafe {
+            let config_options =
+                (*config)
+                    .config_options
+                    .ok_or(DataFusionError::NotImplemented(
+                        "config_options not implemented on FFI_SessionConfig".to_string(),
+                    ))?;
+            let mut num_keys = 0;
+            let mut keys: *const *const c_char = null_mut();
+            let mut values: *const *const c_char = null_mut();
+            config_options(config, &mut num_keys, &mut keys, &mut values);
+            let num_keys = num_keys as usize;
+            println!("Received {} key value pairs", num_keys);
+
+            let keys: Vec<String> = slice::from_raw_parts(keys, num_keys)
+                .iter()
+                .map(|key| CStr::from_ptr(*key))
+                .map(|key| key.to_str().unwrap_or_default().to_string())
+                .collect();
+            let values: Vec<String> = slice::from_raw_parts(values, num_keys)
+                .iter()
+                .map(|value| CStr::from_ptr(*value))
+                .map(|val| val.to_str().unwrap_or_default().to_string())
+                .collect();
+
+            (keys, values)
+        };
+
+        let mut options_map = HashMap::new();
+        keys.into_iter().zip(values).for_each(|(key, value)| {
+            options_map.insert(key, value);
+        });
+
+        Ok(Self(SessionConfig::from_string_hash_map(&options_map)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_round_trip_ffi_session_config() -> Result<()> {
+        let session_config = SessionConfig::new();
+        let original_options = session_config.options().entries();
+
+        let ffi_config = FFI_SessionConfig::new(&session_config);
+        let ffi_config_ptr = Box::into_raw(Box::new(ffi_config));
+
+        let foreign_config = unsafe { ForeignSessionConfig::new(ffi_config_ptr)? };
+
+        let returned_options = foreign_config.0.options().entries();
+
+        println!(
+            "Length of original options: {} returned {}",
+            original_options.len(),
+            returned_options.len()
+        );
+
+        let _ = unsafe { Box::from_raw(ffi_config_ptr) };
+
+        Ok(())
     }
 }

--- a/datafusion/ffi/src/session_config.rs
+++ b/datafusion/ffi/src/session_config.rs
@@ -1,6 +1,4 @@
-use std::{
-    ffi::{c_void, CString},
-};
+use std::ffi::{c_void, CString};
 
 use datafusion::{catalog::Session, prelude::SessionConfig};
 
@@ -21,7 +19,7 @@ pub struct SessionConfigPrivateData {
     pub last_error: Option<CString>,
 }
 
-struct ExportedSessionConfig {
+pub struct ExportedSessionConfig {
     session: *mut FFI_SessionConfig,
 }
 

--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::{
     any::Any,
     ffi::{c_char, c_int, c_void, CStr, CString},
@@ -433,7 +450,8 @@ impl TableProvider for ForeignTableProvider {
             let mut num_return = 0;
             let pushdowns = null_mut();
             let err_code = pushdown_fn(self.0, buffer_size as c_int, buffer, &mut num_return, pushdowns);
-            let pushdowns_slice = slice::from_raw_parts(pushdowns, num_return as usize);
+            let num_return = num_return as usize;
+            let pushdowns_slice = Vec::from_raw_parts(pushdowns, num_return, num_return);
 
             match err_code {
                 0 => {

--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -1,0 +1,296 @@
+use std::{
+    any::Any,
+    ffi::{c_char, c_int, c_void, CStr, CString},
+    ptr::null_mut,
+    sync::Arc,
+};
+
+use arrow::{
+    datatypes::{Schema, SchemaRef},
+    ffi::FFI_ArrowSchema,
+};
+use async_trait::async_trait;
+use datafusion::{
+    catalog::{Session, TableProvider},
+    common::DFSchema,
+    datasource::TableType,
+    error::DataFusionError,
+    execution::session_state::SessionStateBuilder,
+    logical_expr::TableProviderFilterPushDown,
+    physical_plan::ExecutionPlan,
+    prelude::{Expr, SessionContext},
+};
+use futures::executor::block_on;
+
+use super::{
+    execution_plan::{ExportedExecutionPlan, FFI_ExecutionPlan},
+    session_config::{FFI_SessionConfig, SessionConfigPrivateData},
+};
+use datafusion::error::Result;
+
+#[repr(C)]
+#[derive(Debug)]
+#[allow(missing_docs)]
+#[allow(non_camel_case_types)]
+pub struct FFI_TableProvider {
+    pub version: i64,
+    pub schema: Option<unsafe extern "C" fn(provider: *const FFI_TableProvider) -> FFI_ArrowSchema>,
+    pub scan: Option<
+        unsafe extern "C" fn(
+            provider: *const FFI_TableProvider,
+            session_config: *const FFI_SessionConfig,
+            n_projections: c_int,
+            projections: *const c_int,
+            n_filters: c_int,
+            filters: *const *const c_char,
+            limit: c_int,
+            err_code: *mut c_int,
+        ) -> *mut FFI_ExecutionPlan,
+    >,
+    pub private_data: *mut c_void,
+}
+
+unsafe impl Send for FFI_TableProvider {}
+unsafe impl Sync for FFI_TableProvider {}
+
+struct ProviderPrivateData {
+    provider: Box<dyn TableProvider + Send>,
+}
+
+struct ExportedTableProvider(*const FFI_TableProvider);
+
+// The callback used to get array schema
+unsafe extern "C" fn provider_schema(provider: *const FFI_TableProvider) -> FFI_ArrowSchema {
+    ExportedTableProvider(provider).provider_schema()
+}
+
+unsafe extern "C" fn scan_fn_wrapper(
+    provider: *const FFI_TableProvider,
+    session_config: *const FFI_SessionConfig,
+    n_projections: c_int,
+    projections: *const c_int,
+    n_filters: c_int,
+    filters: *const *const c_char,
+    limit: c_int,
+    err_code: *mut c_int,
+) -> *mut FFI_ExecutionPlan {
+    println!("entered scan_fn_wrapper");
+    let config = unsafe { (*session_config).private_data as *const SessionConfigPrivateData };
+    let session = SessionStateBuilder::new()
+        .with_config((*config).config.clone())
+        .build();
+    let ctx = SessionContext::new_with_state(session);
+
+    let num_projections: usize = n_projections.try_into().unwrap_or(0);
+
+    let projections: Vec<usize> = std::slice::from_raw_parts(projections, num_projections)
+        .iter()
+        .filter_map(|v| (*v).try_into().ok())
+        .collect();
+    let maybe_projections = match projections.is_empty() {
+        true => None,
+        false => Some(&projections),
+    };
+
+    let filters_slice = std::slice::from_raw_parts(filters, n_filters as usize);
+    let filters_vec: Vec<String> = filters_slice
+        .iter()
+        .map(|&s| CStr::from_ptr(s).to_string_lossy().to_string())
+        .collect();
+
+    let limit = limit.try_into().ok();
+
+    let plan =
+        ExportedTableProvider(provider).provider_scan(&ctx, maybe_projections, filters_vec, limit);
+
+    println!("leaving scan_fn_wrapper, has plan? {}", plan.is_ok());
+
+    match plan {
+        Ok(plan) => {
+            *err_code = 0;
+            plan
+        }
+        Err(_) => {
+            *err_code = 1;
+            null_mut()
+        }
+    }
+}
+
+impl ExportedTableProvider {
+    fn get_private_data(&self) -> &ProviderPrivateData {
+        unsafe { &*((*self.0).private_data as *const ProviderPrivateData) }
+    }
+
+    pub fn provider_schema(&self) -> FFI_ArrowSchema {
+        let private_data = self.get_private_data();
+        let provider = &private_data.provider;
+
+        // This does silently fail because TableProvider does not return a result
+        // so we expect it to always pass. Maybe some logging should be added.
+        FFI_ArrowSchema::try_from(provider.schema().as_ref()).unwrap_or(FFI_ArrowSchema::empty())
+    }
+
+    pub fn provider_scan(
+        &mut self,
+        ctx: &SessionContext,
+        projections: Option<&Vec<usize>>,
+        filters: Vec<String>,
+        limit: Option<usize>,
+    ) -> Result<*mut FFI_ExecutionPlan> {
+        let private_data = self.get_private_data();
+        let provider = &private_data.provider;
+
+        let schema = provider.schema();
+        let df_schema: DFSchema = schema.try_into()?;
+
+        let filter_exprs = filters
+            .into_iter()
+            .map(|expr_str| ctx.state().create_logical_expr(&expr_str, &df_schema))
+            .collect::<datafusion::common::Result<Vec<Expr>>>()?;
+
+        let plan =
+            block_on(provider.scan(&ctx.state(), projections, &filter_exprs, limit))?;
+
+        let plan_boxed = Box::new(FFI_ExecutionPlan::new(plan, ctx.task_ctx()));
+        Ok(Box::into_raw(plan_boxed))
+    }
+}
+
+impl FFI_TableProvider {
+    /// Creates a new [`FFI_TableProvider`].
+    pub fn new(provider: Box<dyn TableProvider + Send>) -> Self {
+        let private_data = Box::new(ProviderPrivateData { provider });
+
+        Self {
+            version: 2,
+            schema: Some(provider_schema),
+            scan: Some(scan_fn_wrapper),
+            private_data: Box::into_raw(private_data) as *mut c_void,
+        }
+    }
+
+    /**
+        Replace temporary pointer with updated
+        # Safety
+        User must validate the raw pointer is valid.
+    */
+    pub unsafe fn from_raw(raw_provider: *mut FFI_TableProvider) -> Self {
+        std::ptr::replace(raw_provider, Self::empty())
+    }
+
+    /// Creates a new empty [FFI_ArrowArrayStream]. Used to import from the C Stream Interface.
+    pub fn empty() -> Self {
+        Self {
+            version: 0,
+            schema: None,
+            scan: None,
+            private_data: std::ptr::null_mut(),
+        }
+    }
+}
+
+#[async_trait]
+impl TableProvider for FFI_TableProvider {
+    /// Returns the table provider as [`Any`](std::any::Any) so that it can be
+    /// downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Get a reference to the schema for this table
+    fn schema(&self) -> SchemaRef {
+        let schema = match self.schema {
+            Some(func) => unsafe { Schema::try_from(&func(self)).ok() },
+            None => None,
+        };
+        Arc::new(schema.unwrap_or(Schema::empty()))
+    }
+
+    /// Get the type of this table for metadata/catalog purposes.
+    fn table_type(&self) -> TableType {
+        todo!()
+    }
+
+    /// Create an ExecutionPlan that will scan the table.
+    /// The table provider will be usually responsible of grouping
+    /// the source data into partitions that can be efficiently
+    /// parallelized or distributed.
+    async fn scan(
+        &self,
+        session: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        // limit can be used to reduce the amount scanned
+        // from the datasource as a performance optimization.
+        // If set, it contains the amount of rows needed by the `LogicalPlan`,
+        // The datasource should return *at least* this number of rows if available.
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let scan_fn = self.scan.ok_or(DataFusionError::NotImplemented(
+            "Scan not defined on FFI_TableProvider".to_string(),
+        ))?;
+
+        let session_config = FFI_SessionConfig::new(session);
+
+        let n_projections = projection.map(|p| p.len()).unwrap_or(0) as c_int;
+        let projections: Vec<c_int> = projection
+            .map(|p| p.iter().map(|v| *v as c_int).collect())
+            .unwrap_or_default();
+        let projections_ptr = projections.as_ptr();
+
+        let n_filters = filters.len() as c_int;
+        let filters: Vec<CString> = filters
+            .iter()
+            .filter_map(|f| CString::new(f.to_string()).ok())
+            .collect();
+        let filters_ptr: Vec<*const i8> = filters.iter().map(|s| s.as_ptr()).collect();
+
+        let limit = match limit {
+            Some(l) => l as c_int,
+            None => -1,
+        };
+
+        println!("Within scan about to call unsafe scan_fn");
+        let mut err_code = 0;
+        let plan = unsafe {
+            let plan_ptr = scan_fn(
+                self,
+                &session_config,
+                n_projections,
+                projections_ptr,
+                n_filters,
+                filters_ptr.as_ptr(),
+                limit,
+                &mut err_code,
+            );
+
+            if 0 != err_code {
+                return Err(datafusion::error::DataFusionError::Internal(
+                    "Unable to perform scan via FFI".to_string(),
+                ));
+            }
+
+            println!(
+                "Finished scan_fn inside FFI_TableProvider::scan {}",
+                plan_ptr.is_null()
+            );
+
+            let p = ExportedExecutionPlan::new(plan_ptr)?;
+            println!("ExportedExecutionPlan::new returned inside scan()");
+            p
+        };
+        println!("Scan returned with some plan.");
+
+        Ok(Arc::new(plan))
+    }
+
+    /// Tests whether the table provider can make use of a filter expression
+    /// to optimise data retrieval.
+    fn supports_filters_pushdown(
+        &self,
+        filter: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        todo!()
+    }
+}

--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -17,8 +17,8 @@
 
 use std::{
     any::Any,
-    ffi::{c_char, c_int, c_void, CStr, CString},
-    ptr::null_mut,
+    ffi::{c_int, c_uint, c_void},
+    ptr::{addr_of, null},
     slice,
     sync::Arc,
 };
@@ -30,7 +30,6 @@ use arrow::{
 use async_trait::async_trait;
 use datafusion::{
     catalog::{Session, TableProvider},
-    common::DFSchema,
     datasource::TableType,
     error::DataFusionError,
     execution::session_state::SessionStateBuilder,
@@ -39,16 +38,21 @@ use datafusion::{
     prelude::{Expr, SessionContext},
 };
 use datafusion_proto::{
-    logical_plan::{from_proto::parse_exprs, to_proto::serialize_exprs, DefaultLogicalExtensionCodec},
+    logical_plan::{
+        from_proto::parse_exprs, to_proto::serialize_exprs, DefaultLogicalExtensionCodec,
+    },
     protobuf::LogicalExprList,
 };
 use futures::executor::block_on;
 use prost::Message;
 
-use crate::{session_config::ExportedSessionConfig, table_source::{FFI_TableProviderFilterPushDown, FFI_TableType}};
+use crate::{
+    session_config::ForeignSessionConfig,
+    table_source::{FFI_TableProviderFilterPushDown, FFI_TableType},
+};
 
 use super::{
-    execution_plan::{ForeignExecutionPlan, FFI_ExecutionPlan},
+    execution_plan::{FFI_ExecutionPlan, ForeignExecutionPlan},
     session_config::FFI_SessionConfig,
 };
 use datafusion::error::Result;
@@ -65,13 +69,13 @@ pub struct FFI_TableProvider {
         unsafe extern "C" fn(
             provider: *const FFI_TableProvider,
             session_config: *const FFI_SessionConfig,
-            n_projections: c_int,
-            projections: *const c_int,
-            n_filters: c_int,
-            filters: *const *const c_char,
+            n_projections: c_uint,
+            projections: *const c_uint,
+            filter_buffer_size: c_uint,
+            filter_buffer: *const u8,
             limit: c_int,
             err_code: *mut c_int,
-        ) -> *mut FFI_ExecutionPlan,
+        ) -> FFI_ExecutionPlan,
     >,
     pub table_type:
         Option<unsafe extern "C" fn(provider: *const FFI_TableProvider) -> FFI_TableType>,
@@ -79,13 +83,14 @@ pub struct FFI_TableProvider {
     pub supports_filters_pushdown: Option<
         unsafe extern "C" fn(
             provider: *const FFI_TableProvider,
-            filter_buff_size: c_int,
+            filter_buff_size: c_uint,
             filter_buffer: *const u8,
             num_filters: &mut c_int,
-            out: *mut FFI_TableProviderFilterPushDown,
+            out: &mut *const FFI_TableProviderFilterPushDown,
         ) -> c_int,
     >,
 
+    pub clone: Option<unsafe extern "C" fn(plan: *const Self) -> Self>,
     pub release: Option<unsafe extern "C" fn(arg: *mut Self)>,
     pub private_data: *mut c_void,
 }
@@ -94,7 +99,8 @@ unsafe impl Send for FFI_TableProvider {}
 unsafe impl Sync for FFI_TableProvider {}
 
 struct ProviderPrivateData {
-    provider: Box<dyn TableProvider + Send>,
+    provider: Arc<dyn TableProvider + Send>,
+    last_filter_pushdowns: Vec<FFI_TableProviderFilterPushDown>,
 }
 
 /// Wrapper struct to provide access functions from the FFI interface to the underlying
@@ -116,19 +122,18 @@ unsafe extern "C" fn table_type_fn_wrapper(
 
 unsafe extern "C" fn supports_filters_pushdown_fn_wrapper(
     provider: *const FFI_TableProvider,
-    filter_buff_size: c_int,
+    filter_buff_size: c_uint,
     filter_buffer: *const u8,
     num_filters: &mut c_int,
-    out: *mut FFI_TableProviderFilterPushDown,
+    out: &mut *const FFI_TableProviderFilterPushDown,
 ) -> c_int {
     let results = ExportedTableProvider(provider)
         .supports_filters_pushdown(filter_buff_size, filter_buffer);
 
     match results {
-        Ok(pushdowns) => {
-            *num_filters = pushdowns.len() as c_int;
-            std::ptr::copy(pushdowns.as_ptr(), out, 1);
-            std::mem::forget(pushdowns);
+        Ok((num_pushdowns, pushdowns_ptr)) => {
+            *num_filters = num_pushdowns as c_int;
+            std::ptr::copy(addr_of!(pushdowns_ptr), out, 1);
             0
         }
         Err(_e) => 1,
@@ -138,16 +143,23 @@ unsafe extern "C" fn supports_filters_pushdown_fn_wrapper(
 unsafe extern "C" fn scan_fn_wrapper(
     provider: *const FFI_TableProvider,
     session_config: *const FFI_SessionConfig,
-    n_projections: c_int,
-    projections: *const c_int,
-    n_filters: c_int,
-    filters: *const *const c_char,
+    n_projections: c_uint,
+    projections: *const c_uint,
+    filter_buffer_size: c_uint,
+    filter_buffer: *const u8,
     limit: c_int,
     err_code: *mut c_int,
-) -> *mut FFI_ExecutionPlan {
-    let config = ExportedSessionConfig(session_config).session_config().clone();
+) -> FFI_ExecutionPlan {
+    let config = match ForeignSessionConfig::new(session_config) {
+        Ok(c) => c,
+        Err(_) => {
+            *err_code = 1;
+            return FFI_ExecutionPlan::empty();
+        }
+    };
     let session = SessionStateBuilder::new()
-        .with_config(config)
+        .with_default_features()
+        .with_config(config.0)
         .build();
     let ctx = SessionContext::new_with_state(session);
 
@@ -163,18 +175,13 @@ unsafe extern "C" fn scan_fn_wrapper(
         false => Some(&projections),
     };
 
-    let filters_slice = std::slice::from_raw_parts(filters, n_filters as usize);
-    let filters_vec: Vec<String> = filters_slice
-        .iter()
-        .map(|&s| CStr::from_ptr(s).to_string_lossy().to_string())
-        .collect();
-
     let limit = limit.try_into().ok();
 
     let plan = ExportedTableProvider(provider).provider_scan(
         &ctx,
         maybe_projections,
-        filters_vec,
+        filter_buffer_size,
+        filter_buffer,
         limit,
     );
 
@@ -185,11 +192,22 @@ unsafe extern "C" fn scan_fn_wrapper(
         }
         Err(_) => {
             *err_code = 1;
-            null_mut()
+            FFI_ExecutionPlan::empty()
         }
     }
 }
 
+unsafe extern "C" fn clone_fn_wrapper(
+    provider: *const FFI_TableProvider,
+) -> FFI_TableProvider {
+    if provider.is_null() {
+        return FFI_TableProvider::empty();
+    }
+
+    let private_data = (*provider).private_data as *const ProviderPrivateData;
+    let table_provider = unsafe { Arc::clone(&(*private_data).provider) };
+    FFI_TableProvider::new(table_provider)
+}
 
 unsafe extern "C" fn release_fn_wrapper(provider: *mut FFI_TableProvider) {
     if provider.is_null() {
@@ -203,28 +221,32 @@ unsafe extern "C" fn release_fn_wrapper(provider: *mut FFI_TableProvider) {
     provider.supports_filters_pushdown = None;
 
     let private_data = Box::from_raw(provider.private_data as *mut ProviderPrivateData);
+
     drop(private_data);
 
     provider.release = None;
 }
 
-
 impl Drop for FFI_TableProvider {
     fn drop(&mut self) {
         match self.release {
             None => (),
-            Some(release) => unsafe { release(self) },
+            Some(release) => unsafe { release(self as *mut FFI_TableProvider) },
         };
     }
 }
 
 impl ExportedTableProvider {
-    fn get_private_data(&self) -> &ProviderPrivateData {
+    fn private_data(&self) -> &ProviderPrivateData {
         unsafe { &*((*self.0).private_data as *const ProviderPrivateData) }
     }
 
+    fn mut_private_data(&mut self) -> &mut ProviderPrivateData {
+        unsafe { &mut *((*self.0).private_data as *mut ProviderPrivateData) }
+    }
+
     pub fn schema(&self) -> FFI_ArrowSchema {
-        let private_data = self.get_private_data();
+        let private_data = self.private_data();
         let provider = &private_data.provider;
 
         // This does silently fail because TableProvider does not return a result
@@ -234,7 +256,7 @@ impl ExportedTableProvider {
     }
 
     pub fn table_type(&self) -> FFI_TableType {
-        let private_data = self.get_private_data();
+        let private_data = self.private_data();
         let provider = &private_data.provider;
 
         provider.table_type().into()
@@ -244,32 +266,40 @@ impl ExportedTableProvider {
         &mut self,
         ctx: &SessionContext,
         projections: Option<&Vec<usize>>,
-        filters: Vec<String>,
+        filter_buffer_size: c_uint,
+        filter_buffer: *const u8,
         limit: Option<usize>,
-    ) -> Result<*mut FFI_ExecutionPlan> {
-        let private_data = self.get_private_data();
+    ) -> Result<FFI_ExecutionPlan> {
+        let private_data = self.private_data();
         let provider = &private_data.provider;
 
-        let schema = provider.schema();
-        let df_schema: DFSchema = schema.try_into()?;
+        let filters = match filter_buffer_size > 0 {
+            false => vec![],
+            true => {
+                let default_ctx = SessionContext::new();
+                let codec = DefaultLogicalExtensionCodec {};
 
-        let filter_exprs = filters
-            .into_iter()
-            .map(|expr_str| ctx.state().create_logical_expr(&expr_str, &df_schema))
-            .collect::<datafusion::common::Result<Vec<Expr>>>()?;
+                let data = unsafe {
+                    slice::from_raw_parts(filter_buffer, filter_buffer_size as usize)
+                };
 
-        let plan =
-            block_on(provider.scan(&ctx.state(), projections, &filter_exprs, limit))?;
+                let proto_filters = LogicalExprList::decode(data)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-        let plan_boxed = Box::new(FFI_ExecutionPlan::new(plan, ctx.task_ctx()));
-        Ok(Box::into_raw(plan_boxed))
+                parse_exprs(proto_filters.expr.iter(), &default_ctx, &codec)?
+            }
+        };
+
+        let plan = block_on(provider.scan(&ctx.state(), projections, &filters, limit))?;
+
+        FFI_ExecutionPlan::new(plan, ctx.task_ctx())
     }
 
     pub fn supports_filters_pushdown(
-        &self,
-        buffer_size: c_int,
+        &mut self,
+        buffer_size: c_uint,
         filter_buffer: *const u8,
-    ) -> Result<Vec<FFI_TableProviderFilterPushDown>> {
+    ) -> Result<(usize, *const FFI_TableProviderFilterPushDown)> {
         unsafe {
             let default_ctx = SessionContext::new();
             let codec = DefaultLogicalExtensionCodec {};
@@ -287,20 +317,29 @@ impl ExportedTableProvider {
             };
             let filters_borrowed: Vec<&Expr> = filters.iter().collect();
 
-            let private_data = self.get_private_data();
-            let provider = &private_data.provider;
+            let private_data = self.mut_private_data();
+            private_data.last_filter_pushdowns = private_data
+                .provider
+                .supports_filters_pushdown(&filters_borrowed)?
+                .iter()
+                .map(|v| v.into())
+                .collect();
 
-            provider
-                .supports_filters_pushdown(&filters_borrowed)
-                .map(|f| f.iter().map(|v| v.into()).collect())
+            Ok((
+                private_data.last_filter_pushdowns.len(),
+                private_data.last_filter_pushdowns.as_ptr(),
+            ))
         }
     }
 }
 
 impl FFI_TableProvider {
     /// Creates a new [`FFI_TableProvider`].
-    pub fn new(provider: Box<dyn TableProvider + Send>) -> Self {
-        let private_data = Box::new(ProviderPrivateData { provider });
+    pub fn new(provider: Arc<dyn TableProvider + Send>) -> Self {
+        let private_data = Box::new(ProviderPrivateData {
+            provider,
+            last_filter_pushdowns: Vec::default(),
+        });
 
         Self {
             schema: Some(schema_fn_wrapper),
@@ -308,15 +347,16 @@ impl FFI_TableProvider {
             table_type: Some(table_type_fn_wrapper),
             supports_filters_pushdown: Some(supports_filters_pushdown_fn_wrapper),
             release: Some(release_fn_wrapper),
+            clone: Some(clone_fn_wrapper),
             private_data: Box::into_raw(private_data) as *mut c_void,
         }
     }
 
-    /**
-        Replace temporary pointer with updated
-        # Safety
-        User must validate the raw pointer is valid.
-    */
+    /// Create a FFI_TableProvider from a raw pointer
+    ///
+    /// # Safety
+    ///
+    /// This function assumes the raw pointer is valid and takes onwership of it.
     pub unsafe fn from_raw(raw_provider: *mut FFI_TableProvider) -> Self {
         std::ptr::replace(raw_provider, Self::empty())
     }
@@ -329,6 +369,7 @@ impl FFI_TableProvider {
             table_type: None,
             supports_filters_pushdown: None,
             release: None,
+            clone: None,
             private_data: std::ptr::null_mut(),
         }
     }
@@ -339,10 +380,16 @@ impl FFI_TableProvider {
 /// defined on this struct must only use the stable functions provided in
 /// FFI_TableProvider to interact with the foreign table provider.
 #[derive(Debug)]
-pub struct ForeignTableProvider(pub *const FFI_TableProvider);
+pub struct ForeignTableProvider(FFI_TableProvider);
 
 unsafe impl Send for ForeignTableProvider {}
 unsafe impl Sync for ForeignTableProvider {}
+
+impl ForeignTableProvider {
+    pub fn new(provider: FFI_TableProvider) -> Self {
+        Self(provider)
+    }
+}
 
 #[async_trait]
 impl TableProvider for ForeignTableProvider {
@@ -352,21 +399,20 @@ impl TableProvider for ForeignTableProvider {
 
     fn schema(&self) -> SchemaRef {
         let schema = unsafe {
-            let schema_fn = (*self.0).schema;
+            let schema_fn = self.0.schema;
             schema_fn
-                .map(|func| func(self.0))
+                .map(|func| func(&self.0))
                 .and_then(|s| Schema::try_from(&s).ok())
                 .unwrap_or(Schema::empty())
         };
-
         Arc::new(schema)
     }
 
     fn table_type(&self) -> TableType {
         unsafe {
-            let table_type_fn = (*self.0).table_type;
+            let table_type_fn = self.0.table_type;
             table_type_fn
-                .map(|func| func(self.0))
+                .map(|func| func(&self.0))
                 .unwrap_or(FFI_TableType::Base)
                 .into()
         }
@@ -379,26 +425,25 @@ impl TableProvider for ForeignTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let scan_fn = unsafe {
-            (*self.0).scan.ok_or(DataFusionError::NotImplemented(
-                "Scan not defined on FFI_TableProvider".to_string(),
-            ))?
-        };
+        let scan_fn = self.0.scan.ok_or(DataFusionError::NotImplemented(
+            "Scan not defined on FFI_TableProvider".to_string(),
+        ))?;
 
-        let session_config = FFI_SessionConfig::new(session);
+        let session_config = FFI_SessionConfig::new(session.config());
 
-        let n_projections = projection.map(|p| p.len()).unwrap_or(0) as c_int;
-        let projections: Vec<c_int> = projection
-            .map(|p| p.iter().map(|v| *v as c_int).collect())
+        let n_projections = projection.map(|p| p.len()).unwrap_or(0) as c_uint;
+        let projections: Vec<c_uint> = projection
+            .map(|p| p.iter().map(|v| *v as c_uint).collect())
             .unwrap_or_default();
         let projections_ptr = projections.as_ptr();
 
-        let n_filters = filters.len() as c_int;
-        let filters: Vec<CString> = filters
-            .iter()
-            .filter_map(|f| CString::new(f.to_string()).ok())
-            .collect();
-        let filters_ptr: Vec<*const i8> = filters.iter().map(|s| s.as_ptr()).collect();
+        let codec = DefaultLogicalExtensionCodec {};
+        let filter_list = LogicalExprList {
+            expr: serialize_exprs(filters, &codec)?,
+        };
+        let filter_bytes = filter_list.encode_to_vec();
+        let filter_buffer_size = filter_bytes.len() as c_uint;
+        let filter_buffer = filter_bytes.as_ptr();
 
         let limit = match limit {
             Some(l) => l as c_int,
@@ -408,12 +453,12 @@ impl TableProvider for ForeignTableProvider {
         let mut err_code = 0;
         let plan = unsafe {
             let plan_ptr = scan_fn(
-                self.0,
+                &self.0,
                 &session_config,
                 n_projections,
                 projections_ptr,
-                n_filters,
-                filters_ptr.as_ptr(),
+                filter_buffer_size,
+                filter_buffer,
                 limit,
                 &mut err_code,
             );
@@ -440,46 +485,59 @@ impl TableProvider for ForeignTableProvider {
             let codec = DefaultLogicalExtensionCodec {};
 
             let expr_list = LogicalExprList {
-                expr: serialize_exprs(filter.iter().map(|f| f.to_owned()), &codec)?
+                expr: serialize_exprs(filter.iter().map(|f| f.to_owned()), &codec)?,
             };
             let expr_bytes = expr_list.encode_to_vec();
             let buffer_size = expr_bytes.len();
             let buffer = expr_bytes.as_ptr();
 
-            let pushdown_fn = (*self.0).supports_filters_pushdown.ok_or(DataFusionError::Plan("FFI_TableProvider does not implement supports_filters_pushdown".to_string()))?;
+            let pushdown_fn =
+                self.0
+                    .supports_filters_pushdown
+                    .ok_or(DataFusionError::Plan(
+                        "FFI_TableProvider does not implement supports_filters_pushdown"
+                            .to_string(),
+                    ))?;
             let mut num_return = 0;
-            let pushdowns = null_mut();
-            let err_code = pushdown_fn(self.0, buffer_size as c_int, buffer, &mut num_return, pushdowns);
+            let mut pushdowns = null();
+            let err_code = pushdown_fn(
+                &self.0,
+                buffer_size as c_uint,
+                buffer,
+                &mut num_return,
+                &mut pushdowns,
+            );
             let num_return = num_return as usize;
-            let pushdowns_slice = Vec::from_raw_parts(pushdowns, num_return, num_return);
+            let pushdowns_slice = slice::from_raw_parts(pushdowns, num_return);
 
             match err_code {
-                0 => {
-                    Ok(pushdowns_slice.iter().map(|v| v.into()).collect())
-                }
-                _ => {
-                    Err(DataFusionError::Plan("Error occurred during FFI call to supports_filters_pushdown".to_string()))
-                }
+                0 => Ok(pushdowns_slice.iter().map(|v| v.into()).collect()),
+                _ => Err(DataFusionError::Plan(
+                    "Error occurred during FFI call to supports_filters_pushdown"
+                        .to_string(),
+                )),
             }
         }
     }
 }
 
-
 #[cfg(test)]
 mod tests {
+    use datafusion::prelude::{col, lit};
+
     use super::*;
 
-    #[test]
-    fn test_round_trip_ffi_table_provider() -> Result<()> {
-        use datafusion::datasource::MemTable;
+    #[tokio::test]
+    async fn test_round_trip_ffi_table_provider() -> Result<()> {
+        use arrow::datatypes::Field;
         use datafusion::arrow::{
             array::Float32Array, datatypes::DataType, record_batch::RecordBatch,
         };
-        use arrow::datatypes::Field;
+        use datafusion::datasource::MemTable;
 
-        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Float32, false)]));
-        
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Float32, false)]));
+
         // define data in two partitions
         let batch1 = RecordBatch::try_new(
             Arc::clone(&schema),
@@ -489,15 +547,25 @@ mod tests {
             Arc::clone(&schema),
             vec![Arc::new(Float32Array::from(vec![64.0]))],
         )?;
-        
-        // declare a new context. In spark API, this corresponds to a new spark SQLsession
+
         let ctx = SessionContext::new();
-        
-        // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-        let provider = MemTable::try_new(schema, vec![vec![batch1], vec![batch2]])?;
-        ctx.register_table("t", Arc::new(provider))?;
+
+        let provider =
+            Arc::new(MemTable::try_new(schema, vec![vec![batch1], vec![batch2]])?);
+
+        let ffi_provider = FFI_TableProvider::new(provider);
+
+        let foreign_table_provider = ForeignTableProvider::new(ffi_provider);
+
+        ctx.register_table("t", Arc::new(foreign_table_provider))?;
+
+        let df = ctx.table("t").await?;
+
+        df.select(vec![col("a")])?
+            .filter(col("a").gt(lit(3.0)))?
+            .show()
+            .await?;
 
         Ok(())
     }
-
 }

--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -22,15 +22,17 @@ use datafusion::{
 };
 use futures::executor::block_on;
 
+use crate::table_source::FFI_TableType;
+
 use super::{
     execution_plan::{ExportedExecutionPlan, FFI_ExecutionPlan},
     session_config::{FFI_SessionConfig, SessionConfigPrivateData},
 };
 use datafusion::error::Result;
 
+/// A stable interface for creating a DataFusion TableProvider.
 #[repr(C)]
 #[derive(Debug)]
-#[allow(missing_docs)]
 #[allow(non_camel_case_types)]
 pub struct FFI_TableProvider {
     pub version: i64,
@@ -47,6 +49,8 @@ pub struct FFI_TableProvider {
             err_code: *mut c_int,
         ) -> *mut FFI_ExecutionPlan,
     >,
+    pub table_type: Option<unsafe extern "C" fn(provider: *const FFI_TableProvider) -> FFI_TableType>,
+
     pub private_data: *mut c_void,
 }
 
@@ -57,11 +61,17 @@ struct ProviderPrivateData {
     provider: Box<dyn TableProvider + Send>,
 }
 
+/// Wrapper struct to provide access functions from the FFI interface to the underlying
+/// TableProvider. This struct is allowed to access `private_data` because it lives on
+/// the provider's side of the FFI interace.
 struct ExportedTableProvider(*const FFI_TableProvider);
 
-// The callback used to get array schema
-unsafe extern "C" fn provider_schema(provider: *const FFI_TableProvider) -> FFI_ArrowSchema {
-    ExportedTableProvider(provider).provider_schema()
+unsafe extern "C" fn schema_fn_wrapper(provider: *const FFI_TableProvider) -> FFI_ArrowSchema {
+    ExportedTableProvider(provider).schema()
+}
+
+unsafe extern "C" fn table_type_fn_wrapper(provider: *const FFI_TableProvider) -> FFI_TableType {
+    ExportedTableProvider(provider).table_type()
 }
 
 unsafe extern "C" fn scan_fn_wrapper(
@@ -74,7 +84,6 @@ unsafe extern "C" fn scan_fn_wrapper(
     limit: c_int,
     err_code: *mut c_int,
 ) -> *mut FFI_ExecutionPlan {
-    println!("entered scan_fn_wrapper");
     let config = unsafe { (*session_config).private_data as *const SessionConfigPrivateData };
     let session = SessionStateBuilder::new()
         .with_config((*config).config.clone())
@@ -103,8 +112,6 @@ unsafe extern "C" fn scan_fn_wrapper(
     let plan =
         ExportedTableProvider(provider).provider_scan(&ctx, maybe_projections, filters_vec, limit);
 
-    println!("leaving scan_fn_wrapper, has plan? {}", plan.is_ok());
-
     match plan {
         Ok(plan) => {
             *err_code = 0;
@@ -122,13 +129,20 @@ impl ExportedTableProvider {
         unsafe { &*((*self.0).private_data as *const ProviderPrivateData) }
     }
 
-    pub fn provider_schema(&self) -> FFI_ArrowSchema {
+    pub fn schema(&self) -> FFI_ArrowSchema {
         let private_data = self.get_private_data();
         let provider = &private_data.provider;
 
         // This does silently fail because TableProvider does not return a result
-        // so we expect it to always pass. Maybe some logging should be added.
+        // so we expect it to always pass.
         FFI_ArrowSchema::try_from(provider.schema().as_ref()).unwrap_or(FFI_ArrowSchema::empty())
+    }
+
+    pub fn table_type(&self) -> FFI_TableType {
+        let private_data = self.get_private_data();
+        let provider = &private_data.provider;
+
+        provider.table_type().into()
     }
 
     pub fn provider_scan(
@@ -164,8 +178,9 @@ impl FFI_TableProvider {
 
         Self {
             version: 2,
-            schema: Some(provider_schema),
+            schema: Some(schema_fn_wrapper),
             scan: Some(scan_fn_wrapper),
+            table_type: Some(table_type_fn_wrapper),
             private_data: Box::into_raw(private_data) as *mut c_void,
         }
     }
@@ -185,51 +200,54 @@ impl FFI_TableProvider {
             version: 0,
             schema: None,
             scan: None,
+            table_type: None,
             private_data: std::ptr::null_mut(),
         }
     }
 }
 
+/// This wrapper struct exists on the reciever side of the FFI interface, so it has
+/// no guarantees about being able to access the data in `private_data`. Any functions
+/// defined on this struct must only use the stable functions provided in 
+/// FFI_TableProvider to interact with the foreign table provider.
+#[derive(Debug)]
+struct ForeignTableProvider(*const FFI_TableProvider);
+
+unsafe impl Send for ForeignTableProvider {}
+unsafe impl Sync for ForeignTableProvider {}
+
 #[async_trait]
-impl TableProvider for FFI_TableProvider {
-    /// Returns the table provider as [`Any`](std::any::Any) so that it can be
-    /// downcast to a specific implementation.
+impl TableProvider for ForeignTableProvider {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
-    /// Get a reference to the schema for this table
     fn schema(&self) -> SchemaRef {
-        let schema = match self.schema {
-            Some(func) => unsafe { Schema::try_from(&func(self)).ok() },
-            None => None,
+        let schema = unsafe {
+            let schema_fn = (*self.0).schema;
+            schema_fn.map(|func| func(self.0)).and_then(|s| Schema::try_from(&s).ok()).unwrap_or(Schema::empty())
         };
-        Arc::new(schema.unwrap_or(Schema::empty()))
+
+        Arc::new(schema)
     }
 
-    /// Get the type of this table for metadata/catalog purposes.
     fn table_type(&self) -> TableType {
-        todo!()
+        unsafe {
+            let table_type_fn = (*self.0).table_type;
+            table_type_fn.map(|func| func(self.0)).unwrap_or(FFI_TableType::Base).into()
+        }
     }
 
-    /// Create an ExecutionPlan that will scan the table.
-    /// The table provider will be usually responsible of grouping
-    /// the source data into partitions that can be efficiently
-    /// parallelized or distributed.
     async fn scan(
         &self,
         session: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
-        // limit can be used to reduce the amount scanned
-        // from the datasource as a performance optimization.
-        // If set, it contains the amount of rows needed by the `LogicalPlan`,
-        // The datasource should return *at least* this number of rows if available.
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let scan_fn = self.scan.ok_or(DataFusionError::NotImplemented(
+        let scan_fn = unsafe { (*self.0).scan.ok_or(DataFusionError::NotImplemented(
             "Scan not defined on FFI_TableProvider".to_string(),
-        ))?;
+        ))?};
 
         let session_config = FFI_SessionConfig::new(session);
 
@@ -251,11 +269,10 @@ impl TableProvider for FFI_TableProvider {
             None => -1,
         };
 
-        println!("Within scan about to call unsafe scan_fn");
         let mut err_code = 0;
         let plan = unsafe {
             let plan_ptr = scan_fn(
-                self,
+                self.0,
                 &session_config,
                 n_projections,
                 projections_ptr,
@@ -271,16 +288,8 @@ impl TableProvider for FFI_TableProvider {
                 ));
             }
 
-            println!(
-                "Finished scan_fn inside FFI_TableProvider::scan {}",
-                plan_ptr.is_null()
-            );
-
-            let p = ExportedExecutionPlan::new(plan_ptr)?;
-            println!("ExportedExecutionPlan::new returned inside scan()");
-            p
+            ExportedExecutionPlan::new(plan_ptr)?
         };
-        println!("Scan returned with some plan.");
 
         Ok(Arc::new(plan))
     }

--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -35,7 +35,7 @@ use datafusion::error::Result;
 #[derive(Debug)]
 #[allow(non_camel_case_types)]
 pub struct FFI_TableProvider {
-    pub version: i64,
+    pub version: c_int,
     pub schema: Option<unsafe extern "C" fn(provider: *const FFI_TableProvider) -> FFI_ArrowSchema>,
     pub scan: Option<
         unsafe extern "C" fn(
@@ -177,7 +177,7 @@ impl FFI_TableProvider {
         let private_data = Box::new(ProviderPrivateData { provider });
 
         Self {
-            version: 2,
+            version: 1,
             schema: Some(schema_fn_wrapper),
             scan: Some(scan_fn_wrapper),
             table_type: Some(table_type_fn_wrapper),
@@ -211,7 +211,7 @@ impl FFI_TableProvider {
 /// defined on this struct must only use the stable functions provided in 
 /// FFI_TableProvider to interact with the foreign table provider.
 #[derive(Debug)]
-struct ForeignTableProvider(*const FFI_TableProvider);
+pub struct ForeignTableProvider(pub *const FFI_TableProvider);
 
 unsafe impl Send for ForeignTableProvider {}
 unsafe impl Sync for ForeignTableProvider {}

--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -28,11 +28,11 @@ use datafusion_proto::{
 use futures::executor::block_on;
 use prost::Message;
 
-use crate::table_source::{FFI_TableProviderFilterPushDown, FFI_TableType};
+use crate::{session_config::ExportedSessionConfig, table_source::{FFI_TableProviderFilterPushDown, FFI_TableType}};
 
 use super::{
     execution_plan::{ExportedExecutionPlan, FFI_ExecutionPlan},
-    session_config::{FFI_SessionConfig, SessionConfigPrivateData},
+    session_config::FFI_SessionConfig,
 };
 use datafusion::error::Result;
 
@@ -127,10 +127,9 @@ unsafe extern "C" fn scan_fn_wrapper(
     limit: c_int,
     err_code: *mut c_int,
 ) -> *mut FFI_ExecutionPlan {
-    let config =
-        unsafe { (*session_config).private_data as *const SessionConfigPrivateData };
+    let config = ExportedSessionConfig(session_config).session_config().clone();
     let session = SessionStateBuilder::new()
-        .with_config((*config).config.clone())
+        .with_config(config)
         .build();
     let ctx = SessionContext::new_with_state(session);
 

--- a/datafusion/ffi/src/table_source.rs
+++ b/datafusion/ffi/src/table_source.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use datafusion::{datasource::TableType, logical_expr::TableProviderFilterPushDown};
 
 // TODO Should we just define TableProviderFilterPushDown as repr(C)?

--- a/datafusion/ffi/src/table_source.rs
+++ b/datafusion/ffi/src/table_source.rs
@@ -9,21 +9,29 @@ pub enum FFI_TableProviderFilterPushDown {
     Exact,
 }
 
-impl From<FFI_TableProviderFilterPushDown> for TableProviderFilterPushDown {
-    fn from(value: FFI_TableProviderFilterPushDown) -> Self {
+impl From<&FFI_TableProviderFilterPushDown> for TableProviderFilterPushDown {
+    fn from(value: &FFI_TableProviderFilterPushDown) -> Self {
         match value {
-            FFI_TableProviderFilterPushDown::Unsupported => TableProviderFilterPushDown::Unsupported,
-            FFI_TableProviderFilterPushDown::Inexact => TableProviderFilterPushDown::Inexact,
+            FFI_TableProviderFilterPushDown::Unsupported => {
+                TableProviderFilterPushDown::Unsupported
+            }
+            FFI_TableProviderFilterPushDown::Inexact => {
+                TableProviderFilterPushDown::Inexact
+            }
             FFI_TableProviderFilterPushDown::Exact => TableProviderFilterPushDown::Exact,
         }
     }
 }
 
-impl From<TableProviderFilterPushDown> for FFI_TableProviderFilterPushDown {
-    fn from(value: TableProviderFilterPushDown) -> Self {
+impl From<&TableProviderFilterPushDown> for FFI_TableProviderFilterPushDown {
+    fn from(value: &TableProviderFilterPushDown) -> Self {
         match value {
-            TableProviderFilterPushDown::Unsupported => FFI_TableProviderFilterPushDown::Unsupported,
-            TableProviderFilterPushDown::Inexact => FFI_TableProviderFilterPushDown::Inexact,
+            TableProviderFilterPushDown::Unsupported => {
+                FFI_TableProviderFilterPushDown::Unsupported
+            }
+            TableProviderFilterPushDown::Inexact => {
+                FFI_TableProviderFilterPushDown::Inexact
+            }
             TableProviderFilterPushDown::Exact => FFI_TableProviderFilterPushDown::Exact,
         }
     }

--- a/datafusion/ffi/src/table_source.rs
+++ b/datafusion/ffi/src/table_source.rs
@@ -1,0 +1,60 @@
+use datafusion::{datasource::TableType, logical_expr::TableProviderFilterPushDown};
+
+// TODO Should we just define TableProviderFilterPushDown as repr(C)?
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum FFI_TableProviderFilterPushDown {
+    Unsupported,
+    Inexact,
+    Exact,
+}
+
+impl From<FFI_TableProviderFilterPushDown> for TableProviderFilterPushDown {
+    fn from(value: FFI_TableProviderFilterPushDown) -> Self {
+        match value {
+            FFI_TableProviderFilterPushDown::Unsupported => TableProviderFilterPushDown::Unsupported,
+            FFI_TableProviderFilterPushDown::Inexact => TableProviderFilterPushDown::Inexact,
+            FFI_TableProviderFilterPushDown::Exact => TableProviderFilterPushDown::Exact,
+        }
+    }
+}
+
+impl From<TableProviderFilterPushDown> for FFI_TableProviderFilterPushDown {
+    fn from(value: TableProviderFilterPushDown) -> Self {
+        match value {
+            TableProviderFilterPushDown::Unsupported => FFI_TableProviderFilterPushDown::Unsupported,
+            TableProviderFilterPushDown::Inexact => FFI_TableProviderFilterPushDown::Inexact,
+            TableProviderFilterPushDown::Exact => FFI_TableProviderFilterPushDown::Exact,
+        }
+    }
+}
+
+// TODO Should we just define FFI_TableType as repr(C)?
+#[repr(C)]
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FFI_TableType {
+    Base,
+    View,
+    Temporary,
+}
+
+impl From<FFI_TableType> for TableType {
+    fn from(value: FFI_TableType) -> Self {
+        match value {
+            FFI_TableType::Base => TableType::Base,
+            FFI_TableType::View => TableType::View,
+            FFI_TableType::Temporary => TableType::Temporary,
+        }
+    }
+}
+
+impl From<TableType> for FFI_TableType {
+    fn from(value: TableType) -> Self {
+        match value {
+            TableType::Base => FFI_TableType::Base,
+            TableType::View => FFI_TableType::View,
+            TableType::Temporary => FFI_TableType::Temporary,
+        }
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

This is to address part of https://github.com/apache/datafusion-python/issues/823 downstream but may have wider application than just python.

## Rationale for this change

This PR allows for registering table providers via a stable FFI. With this change it enables breaking the requirement for python providers to include all of datafusion-python and re-export it. With this change we can allow providers with different underlying datafusion versions to interoperate.

## What changes are included in this PR?

Adds support for `TableProvider` via FFI. In order to support this, it also includes `ExecutionPlan`, `SessionConfig`, `PlanProperties`, and `TableType`. As this gets used more, I expect we will want to expose other features but this gives an initial first implementation that solves an immediate need.

## Are these changes tested?

Some unit tests are provided. Additionally I did the following test:

I created a separate crate with the contents of `datafusion/ffi` so that I can test it against different versions of DataFusion by modifying the dependencies in Cargo.toml. Then I used this crate to build a test implementation of `datafusion-python` against DataFusion 42.0.0. I adjusted the test crate and built a test implementation of `delta-rs` against DataFusion 41.0.0. Then I registered the delta table in python against the session context. I was able to query the table with push down filters via this FFI interface even though the underlying DataFusion versions were different.

Additionally I ran memory leak checks against the provided unit tests and against running in python.

## Are there any user-facing changes?

This is not breaking, but a pure addition of a new `datafusion-ffi` library.


## Remaining Issues

- [ ] There is some inconsistency between the usage of `ExportedXYZ` and just using the raw `FFI_XYZ`. We should make the usage consistent across all struct types.
- [ ] Add documentation to explain the reasoning behind creating the data the way we do in the private data and foreign structs.
- [ ] Add documentation to explain more clearly the delineation between the `ExportedXYZ` and `ForeignXYZ`. It would probably be good to have a use case since which is "foreign" and which is "exported" can be complicated during some of the function calls.
- [ ] It would be *great* to demonstrate a C++ implementation linked against DataFusion rust. This might really open the doors for some implementations that are not feasible to convert to Rust.