### PR TITLE
Update dev script to publish FFI crate

### DIFF
--- a/dev/update_datafusion_versions.py
+++ b/dev/update_datafusion_versions.py
@@ -32,6 +32,7 @@ crates = {
     'datafusion': 'datafusion/core/Cargo.toml',
     'datafusion-execution': 'datafusion/execution/Cargo.toml',
     'datafusion-expr': 'datafusion/expr/Cargo.toml',
+    'datafusion-ffi': 'datafusion/ffi/Cargo.toml',
     'datafusion-functions': 'datafusion/functions/Cargo.toml',
     'datafusion-functions-aggregate': 'datafusion/functions-aggregate/Cargo.toml',
     'datafusion-functions-nested': 'datafusion/functions-nested/Cargo.toml',


### PR DESCRIPTION
## Which issue does this PR close?

None

## Rationale for this change

In the last update to 43.0.0 we have a new crate that needs to be published but it was not included in the script.

## What changes are included in this PR?

Adds `datafusion-ffi` to publish list

## Are these changes tested?

No, I do not have the ability to test it.

## Are there any user-facing changes?

None