### PR TITLE
Fix logical vs physical schema mismatch for UNION where some inputs are constants

### DIFF
--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -468,7 +468,9 @@ pub fn can_interleave<T: Borrow<Arc<dyn ExecutionPlan>>>(
 }
 
 fn union_schema(inputs: &[Arc<dyn ExecutionPlan>]) -> SchemaRef {
-    let fields: Vec<Field> = (0..inputs[0].schema().fields().len())
+    let first_schema = inputs[0].schema();
+
+    let fields = (0..first_schema.fields().len())
         .map(|i| {
             inputs
                 .iter()
@@ -477,25 +479,30 @@ fn union_schema(inputs: &[Arc<dyn ExecutionPlan>]) -> SchemaRef {
                     let field = input.schema().field(i).clone();
                     let mut metadata = field.metadata().clone();
 
-                    let other_side_metdata = inputs
-                        .get(input_idx ^ (1 << 0))
-                        .map(|other_input| {
-                            other_input.schema().field(i).metadata().clone()
-                        })
-                        .unwrap_or_default();
+                    let other_metadatas = inputs
+                        .iter()
+                        .enumerate()
+                        .filter(|(other_idx, _)| *other_idx != input_idx)
+                        .flat_map(|(_, other_input)| {
+                            other_input.schema().field(i).metadata().clone().into_iter()
+                        });
 
-                    metadata.extend(other_side_metdata);
+                    metadata.extend(other_metadatas);
                     field.with_metadata(metadata)
                 })
-                .find_or_first(|f| f.is_nullable())
+                .find_or_first(Field::is_nullable)
+                // We can unwrap this because if inputs was empty, this would've already panic'ed when we
+                // indexed into inputs[0].
                 .unwrap()
         })
+        .collect::<Vec<_>>();
+
+    let all_metadata_merged = inputs
+        .iter()
+        .flat_map(|i| i.schema().metadata().clone().into_iter())
         .collect();
 
-    Arc::new(Schema::new_with_metadata(
-        fields,
-        inputs[0].schema().metadata().clone(),
-    ))
+    Arc::new(Schema::new_with_metadata(fields, all_metadata_merged))
 }
 
 /// CombinedRecordBatchStream can be used to combine a Vec of SendableRecordBatchStreams into one

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -472,21 +472,20 @@ fn union_schema(inputs: &[Arc<dyn ExecutionPlan>]) -> SchemaRef {
         .map(|i| {
             inputs
                 .iter()
-                .filter_map(|input| {
-                    if input.schema().fields().len() > i {
-                        let field = input.schema().field(i).clone();
-                        let right_hand_metdata = inputs
-                            .get(1)
-                            .map(|right_input| {
-                                right_input.schema().field(i).metadata().clone()
-                            })
-                            .unwrap_or_default();
-                        let mut metadata = field.metadata().clone();
-                        metadata.extend(right_hand_metdata);
-                        Some(field.with_metadata(metadata))
-                    } else {
-                        None
-                    }
+                .enumerate()
+                .map(|(input_idx, input)| {
+                    let field = input.schema().field(i).clone();
+                    let mut metadata = field.metadata().clone();
+
+                    let other_side_metdata = inputs
+                        .get(input_idx ^ (1 << 0))
+                        .map(|other_input| {
+                            other_input.schema().field(i).metadata().clone()
+                        })
+                        .unwrap_or_default();
+
+                    metadata.extend(other_side_metdata);
+                    field.with_metadata(metadata)
                 })
                 .find_or_first(|f| f.is_nullable())
                 .unwrap()

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -334,13 +334,12 @@ pub async fn register_metadata_tables(ctx: &SessionContext) {
             ),
         ]));
 
-    let schema =
-        Schema::new(vec![id, name, l_name, ts, nonnull_name]).with_metadata(HashMap::from([
-            (
-                String::from("metadata_key"),
-                String::from("the entire schema"),
-            ),
-        ]));
+    let schema = Schema::new(vec![id, name, l_name, ts, nonnull_name]).with_metadata(
+        HashMap::from([(
+            String::from("metadata_key"),
+            String::from("the entire schema"),
+        )]),
+    );
 
     let batch = RecordBatch::try_new(
         Arc::new(schema),

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -319,17 +319,28 @@ pub async fn register_metadata_tables(ctx: &SessionContext) {
             String::from("metadata_key"),
             String::from("the l_name field"),
         )]));
