### PR TITLE
Fix 'Too many open files' on fuzz test.

### DIFF
--- a/datafusion/core/tests/fuzz_cases/sort_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_fuzz.rs
@@ -37,8 +37,8 @@ use test_utils::{batches_to_vec, partitions_to_sorted_vec};
 const KB: usize = 1 << 10;
 #[tokio::test]
 #[cfg_attr(tarpaulin, ignore)]
-async fn test_sort_1k_mem() {
-    for (batch_size, should_spill) in [(5, false), (20000, true), (1000000, true)] {
+async fn test_sort_10k_mem() {
+    for (batch_size, should_spill) in [(5, false), (20000, true), (500000, true)] {
         SortTest::new()
             .with_int32_batches(batch_size)
             .with_pool_size(10 * KB)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10674.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

* On MacOS a batch size of 1,000,000 with a 10KB pool size results in a panic `Too many open files`.
* The spill threshold for 10KB pool size already spills at the 20,000 batch size, so going to 1,000,000 for this test seem unnecessary.


## What changes are included in this PR?
* change upper spill test threshold batch size to 500,000 from 1,000,000.
* rename test to `test_sort_10k_mem` to reflect the 10KB pool size to be consistent with the test `test_sort_100k_mem` which uses a 100KB pool size.

## Are these changes tested?

Changes are to tests.

## Are there any user-facing changes?

No
