### PR TITLE
Add getters to  `ExecutionPlan` Properties

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -86,6 +86,11 @@ impl NdJsonExec {
         &self.base_config
     }
 
+    /// Ref to the file compression type
+    pub fn file_compression_type(&self) -> &FileCompressionType {
+        &self.file_compression_type
+    }
+
     fn output_partitioning_helper(file_scan_config: &FileScanConfig) -> Partitioning {
         Partitioning::UnknownPartitioning(file_scan_config.file_groups.len())
     }

--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -86,7 +86,7 @@ impl NdJsonExec {
         &self.base_config
     }
 
-    /// Ref to the file compression type
+    /// Ref to file compression type
     pub fn file_compression_type(&self) -> &FileCompressionType {
         &self.file_compression_type
     }

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -204,16 +204,34 @@ impl SortMergeJoinExec {
         &self.on
     }
 
+    /// Ref to right execution plan
     pub fn right(&self) -> &Arc<dyn ExecutionPlan> {
         &self.right
     }
 
+    /// Join type
     pub fn join_type(&self) -> JoinType {
         self.join_type
     }
 
+    /// Ref to left execution plan
     pub fn left(&self) -> &Arc<dyn ExecutionPlan> {
         &self.left
+    }
+
+    /// Ref to join filter
+    pub fn filter(&self) -> &Option<JoinFilter> {
+        &self.filter
+    }
+
+    /// Ref to sort options
+    pub fn sort_options(&self) -> &[SortOptions] {
+        &self.sort_options
+    }
+
+    /// Null equals null
+    pub fn null_equals_null(&self) -> bool {
+        self.null_equals_null
     }
 
     /// This function creates the cache object that stores the plan properties such as schema, equivalence properties, ordering, partitioning, etc.

--- a/datafusion/physical-plan/src/memory.rs
+++ b/datafusion/physical-plan/src/memory.rs
@@ -178,12 +178,24 @@ impl MemoryExec {
         self
     }
 
+    /// Ref to partitions
     pub fn partitions(&self) -> &[Vec<RecordBatch>] {
         &self.partitions
     }
 
+    /// Ref to projection
     pub fn projection(&self) -> &Option<Vec<usize>> {
         &self.projection
+    }
+
+    /// show sizes
+    pub fn show_sizes(&self) -> bool {
+        self.show_sizes
+    }
+
+    /// Ref to sort information
+    pub fn sort_information(&self) -> &[LexOrdering] {
+        &self.sort_information
     }
 
     /// A memory table can be ordered by multiple expressions simultaneously.

--- a/datafusion/physical-plan/src/memory.rs
+++ b/datafusion/physical-plan/src/memory.rs
@@ -188,7 +188,7 @@ impl MemoryExec {
         &self.projection
     }
 
-    /// show sizes
+    /// Show sizes
     pub fn show_sizes(&self) -> bool {
         self.show_sizes
     }
@@ -273,6 +273,7 @@ impl MemoryExec {
         Ok(self)
     }
 
+    /// Arc clone of ref to original schema
     pub fn original_schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
     }

