### PR TITLE
Deprecate ScalarUDF::invoke and invoke_no_args for invoke_batch

### DIFF
--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -193,6 +193,7 @@ impl ScalarUDF {
     /// Invoke the function on `args`, returning the appropriate result.
     ///
     /// See [`ScalarUDFImpl::invoke`] for more details.
+    #[deprecated(since = "42.1.0", note = "Use `invoke_batch` instead")]
     pub fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         self.inner.invoke(args)
     }
@@ -215,13 +216,14 @@ impl ScalarUDF {
     /// Invoke the function without `args` but number of rows, returning the appropriate result.
     ///
     /// See [`ScalarUDFImpl::invoke_no_args`] for more details.
+    #[deprecated(since = "42.1.0", note = "Use `invoke_batch` instead")]
     pub fn invoke_no_args(&self, number_rows: usize) -> Result<ColumnarValue> {
         self.inner.invoke_no_args(number_rows)
     }
 
     /// Returns a `ScalarFunctionImplementation` that can invoke the function
     /// during execution
-    #[deprecated(since = "42.0.0", note = "Use `invoke` or `invoke_no_args` instead")]
+    #[deprecated(since = "42.0.0", note = "Use `invoke_batch` instead")]
     pub fn fun(&self) -> ScalarFunctionImplementation {
         let captured = Arc::clone(&self.inner);
         Arc::new(move |args| captured.invoke(args))

--- a/datafusion/functions-nested/benches/map.rs
+++ b/datafusion/functions-nested/benches/map.rs
@@ -96,6 +96,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             black_box(
+                #[allow(deprecated)] // TODO use invoke_batch
                 map_udf()
                     .invoke(&[keys.clone(), values.clone()])
                     .expect("map should work on valid values"),

--- a/datafusion/functions/benches/character_length.rs
+++ b/datafusion/functions/benches/character_length.rs
@@ -84,28 +84,48 @@ fn criterion_benchmark(c: &mut Criterion) {
         let args_string_ascii = gen_string_array(n_rows, str_len, 0.1, 0.0, false);
         c.bench_function(
             &format!("character_length_StringArray_ascii_str_len_{}", str_len),
-            |b| b.iter(|| black_box(character_length.invoke(&args_string_ascii))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(character_length.invoke(&args_string_ascii))
+                })
+            },
         );
 
         // StringArray UTF8
         let args_string_utf8 = gen_string_array(n_rows, str_len, 0.1, 0.5, false);
         c.bench_function(
             &format!("character_length_StringArray_utf8_str_len_{}", str_len),
-            |b| b.iter(|| black_box(character_length.invoke(&args_string_utf8))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(character_length.invoke(&args_string_utf8))
+                })
+            },
         );
 
         // StringViewArray ASCII only
         let args_string_view_ascii = gen_string_array(n_rows, str_len, 0.1, 0.0, true);
         c.bench_function(
             &format!("character_length_StringViewArray_ascii_str_len_{}", str_len),
-            |b| b.iter(|| black_box(character_length.invoke(&args_string_view_ascii))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(character_length.invoke(&args_string_view_ascii))
+                })
+            },
         );
 
         // StringViewArray UTF8
         let args_string_view_utf8 = gen_string_array(n_rows, str_len, 0.1, 0.5, true);
         c.bench_function(
             &format!("character_length_StringViewArray_utf8_str_len_{}", str_len),
-            |b| b.iter(|| black_box(character_length.invoke(&args_string_view_utf8))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(character_length.invoke(&args_string_view_utf8))
+                })
+            },
         );
     }
 }

--- a/datafusion/functions/benches/concat.rs
+++ b/datafusion/functions/benches/concat.rs
@@ -38,7 +38,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         let args = create_args(size, 32);
         let mut group = c.benchmark_group("concat function");
         group.bench_function(BenchmarkId::new("concat", size), |b| {
-            b.iter(|| criterion::black_box(concat().invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                criterion::black_box(concat().invoke(&args).unwrap())
+            })
         });
         group.finish();
     }

