### PR TITLE
Fix `regex` cache on pattern, less alloc, hash less often

### DIFF
--- a/datafusion/functions/src/regex/regexpcount.rs
+++ b/datafusion/functions/src/regex/regexpcount.rs
@@ -567,10 +567,7 @@ where
     Ok(result)
 }
 
-fn compile_regex<'a>(
-    regex: &'a str,
-    flags: Option<&'a str>,
-) -> Result<Regex, ArrowError> {
+fn compile_regex(regex: &str, flags: Option<&str>) -> Result<Regex, ArrowError> {
     let pattern = match flags {
         None | Some("") => regex.to_string(),
         Some(flags) => {
@@ -582,6 +579,7 @@ fn compile_regex<'a>(
             format!("(?{}){}", flags, regex)
         }
     };
+
     Regex::new(&pattern).map_err(|_| {
         ArrowError::ComputeError(format!(
             "Regular expression did not compile: {}",

--- a/datafusion/functions/src/regex/regexpcount.rs
+++ b/datafusion/functions/src/regex/regexpcount.rs
@@ -557,11 +557,14 @@ fn compile_and_cache_regex<'strings, 'cache>(
 where
     'strings: 'cache,
 {
-    if let Entry::Vacant(e) = regex_cache.entry((regex, flags)) {
-        let compiled = compile_regex(regex, flags)?;
-        e.insert(compiled);
-    }
-    Ok(regex_cache.get(&(regex, flags)).unwrap())
+    let result = match regex_cache.entry((regex, flags)) {
+        Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
+        Entry::Vacant(vacant_entry) => {
+            let compiled = compile_regex(regex, flags)?;
+            vacant_entry.insert(compiled)
+        }
+    };
+    Ok(result)
 }
 
 fn compile_regex<'a>(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13413

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fixes bug, also code refactoring to have less allocations and calculate hash less often.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes, the new unit test has been added to cover a bug fix. Also, bench results.. so regexp_count has similar perf as other regexp functions now:

```rs
regexp_count_1000 string
                        time:   [2.4421 ms 2.4491 ms 2.4562 ms]
                        change: [-2.4790% -2.1304% -1.7839%] (p = 0.00 < 0.05)
                        Performance has improved.

regexp_count_1000 utf8view
                        time:   [2.4608 ms 2.4686 ms 2.4766 ms]
                        change: [-2.4392% -1.9838% -1.5766%] (p = 0.00 < 0.05)
                        Performance has improved.

regexp_like_1000        time:   [2.4550 ms 2.4806 ms 2.5182 ms]
                        change: [-2.9338% -1.1353% +0.4878%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

regexp_match_1000       time:   [2.8470 ms 2.8799 ms 2.9283 ms]
                        change: [-2.7508% -0.8240% +1.3563%] (p = 0.46 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

regexp_replace_1000     time:   [2.2726 ms 2.2786 ms 2.2851 ms]
                        change: [-3.7486% -2.7447% -1.9508%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
