### PR TITLE
Example: FFI Table Provider as dynamic module loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ members = [
     "datafusion/substrait",
     "datafusion/wasmtest",
     "datafusion-examples",
+    "datafusion-examples/examples/ffi/ffi_example_table_provider",
+    "datafusion-examples/examples/ffi/ffi_module_interface",
+    "datafusion-examples/examples/ffi/ffi_module_loader",
     "test-utils",
     "benchmarks",
 ]

--- a/datafusion-examples/examples/ffi/README.md
+++ b/datafusion-examples/examples/ffi/README.md
@@ -1,0 +1,48 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Example FFI Usage
+
+The purpose of these crates is to provide an example of how one can use the
+DataFusion Foreign Function Interface (FFI). See [API Docs] for detailed
+usage.
+
+This example is broken into three crates.
+
+- `ffi_module_interface` is a common library to be shared by both the module
+  to be loaded and the program that will load it. It defines how the module
+  is to be structured.
+- `ffi_example_table_provider` creates a library to exposes the module.
+- `ffi_module_loader` is an example program that loads the module, gets data
+  from it, and displays this data to the user.
+
+## Building and running
+
+In order for the program to run successfully, the module to be loaded must be
+built first. This example expects both the module and the program to be
+built using the same build mode (debug or release).
+
+```shell
+cd ffi_example_table_provider
+cargo build
+cd ../ffi_module_loader
+cargo run
+```
+
+[api docs]: http://docs.rs/datafusion-ffi/latest

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "ffi_example_table_provider"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 publish = false
 
 [dependencies]

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
@@ -21,14 +21,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-datafusion = { workspace = true }
-datafusion-ffi = { workspace = true }
 abi_stable = "0.11.3"
 arrow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
+datafusion = { workspace = true }
+datafusion-ffi = { workspace = true }
 ffi_module_interface = { path = "../ffi_module_interface" }
 
 [lib]
 name = "ffi_example_table_provider"
-crate-type = ["cdylib",'rlib']
+crate-type = ["cdylib", 'rlib']

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
@@ -19,6 +19,7 @@
 name = "ffi_example_table_provider"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 abi_stable = "0.11.3"

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = "ffi_example_table_provider"
 version = "0.1.0"

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ffi_example_table_provider"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+datafusion = { workspace = true }
+datafusion-ffi = { workspace = true }
+abi_stable = "0.11.3"
+arrow = { workspace = true }
+arrow-array = { workspace = true }
+arrow-schema = { workspace = true }
+ffi_module_interface = { path = "../ffi_module_interface" }
+
+[lib]
+name = "ffi_example_table_provider"
+crate-type = ["cdylib",'rlib']

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/src/lib.rs
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/src/lib.rs
@@ -35,12 +35,16 @@ fn create_record_batch(start_value: i32, num_values: usize) -> RecordBatch {
     record_batch!(("a", Int32, a_vals), ("b", Float64, b_vals)).unwrap()
 }
 
+/// Here we only wish to create a simple table provider as an example.
+/// We create an in-memory table and convert it to it's FFI counterpart.
 extern "C" fn construct_simple_table_provider() -> FFI_TableProvider {
     let schema = Arc::new(Schema::new(vec![
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Float64, true),
     ]));
 
+    // It is useful to create these as multiple record batches
+    // so that we can demonstrate the FFI stream.
     let batches = vec![
         create_record_batch(1, 5),
         create_record_batch(6, 1),
@@ -53,6 +57,7 @@ extern "C" fn construct_simple_table_provider() -> FFI_TableProvider {
 }
 
 #[export_root_module]
+/// This defines the entry point for using the module.
 pub fn get_simple_memory_table() -> TableProviderModuleRef {
     TableProviderModule {
         create_table: construct_simple_table_provider,

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/src/lib.rs
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/src/lib.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use abi_stable::{export_root_module, prefix_type::PrefixTypeTrait};
+use arrow_array::RecordBatch;
+use datafusion::{
+    arrow::datatypes::{DataType, Field, Schema},
+    common::record_batch,
+    datasource::MemTable,
+};
+use datafusion_ffi::table_provider::FFI_TableProvider;
+use ffi_module_interface::{TableProviderModule, TableProviderModuleRef};
+
+fn create_record_batch(start_value: i32, num_values: usize) -> RecordBatch {
+    let end_value = start_value + num_values as i32;
+    let a_vals: Vec<i32> = (start_value..end_value).collect();
+    let b_vals: Vec<f64> = a_vals.iter().map(|v| *v as f64).collect();
+
+    record_batch!(("a", Int32, a_vals), ("b", Float64, b_vals)).unwrap()
+}
+
+extern "C" fn construct_simple_table_provider() -> FFI_TableProvider {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, true),
+        Field::new("b", DataType::Float64, true),
+    ]));
+
+    let batches = vec![
+        create_record_batch(1, 5),
+        create_record_batch(6, 1),
+        create_record_batch(7, 5),
+    ];
+
+    let table_provider = MemTable::try_new(schema, vec![batches]).unwrap();
+
+    FFI_TableProvider::new(Arc::new(table_provider), true)
+}
+
+#[export_root_module]
+pub fn get_simple_memory_table() -> TableProviderModuleRef {
+    TableProviderModule {
+        create_table: construct_simple_table_provider,
+    }
+    .leak_into_prefix()
+}

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/src/lib.rs
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/src/lib.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::sync::Arc;
 
 use abi_stable::{export_root_module, prefix_type::PrefixTypeTrait};

