### PR TITLE
Evaluate cheaper condition first in join selection and physical planner 

### DIFF
--- a/datafusion/core/src/physical_optimizer/join_selection.rs
+++ b/datafusion/core/src/physical_optimizer/join_selection.rs
@@ -382,8 +382,8 @@ fn try_collect_left(
 
     match (left_can_collect, right_can_collect) {
         (true, true) => {
-            if should_swap_join_order(&**left, &**right)?
-                && supports_swap(*hash_join.join_type())
+            if supports_swap(*hash_join.join_type())
+                && should_swap_join_order(&**left, &**right)?
             {
                 Ok(Some(swap_hash_join(hash_join, PartitionMode::CollectLeft)?))
             } else {
@@ -423,7 +423,7 @@ fn try_collect_left(
 fn partitioned_hash_join(hash_join: &HashJoinExec) -> Result<Arc<dyn ExecutionPlan>> {
     let left = hash_join.left();
     let right = hash_join.right();
-    if should_swap_join_order(&**left, &**right)? && supports_swap(*hash_join.join_type())
+    if supports_swap(*hash_join.join_type()) && should_swap_join_order(&**left, &**right)?
     {
         swap_hash_join(hash_join, PartitionMode::Partitioned)
     } else {
@@ -468,8 +468,8 @@ fn statistical_join_selection_subrule(
                 PartitionMode::Partitioned => {
                     let left = hash_join.left();
                     let right = hash_join.right();
-                    if should_swap_join_order(&**left, &**right)?
-                        && supports_swap(*hash_join.join_type())
+                    if supports_swap(*hash_join.join_type())
+                        && should_swap_join_order(&**left, &**right)?
                     {
                         swap_hash_join(hash_join, PartitionMode::Partitioned).map(Some)?
                     } else {

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -656,8 +656,8 @@ impl DefaultPhysicalPlanner {
                 let logical_input_schema = input.as_ref().schema();
                 let physical_input_schema_from_logical = logical_input_schema.inner();
 
-                if &physical_input_schema != physical_input_schema_from_logical
-                    && !options.execution.skip_physical_aggregate_schema_check
+                if !options.execution.skip_physical_aggregate_schema_check
+                    && &physical_input_schema != physical_input_schema_from_logical
                 {
                     return internal_err!("Physical input schema should be the same as the one converted from logical input schema.");
                 }


### PR DESCRIPTION
## Which issue does this PR close?

none

## Rationale for this change

Do not compute expensive condition before checking inexpensive condition first

## What changes are included in this PR?


## Are these changes tested?

no

## Are there any user-facing changes?

no
