### PR TITLE
feat(substrait): handle emit_kind when consuming Substrait plans

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1121,8 +1121,9 @@ fn apply_emit_kind(
 
             let mut exprs: Vec<Expr> = vec![];
             for index in emit.output_mapping.into_iter() {
-                let column =
-                    Expr::Column(Column::from(input_schema.qualified_field(index as usize)));
+                let column = Expr::Column(Column::from(
+                    input_schema.qualified_field(index as usize),
+                ));
                 let expr = name_tracker.get_uniquely_named_expr(column)?;
                 exprs.push(expr);
             }

--- a/datafusion/substrait/tests/cases/emit_kind_tests.rs
+++ b/datafusion/substrait/tests/cases/emit_kind_tests.rs
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tests for Emit Kind usage
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::test::{add_plan_schemas_to_ctx, read_json};
+
+    use datafusion::common::Result;
+    use datafusion::prelude::SessionContext;
+    use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
+
+    #[tokio::test]
+    async fn project_respects_direct_emit_kind() -> Result<()> {
+        let proto_plan = read_json(
+            "tests/testdata/test_plans/emit_kind/direct_on_project.substrait.json",
+        );
+        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan)?;
+        let plan = from_substrait_plan(&ctx, &proto_plan).await?;
+
+        let plan_str = format!("{}", plan);
+
+        assert_eq!(
+            plan_str,
+            "Projection: DATA.A AS a, DATA.B AS b, DATA.A + Int64(1) AS add1\
+            \n  TableScan: DATA"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn handle_emit_as_project() -> Result<()> {
+        let proto_plan = read_json(
+            "tests/testdata/test_plans/emit_kind/emit_on_filter.substrait.json",
+        );
+        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan)?;
+        let plan = from_substrait_plan(&ctx, &proto_plan).await?;
+
+        let plan_str = format!("{}", plan);
+
+        assert_eq!(
+            plan_str,
+            // Note that duplicate references in the remap are aliased
+            "Projection: DATA.B, DATA.A AS A1, DATA.A AS DATA.A__temp__0 AS A2\
+             \n  Filter: DATA.B = Int64(2)\
+             \n    TableScan: DATA"
+        );
+        Ok(())
+    }
+}

--- a/datafusion/substrait/tests/cases/mod.rs
+++ b/datafusion/substrait/tests/cases/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 mod consumer_integration;
+mod emit_kind_tests;
 mod function_test;
 mod logical_plans;
 mod roundtrip_logical_plan;