--- a/datafusion/physical-plan/src/recursive_query.rs
+++ b/datafusion/physical-plan/src/recursive_query.rs
@@ -72,7 +72,7 @@ pub struct RecursiveQueryExec {
 }
 
 impl RecursiveQueryExec {
-    /// Create a new RecursiveQueryExec
+    /// Try to create a new RecursiveQueryExec
     pub fn try_new(
         name: String,
         static_term: Arc<dyn ExecutionPlan>,
@@ -83,8 +83,25 @@ impl RecursiveQueryExec {
         let work_table = Arc::new(WorkTable::new());
         // Use the same work table for both the WorkTableExec and the recursive term
         let recursive_term = assign_work_table(recursive_term, Arc::clone(&work_table))?;
+        Ok(Self::new(
+            name,
+            static_term,
+            recursive_term,
+            is_distinct,
+            work_table,
+        ))
+    }
+
+    /// Create a new RecursiveQueryExec
+    pub fn new(
+        name: String,
+        static_term: Arc<dyn ExecutionPlan>,
+        recursive_term: Arc<dyn ExecutionPlan>,
+        is_distinct: bool,
+        work_table: Arc<WorkTable>,
+    ) -> Self {
         let cache = Self::compute_properties(static_term.schema());
-        Ok(RecursiveQueryExec {
+        RecursiveQueryExec {
             name,
             static_term,
             recursive_term,
@@ -92,7 +109,32 @@ impl RecursiveQueryExec {
             work_table,
             metrics: ExecutionPlanMetricsSet::new(),
             cache,
-        })
+        }
+    }
+
+    /// Ref to the name
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Ref to the static term
+    pub fn static_term(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.static_term
+    }
+
+    /// Ref to the recursive term
+    pub fn recursive_term(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.recursive_term
+    }
+
+    /// is distinct
+    pub fn is_distinct(&self) -> bool {
+        self.is_distinct
+    }
+
+    /// Ref to the work table
+    pub fn work_table(&self) -> &Arc<WorkTable> {
+        &self.work_table
     }
 
     /// This function creates the cache object that stores the plan properties such as schema, equivalence properties, ordering, partitioning, etc.

--- a/datafusion/physical-plan/src/recursive_query.rs
+++ b/datafusion/physical-plan/src/recursive_query.rs
@@ -112,17 +112,17 @@ impl RecursiveQueryExec {
         }
     }
 
-    /// Ref to the name
+    /// Ref to name
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// Ref to the static term
+    /// Ref to static term
     pub fn static_term(&self) -> &Arc<dyn ExecutionPlan> {
         &self.static_term
     }
 
-    /// Ref to the recursive term
+    /// Ref to recursive term
     pub fn recursive_term(&self) -> &Arc<dyn ExecutionPlan> {
         &self.recursive_term
     }
@@ -132,7 +132,7 @@ impl RecursiveQueryExec {
         self.is_distinct
     }
 
-    /// Ref to the work table
+    /// Ref to work table
     pub fn work_table(&self) -> &Arc<WorkTable> {
         &self.work_table
     }

--- a/datafusion/physical-plan/src/recursive_query.rs
+++ b/datafusion/physical-plan/src/recursive_query.rs
@@ -72,7 +72,7 @@ pub struct RecursiveQueryExec {
 }
 
 impl RecursiveQueryExec {
-    /// Try to create a new RecursiveQueryExec
+    /// Create a new RecursiveQueryExec
     pub fn try_new(
         name: String,
         static_term: Arc<dyn ExecutionPlan>,
@@ -83,25 +83,8 @@ impl RecursiveQueryExec {
         let work_table = Arc::new(WorkTable::new());
         // Use the same work table for both the WorkTableExec and the recursive term
         let recursive_term = assign_work_table(recursive_term, Arc::clone(&work_table))?;
-        Ok(Self::new(
-            name,
-            static_term,
-            recursive_term,
-            is_distinct,
-            work_table,
-        ))
-    }
-
-    /// Create a new RecursiveQueryExec
-    pub fn new(
-        name: String,
-        static_term: Arc<dyn ExecutionPlan>,
-        recursive_term: Arc<dyn ExecutionPlan>,
-        is_distinct: bool,
-        work_table: Arc<WorkTable>,
-    ) -> Self {
         let cache = Self::compute_properties(static_term.schema());
-        RecursiveQueryExec {
+        Ok(RecursiveQueryExec {
             name,
             static_term,
             recursive_term,
@@ -109,7 +92,7 @@ impl RecursiveQueryExec {
             work_table,
             metrics: ExecutionPlanMetricsSet::new(),
             cache,
-        }
+        })
     }
 
     /// Ref to name
@@ -130,11 +113,6 @@ impl RecursiveQueryExec {
     /// is distinct
     pub fn is_distinct(&self) -> bool {
         self.is_distinct
-    }
-
-    /// Ref to work table
-    pub fn work_table(&self) -> &Arc<WorkTable> {
-        &self.work_table
     }
 
     /// This function creates the cache object that stores the plan properties such as schema, equivalence properties, ordering, partitioning, etc.

--- a/datafusion/physical-plan/src/sorts/partial_sort.rs
+++ b/datafusion/physical-plan/src/sorts/partial_sort.rs
@@ -167,6 +167,11 @@ impl PartialSortExec {
         self.fetch
     }
 
+    /// Common prefix length
+    pub fn common_prefix_length(&self) -> usize {
+        self.common_prefix_length
+    }
+
     fn output_partitioning_helper(
         input: &Arc<dyn ExecutionPlan>,
         preserve_partitioning: bool,

--- a/datafusion/physical-plan/src/work_table.rs
+++ b/datafusion/physical-plan/src/work_table.rs
@@ -36,14 +36,14 @@ use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 
 /// A vector of record batches with a memory reservation.
 #[derive(Debug)]
-pub(super) struct ReservedBatches {
+pub struct ReservedBatches {
     batches: Vec<RecordBatch>,
     #[allow(dead_code)]
     reservation: MemoryReservation,
 }
 
 impl ReservedBatches {
-    pub(super) fn new(batches: Vec<RecordBatch>, reservation: MemoryReservation) -> Self {
+    pub fn new(batches: Vec<RecordBatch>, reservation: MemoryReservation) -> Self {
         ReservedBatches {
             batches,
             reservation,
@@ -55,13 +55,19 @@ impl ReservedBatches {
 /// See <https://wiki.postgresql.org/wiki/CTEReadme#How_Recursion_Works>
 /// This table serves as a mirror or buffer between each iteration of a recursive query.
 #[derive(Debug)]
-pub(super) struct WorkTable {
+pub struct WorkTable {
     batches: Mutex<Option<ReservedBatches>>,
+}
+
+impl Default for WorkTable {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl WorkTable {
     /// Create a new work table.
-    pub(super) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             batches: Mutex::new(None),
         }
@@ -78,7 +84,7 @@ impl WorkTable {
     }
 
     /// Update the results of a recursive query iteration to the work table.
-    pub(super) fn update(&self, batches: ReservedBatches) {
+    pub fn update(&self, batches: ReservedBatches) {
         self.batches.lock().unwrap().replace(batches);
     }
 }
@@ -120,7 +126,7 @@ impl WorkTableExec {
         }
     }
 
-    pub(super) fn with_work_table(&self, work_table: Arc<WorkTable>) -> Self {
+    pub fn with_work_table(&self, work_table: Arc<WorkTable>) -> Self {
         Self {
             name: self.name.clone(),
             schema: Arc::clone(&self.schema),

--- a/datafusion/physical-plan/src/work_table.rs
+++ b/datafusion/physical-plan/src/work_table.rs
@@ -126,6 +126,16 @@ impl WorkTableExec {
         }
     }
 
+    /// Ref to name
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Arc clone of ref to schema
+    pub fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
     pub fn with_work_table(&self, work_table: Arc<WorkTable>) -> Self {
         Self {
             name: self.name.clone(),

--- a/datafusion/physical-plan/src/work_table.rs
+++ b/datafusion/physical-plan/src/work_table.rs
@@ -36,14 +36,14 @@ use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 
 /// A vector of record batches with a memory reservation.
 #[derive(Debug)]
-pub struct ReservedBatches {
+pub(super) struct ReservedBatches {
     batches: Vec<RecordBatch>,
     #[allow(dead_code)]
     reservation: MemoryReservation,
 }
 
 impl ReservedBatches {
-    pub fn new(batches: Vec<RecordBatch>, reservation: MemoryReservation) -> Self {
+    pub(super) fn new(batches: Vec<RecordBatch>, reservation: MemoryReservation) -> Self {
         ReservedBatches {
             batches,
             reservation,
@@ -55,19 +55,13 @@ impl ReservedBatches {
 /// See <https://wiki.postgresql.org/wiki/CTEReadme#How_Recursion_Works>
 /// This table serves as a mirror or buffer between each iteration of a recursive query.
 #[derive(Debug)]
-pub struct WorkTable {
+pub(super) struct WorkTable {
     batches: Mutex<Option<ReservedBatches>>,
-}
-
-impl Default for WorkTable {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl WorkTable {
     /// Create a new work table.
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             batches: Mutex::new(None),
         }
@@ -84,7 +78,7 @@ impl WorkTable {
     }
 
     /// Update the results of a recursive query iteration to the work table.
-    pub fn update(&self, batches: ReservedBatches) {
+    pub(super) fn update(&self, batches: ReservedBatches) {
         self.batches.lock().unwrap().replace(batches);
     }
 }
@@ -136,7 +130,7 @@ impl WorkTableExec {
         Arc::clone(&self.schema)
     }
 
-    pub fn with_work_table(&self, work_table: Arc<WorkTable>) -> Self {
+    pub(super) fn with_work_table(&self, work_table: Arc<WorkTable>) -> Self {
         Self {
             name: self.name.clone(),
             schema: Arc::clone(&self.schema),


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change
These were all of the `ExecutionPlan` implementations that I found that didn't expose all of their properties needed for instantiation. Exposing the properties now makes the API consistent across all `ExecutionPlan` implementations.

## What changes are included in this PR?
We exposed the properties of `NdJsonExec`, `SortMergeJoinExec`, `MemoryExec`, `RecursiveQueryExec`, `PartialSortExec`, and `WorkTableExec`.

## Are these changes tested?
These are simple getters. No tests are needed.

## Are there any user-facing changes?
These are backwards compatible changes to user-facing APIs.