--- a/datafusion-examples/examples/ffi/ffi_module_interface/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_module_interface/Cargo.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = "ffi_module_interface"
 version = "0.1.0"

--- a/datafusion-examples/examples/ffi/ffi_module_interface/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_module_interface/Cargo.toml
@@ -19,6 +19,7 @@
 name = "ffi_module_interface"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 abi_stable = "0.11.3"

--- a/datafusion-examples/examples/ffi/ffi_module_interface/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_module_interface/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ffi_module_interface"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+abi_stable = "0.11.3"
+datafusion-ffi = { workspace = true }

--- a/datafusion-examples/examples/ffi/ffi_module_interface/src/lib.rs
+++ b/datafusion-examples/examples/ffi/ffi_module_interface/src/lib.rs
@@ -1,0 +1,27 @@
+use abi_stable::{
+    declare_root_module_statics,
+    library::{LibraryError, RootModule},
+    package_version_strings,
+    sabi_types::VersionStrings,
+    StableAbi,
+};
+use datafusion_ffi::table_provider::FFI_TableProvider;
+
+#[repr(C)]
+#[derive(StableAbi)]
+#[sabi(kind(Prefix(prefix_ref = TableProviderModuleRef)))]
+pub struct TableProviderModule {
+    /// Constructs the table provider
+    pub create_table: extern "C" fn() -> FFI_TableProvider,
+}
+
+impl RootModule for TableProviderModuleRef {
+    declare_root_module_statics! {TableProviderModuleRef}
+    const BASE_NAME: &'static str = "ffi_example_table_provider";
+    const NAME: &'static str = "ffi_example_table_provider";
+    const VERSION_STRINGS: VersionStrings = package_version_strings!();
+
+    fn initialization(self) -> Result<Self, LibraryError> {
+        Ok(self)
+    }
+}

--- a/datafusion-examples/examples/ffi/ffi_module_interface/src/lib.rs
+++ b/datafusion-examples/examples/ffi/ffi_module_interface/src/lib.rs
@@ -27,6 +27,11 @@ use datafusion_ffi::table_provider::FFI_TableProvider;
 #[repr(C)]
 #[derive(StableAbi)]
 #[sabi(kind(Prefix(prefix_ref = TableProviderModuleRef)))]
+/// This struct defines the module interfaces. It is to be shared by
+/// both the module loading program and library that implements the
+/// module. It is possible to move this definition into the loading
+/// program and reference it in the modules, but this example shows
+/// how a user may wish to separate these concerns.
 pub struct TableProviderModule {
     /// Constructs the table provider
     pub create_table: extern "C" fn() -> FFI_TableProvider,

--- a/datafusion-examples/examples/ffi/ffi_module_interface/src/lib.rs
+++ b/datafusion-examples/examples/ffi/ffi_module_interface/src/lib.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use abi_stable::{
     declare_root_module_statics,
     library::{LibraryError, RootModule},

--- a/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
@@ -21,8 +21,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }
+abi_stable = "0.11.3"
 datafusion = { workspace = true }
 datafusion-ffi = { workspace = true }
 ffi_module_interface = { path = "../ffi_module_interface" }
-abi_stable = "0.11.3"
+tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }

--- a/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ffi_module_loader"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }
+datafusion = { workspace = true }
+datafusion-ffi = { workspace = true }
+ffi_module_interface = { path = "../ffi_module_interface" }
+abi_stable = "0.11.3"

--- a/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = "ffi_module_loader"
 version = "0.1.0"

--- a/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
@@ -19,6 +19,7 @@
 name = "ffi_module_loader"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 abi_stable = "0.11.3"

--- a/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::sync::Arc;
 
 use datafusion::{

--- a/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+
+use datafusion::{
+    error::{DataFusionError, Result},
+    prelude::SessionContext,
+};
+
+use abi_stable::library::{development_utils::compute_library_path, RootModule};
+use datafusion_ffi::table_provider::ForeignTableProvider;
+use ffi_module_interface::TableProviderModuleRef;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let target: &std::path::Path = "../../../../target/".as_ref();
+    let library_path = compute_library_path::<TableProviderModuleRef>(target).unwrap();
+
+    let table_provider_module =
+        TableProviderModuleRef::load_from_directory(&library_path)
+            .unwrap_or_else(|e| panic!("{}", e));
+
+    let ffi_table_provider =
+        table_provider_module
+            .create_table()
+            .ok_or(DataFusionError::NotImplemented(
+                "External table provider failed to implement create_table".to_string(),
+            ))?();
+
+    let foreign_table_provider: ForeignTableProvider = (&ffi_table_provider).into();
+
+    let ctx = SessionContext::new();
+
+    ctx.register_table("external_table", Arc::new(foreign_table_provider))?;
+
+    let df = ctx.table("external_table").await?;
+
+    df.show().await?;
+
+    Ok(())
+}

