### PR TITLE
Fix redundant data copying in unnest

### DIFF
--- a/datafusion/physical-plan/src/unnest.rs
+++ b/datafusion/physical-plan/src/unnest.rs
@@ -938,7 +938,7 @@ fn repeat_arrs_from_indices(
             if repeat {
                 Ok(kernels::take::take(arr, indices, None)?)
             } else {
-                Ok(new_null_array(arr.data_type(), indices.len()))
+                Ok(new_null_array(arr.data_type(), arr.len()))
             }
         })
         .collect()

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -853,3 +853,9 @@ select unnest(u.column5), j.* except(column2, column3) from unnest_table u join 
 1 2 1
 3 4 2
 NULL NULL 4
+
+## Issue: https://github.com/apache/datafusion/issues/13237
+query I
+select count(*) from (select unnest(range(0, 100000)) id) t inner join (select unnest(range(0, 100000)) id) t1 on t.id = t1.id;
+----
+100000


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13237.

## Rationale for this change

In the current implementation, during the process where we align all columns to match the length of the longest unnest operation, it can result in excessive data copying and lead to unexpected errors for queries such as:

`select * from (select unnest(range(0, 100000)) id) t inner join (select unnest(range(0, 100000)) id) t1 on t.id = t1.id;`

This can trigger errors like `attempt to add with overflow`

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Introduced repeat_mask to determine which columns need to be repeated or replaced with nulls based on:

1. Whether the column is required in future unnesting levels.
2. Whether the column is involved in unnesting at all.

Ensures only necessary columns are repeated, reducing unnecessary data copying.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
