### PR TITLE
Add Common Subexpression Elimination for `PhysicalExpr` trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,7 +1886,6 @@ dependencies = [
  "chrono",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
  "libc",
  "log",
  "object_store",

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -56,7 +56,6 @@ arrow-schema = { workspace = true }
 base64 = "0.22.1"
 half = { workspace = true }
 hashbrown = { workspace = true }
-indexmap = { workspace = true }
 libc = "0.2.140"
 log = { workspace = true }
 object_store = { workspace = true, optional = true }

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -23,10 +23,12 @@ use std::error::Error;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
+use crate::alias::AliasGenerator;
 use crate::error::_config_err;
 use crate::parsers::CompressionTypeVariant;
 use crate::utils::get_available_parallelism;
 use crate::{DataFusionError, Result};
+use std::sync::Arc;
 
 /// A macro that wraps a configuration struct and automatically derives
 /// [`Default`] and [`ConfigField`] for it, allowing it to be used
@@ -736,6 +738,8 @@ pub struct ConfigOptions {
     pub explain: ExplainOptions,
     /// Optional extensions registered using [`Extensions::insert`]
     pub extensions: Extensions,
+    /// Return alias generator used to generate unique aliases
+    pub alias_generator: Arc<AliasGenerator>,
 }
 
 impl ConfigField for ConfigOptions {

--- a/datafusion/physical-expr-common/src/sort_expr.rs
+++ b/datafusion/physical-expr-common/src/sort_expr.rs
@@ -42,6 +42,7 @@ use itertools::Itertools;
 /// # use std::sync::Arc;
 /// # use arrow::array::RecordBatch;
 /// # use datafusion_common::Result;
+/// # use datafusion_common::cse::HashNode;
 /// # use arrow::compute::SortOptions;
 /// # use arrow::datatypes::{DataType, Schema};
 /// # use datafusion_expr_common::columnar_value::ColumnarValue;
@@ -61,6 +62,9 @@ use itertools::Itertools;
 /// # }
 /// # impl Display for MyPhysicalExpr {
 /// #    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { write!(f, "a") }
+/// # }
+/// # impl HashNode for MyPhysicalExpr {
+/// #    fn hash_node<H: Hasher>(&self, _state: &mut H) {}
 /// # }
 /// # fn col(name: &str) -> Arc<dyn PhysicalExpr> { Arc::new(MyPhysicalExpr) }
 /// // Sort by a ASC

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -17,7 +17,7 @@
 
 mod kernels;
 
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::{any::Any, sync::Arc};
 
 use crate::intervals::cp_solver::{propagate_arithmetic, propagate_comparison};
@@ -32,6 +32,7 @@ use arrow::compute::{cast, ilike, like, nilike, nlike};
 use arrow::datatypes::*;
 use arrow_schema::ArrowError;
 use datafusion_common::cast::as_boolean_array;
+use datafusion_common::cse::HashNode;
 use datafusion_common::{internal_err, Result, ScalarValue};
 use datafusion_expr::binary::BinaryTypeCoercer;
 use datafusion_expr::interval_arithmetic::{apply_operator, Interval};
@@ -66,10 +67,17 @@ impl PartialEq for BinaryExpr {
     }
 }
 impl Hash for BinaryExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.left.hash(state);
         self.op.hash(state);
         self.right.hash(state);
+        self.fail_on_overflow.hash(state);
+    }
+}
+
+impl HashNode for BinaryExpr {
+    fn hash_node<H: Hasher>(&self, state: &mut H) {
+        self.op.hash(state);
         self.fail_on_overflow.hash(state);
     }
 }

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::borrow::Cow;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::{any::Any, sync::Arc};
 
 use crate::expressions::try_cast;
