### PR TITLE
Bug-fix / Limit with_new_exprs()

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -4102,7 +4102,7 @@ digraph {
     }
 
     #[test]
-    fn test_with_new_children() {
+    fn test_limit_with_new_children() {
         let limit = LogicalPlan::Limit(Limit {
             skip: None,
             fetch: Some(Box::new(Expr::Literal(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

https://github.com/apache/datafusion/pull/13028/files#diff-f69e720234d9da6cb3a4a178d3a5575fcd34f68191335a8c2465a172e8c4e6f1 introduced a minor bug. When there is a fetch but no skip in limit, its rewrite would discard that fetch. 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Rather than using eager relation op `and()`, lazy `and_then()`'s should be used to avoid popping `expr` when skip is `None` but fetch is `Some()`, as `expr` need to be popped to fetch.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, a unit test is added

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