--- a/datafusion/substrait/tests/testdata/test_plans/emit_kind/direct_on_project.substrait.json
+++ b/datafusion/substrait/tests/testdata/test_plans/emit_kind/direct_on_project.substrait.json
@@ -1,0 +1,90 @@
+{
+  "extensionUris": [{
+    "extensionUriAnchor": 1,
+    "uri": "/functions_arithmetic.yaml"
+  }],
+  "extensions": [{
+    "extensionFunction": {
+      "extensionUriReference": 1,
+      "functionAnchor": 0,
+      "name": "add:i64_i64"
+    }
+  }],
+  "relations": [{
+    "root": {
+      "input": {
+        "project": {
+          "common": {
+            "direct": {
+            }
+          },
+          "input": {
+            "read": {
+              "common": {
+                "direct": {
+                }
+              },
+              "baseSchema": {
+                "names": ["A", "B"],
+                "struct": {
+                  "types": [{
+                    "i64": {
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  }, {
+                    "i64": {
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  }],
+                  "typeVariationReference": 0,
+                  "nullability": "NULLABILITY_REQUIRED"
+                }
+              },
+              "namedTable": {
+                "names": ["DATA"]
+              }
+            }
+          },
+          "expressions": [{
+            "scalarFunction": {
+              "functionReference": 0,
+              "args": [],
+              "outputType": {
+                "i64": {
+                  "typeVariationReference": 0,
+                  "nullability": "NULLABILITY_NULLABLE"
+                }
+              },
+              "arguments": [{
+                "value": {
+                  "selection": {
+                    "directReference": {
+                      "structField": {
+                        "field": 0
+                      }
+                    },
+                    "rootReference": {
+                    }
+                  }
+                }
+              }, {
+                "value": {
+                  "literal": {
+                    "i64": 1,
+                    "nullable": false,
+                    "typeVariationReference": 0
+                  }
+                }
+              }],
+              "options": []
+            }
+          }]
+        }
+      },
+      "names": ["a", "b", "add1"]
+    }
+  }],
+  "expectedTypeUrls": []
+}

--- a/datafusion/substrait/tests/testdata/test_plans/emit_kind/emit_on_filter.substrait.json
+++ b/datafusion/substrait/tests/testdata/test_plans/emit_kind/emit_on_filter.substrait.json
@@ -1,0 +1,91 @@
+{
+  "extensionUris": [{
+    "extensionUriAnchor": 1,
+    "uri": "/functions_comparison.yaml"
+  }],
+  "extensions": [{
+    "extensionFunction": {
+      "extensionUriReference": 1,
+      "functionAnchor": 0,
+      "name": "equal:any_any"
+    }
+  }],
+  "relations": [{
+    "root": {
+      "input": {
+        "filter": {
+          "common": {
+            "emit": {
+              "outputMapping": [1, 0, 0]
+            }
+          },
+          "input": {
+            "read": {
+              "common": {
+                "direct": {
+                }
+              },
+              "baseSchema": {
+                "names": ["A", "B"],
+                "struct": {
+                  "types": [{
+                    "i64": {
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  }, {
+                    "i64": {
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                    }
+                  }],
+                  "typeVariationReference": 0,
+                  "nullability": "NULLABILITY_REQUIRED"
+                }
+              },
+              "namedTable": {
+                "names": ["DATA"]
+              }
+            }
+          },
+          "condition": {
+            "scalarFunction": {
+              "functionReference": 0,
+              "args": [],
+              "outputType": {
+                "bool": {
+                  "typeVariationReference": 0,
+                  "nullability": "NULLABILITY_NULLABLE"
+                }
+              },
+              "arguments": [{
+                "value": {
+                  "selection": {
+                    "directReference": {
+                      "structField": {
+                        "field": 1
+                      }
+                    },
+                    "rootReference": {
+                    }
+                  }
+                }
+              }, {
+                "value": {
+                  "literal": {
+                    "i64": "2",
+                    "nullable": false,
+                    "typeVariationReference": 0
+                  }
+                }
+              }],
+              "options": []
+            }
+          }
+        }
+      },
+      "names": ["B", "A1", "A2"]
+    }
+  }],
+  "expectedTypeUrls": []
+}


### PR DESCRIPTION
## Which issue does this PR close?
Follows up from https://github.com/apache/datafusion/pull/12495

Closes https://github.com/apache/datafusion/issues/12347

## Rationale for this change
Substrait relations have an [emit_kind](https://github.com/substrait-io/substrait/blob/683f4179a058c2c99c04501b920a48ff372356ff/proto/substrait/algebra.proto#L15-L22) which is either Direct, in which case the default fields of the relation are output, or Emit, which enables precise control of the order and inclusion of fields.

For example, given a relation with the following emit
```json
"emit": {
  "outputMapping": [2, 0, 1]
}
```
The output mapping indicates that from the default columns output from the relation, only the 2nd, 0th and 1st column should be output (in that order).

DataFusion currently ignores the emit_kind field entirely when reading Substrait plans.

## What changes are included in this PR?
This PR adds support for handling output mappings by treating them as DataFusion Projections that are layered on top of the default translation of the relation.

The one exception to this is Substrait Project, for which special handling has been added to avoid creating a Projection on top of a Projection.

## Are these changes tested?
Yes. Two new tests have been added to check the remap logic.

Additionally, DataFusion currently includes output mappings when it produces Substrait Projects, so any test which roundtrips a Projection also serves as a test of this functionality.

## Are there any user-facing changes?

Substrait plans generated by DataFusion prior to version 0.42 did not set the output mapping correctly for Substrait Projects (see https://github.com/apache/datafusion/pull/12495 for details).

After these changes, attempting to consume Substrait plans generated before version 0.42 will not work.



