### PR TITLE
Coerce Array inner types

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1151,18 +1151,17 @@ fn coerce_list_children(lhs_field: &FieldRef, rhs_field: &FieldRef) -> Option<Fi
 fn list_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
     match (lhs_type, rhs_type) {
-        (List(lhs_field), List(rhs_field))
-        | (List(lhs_field), FixedSizeList(rhs_field, _))
-        | (FixedSizeList(lhs_field, _), List(rhs_field)) => {
-            Some(List(coerce_list_children(lhs_field, rhs_field)?))
+        (
+            LargeList(lhs_field),
+            List(rhs_field) | LargeList(rhs_field) | FixedSizeList(rhs_field, _),
+        )
+        | (FixedSizeList(lhs_field, _) | List(lhs_field), LargeList(rhs_field)) => {
+            Some(LargeList(coerce_list_children(lhs_field, rhs_field)?))
         }
 
-        (LargeList(lhs_field), List(rhs_field))
-        | (List(lhs_field), LargeList(rhs_field))
-        | (LargeList(lhs_field), LargeList(rhs_field))
-        | (LargeList(lhs_field), FixedSizeList(rhs_field, _))
-        | (FixedSizeList(lhs_field, _), LargeList(rhs_field)) => {
-            Some(LargeList(coerce_list_children(lhs_field, rhs_field)?))
+        (List(lhs_field), List(rhs_field) | FixedSizeList(rhs_field, _))
+        | (FixedSizeList(lhs_field, _), List(rhs_field)) => {
+            Some(List(coerce_list_children(lhs_field, rhs_field)?))
         }
 
         // Coerce to the left side FixedSizeList type if the list lengths are the same,

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1139,13 +1139,11 @@ fn numeric_string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<D
 }
 
 fn coerce_list_children(lhs_field: &FieldRef, rhs_field: &FieldRef) -> Option<FieldRef> {
+    let data_types = vec![lhs_field.data_type().clone(), rhs_field.data_type().clone()];
     Some(Arc::new(
         (**lhs_field)
             .clone()
-            .with_data_type(comparison_coercion(
-                lhs_field.data_type(),
-                rhs_field.data_type(),
-            )?)
+            .with_data_type(type_union_resolution(&data_types)?)
             .with_nullable(lhs_field.is_nullable() || rhs_field.is_nullable()),
     ))
 }

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1138,6 +1138,7 @@ fn numeric_string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<D
     }
 }
 
+/// Coerces two fields together, ensuring the field data (name and nullability) is correctly set.
 fn coerce_list_children(lhs_field: &FieldRef, rhs_field: &FieldRef) -> Option<FieldRef> {
     let data_types = vec![lhs_field.data_type().clone(), rhs_field.data_type().clone()];
     Some(Arc::new(

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1149,19 +1149,6 @@ fn coerce_list_children(lhs_field: &FieldRef, rhs_field: &FieldRef) -> Option<Fi
 fn list_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
     match (lhs_type, rhs_type) {
-        (
-            LargeList(lhs_field),
-            List(rhs_field) | LargeList(rhs_field) | FixedSizeList(rhs_field, _),
-        )
-        | (List(lhs_field) | FixedSizeList(lhs_field, _), LargeList(rhs_field)) => {
-            Some(LargeList(coerce_list_children(lhs_field, rhs_field)?))
-        }
-
-        (List(lhs_field), List(rhs_field) | FixedSizeList(rhs_field, _))
-        | (FixedSizeList(lhs_field, _), List(rhs_field)) => {
-            Some(List(coerce_list_children(lhs_field, rhs_field)?))
-        }
-
         // Coerce to the left side FixedSizeList type if the list lengths are the same,
         // otherwise coerce to list with the left type for dynamic length
         (FixedSizeList(lhs_field, ls), FixedSizeList(rhs_field, rs)) => {
@@ -1173,6 +1160,19 @@ fn list_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
             } else {
                 Some(List(coerce_list_children(lhs_field, rhs_field)?))
             }
+        }
+        // LargeList on any side
+        (
+            LargeList(lhs_field),
+            List(rhs_field) | LargeList(rhs_field) | FixedSizeList(rhs_field, _),
+        )
+        | (List(lhs_field) | FixedSizeList(lhs_field, _), LargeList(rhs_field)) => {
+            Some(LargeList(coerce_list_children(lhs_field, rhs_field)?))
+        }
+        // Lists on both sides
+        (List(lhs_field), List(rhs_field) | FixedSizeList(rhs_field, _))
+        | (FixedSizeList(lhs_field, _), List(rhs_field)) => {
+            Some(List(coerce_list_children(lhs_field, rhs_field)?))
         }
         _ => None,
     }

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1173,7 +1173,7 @@ fn list_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
                     *rs,
                 ))
             } else {
-                Some(List(Arc::clone(lhs_field)))
+                Some(List(coerce_list_children(lhs_field, rhs_field)?))
             }
         }
         _ => None,

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1139,12 +1139,9 @@ fn numeric_string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<D
 }
 
 fn coerce_list_children(lhs_field: &FieldRef, rhs_field: &FieldRef) -> Option<FieldRef> {
-    Some(Arc::new(
-        Arc::unwrap_or_clone(Arc::clone(lhs_field)).with_data_type(comparison_coercion(
-            lhs_field.data_type(),
-            rhs_field.data_type(),
-        )?),
-    ))
+    Some(Arc::new((**lhs_field).clone().with_data_type(
+        comparison_coercion(lhs_field.data_type(), rhs_field.data_type())?,
+    )))
 }
 
 /// Coercion rules for list types.

