### PR TITLE
Improve TableScan with filters pushdown unparsing (multiple filters)

### DIFF
--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -968,6 +968,21 @@ fn test_table_scan_pushdown() -> Result<()> {
         table_scan_with_all.to_string(),
         "SELECT t1.id, t1.age FROM t1 WHERE (t1.id > t1.age) LIMIT 10"
     );
+
+    let table_scan_with_additional_filter = table_scan_with_filters(
+        Some("t1"),
+        &schema,
+        None,
+        vec![col("id").gt(col("age"))],
+    )?
+    .filter(col("id").eq(lit(5)))?
+    .build()?;
+    let table_scan_with_filter = plan_to_sql(&table_scan_with_additional_filter)?;
+    assert_eq!(
+        table_scan_with_filter.to_string(),
+        "SELECT * FROM t1 WHERE (t1.id = 5) AND (t1.id > t1.age)"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

With filters pushdown optimization, the LogicalPlan can have filters defined as part of `TableScan` and `Filter` nodes.
To avoid overwriting one of the filters, we combine the existing filter with the additional filter.

Example query

```sql
select
        c_phone as cntrycode,
        c_acctbal
from
        customer
where c_mktsegment = 'BUILDING' and c_acctbal > (
        select
                avg(c_acctbal)
        from
                customer);
```
Logical Plan
```                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
|  Projection: customer.c_phone AS cntrycode, customer.c_acctbal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
|   Filter: CAST(customer.c_acctbal AS Decimal128(38, 6)) > (<subquery>)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
|     Subquery:
|     ..                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
|     TableScan: customer, full_filters=[customer.c_mktsegment = Utf8("BUILDING")]
```

W/o this change it will be unparsed as 

```sql
select
        c_phone as cntrycode,
        c_acctbal
from
        customer
where c_mktsegment = 'BUILDING'
```

## What changes are included in this PR?

Improves QueryBuilder `pub fn selection` to combine filters if `select` is called multiple times (`select` corresponds to query filter / `WHERE` clause).

## Are these changes tested?

Added unit test, tested as part of TPC-H and TPC-DS queries unparsing by https://github.com/spiceai/spiceai (running benchmarks with some filters pushdown optimizations enabled)

## Are there any user-facing changes?

Fixes some unparsing issues related to missing `WHERE`  clauses when running TPC-H and TPC-DS queries with filters pushdown optimization enabled
