### PR TITLE
chore: re-export functions_window_common::ExpressionArgs

### DIFF
--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -29,6 +29,7 @@ pub use datafusion_functions_aggregate_common::accumulator::{
 
 pub use datafusion_functions_window_common::field::WindowUDFFieldArgs;
 pub use datafusion_functions_window_common::partition::PartitionEvaluatorArgs;
+pub use datafusion_functions_window_common::expr::ExpressionArgs;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Hint {

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -27,9 +27,9 @@ pub use datafusion_functions_aggregate_common::accumulator::{
     AccumulatorArgs, AccumulatorFactoryFunction, StateFieldsArgs,
 };
 
+pub use datafusion_functions_window_common::expr::ExpressionArgs;
 pub use datafusion_functions_window_common::field::WindowUDFFieldArgs;
 pub use datafusion_functions_window_common::partition::PartitionEvaluatorArgs;
-pub use datafusion_functions_window_common::expr::ExpressionArgs;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Hint {


### PR DESCRIPTION

## Which issue does this PR close?

Closes #13148.

## Rationale for this change

`ExpressionArgs` is needed to implement `WindowUDFImpl` as of https://github.com/apache/datafusion/pull/12857, but it is not currently re-exported.

## What changes are included in this PR?

`ExpressionArgs` is re-exported in datafusion_expr::function.

I placed it here because that is where `WindowUDFFieldArgs` and `PartitionEvaluatorArgs` are re-exported.

## Are these changes tested?

N/A

## Are there any user-facing changes?

Not from any released version