### PR TITLE
Fix rendering of dictionary empty string values in SLT tests

### DIFF
--- a/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::engines::output::DFColumnType;
-use arrow::array::Array;
+use arrow::array::{Array, AsArray};
 use arrow::datatypes::Fields;
 use arrow::util::display::ArrayFormatter;
 use arrow::{array, array::ArrayRef, datatypes::DataType, record_batch::RecordBatch};
@@ -238,6 +238,11 @@ pub fn cell_to_string(col: &ArrayRef, row: usize) -> Result<String> {
                 col,
                 row
             ))),
+            DataType::Dictionary(_, _) => {
+                let dict = col.as_any_dictionary();
+                let key = dict.normalized_keys()[row];
+                Ok(cell_to_string(dict.values(), key)?)
+            }
             _ => {
                 let f = ArrayFormatter::try_new(col.as_ref(), &DEFAULT_FORMAT_OPTIONS);
                 Ok(f.unwrap().value(row).to_string())

--- a/datafusion/sqllogictest/test_files/string/dictionary_utf8.slt
+++ b/datafusion/sqllogictest/test_files/string/dictionary_utf8.slt
@@ -37,6 +37,11 @@ select arrow_cast(col1, 'Dictionary(Int32, Utf8)') as c1 from test_substr_base;
 statement ok
 drop table test_source
 
+query T
+SELECT arrow_cast('', 'Dictionary(Int32, Utf8)');
+----
+(empty)
+
 # TODO: move it back to `string_query.slt.part` after fixing the issue
 # see detail: https://github.com/apache/datafusion/issues/12637
 # Test pattern with wildcard characters


### PR DESCRIPTION
In SLT tests string rendering, including empty string rendering, needs to be consistent.
This fixes the rendering of `''` dictionary-encoded values.

The consistency guarantee could be made through string_query.slt.part, but this triggers other problems in the SLT framework that need to be solved first. See https://github.com/apache/datafusion/pull/13197 