--- a/datafusion/functions/benches/cot.rs
+++ b/datafusion/functions/benches/cot.rs
@@ -33,12 +33,18 @@ fn criterion_benchmark(c: &mut Criterion) {
         let f32_array = Arc::new(create_primitive_array::<Float32Type>(size, 0.2));
         let f32_args = vec![ColumnarValue::Array(f32_array)];
         c.bench_function(&format!("cot f32 array: {}", size), |b| {
-            b.iter(|| black_box(cot_fn.invoke(&f32_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(cot_fn.invoke(&f32_args).unwrap())
+            })
         });
         let f64_array = Arc::new(create_primitive_array::<Float64Type>(size, 0.2));
         let f64_args = vec![ColumnarValue::Array(f64_array)];
         c.bench_function(&format!("cot f64 array: {}", size), |b| {
-            b.iter(|| black_box(cot_fn.invoke(&f64_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(cot_fn.invoke(&f64_args).unwrap())
+            })
         });
     }
 }

--- a/datafusion/functions/benches/date_bin.rs
+++ b/datafusion/functions/benches/date_bin.rs
@@ -45,6 +45,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let udf = date_bin();
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 udf.invoke(&[interval.clone(), timestamps.clone()])
                     .expect("date_bin should work on valid values"),

--- a/datafusion/functions/benches/encoding.rs
+++ b/datafusion/functions/benches/encoding.rs
@@ -29,22 +29,30 @@ fn criterion_benchmark(c: &mut Criterion) {
         let str_array = Arc::new(create_string_array_with_len::<i32>(size, 0.2, 32));
         c.bench_function(&format!("base64_decode/{size}"), |b| {
             let method = ColumnarValue::Scalar("base64".into());
+            #[allow(deprecated)] // TODO use invoke_batch
             let encoded = encoding::encode()
                 .invoke(&[ColumnarValue::Array(str_array.clone()), method.clone()])
                 .unwrap();
 
             let args = vec![encoded, method];
-            b.iter(|| black_box(decode.invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(decode.invoke(&args).unwrap())
+            })
         });
 
         c.bench_function(&format!("hex_decode/{size}"), |b| {
             let method = ColumnarValue::Scalar("hex".into());
+            #[allow(deprecated)] // TODO use invoke_batch
             let encoded = encoding::encode()
                 .invoke(&[ColumnarValue::Array(str_array.clone()), method.clone()])
                 .unwrap();
 
             let args = vec![encoded, method];
-            b.iter(|| black_box(decode.invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(decode.invoke(&args).unwrap())
+            })
         });
     }
 }

--- a/datafusion/functions/benches/isnan.rs
+++ b/datafusion/functions/benches/isnan.rs
@@ -32,12 +32,18 @@ fn criterion_benchmark(c: &mut Criterion) {
         let f32_array = Arc::new(create_primitive_array::<Float32Type>(size, 0.2));
         let f32_args = vec![ColumnarValue::Array(f32_array)];
         c.bench_function(&format!("isnan f32 array: {}", size), |b| {
-            b.iter(|| black_box(isnan.invoke(&f32_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(isnan.invoke(&f32_args).unwrap())
+            })
         });
         let f64_array = Arc::new(create_primitive_array::<Float64Type>(size, 0.2));
         let f64_args = vec![ColumnarValue::Array(f64_array)];
         c.bench_function(&format!("isnan f64 array: {}", size), |b| {
-            b.iter(|| black_box(isnan.invoke(&f64_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(isnan.invoke(&f64_args).unwrap())
+            })
         });
     }
 }

--- a/datafusion/functions/benches/iszero.rs
+++ b/datafusion/functions/benches/iszero.rs
@@ -32,12 +32,18 @@ fn criterion_benchmark(c: &mut Criterion) {
         let f32_array = Arc::new(create_primitive_array::<Float32Type>(size, 0.2));
         let f32_args = vec![ColumnarValue::Array(f32_array)];
         c.bench_function(&format!("iszero f32 array: {}", size), |b| {
-            b.iter(|| black_box(iszero.invoke(&f32_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(iszero.invoke(&f32_args).unwrap())
+            })
         });
         let f64_array = Arc::new(create_primitive_array::<Float64Type>(size, 0.2));
         let f64_args = vec![ColumnarValue::Array(f64_array)];
         c.bench_function(&format!("iszero f64 array: {}", size), |b| {
-            b.iter(|| black_box(iszero.invoke(&f64_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(iszero.invoke(&f64_args).unwrap())
+            })
         });
     }
 }

--- a/datafusion/functions/benches/lower.rs
+++ b/datafusion/functions/benches/lower.rs
@@ -124,19 +124,32 @@ fn criterion_benchmark(c: &mut Criterion) {
     for size in [1024, 4096, 8192] {
         let args = create_args1(size, 32);
         c.bench_function(&format!("lower_all_values_are_ascii: {}", size), |b| {
-            b.iter(|| black_box(lower.invoke(&args)))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(lower.invoke(&args))
+            })
         });
 
         let args = create_args2(size);
         c.bench_function(
             &format!("lower_the_first_value_is_nonascii: {}", size),
-            |b| b.iter(|| black_box(lower.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(lower.invoke(&args))
+                })
+            },
         );
 
         let args = create_args3(size);
         c.bench_function(
             &format!("lower_the_middle_value_is_nonascii: {}", size),
-            |b| b.iter(|| black_box(lower.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(lower.invoke(&args))
+                })
+            },
         );
     }
 
