### PR TITLE
feat: Add `Date32`/`Date64`  in aggregate fuzz testing

### DIFF
--- a/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
@@ -164,6 +164,8 @@ fn baseline_config() -> DatasetGeneratorConfig {
         ColumnDescr::new("u16", DataType::UInt16),
         ColumnDescr::new("u32", DataType::UInt32),
         ColumnDescr::new("u64", DataType::UInt64),
+        ColumnDescr::new("date32", DataType::Date32),
+        ColumnDescr::new("date64", DataType::Date64),
         // TODO: date/time columns
         // todo decimal columns
         // begin string columns

--- a/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
@@ -226,7 +226,7 @@ macro_rules! generate_string_array {
 }
 
 macro_rules! generate_primitive_array {
-    ($SELF:ident, $NUM_ROWS:ident, $BATCH_GEN_RNG:ident, $ARRAY_GEN_RNG:ident, $DATA_TYPE:ident, $ARROW_TYPE:ident) => {
+    ($SELF:ident, $NUM_ROWS:ident, $BATCH_GEN_RNG:ident, $ARRAY_GEN_RNG:ident, $ARROW_TYPE:ident) => {
         paste::paste! {{
             let null_pct_idx = $BATCH_GEN_RNG.gen_range(0..$SELF.candidate_null_pcts.len());
             let null_pct = $SELF.candidate_null_pcts[null_pct_idx];
@@ -243,7 +243,7 @@ macro_rules! generate_primitive_array {
                 rng: $ARRAY_GEN_RNG,
             };
 
-            generator.gen_data::<$DATA_TYPE, $ARROW_TYPE>()
+            generator.gen_data::<$ARROW_TYPE>()
     }}}
 }
 
@@ -301,7 +301,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i8,
                     Int8Type
                 )
             }
@@ -311,7 +310,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i16,
                     Int16Type
                 )
             }
@@ -321,7 +319,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i32,
                     Int32Type
                 )
             }
@@ -331,7 +328,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i64,
                     Int64Type
                 )
             }
@@ -341,7 +337,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    u8,
                     UInt8Type
                 )
             }
@@ -351,7 +346,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    u16,
                     UInt16Type
                 )
             }
@@ -361,7 +355,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    u32,
                     UInt32Type
                 )
             }
@@ -371,7 +364,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    u64,
                     UInt64Type
                 )
             }
@@ -381,7 +373,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    f32,
                     Float32Type
                 )
             }
@@ -391,7 +382,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    f64,
                     Float64Type
                 )
             }
@@ -401,7 +391,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i32,
                     Date32Type
                 )
             }
@@ -411,7 +400,6 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i64,
                     Date64Type
                 )
             }

--- a/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
@@ -17,7 +17,10 @@
 
 use std::sync::Arc;
 
-use arrow::datatypes::{Date32Type, Date64Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type};
+use arrow::datatypes::{
+    Date32Type, Date64Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type,
+    Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+};
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion_common::{arrow_datafusion_err, DataFusionError, Result};

