### PR TITLE
join_with_expr_keys to support expressions with both unqualified and qualified column names

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1214,15 +1214,37 @@ impl LogicalPlanBuilder {
             return plan_err!("left_keys and right_keys were not the same length");
         }
 
-        let join_key_pairs = equi_exprs
+        let exprs: Vec<(Expr, Expr)> = equi_exprs
             .0
             .into_iter()
             .zip(equi_exprs.1.into_iter())
-            .map(|(l, r)| {
-                let left_key = l.into();
-                let right_key = r.into();
+            .map(|(l, r)| (l.into(), r.into()))
+            .collect();
 
-                let mut left_using_columns = HashSet::new();
+        let columns: Vec<_> = exprs
+            .iter()
+            .filter_map(|(l, r)| {
+                l.try_as_col().and_then(|left_col| {
+                    r.try_as_col().map(|right_col| (left_col, right_col))
+                })
+            })
+            .collect();
+        if columns.len() == exprs.len() {
+            // all expressions are columns
+            return self.join(
+                right,
+                join_type,
+                columns
+                    .into_iter()
+                    .map(|(c1, c2)| (c1.clone(), c2.clone()))
+                    .unzip(),
+                filter,
+            );
+        }
+
+        let join_key_pairs = exprs.into_iter()
+            .map(|(left_key, right_key)| {
+                let mut left_using_columns  = HashSet::new();
                 expr_to_columns(&left_key, &mut left_using_columns)?;
                 let normalized_left_key = normalize_col_with_schemas_and_ambiguity_check(
                     left_key,

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1217,7 +1217,7 @@ impl LogicalPlanBuilder {
         let exprs: Vec<(Expr, Expr)> = equi_exprs
             .0
             .into_iter()
-            .zip(equi_exprs.1.into_iter())
+            .zip(equi_exprs.1)
             .map(|(l, r)| (l.into(), r.into()))
             .collect();
 

--- a/datafusion/optimizer/src/filter_null_join_keys.rs
+++ b/datafusion/optimizer/src/filter_null_join_keys.rs
@@ -264,6 +264,25 @@ mod tests {
         assert_optimized_plan_equal(plan, expected)
     }
 
+    #[test]
+    fn one_side_unqualified() -> Result<()> {
+        let (t1, t2) = test_tables()?;
+        let plan = LogicalPlanBuilder::from(t1)
+            .join_with_expr_keys(
+                t2,
+                JoinType::Inner,
+                (vec![col("optional_id")], vec![col("t2.optional_id")]),
+                None,
+            )?
+            .build()?;
+        let expected = "Inner Join: t1.optional_id = t2.optional_id\
+        \n  Filter: t1.optional_id + UInt32(1) IS NOT NULL\
+        \n    TableScan: t1\
+        \n  Filter: t2.optional_id + UInt32(1) IS NOT NULL\
+        \n    TableScan: t2";
+        assert_optimized_plan_equal(plan, expected)
+    }
+
     fn build_plan(
         left_table: LogicalPlan,
         right_table: LogicalPlan,

--- a/datafusion/optimizer/src/filter_null_join_keys.rs
+++ b/datafusion/optimizer/src/filter_null_join_keys.rs
@@ -265,22 +265,31 @@ mod tests {
     }
 
     #[test]
-    fn one_side_unqualified() -> Result<()> {
+    fn exprs_are_all_columns() -> Result<()> {
         let (t1, t2) = test_tables()?;
-        let plan = LogicalPlanBuilder::from(t1)
+        let plan_from_exprs = LogicalPlanBuilder::from(t1.clone())
             .join_with_expr_keys(
-                t2,
+                t2.clone(),
                 JoinType::Inner,
                 (vec![col("optional_id")], vec![col("t2.optional_id")]),
                 None,
             )?
             .build()?;
+        let plan_from_cols = LogicalPlanBuilder::from(t1)
+            .join(
+                t2,
+                JoinType::Inner,
+                (vec!["optional_id"], vec!["t2.optional_id"]),
+                None,
+            )?
+            .build()?;
         let expected = "Inner Join: t1.optional_id = t2.optional_id\
-        \n  Filter: t1.optional_id + UInt32(1) IS NOT NULL\
+        \n  Filter: t1.optional_id IS NOT NULL\
         \n    TableScan: t1\
-        \n  Filter: t2.optional_id + UInt32(1) IS NOT NULL\
+        \n  Filter: t2.optional_id IS NOT NULL\
         \n    TableScan: t2";
-        assert_optimized_plan_equal(plan, expected)
+        assert_optimized_plan_equal(plan_from_cols, expected)?;
+        assert_optimized_plan_equal(plan_from_exprs, expected)
     }
 
     fn build_plan(

--- a/datafusion/optimizer/src/filter_null_join_keys.rs
+++ b/datafusion/optimizer/src/filter_null_join_keys.rs
@@ -265,7 +265,7 @@ mod tests {
     }
 
     #[test]
-    fn exprs_are_all_columns() -> Result<()> {
+    fn one_side_unqualified() -> Result<()> {
         let (t1, t2) = test_tables()?;
         let plan_from_exprs = LogicalPlanBuilder::from(t1.clone())
             .join_with_expr_keys(


### PR DESCRIPTION
## Which issue does this PR close?
`LogicalPlanBuilder::join_with_expr_keys` rejects join conditions when the join expression has one unqualified and one qualified column with the same name. This is not consistent with `LogicalPlanBuilder::join` where such cases are handled well.



## Rationale for this change
This becomes a problem in `datafusion::proto` where joins are deserialised with using `join_with_expr_keys`.

Specifically, a join condition like `... from t1 join t2 where id = t2.id` where `t1.id` is written unqualified is successfully parsed and the logical plan is created. However, when it comes to deserialising such plan from proto, we hit get ambiguous reference error, and fail to deserialise.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Normalising left and right keys only get the schema for their respective tables
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
A new unit test is added
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

`join_with_expr_keys` already has a constraint on expression order, that the left side expressions can only refer to the left input and vice-a-versa for right side expressions. This PR carries that same constraint to the column normalisation part. No behaviour changes should occur.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
