### PR TITLE
feat(substrait): add support for insert roundtrip in append mode

### DIFF
--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -1093,6 +1093,19 @@ async fn roundtrip_repartition_hash() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn roundtrip_insert() -> Result<()> {
+    assert_expected_plan_unoptimized(
+        "INSERT INTO data SELECT * FROM data",
+        "Dml: op=[Insert Into] table=[data]\
+        \n  Projection: data.a, data.b, data.c, data.d, data.e, data.f\
+        \n    Projection: data.a, data.b, data.c, data.d, data.e, data.f\
+        \n      TableScan: data",
+        true,
+    )
+    .await
+}
+
 fn check_post_join_filters(rel: &Rel) -> Result<()> {
     // search for target_rel and field value in proto
     match &rel.rel_type {


### PR DESCRIPTION
## Rationale for this change

Adds support for append-mode inserts for substrait producer and consumer.

## What changes are included in this PR?

The trickiest part is to get output schema right as substrait and datafusion don't fit very well there. Datafusion returns a single field named `count` after an insert. substrait has no explicit OutputMode that does the same. For the sake of this PR, I assumed that `OutputMode.Unspecified` replicates this behavior during an insert. I'll open an issue on the substrait side for this. We might need a new OutputMode named OperationStats or something similar.


## Are these changes tested?

yes

## Are there any user-facing changes?

yes