--- a/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
@@ -28,13 +28,19 @@ use ffi_module_interface::TableProviderModuleRef;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Find the location of the library. This is specific to the build environment,
+    // so you will need to change the approach here based on your use case.
     let target: &std::path::Path = "../../../../target/".as_ref();
-    let library_path = compute_library_path::<TableProviderModuleRef>(target).unwrap();
+    let library_path = compute_library_path::<TableProviderModuleRef>(target)
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
+    // Load the module
     let table_provider_module =
         TableProviderModuleRef::load_from_directory(&library_path)
-            .unwrap_or_else(|e| panic!("{}", e));
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
+    // By calling the code below, the table provided will be created within
+    // the module's code.
     let ffi_table_provider =
         table_provider_module
             .create_table()
@@ -42,14 +48,15 @@ async fn main() -> Result<()> {
                 "External table provider failed to implement create_table".to_string(),
             ))?();
 
+    // In order to access the table provider within this executable, we need to
+    // turn it into a `ForeignTableProvider`.
     let foreign_table_provider: ForeignTableProvider = (&ffi_table_provider).into();
 
     let ctx = SessionContext::new();
 
+    // Display the data to show the full cycle works.
     ctx.register_table("external_table", Arc::new(foreign_table_provider))?;
-
     let df = ctx.table("external_table").await?;
-
     df.show().await?;
 
     Ok(())

--- a/datafusion/ffi/README.md
+++ b/datafusion/ffi/README.md
@@ -25,7 +25,7 @@ with functions from other languages using a stable interface.
 See [API Docs] for details and examples.
 
 We expect this crate may be used by both sides of the FFI. This allows users
-to create modules that can interoperate with the necessity of using the same
+to create modules that can interoperate without the necessity of using the same
 version of DataFusion. The driving use case has been the `datafusion-python`
 repository, but many other use cases may exist. We envision at least two
 use cases.
@@ -43,7 +43,7 @@ In this crate we have a variety of structs which closely mimic the behavior of
 their internal counterparts. In the following example, we will refer to the
 `TableProvider`, but the same pattern exists for other structs.
 
-Each of the exposted structs in this crate is provided with a variant prefixed
+Each of the exposed structs in this crate is provided with a variant prefixed
 with `Foreign`. This variant is designed to be used by the consumer of the
 foreign code. The `Foreign` structs should _never_ access the `private_data`
 fields. Instead they should only access the data returned through the function

--- a/datafusion/ffi/README.md
+++ b/datafusion/ffi/README.md
@@ -51,7 +51,7 @@ be all inclusive.
    code base. With `datafusion-ffi` these packages do not need `datafusion-python`
    as a dependency at all.
 2. Users may want to create a modular interface that allows runtime loading of
-   libraries. For example, you may wish to design a program that only uses the 
+   libraries. For example, you may wish to design a program that only uses the
    built in table sources, but also allows for extension from the community led
    [datafusion-contrib] repositories. You could enable module loading so that
    users could at runtime load a library to access additional data sources.
@@ -96,8 +96,8 @@ the example in `FFI_TableProvider`.
 
 [datafusion]: https://datafusion.apache.org
 [api docs]: http://docs.rs/datafusion-ffi/latest
-[Rust ABI]: https://doc.rust-lang.org/reference/abi.html
-[FFI]: https://doc.rust-lang.org/nomicon/ffi.html
+[rust abi]: https://doc.rust-lang.org/reference/abi.html
+[ffi]: https://doc.rust-lang.org/nomicon/ffi.html
 [abi_stable]: https://crates.io/crates/abi_stable
 [async-ffi]: https://crates.io/crates/async-ffi
 [bindgen]: https://crates.io/crates/bindgen

--- a/datafusion/ffi/README.md
+++ b/datafusion/ffi/README.md
@@ -88,6 +88,13 @@ can expose it by using `FFI_TableProvider::new()`. When you need to consume a
 There is a complete end to end demonstration in the
 [examples](https://github.com/apache/datafusion/tree/main/datafusion-examples/examples/ffi).
 
+## Asynchronous Calls
+
+Some of the functions with this crate require asynchronous operation. These
+will perform similar to their pure rust counterparts by using the [async-ffi]
+crate. In general, any call to an asynchronous function in this interface will
+not block the rest of the program's execution.
+
 ## Struct Layout
 
 In this crate we have a variety of structs which closely mimic the behavior of


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13175

## Rationale for this change

PR #12920 introduces FFI bindings for TableProvider but did not show an end to end example of using these. This PR improves the documentation for how to use the `datafusion-ffi` crate and a complete example of building one library that exposes a table provider and loading it from a different binary.

## What changes are included in this PR?

Adds three crates to show interface, implementation, and using a library table provider.

## Are these changes tested?

These are an example, not any change to core functionality.

## Are there any user-facing changes?

None.