### PR TITLE
fix: planning of prepare statement with limit clause

### DIFF
--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4213,10 +4213,10 @@ fn test_prepare_statement_to_plan_having() {
 fn test_prepare_statement_to_plan_limit() {
     let sql = "PREPARE my_plan(BIGINT, BIGINT) AS
         SELECT id FROM person \
-        LIMIT $1 OFFSET $2";
+        OFFSET $1 LIMIT $2";
 
     let expected_plan = "Prepare: \"my_plan\" [Int64, Int64] \
-        \n  Limit: skip=$2, fetch=$1\
+        \n  Limit: skip=$1, fetch=$2\
         \n    Projection: person.id\
         \n      TableScan: person";
 
@@ -4226,7 +4226,7 @@ fn test_prepare_statement_to_plan_limit() {
 
     // replace params with values
     let param_values = vec![ScalarValue::Int64(Some(10)), ScalarValue::Int64(Some(200))];
-    let expected_plan = "Limit: skip=200, fetch=10\
+    let expected_plan = "Limit: skip=10, fetch=200\
         \n  Projection: person.id\
         \n    TableScan: person";
     prepare_stmt_replace_params_quick_test(plan, param_values, expected_plan);

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4210,6 +4210,29 @@ fn test_prepare_statement_to_plan_having() {
 }
 
 #[test]
+fn test_prepare_statement_to_plan_limit() {
+    let sql = "PREPARE my_plan(BIGINT, BIGINT) AS
+        SELECT id FROM person \
+        LIMIT $1 OFFSET $2";
+
+    let expected_plan = "Prepare: \"my_plan\" [Int64, Int64] \
+        \n  Limit: skip=$2, fetch=$1\
+        \n    Projection: person.id\
+        \n      TableScan: person";
+
+    let expected_dt = "[Int64, Int64]";
+
+    let plan = prepare_stmt_quick_test(sql, expected_plan, expected_dt);
+
+    // replace params with values
+    let param_values = vec![ScalarValue::Int64(Some(10)), ScalarValue::Int64(Some(200))];
+    let expected_plan = "Limit: skip=200, fetch=10\
+        \n  Projection: person.id\
+        \n    TableScan: person";
+    prepare_stmt_replace_params_quick_test(plan, param_values, expected_plan);
+}
+
+#[test]
 fn test_prepare_statement_to_plan_value_list() {
     let sql = "PREPARE my_plan(STRING, STRING) AS SELECT * FROM (VALUES(1, $1), (2, $2)) AS t (num, letter);";
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12294.

## Rationale for this change
This PR enables creating logical plan for a prepare statement with a limit clause.
Creating  physical plan for prepare is not yet supported and is being tracked in #4539.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