@@ -151,24 +164,33 @@ fn criterion_benchmark(c: &mut Criterion) {
                 for &size in &sizes {
                     let args = create_args4(size, str_len, *null_density, mixed);
                     c.bench_function(
-            &format!("lower_all_values_are_ascii_string_views: size: {}, str_len: {}, null_density: {}, mixed: {}",
+                        &format!("lower_all_values_are_ascii_string_views: size: {}, str_len: {}, null_density: {}, mixed: {}",
                      size, str_len, null_density, mixed),
-            |b| b.iter(|| black_box(lower.invoke(&args))),
-        );
+                        |b| b.iter(|| {
+                            #[allow(deprecated)] // TODO use invoke_batch
+                            black_box(lower.invoke(&args))
+                        }),
+                    );
 
                     let args = create_args4(size, str_len, *null_density, mixed);
                     c.bench_function(
-            &format!("lower_all_values_are_ascii_string_views: size: {}, str_len: {}, null_density: {}, mixed: {}",
+                        &format!("lower_all_values_are_ascii_string_views: size: {}, str_len: {}, null_density: {}, mixed: {}",
                      size, str_len, null_density, mixed),
-            |b| b.iter(|| black_box(lower.invoke(&args))),
-        );
+                        |b| b.iter(|| {
+                            #[allow(deprecated)] // TODO use invoke_batch
+                            black_box(lower.invoke(&args))
+                        }),
+                    );
 
                     let args = create_args5(size, 0.1, *null_density);
                     c.bench_function(
-            &format!("lower_some_values_are_nonascii_string_views: size: {}, str_len: {}, non_ascii_density: {}, null_density: {}, mixed: {}",
+                        &format!("lower_some_values_are_nonascii_string_views: size: {}, str_len: {}, non_ascii_density: {}, null_density: {}, mixed: {}",
                      size, str_len, 0.1, null_density, mixed),
-            |b| b.iter(|| black_box(lower.invoke(&args))),
-        );
+                        |b| b.iter(|| {
+                            #[allow(deprecated)] // TODO use invoke_batch
+                            black_box(lower.invoke(&args))
+                        }),
+                    );
                 }
             }
         }

--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -139,7 +139,12 @@ fn run_with_string_type<M: Measurement>(
         format!(
             "{string_type} [size={size}, len_before={len}, len_after={remaining_len}]",
         ),
-        |b| b.iter(|| black_box(ltrim.invoke(&args))),
+        |b| {
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(ltrim.invoke(&args))
+            })
+        },
     );
 }
 

--- a/datafusion/functions/benches/make_date.rs
+++ b/datafusion/functions/benches/make_date.rs
@@ -62,6 +62,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let days = ColumnarValue::Array(Arc::new(days(&mut rng)) as ArrayRef);
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 make_date()
                     .invoke(&[years.clone(), months.clone(), days.clone()])
@@ -77,6 +78,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let days = ColumnarValue::Array(Arc::new(days(&mut rng)) as ArrayRef);
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 make_date()
                     .invoke(&[year.clone(), months.clone(), days.clone()])
@@ -92,6 +94,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let days = ColumnarValue::Array(Arc::new(days(&mut rng)) as ArrayRef);
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 make_date()
                     .invoke(&[year.clone(), month.clone(), days.clone()])
@@ -106,6 +109,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let day = ColumnarValue::Scalar(ScalarValue::Int32(Some(26)));
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 make_date()
                     .invoke(&[year.clone(), month.clone(), day.clone()])

--- a/datafusion/functions/benches/nullif.rs
+++ b/datafusion/functions/benches/nullif.rs
@@ -33,7 +33,10 @@ fn criterion_benchmark(c: &mut Criterion) {
             ColumnarValue::Array(array),
         ];
         c.bench_function(&format!("nullif scalar array: {}", size), |b| {
-            b.iter(|| black_box(nullif.invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(nullif.invoke(&args).unwrap())
+            })
         });
     }
 }

