### PR TITLE
Fix ExprSchema extraction of metadata for Cast expressions.

### DIFF
--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -682,13 +682,11 @@ mod tests {
             .with_data_type(DataType::Int32)
             .with_metadata(meta.clone());
 
-        // col and alias should be metadata-preserving
+        // col, alias, and cast should be metadata-preserving
         assert_eq!(meta, expr.metadata(&schema).unwrap());
         assert_eq!(meta, expr.clone().alias("bar").metadata(&schema).unwrap());
-
-        // cast should drop input metadata since the type has changed
         assert_eq!(
-            HashMap::new(),
+            meta,
             expr.clone()
                 .cast_to(&DataType::Int64, &schema)
                 .unwrap()

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -347,6 +347,7 @@ impl ExprSchemable for Expr {
         match self {
             Expr::Column(c) => Ok(schema.metadata(c)?.clone()),
             Expr::Alias(Alias { expr, .. }) => expr.metadata(schema),
+            Expr::Cast(Cast { expr, .. }) => expr.metadata(schema),
             _ => Ok(HashMap::new()),
         }
     }

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -188,9 +188,11 @@ FROM table_with_metadata;
 2020-09-08
 
 # Regression test: distinct with cast
-statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema
+query D
 SELECT DISTINCT (ts::DATE) AS dist
     FROM table_with_metadata;
+----
+2020-09-08
 
 
 
@@ -221,13 +223,17 @@ order by 1 asc nulls last;
 NULL 1
 
 # Regression test: count distinct & cast, with group by
-statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema
+query TI
 SELECT
     CAST(id AS TEXT) AS grp,
     COUNT(DISTINCT nonnull_name) as dist
 FROM table_with_metadata
 GROUP BY grp
 order by 1 asc nulls last;
+----
+1 1
+3 1
+NULL 1
 
 
 

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -168,5 +168,68 @@ LIMIT 1;
 2020-09-08T13:42:29.190855123Z
 
 
+
+# distinct (aggregate) alone
+query P
+SELECT
+    DISTINCT ts as dist
+FROM table_with_metadata;
+----
+2020-09-08T13:42:29.190855123
+
+# cast alone
+query D
+SELECT
+    ts::DATE as casted
+FROM table_with_metadata;
+----
+2020-09-08
+2020-09-08
+2020-09-08
+
+# Regression test: distinct with cast
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema
+SELECT DISTINCT (ts::DATE) AS dist
+    FROM table_with_metadata;
+
+
+
+# count distinct with group by
+query II
+SELECT
+    id AS grp,
+    COUNT(DISTINCT nonnull_name) as dist
+FROM table_with_metadata
+GROUP BY grp
+order by 1 asc nulls last;
+----
+1 1
+3 1
+NULL 1
+
+# count (not distinct) & cast, with group by
+query TI
+SELECT
+    CAST(id AS TEXT) AS grp,
+    COUNT(nonnull_name) as dist
+FROM table_with_metadata
+GROUP BY grp
+order by 1 asc nulls last;
+----
+1 1
+3 1
+NULL 1
+
+# Regression test: count distinct & cast, with group by
+statement error DataFusion error: Internal error: Physical input schema should be the same as the one converted from logical input schema
+SELECT
+    CAST(id AS TEXT) AS grp,
+    COUNT(DISTINCT nonnull_name) as dist
+FROM table_with_metadata
+GROUP BY grp
+order by 1 asc nulls last;
+
+
+
 statement ok
 drop table table_with_metadata;


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/12733

## Rationale for this change

The field metadata was not being extracted from the ExprSchema for cast expressions. When cast was used as a projection on an aggregate, it would be missing the field metadata and fail the [schema-misalignment check](https://github.com/apache/datafusion/blob/322d83526909ab44cfbe34b982d1a1c36a4dbe8f/datafusion/core/src/physical_planner.rs#L676) (see [background epic](https://github.com/apache/datafusion/issues/12733#issue-2563622229)).

The result was that the logical plan schema did not have the field metadata, whereas the physical plan schema did:
```
# physical_input_schema
Schema { 
   fields: [
      Field { 
        name: "dist", 
        data_type: Date32, 
        nullable: false, 
        dict_id: 0, 
        dict_is_ordered: false, 
        metadata: {"metadata_key": "ts non-nullable field"} 
      }
    ],
    metadata: {"metadata_key": "the entire schema"} 
}

# physical_input_schema_from_logical
Schema { 
    fields: [
      Field { 
        name: "dist", 
        data_type: Date32, 
        nullable: false, 
        dict_id: 0, 
        dict_is_ordered: false, 
        metadata: {}                     // the difference
      }
    ], 
    metadata: {"metadata_key": "the entire schema"} 
}
```

~However, I'm not 💯 that this is the right fix. Since it triggers [another test to fail ](https://github.com/apache/datafusion/blob/f190fc6de6a6171c1cd6aa99233bc647ed8b1377/datafusion/expr/src/expr_schema.rs#L688)-- because `cast should drop input metadata since the type has changed`. What is the proper behavior here? Instead, should we be removing the field metadata from the physical schema?~ Per the [comment below](https://github.com/apache/datafusion/pull/13305#issuecomment-2465065827), we agreed to have the cast expr retain the field metadata.

## What changes are included in this PR?

[commit 1](https://github.com/apache/datafusion/pull/13305/commits/88a4d70bcdea3f0393ea9dd4d38beb923d2ef7e2) = test case with reproducer. Demonstrates exactly which scenario fails (vs is ok).
commit 2 = fix, and update test cases

## Are these changes tested?

yes

## Are there any user-facing changes?

no
