### PR TITLE
Improve unparsing for `ORDER BY`, `UNION`, Windows functions with Aggregation

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -225,7 +225,7 @@ impl Unparser<'_> {
                     }
                 };
 
-                let order_by =order_by
+                let order_by = order_by
                     .iter()
                     .map(|sort_expr| self.sort_to_sql(sort_expr))
                     .collect::<Result<Vec<_>>>()?;

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -76,11 +76,6 @@ pub fn expr_to_sql(expr: &Expr) -> Result<ast::Expr> {
     unparser.expr_to_sql(expr)
 }
 
-pub fn sort_to_sql(sort: &Sort) -> Result<ast::OrderByExpr> {
-    let unparser = Unparser::default();
-    unparser.sort_to_sql(sort)
-}
-
 const LOWEST: &BinaryOperator = &BinaryOperator::Or;
 // Closest precedence we have to IS operator is BitwiseAnd (any other) in PG docs
 // (https://www.postgresql.org/docs/7.2/sql-precedence.html)
@@ -229,9 +224,10 @@ impl Unparser<'_> {
                         ast::WindowFrameUnits::Groups
                     }
                 };
-                let order_by: Vec<ast::OrderByExpr> = order_by
+
+                let order_by =order_by
                     .iter()
-                    .map(sort_to_sql)
+                    .map(|sort_expr| self.sort_to_sql(sort_expr))
                     .collect::<Result<Vec<_>>>()?;
 
                 let start_bound = self.convert_bound(&window_frame.start_bound)?;

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -356,19 +356,51 @@ impl Unparser<'_> {
                 if select.already_projected() {
                     return self.derive(plan, relation);
                 }
