### PR TITLE
Fix `concat` simplifier for Utf8View types

### DIFF
--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -110,8 +110,19 @@ impl ScalarUDFImpl for ConcatFunc {
         if array_len.is_none() {
             let mut result = String::new();
             for arg in args {
-                if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(v))) = arg {
-                    result.push_str(v);
+                match arg {
+                    ColumnarValue::Scalar(ScalarValue::Utf8(Some(v)))
+                    | ColumnarValue::Scalar(ScalarValue::Utf8View(Some(v)))
+                    | ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(v))) => {
+                        result.push_str(v);
+                    }
+                    ColumnarValue::Scalar(ScalarValue::Utf8(None))
+                    | ColumnarValue::Scalar(ScalarValue::Utf8View(None))
+                    | ColumnarValue::Scalar(ScalarValue::LargeUtf8(None)) => {}
+                    other => plan_err!(
+                        "Concat function does not support scalar type {:?}",
+                        other
+                    )?,
                 }
             }
 
@@ -282,15 +293,34 @@ pub fn simplify_concat(args: Vec<Expr>) -> Result<ExprSimplifyResult> {
     let mut new_args = Vec::with_capacity(args.len());
     let mut contiguous_scalar = "".to_string();
 
+    let mut merged_type = DataType::Utf8;
     for arg in args.clone() {
         match arg {
+            Expr::Literal(ScalarValue::Utf8(None)) => {}
+            Expr::Literal(ScalarValue::LargeUtf8(None)) => {
+                if merged_type != DataType::Utf8View {
+                    merged_type = DataType::LargeUtf8;
+                }
+            }
+            Expr::Literal(ScalarValue::Utf8View(None)) => { merged_type = DataType::Utf8View }
+
             // filter out `null` args
-            Expr::Literal(ScalarValue::Utf8(None) | ScalarValue::LargeUtf8(None) | ScalarValue::Utf8View(None)) => {}
             // All literals have been converted to Utf8 or LargeUtf8 in type_coercion.
             // Concatenate it with the `contiguous_scalar`.
-            Expr::Literal(
-                ScalarValue::Utf8(Some(v)) | ScalarValue::LargeUtf8(Some(v)) | ScalarValue::Utf8View(Some(v)),
-            ) => contiguous_scalar += &v,
+            Expr::Literal(ScalarValue::Utf8(Some(v))) => {
+                contiguous_scalar += &v;
+            }
+            Expr::Literal(ScalarValue::LargeUtf8(Some(v))) => {
+                if merged_type != DataType::Utf8View {
+                    merged_type = DataType::LargeUtf8;
+                }
+                contiguous_scalar += &v;
+            }
+            Expr::Literal(ScalarValue::Utf8View(Some(v))) => {
+                merged_type = DataType::Utf8View;
+                contiguous_scalar += &v;
+            }
+
             Expr::Literal(x) => {
                 return internal_err!(
                     "The scalar {x} should be casted to string type during the type coercion."
@@ -301,7 +331,13 @@ pub fn simplify_concat(args: Vec<Expr>) -> Result<ExprSimplifyResult> {
             // Then pushing this arg to the `new_args`.
             arg => {
                 if !contiguous_scalar.is_empty() {
-                    new_args.push(lit(contiguous_scalar));
+                    match merged_type {
+                        DataType::Utf8 => new_args.push(lit(contiguous_scalar)),
+                        DataType::LargeUtf8 => new_args.push(lit(ScalarValue::LargeUtf8(Some(contiguous_scalar)))),
+                        DataType::Utf8View => new_args.push(lit(ScalarValue::Utf8View(Some(contiguous_scalar)))),
+                        _ => unreachable!(),
+                    }
+                    merged_type = DataType::Utf8;
                     contiguous_scalar = "".to_string();
                 }
                 new_args.push(arg);
@@ -310,7 +346,16 @@ pub fn simplify_concat(args: Vec<Expr>) -> Result<ExprSimplifyResult> {
     }
 
     if !contiguous_scalar.is_empty() {
-        new_args.push(lit(contiguous_scalar));
+        match merged_type {
+            DataType::Utf8 => new_args.push(lit(contiguous_scalar)),
+            DataType::LargeUtf8 => {
+                new_args.push(lit(ScalarValue::LargeUtf8(Some(contiguous_scalar))))
+            }
+            DataType::Utf8View => {
+                new_args.push(lit(ScalarValue::Utf8View(Some(contiguous_scalar))))
+            }
+            _ => unreachable!(),
+        }
     }
 
     if !args.eq(&new_args) {
@@ -392,6 +437,17 @@ mod tests {
             LargeUtf8,
             LargeStringArray
         );
+        test_function!(
+            ConcatFunc::new(),
+            &[
+                ColumnarValue::Scalar(ScalarValue::Utf8View(Some("aa".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("cc".to_string()))),
+            ],
+            Ok(Some("aacc")),
+            &str,
+            Utf8View,
+            StringViewArray
+        );
 
         Ok(())
     }
@@ -406,12 +462,19 @@ mod tests {
             None,
             Some("z"),
         ])));
-        let args = &[c0, c1, c2];
+        let c3 = ColumnarValue::Scalar(ScalarValue::Utf8View(Some(",".to_string())));
+        let c4 = ColumnarValue::Array(Arc::new(StringViewArray::from(vec![
+            Some("a"),
+            None,
+            Some("b"),
+        ])));
+        let args = &[c0, c1, c2, c3, c4];
 
         #[allow(deprecated)] // TODO migrate UDF invoke to invoke_batch
         let result = ConcatFunc::new().invoke(args)?;
         let expected =
-            Arc::new(StringArray::from(vec!["foo,x", "bar,", "baz,z"])) as ArrayRef;
+            Arc::new(StringViewArray::from(vec!["foo,x,a", "bar,,", "baz,z,b"]))
+                as ArrayRef;
         match &result {
             ColumnarValue::Array(array) => {
                 assert_eq!(&expected, array);

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -48,7 +48,7 @@ impl ConcatFunc {
         use DataType::*;
         Self {
             signature: Signature::variadic(
-                vec![Utf8, Utf8View, LargeUtf8],
+                vec![Utf8View, LargeUtf8, Utf8],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -48,7 +48,7 @@ impl ConcatFunc {
         use DataType::*;
         Self {
             signature: Signature::variadic(
-                vec![Utf8View, LargeUtf8, Utf8],
+                vec![Utf8View, Utf8, LargeUtf8],
                 Volatility::Immutable,
             ),
         }


### PR DESCRIPTION
## Which issue does this PR close?

This addresses one item of https://github.com/apache/datafusion/issues/13330

## Rationale for this change

Concat simplifier was not correctly combining the return types, so Utf8View was instead getting returned as Utf8, causing a schema failure.

## What changes are included in this PR?

When combining schema in simplifier, follows the same rules to set the return type.

## Are these changes tested?

Tested in unit tests and with tests in `datafusion-python` that identified the problem.
Added additional checks in current unit test.

## Are there any user-facing changes?

None