--- a/datafusion/functions/benches/pad.rs
+++ b/datafusion/functions/benches/pad.rs
@@ -101,17 +101,26 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, false);
         group.bench_function(BenchmarkId::new("utf8 type", size), |b| {
-            b.iter(|| criterion::black_box(lpad().invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                criterion::black_box(lpad().invoke(&args).unwrap())
+            })
         });
 
         let args = create_args::<i64>(size, 32, false);
         group.bench_function(BenchmarkId::new("largeutf8 type", size), |b| {
-            b.iter(|| criterion::black_box(lpad().invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                criterion::black_box(lpad().invoke(&args).unwrap())
+            })
         });
 
         let args = create_args::<i32>(size, 32, true);
         group.bench_function(BenchmarkId::new("stringview type", size), |b| {
-            b.iter(|| criterion::black_box(lpad().invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                criterion::black_box(lpad().invoke(&args).unwrap())
+            })
         });
 
         group.finish();
@@ -120,18 +129,27 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, false);
         group.bench_function(BenchmarkId::new("utf8 type", size), |b| {
-            b.iter(|| criterion::black_box(rpad().invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                criterion::black_box(rpad().invoke(&args).unwrap())
+            })
         });
 
         let args = create_args::<i64>(size, 32, false);
         group.bench_function(BenchmarkId::new("largeutf8 type", size), |b| {
-            b.iter(|| criterion::black_box(rpad().invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                criterion::black_box(rpad().invoke(&args).unwrap())
+            })
         });
 
         // rpad for stringview type
         let args = create_args::<i32>(size, 32, true);
         group.bench_function(BenchmarkId::new("stringview type", size), |b| {
-            b.iter(|| criterion::black_box(rpad().invoke(&args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                criterion::black_box(rpad().invoke(&args).unwrap())
+            })
         });
 
         group.finish();

--- a/datafusion/functions/benches/repeat.rs
+++ b/datafusion/functions/benches/repeat.rs
@@ -71,7 +71,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "repeat_string_view [size={}, repeat_times={}]",
                 size, repeat_times
             ),
-            |b| b.iter(|| black_box(repeat.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(repeat.invoke(&args))
+                })
+            },
         );
 
         let args = create_args::<i32>(size, 32, repeat_times, false);
@@ -80,7 +85,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "repeat_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
-            |b| b.iter(|| black_box(repeat.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(repeat.invoke(&args))
+                })
+            },
         );
 
         let args = create_args::<i64>(size, 32, repeat_times, false);
@@ -89,7 +99,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "repeat_large_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
-            |b| b.iter(|| black_box(repeat.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(repeat.invoke(&args))
+                })
+            },
         );
 
         group.finish();
@@ -107,7 +122,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "repeat_string_view [size={}, repeat_times={}]",
                 size, repeat_times
             ),
-            |b| b.iter(|| black_box(repeat.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(repeat.invoke(&args))
+                })
+            },
         );
 
         let args = create_args::<i32>(size, 32, repeat_times, false);
@@ -116,7 +136,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "repeat_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
-            |b| b.iter(|| black_box(repeat.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(repeat.invoke(&args))
+                })
+            },
         );
 
         let args = create_args::<i64>(size, 32, repeat_times, false);
@@ -125,7 +150,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "repeat_large_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
-            |b| b.iter(|| black_box(repeat.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(repeat.invoke(&args))
+                })
+            },
         );
 
         group.finish();

