### PR TITLE
docs: Add documentation about conventional commits

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -116,6 +116,20 @@ If you are concerned that a larger design will be lost in a string of small PRs,
 
 Note all commits in a PR are squashed when merged to the `main` branch so there is one commit per PR after merge.
 
+## Conventional Commits & Labeling PRs
+
+We generate change logs for each release using an automated process that will categorize PRs based on the title
+and/or the GitHub labels attached to the PR.
+
+We follow the [Conventional Commits] specification to categorize PRs based on the title. This most often simply means
+looking for titles starting with prefixes such as `fix:`, `feat:`, `docs:`, or `chore:`. We do not enforce this
+convention but encourage its use if you want your PR to feature in the correct section of the changelog.
+
+The change log generator will also look at GitHub labels such as `bug`, `enhancement`, or `api change`, and labels
+do take priority over the conventional commit approach, allowing maintainers to re-categorize PRs after they have been merged.
+
+[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/
+
 # Reviewing Pull Requests
 
 Some helpful links:

--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -128,7 +128,7 @@ convention but encourage its use if you want your PR to feature in the correct s
 The change log generator will also look at GitHub labels such as `bug`, `enhancement`, or `api change`, and labels
 do take priority over the conventional commit approach, allowing maintainers to re-categorize PRs after they have been merged.
 
-[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/
+[conventional commits]: https://www.conventionalcommits.org/en/v1.0.0/
 
 # Reviewing Pull Requests
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We generate changelogs based on PR titles where PRs following the conventional commits specification, and also based on labels associated with PRs, but we did not documentation for this process.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR adds documentation.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
