### PR TITLE
minor: simplify associated item bound of `hash_array_primitive`

### DIFF
--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -102,8 +102,7 @@ fn hash_array_primitive<T>(
     hashes_buffer: &mut [u64],
     rehash: bool,
 ) where
-    T: ArrowPrimitiveType,
-    <T as arrow_array::ArrowPrimitiveType>::Native: HashValue,
+    T: ArrowPrimitiveType<Native: HashValue>,
 {
     assert_eq!(
         hashes_buffer.len(),


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change
`where T: Trait, <T as Trait>::Assoc: Bound` can be simplified to `where T: Trait<Assoc: Bound>`
The syntax has been stablized since Rust 1.79.0, which is the current Rust version used by DataFusion.

Ref: https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html#bounds-in-associated-type-position

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