--- a/datafusion/functions/benches/signum.rs
+++ b/datafusion/functions/benches/signum.rs
@@ -32,12 +32,18 @@ fn criterion_benchmark(c: &mut Criterion) {
         let f32_array = Arc::new(create_primitive_array::<Float32Type>(size, 0.2));
         let f32_args = vec![ColumnarValue::Array(f32_array)];
         c.bench_function(&format!("signum f32 array: {}", size), |b| {
-            b.iter(|| black_box(signum.invoke(&f32_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(signum.invoke(&f32_args).unwrap())
+            })
         });
         let f64_array = Arc::new(create_primitive_array::<Float64Type>(size, 0.2));
         let f64_args = vec![ColumnarValue::Array(f64_array)];
         c.bench_function(&format!("signum f64 array: {}", size), |b| {
-            b.iter(|| black_box(signum.invoke(&f64_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(signum.invoke(&f64_args).unwrap())
+            })
         });
     }
 }

--- a/datafusion/functions/benches/strpos.rs
+++ b/datafusion/functions/benches/strpos.rs
@@ -112,28 +112,48 @@ fn criterion_benchmark(c: &mut Criterion) {
         let args_string_ascii = gen_string_array(n_rows, str_len, 0.1, 0.0, false);
         c.bench_function(
             &format!("strpos_StringArray_ascii_str_len_{}", str_len),
-            |b| b.iter(|| black_box(strpos.invoke(&args_string_ascii))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(strpos.invoke(&args_string_ascii))
+                })
+            },
         );
 
         // StringArray UTF8
         let args_string_utf8 = gen_string_array(n_rows, str_len, 0.1, 0.5, false);
         c.bench_function(
             &format!("strpos_StringArray_utf8_str_len_{}", str_len),
-            |b| b.iter(|| black_box(strpos.invoke(&args_string_utf8))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(strpos.invoke(&args_string_utf8))
+                })
+            },
         );
 
         // StringViewArray ASCII only
         let args_string_view_ascii = gen_string_array(n_rows, str_len, 0.1, 0.0, true);
         c.bench_function(
             &format!("strpos_StringViewArray_ascii_str_len_{}", str_len),
-            |b| b.iter(|| black_box(strpos.invoke(&args_string_view_ascii))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(strpos.invoke(&args_string_view_ascii))
+                })
+            },
         );
 
         // StringViewArray UTF8
         let args_string_view_utf8 = gen_string_array(n_rows, str_len, 0.1, 0.5, true);
         c.bench_function(
             &format!("strpos_StringViewArray_utf8_str_len_{}", str_len),
-            |b| b.iter(|| black_box(strpos.invoke(&args_string_view_utf8))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(strpos.invoke(&args_string_view_utf8))
+                })
+            },
         );
     }
 }

--- a/datafusion/functions/benches/substr.rs
+++ b/datafusion/functions/benches/substr.rs
@@ -107,19 +107,34 @@ fn criterion_benchmark(c: &mut Criterion) {
         let args = create_args_without_count::<i32>(size, len, true, true);
         group.bench_function(
             format!("substr_string_view [size={}, strlen={}]", size, len),
-            |b| b.iter(|| black_box(substr.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(substr.invoke(&args))
+                })
+            },
         );
 
         let args = create_args_without_count::<i32>(size, len, false, false);
         group.bench_function(
             format!("substr_string [size={}, strlen={}]", size, len),
-            |b| b.iter(|| black_box(substr.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(substr.invoke(&args))
+                })
+            },
         );
 
         let args = create_args_without_count::<i64>(size, len, true, false);
         group.bench_function(
             format!("substr_large_string [size={}, strlen={}]", size, len),
-            |b| b.iter(|| black_box(substr.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(substr.invoke(&args))
+                })
+            },
         );
 
         group.finish();
@@ -137,7 +152,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "substr_string_view [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
-            |b| b.iter(|| black_box(substr.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(substr.invoke(&args))
+                })
+            },
         );
 
         let args = create_args_with_count::<i32>(size, len, count, false);
@@ -146,7 +166,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "substr_string [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
-            |b| b.iter(|| black_box(substr.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(substr.invoke(&args))
+                })
+            },
         );
 
         let args = create_args_with_count::<i64>(size, len, count, false);
@@ -155,7 +180,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "substr_large_string [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
-            |b| b.iter(|| black_box(substr.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(substr.invoke(&args))
+                })
+            },
         );
 
         group.finish();
@@ -173,7 +203,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "substr_string_view [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
-            |b| b.iter(|| black_box(substr.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(substr.invoke(&args))
+                })
+            },
         );
 
         let args = create_args_with_count::<i32>(size, len, count, false);
@@ -182,7 +217,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "substr_string [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
-            |b| b.iter(|| black_box(substr.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(substr.invoke(&args))
+                })
+            },
         );
 
         let args = create_args_with_count::<i64>(size, len, count, false);
@@ -191,7 +231,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 "substr_large_string [size={}, count={}, strlen={}]",
                 size, count, len,
             ),
-            |b| b.iter(|| black_box(substr.invoke(&args))),
+            |b| {
+                b.iter(|| {
+                    #[allow(deprecated)] // TODO use invoke_batch
+                    black_box(substr.invoke(&args))
+                })
+            },
         );
 
         group.finish();

