### PR TITLE
parquet:Add file_extension for specify file_extension of ParquetReadOptions

### DIFF
--- a/datafusion/core/src/datasource/file_format/options.rs
+++ b/datafusion/core/src/datasource/file_format/options.rs
@@ -262,6 +262,12 @@ impl<'a> ParquetReadOptions<'a> {
         Default::default()
     }
 
+    /// Specify file_extension
+    pub fn file_extension(mut self, file_extension: &'a str) -> Self {
+        self.file_extension = file_extension;
+        self
+    }
+    
     /// Specify parquet_pruning
     pub fn parquet_pruning(mut self, parquet_pruning: bool) -> Self {
         self.parquet_pruning = Some(parquet_pruning);


### PR DESCRIPTION
## Which issue does this PR close?
## Rationale for this change

This allows users to specify the file extendsion in ParquetReadOptions
```
let opt = ParquetReadOptions::new().file_extension("").table_partition_cols(vec![("dt".as_str, DataType::Utf8)]);
```

## What changes are included in this PR?

add a new fn `file_extension` for ParquetReadOptions

## Are these changes tested?

tests covered by existing tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
