### PR TITLE
Minor: Reduce indirection for finding changlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   under the License.
 -->
 
-* [DataFusion CHANGELOG](./datafusion/CHANGELOG.md)
+Change logs for each release can be found [here](dev/changelog).
+
 
 For older versions, see [apache/arrow/CHANGELOG.md](https://github.com/apache/arrow/blob/master/CHANGELOG.md).

--- a/datafusion/CHANGELOG.md
+++ b/datafusion/CHANGELOG.md
@@ -19,4 +19,4 @@
 
 # Changelog
 
-Change logs for each release can be found [here](../dev/changelog).
+Change logs for each release can be found [here](https://github.com/apache/datafusion/tree/main/dev/changelog).

--- a/datafusion/CHANGELOG.md
+++ b/datafusion/CHANGELOG.md
@@ -19,4 +19,4 @@
 
 # Changelog
 
-Change logs for each release can be found [here](https://github.com/apache/datafusion/tree/main/dev/changelog).
+Change logs for each release can be found [here](../dev/changelog).


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Right now, if you look at the datafusion changelog

https://github.com/apache/datafusion/blob/main/CHANGELOG.md

It directs you to
https://github.com/apache/datafusion/blob/main/datafusion/CHANGELOG.md

Which then directs you to
https://github.com/apache/datafusion/tree/main/dev/changelog

This both requires 3 clicks as well as ends up directing you to the `main` version of the tree rather than a previous branch. 
## What changes are included in this PR?
1. Update the main changelog page to point directly to the changelog directory

See rendered versions here: 
https://github.com/alamb/datafusion/blob/alamb/improve_changelog/CHANGELOG.md


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