--- a/datafusion/functions/benches/substr_index.rs
+++ b/datafusion/functions/benches/substr_index.rs
@@ -90,6 +90,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = [strings, delimiters, counts];
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 substr_index()
                     .invoke(&args)

--- a/datafusion/functions/benches/to_char.rs
+++ b/datafusion/functions/benches/to_char.rs
@@ -86,6 +86,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let patterns = ColumnarValue::Array(Arc::new(patterns(&mut rng)) as ArrayRef);
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 to_char()
                     .invoke(&[data.clone(), patterns.clone()])
@@ -101,6 +102,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ColumnarValue::Scalar(ScalarValue::Utf8(Some("%Y-%m-%d".to_string())));
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 to_char()
                     .invoke(&[data.clone(), patterns.clone()])
@@ -124,6 +126,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         )));
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 to_char()
                     .invoke(&[data.clone(), pattern.clone()])

--- a/datafusion/functions/benches/to_timestamp.rs
+++ b/datafusion/functions/benches/to_timestamp.rs
@@ -113,6 +113,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let string_array = ColumnarValue::Array(Arc::new(data()) as ArrayRef);
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 to_timestamp()
                     .invoke(&[string_array.clone()])
@@ -126,6 +127,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let string_array = ColumnarValue::Array(Arc::new(data) as ArrayRef);
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 to_timestamp()
                     .invoke(&[string_array.clone()])
@@ -139,6 +141,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let string_array = ColumnarValue::Array(Arc::new(data) as ArrayRef);
 
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 to_timestamp()
                     .invoke(&[string_array.clone()])
@@ -157,6 +160,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ColumnarValue::Array(Arc::new(format3) as ArrayRef),
         ];
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 to_timestamp()
                     .invoke(&args.clone())
@@ -183,6 +187,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ),
         ];
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 to_timestamp()
                     .invoke(&args.clone())
@@ -209,6 +214,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ),
         ];
         b.iter(|| {
+            #[allow(deprecated)] // TODO use invoke_batch
             black_box(
                 to_timestamp()
                     .invoke(&args.clone())

--- a/datafusion/functions/benches/trunc.rs
+++ b/datafusion/functions/benches/trunc.rs
@@ -33,12 +33,18 @@ fn criterion_benchmark(c: &mut Criterion) {
         let f32_array = Arc::new(create_primitive_array::<Float32Type>(size, 0.2));
         let f32_args = vec![ColumnarValue::Array(f32_array)];
         c.bench_function(&format!("trunc f32 array: {}", size), |b| {
-            b.iter(|| black_box(trunc.invoke(&f32_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(trunc.invoke(&f32_args).unwrap())
+            })
         });
         let f64_array = Arc::new(create_primitive_array::<Float64Type>(size, 0.2));
         let f64_args = vec![ColumnarValue::Array(f64_array)];
         c.bench_function(&format!("trunc f64 array: {}", size), |b| {
-            b.iter(|| black_box(trunc.invoke(&f64_args).unwrap()))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(trunc.invoke(&f64_args).unwrap())
+            })
         });
     }
 }

--- a/datafusion/functions/benches/upper.rs
+++ b/datafusion/functions/benches/upper.rs
@@ -37,7 +37,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     for size in [1024, 4096, 8192] {
         let args = create_args(size, 32);
         c.bench_function("upper_all_values_are_ascii", |b| {
-            b.iter(|| black_box(upper.invoke(&args)))
+            b.iter(|| {
+                #[allow(deprecated)] // TODO use invoke_batch
+                black_box(upper.invoke(&args))
+            })
         });
     }
 }

--- a/datafusion/functions/src/core/version.rs
+++ b/datafusion/functions/src/core/version.rs
@@ -118,7 +118,7 @@ mod test {
     #[tokio::test]
     async fn test_version_udf() {
         let version_udf = ScalarUDF::from(VersionFunc::new());
-        let version = version_udf.invoke_no_args(0).unwrap();
+        let version = version_udf.invoke_batch(&[], 1).unwrap();
 
         if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(version))) = version {
             assert!(version.starts_with("Apache DataFusion"));


### PR DESCRIPTION
`invoke_batch` is the one used now. The others are no longer in use and we should deprecate and remove them.

Extracted from https://github.com/apache/datafusion/pull/13174
