### PR TITLE
feat: Optimize `SortPreservingMergeExec` to avoid merging non-overlapping partitions

### DIFF
--- a/datafusion/common/src/stats.rs
+++ b/datafusion/common/src/stats.rs
@@ -365,7 +365,7 @@ impl Statistics {
     }
 
     /// Attempt to merge these statistics.
-    /// Merging provides conservative estimates for null & distinct counts as well as num_rows,
+    /// Merging provides conservatively large estimates for null & distinct counts as well as num_rows,
     /// so those will be converted to inexact values.
     pub fn merge(&self, other: &Self) -> Self {
         Self {
@@ -493,7 +493,7 @@ impl ColumnStatistics {
     }
 
     /// Attempt to merge these statistics.
-    /// Merging provides conservative estimates for null & distinct counts,
+    /// Merging provides conservatively large estimates for null & distinct counts,
     /// so those will be converted to inexact values.
     pub fn merge(&self, other: &Self) -> Self {
         Self {

--- a/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
@@ -275,6 +275,7 @@ impl FileScanConfig {
                     .unwrap_or(Statistics::new_unknown(&self.file_schema));
 
                 for _ in 0..self.table_partition_cols.len() {
+                    // TODO provide accurate stat for partition column (#1186)
                     stats
                         .column_statistics
                         .push(ColumnStatistics::new_unknown())

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -397,6 +397,13 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
         Ok(Statistics::new_unknown(&self.schema()))
     }
 
+    fn statistics_by_partition(&self) -> Result<Vec<Statistics>> {
+        Ok(vec![
+            self.statistics()?;
+            self.properties().partitioning.partition_count()
+        ])
+    }
+
     /// Returns `true` if a limit can be safely pushed down through this
     /// `ExecutionPlan` node.
     ///

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -72,6 +72,7 @@ pub mod recursive_query;
 pub mod repartition;
 pub mod sorts;
 pub mod spill;
+pub mod statistics;
 pub mod stream;
 pub mod streaming;
 pub mod tree_node;

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -191,10 +191,10 @@ impl DisplayAs for SortPreservingMergeExec {
                         ", partition_groups=[{}]",
                         partition_groups
                             .iter()
-                            .map(|group| group
-                                .iter()
-                                .map(|index| index.to_string())
-                                .join(","))
+                            .map(|group| format!(
+                                "[{}]",
+                                group.iter().map(|index| index.to_string()).join(",")
+                            ))
                             .join(",")
                     )?;
                 }

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -257,6 +257,17 @@ impl ExecutionPlan for UnionExec {
             .unwrap_or_else(|| Statistics::new_unknown(&self.schema())))
     }
 
+    fn statistics_by_partition(&self) -> Result<Vec<Statistics>> {
+        Ok(self
+            .inputs
+            .iter()
+            .map(|child| child.statistics_by_partition())
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect())
+    }
+
     fn benefits_from_input_partitioning(&self) -> Vec<bool> {
         vec![false; self.children().len()]
     }

--- a/datafusion/sqllogictest/test_files/optimize_sort_preserving_merge.slt
+++ b/datafusion/sqllogictest/test_files/optimize_sort_preserving_merge.slt
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+## Optimize Sort Preserving Merge
+##########
+
+# Collect statistics
+statement ok
+set datafusion.execution.collect_statistics = true;
+
+statement ok
+set datafusion.optimizer.prefer_existing_sort = true;
+
+# Partition 1 has only columns a and b
+statement ok
+COPY  (
+  SELECT column1 as a, column2 as b
+  FROM ( VALUES ('foo', 1), ('qux', 3) )
+ )  TO 'test_files/scratch/optimize_sort_preserving_merge/parquet_table/partition=1/1_1.parquet'
+STORED AS PARQUET;
+
+# Add another file to this partition
+statement ok
+COPY  (
+  SELECT column1 as a, column2 as b
+  FROM ( VALUES ('foobar', 2), ('quux', 4) )
+ )  TO 'test_files/scratch/optimize_sort_preserving_merge/parquet_table/partition=1/1_2.parquet'
+STORED AS PARQUET;
+
+# Partition 2 has only a
+statement ok
+COPY  (
+  SELECT column1 as a
+  FROM ( VALUES  ('bar'), ('baz') )
+ )  TO 'test_files/scratch/optimize_sort_preserving_merge/parquet_table/partition=2/2_2.parquet'
+STORED AS PARQUET;
+
+statement ok
+CREATE EXTERNAL TABLE t(a varchar NOT NULL, b int, c float, partition int) STORED AS PARQUET
+PARTITIONED BY (partition)
+WITH ORDER (a)
+LOCATION 'test_files/scratch/optimize_sort_preserving_merge/parquet_table/';
+
+query TT
+EXPLAIN 
+select a from t WHERE partition = 1
+UNION all
+select a from t WHERE partition = 2
+ORDER BY a;
+----
+logical_plan
+01)Sort: t.a ASC NULLS LAST
+02)--Union
+03)----TableScan: t projection=[a], full_filters=[t.partition = Int32(1)]
+04)----TableScan: t projection=[a], full_filters=[t.partition = Int32(2)]
+physical_plan
+01)SortPreservingMergeExec: [a@0 ASC NULLS LAST], partition_groups=[2,0,1]
+02)--UnionExec
+03)----ParquetExec: file_groups={2 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/optimize_sort_preserving_merge/parquet_table/partition=1/1_1.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/optimize_sort_preserving_merge/parquet_table/partition=1/1_2.parquet]]}, projection=[a], output_ordering=[a@0 ASC NULLS LAST]
+04)----ParquetExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/optimize_sort_preserving_merge/parquet_table/partition=2/2_2.parquet]]}, projection=[a], output_ordering=[a@0 ASC NULLS LAST]
+
+
+query T
+select a from t WHERE partition = 1
+UNION all
+select a from t WHERE partition = 2
+ORDER BY a;
+----
+bar
+baz
+foo
+foobar
+quux
+qux

