### PR TITLE
feat: Add `Time`/`Interval`/`Decimal`/`Utf8View` in aggregate fuzz testing

### DIFF
--- a/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
@@ -186,7 +186,7 @@ fn baseline_config() -> DatasetGeneratorConfig {
         // begin decimal columns
         ColumnDescr::new("decimal128", {
             // Generate valid precision and scale for Decimal128 randomly.
-            let precision: u8 = rng.gen_range(0..=DECIMAL128_MAX_PRECISION);
+            let precision: u8 = rng.gen_range(1..=DECIMAL128_MAX_PRECISION);
             // It's safe to cast `precision` to i8 type directly.
             let scale: i8 = rng.gen_range(
                 i8::MIN..=std::cmp::min(precision as i8, DECIMAL128_MAX_SCALE),
@@ -195,7 +195,7 @@ fn baseline_config() -> DatasetGeneratorConfig {
         }),
         ColumnDescr::new("decimal256", {
             // Generate valid precision and scale for Decimal256 randomly.
-            let precision: u8 = rng.gen_range(0..=DECIMAL256_MAX_PRECISION);
+            let precision: u8 = rng.gen_range(1..=DECIMAL256_MAX_PRECISION);
             // It's safe to cast `precision` to i8 type directly.
             let scale: i8 = rng.gen_range(
                 i8::MIN..=std::cmp::min(precision as i8, DECIMAL256_MAX_SCALE),

--- a/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
@@ -23,6 +23,10 @@ use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::pretty_format_batches;
 use arrow_array::types::Int64Type;
+use arrow_schema::{
+    IntervalUnit, TimeUnit, DECIMAL128_MAX_PRECISION, DECIMAL128_MAX_SCALE,
+    DECIMAL256_MAX_PRECISION, DECIMAL256_MAX_SCALE,
+};
 use datafusion::common::Result;
 use datafusion::datasource::MemTable;
 use datafusion::physical_expr::aggregate::AggregateExprBuilder;
@@ -45,7 +49,7 @@ use crate::fuzz_cases::aggregation_fuzzer::{
 use datafusion_physical_expr_common::sort_expr::LexOrdering;
 use hashbrown::HashMap;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{thread_rng, Rng, SeedableRng};
 use tokio::task::JoinSet;
 
 // ========================================================================
@@ -151,6 +155,7 @@ async fn test_count() {
 /// 1. Floating point numbers
 /// 1. structured types
 fn baseline_config() -> DatasetGeneratorConfig {
+    let mut rng = thread_rng();
     let columns = vec![
         ColumnDescr::new("i8", DataType::Int8),
         ColumnDescr::new("i16", DataType::Int16),
@@ -162,8 +167,41 @@ fn baseline_config() -> DatasetGeneratorConfig {
         ColumnDescr::new("u64", DataType::UInt64),
         ColumnDescr::new("date32", DataType::Date32),
         ColumnDescr::new("date64", DataType::Date64),
-        // TODO: date/time columns
-        // todo decimal columns
+        ColumnDescr::new("time32_s", DataType::Time32(TimeUnit::Second)),
+        ColumnDescr::new("time32_ms", DataType::Time32(TimeUnit::Millisecond)),
+        ColumnDescr::new("time64_us", DataType::Time64(TimeUnit::Microsecond)),
+        ColumnDescr::new("time64_ns", DataType::Time64(TimeUnit::Nanosecond)),
+        ColumnDescr::new(
+            "interval_year_month",
+            DataType::Interval(IntervalUnit::YearMonth),
+        ),
+        ColumnDescr::new(
+            "interval_day_time",
+            DataType::Interval(IntervalUnit::DayTime),
+        ),
+        ColumnDescr::new(
+            "interval_month_day_nano",
+            DataType::Interval(IntervalUnit::MonthDayNano),
+        ),
+        // begin decimal columns
+        ColumnDescr::new("decimal128", {
+            // Generate valid precision and scale for Decimal128 randomly.
+            let precision: u8 = rng.gen_range(0..=DECIMAL128_MAX_PRECISION);
+            // It's safe to cast `precision` to i8 type directly.
+            let scale: i8 = rng.gen_range(
+                i8::MIN..=std::cmp::min(precision as i8, DECIMAL128_MAX_SCALE),
+            );
+            DataType::Decimal128(precision, scale)
+        }),
+        ColumnDescr::new("decimal256", {
+            // Generate valid precision and scale for Decimal256 randomly.
+            let precision: u8 = rng.gen_range(0..=DECIMAL256_MAX_PRECISION);
+            // It's safe to cast `precision` to i8 type directly.
+            let scale: i8 = rng.gen_range(
+                i8::MIN..=std::cmp::min(precision as i8, DECIMAL256_MAX_SCALE),
+            );
+            DataType::Decimal256(precision, scale)
+        }),
         // begin string columns
         ColumnDescr::new("utf8", DataType::Utf8),
         ColumnDescr::new("largeutf8", DataType::LargeUtf8),

--- a/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
@@ -205,8 +205,7 @@ fn baseline_config() -> DatasetGeneratorConfig {
         // begin string columns
         ColumnDescr::new("utf8", DataType::Utf8),
         ColumnDescr::new("largeutf8", DataType::LargeUtf8),
-        // TODO add support for utf8view in data generator
-        // ColumnDescr::new("utf8view", DataType::Utf8View),
+        ColumnDescr::new("utf8view", DataType::Utf8View),
         // todo binary
         // low cardinality columns
         ColumnDescr::new("u8_low", DataType::UInt8).with_max_num_distinct(10),

--- a/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
@@ -18,10 +18,11 @@
 use std::sync::Arc;
 
 use arrow::datatypes::{
-    Date32Type, Date64Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type,
-    Int8Type, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalYearMonthType,
-    Time32MillisecondType, Time32SecondType, Time64MicrosecondType, Time64NanosecondType,
-    UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+    Date32Type, Date64Type, Decimal128Type, Decimal256Type, Float32Type, Float64Type,
+    Int16Type, Int32Type, Int64Type, Int8Type, IntervalDayTimeType,
+    IntervalMonthDayNanoType, IntervalYearMonthType, Time32MillisecondType,
+    Time32SecondType, Time64MicrosecondType, Time64NanosecondType, UInt16Type,
+    UInt32Type, UInt64Type, UInt8Type,
 };
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, IntervalUnit, Schema, TimeUnit};
@@ -239,7 +240,7 @@ macro_rules! generate_string_array {
 }
 
 macro_rules! generate_decimal_array {
-    ($SELF:ident, $NUM_ROWS:ident, $MAX_NUM_DISTINCT: expr, $BATCH_GEN_RNG:ident, $ARRAY_GEN_RNG:ident, $PRECISION: ident, $SCALE: ident, $NATIVE_TYPE: ident) => {{
+    ($SELF:ident, $NUM_ROWS:ident, $MAX_NUM_DISTINCT: expr, $BATCH_GEN_RNG:ident, $ARRAY_GEN_RNG:ident, $PRECISION: ident, $SCALE: ident, $ARROW_TYPE: ident) => {{
         let null_pct_idx = $BATCH_GEN_RNG.gen_range(0..$SELF.candidate_null_pcts.len());
         let null_pct = $SELF.candidate_null_pcts[null_pct_idx];
 
@@ -252,9 +253,7 @@ macro_rules! generate_decimal_array {
             rng: $ARRAY_GEN_RNG,
         };
 
-        paste::paste! {
-            generator.[< gen_data_ $NATIVE_TYPE >]()
-        }
+        generator.gen_data::<$ARROW_TYPE>()
     }};
 }
 
@@ -532,7 +531,7 @@ impl RecordBatchGenerator {
                     array_gen_rng,
                     precision,
                     scale,
-                    i128
+                    Decimal128Type
                 )
             }
             DataType::Decimal256(precision, scale) => {
@@ -544,7 +543,7 @@ impl RecordBatchGenerator {
                     array_gen_rng,
                     precision,
                     scale,
-                    i256
+                    Decimal256Type
                 )
             }
             DataType::Utf8 => {

--- a/datafusion/functions-aggregate/src/min_max/min_max_bytes.rs
+++ b/datafusion/functions-aggregate/src/min_max/min_max_bytes.rs
@@ -338,6 +338,10 @@ impl GroupsAccumulator for MinMaxBytesAccumulator {
 /// This is a heuristic to avoid allocating too many small buffers
 fn capacity_to_view_block_size(data_capacity: usize) -> u32 {
     let max_block_size = 2 * 1024 * 1024;
+    // Avoid block size equal to zero when calling `with_fixed_block_size()`.
+    if data_capacity == 0 {
+        return 1;
+    }
     if let Ok(block_size) = u32::try_from(data_capacity) {
         block_size.min(max_block_size)
     } else {

--- a/test-utils/src/array_gen/decimal.rs
+++ b/test-utils/src/array_gen/decimal.rs
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{ArrayRef, PrimitiveArray, PrimitiveBuilder, UInt32Array};
+use arrow::datatypes::{i256, Decimal128Type, Decimal256Type};
+use rand::rngs::StdRng;
+use rand::Rng;
+
+/// Randomly generate decimal arrays
+pub struct DecimalArrayGenerator {
+    /// The precision of the decimal type
+    pub precision: u8,
+    /// The scale of the decimal type
+    pub scale: i8,
+    /// The total number of decimals in the output
+    pub num_decimals: usize,
+    /// The number of distinct decimals in the columns
+    pub num_distinct_decimals: usize,
+    /// The percentage of nulls in the columns
+    pub null_pct: f64,
+    /// Random number generator
+    pub rng: StdRng,
+}
+
+macro_rules! impl_gen_decimal_data {
+    ($NATIVE_TYPE:ident, $DECIMAL_TYPE:ident) => {
+        paste::paste! {
+            /// Create a Decimal128Array / Decimal256Array with random values.
+            pub fn [< gen_data_ $NATIVE_TYPE >](&mut self) -> ArrayRef {
+                // table of decimals from which to draw
+                let distinct_decimals : PrimitiveArray<$DECIMAL_TYPE> = {
+                    let mut decimal_builder = PrimitiveBuilder::<$DECIMAL_TYPE>::with_capacity(self.num_distinct_decimals);
+                    for _ in 0..self.num_distinct_decimals {
+                        decimal_builder.append_option(Some(
+                            [< random_ $NATIVE_TYPE >](&mut self.rng)
+                        ));
+                    }
+
+                    let decimal_array = decimal_builder
+                        .finish()
+                        .with_precision_and_scale(self.precision, self.scale)
+                        .unwrap();
+                    decimal_array
+                };
+
+                // pick num_decimals randomly from the distinct decimal table
+                let indicies: UInt32Array = (0..self.num_decimals)
+                    .map(|_| {
+                        if self.rng.gen::<f64>() < self.null_pct {
+                            None
+                        } else if self.num_distinct_decimals > 1 {
+                            let range = 1..(self.num_distinct_decimals as u32);
+                            Some(self.rng.gen_range(range))
+                        } else {
+                            Some(0)
+                        }
+                    })
+                    .collect();
+
+                let options = None;
+                arrow::compute::take(&distinct_decimals, &indicies, options).unwrap()
+            }
+        }
+    };
+}
+
+impl DecimalArrayGenerator {
+    impl_gen_decimal_data!(i128, Decimal128Type);
+    impl_gen_decimal_data!(i256, Decimal256Type);
+}
+
+fn random_i128(rng: &mut StdRng) -> i128 {
+    rng.gen::<i128>()
+}
+
+fn random_i256(rng: &mut StdRng) -> i256 {
+    i256::from_parts(rng.gen::<u128>(), rng.gen::<i128>())
+}

--- a/test-utils/src/array_gen/decimal.rs
+++ b/test-utils/src/array_gen/decimal.rs
@@ -53,11 +53,10 @@ impl DecimalArrayGenerator {
                     .append_option(Some(D::generate_random_native_data(&mut self.rng)));
             }
 
-            let decimal_array = decimal_builder
+            decimal_builder
                 .finish()
                 .with_precision_and_scale(self.precision, self.scale)
-                .unwrap();
-            decimal_array
+                .unwrap()
         };
 
         // pick num_decimals randomly from the distinct decimal table

--- a/test-utils/src/array_gen/mod.rs
+++ b/test-utils/src/array_gen/mod.rs
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+mod decimal;
 mod primitive;
 mod string;
 
+pub use decimal::DecimalArrayGenerator;
 pub use primitive::PrimitiveArrayGenerator;
 pub use string::StringArrayGenerator;

--- a/test-utils/src/array_gen/mod.rs
+++ b/test-utils/src/array_gen/mod.rs
@@ -17,6 +17,7 @@
 
 mod decimal;
 mod primitive;
+mod random_data;
 mod string;
 
 pub use decimal::DecimalArrayGenerator;

--- a/test-utils/src/array_gen/random_data.rs
+++ b/test-utils/src/array_gen/random_data.rs
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::ArrowPrimitiveType;
+use arrow::datatypes::{
+    i256, Date32Type, Date64Type, Decimal128Type, Decimal256Type, Float32Type,
+    Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, IntervalDayTime,
+    IntervalDayTimeType, IntervalMonthDayNano, IntervalMonthDayNanoType,
+    IntervalYearMonthType, Time32MillisecondType, Time32SecondType,
+    Time64MicrosecondType, Time64NanosecondType, UInt16Type, UInt32Type, UInt64Type,
+    UInt8Type,
+};
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+use rand::rngs::StdRng;
+use rand::Rng;
+
+/// Generate corresponding NativeType value randomly according to
+/// ArrowPrimitiveType.
+pub trait RandomNativeData: ArrowPrimitiveType {
+    fn generate_random_native_data(rng: &mut StdRng) -> Self::Native;
+}
+
+macro_rules! basic_random_data {
+    ($ARROW_TYPE: ty) => {
+        impl RandomNativeData for $ARROW_TYPE
+        where
+            Standard: Distribution<Self::Native>,
+        {
+            #[inline]
+            fn generate_random_native_data(rng: &mut StdRng) -> Self::Native {
+                rng.gen::<Self::Native>()
+            }
+        }
+    };
+}
+
+basic_random_data!(Int8Type);
+basic_random_data!(Int16Type);
+basic_random_data!(Int32Type);
+basic_random_data!(Int64Type);
+basic_random_data!(UInt8Type);
+basic_random_data!(UInt16Type);
+basic_random_data!(UInt32Type);
+basic_random_data!(UInt64Type);
+basic_random_data!(Float32Type);
+basic_random_data!(Float64Type);
+basic_random_data!(Date32Type);
+basic_random_data!(Time32SecondType);
+basic_random_data!(Time32MillisecondType);
+basic_random_data!(Time64MicrosecondType);
+basic_random_data!(Time64NanosecondType);
+basic_random_data!(IntervalYearMonthType);
+basic_random_data!(Decimal128Type);
+
+impl RandomNativeData for Date64Type {
+    fn generate_random_native_data(rng: &mut StdRng) -> Self::Native {
+        // TODO: constrain this range to valid dates if necessary
+        let date_value = rng.gen_range(i64::MIN..=i64::MAX);
+        let millis_per_day = 86_400_000;
+        date_value - (date_value % millis_per_day)
+    }
+}
+
+impl RandomNativeData for IntervalDayTimeType {
+    fn generate_random_native_data(rng: &mut StdRng) -> Self::Native {
+        IntervalDayTime {
+            days: rng.gen::<i32>(),
+            milliseconds: rng.gen::<i32>(),
+        }
+    }
+}
+
+impl RandomNativeData for IntervalMonthDayNanoType {
+    fn generate_random_native_data(rng: &mut StdRng) -> Self::Native {
+        IntervalMonthDayNano {
+            months: rng.gen::<i32>(),
+            days: rng.gen::<i32>(),
+            nanoseconds: rng.gen::<i64>(),
+        }
+    }
+}
+
+impl RandomNativeData for Decimal256Type {
+    fn generate_random_native_data(rng: &mut StdRng) -> Self::Native {
+        i256::from_parts(rng.gen::<u128>(), rng.gen::<i128>())
+    }
+}

--- a/test-utils/src/array_gen/string.rs
+++ b/test-utils/src/array_gen/string.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{ArrayRef, GenericStringArray, OffsetSizeTrait, UInt32Array};
+use arrow::array::{
+    ArrayRef, GenericStringArray, OffsetSizeTrait, StringViewArray, UInt32Array,
+};
 use rand::rngs::StdRng;
 use rand::Rng;
 
@@ -58,6 +60,30 @@ impl StringArrayGenerator {
 
         let options = None;
         arrow::compute::take(&distinct_strings, &indicies, options).unwrap()
+    }
+
+    /// Creates a StringViewArray with random strings.
+    pub fn gen_string_view(&mut self) -> ArrayRef {
+        let distinct_string_views: StringViewArray = (0..self.num_distinct_strings)
+            .map(|_| Some(random_string(&mut self.rng, self.max_len)))
+            .collect();
+
+        // pick num_strings randomly from the distinct string table
+        let indicies: UInt32Array = (0..self.num_strings)
+            .map(|_| {
+                if self.rng.gen::<f64>() < self.null_pct {
+                    None
+                } else if self.num_distinct_strings > 1 {
+                    let range = 1..(self.num_distinct_strings as u32);
+                    Some(self.rng.gen_range(range))
+                } else {
+                    Some(0)
+                }
+            })
+            .collect();
+
+        let options = None;
+        arrow::compute::take(&distinct_string_views, &indicies, options).unwrap()
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #12114 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Supporting more types for dataset generator in fuzzer framework is needed to improve aggregation fuzzer coverage.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Support `Interval` and `Time` types for `PrimitiveArrayGenerator`.
- Introduce `DecimalArrayGenerator` to support `Decimal` type.
- Support `Utf8View` type.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
