### PR TITLE
Support `Utf8View` for string function `bit_length()`

### DIFF
--- a/datafusion/functions/src/string/bit_length.rs
+++ b/datafusion/functions/src/string/bit_length.rs
@@ -79,6 +79,9 @@ impl ScalarUDFImpl for BitLengthFunc {
                 ScalarValue::LargeUtf8(v) => Ok(ColumnarValue::Scalar(
                     ScalarValue::Int64(v.as_ref().map(|x| (x.len() * 8) as i64)),
                 )),
+                ScalarValue::Utf8View(v) => Ok(ColumnarValue::Scalar(
+                    ScalarValue::Int32(v.as_ref().map(|x| (x.len() * 8) as i32)),
+                )),
                 _ => unreachable!("bit length"),
             },
         }

--- a/datafusion/sqllogictest/test_files/string/string_literal.slt
+++ b/datafusion/sqllogictest/test_files/string/string_literal.slt
@@ -1623,6 +1623,7 @@ a\_c \%abc false
 \%abc a\_c false
 \%abc %abc true
 \%abc \%abc false
+
 # test utf8, largeutf8, utf8view, DictionaryString for bit_length
 query IIII
 SELECT

--- a/datafusion/sqllogictest/test_files/string/string_literal.slt
+++ b/datafusion/sqllogictest/test_files/string/string_literal.slt
@@ -1623,3 +1623,43 @@ a\_c \%abc false
 \%abc a\_c false
 \%abc %abc true
 \%abc \%abc false
+# test utf8, largeutf8, utf8view, DictionaryString for bit_length
+query IIII
+SELECT
+  bit_length('Andrew'),
+  bit_length('datafusion数据融合'),
+  bit_length('💖'),
+  bit_length('josé')
+;
+----
+48 176 32 40
+
+query IIII
+SELECT
+  bit_length(arrow_cast('Andrew', 'LargeUtf8')),
+  bit_length(arrow_cast('datafusion数据融合', 'LargeUtf8')),
+  bit_length(arrow_cast('💖', 'LargeUtf8')),
+  bit_length(arrow_cast('josé', 'LargeUtf8'))
+;
+----
+48 176 32 40
+
+query IIII
+SELECT
+  bit_length(arrow_cast('Andrew', 'Utf8View')),
+  bit_length(arrow_cast('datafusion数据融合', 'Utf8View')),
+  bit_length(arrow_cast('💖', 'Utf8View')),
+  bit_length(arrow_cast('josé', 'Utf8View'))
+;
+----
+48 176 32 40
+
+query IIII
+SELECT
+  bit_length(arrow_cast('Andrew', 'Dictionary(Int32, Utf8)')),
+  bit_length(arrow_cast('datafusion数据融合', 'Dictionary(Int32, Utf8)')),
+  bit_length(arrow_cast('💖', 'Dictionary(Int32, Utf8)')),
+  bit_length(arrow_cast('josé', 'Dictionary(Int32, Utf8)'))
+;
+----
+48 176 32 40

--- a/datafusion/sqllogictest/test_files/string/string_query.slt.part
+++ b/datafusion/sqllogictest/test_files/string/string_query.slt.part
@@ -1373,3 +1373,20 @@ p percent NULL pan Tadeusz ma iść w kąt pan Tadeusz ma iść w kąt NULL
 _ _ NULL (empty) (empty) NULL
 NULL NULL NULL NULL NULL NULL
 NULL NULL NULL NULL NULL NULL
+
+# TODO: Support Utf8View for bit_length array string function
+# --------------------------------------
+# Test BIT_LENGTH
+# --------------------------------------
+# query II
+# SELECT
+#   BIT_LENGTH(ascii_1),
+#   BIT_LENGTH(unicode_1)
+# FROM test_basic_operator;
+# ----
+# 48 144
+# 72 176
+# 56 240
+# 88 104
+# 56 216
+# NULL NULL

--- a/datafusion/sqllogictest/test_files/string/string_query.slt.part
+++ b/datafusion/sqllogictest/test_files/string/string_query.slt.part
@@ -1373,20 +1373,3 @@ p percent NULL pan Tadeusz ma iść w kąt pan Tadeusz ma iść w kąt NULL
 _ _ NULL (empty) (empty) NULL
 NULL NULL NULL NULL NULL NULL
 NULL NULL NULL NULL NULL NULL
-
-# TODO: Support Utf8View for bit_length array string function
-# --------------------------------------
-# Test BIT_LENGTH
-# --------------------------------------
-# query II
-# SELECT
-#   BIT_LENGTH(ascii_1),
-#   BIT_LENGTH(unicode_1)
-# FROM test_basic_operator;
-# ----
-# 48 144
-# 72 176
-# 56 240
-# 88 104
-# 56 216
-# NULL NULL

--- a/datafusion/sqllogictest/test_files/string/string_view.slt
+++ b/datafusion/sqllogictest/test_files/string/string_view.slt
@@ -93,6 +93,16 @@ select octet_length(column1_utf8view) from test;
 0
 NULL
 
+query IIII
+SELECT
+  BIT_LENGTH(arrow_cast('Andrew', 'Utf8View')),
+  BIT_LENGTH(arrow_cast('datafusion数据融合', 'Utf8View')),
+  BIT_LENGTH(arrow_cast('💖', 'Utf8View')),
+  BIT_LENGTH(arrow_cast('josé', 'Utf8View'))
+;
+----
+48 176 32 40
+
 query error DataFusion error: Arrow error: Compute error: bit_length not supported for Utf8View
 select bit_length(column1_utf8view) from test;
 

--- a/datafusion/sqllogictest/test_files/string/string_view.slt
+++ b/datafusion/sqllogictest/test_files/string/string_view.slt
@@ -93,16 +93,7 @@ select octet_length(column1_utf8view) from test;
 0
 NULL
 
-query IIII
-SELECT
-  BIT_LENGTH(arrow_cast('Andrew', 'Utf8View')),
-  BIT_LENGTH(arrow_cast('datafusion数据融合', 'Utf8View')),
-  BIT_LENGTH(arrow_cast('💖', 'Utf8View')),
-  BIT_LENGTH(arrow_cast('josé', 'Utf8View'))
-;
-----
-48 176 32 40
-
+# TODO: Revisit this issue after upgrading to the arrow-rs version that includes apache/arrow-rs#6671.
 query error DataFusion error: Arrow error: Compute error: bit_length not supported for Utf8View
 select bit_length(column1_utf8view) from test;
 


### PR DESCRIPTION

## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/13195

## Rationale for this change

Thanks to @jayzhan211 , he noticed following issue which string scalar function `bit_length()` doesn't support `Utf8View` type:
```rust
select bit_length(arrow_cast('a', 'Utf8View'));
```

## What changes are included in this PR?

Update `bit_length()` scalar function to support `Utf8View`

## Are these changes tested?

Yes for scalar function. No for array function as it's still PR in https://github.com/apache/arrow-rs/pull/6671

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
