### PR TITLE
Add docs on TableProvider::statistics()

### DIFF
--- a/datafusion/catalog/src/table.rs
+++ b/datafusion/catalog/src/table.rs
@@ -247,6 +247,9 @@ pub trait TableProvider: Debug + Sync + Send {
     }
 
     /// Get statistics for this table, if available
+    /// Although not presently used in mainline DataFusion, this allows implementation specific
+    /// behavior for downstream repositories, in conjunction with specialized optimizer rules to
+    /// perform operations such as re-ordering of joins.
     fn statistics(&self) -> Option<Statistics> {
         None
     }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13439

## Rationale for this change

We don't want to lose this method in a refactor, and it has no tests.

## What changes are included in this PR?

Docs indicating that it is being used.

## Are these changes tested?

No, its just docs.

## Are there any user-facing changes?

They will see the docs.