### PR TITLE
Make DFSchema::datatype_is_semantically_equal public

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -686,7 +686,7 @@ impl DFSchema {
     /// name and type), ignoring both metadata and nullability.
     ///
     /// request to upstream: <https://github.com/apache/arrow-rs/issues/3199>
-    fn datatype_is_semantically_equal(dt1: &DataType, dt2: &DataType) -> bool {
+    pub fn datatype_is_semantically_equal(dt1: &DataType, dt2: &DataType) -> bool {
         // check nested fields
         match (dt1, dt2) {
             (DataType::Dictionary(k1, v1), DataType::Dictionary(k2, v2)) => {


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

I’m trying to implement a schema comparison functionality in my project based on the semantic equality of `DFSchema`. However the helper function `datatype_is_semantically_equal ` is currently private. It would be really helpful if this could be made public, similar to `datatype_is_logically_equal`.

## What changes are included in this PR?

Make `DFSchema::datatype_is_semantically_equal` public

## Are these changes tested?

N/A

## Are there any user-facing changes?

Yes, Documentation needs to be updated to reflect the new public function