-                if let Some(query_ref) = query {
-                    if let Some(fetch) = sort.fetch {
-                        query_ref.limit(Some(ast::Expr::Value(ast::Value::Number(
-                            fetch.to_string(),
-                            false,
-                        ))));
-                    }
-                    query_ref.order_by(self.sorts_to_sql(sort.expr.clone())?);
-                } else {
+                let Some(query_ref) = query else {
                     return internal_err!(
                         "Sort operator only valid in a statement context."
                     );
-                }
+                };
+
+                if let Some(fetch) = sort.fetch {
+                	query_ref.limit(Some(ast::Expr::Value(ast::Value::Number(
+                       fetch.to_string(),
+                       false,
+                    ))));
+                };
+
+                let sort_exprs: &Vec<SortExpr> =
+                    // In case of aggregation there could be columns containing aggregation functions we need to unproject
+                    match find_agg_node_within_select(plan, select.already_projected()) {
+                        Some(agg) => &sort
+                            .expr
+                            .iter()
+                            .map(|sort_expr| {
+                                let mut sort_expr = sort_expr.clone();
+
+                                // ORDER BY can't have aliases, this indicates that the column was not properly unparsed, update it
+                                if let Expr::Alias(alias) = &sort_expr.expr {
+                                    sort_expr.expr = *alias.expr.clone();
+                                }
+
+                                // Unproject the sort expression if it is a column from the aggregation
+                                if let Expr::Column(c) = &sort_expr.expr {
+                                    if c.relation.is_none() && agg.schema.is_column_from_schema(&c) {
+                                        sort_expr.expr = unproject_agg_exprs(
+                                            &sort_expr.expr,
+                                            agg,
+                                            None,
+                                        )?;
+                                    }
+                                }
+
+                                Ok::<_, DataFusionError>(sort_expr)
+                            })
+                            .collect::<Result<Vec<_>>>()?,
+                        None => &sort.expr,
+                    };
+
+                query_ref.order_by(self.sorts_to_sql(sort_exprs)?);
 
                 self.select_to_sql_recursively(
                     sort.input.as_ref(),
@@ -406,7 +438,7 @@ impl Unparser<'_> {
                             .collect::<Result<Vec<_>>>()?;
                         if let Some(sort_expr) = &on.sort_expr {
                             if let Some(query_ref) = query {
-                                query_ref.order_by(self.sorts_to_sql(sort_expr.clone())?);
+                                query_ref.order_by(self.sorts_to_sql(sort_expr)?);
                             } else {
                                 return internal_err!(
                                     "Sort operator only valid in a statement context."
@@ -681,7 +713,7 @@ impl Unparser<'_> {
         }
     }
 
-    fn sorts_to_sql(&self, sort_exprs: Vec<SortExpr>) -> Result<Vec<ast::OrderByExpr>> {
+    fn sorts_to_sql(&self, sort_exprs: &Vec<SortExpr>) -> Result<Vec<ast::OrderByExpr>> {
         sort_exprs
             .iter()
             .map(|sort_expr| self.sort_to_sql(sort_expr))

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -22,7 +22,8 @@ use datafusion_common::{
     Column, DataFusionError, Result, TableReference,
 };
 use datafusion_expr::{
-   expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan, LogicalPlanBuilder, Projection, SortExpr
+    expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan,
+    LogicalPlanBuilder, Projection, SortExpr,
 };
 use sqlparser::ast::{self, Ident, SetExpr};
 use std::sync::Arc;
@@ -38,7 +39,8 @@ use super::{
         subquery_alias_inner_query_and_columns, TableAliasRewriter,
     },
     utils::{
-        find_agg_node_within_select, find_window_nodes_within_select, unproject_sort_expr, unproject_window_exprs
+        find_agg_node_within_select, find_window_nodes_within_select,
+        unproject_sort_expr, unproject_window_exprs,
     },
     Unparser,
 };
@@ -299,7 +301,6 @@ impl Unparser<'_> {
                     let filter_expr = self.expr_to_sql(&unprojected)?;
                     select.having(Some(filter_expr));
                 } else {
-
                     let filter_expr = self.expr_to_sql(&filter.predicate)?;
                     select.selection(Some(filter_expr));
                 }
@@ -362,17 +363,21 @@ impl Unparser<'_> {
                 };
 
                 if let Some(fetch) = sort.fetch {
-                	query_ref.limit(Some(ast::Expr::Value(ast::Value::Number(
-                       fetch.to_string(),
-                       false,
+                    query_ref.limit(Some(ast::Expr::Value(ast::Value::Number(
+                        fetch.to_string(),
+                        false,
                     ))));
                 };
 
                 let agg = find_agg_node_within_select(plan, select.already_projected());
                 // unproject sort expressions
-                let sort_exprs: Vec<SortExpr> = sort.expr.iter().map(|sort_expr| {
-                    unproject_sort_expr(sort_expr, agg, sort.input.as_ref())
-                }).collect::<Result<Vec<_>>>()?;
+                let sort_exprs: Vec<SortExpr> = sort
+                    .expr
+                    .iter()
+                    .map(|sort_expr| {
+                        unproject_sort_expr(sort_expr, agg, sort.input.as_ref())
+                    })
+                    .collect::<Result<Vec<_>>>()?;
 
                 query_ref.order_by(self.sorts_to_sql(&sort_exprs)?);
 

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -574,6 +574,11 @@ impl Unparser<'_> {
                     );
                 }
 
+                // Covers cases where the UNION is a subquery and the projection is at the top level
+                if select.already_projected() {
+                    return self.derive(plan, relation);
+                }
+
                 let input_exprs: Vec<SetExpr> = union
                     .inputs
                     .iter()

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -22,8 +22,7 @@ use datafusion_common::{
     Column, DataFusionError, Result, TableReference,
 };
 use datafusion_expr::{
-    expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan,
-    LogicalPlanBuilder, Projection, SortExpr,
+   expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan, LogicalPlanBuilder, Projection, SortExpr
 };
 use sqlparser::ast::{self, Ident, SetExpr};
 use std::sync::Arc;
@@ -39,8 +38,7 @@ use super::{
         subquery_alias_inner_query_and_columns, TableAliasRewriter,
     },
     utils::{
-        find_agg_node_within_select, find_window_nodes_within_select,
-        unproject_window_exprs,
+        find_agg_node_within_select, find_window_nodes_within_select, unproject_sort_expr, unproject_window_exprs
     },
     Unparser,
 };
@@ -301,6 +299,7 @@ impl Unparser<'_> {
                     let filter_expr = self.expr_to_sql(&unprojected)?;
                     select.having(Some(filter_expr));
                 } else {
+
                     let filter_expr = self.expr_to_sql(&filter.predicate)?;
                     select.selection(Some(filter_expr));
                 }
@@ -369,38 +368,13 @@ impl Unparser<'_> {
                     ))));
                 };
 
