### PR TITLE
feat: support normalized expr in CSE

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -34,7 +34,7 @@ use crate::{
 };
 
 use arrow::datatypes::{DataType, FieldRef};
-use datafusion_common::cse::HashNode;
+use datafusion_common::cse::{HashNode, NormalizeNode};
 use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
 };
@@ -1647,6 +1647,60 @@ impl Expr {
             | Expr::WindowFunction(..)
             | Expr::Literal(..)
             | Expr::Placeholder(..) => false,
+        }
+    }
+}
+
+impl NormalizeNode for Expr {
+    fn normalize(&self) -> Expr {
+        match self {
+            Expr::BinaryExpr(BinaryExpr {
+                ref left,
+                ref op,
+                ref right,
+            }) => {
+                let normalized_left = left.normalize();
+                let normalized_right = right.normalize();
+                let new_binary = match op {
+                    Operator::Eq
+                    | Operator::NotEq
+                    | Operator::Plus
+                    | Operator::Multiply
+                    | Operator::BitwiseAnd
+                    | Operator::BitwiseOr
+                    | Operator::BitwiseXor => {
+                        let (l_expr, r_expr) = if format!("{normalized_left}")
+                            < format!("{normalized_right}")
+                        {
+                            (normalized_left, normalized_right)
+                        } else {
+                            (normalized_right, normalized_left)
+                        };
+                        BinaryExpr {
+                            left: Box::new(l_expr),
+                            op: *op,
+                            right: Box::new(r_expr),
+                        }
+                    }
+                    Operator::Gt => BinaryExpr {
+                        left: Box::new(normalized_right),
+                        op: Operator::Lt,
+                        right: Box::new(normalized_left),
+                    },
+                    Operator::GtEq => BinaryExpr {
+                        left: Box::new(normalized_right),
+                        op: Operator::LtEq,
+                        right: Box::new(normalized_left),
+                    },
+                    _ => BinaryExpr {
+                        left: Box::new(normalized_left),
+                        op: *op,
+                        right: Box::new(normalized_right),
+                    },
+                };
+                Expr::BinaryExpr(new_binary)
+            }
+            other => other.clone(),
         }
     }
 }

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -851,7 +851,7 @@ mod test {
             ])?
             .build()?;
 
-        let expected = "Projection: __common_expr_1 - test.c AS alias1 * __common_expr_1 AS test.a + test.b, __common_expr_1 AS test.a + test.b\
+        let expected = "Projection: __common_expr_1 AS test.a + test.b * __common_expr_1 - test.c AS alias1, __common_expr_1 AS test.a + test.b\
         \n  Projection: test.a + test.b AS __common_expr_1, test.a, test.b, test.c\
         \n    TableScan: test";
 
