### PR TITLE
fix: Remove dangling table references in `unparser`

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -257,31 +257,29 @@ impl SelectBuilder {
         }
 
         if let Some(twg) = self.from.last() {
-            twg.get_joins()
-                .iter()
-                .for_each(|join| match &join.relation {
-                    ast::TableFactor::Table { alias, name, .. } => {
-                        if let Some(alias) = alias {
-                            all_idents.push(alias.name.to_string());
-                        } else {
-                            let full_ident = name.to_string();
-                            if let Some(name) = name.0.last() {
-                                if full_ident != name.to_string() {
-                                    // supports identifiers that contain the entire path, as well as just the end table leaf
-                                    // like catalog.schema.table and table
-                                    all_idents.push(name.to_string());
-                                }
-                            }
-                            all_idents.push(full_ident);
-                        }
-                    }
-                    ast::TableFactor::Derived {
-                        alias: Some(alias), ..
-                    } => {
+            twg.joins.iter().for_each(|join| match &join.relation {
+                ast::TableFactor::Table { alias, name, .. } => {
+                    if let Some(alias) = alias {
                         all_idents.push(alias.name.to_string());
+                    } else {
+                        let full_ident = name.to_string();
+                        if let Some(name) = name.0.last() {
+                            if full_ident != name.to_string() {
+                                // supports identifiers that contain the entire path, as well as just the end table leaf
+                                // like catalog.schema.table and table
+                                all_idents.push(name.to_string());
+                            }
+                        }
+                        all_idents.push(full_ident);
                     }
-                    _ => {}
-                });
+                }
+                ast::TableFactor::Derived {
+                    alias: Some(alias), ..
+                } => {
+                    all_idents.push(alias.name.to_string());
+                }
+                _ => {}
+            });
         }
 
         all_idents
@@ -405,10 +403,6 @@ impl TableWithJoinsBuilder {
         self.relation = Some(value);
         self
     }
-    pub fn get_joins(&self) -> Vec<ast::Join> {
-        self.joins.clone()
-    }
-
     pub fn joins(&mut self, value: Vec<ast::Join>) -> &mut Self {
         self.joins = value;
         self

--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -212,9 +212,19 @@ impl SelectBuilder {
 
         self
     }
+    pub fn set_selection(&mut self, value: Option<ast::Expr>) -> &mut Self {
+        self.selection = value;
+        self
+    }
+    pub fn get_selection(&self) -> Option<ast::Expr> {
+        self.selection.clone()
+    }
     pub fn group_by(&mut self, value: ast::GroupByExpr) -> &mut Self {
         self.group_by = Some(value);
         self
+    }
+    pub fn get_group_by(&self) -> Option<ast::GroupByExpr> {
+        self.group_by.clone()
     }
     pub fn cluster_by(&mut self, value: Vec<ast::Expr>) -> &mut Self {
         self.cluster_by = value;
@@ -372,11 +382,9 @@ impl RelationBuilder {
     pub fn has_relation(&self) -> bool {
         self.relation.is_some()
     }
-    pub fn get_name(&self) -> Option<String> {
+    pub fn get_name(&self) -> Option<&ast::ObjectName> {
         match self.relation {
-            Some(TableFactorBuilder::Table(ref value)) => {
-                value.name.as_ref().map(|a| a.to_string())
-            }
+            Some(TableFactorBuilder::Table(ref value)) => value.name.as_ref(),
             _ => None,
         }
     }

--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -57,9 +57,6 @@ impl QueryBuilder {
         self.order_by = value;
         self
     }
-    pub fn get_order_by(&self) -> Vec<ast::OrderByExpr> {
-        self.order_by.clone()
-    }
     pub fn limit(&mut self, value: Option<ast::Expr>) -> &mut Self {
         self.limit = value;
         self
@@ -313,13 +310,10 @@ impl SelectBuilder {
 
         // Check the order by as well
         if let Some(query) = query.as_mut() {
-            let mut order_by = query.get_order_by();
-            order_by.iter_mut().for_each(|sort_item| {
+            query.order_by.iter_mut().for_each(|sort_item| {
                 sort_item.expr =
                     remove_dangling_expr(sort_item.expr.clone(), &all_idents);
             });
-
-            query.order_by(order_by);
         }
 
         // Order by could be a sort in the select builder

--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -55,6 +55,9 @@ impl QueryBuilder {
         self.order_by = value;
         self
     }
+    pub fn get_order_by(&self) -> Vec<ast::OrderByExpr> {
+        self.order_by.clone()
+    }
     pub fn limit(&mut self, value: Option<ast::Expr>) -> &mut Self {
         self.limit = value;
         self
@@ -159,6 +162,9 @@ impl SelectBuilder {
         self.projection = value;
         self
     }
+    pub fn get_projection(&self) -> Vec<ast::SelectItem> {
+        self.projection.clone()
+    }
     pub fn already_projected(&self) -> bool {
         !self.projection.is_empty()
     }
@@ -221,6 +227,9 @@ impl SelectBuilder {
     pub fn sort_by(&mut self, value: Vec<ast::Expr>) -> &mut Self {
         self.sort_by = value;
         self
+    }
+    pub fn get_sort_by(&self) -> Vec<ast::Expr> {
+        self.sort_by.clone()
     }
     pub fn having(&mut self, value: Option<ast::Expr>) -> &mut Self {
         self.having = value;
@@ -307,6 +316,9 @@ impl TableWithJoinsBuilder {
         self.relation = Some(value);
         self
     }
+    pub fn get_joins(&self) -> Vec<ast::Join> {
+        self.joins.clone()
+    }
 
     pub fn joins(&mut self, value: Vec<ast::Join>) -> &mut Self {
         self.joins = value;
@@ -359,6 +371,25 @@ enum TableFactorBuilder {
 impl RelationBuilder {
     pub fn has_relation(&self) -> bool {
         self.relation.is_some()
+    }
+    pub fn get_name(&self) -> Option<String> {
+        match self.relation {
+            Some(TableFactorBuilder::Table(ref value)) => {
+                value.name.as_ref().map(|a| a.to_string())
+            }
+            _ => None,
+        }
+    }
+    pub fn get_alias(&self) -> Option<String> {
+        match self.relation {
+            Some(TableFactorBuilder::Table(ref value)) => {
+                value.alias.as_ref().map(|a| a.name.to_string())
+            }
+            Some(TableFactorBuilder::Derived(ref value)) => {
+                value.alias.as_ref().map(|a| a.name.to_string())
+            }
+            _ => None,
+        }
     }
     pub fn table(&mut self, value: TableRelationBuilder) -> &mut Self {
         self.relation = Some(TableFactorBuilder::Table(value));

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -413,10 +413,12 @@ pub fn remove_dangling_expr(
             let mut idents = idents.clone();
             remove_dangling_identifiers(&mut idents, available_idents);
 
-            if idents.len() > 1 {
-                ast::Expr::CompoundIdentifier(idents)
-            } else {
+            if idents.len() == 0 {
+                unreachable!("Identifier must have at least one element");
+            } else if idents.len() == 1 {
                 ast::Expr::Identifier(idents[0].clone())
+            } else {
+                ast::Expr::CompoundIdentifier(idents)
             }
         }
         ast::Expr::Function(ast::Function {

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -413,7 +413,7 @@ pub fn remove_dangling_expr(
             let mut idents = idents.clone();
             remove_dangling_identifiers(&mut idents, available_idents);
 
-            if idents.len() == 0 {
+            if idents.is_empty() {
                 unreachable!("Identifier must have at least one element");
             } else if idents.len() == 1 {
                 ast::Expr::Identifier(idents[0].clone())

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -366,10 +366,7 @@ impl TreeNodeRewriter for TableAliasRewriter<'_> {
 
 /// Takes an input list of identifiers and a list of identifiers that are available from relations or joins.
 /// Removes any table identifiers that are not present in the list of available identifiers, retains original column names.
-pub fn remove_dangling_identifiers(
-    idents: &mut Vec<Ident>,
-    available_idents: &Vec<String>,
-) -> () {
+pub fn remove_dangling_identifiers(idents: &mut Vec<Ident>, available_idents: &[String]) {
     if idents.len() > 1 {
         let ident_source = display_separated(
             &idents

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -346,6 +346,80 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             unparser_dialect: Box::new(UnparserDefaultDialect {}),
         },
         TestStatementWithDialect {
+            sql: "select j1_id from (select ta.j1_id from j1 ta)",
+            expected:
+                // This seems like desirable behavior, but is actually hiding an underlying issue
+                // The re-written identifier is `ta`.`j1_id`, because `reconstuct_select_statement` runs before the derived projection
+                // and for some reason, the derived table alias is pre-set to `ta` for the top-level projection
+                "SELECT `j1_id` FROM (SELECT `ta`.`j1_id` FROM `j1` AS `ta`) AS `derived_projection`",
+            parser_dialect: Box::new(MySqlDialect {}),
+            unparser_dialect: Box::new(UnparserMySqlDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "select j1_id from (select ta.j1_id from j1 ta)",
+            expected:
+                "SELECT j1_id FROM (SELECT ta.j1_id FROM j1 AS ta)",
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "select j1_id from (select ta.j1_id from j1 ta) order by j1_id",
+            expected:
+                "SELECT j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) ORDER BY j1_id ASC NULLS LAST",
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        // TODO: remove dangling identifiers from group by, filter, etc
+        // TestStatementWithDialect {
+        //     sql: "select j1_id from (select ta.j1_id from j1 ta) where j1_id = 1",
+        //     expected:
+        //         "SELECT j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) WHERE (ta.j1_id = 1)",
+        //     parser_dialect: Box::new(GenericDialect {}),
+        //     unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        // },
+        TestStatementWithDialect {
+            sql: "select j1_id from (select ta.j1_id from j1 ta) order by j1_id",
+            expected:
+                "SELECT `j1_id` FROM (SELECT `ta`.`j1_id` FROM `j1` AS `ta`) AS `derived_projection` ORDER BY `j1_id` ASC",
+            parser_dialect: Box::new(MySqlDialect {}),
+            unparser_dialect: Box::new(UnparserMySqlDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "select j1_id from (select ta.j1_id from j1 ta) AS tbl1",
+            expected:
+                "SELECT tbl1.j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) AS tbl1",
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "select j1_id, j2_id from (select ta.j1_id from j1 ta) AS tbl1, (select ta.j1_id as j2_id from j1 ta) as tbl2",
+            expected:
+                "SELECT tbl1.j1_id, tbl2.j2_id FROM (SELECT ta.j1_id FROM j1 AS ta) AS tbl1 JOIN (SELECT ta.j1_id AS j2_id FROM j1 AS ta) AS tbl2",
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "select j1_id, j2_id from (select ta.j1_id from j1 ta) AS tbl1, (select ta.j1_id as j2_id from j1 ta) as tbl2",
+            expected:
+                "SELECT `tbl1`.`j1_id`, `tbl2`.`j2_id` FROM (SELECT `ta`.`j1_id` FROM `j1` AS `ta`) AS `tbl1` JOIN (SELECT `ta`.`j1_id` AS `j2_id` FROM `j1` AS `ta`) AS `tbl2`",
+            parser_dialect: Box::new(MySqlDialect {}),
+            unparser_dialect: Box::new(UnparserMySqlDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "select j1_id, j2_id from (select ta.j1_id from j1 ta), (select ta.j1_id as j2_id from j1 ta)",
+            expected:
+                "SELECT `j1_id`, `j2_id` FROM (SELECT `ta`.`j1_id` FROM `j1` AS `ta`) AS `derived_projection` JOIN (SELECT `ta`.`j1_id` AS `j2_id` FROM `j1` AS `ta`) AS `derived_projection`",
+            parser_dialect: Box::new(MySqlDialect {}),
+            unparser_dialect: Box::new(UnparserMySqlDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "select j1_id, j2_id from (select ta.j1_id from j1 ta), (select ta.j1_id AS j2_id from j1 ta)",
+            expected:
+                "SELECT j1_id, j2_id FROM (SELECT ta.j1_id FROM j1 AS ta) JOIN (SELECT ta.j1_id AS j2_id FROM j1 AS ta)",
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        TestStatementWithDialect {
             sql: "
                 SELECT
                   j1_string,

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -369,14 +369,6 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             parser_dialect: Box::new(GenericDialect {}),
             unparser_dialect: Box::new(UnparserDefaultDialect {}),
         },
-        // TODO: remove dangling identifiers from group by, filter, etc
-        // TestStatementWithDialect {
-        //     sql: "select j1_id from (select ta.j1_id from j1 ta) where j1_id = 1",
-        //     expected:
-        //         "SELECT j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) WHERE (ta.j1_id = 1)",
-        //     parser_dialect: Box::new(GenericDialect {}),
-        //     unparser_dialect: Box::new(UnparserDefaultDialect {}),
-        // },
         TestStatementWithDialect {
             sql: "select j1_id from (select ta.j1_id from j1 ta) order by j1_id",
             expected:

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -363,6 +363,20 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             unparser_dialect: Box::new(UnparserDefaultDialect {}),
         },
         TestStatementWithDialect {
+            sql: "select j1_id from (select ta.j1_id from j1 ta) where j1_id > 1",
+            expected:
+                "SELECT j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) WHERE (j1_id > 1)",
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "select j1_id from (select ta.j1_id from j1 ta) group by j1_id",
+            expected:
+                "SELECT j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) GROUP BY j1_id",
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        TestStatementWithDialect {
             sql: "select j1_id from (select ta.j1_id from j1 ta) order by j1_id",
             expected:
                 "SELECT j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) ORDER BY j1_id ASC NULLS LAST",
@@ -651,7 +665,7 @@ fn test_aggregation_without_projection() -> Result<()> {
 
     assert_eq!(
         actual,
-        r#"SELECT sum(users.age), users."name" FROM (SELECT users."name", users.age FROM users) GROUP BY users."name""#
+        r#"SELECT sum(age), "name" FROM (SELECT users."name", users.age FROM users) GROUP BY "name""#
     );
 
     Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13027 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This change ensures that table references which don't exist at their current level are removed. For example, `SELECT ta.j1_id FROM (SELECT j1_id FROM j1 ta)` is invalid because the subquery is un-aliased so `ta` is not a valid reference at the top-level projection.

This is usually caused by derived subqueries, both un-aliased and aliased.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* For each `select_to_sql_expr`, collects the available table identifiers at that level from the projection and table joins.
* Iterates over the projection and order by and compares them to the list of collected identifiers. For identifiers that are not found, strips their table reference leaving just the bare column (e.g. `ta.j1_id` -> `j1_id`).

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. A collection of new plan-to-SQL roundtrip tests to validate the changes.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
