### PR TITLE
Remove elements deprecated since v 38.

### DIFF
--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -238,15 +238,6 @@ pub trait TreeNode: Sized {
         transform_down_impl(self, &mut f)
     }
 
-    /// Same as [`Self::transform_down`] but with a mutable closure.
-    #[deprecated(since = "38.0.0", note = "Use `transform_down` instead")]
-    fn transform_down_mut<F: FnMut(Self) -> Result<Transformed<Self>>>(
-        self,
-        f: &mut F,
-    ) -> Result<Transformed<Self>> {
-        self.transform_down(f)
-    }
-
     /// Recursively rewrite the node using `f` in a bottom-up (post-order)
     /// fashion.
     ///
@@ -269,15 +260,6 @@ pub trait TreeNode: Sized {
         }
 
         transform_up_impl(self, &mut f)
-    }
-
-    /// Same as [`Self::transform_up`] but with a mutable closure.
-    #[deprecated(since = "38.0.0", note = "Use `transform_up` instead")]
-    fn transform_up_mut<F: FnMut(Self) -> Result<Transformed<Self>>>(
-        self,
-        f: &mut F,
-    ) -> Result<Transformed<Self>> {
-        self.transform_up(f)
     }
 
     /// Transforms the node using `f_down` while traversing the tree top-down

--- a/datafusion/physical-plan/src/insert.rs
+++ b/datafusion/physical-plan/src/insert.rs
@@ -73,9 +73,6 @@ pub trait DataSink: DisplayAs + Debug + Send + Sync {
     ) -> Result<u64>;
 }
 
-#[deprecated(since = "38.0.0", note = "Use [`DataSinkExec`] instead")]
-pub type FileSinkExec = DataSinkExec;
-
 /// Execution plan for writing record batches to a [`DataSink`]
 ///
 /// Returns a single row with the number of values written


### PR DESCRIPTION
They were deprecated since 38.0.0, which was released 6 months ago.