@@ -33,6 +33,7 @@ use datafusion_common::{
 use datafusion_expr::ColumnarValue;
 
 use super::{Column, Literal};
+use datafusion_common::cse::HashNode;
 use datafusion_physical_expr_common::datum::compare_with_eq;
 use itertools::Itertools;
 
@@ -96,6 +97,12 @@ pub struct CaseExpr {
     else_expr: Option<Arc<dyn PhysicalExpr>>,
     /// Evaluation method to use
     eval_method: EvalMethod,
+}
+
+impl HashNode for CaseExpr {
+    fn hash_node<H: Hasher>(&self, state: &mut H) {
+        self.eval_method.hash(state);
+    }
 }
 
 impl std::fmt::Display for CaseExpr {

--- a/datafusion/physical-expr/src/expressions/cast.rs
+++ b/datafusion/physical-expr/src/expressions/cast.rs
@@ -17,7 +17,7 @@
 
 use std::any::Any;
 use std::fmt;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::physical_expr::PhysicalExpr;
@@ -25,6 +25,7 @@ use crate::physical_expr::PhysicalExpr;
 use arrow::compute::{can_cast_types, CastOptions};
 use arrow::datatypes::{DataType, DataType::*, Schema};
 use arrow::record_batch::RecordBatch;
+use datafusion_common::cse::HashNode;
 use datafusion_common::format::DEFAULT_FORMAT_OPTIONS;
 use datafusion_common::{not_impl_err, Result};
 use datafusion_expr_common::columnar_value::ColumnarValue;
@@ -62,8 +63,15 @@ impl PartialEq for CastExpr {
 }
 
 impl Hash for CastExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.expr.hash(state);
+        self.cast_type.hash(state);
+        self.cast_options.hash(state);
+    }
+}
+
+impl HashNode for CastExpr {
+    fn hash_node<H: Hasher>(&self, state: &mut H) {
         self.cast_type.hash(state);
         self.cast_options.hash(state);
     }

--- a/datafusion/physical-expr/src/expressions/column.rs
+++ b/datafusion/physical-expr/src/expressions/column.rs
@@ -18,7 +18,7 @@
 //! Physical column reference: [`Column`]
 
 use std::any::Any;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::physical_expr::PhysicalExpr;
@@ -27,6 +27,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use arrow_schema::SchemaRef;
+use datafusion_common::cse::HashNode;
 use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::{internal_err, plan_err, Result};
 use datafusion_expr::ColumnarValue;
@@ -69,6 +70,13 @@ pub struct Column {
     name: String,
     /// The index of the column in its schema
     index: usize,
+}
+
+impl HashNode for Column {
+    fn hash_node<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.index.hash(state);
+    }
 }
 
 impl Column {

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -44,6 +44,7 @@ use datafusion_expr::ColumnarValue;
 use datafusion_physical_expr_common::datum::compare_with_eq;
 
 use ahash::RandomState;
+use datafusion_common::cse::HashNode;
 use datafusion_common::HashMap;
 use hashbrown::hash_map::RawEntryMut;
 
@@ -415,6 +416,13 @@ impl Hash for InListExpr {
         self.expr.hash(state);
         self.negated.hash(state);
         self.list.hash(state);
+        // Add `self.static_filter` when hash is available
+    }
+}
+
+impl HashNode for InListExpr {
+    fn hash_node<H: Hasher>(&self, state: &mut H) {
+        self.negated.hash(state);
         // Add `self.static_filter` when hash is available
     }
 }

--- a/datafusion/physical-expr/src/expressions/is_not_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_not_null.rs
@@ -17,7 +17,7 @@
 
 //! IS NOT NULL expression
 
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::{any::Any, sync::Arc};
 
 use crate::PhysicalExpr;
@@ -25,6 +25,7 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use datafusion_common::cse::HashNode;
 use datafusion_common::Result;
 use datafusion_common::ScalarValue;
 use datafusion_expr::ColumnarValue;
@@ -44,9 +45,13 @@ impl PartialEq for IsNotNullExpr {
 }
 
 impl Hash for IsNotNullExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.arg.hash(state);
     }
+}
+
+impl HashNode for IsNotNullExpr {
+    fn hash_node<H: Hasher>(&self, _state: &mut H) {}
 }
 
 impl IsNotNullExpr {

--- a/datafusion/physical-expr/src/expressions/is_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_null.rs
@@ -17,7 +17,7 @@
 
 //! IS NULL expression
 
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::{any::Any, sync::Arc};
 
 use crate::PhysicalExpr;
@@ -25,6 +25,7 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use datafusion_common::cse::HashNode;
 use datafusion_common::Result;
 use datafusion_common::ScalarValue;
 use datafusion_expr::ColumnarValue;
@@ -44,9 +45,13 @@ impl PartialEq for IsNullExpr {
 }
 
 impl Hash for IsNullExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.arg.hash(state);
     }
