### PR TITLE
fix: Support `Utf8View` in `numeric_string_coercion`

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1127,7 +1127,8 @@ fn regex_comparison_string_coercion(
 fn numeric_string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
     match (lhs_type, rhs_type) {
-        (Utf8 | LargeUtf8, other_type) | (other_type, Utf8 | LargeUtf8)
+        (Utf8 | Utf8View | LargeUtf8, other_type)
+        | (other_type, Utf8 | Utf8View | LargeUtf8)
             if other_type.is_numeric() =>
         {
             Some(other_type.clone())
@@ -1487,6 +1488,92 @@ mod tests {
         assert_eq!(
             coerce_numeric_type_to_decimal(&DataType::Float64).unwrap(),
             DataType::Decimal128(30, 15)
+        );
+    }
+
+    #[test]
+    fn test_numeric_string_coercion_with_utf8view() {
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::Int8),
+            Some(DataType::Int8)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Int8, &DataType::Utf8View),
+            Some(DataType::Int8)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::Int16),
+            Some(DataType::Int16)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Int16, &DataType::Utf8View),
+            Some(DataType::Int16)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::Int32),
+            Some(DataType::Int32)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Int32, &DataType::Utf8View),
+            Some(DataType::Int32)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::Int64),
+            Some(DataType::Int64)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Int64, &DataType::Utf8View),
+            Some(DataType::Int64)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::Float32),
+            Some(DataType::Float32)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Float32, &DataType::Utf8View),
+            Some(DataType::Float32)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::Float64),
+            Some(DataType::Float64)
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Float64, &DataType::Utf8View),
+            Some(DataType::Float64)
+        );
+
+        // should return `None`, it doesn't match the expected `string` <=> `numeric`
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::LargeUtf8),
+            None
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::LargeUtf8, &DataType::Utf8View),
+            None
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::Boolean),
+            None
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Boolean, &DataType::Utf8View),
+            None
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::Utf8),
+            None
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8, &DataType::Utf8View),
+            None
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Utf8View, &DataType::Null),
+            None
+        );
+        assert_eq!(
+            numeric_string_coercion(&DataType::Null, &DataType::Utf8View),
+            None
         );
     }
 

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -650,8 +650,10 @@ fn string_numeric_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<D
     match (lhs_type, rhs_type) {
         (Utf8, _) if rhs_type.is_numeric() => Some(Utf8),
         (LargeUtf8, _) if rhs_type.is_numeric() => Some(LargeUtf8),
+        (Utf8View, _) if rhs_type.is_numeric() => Some(Utf8View),
         (_, Utf8) if lhs_type.is_numeric() => Some(Utf8),
         (_, LargeUtf8) if lhs_type.is_numeric() => Some(LargeUtf8),
+        (_, Utf8View) if lhs_type.is_numeric() => Some(Utf8View),
         _ => None,
     }
 }
@@ -1488,92 +1490,6 @@ mod tests {
         assert_eq!(
             coerce_numeric_type_to_decimal(&DataType::Float64).unwrap(),
             DataType::Decimal128(30, 15)
-        );
-    }
-
-    #[test]
-    fn test_numeric_string_coercion_with_utf8view() {
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::Int8),
-            Some(DataType::Int8)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Int8, &DataType::Utf8View),
-            Some(DataType::Int8)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::Int16),
-            Some(DataType::Int16)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Int16, &DataType::Utf8View),
-            Some(DataType::Int16)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::Int32),
-            Some(DataType::Int32)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Int32, &DataType::Utf8View),
-            Some(DataType::Int32)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::Int64),
-            Some(DataType::Int64)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Int64, &DataType::Utf8View),
-            Some(DataType::Int64)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::Float32),
-            Some(DataType::Float32)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Float32, &DataType::Utf8View),
-            Some(DataType::Float32)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::Float64),
-            Some(DataType::Float64)
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Float64, &DataType::Utf8View),
-            Some(DataType::Float64)
-        );
-
-        // should return `None`, it doesn't match the expected `string` <=> `numeric`
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::LargeUtf8),
-            None
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::LargeUtf8, &DataType::Utf8View),
-            None
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::Boolean),
-            None
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Boolean, &DataType::Utf8View),
-            None
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::Utf8),
-            None
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8, &DataType::Utf8View),
-            None
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Utf8View, &DataType::Null),
-            None
-        );
-        assert_eq!(
-            numeric_string_coercion(&DataType::Null, &DataType::Utf8View),
-            None
         );
     }
 

--- a/datafusion/sqllogictest/test_files/strings.slt
+++ b/datafusion/sqllogictest/test_files/strings.slt
@@ -172,3 +172,15 @@ def
 
 statement ok
 drop table vals;
+
+# test numeric_string_conversion
+statement ok
+create table foo as values (arrow_cast('1', 'Utf8View')), (arrow_cast('2', 'Utf8View'));
+
+query T
+select column1 = 1 from foo1;
+----
+
+
+statement ok 
+drop table foo;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13359 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Added `utf8view` to `string_numeric_coercion`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Added tests for most numeric possibilities
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
