### PR TITLE
Raise a plan error on union if column count is not the same between plans

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1482,6 +1482,15 @@ pub fn validate_unique_names<'a>(
 /// [`TypeCoercionRewriter::coerce_union`]: https://docs.rs/datafusion-optimizer/latest/datafusion_optimizer/analyzer/type_coercion/struct.TypeCoercionRewriter.html#method.coerce_union
 /// [`coerce_union_schema`]: https://docs.rs/datafusion-optimizer/latest/datafusion_optimizer/analyzer/type_coercion/fn.coerce_union_schema.html
 pub fn union(left_plan: LogicalPlan, right_plan: LogicalPlan) -> Result<LogicalPlan> {
+    if left_plan.schema().fields().len() != right_plan.schema().fields().len() {
+        return plan_err!(
+            "UNION queries have different number of columns: \
+            left has {} columns whereas right has {} columns",
+            left_plan.schema().fields().len(),
+            right_plan.schema().fields().len()
+        );
+    }
+
     // Temporarily use the schema from the left input and later rely on the analyzer to
     // coerce the two schemas into a common one.
 

--- a/datafusion/sqllogictest/test_files/type_coercion.slt
+++ b/datafusion/sqllogictest/test_files/type_coercion.slt
@@ -103,11 +103,11 @@ CREATE TABLE orders(
 );
 
 # union_different_num_columns_error() / UNION
-query error Error during planning: Union schemas have different number of fields: query 1 has 1 fields whereas query 2 has 2 fields
+query error DataFusion error: Error during planning: UNION queries have different number of columns: left has 1 columns whereas right has 2 columns
 SELECT order_id FROM orders UNION SELECT customer_id, o_item_id FROM orders
 
 # union_different_num_columns_error() / UNION ALL
-query error Error during planning: Union schemas have different number of fields: query 1 has 1 fields whereas query 2 has 2 fields
+query error DataFusion error: Error during planning: UNION queries have different number of columns: left has 1 columns whereas right has 2 columns
 SELECT order_id FROM orders UNION ALL SELECT customer_id, o_item_id FROM orders
 
 # union_with_different_column_names()


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13092

## Rationale for this change

Raise the error earlier, restore the behaviour of previous versions of DF

## What changes are included in this PR?

code, slt test.

## Are these changes tested?

yes

## Are there any user-facing changes?
no