--- a/datafusion/functions-nested/src/make_array.rs
+++ b/datafusion/functions-nested/src/make_array.rs
@@ -26,7 +26,7 @@ use arrow_array::{
     new_null_array, Array, ArrayRef, GenericListArray, NullArray, OffsetSizeTrait,
 };
 use arrow_buffer::OffsetBuffer;
-use arrow_schema::DataType::{LargeList, List, Null};
+use arrow_schema::DataType::{List, Null};
 use arrow_schema::{DataType, Field};
 use datafusion_common::{plan_err, utils::array_into_list_array_nullable, Result};
 use datafusion_expr::binary::{
@@ -198,7 +198,6 @@ pub(crate) fn make_array_inner(arrays: &[ArrayRef]) -> Result<ArrayRef> {
             let array = new_null_array(&DataType::Int64, length);
             Ok(Arc::new(array_into_list_array_nullable(array)))
         }
-        LargeList(..) => array_array::<i64>(arrays, data_type),
         _ => array_array::<i32>(arrays, data_type),
     }
 }

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1155,6 +1155,10 @@ select column1, column5 from arrays_values_without_nulls;
 [21, 22, 23, 24, 25, 26, 27, 28, 29, 30] [6, 7]
 [31, 32, 33, 34, 35, 26, 37, 38, 39, 40] [8, 9]
 
+# make array with arrays of different types
+query ?
+select make_array(make_array(1), arrow_cast(make_array(-1), 'LargeList(Int8)'))
+
 query ???
 select make_array(column1),
        make_array(column1, column5),

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1158,6 +1158,8 @@ select column1, column5 from arrays_values_without_nulls;
 # make array with arrays of different types
 query ?
 select make_array(make_array(1), arrow_cast(make_array(-1), 'LargeList(Int8)'))
+----
+[[1], [-1]]
 
 query ???
 select make_array(column1),

--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -763,5 +763,5 @@ SELECT NULL WHERE FALSE;
 1
 
 # Test Union of List Types. Issue: https://github.com/apache/datafusion/issues/12291
-query error DataFusion error: type_coercion
+query error DataFusion error: type_coercion\ncaused by\nError during planning: Incompatible inputs for Union: Previous inputs were  of type List(.*), but got incompatible type List(.*) on column 'x'
 SELECT make_array(2) x UNION ALL SELECT make_array(now()) x;

--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -761,3 +761,11 @@ SELECT NULL WHERE FALSE;
 ----
 0.5
 1
+
+# Test Union of List Types. Issue: https://github.com/apache/datafusion/issues/12291
+query error
+SELECT make_array(2) x UNION ALL SELECT make_array(now()) x;
+----
+DataFusion error: type_coercion
+caused by
+Error during planning: Incompatible inputs for Union: Previous inputs were of type List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), but got incompatible type List(Field { name: "item", data_type: Timestamp(Nanosecond, Some("+00:00")), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) on column 'x'

--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -763,5 +763,11 @@ SELECT NULL WHERE FALSE;
 1
 
 # Test Union of List Types. Issue: https://github.com/apache/datafusion/issues/12291
-query error DataFusion error: type_coercion\ncaused by\nError during planning: Incompatible inputs for Union: Previous inputs were  of type List(.*), but got incompatible type List(.*) on column 'x'
+query error DataFusion error: type_coercion\ncaused by\nError during planning: Incompatible inputs for Union: Previous inputs were of type List(.*), but got incompatible type List(.*) on column 'x'
 SELECT make_array(2) x UNION ALL SELECT make_array(now()) x;
+
+query ?
+select make_array(arrow_cast(2, 'UInt8')) x UNION ALL SELECT make_array(arrow_cast(-2, 'Int8')) x;
+----
+[-2]
+[2]

--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -763,9 +763,5 @@ SELECT NULL WHERE FALSE;
 1
 
 # Test Union of List Types. Issue: https://github.com/apache/datafusion/issues/12291
-query error
+query error DataFusion error: type_coercion
 SELECT make_array(2) x UNION ALL SELECT make_array(now()) x;
-----
-DataFusion error: type_coercion
-caused by
-Error during planning: Incompatible inputs for Union: Previous inputs were of type List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), but got incompatible type List(Field { name: "item", data_type: Timestamp(Nanosecond, Some("+00:00")), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) on column 'x'


### PR DESCRIPTION
## Which issue does this PR close?


Closes #12291

## Rationale for this change

Currently, we don't attempt to coerce inner list types, and so this works (although it shouldn't)

```sql
SELECT make_array(2) x UNION ALL SELECT make_array(now()) x;
```

## What changes are included in this PR?

Now we’ll try to coerce inner types instead of just using the type of the first array.

## Are these changes tested?

Yes, added a test

## Are there any user-facing changes?

No
