### PR TITLE
Annotate `Expr::get_type()` with recursive

### DIFF
--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -32,6 +32,7 @@ use datafusion_common::{
     TableReference,
 };
 use datafusion_functions_window_common::field::WindowUDFFieldArgs;
+use recursive::recursive;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -99,6 +100,7 @@ impl ExprSchemable for Expr {
     /// expression refers to a column that does not exist in the
     /// schema, or when the expression is incorrectly typed
     /// (e.g. `[utf8] + [bool]`).
+    #[recursive]
     fn get_type(&self, schema: &dyn ExprSchema) -> Result<DataType> {
         match self {
             Expr::Alias(Alias { expr, name, .. }) => match &**expr {


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to https://github.com/apache/datafusion/pull/13310, closes https://github.com/apache/datafusion/issues/9375.

## Rationale for this change

This is a small follow-up change to the previous PR to fix the stack overflow issue in https://github.com/apache/datafusion/issues/9375.

Please note that during the investigation 2 different issues were discovered:
- There was a stack overflow with `debug` build due to `sqlparser`, and this didn't come up with `release` build: https://github.com/apache/datafusion/issues/9375#issuecomment-2469909998.
- And there was a different stack overflow with `release` build: https://github.com/apache/datafusion/issues/9375#issuecomment-2470000115.

This PR fixes only the 2nd issue.
Most likely the 1st issue can also be fixed with stacker/recursive, but the change would be required in https://github.com/apache/datafusion-sqlparser-rs.

## What changes are included in this PR?

This PR annotates `Expr::get_type` with `#[recursive]`

## Are these changes tested?

Yes, with the `blowout2.zip` test provided in the issue description:

```
% cargo run --release -- -f ~/Downloads/blowout2.sql

...
DataFusion CLI v43.0.0
0 row(s) fetched.
Elapsed 0.007 seconds.

+-------+
| count |
+-------+
| 1     |
+-------+
1 row(s) fetched.
Elapsed 0.007 seconds.

+---+
| x |
+---+
| 1 |
+---+
1 row(s) fetched.
Elapsed 1.262 seconds.
```

## Are there any user-facing changes?

No.
