### PR TITLE
fix: default UDWFImpl::expressions returns all expressions

### DIFF
--- a/datafusion/core/tests/user_defined/user_defined_window_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_window_functions.rs
@@ -740,9 +740,7 @@ fn test_default_expressions() -> Result<()> {
     for input_exprs in &test_cases {
         let input_types = input_exprs
             .iter()
-            .map(|expr: &Arc<dyn PhysicalExpr>| {
-                expr.data_type(&schema).unwrap()
-            })
+            .map(|expr: &Arc<dyn PhysicalExpr>| expr.data_type(&schema).unwrap())
             .collect::<Vec<_>>();
         let expr_args = ExpressionArgs::new(input_exprs, &input_types);
 

--- a/datafusion/core/tests/user_defined/user_defined_window_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_window_functions.rs
@@ -740,7 +740,7 @@ fn test_default_expressions() -> Result<()> {
     for input_exprs in &test_cases {
         let input_types = input_exprs
             .iter()
-            .map(|expr: &std::sync::Arc<dyn PhysicalExpr>| {
+            .map(|expr: &Arc<dyn PhysicalExpr>| {
                 expr.data_type(&schema).unwrap()
             })
             .collect::<Vec<_>>();

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -312,10 +312,7 @@ pub trait WindowUDFImpl: Debug + Send + Sync {
 
     /// Returns the expressions that are passed to the [`PartitionEvaluator`].
     fn expressions(&self, expr_args: ExpressionArgs) -> Vec<Arc<dyn PhysicalExpr>> {
-        expr_args
-            .input_exprs()
-            .first()
-            .map_or(vec![], |expr| vec![Arc::clone(expr)])
+        expr_args.input_exprs().into()
     }
 
     /// Invoke the function, returning the [`PartitionEvaluator`] instance


### PR DESCRIPTION
## Which issue does this PR close?


Closes #13168.

## Rationale for this change

Same as in  #13168.

## What changes are included in this PR?

`WindowUDFImpl::expressions` is changed to return all the input expressions by default instead of only the 1st one.

## Are these changes tested?

Covered by existing tests.

## Are there any user-facing changes?

Not from a released version.