### PR TITLE
Ensure that math functions fulfil the ColumnarValue contract

### DIFF
--- a/datafusion/expr-common/src/columnar_value.rs
+++ b/datafusion/expr-common/src/columnar_value.rs
@@ -17,8 +17,7 @@
 
 //! [`ColumnarValue`] represents the result of evaluating an expression.
 
-use arrow::array::ArrayRef;
-use arrow::array::NullArray;
+use arrow::array::{Array, ArrayRef, NullArray};
 use arrow::compute::{kernels, CastOptions};
 use arrow::datatypes::{DataType, TimeUnit};
 use datafusion_common::format::DEFAULT_CAST_OPTIONS;
@@ -216,6 +215,17 @@ impl ColumnarValue {
                 let cast_scalar = ScalarValue::try_from_array(&cast_array, 0)?;
                 Ok(ColumnarValue::Scalar(cast_scalar))
             }
+        }
+    }
+
+    /// Converts an [`ArrayRef`] to a [`ColumnarValue`] based on the supplied arguments.
+    /// This is useful for scalar UDF implementations to fulfil their contract:
+    /// if all arguments are scalar values, the result should also be a scalar value.
+    pub fn from_args_and_result(args: &[Self], result: ArrayRef) -> Result<Self> {
+        if result.len() == 1 && args.iter().all(|arg| matches!(arg, Self::Scalar(_))) {
+            Ok(Self::Scalar(ScalarValue::try_from_array(&result, 0)?))
+        } else {
+            Ok(Self::Array(result))
         }
     }
 }

--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -226,9 +226,8 @@ macro_rules! make_math_unary_udf {
                     $EVALUATE_BOUNDS(inputs)
                 }
 
-                fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
-                    let args = ColumnarValue::values_to_arrays(args)?;
-
+                fn invoke(&self, col_args: &[ColumnarValue]) -> Result<ColumnarValue> {
+                    let args = ColumnarValue::values_to_arrays(col_args)?;
                     let arr: ArrayRef = match args[0].data_type() {
                         DataType::Float64 => {
                             Arc::new(make_function_scalar_inputs_return_type!(
@@ -255,7 +254,8 @@ macro_rules! make_math_unary_udf {
                             )
                         }
                     };
-                    Ok(ColumnarValue::Array(arr))
+
+                    ColumnarValue::from_args_and_result(col_args, arr)
                 }
             }
         }
@@ -336,9 +336,8 @@ macro_rules! make_math_binary_udf {
                     $OUTPUT_ORDERING(input)
                 }
 
-                fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
-                    let args = ColumnarValue::values_to_arrays(args)?;
-
+                fn invoke(&self, col_args: &[ColumnarValue]) -> Result<ColumnarValue> {
+                    let args = ColumnarValue::values_to_arrays(col_args)?;
                     let arr: ArrayRef = match args[0].data_type() {
                         DataType::Float64 => Arc::new(make_function_inputs2!(
                             &args[0],
@@ -364,7 +363,8 @@ macro_rules! make_math_binary_udf {
                             )
                         }
                     };
-                    Ok(ColumnarValue::Array(arr))
+
+                    ColumnarValue::from_args_and_result(col_args, arr)
                 }
             }
         }


### PR DESCRIPTION
If all UDF arguments are scalars, so should be the result. In most cases, such function calls will be contant-folded, however, if for whatever reason the are not optimized, we want to avoid an error due to array length mismatch.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

No particular issue, as I couldn't find a case that is not constant-folded with pure DataFusion, however we have some custom optimizer rules that might result in expressions that are not constant-folded.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The rationale is that the UDF implementations shouldn't rely on optimizer rules to work correctly.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Added a new helper function `ColumnarValue::from_args_and_result` to perform the check and conversion.
* Updated the math UDF macros to return a scalar value when all their arguments are scalar.

## Are these changes tested?

Relying on existing tests to ensure nothing breaks.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

I made `ColumnarValue::from_args_and_result` public but if that's not desirable, I can move it to the math module.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
