### PR TITLE
feat(substrait): add wildcard handling to producer

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -107,6 +107,7 @@ pub fn to_substrait_plan(plan: &LogicalPlan, ctx: &SessionContext) -> Result<Box
     // Generate PlanRel(s)
     // Note: Only 1 relation tree is currently supported
 
+    // We have to expand wildcard expressions first as wildcards can't be represented in substrait
     let plan = Arc::new(ExpandWildcardRule::new())
         .analyze(plan.clone(), &ConfigOptions::default())?;
 

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -183,7 +183,13 @@ async fn simple_select() -> Result<()> {
 
 #[tokio::test]
 async fn wildcard_select() -> Result<()> {
-    roundtrip("SELECT * FROM data").await
+    assert_expected_plan_unoptimized(
+        "SELECT * FROM data",
+        "Projection: data.a, data.b, data.c, data.d, data.e, data.f\
+        \n  TableScan: data",
+        true,
+    )
+    .await
 }
 
 #[tokio::test]
@@ -1104,6 +1110,32 @@ async fn verify_post_join_filter_value(proto: Box<Plan>) -> Result<()> {
             None => return plan_err!("Cannot parse plan relation: None"),
         }
     }
+
+    Ok(())
+}
+
+async fn assert_expected_plan_unoptimized(
+    sql: &str,
+    expected_plan_str: &str,
+    assert_schema: bool,
+) -> Result<()> {
+    let ctx = create_context().await?;
+    let df = ctx.sql(sql).await?;
+    let plan = df.into_unoptimized_plan();
+    let proto = to_substrait_plan(&plan, &ctx)?;
+    let plan2 = from_substrait_plan(&ctx, &proto).await?;
+
+    println!("{plan}");
+    println!("{plan2}");
+
+    println!("{proto:?}");
+
+    if assert_schema {
+        assert_eq!(plan.schema(), plan2.schema());
+    }
+
+    let plan2str = format!("{plan2}");
+    assert_eq!(expected_plan_str, &plan2str);
 
     Ok(())
 }


### PR DESCRIPTION
## Rationale for this change

Current roundtrip tests for wildcard expression pass only because tests themselves optimize the plan beforehand and "optimize" the wildcard away before actually doing a roundtrip. Producer should be able to convert the plan to substrait even if the plan isn't optimized beforehand.

## What changes are included in this PR?

- Changes the wildcard test not to optimize the query beforehand
- Injects `ExpandWildcardRule` at the top of the producer. Substrait doesn't have anything analogous to the wildcard, so the easiest solution I found was to run ExpandWildcardRule to work around that. The main thing is that it's run as part of the producer so the producer no longer assumes that full optimizer has been run before.

## Are these changes tested?

yes

## Are there any user-facing changes?

yes, producer can convert wildcard expression independently of the optimizer.