-                let sort_exprs: &Vec<SortExpr> =
-                    // In case of aggregation there could be columns containing aggregation functions we need to unproject
-                    match find_agg_node_within_select(plan, select.already_projected()) {
-                        Some(agg) => &sort
-                            .expr
-                            .iter()
-                            .map(|sort_expr| {
-                                let mut sort_expr = sort_expr.clone();
+                let agg = find_agg_node_within_select(plan, select.already_projected());
+                // unproject sort expressions
+                let sort_exprs: Vec<SortExpr> = sort.expr.iter().map(|sort_expr| {
+                    unproject_sort_expr(sort_expr, agg, sort.input.as_ref())
+                }).collect::<Result<Vec<_>>>()?;
 
-                                // ORDER BY can't have aliases, this indicates that the column was not properly unparsed, update it
-                                if let Expr::Alias(alias) = &sort_expr.expr {
-                                    sort_expr.expr = *alias.expr.clone();
-                                }
-
-                                // Unproject the sort expression if it is a column from the aggregation
-                                if let Expr::Column(c) = &sort_expr.expr {
-                                    if c.relation.is_none() && agg.schema.is_column_from_schema(&c) {
-                                        sort_expr.expr = unproject_agg_exprs(
-                                            &sort_expr.expr,
-                                            agg,
-                                            None,
-                                        )?;
-                                    }
-                                }
-
-                                Ok::<_, DataFusionError>(sort_expr)
-                            })
-                            .collect::<Result<Vec<_>>>()?,
-                        None => &sort.expr,
-                    };
-
-                query_ref.order_by(self.sorts_to_sql(sort_exprs)?);
+                query_ref.order_by(self.sorts_to_sql(&sort_exprs)?);
 
                 self.select_to_sql_recursively(
                     sort.input.as_ref(),
@@ -718,7 +692,7 @@ impl Unparser<'_> {
         }
     }
 