+}
+
+impl HashNode for IsNullExpr {
+    fn hash_node<H: Hasher>(&self, _state: &mut H) {}
 }
 
 impl IsNullExpr {

--- a/datafusion/physical-expr/src/expressions/like.rs
+++ b/datafusion/physical-expr/src/expressions/like.rs
@@ -15,12 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::{any::Any, sync::Arc};
 
 use crate::PhysicalExpr;
 use arrow::record_batch::RecordBatch;
 use arrow_schema::{DataType, Schema};
+use datafusion_common::cse::HashNode;
 use datafusion_common::{internal_err, Result};
 use datafusion_expr::ColumnarValue;
 use datafusion_physical_expr_common::datum::apply_cmp;
@@ -45,11 +46,18 @@ impl PartialEq for LikeExpr {
 }
 
 impl Hash for LikeExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.negated.hash(state);
         self.case_insensitive.hash(state);
         self.expr.hash(state);
         self.pattern.hash(state);
+    }
+}
+
+impl HashNode for LikeExpr {
+    fn hash_node<H: Hasher>(&self, state: &mut H) {
+        self.negated.hash(state);
+        self.case_insensitive.hash(state);
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -18,7 +18,7 @@
 //! Literal expressions for physical operations
 
 use std::any::Any;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::physical_expr::PhysicalExpr;
@@ -27,6 +27,7 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use datafusion_common::cse::HashNode;
 use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::Expr;
 use datafusion_expr_common::columnar_value::ColumnarValue;
@@ -37,6 +38,12 @@ use datafusion_expr_common::sort_properties::{ExprProperties, SortProperties};
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Literal {
     value: ScalarValue,
+}
+
+impl HashNode for Literal {
+    fn hash_node<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
 }
 
 impl Literal {

--- a/datafusion/physical-expr/src/expressions/negative.rs
+++ b/datafusion/physical-expr/src/expressions/negative.rs
@@ -18,7 +18,7 @@
 //! Negation (-) expression
 
 use std::any::Any;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::PhysicalExpr;
@@ -28,6 +28,7 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use datafusion_common::cse::HashNode;
 use datafusion_common::{plan_err, Result};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::sort_properties::ExprProperties;
@@ -51,9 +52,13 @@ impl PartialEq for NegativeExpr {
 }
 
 impl Hash for NegativeExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.arg.hash(state);
     }
+}
+
+impl HashNode for NegativeExpr {
+    fn hash_node<H: Hasher>(&self, _state: &mut H) {}
 }
 
 impl NegativeExpr {

--- a/datafusion/physical-expr/src/expressions/no_op.rs
+++ b/datafusion/physical-expr/src/expressions/no_op.rs
@@ -18,7 +18,7 @@
 //! NoOp placeholder for physical operations
 
 use std::any::Any;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use arrow::{
@@ -27,6 +27,7 @@ use arrow::{
 };
 
 use crate::PhysicalExpr;
+use datafusion_common::cse::HashNode;
 use datafusion_common::{internal_err, Result};
 use datafusion_expr::ColumnarValue;
 
@@ -41,6 +42,10 @@ impl NoOp {
     pub fn new() -> Self {
         Self {}
     }
+}
+
+impl HashNode for NoOp {
+    fn hash_node<H: Hasher>(&self, _state: &mut H) {}
 }
 
 impl std::fmt::Display for NoOp {

--- a/datafusion/physical-expr/src/expressions/not.rs
+++ b/datafusion/physical-expr/src/expressions/not.rs
@@ -19,12 +19,13 @@
 
 use std::any::Any;
 use std::fmt;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::PhysicalExpr;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
+use datafusion_common::cse::HashNode;
 use datafusion_common::{cast::as_boolean_array, Result, ScalarValue};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::ColumnarValue;
@@ -44,9 +45,13 @@ impl PartialEq for NotExpr {
 }
 
 impl Hash for NotExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.arg.hash(state);
     }
+}
+
+impl HashNode for NotExpr {
+    fn hash_node<H: Hasher>(&self, _state: &mut H) {}
 }
 
 impl NotExpr {

--- a/datafusion/physical-expr/src/expressions/try_cast.rs
+++ b/datafusion/physical-expr/src/expressions/try_cast.rs
@@ -17,7 +17,7 @@
 
 use std::any::Any;
 use std::fmt;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::PhysicalExpr;
@@ -26,6 +26,7 @@ use arrow::compute::{cast_with_options, CastOptions};
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use compute::can_cast_types;
+use datafusion_common::cse::HashNode;
 use datafusion_common::format::DEFAULT_FORMAT_OPTIONS;
 use datafusion_common::{not_impl_err, Result, ScalarValue};
 use datafusion_expr::ColumnarValue;
@@ -47,8 +48,14 @@ impl PartialEq for TryCastExpr {
 }
 
 impl Hash for TryCastExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.expr.hash(state);
+        self.cast_type.hash(state);
+    }
+}
+
+impl HashNode for TryCastExpr {
+    fn hash_node<H: Hasher>(&self, state: &mut H) {
         self.cast_type.hash(state);
     }
 }

--- a/datafusion/physical-expr/src/expressions/unknown_column.rs
+++ b/datafusion/physical-expr/src/expressions/unknown_column.rs
@@ -27,6 +27,7 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use datafusion_common::cse::HashNode;
 use datafusion_common::{internal_err, Result};
 use datafusion_expr::ColumnarValue;
 
@@ -90,6 +91,12 @@ impl PhysicalExpr for UnKnownColumn {
 
 impl Hash for UnKnownColumn {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl HashNode for UnKnownColumn {
+    fn hash_node<H: Hasher>(&self, state: &mut H) {
         self.name.hash(state);
     }
 }

--- a/datafusion/physical-optimizer/src/eliminate_common_physical_subexprs.rs
+++ b/datafusion/physical-optimizer/src/eliminate_common_physical_subexprs.rs
@@ -1,0 +1,588 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`EliminateCommonPhysicalSubexprs`] to avoid redundant computation of common physical
+//! sub-expressions.
+
+use datafusion_common::alias::AliasGenerator;
+use datafusion_common::config::ConfigOptions;
+use datafusion_common::cse::{CSEController, FoundCommonNodes, CSE};
+use datafusion_common::Result;
+use datafusion_physical_plan::ExecutionPlan;
+use std::sync::Arc;
+
+use crate::PhysicalOptimizerRule;
+use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion_expr_common::operator::Operator;
+use datafusion_physical_expr::expressions::{BinaryExpr, CaseExpr, Column};
+use datafusion_physical_expr::{PhysicalExpr, ScalarFunctionExpr};
+use datafusion_physical_plan::projection::ProjectionExec;
+
+const CSE_PREFIX: &str = "__common_physical_expr";
+
+// Optimizer rule to avoid redundant computation of common physical subexpressions
+#[derive(Default, Debug)]
+pub struct EliminateCommonPhysicalSubexprs {}
+
+impl EliminateCommonPhysicalSubexprs {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl PhysicalOptimizerRule for EliminateCommonPhysicalSubexprs {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        plan.transform_down(|plan| {
+            let plan_any = plan.as_any();
+            if let Some(p) = plan_any.downcast_ref::<ProjectionExec>() {
+                match CSE::new(PhysicalExprCSEController::new(
+                    config.alias_generator.as_ref(),
+                    p.input().schema().fields().len(),
+                ))
+                .extract_common_nodes(vec![p
+                    .expr()
+                    .iter()
+                    .map(|(e, _)| e)
+                    .cloned()
+                    .collect()])?
+                {
+                    FoundCommonNodes::Yes {
+                        common_nodes: common_exprs,
+                        new_nodes_list: mut new_exprs_list,
+                        original_nodes_list: _,
+                    } => {
+                        let common_exprs = p
+                            .input()
+                            .schema()
+                            .fields()
+                            .iter()
+                            .enumerate()
+                            .map(|(i, field)| {
+                                (
+                                    Arc::new(Column::new(field.name(), i))
+                                        as Arc<dyn PhysicalExpr>,
+                                    field.name().to_string(),
+                                )
+                            })
+                            .chain(common_exprs)
+                            .collect();
+                        let common = Arc::new(ProjectionExec::try_new(
+                            common_exprs,
+                            Arc::clone(p.input()),
+                        )?);
+
+                        let new_exprs = new_exprs_list
+                            .pop()
+                            .unwrap()
+                            .into_iter()
+                            .zip(p.expr().iter().map(|(_, alias)| alias.to_string()))
+                            .collect();
+                        let new_project =
+                            Arc::new(ProjectionExec::try_new(new_exprs, common)?)
+                                as Arc<dyn ExecutionPlan>;
+
+                        Ok(Transformed::yes(new_project))
+                    }
+                    FoundCommonNodes::No { .. } => Ok(Transformed::no(plan)),
+                }
+            } else {
+                Ok(Transformed::no(plan))
+            }
+        })
+        .data()
+    }
+
+    fn name(&self) -> &str {
+        "eliminate_common_physical_subexpressions"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+pub struct PhysicalExprCSEController<'a> {
+    alias_generator: &'a AliasGenerator,
+    base_index: usize,
+}
+
+impl<'a> PhysicalExprCSEController<'a> {
+    fn new(alias_generator: &'a AliasGenerator, base_index: usize) -> Self {
+        Self {
+            alias_generator,
+            base_index,
+        }
+    }
+}
+
+impl CSEController for PhysicalExprCSEController<'_> {
+    type Node = Arc<dyn PhysicalExpr>;
+
+    fn conditional_children(
+        node: &Self::Node,
+    ) -> Option<(Vec<&Self::Node>, Vec<&Self::Node>)> {
+        if let Some(s) = node.as_any().downcast_ref::<ScalarFunctionExpr>() {
+            // In case of `ScalarFunction`s all children can be conditionally executed.
+            if s.fun().short_circuits() {
+                Some((vec![], s.args().iter().collect()))
+            } else {
+                None
+            }
+        } else if let Some(b) = node.as_any().downcast_ref::<BinaryExpr>() {
+            // In case of `And` and `Or` the first child is surely executed, but we
+            // account subexpressions as conditional in the second.
+            if *b.op() == Operator::And || *b.op() == Operator::Or {
+                Some((vec![b.left()], vec![b.right()]))
+            } else {
+                None
+            }
+        } else {
+            node.as_any().downcast_ref::<CaseExpr>().map(|c| {
+                (
+                    // In case of `Case` the optional base expression and the first when
+                    // expressions are surely executed, but we account subexpressions as
+                    // conditional in the others.
+                    c.expr()
+                        .into_iter()
+                        .chain(c.when_then_expr().iter().take(1).map(|(when, _)| when))
+                        .collect(),
+                    c.when_then_expr()
+                        .iter()
+                        .take(1)
+                        .map(|(_, then)| then)
+                        .chain(
+                            c.when_then_expr()
+                                .iter()
+                                .skip(1)
+                                .flat_map(|(when, then)| [when, then]),
+                        )
+                        .chain(c.else_expr())
+                        .collect(),
+                )
+            })
+        }
+    }
+
+    fn is_valid(node: &Self::Node) -> bool {
+        !node.is_volatile()
+    }
+
+    fn is_ignored(&self, node: &Self::Node) -> bool {
+        node.children().is_empty()
+    }
+
+    fn generate_alias(&self) -> String {
+        self.alias_generator.next(CSE_PREFIX)
+    }
+
+    fn rewrite(&mut self, _node: &Self::Node, alias: &str, index: usize) -> Self::Node {
+        Arc::new(Column::new(alias, self.base_index + index))
+    }
+
+    fn rewrite_f_down(&mut self, _node: &Self::Node) {}
+
+    fn rewrite_f_up(&mut self, _node: &Self::Node) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::eliminate_common_physical_subexprs::EliminateCommonPhysicalSubexprs;
+    use crate::optimizer::PhysicalOptimizerRule;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::config::ConfigOptions;
+    use datafusion_common::Result;
+    use datafusion_expr::{ScalarUDF, ScalarUDFImpl};
+    use datafusion_expr_common::columnar_value::ColumnarValue;
+    use datafusion_expr_common::operator::Operator;
+    use datafusion_expr_common::signature::{Signature, Volatility};
+    use datafusion_physical_expr::expressions::{binary, col, lit};
+    use datafusion_physical_expr::{PhysicalExpr, ScalarFunctionExpr};
+    use datafusion_physical_plan::memory::MemorySourceConfig;
+    use datafusion_physical_plan::projection::ProjectionExec;
+    use datafusion_physical_plan::source::DataSourceExec;
+    use datafusion_physical_plan::{get_plan_string, ExecutionPlan};
+    use std::any::Any;
+    use std::sync::Arc;
+
+    fn mock_data() -> Arc<DataSourceExec> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+        ]));
+
+        Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![]], Arc::clone(&schema), None).unwrap(),
+        )))
+    }
+
+    #[test]
+    fn subexpr_in_same_order() -> Result<()> {
+        let table_scan = mock_data();
+
+        let a = col("a", &table_scan.schema())?;
+        let lit_1 = lit(1);
+        let _1_plus_a = binary(lit_1, Operator::Plus, a, &table_scan.schema())?;
+
+        let exprs = vec![
+            (Arc::clone(&_1_plus_a), "first".to_string()),
+            (_1_plus_a, "second".to_string()),
+        ];
+        let plan = Arc::new(ProjectionExec::try_new(exprs, mock_data())?);
+
+        let config = ConfigOptions::new();
+        let optimizer = EliminateCommonPhysicalSubexprs::new();
+        let optimized = optimizer.optimize(plan, &config)?;
+
+        let actual = get_plan_string(&optimized);
+        let expected = [
+            "ProjectionExec: expr=[__common_physical_expr_1@2 as first, __common_physical_expr_1@2 as second]",
+            "  ProjectionExec: expr=[a@0 as a, b@1 as b, 1 + a@0 as __common_physical_expr_1]",
+            "    DataSourceExec: partitions=1, partition_sizes=[0]"];
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn subexpr_in_different_order() -> Result<()> {
+        let table_scan = mock_data();
+
+        let a = col("a", &table_scan.schema())?;
+        let lit_1 = lit(1);
+        let _1_plus_a = binary(
+            Arc::clone(&lit_1),
+            Operator::Plus,
+            Arc::clone(&a),
+            &table_scan.schema(),
+        )?;
+        let a_plus_1 = binary(a, Operator::Plus, lit_1, &table_scan.schema())?;
+
+        let exprs = vec![
+            (_1_plus_a, "first".to_string()),
+            (a_plus_1, "second".to_string()),
+        ];
+        let plan = Arc::new(ProjectionExec::try_new(exprs, mock_data())?);
+
+        let config = ConfigOptions::new();
+        let optimizer = EliminateCommonPhysicalSubexprs::new();
+        let optimized = optimizer.optimize(plan, &config)?;
+
+        let actual = get_plan_string(&optimized);
+        let expected = [
+            "ProjectionExec: expr=[1 + a@0 as first, a@0 + 1 as second]",
+            "  DataSourceExec: partitions=1, partition_sizes=[0]",
+        ];
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_short_circuits() -> Result<()> {
+        let table_scan = mock_data();
+
+        let a = col("a", &table_scan.schema())?;
+        let b = col("b", &table_scan.schema())?;
+
+        let extracted_short_circuit = binary(
+            binary(Arc::clone(&a), Operator::Eq, lit(0), &table_scan.schema())?,
+            Operator::Or,
+            binary(Arc::clone(&b), Operator::Eq, lit(0), &table_scan.schema())?,
+            &table_scan.schema(),
+        )?;
+        let extracted_short_circuit_leg_1 = binary(
+            binary(
+                Arc::clone(&a),
+                Operator::Plus,
+                Arc::clone(&b),
+                &table_scan.schema(),
+            )?,
+            Operator::Eq,
+            lit(0),
+            &table_scan.schema(),
+        )?;
+        let not_extracted_short_circuit_leg_2 = binary(
+            binary(
+                Arc::clone(&a),
+                Operator::Minus,
+                Arc::clone(&b),
+                &table_scan.schema(),
+            )?,
+            Operator::Eq,
+            lit(0),
+            &table_scan.schema(),
+        )?;
+        let extracted_short_circuit_leg_3 = binary(
+            binary(a, Operator::Multiply, b, &table_scan.schema())?,
+            Operator::Eq,
+            lit(0),
+            &table_scan.schema(),
+        )?;
+
+        let exprs = vec![
+            (Arc::clone(&extracted_short_circuit), "c1".to_string()),
+            (extracted_short_circuit, "c2".to_string()),
+            (
+                binary(
+                    Arc::clone(&extracted_short_circuit_leg_1),
+                    Operator::Or,
+                    Arc::clone(&not_extracted_short_circuit_leg_2),
+                    &table_scan.schema(),
+                )?,
+                "c3".to_string(),
+            ),
+            (
+                binary(
+                    extracted_short_circuit_leg_1,
+                    Operator::And,
+                    Arc::clone(&not_extracted_short_circuit_leg_2),
+                    &table_scan.schema(),
+                )?,
+                "c4".to_string(),
+            ),
+            (
+                binary(
+                    Arc::clone(&extracted_short_circuit_leg_3),
+                    Operator::Or,
+                    extracted_short_circuit_leg_3,
+                    &table_scan.schema(),
+                )?,
+                "c5".to_string(),
+            ),
+        ];
+        let plan = Arc::new(ProjectionExec::try_new(exprs, mock_data())?);
+
+        let config = ConfigOptions::new();
+        let optimizer = EliminateCommonPhysicalSubexprs::new();
+        let optimized = optimizer.optimize(plan, &config)?;
+
+        let actual = get_plan_string(&optimized);
+        let expected = [
+            "ProjectionExec: expr=[__common_physical_expr_1@2 as c1, __common_physical_expr_1@2 as c2, __common_physical_expr_2@3 OR a@0 - b@1 = 0 as c3, __common_physical_expr_2@3 AND a@0 - b@1 = 0 as c4, __common_physical_expr_3@4 OR __common_physical_expr_3@4 as c5]",
+            "  ProjectionExec: expr=[a@0 as a, b@1 as b, a@0 = 0 OR b@1 = 0 as __common_physical_expr_1, a@0 + b@1 = 0 as __common_physical_expr_2, a@0 * b@1 = 0 as __common_physical_expr_3]",
+            "    DataSourceExec: partitions=1, partition_sizes=[0]"];
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_volatile() -> Result<()> {
+        let table_scan = mock_data();
+
+        let a = col("a", &table_scan.schema())?;
+        let b = col("b", &table_scan.schema())?;
+        let extracted_child = binary(a, Operator::Plus, b, &table_scan.schema())?;
+        let rand = rand_expr();
+        let not_extracted_volatile =
+            binary(extracted_child, Operator::Plus, rand, &table_scan.schema())?;
+
+        let exprs = vec![
+            (Arc::clone(&not_extracted_volatile), "c1".to_string()),
+            (not_extracted_volatile, "c2".to_string()),
+        ];
+        let plan = Arc::new(ProjectionExec::try_new(exprs, mock_data())?);
+
+        let config = ConfigOptions::new();
+        let optimizer = EliminateCommonPhysicalSubexprs::new();
+        let optimized = optimizer.optimize(plan, &config)?;
+
+        let actual = get_plan_string(&optimized);
+        let expected = [
+            "ProjectionExec: expr=[__common_physical_expr_1@2 + random() as c1, __common_physical_expr_1@2 + random() as c2]",
+            "  ProjectionExec: expr=[a@0 as a, b@1 as b, a@0 + b@1 as __common_physical_expr_1]",
+            "    DataSourceExec: partitions=1, partition_sizes=[0]"];
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_volatile_short_circuits() -> Result<()> {
+        let table_scan = mock_data();
+
+        let a = col("a", &table_scan.schema())?;
+        let b = col("b", &table_scan.schema())?;
+        let rand = rand_expr();
+        let rand_eq_0 = binary(rand, Operator::Eq, lit(0), &table_scan.schema())?;
+
+        let extracted_short_circuit_leg_1 =
+            binary(a, Operator::Eq, lit(0), &table_scan.schema())?;
+        let not_extracted_volatile_short_circuit_1 = binary(
+            extracted_short_circuit_leg_1,
+            Operator::Or,
+            Arc::clone(&rand_eq_0),
+            &table_scan.schema(),
+        )?;
+
+        let not_extracted_short_circuit_leg_2 =
+            binary(b, Operator::Eq, lit(0), &table_scan.schema())?;
+        let not_extracted_volatile_short_circuit_2 = binary(
+            rand_eq_0,
+            Operator::Or,
+            not_extracted_short_circuit_leg_2,
+            &table_scan.schema(),
+        )?;
+
+        let exprs = vec![
+            (
+                Arc::clone(&not_extracted_volatile_short_circuit_1),
+                "c1".to_string(),
+            ),
+            (not_extracted_volatile_short_circuit_1, "c2".to_string()),
+            (
+                Arc::clone(&not_extracted_volatile_short_circuit_2),
+                "c3".to_string(),
+            ),
+            (not_extracted_volatile_short_circuit_2, "c4".to_string()),
+        ];
+        let plan = Arc::new(ProjectionExec::try_new(exprs, mock_data())?);
+
+        let config = ConfigOptions::new();
+        let optimizer = EliminateCommonPhysicalSubexprs::new();
+        let optimized = optimizer.optimize(plan, &config)?;
+
+        let actual = get_plan_string(&optimized);
+        let expected = [
+            "ProjectionExec: expr=[__common_physical_expr_1@2 OR random() = 0 as c1, __common_physical_expr_1@2 OR random() = 0 as c2, random() = 0 OR b@1 = 0 as c3, random() = 0 OR b@1 = 0 as c4]",
+            "  ProjectionExec: expr=[a@0 as a, b@1 as b, a@0 = 0 as __common_physical_expr_1]",
+            "    DataSourceExec: partitions=1, partition_sizes=[0]"];
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_non_top_level_common_expression() -> Result<()> {
+        let table_scan = mock_data();
+
+        let a = col("a", &table_scan.schema())?;
+        let b = col("b", &table_scan.schema())?;
+        let common_expr = binary(a, Operator::Plus, b, &table_scan.schema())?;
+
+        let exprs = vec![
+            (Arc::clone(&common_expr), "c1".to_string()),
+            (common_expr, "c2".to_string()),
+        ];
+        let plan = Arc::new(ProjectionExec::try_new(exprs, mock_data())?);
+
+        let c1 = col("c1", &plan.schema())?;
+        let c2 = col("c2", &plan.schema())?;
+
+        let exprs = vec![(c1, "c1".to_string()), (c2, "c2".to_string())];
+        let plan = Arc::new(ProjectionExec::try_new(exprs, plan)?);
+
+        let config = ConfigOptions::new();
+        let optimizer = EliminateCommonPhysicalSubexprs::new();
+        let optimized = optimizer.optimize(plan, &config)?;
+
+        let actual = get_plan_string(&optimized);
+        let expected = [
+            "ProjectionExec: expr=[c1@0 as c1, c2@1 as c2]",
+            "  ProjectionExec: expr=[__common_physical_expr_1@2 as c1, __common_physical_expr_1@2 as c2]",
+            "    ProjectionExec: expr=[a@0 as a, b@1 as b, a@0 + b@1 as __common_physical_expr_1]",
+            "      DataSourceExec: partitions=1, partition_sizes=[0]"];
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nested_common_expression() -> Result<()> {
+        let table_scan = mock_data();
+
+        let a = col("a", &table_scan.schema())?;
+        let b = col("b", &table_scan.schema())?;
+        let nested_common_expr = binary(a, Operator::Plus, b, &table_scan.schema())?;
+        let common_expr = binary(
+            Arc::clone(&nested_common_expr),
+            Operator::Multiply,
+            nested_common_expr,
+            &table_scan.schema(),
+        )?;
+
+        let exprs = vec![
+            (Arc::clone(&common_expr), "c1".to_string()),
+            (common_expr, "c2".to_string()),
+        ];
+        let plan = Arc::new(ProjectionExec::try_new(exprs, mock_data())?);
+
+        let config = ConfigOptions::new();
+        let optimizer = EliminateCommonPhysicalSubexprs::new();
+        let optimized = optimizer.optimize(plan, &config)?;
+
+        let actual = get_plan_string(&optimized);
+        let expected = [
+            "ProjectionExec: expr=[__common_physical_expr_1@2 as c1, __common_physical_expr_1@2 as c2]",
+            "  ProjectionExec: expr=[a@0 as a, b@1 as b, __common_physical_expr_2@2 * __common_physical_expr_2@2 as __common_physical_expr_1]",
+            "    ProjectionExec: expr=[a@0 as a, b@1 as b, a@0 + b@1 as __common_physical_expr_2]",
+            "      DataSourceExec: partitions=1, partition_sizes=[0]"];
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    fn rand_expr() -> Arc<dyn PhysicalExpr> {
+        let r = RandomStub::new();
+        let n = r.name().to_string();
+        let t = r.return_type(&[]).unwrap();
+        Arc::new(ScalarFunctionExpr::new(
+            &n,
+            Arc::new(ScalarUDF::new_from_impl(r)),
+            vec![],
+            t,
+        ))
+    }
+
+    #[derive(Debug)]
+    struct RandomStub {
+        signature: Signature,
+    }
+
+    impl RandomStub {
+        fn new() -> Self {
+            Self {
+                signature: Signature::exact(vec![], Volatility::Volatile),
+            }
+        }
+    }
+    impl ScalarUDFImpl for RandomStub {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn name(&self) -> &str {
+            "random"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+
+        fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Float64)
+        }
+
+        fn invoke(&self, _args: &[ColumnarValue]) -> Result<ColumnarValue> {
+            unimplemented!()
+        }
+    }
+}

--- a/datafusion/physical-optimizer/src/lib.rs
+++ b/datafusion/physical-optimizer/src/lib.rs
@@ -21,6 +21,7 @@
 pub mod aggregate_statistics;
 pub mod coalesce_batches;
 pub mod combine_partial_final_agg;
+pub mod eliminate_common_physical_subexprs;
 pub mod enforce_distribution;
 pub mod enforce_sorting;
 pub mod join_selection;

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -17,6 +17,7 @@
 
 use std::any::Any;
 use std::fmt::Display;
+use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::sync::Arc;
 use std::vec;
@@ -90,6 +91,7 @@ use datafusion::physical_plan::{
 use datafusion::prelude::SessionContext;
 use datafusion::scalar::ScalarValue;
 use datafusion_common::config::TableParquetOptions;
+use datafusion_common::cse::HashNode;
 use datafusion_common::file_options::csv_writer::CsvWriterOptions;
 use datafusion_common::file_options::json_writer::JsonWriterOptions;
 use datafusion_common::parsers::CompressionTypeVariant;
@@ -825,10 +827,14 @@ fn roundtrip_parquet_exec_with_custom_predicate_expr() -> Result<()> {
         }
     }
 
-    impl std::hash::Hash for CustomPredicateExpr {
-        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    impl Hash for CustomPredicateExpr {
+        fn hash<H: Hasher>(&self, state: &mut H) {
             self.inner.hash(state);
         }
+    }
+
+    impl HashNode for CustomPredicateExpr {
+        fn hash_node<H: Hasher>(&self, _state: &mut H) {}
     }
 
     impl Display for CustomPredicateExpr {


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/12599.

## Rationale for this change
As described in https://github.com/apache/datafusion/issues/12599, there is a CSE rule for logical plans already, but some projects create physical plans directly that could benefit from physical CSE.

## What changes are included in this PR?
This PR:
- Adds `EliminateCommonPhysicalSubexprs` rule to eliminate common subtrees for `Arc<dyn PhysicalExpr>` trees. This initial implementation targets `ProjectionExec` nodes only. Follow-up PR can add support for other nodes like aggregates and filters.
- Adds `DynHashNode` trait and implements it for `PhysicalExpr`s.
- Contains some code cleanup in `CommonSubexprEliminate` rule.

## Are these changes tested?

Added new UTs.

## Are there any user-facing changes?

No.
