### PR TITLE
Fix Binary & Binary View Unparsing

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -853,7 +853,9 @@ impl Unparser<'_> {
         let inner_expr = self.expr_to_sql_inner(expr)?;
         match inner_expr {
             ast::Expr::Value(_) => match data_type {
-                DataType::Dictionary(_, _) | DataType::Binary => Ok(inner_expr),
+                DataType::Dictionary(_, _) | DataType::Binary | DataType::BinaryView => {
+                    Ok(inner_expr)
+                }
                 _ => Ok(ast::Expr::Cast {
                     kind: ast::CastKind::Cast,
                     expr: Box::new(inner_expr),
@@ -2180,6 +2182,13 @@ mod tests {
                     "blah".to_string(),
                 )))),
                 data_type: DataType::Binary,
+            }),
+            "'blah'",
+            Expr::Cast(Cast {
+                expr: Box::new(Expr::Literal(ScalarValue::Utf8(Some(
+                    "blah".to_string(),
+                )))),
+                data_type: DataType::BinaryView,
             }),
             "'blah'",
         )];


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Datafusion enforces an eager cast of value to `Binary` / `BinaryView` value in the logical plan where a comparison with binary value is presented. For example, in the following plan

`Filter: value = CAST(Utf8("binary_value") AS Binary`
However, when using unparser to convert the plan back to sql, where the sql will be sent to various query engine (e.g. DuckDB). the cast is not needed for the value, in the example above the value "binary_value", since the raw value can be directly used in SQL engines without casting to an engine specific dictionary type. Therefore, the plan can simply be rewritten into where value = 'binary_value'

## What changes are included in this PR?

- Add function `cast_to_sql`, which directly pass inner_expr instead of cast inner_expr when casting to binary / binaryview / dictionary in the Expr::Cast, and keep the original casting logic in all other cases.
- Add a test for the change

## Are these changes tested?

Yes

## Are there any user-facing changes?

No