### PR TITLE
Minor: Add documentation for `cot`

### DIFF
--- a/datafusion/functions/src/math/cot.rs
+++ b/datafusion/functions/src/math/cot.rs
@@ -16,17 +16,17 @@
 // under the License.
 
 use std::any::Any;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use arrow::array::{ArrayRef, AsArray};
 use arrow::datatypes::DataType::{Float32, Float64};
 use arrow::datatypes::{DataType, Float32Type, Float64Type};
 
-use datafusion_common::{exec_err, Result};
-use datafusion_expr::ColumnarValue;
-use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
-
 use crate::utils::make_scalar_function;
+use datafusion_common::{exec_err, Result};
+use datafusion_expr::scalar_doc_sections::DOC_SECTION_MATH;
+use datafusion_expr::{ColumnarValue, Documentation};
+use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
 
 #[derive(Debug)]
 pub struct CotFunc {
@@ -37,6 +37,20 @@ impl Default for CotFunc {
     fn default() -> Self {
         CotFunc::new()
     }
+}
+
+static DOCUMENTATION: OnceLock<Documentation> = OnceLock::new();
+
+fn get_cot_doc() -> &'static Documentation {
+    DOCUMENTATION.get_or_init(|| {
+        Documentation::builder()
+            .with_doc_section(DOC_SECTION_MATH)
+            .with_description("Returns the cotangent of a number.")
+            .with_syntax_example(r#"cot(numeric_expression)"#)
+            .with_standard_argument("numeric_expression", Some("Numeric"))
+            .build()
+            .unwrap()
+    })
 }
 
 impl CotFunc {
@@ -76,6 +90,11 @@ impl ScalarUDFImpl for CotFunc {
             _ => Ok(Float64),
         }
     }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        Some(get_cot_doc())
+    }
+
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(cot, vec![])(args)

--- a/datafusion/functions/src/math/cot.rs
+++ b/datafusion/functions/src/math/cot.rs
@@ -95,7 +95,6 @@ impl ScalarUDFImpl for CotFunc {
         Some(get_cot_doc())
     }
 
-
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         make_scalar_function(cot, vec![])(args)
     }

--- a/docs/source/user-guide/sql/scalar_functions_new.md
+++ b/docs/source/user-guide/sql/scalar_functions_new.md
@@ -47,6 +47,7 @@ the rest of the documentation.
 - [ceil](#ceil)
 - [cos](#cos)
 - [cosh](#cosh)
+- [cot](#cot)
 - [degrees](#degrees)
 - [exp](#exp)
 - [factorial](#factorial)
@@ -215,6 +216,18 @@ Returns the hyperbolic cosine of a number.
 
 ```
 cosh(numeric_expression)
+```
+
+#### Arguments
+
+- **numeric_expression**: Numeric expression to operate on. Can be a constant, column, or function, and any combination of operators.
+
+### `cot`
+
+Returns the cotangent of a number.
+
+```
+cot(numeric_expression)
 ```
 
 #### Arguments


### PR DESCRIPTION
## Which issue does this PR close?

Part of #12740


## Rationale for this change

I noticed that the `cot` function does not have documentation by running the script in https://github.com/apache/datafusion/issues/12872

```shell
(venv) andrewlamb@Andrews-MacBook-Pro-2:~/Software/datafusion$ ./dev/update_function_docs.sh
...
Running CLI and inserting scalar function docs table
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/print_functions_docs scalar`
INFO: The following functions do not have documentation:
  - map_extract
  - map
  - cot
  - map_keys
  - map_values
```

Note that @ jonathanc-n  is working on the map functions in https://github.com/apache/datafusion/pull/13047


In fact it appears to be completely undocumented in the old docs too: https://datafusion.apache.org/user-guide/sql/scalar_functions.html so this is a win for the automated script

## What changes are included in this PR?

Add docs to `cot`

## Are these changes tested?

Yes by CI

## Are there any user-facing changes?
More docs!

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
