### PR TITLE
Display ValuesExec schema in EXPLAIN

### DIFF
--- a/datafusion/physical-plan/src/values.rs
+++ b/datafusion/physical-plan/src/values.rs
@@ -34,6 +34,7 @@ use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion_common::{internal_err, plan_err, Result, ScalarValue};
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::EquivalenceProperties;
+use itertools::Itertools;
 
 /// Execution plan for values list based relation (produces constant rows)
 #[derive(Debug)]
@@ -151,7 +152,13 @@ impl DisplayAs for ValuesExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                write!(f, "ValuesExec")
+                let schema = self
+                    .schema
+                    .fields()
+                    .iter()
+                    .map(|f| format!("{}:{}", f.name(), f.data_type()))
+                    .join(", ");
+                write!(f, "ValuesExec [{}]", schema)
             }
         }
     }

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -415,3 +415,9 @@ logical_plan
 physical_plan
 01)ProjectionExec: expr=[{c0:1,c1:2.3,c2:abc} as struct(Int64(1),Float64(2.3),Utf8("abc"))]
 02)--PlaceholderRowExec
+
+query TT
+EXPLAIN VALUES (NULL), (NULL)
+----
+logical_plan Values: (NULL), (NULL)
+physical_plan ValuesExec [column1:Null]

--- a/datafusion/sqllogictest/test_files/insert_to_external.slt
+++ b/datafusion/sqllogictest/test_files/insert_to_external.slt
@@ -128,7 +128,7 @@ physical_plan
 01)DataSinkExec: sink=CsvSink(file_groups=[])
 02)--SortExec: expr=[a@0 ASC NULLS LAST,b@1 DESC], preserve_partitioning=[false]
 03)----ProjectionExec: expr=[column1@0 as a, column2@1 as b]
-04)------ValuesExec
+04)------ValuesExec [column1:Int64, column2:Int64]
 
 query I
 INSERT INTO ordered_insert_test values (5, 1), (4, 2), (7,7), (7,8), (7,9), (7,10), (3, 3), (2, 4), (1, 5);

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -778,7 +778,7 @@ physical_plan
 08)--------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
 09)----------------AggregateExec: mode=Partial, gby=[t@0 as t], aggr=[]
 10)------------------ProjectionExec: expr=[column1@0 as t]
-11)--------------------ValuesExec
+11)--------------------ValuesExec [column1:Int64]
 12)------ProjectionExec: expr=[1 as m, t@0 as t]
 13)--------AggregateExec: mode=FinalPartitioned, gby=[t@0 as t], aggr=[]
 14)----------CoalesceBatchesExec: target_batch_size=8192
@@ -786,7 +786,7 @@ physical_plan
 16)--------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
 17)----------------AggregateExec: mode=Partial, gby=[t@0 as t], aggr=[]
 18)------------------ProjectionExec: expr=[column1@0 as t]
-19)--------------------ValuesExec
+19)--------------------ValuesExec [column1:Int64]
 
 #####
 # Multi column sorting with lists

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -424,19 +424,19 @@ query TT
 EXPLAIN VALUES (1, 'a', -1, 1.1),(NULL, 'b', -3, 0.5)
 ----
 logical_plan Values: (Int64(1), Utf8("a"), Int64(-1), Float64(1.1)), (Int64(NULL), Utf8("b"), Int64(-3), Float64(0.5))
-physical_plan ValuesExec
+physical_plan ValuesExec [column1:Int64, column2:Utf8, column3:Int64, column4:Float64]
 
 query TT
 EXPLAIN VALUES ('1'::float)
 ----
 logical_plan Values: (Float32(1) AS Utf8("1"))
-physical_plan ValuesExec
+physical_plan ValuesExec [column1:Float32]
 
 query TT
 EXPLAIN VALUES (('1'||'2')::int unsigned)
 ----
 logical_plan Values: (UInt32(12) AS Utf8("1") || Utf8("2"))
-physical_plan ValuesExec
+physical_plan ValuesExec [column1:UInt32]
 
 
 # all where empty


### PR DESCRIPTION
This makes the EXPLAIN of physical plan fuller. Previously it did not include type-related information.

Relates to https://github.com/apache/datafusion/issues/12997 . Maybe something related is needed for logical plans as well.