### PR TITLE
Support unparsing Array plan to SQL string

### DIFF
--- a/datafusion/functions-nested/src/planner.rs
+++ b/datafusion/functions-nested/src/planner.rs
@@ -34,7 +34,7 @@ use crate::{
     make_array::make_array,
 };
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct NestedFunctionPlanner;
 
 impl ExprPlanner for NestedFunctionPlanner {
@@ -131,9 +131,8 @@ impl ExprPlanner for NestedFunctionPlanner {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct FieldAccessPlanner;
-
 impl ExprPlanner for FieldAccessPlanner {
     fn plan_field_access(
         &self,

--- a/datafusion/functions-nested/src/planner.rs
+++ b/datafusion/functions-nested/src/planner.rs
@@ -34,7 +34,7 @@ use crate::{
     make_array::make_array,
 };
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct NestedFunctionPlanner;
 
 impl ExprPlanner for NestedFunctionPlanner {
@@ -131,7 +131,7 @@ impl ExprPlanner for NestedFunctionPlanner {
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct FieldAccessPlanner;
 
 impl ExprPlanner for FieldAccessPlanner {

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1933,13 +1933,6 @@ mod tests {
                 array_element(make_array(vec![lit(1), lit(2), lit(3)]), lit(1)),
                 "[1, 2, 3][1]",
             ),
-            (
-                Expr::ScalarFunction(ScalarFunction {
-                    func: named_struct(),
-                    args: vec![lit("c0"), lit(1), lit("c1"), lit(2)],
-                }),
-                "{c0: 1, c1: 2}",
-            ),
         ];
 
         for (expr, expected) in tests {

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -18,8 +18,8 @@
 use datafusion_expr::expr::Unnest;
 use sqlparser::ast::Value::SingleQuotedString;
 use sqlparser::ast::{
-    self, BinaryOperator, Expr as AstExpr, Function, Ident, Interval, ObjectName,
-    TimezoneInfo, UnaryOperator,
+    self, Array, BinaryOperator, Expr as AstExpr, Function, Ident, Interval, ObjectName,
+    Subscript, TimezoneInfo, UnaryOperator,
 };
 use std::sync::Arc;
 use std::vec;
@@ -477,6 +477,19 @@ impl Unparser<'_> {
         func_name: &str,
         args: &[Expr],
     ) -> Result<ast::Expr> {
+        match func_name {
+            "make_array" => self.make_array_to_sql(args),
+            "array_element" => self.array_element_to_sql(args),
+            // TODO: support for the construct and access functions of the `map` and `struct` types
+            _ => self.scalar_function_to_sql_internal(func_name, args),
+        }
+    }
+
+    fn scalar_function_to_sql_internal(
+        &self,
+        func_name: &str,
+        args: &[Expr],
+    ) -> Result<ast::Expr> {
         let args = self.function_args_to_sql(args)?;
         Ok(ast::Expr::Function(Function {
             name: ObjectName(vec![Ident {
@@ -494,6 +507,29 @@ impl Unparser<'_> {
             within_group: vec![],
             parameters: ast::FunctionArguments::None,
         }))
+    }
+
+    fn make_array_to_sql(&self, args: &[Expr]) -> Result<ast::Expr> {
+        let args = args
+            .iter()
+            .map(|e| self.expr_to_sql(e))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(ast::Expr::Array(Array {
+            elem: args,
+            named: false,
+        }))
+    }
+
+    fn array_element_to_sql(&self, args: &[Expr]) -> Result<ast::Expr> {
+        if args.len() != 2 {
+            return internal_err!("array_element must have exactly 2 arguments");
+        }
+        let array = self.expr_to_sql(&args[0])?;
+        let index = self.expr_to_sql(&args[1])?;
+        Ok(ast::Expr::Subscript {
+            expr: Box::new(array),
+            subscript: Box::new(Subscript::Index { index }),
+        })
     }
 
     pub fn sort_to_sql(&self, sort: &Sort) -> Result<ast::OrderByExpr> {
@@ -1483,8 +1519,10 @@ mod tests {
         Signature, Volatility, WindowFrame, WindowFunctionDefinition,
     };
     use datafusion_expr::{interval_month_day_nano_lit, ExprFunctionExt};
+    use datafusion_functions::core::named_struct;
     use datafusion_functions_aggregate::count::count_udaf;
     use datafusion_functions_aggregate::expr_fn::sum;
+    use datafusion_functions_nested::expr_fn::{array_element, make_array};
     use datafusion_functions_window::row_number::row_number_udwf;
 
     use crate::unparser::dialect::{
@@ -1888,6 +1926,19 @@ mod tests {
                     })),
                 }),
                 r#"UNNEST("table".array_col)"#,
+            ),
+            (make_array(vec![lit(1), lit(2), lit(3)]), "[1, 2, 3]"),
+            (array_element(col("array_col"), lit(1)), "array_col[1]"),
+            (
+                array_element(make_array(vec![lit(1), lit(2), lit(3)]), lit(1)),
+                "[1, 2, 3][1]",
+            ),
+            (
+                Expr::ScalarFunction(ScalarFunction {
+                    func: named_struct(),
+                    args: vec![lit("c0"), lit(1), lit("c1"), lit(2)],
+                }),
+                "{c0: 1, c1: 2}",
             ),
         ];
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1519,7 +1519,6 @@ mod tests {
         Signature, Volatility, WindowFrame, WindowFunctionDefinition,
     };
     use datafusion_expr::{interval_month_day_nano_lit, ExprFunctionExt};
-    use datafusion_functions::core::named_struct;
     use datafusion_functions_aggregate::count::count_udaf;
     use datafusion_functions_aggregate::expr_fn::sum;
     use datafusion_functions_nested::expr_fn::{array_element, make_array};

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1250,6 +1250,6 @@ fn test_unnest_to_sql() {
     sql_round_trip(
         GenericDialect {},
         r#"SELECT unnest(make_array(1, 2, 2, 5, NULL)) as u1"#,
-        r#"SELECT UNNEST(make_array(1, 2, 2, 5, NULL)) AS u1"#,
+        r#"SELECT UNNEST([1, 2, 2, 5, NULL]) AS u1"#,
     );
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -208,8 +208,8 @@ fn roundtrip_statement() -> Result<()> {
             .with_aggregate_function(count_udaf())
             .with_aggregate_function(max_udaf())
             .with_expr_planner(Arc::new(CoreFunctionPlanner::default()))
-            .with_expr_planner(Arc::new(NestedFunctionPlanner::default()))
-            .with_expr_planner(Arc::new(FieldAccessPlanner::default()));
+            .with_expr_planner(Arc::new(NestedFunctionPlanner))
+            .with_expr_planner(Arc::new(FieldAccessPlanner));
         let context = MockContextProvider { state };
         let sql_to_rel = SqlToRel::new(&context);
         let plan = sql_to_rel.sql_statement_to_plan(statement).unwrap();

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -40,6 +40,8 @@ use datafusion_expr::builder::{
     table_scan_with_filter_and_fetch, table_scan_with_filters,
 };
 use datafusion_functions::core::planner::CoreFunctionPlanner;
+use datafusion_functions_nested::extract::array_element_udf;
+use datafusion_functions_nested::planner::{FieldAccessPlanner, NestedFunctionPlanner};
 use sqlparser::dialect::{Dialect, GenericDialect, MySqlDialect};
 use sqlparser::parser::Parser;
 
@@ -182,6 +184,11 @@ fn roundtrip_statement() -> Result<()> {
             SUM(id) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total
             FROM person
             GROUP BY GROUPING SETS ((id, first_name, last_name), (first_name, last_name), (last_name))"#,
+            "SELECT ARRAY[1, 2, 3]",
+            "SELECT ARRAY[1, 2, 3][1]",
+            "SELECT [1, 2, 3]",
+            "SELECT [1, 2, 3][1]",
+            "SELECT left[1] FROM array"
     ];
 
     // For each test sql string, we transform as follows:
@@ -195,10 +202,14 @@ fn roundtrip_statement() -> Result<()> {
             .try_with_sql(query)?
             .parse_statement()?;
         let state = MockSessionState::default()
+            .with_scalar_function(make_array_udf())
+            .with_scalar_function(array_element_udf())
             .with_aggregate_function(sum_udaf())
             .with_aggregate_function(count_udaf())
             .with_aggregate_function(max_udaf())
-            .with_expr_planner(Arc::new(CoreFunctionPlanner::default()));
+            .with_expr_planner(Arc::new(CoreFunctionPlanner::default()))
+            .with_expr_planner(Arc::new(NestedFunctionPlanner::default()))
+            .with_expr_planner(Arc::new(FieldAccessPlanner::default()));
         let context = MockContextProvider { state };
         let sql_to_rel = SqlToRel::new(&context);
         let plan = sql_to_rel.sql_statement_to_plan(statement).unwrap();


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #11144.

## Rationale for this change
DataFusion will plan the array construction and the elements' access to the corresponding scalar functions. If we don't handle those cases, they will be unparsed to `ast::Expr::ScalarFunction` which isn't a common SQL syntax.
### Array Construction
```
SELECT [1, 2, 3] -> make_array(1, 2, 3)
```
### Elements accessing
```
SELECT [1, 2, 3][1] -> array_element(make_array(1,2,3), 1)
```

This PR tries to allow the array SQL to do SQL-Plan-SQL roundtrip.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Unparse `make_array` to `ast::Expr::Array`
- Unparse `array_element` to `ast::Expr::Subscript`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
expr unit tests and SQL roundtrip tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
