### PR TITLE
Minor: make `Expr::volatile` infallible

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1574,8 +1574,14 @@ impl Expr {
 
     /// Returns true if the expression is volatile, i.e. whether it can return different
     /// results when evaluated multiple times with the same input.
-    pub fn is_volatile(&self) -> Result<bool> {
+    ///
+    /// For example the function call `RANDOM()` is volatile as each call will
+    /// return a different value.
+    ///
+    /// See [`Volatility`] for more information.
+    pub fn is_volatile(&self) -> bool {
         self.exists(|expr| Ok(expr.is_volatile_node()))
+            .unwrap()
     }
 
     /// Recursively find all [`Expr::Placeholder`] expressions, and

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1580,8 +1580,7 @@ impl Expr {
     ///
     /// See [`Volatility`] for more information.
     pub fn is_volatile(&self) -> bool {
-        self.exists(|expr| Ok(expr.is_volatile_node()))
-            .unwrap()
+        self.exists(|expr| Ok(expr.is_volatile_node())).unwrap()
     }
 
     /// Recursively find all [`Expr::Placeholder`] expressions, and

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1200,7 +1200,7 @@ fn rewrite_projection(
 
             (qualified_name(qualifier, field.name()), expr)
         })
-        .partition(|(_, value)| value.is_volatile().unwrap_or(true));
+        .partition(|(_, value)| value.is_volatile());
 
     let mut push_predicates = vec![];
     let mut keep_predicates = vec![];


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to 
- https://github.com/apache/datafusion/issues/13060
- https://github.com/apache/datafusion/pull/13128

## Rationale for this change

While reviewing https://github.com/apache/datafusion/pull/13128  I noticed that the code got a bit more complicated because `Expr::volatile` returns `Result<bool>` and thus the calling code needs now to pass up `Results`

However, `Expr::volatile` is actually infallible (never returns an error) so let's mark it as such to keep the code simpler

This is also consistent with other `Expr` methods such as `Expr::any_column_refs`


## What changes are included in this PR?
1. Minor: `Expr::volatile` infallible
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
By existing CI

## Are there any user-facing changes?
* The signature of `Expr::volatile` has changed