--- a/datafusion/sqllogictest/test_files/optimize_sort_preserving_merge.slt
+++ b/datafusion/sqllogictest/test_files/optimize_sort_preserving_merge.slt
@@ -69,7 +69,7 @@ logical_plan
 03)----TableScan: t projection=[a], full_filters=[t.partition = Int32(1)]
 04)----TableScan: t projection=[a], full_filters=[t.partition = Int32(2)]
 physical_plan
-01)SortPreservingMergeExec: [a@0 ASC NULLS LAST], partition_groups=[2,0,1]
+01)SortPreservingMergeExec: [a@0 ASC NULLS LAST], partition_groups=[[2,0],[1]]
 02)--UnionExec
 03)----ParquetExec: file_groups={2 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/optimize_sort_preserving_merge/parquet_table/partition=1/1_1.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/optimize_sort_preserving_merge/parquet_table/partition=1/1_2.parquet]]}, projection=[a], output_ordering=[a@0 ASC NULLS LAST]
 04)----ParquetExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/optimize_sort_preserving_merge/parquet_table/partition=2/2_2.parquet]]}, projection=[a], output_ordering=[a@0 ASC NULLS LAST]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10316.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR uses the existing `MinMaxStatistics` to reorder the input streams into chains of non-overlapping streams based on the statistics knowledge of its input. This requires some changes:
* A tentative new API, `ExecutionPlan::statistics_by_partition`
  * Left basically unimplemented for now, pending on feedback
* Move the `MinMaxStatistics` type to `datafusion-physical-plan`
* #8078
  * Currently the `MinMaxStatistics` code assumes that the statistics give precise bounds and not (potentially overzealous) estimates.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, there is a new sqllogictest, `optimize_sort_preserving_merge.slt`

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

The `MinMaxStatistics` API is made public, as otherwise we can't use it in the `core` crate where it previously was being used. 

There is a new `ExecutionPlan::statistics_by_partition` method with a default implementation, but it is not breaking. 

There are also the new `Statistics::merge` and `ColumnStatistics::merge` functions. 