--- a/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use arrow::datatypes::{Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type};
+use arrow::datatypes::{Date32Type, Date64Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type};
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion_common::{arrow_datafusion_err, DataFusionError, Result};
@@ -390,6 +390,26 @@ impl RecordBatchGenerator {
                     array_gen_rng,
                     f64,
                     Float64Type
+                )
+            }
+            DataType::Date32 => {
+                generate_primitive_array!(
+                    self,
+                    num_rows,
+                    batch_gen_rng,
+                    array_gen_rng,
+                    i32,
+                    Date32Type
+                )
+            }
+            DataType::Date64 => {
+                generate_primitive_array!(
+                    self,
+                    num_rows,
+                    batch_gen_rng,
+                    array_gen_rng,
+                    i64,
+                    Date64Type
                 )
             }
             DataType::Utf8 => {

--- a/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
@@ -17,6 +17,7 @@
 
 use std::sync::Arc;
 
+use arrow::datatypes::{Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type};
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion_common::{arrow_datafusion_err, DataFusionError, Result};
@@ -222,7 +223,7 @@ macro_rules! generate_string_array {
 }
 
 macro_rules! generate_primitive_array {
-    ($SELF:ident, $NUM_ROWS:ident, $BATCH_GEN_RNG:ident, $ARRAY_GEN_RNG:ident, $DATA_TYPE:ident) => {
+    ($SELF:ident, $NUM_ROWS:ident, $BATCH_GEN_RNG:ident, $ARRAY_GEN_RNG:ident, $DATA_TYPE:ident, $ARROW_TYPE:ident) => {
         paste::paste! {{
             let null_pct_idx = $BATCH_GEN_RNG.gen_range(0..$SELF.candidate_null_pcts.len());
             let null_pct = $SELF.candidate_null_pcts[null_pct_idx];
@@ -239,7 +240,7 @@ macro_rules! generate_primitive_array {
                 rng: $ARRAY_GEN_RNG,
             };
 
-            generator.[< gen_data_ $DATA_TYPE >]()
+            generator.gen_data::<$DATA_TYPE, $ARROW_TYPE>()
     }}}
 }
 
@@ -297,7 +298,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i8
+                    i8,
+                    Int8Type
                 )
             }
             DataType::Int16 => {
@@ -306,7 +308,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i16
+                    i16,
+                    Int16Type
                 )
             }
             DataType::Int32 => {
@@ -315,7 +318,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i32
+                    i32,
+                    Int32Type
                 )
             }
             DataType::Int64 => {
@@ -324,7 +328,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    i64
+                    i64,
+                    Int64Type
                 )
             }
             DataType::UInt8 => {
@@ -333,7 +338,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    u8
+                    u8,
+                    UInt8Type
                 )
             }
             DataType::UInt16 => {
@@ -342,7 +348,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    u16
+                    u16,
+                    UInt16Type
                 )
             }
             DataType::UInt32 => {
@@ -351,7 +358,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    u32
+                    u32,
+                    UInt32Type
                 )
             }
             DataType::UInt64 => {
@@ -360,7 +368,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    u64
+                    u64,
+                    UInt64Type
                 )
             }
             DataType::Float32 => {
@@ -369,7 +378,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    f32
+                    f32,
+                    Float32Type
                 )
             }
             DataType::Float64 => {
@@ -378,7 +388,8 @@ impl RecordBatchGenerator {
                     num_rows,
                     batch_gen_rng,
                     array_gen_rng,
-                    f64
+                    f64,
+                    Float64Type
                 )
             }
             DataType::Utf8 => {

--- a/test-utils/src/array_gen/primitive.rs
+++ b/test-utils/src/array_gen/primitive.rs
@@ -36,43 +36,45 @@ pub struct PrimitiveArrayGenerator {
 
 // TODO: support generating more primitive arrays
 impl PrimitiveArrayGenerator {
-    pub fn gen_data<N, A: ArrowPrimitiveType>(&mut self) -> ArrayRef 
+    pub fn gen_data<N, A>(&mut self) -> ArrayRef
     where
         A: ArrowPrimitiveType<Native = N>,
         N: std::marker::Sync + std::marker::Send,
-        Standard: Distribution<N>
+        Standard: Distribution<N>,
     {
         // table of primitives from which to draw
         let distinct_primitives: PrimitiveArray<A> = (0..self.num_distinct_primitives)
-            .map(|_| Some(match A::DATA_TYPE {
-                DataType::Int8
-                | DataType::Int16
-                | DataType::Int32
-                | DataType::Int64
-                | DataType::UInt8
-                | DataType::UInt16
-                | DataType::UInt32
-                | DataType::UInt64
-                | DataType::Float32
-                | DataType::Float64 
-                | DataType::Date32 => self.rng.gen::<N>(),
+            .map(|_| {
+                Some(match A::DATA_TYPE {
+                    DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::UInt8
+                    | DataType::UInt16
+                    | DataType::UInt32
+                    | DataType::UInt64
+                    | DataType::Float32
+                    | DataType::Float64
+                    | DataType::Date32 => self.rng.gen::<N>(),
 
-                DataType::Date64 => {
-                    // TODO: constrain this range to valid dates if necessary
-                    let date_value = self.rng.gen_range(i64::MIN..=i64::MAX); 
-                    let millis_per_day: i64 = 86_400_000;
-                    let adjusted_value = date_value - (date_value % millis_per_day);
-                    // SAFETY: here we can convert i64 to N safely since we determine that the type N is i64
-                    unsafe {
-                        std::ptr::read(&adjusted_value as *const i64 as *const N)
+                    DataType::Date64 => {
+                        // TODO: constrain this range to valid dates if necessary
+                        let date_value = self.rng.gen_range(i64::MIN..=i64::MAX);
+                        let millis_per_day: i64 = 86_400_000;
+                        let adjusted_value = date_value - (date_value % millis_per_day);
+                        // SAFETY: here we can convert i64 to N safely since we determine that the type N is i64
+                        unsafe {
+                            std::ptr::read(&adjusted_value as *const i64 as *const N)
+                        }
                     }
-                }
 
-                _ => {
-                    let arrow_type = A::DATA_TYPE;
-                    panic!("Unsupported arrow data type: {arrow_type}")
-                }
-            }))
+                    _ => {
+                        let arrow_type = A::DATA_TYPE;
+                        panic!("Unsupported arrow data type: {arrow_type}")
+                    }
+                })
+            })
             .collect();
 
         // pick num_primitves randomly from the distinct string table

--- a/test-utils/src/array_gen/primitive.rs
+++ b/test-utils/src/array_gen/primitive.rs
@@ -54,7 +54,19 @@ impl PrimitiveArrayGenerator {
                 | DataType::UInt32
                 | DataType::UInt64
                 | DataType::Float32
-                | DataType::Float64 => self.rng.gen::<N>(),
+                | DataType::Float64 
+                | DataType::Date32 => self.rng.gen::<N>(),
+
+                DataType::Date64 => {
+                    // TODO: constrain this range to valid dates if necessary
+                    let date_value = self.rng.gen_range(i64::MIN..=i64::MAX); 
+                    let millis_per_day: i64 = 86_400_000;
+                    let adjusted_value = date_value - (date_value % millis_per_day);
+                    // SAFETY: here we can convert i64 to N safely since we determine that the type N is i64
+                    unsafe {
+                        std::ptr::read(&adjusted_value as *const i64 as *const N)
+                    }
+                }
 
                 _ => {
                     let arrow_type = A::DATA_TYPE;

--- a/test-utils/src/array_gen/primitive.rs
+++ b/test-utils/src/array_gen/primitive.rs
@@ -15,11 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{ArrayRef, PrimitiveArray, UInt32Array};
-use arrow::datatypes::{
-    Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type,
-    UInt32Type, UInt64Type, UInt8Type,
-};
+use arrow::array::{ArrayRef, ArrowPrimitiveType, PrimitiveArray, UInt32Array};
+use arrow::datatypes::DataType;
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
 use rand::rngs::StdRng;
 use rand::Rng;
 
@@ -35,46 +34,50 @@ pub struct PrimitiveArrayGenerator {
     pub rng: StdRng,
 }
 
-macro_rules! impl_gen_data {
-    ($NATIVE_TYPE:ty, $ARROW_TYPE:ident) => {
-        paste::paste! {
-            pub fn [< gen_data_ $NATIVE_TYPE >](&mut self) -> ArrayRef {
-                    // table of strings from which to draw
-                    let distinct_primitives: PrimitiveArray<$ARROW_TYPE> = (0..self.num_distinct_primitives)
-                    .map(|_| Some(self.rng.gen::<$NATIVE_TYPE>()))
-                    .collect();
-
-                // pick num_strings randomly from the distinct string table
-                let indicies: UInt32Array = (0..self.num_primitives)
-                    .map(|_| {
-                        if self.rng.gen::<f64>() < self.null_pct {
-                            None
-                        } else if self.num_distinct_primitives > 1 {
-                            let range = 1..(self.num_distinct_primitives as u32);
-                            Some(self.rng.gen_range(range))
-                        } else {
-                            Some(0)
-                        }
-                    })
-                    .collect();
-
-                let options = None;
-                arrow::compute::take(&distinct_primitives, &indicies, options).unwrap()
-            }
-        }
-    };
-}
-
 // TODO: support generating more primitive arrays
 impl PrimitiveArrayGenerator {
-    impl_gen_data!(i8, Int8Type);
-    impl_gen_data!(i16, Int16Type);
-    impl_gen_data!(i32, Int32Type);
-    impl_gen_data!(i64, Int64Type);
-    impl_gen_data!(u8, UInt8Type);
-    impl_gen_data!(u16, UInt16Type);
-    impl_gen_data!(u32, UInt32Type);
-    impl_gen_data!(u64, UInt64Type);
-    impl_gen_data!(f32, Float32Type);
-    impl_gen_data!(f64, Float64Type);
+    pub fn gen_data<N, A: ArrowPrimitiveType>(&mut self) -> ArrayRef 
+    where
+        A: ArrowPrimitiveType<Native = N>,
+        N: std::marker::Sync + std::marker::Send,
+        Standard: Distribution<N>
+    {
+        // table of primitives from which to draw
+        let distinct_primitives: PrimitiveArray<A> = (0..self.num_distinct_primitives)
+            .map(|_| Some(match A::DATA_TYPE {
+                DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+                | DataType::Float32
+                | DataType::Float64 => self.rng.gen::<N>(),
+
+                _ => {
+                    let arrow_type = A::DATA_TYPE;
+                    panic!("Unsupported arrow data type: {arrow_type}")
+                }
+            }))
+            .collect();
+
+        // pick num_primitves randomly from the distinct string table
+        let indicies: UInt32Array = (0..self.num_primitives)
+            .map(|_| {
+                if self.rng.gen::<f64>() < self.null_pct {
+                    None
+                } else if self.num_distinct_primitives > 1 {
+                    let range = 1..(self.num_distinct_primitives as u32);
+                    Some(self.rng.gen_range(range))
+                } else {
+                    Some(0)
+                }
+            })
+            .collect();
+
+        let options = None;
+        arrow::compute::take(&distinct_primitives, &indicies, options).unwrap()
+    }
 }


### PR DESCRIPTION
## Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #12114 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Supporting more types for dataset generator in fuzzer framework is needed according to [this comment](https://github.com/apache/datafusion/issues/12114#issuecomment-2402755758).

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Refactor the `PrimitiveArrayGenerator` to make it easier to introduce new primitive types.
2. Add coverage of Date32/Date64 types.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
