### PR TITLE
allow passing in metadata_size_hint on a per-file basis

### DIFF
--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -422,6 +422,7 @@ pub(crate) mod test_util {
             range: None,
             statistics: None,
             extensions: None,
+            metadata_size_hint: None,
         }]];
 
         let exec = format

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -469,6 +469,7 @@ pub async fn pruned_partition_list<'a>(
                     range: None,
                     statistics: None,
                     extensions: None,
+                    metadata_size_hint: None,
                 })
             }));
 

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -81,6 +81,8 @@ pub struct PartitionedFile {
     pub statistics: Option<Statistics>,
     /// An optional field for user defined per object metadata
     pub extensions: Option<Arc<dyn std::any::Any + Send + Sync>>,
+    /// The estimated size of the parquet metadata, in bytes
+    pub metadata_size_hint: Option<usize>,
 }
 
 impl PartitionedFile {
@@ -98,6 +100,7 @@ impl PartitionedFile {
             range: None,
             statistics: None,
             extensions: None,
+            metadata_size_hint: None,
         }
     }
 
@@ -115,8 +118,14 @@ impl PartitionedFile {
             range: Some(FileRange { start, end }),
             statistics: None,
             extensions: None,
+            metadata_size_hint: None,
         }
         .with_range(start, end)
+    }
+
+    pub fn with_metadata_size_hint(mut self, metadata_size_hint: usize) -> Self {
+        self.metadata_size_hint = Some(metadata_size_hint);
+        self
     }
 
     /// Return a file reference from the given path
@@ -156,6 +165,7 @@ impl From<ObjectMeta> for PartitionedFile {
             range: None,
             statistics: None,
             extensions: None,
+            metadata_size_hint: None,
         }
     }
 }

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -123,6 +123,7 @@ impl PartitionedFile {
         .with_range(start, end)
     }
 
+    /// Add a metadata size hint to this file
     pub fn with_metadata_size_hint(mut self, metadata_size_hint: usize) -> Self {
         self.metadata_size_hint = Some(metadata_size_hint);
         self

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -123,7 +123,9 @@ impl PartitionedFile {
         .with_range(start, end)
     }
 
-    /// Add a metadata size hint to this file
+    /// Provide a hint to the size of the file metadata. If a hint is provided
+    /// the reader will try and fetch the last `size_hint` bytes of the parquet file optimistically.
+    /// Without an appropriate hint, two read may be required to fetch the metadata.
     pub fn with_metadata_size_hint(mut self, metadata_size_hint: usize) -> Self {
         self.metadata_size_hint = Some(metadata_size_hint);
         self

--- a/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
@@ -1207,6 +1207,7 @@ mod tests {
                             .collect::<Vec<_>>(),
                     }),
                     extensions: None,
+                    metadata_size_hint: None,
                 }
             }
         }

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -295,6 +295,7 @@ impl<F: FileOpener> FileStream<F> {
             object_meta: part_file.object_meta,
             range: part_file.range,
             extensions: part_file.extensions,
+            metadata_size_hint: part_file.metadata_size_hint,
         };
 
         Some(

--- a/datafusion/core/src/datasource/physical_plan/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/mod.rs
@@ -247,6 +247,8 @@ pub struct FileMeta {
     pub range: Option<FileRange>,
     /// An optional field for user defined per object metadata
     pub extensions: Option<Arc<dyn std::any::Any + Send + Sync>>,
+    /// Size hint for the metadata of this file
+    pub metadata_size_hint: Option<usize>,
 }
 
 impl FileMeta {
@@ -262,6 +264,7 @@ impl From<ObjectMeta> for FileMeta {
             object_meta,
             range: None,
             extensions: None,
+            metadata_size_hint: None,
         }
     }
 }
@@ -776,6 +779,7 @@ mod tests {
             range: None,
             statistics: None,
             extensions: None,
+            metadata_size_hint: None,
         }
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -2443,6 +2443,7 @@ mod tests {
         }
     }
 
+    /// Test passing `metadata_size_hint` to either a single file or the whole exec
     #[tokio::test]
     async fn test_metadata_size_hint() {
         let store =

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -1656,6 +1656,7 @@ mod tests {
                 range: Some(FileRange { start, end }),
                 statistics: None,
                 extensions: None,
+                metadata_size_hint: None,
             }
         }
 
