### PR TITLE
Remove uses of #[allow(dead_code)] in favor of _identifier

### DIFF
--- a/datafusion-examples/examples/advanced_parquet_index.rs
+++ b/datafusion-examples/examples/advanced_parquet_index.rs
@@ -229,7 +229,8 @@ async fn main() -> Result<()> {
 /// `file1.parquet` contains values `0..1000`
 #[derive(Debug)]
 pub struct IndexTableProvider {
-    /// Where the file is stored (cleanup on drop)
+    /// Pointer to temporary file storage. Keeping it in scope to prevent temporary folder
+    /// to be deleted prematurely
     _tmpdir: TempDir,
     /// The file that is being read.
     indexed_file: IndexedFile,

--- a/datafusion-examples/examples/advanced_parquet_index.rs
+++ b/datafusion-examples/examples/advanced_parquet_index.rs
@@ -230,8 +230,7 @@ async fn main() -> Result<()> {
 #[derive(Debug)]
 pub struct IndexTableProvider {
     /// Where the file is stored (cleanup on drop)
-    #[allow(dead_code)]
-    tmpdir: TempDir,
+    _tmpdir: TempDir,
     /// The file that is being read.
     indexed_file: IndexedFile,
     /// The underlying object store
@@ -250,7 +249,7 @@ impl IndexTableProvider {
 
         Ok(Self {
             indexed_file,
-            tmpdir,
+            _tmpdir: tmpdir,
             object_store,
             use_row_selections: AtomicBool::new(false),
         })

--- a/datafusion/core/tests/parquet/external_access_plan.rs
+++ b/datafusion/core/tests/parquet/external_access_plan.rs
@@ -313,7 +313,7 @@ impl TestFull {
         } = self;
 
         let TestData {
-            temp_file: _,
+            _temp_file: _,
             schema,
             file_name,
             file_size,
@@ -362,8 +362,7 @@ impl TestFull {
 // Holds necessary data for these tests to reuse the same parquet file
 struct TestData {
     // field is present as on drop the file is deleted
-    #[allow(dead_code)]
-    temp_file: NamedTempFile,
+    _temp_file: NamedTempFile,
     schema: SchemaRef,
     file_name: String,
     file_size: u64,
@@ -402,7 +401,7 @@ fn get_test_data() -> &'static TestData {
         let file_size = temp_file.path().metadata().unwrap().len();
 
         TestData {
-            temp_file,
+            _temp_file: temp_file,
             schema,
             file_name,
             file_size,

--- a/datafusion/core/tests/parquet/external_access_plan.rs
+++ b/datafusion/core/tests/parquet/external_access_plan.rs
@@ -361,7 +361,8 @@ impl TestFull {
 
 // Holds necessary data for these tests to reuse the same parquet file
 struct TestData {
-    // field is present as on drop the file is deleted
+    /// Pointer to temporary file storage. Keeping it in scope to prevent temporary folder
+    /// to be deleted prematurely
     _temp_file: NamedTempFile,
     schema: SchemaRef,
     file_name: String,

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -100,10 +100,9 @@ enum Unit {
 /// table "t" registered, pointing at a parquet file made with
 /// `make_test_file`
 struct ContextWithParquet {
-    #[allow(dead_code)]
     /// temp file parquet data is written to. The file is cleaned up
     /// when dropped
-    file: NamedTempFile,
+    _file: NamedTempFile,
     provider: Arc<dyn TableProvider>,
     ctx: SessionContext,
 }
@@ -217,7 +216,7 @@ impl ContextWithParquet {
         ctx.register_table("t", provider.clone()).unwrap();
 
         Self {
-            file,
+            _file: file,
             provider,
             ctx,
         }

--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -139,7 +139,7 @@ impl DiskManager {
 
         let dir_index = thread_rng().gen_range(0..local_dirs.len());
         Ok(RefCountedTempFile {
-            parent_temp_dir: Arc::clone(&local_dirs[dir_index]),
+            _parent_temp_dir: Arc::clone(&local_dirs[dir_index]),
             tempfile: Builder::new()
                 .tempfile_in(local_dirs[dir_index].as_ref())
                 .map_err(DataFusionError::IoError)?,
@@ -153,8 +153,7 @@ impl DiskManager {
 pub struct RefCountedTempFile {
     /// The reference to the directory in which temporary files are created to ensure
     /// it is not cleaned up prior to the NamedTempFile
-    #[allow(dead_code)]
-    parent_temp_dir: Arc<TempDir>,
+    _parent_temp_dir: Arc<TempDir>,
     tempfile: NamedTempFile,
 }
 

--- a/datafusion/physical-plan/src/joins/cross_join.rs
+++ b/datafusion/physical-plan/src/joins/cross_join.rs
@@ -53,8 +53,7 @@ struct JoinLeftData {
     merged_batch: RecordBatch,
     /// Track memory reservation for merged_batch. Relies on drop
     /// semantics to release reservation when JoinLeftData is dropped.
-    #[allow(dead_code)]
-    reservation: MemoryReservation,
+    _reservation: MemoryReservation,
 }
 
 #[allow(rustdoc::private_intra_doc_links)]
@@ -209,7 +208,7 @@ async fn load_left_input(
 
     Ok(JoinLeftData {
         merged_batch,
-        reservation,
+        _reservation: reservation,
     })
 }
 

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -92,8 +92,7 @@ struct JoinLeftData {
     probe_threads_counter: AtomicUsize,
     /// Memory reservation that tracks memory used by `hash_map` hash table
     /// `batch`. Cleared on drop.
-    #[allow(dead_code)]
-    reservation: MemoryReservation,
+    _reservation: MemoryReservation,
 }
 
 impl JoinLeftData {
@@ -110,7 +109,7 @@ impl JoinLeftData {
             batch,
             visited_indices_bitmap,
             probe_threads_counter,
-            reservation,
+            _reservation: reservation,
         }
     }
 

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -69,8 +69,7 @@ struct JoinLeftData {
     probe_threads_counter: AtomicUsize,
     /// Memory reservation for tracking batch and bitmap
     /// Cleared on `JoinLeftData` drop
-    #[allow(dead_code)]
-    reservation: MemoryReservation,
+    _reservation: MemoryReservation,
 }
 
 impl JoinLeftData {
@@ -78,13 +77,13 @@ impl JoinLeftData {
         batch: RecordBatch,
         bitmap: SharedBitmapBuilder,
         probe_threads_counter: AtomicUsize,
-        reservation: MemoryReservation,
+        _reservation: MemoryReservation,
     ) -> Self {
         Self {
             batch,
             bitmap,
             probe_threads_counter,
-            reservation,
+            _reservation,
         }
     }
 

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -623,7 +623,7 @@ impl ExecutionPlan for RepartitionExec {
                         Box::pin(PerPartitionStream {
                             schema: Arc::clone(&schema_captured),
                             receiver,
-                            drop_helper: Arc::clone(&abort_helper),
+                            _drop_helper: Arc::clone(&abort_helper),
                             reservation: Arc::clone(&reservation),
                         }) as SendableRecordBatchStream
                     })
@@ -651,7 +651,7 @@ impl ExecutionPlan for RepartitionExec {
                     num_input_partitions_processed: 0,
                     schema: input.schema(),
                     input: rx.swap_remove(0),
-                    drop_helper: abort_helper,
+                    _drop_helper: abort_helper,
                     reservation,
                 }) as SendableRecordBatchStream)
             }
@@ -906,8 +906,7 @@ struct RepartitionStream {
     input: DistributionReceiver<MaybeBatch>,
 
     /// Handle to ensure background tasks are killed when no longer needed.
-    #[allow(dead_code)]
-    drop_helper: Arc<Vec<SpawnedTask<()>>>,
+    _drop_helper: Arc<Vec<SpawnedTask<()>>>,
 
     /// Memory reservation.
     reservation: SharedMemoryReservation,
@@ -970,8 +969,7 @@ struct PerPartitionStream {
     receiver: DistributionReceiver<MaybeBatch>,
 
     /// Handle to ensure background tasks are killed when no longer needed.
-    #[allow(dead_code)]
-    drop_helper: Arc<Vec<SpawnedTask<()>>>,
+    _drop_helper: Arc<Vec<SpawnedTask<()>>>,
 
     /// Memory reservation.
     reservation: SharedMemoryReservation,

--- a/datafusion/physical-plan/src/sorts/cursor.rs
+++ b/datafusion/physical-plan/src/sorts/cursor.rs
@@ -156,8 +156,7 @@ pub struct RowValues {
 
     /// Tracks for the memory used by in the `Rows` of this
     /// cursor. Freed on drop
-    #[allow(dead_code)]
-    reservation: MemoryReservation,
+    _reservation: MemoryReservation,
 }
 
 impl RowValues {
@@ -173,7 +172,10 @@ impl RowValues {
             "memory reservation mismatch"
         );
         assert!(rows.num_rows() > 0);
-        Self { rows, reservation }
+        Self {
+            rows,
+            _reservation: reservation,
+        }
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13278.


## What changes are included in this PR?
This PR refactors instances where `#[allow(dead_code)]` was used on struct fields that exist solely to ensure their `Drop` (destructor) is called. In such cases, the field name has been updated to use an underscore prefix (e.g., `_name`) instead of relying on `#[allow(dead_code)]`. This change aligns with idiomatic Rust practices, where _ prefixes indicate that fields or variables are intentionally unused but still necessary (e.g., memory reservation, tmp file cleanup in the source code).

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, in local environment.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
