### PR TITLE
fix docs of register_table to match implementation

### DIFF
--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -1312,8 +1312,8 @@ impl SessionContext {
     /// Registers a [`TableProvider`] as a table that can be
     /// referenced from SQL statements executed against this context.
     ///
-    /// Returns the [`TableProvider`] previously registered for this
-    /// reference, if any
+    /// If a table of the same name was already registered, returns "Table
+    /// already exists" error.
     pub fn register_table(
         &self,
         table_ref: impl Into<TableReference>,


### PR DESCRIPTION
I'm not sure that changing the implementation is possible at this point. We could call deregister_table but I fear that's not atomic. So we'd have to change the implementation of SchemaProvider, a breaking change.