### PR TITLE
extended log.rs tests for unary/binary and f32/f64 casting

### DIFF
--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -292,6 +292,104 @@ mod tests {
     }
 
     #[test]
+    fn test_log_scalar_f32_unary() {
+        let args = [
+            ColumnarValue::Scalar(ScalarValue::Float32(Some(10.0))), // num
+        ];
+
+        let result = LogFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function log");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float32_array(&arr)
+                    .expect("failed to convert result to a Float32Array");
+
+                assert_eq!(floats.len(), 1);
+                assert!((floats.value(0) - 1.0).abs() < 1e-10);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+
+    #[test]
+    fn test_log_scalar_f64_unary() {
+        let args = [
+            ColumnarValue::Scalar(ScalarValue::Float64(Some(10.0))), // num
+        ];
+
+        let result = LogFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function log");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float64_array(&arr)
+                    .expect("failed to convert result to a Float64Array");
+
+                assert_eq!(floats.len(), 1);
+                assert!((floats.value(0) - 1.0).abs() < 1e-10);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+
+    #[test]
+    fn test_log_scalar_f32() {
+        let args = [
+            ColumnarValue::Scalar(ScalarValue::Float32(Some(2.0))), // num
+            ColumnarValue::Scalar(ScalarValue::Float32(Some(32.0))), // num
+        ];
+
+        let result = LogFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function log");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float32_array(&arr)
+                    .expect("failed to convert result to a Float32Array");
+
+                assert_eq!(floats.len(), 1);
+                assert!((floats.value(0) - 5.0).abs() < 1e-10);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+
+    #[test]
+    fn test_log_scalar_f64() {
+        let args = [
+            ColumnarValue::Scalar(ScalarValue::Float64(Some(2.0))), // num
+            ColumnarValue::Scalar(ScalarValue::Float64(Some(64.0))), // num
+        ];
+
+        let result = LogFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function log");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float64_array(&arr)
+                    .expect("failed to convert result to a Float64Array");
+
+                assert_eq!(floats.len(), 1);
+                assert!((floats.value(0) - 6.0).abs() < 1e-10);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+
+    #[test]
     fn test_log_f64_unary() {
         let args = [
             ColumnarValue::Array(Arc::new(Float64Array::from(vec![

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -261,12 +261,93 @@ mod tests {
 
     use super::*;
 
-    use arrow::array::{Float32Array, Float64Array};
+    use arrow::array::{Float32Array, Float64Array, Int64Array};
     use arrow::compute::SortOptions;
     use datafusion_common::cast::{as_float32_array, as_float64_array};
     use datafusion_common::DFSchema;
     use datafusion_expr::execution_props::ExecutionProps;
     use datafusion_expr::simplify::SimplifyContext;
+
+    #[test]
+    #[should_panic]
+    fn test_log_invalid_base_type() {
+        let args = [
+            ColumnarValue::Array(Arc::new(Float64Array::from(vec![
+                10.0, 100.0, 1000.0, 10000.0,
+            ]))), // num
+            ColumnarValue::Array(Arc::new(Int64Array::from(vec![5, 10, 15, 20]))),
+        ];
+
+        let _ = LogFunc::new().invoke(&args);
+    }
+
+    #[test]
+    fn test_log_invalid_value() {
+        let args = [
+            ColumnarValue::Array(Arc::new(Int64Array::from(vec![10]))), // num
+        ];
+
+        let result = LogFunc::new().invoke(&args);
+        result.expect_err("expected error");
+    }
+
+    #[test]
+    fn test_log_f64_unary() {
+        let args = [
+            ColumnarValue::Array(Arc::new(Float64Array::from(vec![
+                10.0, 100.0, 1000.0, 10000.0,
+            ]))), // num
+        ];
+
+        let result = LogFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function log");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float64_array(&arr)
+                    .expect("failed to convert result to a Float64Array");
+
+                assert_eq!(floats.len(), 4);
+                assert!((floats.value(0) - 1.0).abs() < 1e-10);
+                assert!((floats.value(1) - 2.0).abs() < 1e-10);
+                assert!((floats.value(2) - 3.0).abs() < 1e-10);
+                assert!((floats.value(3) - 4.0).abs() < 1e-10);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+
+    #[test]
+    fn test_log_f32_unary() {
+        let args = [
+            ColumnarValue::Array(Arc::new(Float32Array::from(vec![
+                10.0, 100.0, 1000.0, 10000.0,
+            ]))), // num
+        ];
+
+        let result = LogFunc::new()
+            .invoke(&args)
+            .expect("failed to initialize function log");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float32_array(&arr)
+                    .expect("failed to convert result to a Float64Array");
+
+                assert_eq!(floats.len(), 4);
+                assert!((floats.value(0) - 1.0).abs() < 1e-10);
+                assert!((floats.value(1) - 2.0).abs() < 1e-10);
+                assert!((floats.value(2) - 3.0).abs() < 1e-10);
+                assert!((floats.value(3) - 4.0).abs() < 1e-10);
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
 
     #[test]
     fn test_log_f64() {

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -544,12 +544,27 @@ select log(arrow_cast(10, 'Float64')) a ,log(arrow_cast(100, 'Float32')) b;
 
 # log overloaded base 10 float64 and float32 casting with columns
 query RR rowsort
-select log(arrow_cast(a, 'Float64')) ,log(arrow_cast(b, 'Float32')) from signed_integers;
+select log(arrow_cast(a, 'Float64')), log(arrow_cast(b, 'Float32')) from signed_integers;
 ----
 0.301029995664 NaN
 0.602059991328 NULL
 NaN 2
 NaN 4
+
+# log float64 and float32 casting scalar
+query RR rowsort
+select log(2,arrow_cast(8, 'Float64')) a, log(2,arrow_cast(16, 'Float32')) b;
+----
+3 4
+
+# log float64 and float32 casting with columns
+query RR rowsort
+select log(2,arrow_cast(a, 'Float64')), log(4,arrow_cast(b, 'Float32')) from signed_integers;
+----
+1 NaN
+2 NULL
+NaN 3.321928
+NaN 6.643856
 
 
 ## log10

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -536,6 +536,22 @@ select log(a, 64) a, log(b), log(10, b) from signed_integers;
 NaN 2 2
 NaN 4 4
 
+# log overloaded base 10 float64 and float32 casting scalar
+query RR rowsort
+select log(arrow_cast(10, 'Float64')) a ,log(arrow_cast(100, 'Float32')) b;
+----
+1 2
+
+# log overloaded base 10 float64 and float32 casting with columns
+query RR rowsort
+select log(arrow_cast(a, 'Float64')) ,log(arrow_cast(b, 'Float32')) from signed_integers;
+----
+0.301029995664 NaN
+0.602059991328 NULL
+NaN 2
+NaN 4
+
+
 ## log10
 
 # log10 scalar function


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13020.

## Rationale for this change
Unit tests in log.rs do not cover unary case and failure case. Also added explicit casting to slt tests for f32 and f64 with log(x) and log(x,y) to cover all cases

## What changes are included in this PR?
-added tests

## Are these changes tested?
changes are only tests and all tests pass 

## Are there any user-facing changes?
no