### PR TITLE
Ensure schema and data have the same size

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -218,7 +218,7 @@ impl LogicalPlanBuilder {
         if values.is_empty() {
             return plan_err!("Values list cannot be empty");
         }
-        let n_cols = values[0].len();
+        let n_cols = schema.fields().len();
         if n_cols == 0 {
             return plan_err!("Values list cannot be zero length");
         }

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -137,3 +137,10 @@ select 1 group by substr('');
 # Error in filter should be reported
 query error Divide by zero
 SELECT c2 from aggregate_test_100 where CASE WHEN true THEN 1 / 0 ELSE 0 END = 1;
+
+
+statement error DataFusion error: Error during planning: Inconsistent data length across values list: got 4 values in row 0 but expected 2
+create table records (timestamp timestamp, value float) as values (
+    '2021-01-01 00:00:00', 1.0,
+    '2021-01-01 00:00:00', 2.0
+);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Got a panic when forgot to put braces:

<img width="892" alt="RustRover-EAP 2024-11-05 21 09 43" src="https://github.com/user-attachments/assets/e66caf75-8543-4786-9c53-88770a27c40f">


## What changes are included in this PR?

We have number of column validation, we just don't compare it with with the schema size.

## Are these changes tested?

Yes, added a new test

## Are there any user-facing changes?

No