-    fn sorts_to_sql(&self, sort_exprs: &Vec<SortExpr>) -> Result<Vec<ast::OrderByExpr>> {
+    fn sorts_to_sql(&self, sort_exprs: &[SortExpr]) -> Result<Vec<ast::OrderByExpr>> {
         sort_exprs
             .iter()
             .map(|sort_expr| self.sort_to_sql(sort_expr))

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -23,7 +23,8 @@ use datafusion_common::{
     Column, DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::{
-    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr, Window
+    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr,
+    Window,
 };
 use sqlparser::ast;
 
@@ -123,7 +124,6 @@ pub(crate) fn unproject_agg_exprs(
                 {
                     // Window function can contain an aggregation columns, e.g., 'avg(sum(ss_sales_price)) over ...' that needs to be unprojected
                     return Ok(Transformed::yes(unproject_agg_exprs(&unprojected_expr, agg, None)?));
-                    
                 } else {
                     internal_err!(
                         "Tried to unproject agg expr for column '{}' that was not found in the provided Aggregate!", &c.name

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -23,7 +23,8 @@ use datafusion_common::{
     Column, DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::{
-    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Window,
+    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr,
+    Window,
 };
 use sqlparser::ast;
 
@@ -198,6 +199,54 @@ fn find_window_expr<'a>(
         .iter()
         .flat_map(|w| w.window_expr.iter())
         .find(|expr| expr.schema_name().to_string() == column_name)
+}
+
+/// Transforms a Column expression into the actual expression from aggregation or projection if found.
+/// This is required because if an ORDER BY expression is present in an Aggregate or Select, it is replaced
+/// with a Column expression (e.g., "sum(catalog_returns.cr_net_loss)"). We need to transform it back to
+/// the actual expression, such as sum("catalog_returns"."cr_net_loss").
+pub(crate) fn unproject_sort_expr(
+    sort_expr: &SortExpr,
+    agg: Option<&Aggregate>,
+    input: &LogicalPlan,
+) -> Result<SortExpr> {
+    let mut sort_expr = sort_expr.clone();
+
+    // Remove alias if present, because ORDER BY cannot use aliases
+    if let Expr::Alias(alias) = &sort_expr.expr {
+        sort_expr.expr = *alias.expr.clone();
+    }
+
+    let Expr::Column(ref col_ref) = sort_expr.expr else {
+        return Ok::<_, DataFusionError>(sort_expr);
+    };
+
+    if col_ref.relation.is_some() {
+        return Ok::<_, DataFusionError>(sort_expr);
+    };
+
+    // In case of aggregation there could be columns containing aggregation functions we need to unproject
+    if let Some(agg) = agg {
+        if agg.schema.is_column_from_schema(col_ref) {
+            let new_expr = unproject_agg_exprs(&sort_expr.expr, agg, None)?;
+            sort_expr.expr = new_expr;
+            return Ok::<_, DataFusionError>(sort_expr);
+        }
+    }
+
+    // If SELECT and ORDER BY contain the same expression with a scalar function, the ORDER BY expression will
+    // be replaced by a Column expression (e.g., "substr(customer.c_last_name, Int64(0), Int64(5))"), and we need
+    // to transform it back to the actual expression.
+    if let LogicalPlan::Projection(Projection { expr, schema, .. }) = input {
+        if let Ok(idx) = schema.index_of_column(col_ref) {
+            if let Some(Expr::ScalarFunction(scalar_fn)) = expr.get(idx) {
+                sort_expr.expr = Expr::ScalarFunction(scalar_fn.clone());
+            }
+        }
+        return Ok::<_, DataFusionError>(sort_expr);
+    }
+
+    Ok::<_, DataFusionError>(sort_expr)
 }
 
 /// Converts a date_part function to SQL, tailoring it to the supported date field extraction style.

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -20,7 +20,7 @@ use std::cmp::Ordering;
 use datafusion_common::{
     internal_err,
     tree_node::{Transformed, TreeNode},
-    Column, DataFusionError, Result, ScalarValue,
+    Column, Result, ScalarValue,
 };
 use datafusion_expr::{
     utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr,
@@ -208,11 +208,11 @@ pub(crate) fn unproject_sort_expr(
     }
 
     let Expr::Column(ref col_ref) = sort_expr.expr else {
-        return Ok::<_, DataFusionError>(sort_expr);
+        return Ok(sort_expr);
     };
 
     if col_ref.relation.is_some() {
-        return Ok::<_, DataFusionError>(sort_expr);
+        return Ok(sort_expr);
     };
 
     // In case of aggregation there could be columns containing aggregation functions we need to unproject
@@ -220,7 +220,7 @@ pub(crate) fn unproject_sort_expr(
         if agg.schema.is_column_from_schema(col_ref) {
             let new_expr = unproject_agg_exprs(&sort_expr.expr, agg, None)?;
             sort_expr.expr = new_expr;
-            return Ok::<_, DataFusionError>(sort_expr);
+            return Ok(sort_expr);
         }
     }
 
@@ -233,10 +233,10 @@ pub(crate) fn unproject_sort_expr(
                 sort_expr.expr = Expr::ScalarFunction(scalar_fn.clone());
             }
         }
-        return Ok::<_, DataFusionError>(sort_expr);
+        return Ok(sort_expr);
     }
 
-    Ok::<_, DataFusionError>(sort_expr)
+    Ok(sort_expr)
 }
 
 /// Converts a date_part function to SQL, tailoring it to the supported date field extraction style.

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -139,6 +139,13 @@ fn roundtrip_statement() -> Result<()> {
             SELECT j2_string as string FROM j2
             ORDER BY string DESC
             LIMIT 10"#,
+            r#"SELECT col1, id FROM (
+                SELECT j1_string AS col1, j1_id AS id FROM j1
+                UNION ALL
+                SELECT j2_string AS col1, j2_id AS id FROM j2
+                UNION ALL
+                SELECT j3_string AS col1, j3_id AS id FROM j3
+            ) AS subquery GROUP BY col1, id ORDER BY col1 ASC, id ASC"#,
             "SELECT id, count(*) over (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
             last_name, sum(id) over (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
             first_name from person",

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -24,6 +24,7 @@ use datafusion_expr::test::function_stub::{count_udaf, max_udaf, min_udaf, sum_u
 use datafusion_expr::{col, lit, table_scan, wildcard, LogicalPlanBuilder};
 use datafusion_functions::unicode;
 use datafusion_functions_aggregate::grouping::grouping_udaf;
+use datafusion_functions_window::rank::rank_udwf;
 use datafusion_sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_sql::unparser::dialect::{
     DefaultDialect as UnparserDefaultDialect, Dialect as UnparserDialect,
@@ -667,10 +668,11 @@ where
 
     let context = MockContextProvider {
         state: MockSessionState::default()
-        .with_aggregate_function(sum_udaf())
-        .with_aggregate_function(max_udaf())
-        .with_aggregate_function(grouping_udaf())
-        .with_scalar_function(Arc::new(unicode::substr().as_ref().clone()))
+            .with_aggregate_function(sum_udaf())
+            .with_aggregate_function(max_udaf())
+            .with_aggregate_function(grouping_udaf())
+            .with_window_function(rank_udwf())
+            .with_scalar_function(Arc::new(unicode::substr().as_ref().clone())),
     };
     let sql_to_rel = SqlToRel::new(&context);
     let plan = sql_to_rel.sql_statement_to_plan(statement).unwrap();
@@ -911,18 +913,21 @@ fn test_with_offset95() {
 fn test_order_by_to_sql() {
     // order by aggregation function
     sql_round_trip(
+        GenericDialect {},
         r#"SELECT id, first_name, SUM(id) FROM person GROUP BY id, first_name ORDER BY SUM(id) ASC, first_name DESC, id, first_name LIMIT 10"#,
         r#"SELECT person.id, person.first_name, sum(person.id) FROM person GROUP BY person.id, person.first_name ORDER BY sum(person.id) ASC NULLS LAST, person.first_name DESC NULLS FIRST, person.id ASC NULLS LAST, person.first_name ASC NULLS LAST LIMIT 10"#,
     );
 
     // order by aggregation function alias
     sql_round_trip(
+        GenericDialect {},
         r#"SELECT id, first_name, SUM(id) as total_sum FROM person GROUP BY id, first_name ORDER BY total_sum ASC, first_name DESC, id, first_name LIMIT 10"#,
         r#"SELECT person.id, person.first_name, sum(person.id) AS total_sum FROM person GROUP BY person.id, person.first_name ORDER BY total_sum ASC NULLS LAST, person.first_name DESC NULLS FIRST, person.id ASC NULLS LAST, person.first_name ASC NULLS LAST LIMIT 10"#,
     );
 
     // order by scalar function from projection
     sql_round_trip(
+        GenericDialect {},
         r#"SELECT id, first_name, substr(first_name,0,5) FROM person ORDER BY id, substr(first_name,0,5)"#,
         r#"SELECT person.id, person.first_name, substr(person.first_name, 0, 5) FROM person ORDER BY person.id ASC NULLS LAST, substr(person.first_name, 0, 5) ASC NULLS LAST"#,
     );
@@ -931,6 +936,7 @@ fn test_order_by_to_sql() {
 #[test]
 fn test_aggregation_to_sql() {
     sql_round_trip(
+        GenericDialect {},
         r#"SELECT id, first_name,
         SUM(id) AS total_sum,
         SUM(id) OVER (PARTITION BY first_name ROWS BETWEEN 5 PRECEDING AND 2 FOLLOWING) AS moving_sum,
@@ -942,8 +948,8 @@ fn test_aggregation_to_sql() {
         r#"SELECT person.id, person.first_name,
 sum(person.id) AS total_sum, sum(person.id) OVER (PARTITION BY person.first_name ROWS BETWEEN '5' PRECEDING AND '2' FOLLOWING) AS moving_sum,
 max(sum(person.id)) OVER (PARTITION BY person.first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS max_total,
-RANK() OVER (PARTITION BY (grouping(person.id) + grouping(person.age)), CASE WHEN (grouping(person.age) = 0) THEN person.id END ORDER BY sum(person.id) DESC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS rank_within_parent_1,
-RANK() OVER (PARTITION BY (grouping(person.age) + grouping(person.id)), CASE WHEN (CAST(grouping(person.age) AS BIGINT) = 0) THEN person.id END ORDER BY sum(person.id) DESC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS rank_within_parent_2
+rank() OVER (PARTITION BY (grouping(person.id) + grouping(person.age)), CASE WHEN (grouping(person.age) = 0) THEN person.id END ORDER BY sum(person.id) DESC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS rank_within_parent_1,
+rank() OVER (PARTITION BY (grouping(person.age) + grouping(person.id)), CASE WHEN (CAST(grouping(person.age) AS BIGINT) = 0) THEN person.id END ORDER BY sum(person.id) DESC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS rank_within_parent_2
 FROM person
 GROUP BY person.id, person.first_name"#.replace("\n", " ").as_str(),
     );

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -657,7 +657,8 @@ where
         .unwrap();
 
     let context = MockContextProvider {
-        state: MockSessionState::default(),
+        state: MockSessionState::default()
+        .with_aggregate_function(sum_udaf())
     };
     let sql_to_rel = SqlToRel::new(&context);
     let plan = sql_to_rel.sql_statement_to_plan(statement).unwrap();
@@ -892,4 +893,17 @@ fn test_with_offset0() {
 #[test]
 fn test_with_offset95() {
     sql_round_trip(MySqlDialect {}, "select 1 offset 95", "SELECT 1 OFFSET 95");
+}
+
+#[test]
+fn test_order_by_with_aggr_to_sql() {
+    sql_round_trip(
+        r#"SELECT id, first_name, SUM(id) FROM person GROUP BY id, first_name ORDER BY SUM(id) ASC, first_name DESC, id, first_name LIMIT 10"#,
+        r#"SELECT person.id, person.first_name, sum(person.id) FROM person GROUP BY person.id, person.first_name ORDER BY sum(person.id) ASC NULLS LAST, person.first_name DESC NULLS FIRST, person.id ASC NULLS LAST, person.first_name ASC NULLS LAST LIMIT 10"#,
+    );
+
+    sql_round_trip(
+        r#"SELECT id, first_name, SUM(id) as total_sum FROM person GROUP BY id, first_name ORDER BY total_sum ASC, first_name DESC, id, first_name LIMIT 10"#,
+        r#"SELECT person.id, person.first_name, sum(person.id) AS total_sum FROM person GROUP BY person.id, person.first_name ORDER BY total_sum ASC NULLS LAST, person.first_name DESC NULLS FIRST, person.id ASC NULLS LAST, person.first_name ASC NULLS LAST LIMIT 10"#,
+    );
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -22,6 +22,7 @@ use arrow_schema::*;
 use datafusion_common::{DFSchema, Result, TableReference};
 use datafusion_expr::test::function_stub::{count_udaf, max_udaf, min_udaf, sum_udaf};
 use datafusion_expr::{col, lit, table_scan, wildcard, LogicalPlanBuilder};
+use datafusion_functions::unicode;
 use datafusion_sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_sql::unparser::dialect::{
     DefaultDialect as UnparserDefaultDialect, Dialect as UnparserDialect,
@@ -666,6 +667,7 @@ where
     let context = MockContextProvider {
         state: MockSessionState::default()
         .with_aggregate_function(sum_udaf())
+        .with_scalar_function(Arc::new(unicode::substr().as_ref().clone()))
     };
     let sql_to_rel = SqlToRel::new(&context);
     let plan = sql_to_rel.sql_statement_to_plan(statement).unwrap();
@@ -903,14 +905,22 @@ fn test_with_offset95() {
 }
 
 #[test]
-fn test_order_by_with_aggr_to_sql() {
+fn test_order_by_to_sql() {
+    // order by aggregation function
     sql_round_trip(
         r#"SELECT id, first_name, SUM(id) FROM person GROUP BY id, first_name ORDER BY SUM(id) ASC, first_name DESC, id, first_name LIMIT 10"#,
         r#"SELECT person.id, person.first_name, sum(person.id) FROM person GROUP BY person.id, person.first_name ORDER BY sum(person.id) ASC NULLS LAST, person.first_name DESC NULLS FIRST, person.id ASC NULLS LAST, person.first_name ASC NULLS LAST LIMIT 10"#,
     );
 
+    // order by aggregation function alias
     sql_round_trip(
         r#"SELECT id, first_name, SUM(id) as total_sum FROM person GROUP BY id, first_name ORDER BY total_sum ASC, first_name DESC, id, first_name LIMIT 10"#,
         r#"SELECT person.id, person.first_name, sum(person.id) AS total_sum FROM person GROUP BY person.id, person.first_name ORDER BY total_sum ASC NULLS LAST, person.first_name DESC NULLS FIRST, person.id ASC NULLS LAST, person.first_name ASC NULLS LAST LIMIT 10"#,
+    );
+
+    // order by scalar function from projection
+    sql_round_trip(
+        r#"SELECT id, first_name, substr(first_name,0,5) FROM person ORDER BY id, substr(first_name,0,5)"#,
+        r#"SELECT person.id, person.first_name, substr(person.first_name, 0, 5) FROM person ORDER BY person.id ASC NULLS LAST, substr(person.first_name, 0, 5) ASC NULLS LAST"#,
     );
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -23,6 +23,7 @@ use datafusion_common::{DFSchema, Result, TableReference};
 use datafusion_expr::test::function_stub::{count_udaf, max_udaf, min_udaf, sum_udaf};
 use datafusion_expr::{col, lit, table_scan, wildcard, LogicalPlanBuilder};
 use datafusion_functions::unicode;
+use datafusion_functions_aggregate::grouping::grouping_udaf;
 use datafusion_sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_sql::unparser::dialect::{
     DefaultDialect as UnparserDefaultDialect, Dialect as UnparserDialect,
@@ -667,6 +668,8 @@ where
     let context = MockContextProvider {
         state: MockSessionState::default()
         .with_aggregate_function(sum_udaf())
+        .with_aggregate_function(max_udaf())
+        .with_aggregate_function(grouping_udaf())
         .with_scalar_function(Arc::new(unicode::substr().as_ref().clone()))
     };
     let sql_to_rel = SqlToRel::new(&context);
@@ -922,5 +925,26 @@ fn test_order_by_to_sql() {
     sql_round_trip(
         r#"SELECT id, first_name, substr(first_name,0,5) FROM person ORDER BY id, substr(first_name,0,5)"#,
         r#"SELECT person.id, person.first_name, substr(person.first_name, 0, 5) FROM person ORDER BY person.id ASC NULLS LAST, substr(person.first_name, 0, 5) ASC NULLS LAST"#,
+    );
+}
+
+#[test]
+fn test_aggregation_to_sql() {
+    sql_round_trip(
+        r#"SELECT id, first_name,
+        SUM(id) AS total_sum,
+        SUM(id) OVER (PARTITION BY first_name ROWS BETWEEN 5 PRECEDING AND 2 FOLLOWING) AS moving_sum,
+        MAX(SUM(id)) OVER (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS max_total,
+        rank() OVER (PARTITION BY grouping(id) + grouping(age), CASE WHEN grouping(age) = 0 THEN id END ORDER BY sum(id) DESC) AS rank_within_parent_1,
+        rank() OVER (PARTITION BY grouping(age) + grouping(id), CASE WHEN (CAST(grouping(age) AS BIGINT) = 0) THEN id END ORDER BY sum(id) DESC) AS rank_within_parent_2
+        FROM person
+        GROUP BY id, first_name;"#,
+        r#"SELECT person.id, person.first_name,
+sum(person.id) AS total_sum, sum(person.id) OVER (PARTITION BY person.first_name ROWS BETWEEN '5' PRECEDING AND '2' FOLLOWING) AS moving_sum,
+max(sum(person.id)) OVER (PARTITION BY person.first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS max_total,
+RANK() OVER (PARTITION BY (grouping(person.id) + grouping(person.age)), CASE WHEN (grouping(person.age) = 0) THEN person.id END ORDER BY sum(person.id) DESC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS rank_within_parent_1,
+RANK() OVER (PARTITION BY (grouping(person.age) + grouping(person.id)), CASE WHEN (CAST(grouping(person.age) AS BIGINT) = 0) THEN person.id END ORDER BY sum(person.id) DESC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS rank_within_parent_2
+FROM person
+GROUP BY person.id, person.first_name"#.replace("\n", " ").as_str(),
     );
 }


### PR DESCRIPTION
## Which issue does this PR close?

Improves unparsing to produce valid sql for TPC-DS benchmark queries:

#### Improve UNION unparsing

Fix UNION unparsing for queries where UNION is a subquery

Original query
```sql
select
	channel,
	col_name
from
	(
	select
		'store' as channel,
		'ss_customer_sk' as col_name
	from
		store_sales
union all
	select
		'web' as channel,
		'ws_ship_hdemo_sk' as col_name
	from
		web_sales
    ) as foo
group by
	channel,
	col_name
order by
	channel,
	col_name
```

Before (invalid):
```sql
select
	'store' as "channel",
	'ss_customer_sk' as "col_name"
from
	"store_sales"
union all
select
	'web' as "channel",
	'ws_ship_hdemo_sk' as "col_name"
from
	"web_sales"
order by
	"foo"."channel" asc nulls last,
	"foo"."col_name" asc nulls last
```

After (correct)
```sql
select
	"foo"."channel",
	"foo"."col_name"
from
	(
	select
		'store' as "channel",
		'ss_customer_sk' as "col_name"
	from
		"store_sales"
union all
	select
		'web' as "channel",
		'ws_ship_hdemo_sk' as "col_name"
	from
		"web_sales") as "foo"
group by
	"foo"."channel",
	"foo"."col_name"
order by
	"foo"."channel" asc nulls last,
	"foo"."col_name" asc nulls last
```

#### Fix unparsing for ORDER BY with Aggregation functions 

Improve unparsing to handle cases when `ORDER BY` clause contains  aggregation functions that needs to be unprojected, otherwise it will result in unparsed/incorrect sql  - `Referenced column "sum(catalog_returns.cr_net_loss)" not found in FROM clause` / `Referenced column "count(DISTINCT cs1.cs_order_number)" not found in FROM clause`

For example TPC-DS Q42
>Referenced column "sum(store_sales.ss_ext_sales_price)" not found in FROM clause
```sql
select  dt.d_year
 	,item.i_category_id
 	,item.i_category
 	,sum(ss_ext_sales_price)
 from 	date_dim dt
 	,store_sales
 	,item
 where dt.d_date_sk = store_sales.ss_sold_date_sk
 	and store_sales.ss_item_sk = item.i_item_sk
 	and item.i_manager_id = 1
 	and dt.d_moy=11
 	and dt.d_year=1998
 group by 	dt.d_year
 		,item.i_category_id
 		,item.i_category
 order by       sum(ss_ext_sales_price) desc,dt.d_year
 		,item.i_category_id
 		,item.i_category
 LIMIT 100 ;
```

#### Improve scalar functions in ORDER BY unparsing

Improve unparsing to correctly handle scalar functions in ORDER BY. If SELECT and ORDER BY contain the same expression with a scalar function, the ORDER BY expression will be replaced by a Column expression (e.g., "substr(customer.c_last_name, Int64(0), Int64(5))"), and we need to transform it back to the actual expression. This is done for scalar function expressions only.

```sql
  select c_last_name,c_first_name, substr(c_last_name,0,5)
  from customer
  order by substr(c_last_name,0,5)
  limit 10;
```

Before
```sql
select
	"customer"."c_last_name",
	"customer"."c_first_name",
	substr("customer"."c_last_name",0,5)
from
	"customer"
order by
	"substr(customer.c_last_name,Int64(0),Int64(5))" asc nulls last
limit 10
```

After
```sql
select
	"customer"."c_last_name",
	"customer"."c_first_name",
	substr("customer"."c_last_name",0,5)
from
	"customer"
order by
	substr("customer"."c_last_name",0,5) asc nulls last
limit 10
```

#### Fix unparsing for complex Window functions with Aggregation

Improve `unproject_agg_exprs`  to unparse complex Window functions with aggregation when aggregation functions present in `When/Then and Order By parts`.

For example `case when grouping(i_class) = 0 then i_category end` and  `order by sum(ws_net_paid) desc` in Window `rank()`:

```sql
select
    sum(ws_net_paid) as total_sum
   ,i_category
   ,i_class
   ,grouping(i_category)+grouping(i_class) as lochierarchy
   ,rank() over (
 	partition by grouping(i_category)+grouping(i_class),
 	case when grouping(i_class) = 0 then i_category end
 	order by sum(ws_net_paid) desc) as rank_within_parent
 from
    web_sales
   ,date_dim       d1
   ,item
 where
    d1.d_month_seq between 1205 and 1205+11
 and d1.d_date_sk = ws_sold_date_sk
 and i_item_sk  = ws_item_sk
 group by rollup(i_category,i_class)
 order by
   lochierarchy desc,
   case when lochierarchy = 0 then i_category end,
   rank_within_parent
  LIMIT 100;
```

## Are these changes tested?

Added automated tests

## Are there any user-facing changes?

Unparser will generate valid sql for complex Window functions  and Order By w/ aggregations and Union and Order By with Aggregation functions
