### PR TITLE
fix: Order by mentioning missing column multiple times

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -57,6 +57,7 @@ use datafusion_common::{
     UnnestOptions,
 };
 use datafusion_expr_common::type_coercion::binary::type_union_resolution;
+use indexmap::IndexSet;
 
 /// Default table name for unnamed table
 pub const UNNAMED_TABLE: &str = "?table?";
@@ -567,7 +568,7 @@ impl LogicalPlanBuilder {
     /// See <https://github.com/apache/datafusion/issues/5065> for more details
     fn add_missing_columns(
         curr_plan: LogicalPlan,
-        missing_cols: &HashSet<Column>,
+        missing_cols: &IndexSet<Column>,
         is_distinct: bool,
     ) -> Result<LogicalPlan> {
         match curr_plan {
@@ -612,7 +613,7 @@ impl LogicalPlanBuilder {
 
     fn ambiguous_distinct_check(
         missing_exprs: &[Expr],
-        missing_cols: &HashSet<Column>,
+        missing_cols: &IndexSet<Column>,
         projection_exprs: &[Expr],
     ) -> Result<()> {
         if missing_exprs.is_empty() {
@@ -677,7 +678,7 @@ impl LogicalPlanBuilder {
         let schema = self.plan.schema();
 
         // Collect sort columns that are missing in the input plan's schema
-        let mut missing_cols: HashSet<Column> = HashSet::new();
+        let mut missing_cols: IndexSet<Column> = IndexSet::new();
         sorts.iter().try_for_each::<_, Result<()>>(|sort| {
             let columns = sort.expr.column_refs();
 

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -682,7 +682,7 @@ impl LogicalPlanBuilder {
             let columns = sort.expr.column_refs();
 
             columns.into_iter().for_each(|c| {
-                if !schema.has_column(c) {
+                if !schema.has_column(c) && !missing_cols.contains(c) {
                     missing_cols.push(c.clone());
                 }
             });

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -335,6 +335,14 @@ select column1 from foo order by log(column2);
 3
 5
 
+# Test issue: https://github.com/apache/datafusion/issues/13157
+query I
+select column1 from foo order by column2 % 2, column2;
+----
+1
+3
+5
+
 # Cleanup
 statement ok
 drop table foo;


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13157

## Rationale for this change
Previously we crashed on queries where the order by mentioned a missing
columns multiple times.


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Only add each missing column once.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, new sqllogictest.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Bugfix.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
