### PR TITLE
Improve TableScan with filters pushdown unparsing (joins)

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -27,7 +27,8 @@ use super::{
     },
     utils::{
         find_agg_node_within_select, find_window_nodes_within_select,
-        unproject_sort_expr, unproject_window_exprs,
+        try_transform_to_simple_table_scan_with_filters, unproject_sort_expr,
+        unproject_window_exprs,
     },
     Unparser,
 };
@@ -38,8 +39,8 @@ use datafusion_common::{
     Column, DataFusionError, Result, TableReference,
 };
 use datafusion_expr::{
-    expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan,
-    LogicalPlanBuilder, Projection, SortExpr, TableScan,
+    expr::Alias, BinaryExpr, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan,
+    LogicalPlanBuilder, Operator, Projection, SortExpr, TableScan,
 };
 use sqlparser::ast::{self, Ident, SetExpr};
 use std::sync::Arc;
@@ -459,22 +460,77 @@ impl Unparser<'_> {
                 self.select_to_sql_recursively(input, query, select, relation)
             }
             LogicalPlan::Join(join) => {
-                let join_constraint = self.join_constraint_to_sql(
-                    join.join_constraint,
-                    &join.on,
-                    join.filter.as_ref(),
-                )?;
+                let mut table_scan_filters = vec![];
 
-                let mut right_relation = RelationBuilder::default();
+                let left_plan =
+                    match try_transform_to_simple_table_scan_with_filters(&join.left)? {
+                        Some((plan, filters)) => {
+                            table_scan_filters.extend(filters);
+                            Arc::new(plan)
+                        }
+                        None => Arc::clone(&join.left),
+                    };
 
                 self.select_to_sql_recursively(
-                    join.left.as_ref(),
+                    left_plan.as_ref(),
                     query,
                     select,
                     relation,
                 )?;
+
+                let right_plan =
+                    match try_transform_to_simple_table_scan_with_filters(&join.right)? {
+                        Some((plan, filters)) => {
+                            table_scan_filters.extend(filters);
+                            Arc::new(plan)
+                        }
+                        None => Arc::clone(&join.right),
+                    };
+
+                let mut right_relation = RelationBuilder::default();
+
                 self.select_to_sql_recursively(
-                    join.right.as_ref(),
+                    right_plan.as_ref(),
+                    query,
+                    select,
+                    &mut right_relation,
+                )?;
+
+                let join_filters = if table_scan_filters.is_empty() {
+                    join.filter.clone()
+                } else {
+                    // Combine `table_scan_filters` into a single filter using `AND`
+                    let Some(combined_filters) =
+                        table_scan_filters.into_iter().reduce(|acc, filter| {
+                            Expr::BinaryExpr(BinaryExpr {
+                                left: Box::new(acc),
+                                op: Operator::And,
+                                right: Box::new(filter),
+                            })
+                        })
+                    else {
+                        return internal_err!("Failed to combine TableScan filters");
+                    };
+
+                    // Combine `join.filter` with `combined_filters` using `AND`
+                    match &join.filter {
+                        Some(filter) => Some(Expr::BinaryExpr(BinaryExpr {
+                            left: Box::new(filter.clone()),
+                            op: Operator::And,
+                            right: Box::new(combined_filters),
+                        })),
+                        None => Some(combined_filters),
+                    }
+                };
+
+                let join_constraint = self.join_constraint_to_sql(
+                    join.join_constraint,
+                    &join.on,
+                    join_filters.as_ref(),
+                )?;
+
+                self.select_to_sql_recursively(
+                    right_plan.as_ref(),
                     query,
                     select,
                     &mut right_relation,

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -15,20 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::cmp::Ordering;
+use std::{cmp::Ordering, sync::Arc, vec};
 
 use datafusion_common::{
     internal_err,
-    tree_node::{Transformed, TreeNode},
-    Column, Result, ScalarValue,
+    tree_node::{Transformed, TransformedResult, TreeNode},
+    Column, DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::{
-    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr,
-    Window,
+    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, LogicalPlanBuilder,
+    Projection, SortExpr, Window,
 };
 use sqlparser::ast;
 
-use super::{dialect::DateFieldExtractStyle, Unparser};
+use super::{dialect::DateFieldExtractStyle, rewrite::TableAliasRewriter, Unparser};
 
 /// Recursively searches children of [LogicalPlan] to find an Aggregate node if exists
 /// prior to encountering a Join, TableScan, or a nested subquery (derived table factor).
@@ -237,6 +237,87 @@ pub(crate) fn unproject_sort_expr(
     }
 
     Ok(sort_expr)
+}
+
+/// Iterates through the children of a [LogicalPlan] to find a TableScan node before encountering
+/// a Projection or any unexpected node that indicates the presence of a Projection (SELECT) in the plan.
+/// If a TableScan node is found, returns the TableScan node without filters, along with the collected filters separately.
+/// If the plan contains a Projection, returns None.
+///
+/// Note: If a table alias is present, TableScan filters are rewritten to reference the alias.
+///
+/// LogicalPlan example:
+///   Filter: ta.j1_id < 5
+///     Alias:  ta
+///       TableScan: j1, j1_id > 10
+///
+/// Will return LogicalPlan below:
+///     Alias:  ta
+///       TableScan: j1
+/// And filters: [ta.j1_id < 5, ta.j1_id > 10]
+pub(crate) fn try_transform_to_simple_table_scan_with_filters(
+    plan: &LogicalPlan,
+) -> Result<Option<(LogicalPlan, Vec<Expr>)>> {
+    let mut filters: Vec<Expr> = vec![];
+    let mut plan_stack = vec![plan];
+    let mut table_alias = None;
+
+    while let Some(current_plan) = plan_stack.pop() {
+        match current_plan {
+            LogicalPlan::SubqueryAlias(alias) => {
+                table_alias = Some(alias.alias.clone());
+                plan_stack.push(alias.input.as_ref());
+            }
+            LogicalPlan::Filter(filter) => {
+                filters.push(filter.predicate.clone());
+                plan_stack.push(filter.input.as_ref());
+            }
+            LogicalPlan::TableScan(table_scan) => {
+                let table_schema = table_scan.source.schema();
+                // optional rewriter if table has an alias
+                let mut filter_alias_rewriter =
+                    table_alias.as_ref().map(|alias_name| TableAliasRewriter {
+                        table_schema: &table_schema,
+                        alias_name: alias_name.clone(),
+                    });
+
+                // rewrite filters to use table alias if present
+                let table_scan_filters = table_scan
+                    .filters
+                    .iter()
+                    .cloned()
+                    .map(|expr| {
+                        if let Some(ref mut rewriter) = filter_alias_rewriter {
+                            expr.rewrite(rewriter).data()
+                        } else {
+                            Ok(expr)
+                        }
+                    })
+                    .collect::<Result<Vec<_>, DataFusionError>>()?;
+
+                filters.extend(table_scan_filters);
+
+                let mut builder = LogicalPlanBuilder::scan(
+                    table_scan.table_name.clone(),
+                    Arc::clone(&table_scan.source),
+                    None,
+                )?;
+
+                if let Some(alias) = table_alias.take() {
+                    builder = builder.alias(alias)?;
+                }
+
+                let plan = builder.build()?;
+
+                return Ok(Some((plan, filters)));
+            }
+            _ => {
+                return Ok(None);
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 /// Converts a date_part function to SQL, tailoring it to the supported date field extraction style.

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -992,6 +992,58 @@ fn test_sort_with_push_down_fetch() -> Result<()> {
 }
 
 #[test]
+fn test_join_with_table_scan_filters() -> Result<()> {
+    let schema_left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+    
+    let schema_right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Utf8, false),
+    ]);
+
+    let left_plan = table_scan_with_filters(Some("left_table"), &schema_left, None, vec![col("name").like(lit("some_name"))])?
+        .alias("left")?
+        .build()?;
+
+    let right_plan = table_scan_with_filters(Some("right_table"), &schema_right, None, vec![col("age").gt(lit(10))])?
+        .build()?;
+
+    let join_plan_with_filter = LogicalPlanBuilder::from(left_plan.clone())
+        .join(
+            right_plan.clone(), 
+            datafusion_expr::JoinType::Inner, 
+            (vec!["left.id"], vec!["right_table.id"]), 
+            Some(col("left.id").gt(lit(5))),
+        )?
+        .build()?;
+
+    let sql = plan_to_sql(&join_plan_with_filter)?;
+
+    let expected_sql = r#"SELECT * FROM left_table AS "left" JOIN right_table ON "left".id = right_table.id AND (("left".id > 5) AND ("left"."name" LIKE 'some_name' AND (age > 10)))"#;
+    
+    assert_eq!(sql.to_string(), expected_sql);
+
+    let join_plan_no_filter = LogicalPlanBuilder::from(left_plan)
+        .join(
+            right_plan, 
+            datafusion_expr::JoinType::Inner, 
+            (vec!["left.id"], vec!["right_table.id"]), 
+            None
+        )?
+        .build()?;
+
+    let sql = plan_to_sql(&join_plan_no_filter)?;
+
+    let expected_sql = r#"SELECT * FROM left_table AS "left" JOIN right_table ON "left".id = right_table.id AND ("left"."name" LIKE 'some_name' AND (age > 10))"#;
+    
+    assert_eq!(sql.to_string(), expected_sql);
+
+    Ok(())
+}
+
+#[test]
 fn test_interval_lhs_eq() {
     sql_round_trip(
         GenericDialect {},


### PR DESCRIPTION
## Which issue does this PR close?

With filter pushdown optimization enabled, `TableScan` filters and `LogicalPlan::Filter` without a dedicated `Projection` are incorrectly applied after the join statement, leading to incorrect results. For example

Original query (TPC-H Q13)
```sql
select
            c_custkey,
            count(o_orderkey)
        from
            customer left join orders on
                        c_custkey = o_custkey
                    and o_comment not like '%special%requests%'
        group by
            c_custkey
```
is unparsed as below. You can see that original filter from Join is unparsed after join as `where`. The difference is that original query will contain customer records where there is no matching order and the second version does not (filter is applied after join).

```sql
select
    "customer"."c_custkey",
    count("orders"."o_orderkey")
  from
    "customer"
  left join "orders" on
    ("customer"."c_custkey" = "orders"."o_custkey")
  where
    "orders"."o_comment" not like '%special%requests%'
  group by
    "customer"."c_custkey"
  order by "customer"."c_custkey" asc
```

## What changes are included in this PR?

The PR improves unparsing by determining if the join is a simple table scan (not a subquery that will be translated to a full subquery (`SELECT .. FROM ..`)) so that filters must be applied directly to the join. In the case of a full subquery, filters will be applied within the subquery, and this works correctly. This fixes TPC-H Q12 (filters on the left join were missing/not applied at all) and TPC-H Q13 (the filter was applied after the join instead of during/before, as shown above).

```console
SELECT "customer"."c_custkey", count("orders"."o_orderkey") FROM "customer" LEFT JOIN "orders" ON (("customer"."c_custkey" = "orders"."o_custkey") AND "orders"."o_comment" NOT LIKE '%special%requests%') GROUP BY "customer"."c_custkey" 


sql> explain select
            c_custkey,
            count(o_orderkey)
        from
            customer left join orders on
                        c_custkey = o_custkey
                    and o_comment not like '%special%requests%'
        group by
            c_custkey;
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | BytesProcessedNode                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
|               |   Federated                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
|               |  Projection: customer.c_custkey, count(orders.o_orderkey)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
|               |   Aggregate: groupBy=[[customer.c_custkey]], aggr=[[count(orders.o_orderkey)]]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|               |     Left Join:  Filter: customer.c_custkey = orders.o_custkey                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
|               |       TableScan: customer                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
|               |       TableScan: orders, full_filters=[orders.o_comment NOT LIKE Utf8("%special%requests%")]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| physical_plan | BytesProcessedExec                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
|               |   SchemaCastScanExec                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
|               |     VirtualExecutionPlan name=postgres compute_context=host=Tcp("localhost"),port=6432,db=tpch_sf1,user=postgres, sql=SELECT customer.c_custkey, count(orders.o_orderkey) FROM customer LEFT JOIN orders ON ((customer.c_custkey = orders.o_custkey) AND orders.o_comment NOT LIKE '%special%requests%') GROUP BY customer.c_custkey rewritten_sql=SELECT "customer"."c_custkey", count("orders"."o_orderkey") FROM "customer" LEFT JOIN "orders" ON (("customer"."c_custkey" = "orders"."o_custkey") AND "orders"."o_comment" NOT LIKE '%special%requests%') GROUP BY "customer"."c_custkey" |
|               |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

**Note:** The alternative approach considered was always unparsing join sub-nodes by adding a wildcard projection if needed. However, it requires introducing additional alias for a subquery (and updating corresponding upper nodes to match alias added) as not all engines support adding subquery with the same name as original table, for example `JOIN (SELECT * FROM "orders" WHERE "orders"."o_comment" not like '%special%requests%') as orders ..` - `as orders` needs to be replaced with new alias for most engines

## Are these changes tested?

Added unit test, tested as part of TPC-H and TPC-DS queries unparsing by https://github.com/spiceai/spiceai (running benchmarks with some filters pushdown optimizations enabled)

## Are there any user-facing changes?

Fixes unparsing issues related to incorrectly generated 'JOIN' filters when running TPC-H and TPC-DS queries with filters pushdown optimization enabled