+
     let ts = Field::new("ts", DataType::Timestamp(TimeUnit::Nanosecond, None), false)
         .with_metadata(HashMap::from([(
             String::from("metadata_key"),
             String::from("ts non-nullable field"),
         )]));
 
+    let nonnull_name =
+        Field::new("nonnull_name", DataType::Utf8, false).with_metadata(HashMap::from([
+            (
+                String::from("metadata_key"),
+                String::from("the nonnull_name field"),
+            ),
+        ]));
+
     let schema =
-        Schema::new(vec![id, name, l_name, ts]).with_metadata(HashMap::from([(
-            String::from("metadata_key"),
-            String::from("the entire schema"),
-        )]));
+        Schema::new(vec![id, name, l_name, ts, nonnull_name]).with_metadata(HashMap::from([
+            (
+                String::from("metadata_key"),
+                String::from("the entire schema"),
+            ),
+        ]));
 
     let batch = RecordBatch::try_new(
         Arc::new(schema),
@@ -341,6 +352,11 @@ pub async fn register_metadata_tables(ctx: &SessionContext) {
                 1599572549190855123,
                 1599572549190855123,
                 1599572549190855123,
+            ])) as _,
+            Arc::new(StringArray::from(vec![
+                Some("no_foo"),
+                Some("no_bar"),
+                Some("no_baz"),
             ])) as _,
         ],
     )

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -136,7 +136,21 @@ no_baz
 no_foo
 NULL
 
-
+# Regression test: missing schema metadata from union when schema with metadata isn't the first one
+# and also ensure it works fine with multiple unions
+query T
+select name from (
+  SELECT NULL::string as name
+  UNION ALL
+  SELECT nonnull_name as name FROM "table_with_metadata"
+  UNION ALL
+  SELECT NULL::string as name
+) group by name order by name;
+----
+no_bar
+no_baz
+no_foo
+NULL
 
 query P rowsort
 SELECT ts

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -123,6 +123,15 @@ ORDER BY id, name, l_name;
 NULL bar NULL
 NULL NULL l_bar
 
+# Regression test: missing field metadata from left side of the union when right side is chosen
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+select name from (
+  SELECT nonnull_name as name FROM "table_with_metadata"
+  UNION ALL
+  SELECT NULL::string as name
+) group by name order by name;
+
+
 
 
 query P rowsort

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -124,13 +124,17 @@ NULL bar NULL
 NULL NULL l_bar
 
 # Regression test: missing field metadata from left side of the union when right side is chosen
-statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema..
+query T
 select name from (
   SELECT nonnull_name as name FROM "table_with_metadata"
   UNION ALL
   SELECT NULL::string as name
 ) group by name order by name;
-
+----
+no_bar
+no_baz
+no_foo
+NULL
 
 
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #12733 
closes https://github.com/apache/datafusion/issues/13010

## Rationale for this change

We found another bug for when the logical vs physical schema does not match. In this specific case, the UNION schema will [select which side has the nullable field -- and default to taking the left side](https://github.com/apache/datafusion/blob/5a0ea0bbad3de73ded192bf32080094cee5db9f3/datafusion/physical-plan/src/union.rs#L491).

In the example case, we have the nullable field as the right side. With this setup, it became evident that we are not adding the field metadata from the left side => to the right side.

## What changes are included in this PR?

[First commit](https://github.com/apache/datafusion/commit/a9b6bd56ed10ac23585d1010c923e5c457525274) is the reproducer.
Second commit is the fix.
Third commit updates the test/reproducer now that the fix is in.


## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
