### PR TITLE
Fix duckdb & sqlite character_length scalar unparsing

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -408,16 +408,12 @@ impl Dialect for SqliteDialect {
     ) -> Result<Option<ast::Expr>> {
         match func_name {
             "date_part" => {
-                return date_part_to_sql(unparser, self.date_field_extract_style(), args);
+                date_part_to_sql(unparser, self.date_field_extract_style(), args)
             }
             "character_length" => {
-                return character_length_to_sql(
-                    unparser,
-                    self.character_length_style(),
-                    args,
-                );
+                character_length_to_sql(unparser, self.character_length_style(), args)
             }
-            _ => return Ok(None),
+            _ => Ok(None),
         }
     }
 }
@@ -553,16 +549,12 @@ impl Dialect for CustomDialect {
     ) -> Result<Option<ast::Expr>> {
         match func_name {
             "date_part" => {
-                return date_part_to_sql(unparser, self.date_field_extract_style(), args);
+                date_part_to_sql(unparser, self.date_field_extract_style(), args)
             }
             "character_length" => {
-                return character_length_to_sql(
-                    unparser,
-                    self.character_length_style(),
-                    args,
-                )
+                character_length_to_sql(unparser, self.character_length_style(), args)
             }
-            _ => return Ok(None),
+            _ => Ok(None),
         }
     }
 

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -459,7 +459,8 @@ pub(crate) fn character_length_to_sql(
         CharacterLengthStyle::Length => "length",
     };
 
-    return Ok(Some(
-        unparser.scalar_function_to_sql(func_name, character_length_args)?,
-    ));
+    Ok(Some(unparser.scalar_function_to_sql(
+        func_name,
+        character_length_args,
+    )?))
 }

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -28,7 +28,10 @@ use datafusion_expr::{
 };
 use sqlparser::ast;
 
-use super::{dialect::DateFieldExtractStyle, rewrite::TableAliasRewriter, Unparser};
+use super::{
+    dialect::CharacterLengthStyle, dialect::DateFieldExtractStyle,
+    rewrite::TableAliasRewriter, Unparser,
+};
 
 /// Recursively searches children of [LogicalPlan] to find an Aggregate node if exists
 /// prior to encountering a Join, TableScan, or a nested subquery (derived table factor).
@@ -444,4 +447,19 @@ pub(crate) fn date_part_to_sql(
     };
 
     Ok(None)
+}
+
+pub(crate) fn character_length_to_sql(
+    unparser: &Unparser,
+    style: CharacterLengthStyle,
+    character_length_args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    let func_name = match style {
+        CharacterLengthStyle::CharacterLength => "character_length",
+        CharacterLengthStyle::Length => "length",
+    };
+
+    return Ok(Some(
+        unparser.scalar_function_to_sql(func_name, character_length_args)?,
+    ));
 }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

When unparsing `CharacterLengthFunc` scalar function to DuckDB & SQLite syntax SQL query, the `CharacterLengthFunc` scalar function need to be unparsed to `length`, since `length` is the equivalence of `CharacterLengthFunc` in DuckDB & SQLite.

DuckDB [length()](https://duckdb.org/docs/sql/functions/char.html#lengthstring)
SQLite [length()](https://www.sqlite.org/lang_corefunc.html#length)

## What changes are included in this PR?

- Add struct `DuckDBDialect`, which implements the `Dialect` trait
- Add new method `character_length_style` for `Dialect` trait for determining the `CharacterLengthStyle` to use for a dialect
- Add helper function `character_length_to_sql`, which unparses the `CharacterLengthFunc` to `length` or `character_length` based on  `CharacterLengthStyle` 

## Are these changes tested?

Yes

## Are there any user-facing changes?

No
