### PR TITLE
Fix CI on main ( regenerate function docs)

### DIFF
--- a/docs/source/user-guide/sql/scalar_functions_new.md
+++ b/docs/source/user-guide/sql/scalar_functions_new.md
@@ -1802,6 +1802,7 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
 
 - [current_date](#current_date)
 - [current_time](#current_time)
+- [current_timestamp](#current_timestamp)
 - [date_bin](#date_bin)
 - [date_format](#date_format)
 - [date_part](#date_part)
@@ -1845,6 +1846,10 @@ The `current_time()` return value is determined at query time and will return th
 ```
 current_time()
 ```
+
+### `current_timestamp`
+
+_Alias of [now](#now)._
 
 ### `date_bin`
 
@@ -2002,6 +2007,10 @@ The `now()` return value is determined at query time and will return the same ti
 ```
 now()
 ```
+
+#### Aliases
+
+- current_timestamp
 
 ### `to_char`
 


### PR DESCRIPTION
## Which issue does this PR close?



## Rationale for this change

CI is failing on main https://github.com/apache/datafusion/actions/runs/11389933675/job/31690903265

```
Running prettier
docs/source/user-guide/sql/window_functions_new.md 54ms
'docs/source/user-guide/sql/window_functions_new.md' successfully updated!
diff --git a/docs/source/user-guide/sql/scalar_functions_new.md b/docs/source/user-guide/sql/scalar_functions_new.md
index 8f1e30f..ffc2b68 100644
--- a/docs/source/user-guide/sql/scalar_functions_new.md
+++ b/docs/source/user-guide/sql/scalar_functions_new.md
@@ -1802,6 +1802,7 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
 
 - [current_date](#current_date)
 - [current_time](#current_time)
+- [current_timestamp](#current_timestamp)
 - [date_bin](#date_bin)
 - [date_format](#date_format)
 - [date_part](#date_part)
@@ -1846,6 +1847,10 @@ The `current_time()` return value is determined at query time and will return th
 current_time()
 
+### `current_timestamp`
+
+_Alias of [now](#now)._
+
 ### `date_bin`
 
 Calculates time intervals and returns the start of the interval nearest to the specified timestamp. Use `date_bin` to downsample time series data by grouping rows into time-based "bins" or "windows" and applying an aggregate or selector function to each window.
@@ -2003,6 +2008,10 @@ The `now()` return value is determined at query time and will return the same ti
 now()
 
+#### Aliases
+
+- current_timestamp
+
 ### `to_char`
 
 Returns a string representation of a date, time, timestamp or duration based on a [Chrono format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html). Unlike the PostgreSQL equivalent of this function numerical formatting is not supported.
Error: Process completed with exit code 1.
```

There appears to be a logical conflict introduced wtih https://github.com/apache/datafusion/pull/12966


## What changes are included in this PR?

Run
```shell
./dev/update_function_docs.sh
```

And check in the result

## Are these changes tested?
By CI

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
