### PR TITLE
Minor: Doc and organize fields in `struct ExternalSorter`

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -203,39 +203,54 @@ impl ExternalSorterMetrics {
 ///  in_mem_batches
 /// ```
 struct ExternalSorter {
-    /// schema of the output (and the input)
+    // ========================================================================
+    // PROPERTIES:
+    // Fields that define the sorter's configuration and remain constant
+    // ========================================================================
+    /// Schema of the output (and the input)
     schema: SchemaRef,
-    /// Potentially unsorted in memory buffer
-    in_mem_batches: Vec<RecordBatch>,
-    /// if `Self::in_mem_batches` are sorted
-    in_mem_batches_sorted: bool,
-    /// If data has previously been spilled, the locations of the
-    /// spill files (in Arrow IPC format)
-    spills: Vec<RefCountedTempFile>,
     /// Sort expressions
     expr: Arc<[PhysicalSortExpr]>,
-    /// Runtime metrics
-    metrics: ExternalSorterMetrics,
-    /// If Some, the maximum number of output rows that will be
-    /// produced.
+    /// If Some, the maximum number of output rows that will be produced
     fetch: Option<usize>,
-    /// Reservation for in_mem_batches
-    reservation: MemoryReservation,
-    /// Reservation for the merging of in-memory batches. If the sort
-    /// might spill, `sort_spill_reservation_bytes` will be
-    /// pre-reserved to ensure there is some space for this sort/merge.
-    merge_reservation: MemoryReservation,
-    /// A handle to the runtime to get spill files
-    runtime: Arc<RuntimeEnv>,
     /// The target number of rows for output batches
     batch_size: usize,
-    /// How much memory to reserve for performing in-memory sort/merges
-    /// prior to spilling.
-    sort_spill_reservation_bytes: usize,
     /// If the in size of buffered memory batches is below this size,
     /// the data will be concatenated and sorted in place rather than
     /// sort/merged.
     sort_in_place_threshold_bytes: usize,
+
+    // ========================================================================
+    // STATE BUFFERS:
+    // Fields that hold intermediate data during sorting
+    // ========================================================================
+    /// Potentially unsorted in memory buffer
+    in_mem_batches: Vec<RecordBatch>,
+    /// if `Self::in_mem_batches` are sorted
+    in_mem_batches_sorted: bool,
+
+    /// If data has previously been spilled, the locations of the
+    /// spill files (in Arrow IPC format)
+    spills: Vec<RefCountedTempFile>,
+
+    // ========================================================================
+    // EXECUTION RESOURCES:
+    // Fields related to managing execution resources and monitoring performance.
+    // ========================================================================
+    /// Runtime metrics
+    metrics: ExternalSorterMetrics,
+    /// A handle to the runtime to get spill files
+    runtime: Arc<RuntimeEnv>,
+    /// Reservation for in_mem_batches
+    reservation: MemoryReservation,
+
+    /// Reservation for the merging of in-memory batches. If the sort
+    /// might spill, `sort_spill_reservation_bytes` will be
+    /// pre-reserved to ensure there is some space for this sort/merge.
+    merge_reservation: MemoryReservation,
+    /// How much memory to reserve for performing in-memory sort/merges
+    /// prior to spilling.
+    sort_spill_reservation_bytes: usize,
 }
 
 impl ExternalSorter {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

`ExternalSorter` is a big and important struct for sorting execution, this PR only organizes its fields for readability: fields are put into different categories, and closely related ones are put next to each other.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
