### PR TITLE
Support LIKE with ESCAPE `\`

### DIFF
--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -202,7 +202,9 @@ pub fn create_physical_expr(
         }) => {
             // `\` is the implicit escape, see https://github.com/apache/datafusion/issues/13291
             if escape_char.unwrap_or('\\') != '\\' {
-                return exec_err!("LIKE does not support escape_char other than the backslash (\\)");
+                return exec_err!(
+                    "LIKE does not support escape_char other than the backslash (\\)"
+                );
             }
             let physical_expr =
                 create_physical_expr(expr, input_dfschema, execution_props)?;

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -200,8 +200,9 @@ pub fn create_physical_expr(
             escape_char,
             case_insensitive,
         }) => {
-            if escape_char.is_some() {
-                return exec_err!("LIKE does not support escape_char");
+            // `\` is the implicit escape, see https://github.com/apache/datafusion/issues/13291
+            if escape_char.unwrap_or('\\') != '\\' {
+                return exec_err!("LIKE does not support escape_char other than the backslash (\\)");
             }
             let physical_expr =
                 create_physical_expr(expr, input_dfschema, execution_props)?;

--- a/datafusion/sqllogictest/test_files/string/string_literal.slt
+++ b/datafusion/sqllogictest/test_files/string/string_literal.slt
@@ -861,16 +861,16 @@ SELECT
 ----
 false false true false true false
 
-# \ as an explicit escape character is currently not supported
-query error DataFusion error: Execution error: LIKE does not support escape_char
+query BBBB
 SELECT
     'a' LIKE '\%' ESCAPE '\',
     '\a' LIKE '\%' ESCAPE '\',
     '%' LIKE '\%' ESCAPE '\',
     '\%' LIKE '\%' ESCAPE '\'
+----
+false false true false
 
-# \ as an explicit escape character is currently not supported
-query error DataFusion error: Execution error: LIKE does not support escape_char
+query BBBBBB
 SELECT
     'a' LIKE '\_' ESCAPE '\',
     '\a' LIKE '\_' ESCAPE '\',
@@ -878,6 +878,26 @@ SELECT
     '\_' LIKE '\_' ESCAPE '\',
     'abc' LIKE 'a_c' ESCAPE '\',
     'abc' LIKE 'a\_c' ESCAPE '\'
+----
+false false true false true false
+
+# Only \ is currently supported as an explicit escape character
+query error DataFusion error: Execution error: LIKE does not support escape_char other than the backslash \(\\\)
+SELECT
+    'a' LIKE '$%' ESCAPE '$',
+    '\a' LIKE '$%' ESCAPE '$',
+    '%' LIKE '$%' ESCAPE '$',
+    '\%' LIKE '$%' ESCAPE '$'
+
+# Only \ is currently supported as an explicit escape character
+query error DataFusion error: Execution error: LIKE does not support escape_char other than the backslash \(\\\)
+SELECT
+    'a' LIKE '$_' ESCAPE '$',
+    '\a' LIKE '$_' ESCAPE '$',
+    '_' LIKE '$_' ESCAPE '$',
+    '\_' LIKE '$_' ESCAPE '$',
+    'abc' LIKE 'a_c' ESCAPE '$',
+    'abc' LIKE 'a$_c' ESCAPE '$'
 
 # a LIKE pattern containing escape can never match an empty string
 query BBBBB


### PR DESCRIPTION
Other escape characters are currently not supported.