@@ -1043,8 +1043,9 @@ mod test {
             .project(vec![lit(1) + col("a"), col("a") + lit(1)])?
             .build()?;
 
-        let expected = "Projection: Int32(1) + test.a, test.a + Int32(1)\
-        \n  TableScan: test";
+        let expected = "Projection: __common_expr_1 AS Int32(1) + test.a, __common_expr_1 AS Int32(1) + test.a\
+        \n  Projection: Int32(1) + test.a AS __common_expr_1, test.a, test.b, test.c\
+        \n    TableScan: test";
 
         assert_optimized_plan_eq(expected, plan, None);
 
@@ -1180,7 +1181,7 @@ mod test {
             .build()?;
 
         let expected = "Projection: test.a, test.b, test.c\
-        \n  Filter: __common_expr_1 - Int32(10) > __common_expr_1\
+        \n  Filter: __common_expr_1 < __common_expr_1 - Int32(10)\
         \n    Projection: Int32(1) + test.a AS __common_expr_1, test.a, test.b, test.c\
         \n      TableScan: test";
 
@@ -1396,6 +1397,150 @@ mod test {
         \n    Projection: test.a + test.b AS __common_expr_2, test.a, test.b, test.c\
         \n      TableScan: test";
 
+        assert_optimized_plan_eq(expected, plan, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_add_expression() -> Result<()> {
+        // a + b <=> b + a
+        let table_scan = test_table_scan()?;
+        let expr = ((col("a") + col("b")) * (col("b") + col("a"))).eq(lit(30));
+        let plan = LogicalPlanBuilder::from(table_scan).filter(expr)?.build()?;
+
+        let expected = "Projection: test.a, test.b, test.c\
+        \n  Filter: __common_expr_1 * __common_expr_1 = Int32(30)\
+        \n    Projection: test.a + test.b AS __common_expr_1, test.a, test.b, test.c\
+        \n      TableScan: test";
+        assert_optimized_plan_eq(expected, plan, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_multi_expression() -> Result<()> {
+        // a * b <=> b * a
+        let table_scan = test_table_scan()?;
+        let expr = ((col("a") * col("b")) + (col("b") * col("a"))).eq(lit(30));
+        let plan = LogicalPlanBuilder::from(table_scan).filter(expr)?.build()?;
+
+        let expected = "Projection: test.a, test.b, test.c\
+        \n  Filter: Int32(30) = __common_expr_1 + __common_expr_1\
+        \n    Projection: test.a * test.b AS __common_expr_1, test.a, test.b, test.c\
+        \n      TableScan: test";
+        assert_optimized_plan_eq(expected, plan, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_bitset_and_expression() -> Result<()> {
+        // a & b <=> b & a
+        let table_scan = test_table_scan()?;
+        let expr = ((col("a") & col("b")) + (col("b") & col("a"))).eq(lit(30));
+        let plan = LogicalPlanBuilder::from(table_scan).filter(expr)?.build()?;
+
+        let expected = "Projection: test.a, test.b, test.c\
+        \n  Filter: __common_expr_1 + __common_expr_1 = Int32(30)\
+        \n    Projection: test.a & test.b AS __common_expr_1, test.a, test.b, test.c\
+        \n      TableScan: test";
+        assert_optimized_plan_eq(expected, plan, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_bitset_or_expression() -> Result<()> {
+        // a | b <=> b | a
+        let table_scan = test_table_scan()?;
+        let expr = ((col("a") | col("b")) + (col("b") | col("a"))).eq(lit(30));
+        let plan = LogicalPlanBuilder::from(table_scan).filter(expr)?.build()?;
+
+        let expected = "Projection: test.a, test.b, test.c\
+        \n  Filter: __common_expr_1 + __common_expr_1 = Int32(30)\
+        \n    Projection: test.a | test.b AS __common_expr_1, test.a, test.b, test.c\
+        \n      TableScan: test";
+        assert_optimized_plan_eq(expected, plan, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_bitset_xor_expression() -> Result<()> {
+        // a # b <=> b # a
+        let table_scan = test_table_scan()?;
+        let expr = ((col("a") ^ col("b")) + (col("b") ^ col("a"))).eq(lit(30));
+        let plan = LogicalPlanBuilder::from(table_scan).filter(expr)?.build()?;
+
+        let expected = "Projection: test.a, test.b, test.c\
+        \n  Filter: __common_expr_1 + __common_expr_1 = Int32(30)\
+        \n    Projection: test.a BIT_XOR test.b AS __common_expr_1, test.a, test.b, test.c\
+        \n      TableScan: test";
+        assert_optimized_plan_eq(expected, plan, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_gt_expression() -> Result<()> {
+        // a > b <=> b < a
+        let table_scan = test_table_scan()?;
+        let expr = (col("a").gt(col("b"))).and(col("b").lt(col("a")));
+        let plan = LogicalPlanBuilder::from(table_scan).filter(expr)?.build()?;
+
+        let expected = "Projection: test.a, test.b, test.c\
+        \n  Filter: __common_expr_1 AND __common_expr_1\
+        \n    Projection: test.b < test.a AS __common_expr_1, test.a, test.b, test.c\
+        \n      TableScan: test";
+        assert_optimized_plan_eq(expected, plan, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_gte_expression() -> Result<()> {
+        // a >= b <=> b <= a
+        let table_scan = test_table_scan()?;
+        let expr = (col("a").gt_eq(col("b"))).and(col("b").lt_eq(col("a")));
+        let plan = LogicalPlanBuilder::from(table_scan).filter(expr)?.build()?;
+
+        let expected = "Projection: test.a, test.b, test.c\
+        \n  Filter: __common_expr_1 AND __common_expr_1\
+        \n    Projection: test.b <= test.a AS __common_expr_1, test.a, test.b, test.c\
+        \n      TableScan: test";
+        assert_optimized_plan_eq(expected, plan, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_eq_expression() -> Result<()> {
+        // a = b <=> b = a
+        let table_scan = test_table_scan()?;
+        let expr = (col("a").eq(col("b"))).and(col("b").eq(col("a")));
+        let plan = LogicalPlanBuilder::from(table_scan).filter(expr)?.build()?;
+
+        let expected = "Projection: test.a, test.b, test.c\
+        \n  Filter: __common_expr_1 AND __common_expr_1\
+        \n    Projection: test.a = test.b AS __common_expr_1, test.a, test.b, test.c\
+        \n      TableScan: test";
+        assert_optimized_plan_eq(expected, plan, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_ne_expression() -> Result<()> {
+        // a != b <=> b != a
+        let table_scan = test_table_scan()?;
+        let expr = (col("a").not_eq(col("b"))).and(col("b").not_eq(col("a")));
+        let plan = LogicalPlanBuilder::from(table_scan).filter(expr)?.build()?;
+
+        let expected = "Projection: test.a, test.b, test.c\
+        \n  Filter: __common_expr_1 AND __common_expr_1\
+        \n    Projection: test.a != test.b AS __common_expr_1, test.a, test.b, test.c\
+        \n      TableScan: test";
         assert_optimized_plan_eq(expected, plan, None);
 
         Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

I notice that some expressions are semantically equivalent. (i.g. `a + b` and `b + a` is equivalent). I think their expressions can be optimized in CSE (i.e. common subexper eliminate) process. For example: we can optimize below logical plan.

before:
```text
Filter: (test.a + test.b) * (test.b + test.a) = Int32(30)
  TableScan: test
```
after:
```text
Projection: test.a, test.b, test.c
  Filter: __common_expr_1 * __common_expr_1 = Int32(30)
    Projection: test.a + test.b AS __common_expr_1, test.a, test.b, test.c
      TableScan: test
```

In example, we extract common expr `test.a + test.b`, as `test.a + test.b` is equal to `test.b + test.a` semantically. 

## What changes are included in this PR?

1. adding code of normalizing node before CSE in function `extract_common_nodes`. 
2. adding trait `NormalizeNode` and implement this trait for enum `Expr`.
3. adding some normalize rule for some specific `BinaryExpr` (including `Plus` / `Multi` / `BitsetAnd` / `BitsetOr` / `BitsetXor` / `Gt` / `GtEq` / `Eq` / `NotEq` expressions)

## Are these changes tested?

yes, I add below test cases.
1. test_normalize_add_expression
2. test_normalize_multi_expression
4. test_normalize_bitset_and_expression
5. test_normalize_bitset_or_expression
6. test_normalize_bitset_xor_expression
7. test_normalize_gt_expression
8. test_normalize_gte_expression
9. test_normalize_eq_expression
10. test_normalize_ne_expression

## Are there any user-facing changes?

No
