### PR TITLE
RFC: Add `Precision:AtLeast` and `Precision::AtMost` for more `Statistics`… precision

### DIFF
--- a/datafusion/common/src/stats.rs
+++ b/datafusion/common/src/stats.rs
@@ -49,7 +49,10 @@ impl<T: Debug + Clone + PartialEq + Eq + PartialOrd> Precision<T> {
     /// Otherwise, it returns `None`.
     pub fn get_value(&self) -> Option<&T> {
         match self {
-            Precision::Exact(value) | Precision::Inexact(value) | Precision::AtLeast(value) | Precision::AtMost(T) => Some(value),
+            Precision::Exact(value)
+            | Precision::Inexact(value)
+            | Precision::AtLeast(value)
+            | Precision::AtMost(T) => Some(value),
             Precision::Absent => None,
         }
     }
@@ -83,7 +86,6 @@ impl<T: Debug + Clone + PartialEq + Eq + PartialOrd> Precision<T> {
             Precision::Absent => None,
         }
     }
-
 
     /// Transform the value in this [`Precision`] object, if one exists, using
     /// the given function. Preserves the exactness state.
@@ -142,7 +144,6 @@ impl<T: Debug + Clone + PartialEq + Eq + PartialOrd> Precision<T> {
             (_, _) => Precision::Absent,
         }
     }
-
 
     /// Demotes the precision state from exact to inexact (if present).
     pub fn to_inexact(self) -> Self {
@@ -500,6 +501,16 @@ impl ColumnStatistics {
             min_value: Precision::Absent,
             distinct_count: Precision::Absent,
         }
+    }
+
+    /// return the minimum value this column can have, if known
+    pub fn min_value(&self) -> Option<&ScalarValue> {
+        self.min_value.get_value()
+    }
+
+    /// return the maximum value this column can have, if known
+    pub fn max_value(&self) -> Option<&ScalarValue> {
+        self.max_value.get_value()
     }
 
     /// If the exactness of a [`ColumnStatistics`] instance is lost, this


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/8078
- Related to https://github.com/apache/datafusion/issues/10316

# Discussion:
This is a Request for Comment (and maybe also a POC)

I hacked very briefly on a different approach ( `Precision::Interval`) but found:
-  `ColumnStatistics` already has a `min` and `max` (basically a bound) so introducing an interval into `Precision` would likely mean we would need to change `ColumnStatistics` to have an `value: Precision<..>` as well -- which might be a better choice, but it would be a bigger change
- The [`Interval`](https://docs.rs/datafusion/latest/datafusion/logical_expr/interval_arithmetic/struct.Interval.html) is defined in a different crate so we can't easily use it in `Statistics`s without a bunch of code



## Rationale for this change

For the analysis described on https://github.com/apache/datafusion/issues/10316, we need to know if a value is constrained to a range to avoid merging. However the current `Statistics` are either `Exact` or `Inexact`, so once the precision becomes Inexact we lose the information that the possible minimum / maximum values do not change.

This came up twice for me recently:
1. @suremarc, @findepi and I spoke about this here: https://github.com/apache/datafusion/issues/8227#issuecomment-2458134570 where we need to know if a value is constrained to a range to avoid merging (see https://github.com/apache/datafusion/issues/10316)
2. Yesterday I happened to be working on code in InfluxDB 3.0 that relies on knowing min/max values and I hit https://github.com/influxdata/arrow-datafusion/commit/30d4368127db80c125a1adea22a955a496a516df which marks the statistics as "inexact" when filter pushdown is on for parquet, but that loses the key information that the possible minimum / maximum values do not change

I hacked around it downstream, but I think this is all sounding like it is time to add a new `Precision` enum that allows for this usecase


## What changes are included in this PR?
- [x] Introduce `Precision::AtMost`, `Precision::AtLeast`
- [x] Add `ColumnStatistics::min` and `ColumnStatistics::max` that return the correct value
- [ ] Update code to handle new precision
- [ ] Update ParquetExec to use the new Precision variants when filters are on

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