@@ -1748,6 +1749,7 @@ mod tests {
             range: None,
             statistics: None,
             extensions: None,
+            metadata_size_hint: None,
         };
 
         let expected_schema = Schema::new(vec![
@@ -1835,6 +1837,7 @@ mod tests {
             range: None,
             statistics: None,
             extensions: None,
+            metadata_size_hint: None,
         };
 
         let file_schema = Arc::new(Schema::empty());

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -883,6 +883,7 @@ mod tests {
     // See also `parquet_exec` integration test
     use std::fs::{self, File};
     use std::io::Write;
+    use std::sync::Mutex;
 
     use super::*;
     use crate::dataframe::DataFrameWriteOptions;
@@ -908,6 +909,7 @@ mod tests {
     use arrow::datatypes::{Field, Schema, SchemaBuilder};
     use arrow::record_batch::RecordBatch;
     use arrow_schema::{DataType, Fields};
+    use bytes::{BufMut, BytesMut};
     use datafusion_common::{assert_contains, ScalarValue};
     use datafusion_expr::{col, lit, when, Expr};
     use datafusion_physical_expr::planner::logical2physical;
@@ -917,7 +919,7 @@ mod tests {
     use futures::StreamExt;
     use object_store::local::LocalFileSystem;
     use object_store::path::Path;
-    use object_store::ObjectMeta;
+    use object_store::{ObjectMeta, ObjectStore};
     use parquet::arrow::ArrowWriter;
     use parquet::file::properties::WriterProperties;
     use tempfile::TempDir;
@@ -2380,5 +2382,134 @@ mod tests {
         writer.write(&batch).unwrap();
         writer.flush().unwrap();
         writer.close().unwrap();
+    }
+
+    /// Write out a batch to a parquet file and return the total size of the file
+    async fn write_batch(
+        path: &str,
+        store: Arc<dyn ObjectStore>,
+        batch: RecordBatch,
+    ) -> usize {
+        let mut writer =
+            ArrowWriter::try_new(BytesMut::new().writer(), batch.schema(), None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.flush().unwrap();
+        let bytes = writer.into_inner().unwrap().into_inner().freeze();
+        let total_size = bytes.len();
+        let path = Path::from(path);
+        let payload = object_store::PutPayload::from_bytes(bytes);
+        store
+            .put_opts(&path, payload, object_store::PutOptions::default())
+            .await
+            .unwrap();
+        total_size
+    }
+
+    /// A ParquetFileReaderFactory that tracks the metadata_size_hint passed to it
+    #[derive(Debug, Clone)]
+    struct TrackingParquetFileReaderFactory {
+        inner: Arc<dyn ParquetFileReaderFactory>,
+        metadata_size_hint_calls: Arc<Mutex<Vec<Option<usize>>>>,
+    }
+
+    impl TrackingParquetFileReaderFactory {
+        fn new(store: Arc<dyn ObjectStore>) -> Self {
+            Self {
+                inner: Arc::new(DefaultParquetFileReaderFactory::new(store)) as _,
+                metadata_size_hint_calls: Arc::new(Mutex::new(vec![])),
+            }
+        }
+    }
+
+    impl ParquetFileReaderFactory for TrackingParquetFileReaderFactory {
+        fn create_reader(
+            &self,
+            partition_index: usize,
+            file_meta: crate::datasource::physical_plan::FileMeta,
+            metadata_size_hint: Option<usize>,
+            metrics: &ExecutionPlanMetricsSet,
+        ) -> Result<Box<dyn parquet::arrow::async_reader::AsyncFileReader + Send>>
+        {
+            self.metadata_size_hint_calls
+                .lock()
+                .unwrap()
+                .push(metadata_size_hint);
+            self.inner.create_reader(
+                partition_index,
+                file_meta,
+                metadata_size_hint,
+                metrics,
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn test_metadata_size_hint() {
+        let store =
+            Arc::new(object_store::memory::InMemory::new()) as Arc<dyn ObjectStore>;
+        let store_url = ObjectStoreUrl::parse("memory://test").unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_object_store(store_url.as_ref(), store.clone());
+
+        // write some data out, it doesn't matter what it is
+        let c1: ArrayRef = Arc::new(Int32Array::from(vec![Some(1)]));
+        let batch = create_batch(vec![("c1", c1)]);
+        let schema = batch.schema();
+        let name_1 = "test1.parquet";
+        let name_2 = "test2.parquet";
+        let total_size_1 = write_batch(name_1, store.clone(), batch.clone()).await;
+        let total_size_2 = write_batch(name_2, store.clone(), batch.clone()).await;
+
+        let reader_factory =
+            Arc::new(TrackingParquetFileReaderFactory::new(store.clone()));
+
+        let size_hint_calls = reader_factory.metadata_size_hint_calls.clone();
+
+        let exec = ParquetExec::builder(
+            FileScanConfig::new(store_url, schema)
+                .with_file(
+                    PartitionedFile {
+                        object_meta: ObjectMeta {
+                            location: Path::from(name_1),
+                            last_modified: Utc::now(),
+                            size: total_size_1,
+                            e_tag: None,
+                            version: None,
+                        },
+                        partition_values: vec![],
+                        range: None,
+                        statistics: None,
+                        extensions: None,
+                        metadata_size_hint: None,
+                    }
+                    .with_metadata_size_hint(123),
+                )
+                .with_file(PartitionedFile {
+                    object_meta: ObjectMeta {
+                        location: Path::from(name_2),
+                        last_modified: Utc::now(),
+                        size: total_size_2,
+                        e_tag: None,
+                        version: None,
+                    },
+                    partition_values: vec![],
+                    range: None,
+                    statistics: None,
+                    extensions: None,
+                    metadata_size_hint: None,
+                }),
+        )
+        .with_parquet_file_reader_factory(reader_factory)
+        .with_metadata_size_hint(456)
+        .build();
+
+        let exec = Arc::new(exec);
+        let res = collect(exec, ctx.task_ctx()).await.unwrap();
+        assert_eq!(res.len(), 2);
+
+        let calls = size_hint_calls.lock().unwrap().clone();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls, vec![Some(123), Some(456)]);
     }
 }

--- a/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
@@ -88,12 +88,14 @@ impl FileOpener for ParquetOpener {
         let file_name = file_meta.location().to_string();
         let file_metrics =
             ParquetFileMetrics::new(self.partition_index, &file_name, &self.metrics);
+        
+        let metadata_size_hint = file_meta.metadata_size_hint.or(self.metadata_size_hint);
 
         let mut reader: Box<dyn AsyncFileReader> =
             self.parquet_file_reader_factory.create_reader(
                 self.partition_index,
                 file_meta,
-                self.metadata_size_hint,
+                metadata_size_hint,
                 &self.metrics,
             )?;
 

--- a/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
@@ -88,7 +88,7 @@ impl FileOpener for ParquetOpener {
         let file_name = file_meta.location().to_string();
         let file_metrics =
             ParquetFileMetrics::new(self.partition_index, &file_name, &self.metrics);
-        
+
         let metadata_size_hint = file_meta.metadata_size_hint.or(self.metadata_size_hint);
 
         let mut reader: Box<dyn AsyncFileReader> =

--- a/datafusion/core/src/datasource/schema_adapter.rs
+++ b/datafusion/core/src/datasource/schema_adapter.rs
@@ -493,6 +493,7 @@ mod tests {
             range: None,
             statistics: None,
             extensions: None,
+            metadata_size_hint: None,
         };
 
         let f1 = Field::new("id", DataType::Int32, true);

--- a/datafusion/core/src/test_util/parquet.rs
+++ b/datafusion/core/src/test_util/parquet.rs
@@ -151,6 +151,7 @@ impl TestParquetFile {
                     range: None,
                     statistics: None,
                     extensions: None,
+                    metadata_size_hint: None,
                 });
 
         let df_schema = self.schema.clone().to_dfschema_ref()?;

--- a/datafusion/core/tests/parquet/custom_reader.rs
+++ b/datafusion/core/tests/parquet/custom_reader.rs
@@ -71,6 +71,7 @@ async fn route_data_access_ops_to_parquet_file_reader_factory() {
             range: None,
             statistics: None,
             extensions: Some(Arc::new(String::from(EXPECTED_USER_DEFINED_METADATA))),
+            metadata_size_hint: None,
         })
         .collect();
 

--- a/datafusion/core/tests/parquet/page_pruning.rs
+++ b/datafusion/core/tests/parquet/page_pruning.rs
@@ -64,6 +64,7 @@ async fn get_parquet_exec(state: &SessionState, filter: Expr) -> ParquetExec {
         range: None,
         statistics: None,
         extensions: None,
+        metadata_size_hint: None,
     };
 
     let df_schema = schema.clone().to_dfschema().unwrap();

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -12844,7 +12844,6 @@ impl<'de> serde::Deserialize<'de> for PartitionedFile {
                     partition_values: partition_values__.unwrap_or_default(),
                     range: range__,
                     statistics: statistics__,
-                    metadata_size_hint: None,
                 })
             }
         }

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -12844,6 +12844,7 @@ impl<'de> serde::Deserialize<'de> for PartitionedFile {
                     partition_values: partition_values__.unwrap_or_default(),
                     range: range__,
                     statistics: statistics__,
+                    metadata_size_hint: None,
                 })
             }
         }

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -559,6 +559,7 @@ impl TryFrom<&protobuf::PartitionedFile> for PartitionedFile {
             range: val.range.as_ref().map(|v| v.try_into()).transpose()?,
             statistics: val.statistics.as_ref().map(|v| v.try_into()).transpose()?,
             extensions: None,
+            metadata_size_hint: None,
         })
     }
 }

--- a/datafusion/substrait/src/physical_plan/consumer.rs
+++ b/datafusion/substrait/src/physical_plan/consumer.rs
@@ -127,6 +127,7 @@ pub async fn from_substrait_rel(
                             range: None,
                             statistics: None,
                             extensions: None,
+                            metadata_size_hint: None,
                         };
 
                         let part_index = file.partition_index as usize;


### PR DESCRIPTION
Currently you can only pass it to `ParquetExecBuilder` but that applies to entire groups of files. This adds an API to set it on a per-file basis in cases where you know the size of the metadata in each file. In our case we have a metadata store that stores information about each file, including the size of the metadata, so we know the _exact_ size in bytes and can ensure that we never have to double-request to read the entire metadata.