### PR TITLE
Support Utf8View in Unparser `expr_to_sql`

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -2518,13 +2518,7 @@ mod tests {
 
         assert_eq!(actual, expected);
 
-        let expr = Expr::Column(Column {
-            name: "a".to_string(),
-            relation: None,
-        });
-        let expr = expr.eq(Expr::Literal(ScalarValue::Utf8View(Some(
-            "hello".to_string(),
-        ))));
+        let expr = col("a").eq(lit(ScalarValue::Utf8View(Some("hello".to_string()))));
         let ast = unparser.expr_to_sql(&expr)?;
 
         let actual = format!("{}", ast);

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -2510,10 +2510,7 @@ mod tests {
 
         assert_eq!(ast_dtype, ast::DataType::Char(None));
 
-        let expr = Expr::Cast(Cast {
-            expr: Box::new(col("a")),
-            data_type: DataType::Utf8View,
-        });
+        let expr = cast(col("a"), DataType::Utf8View);
         let ast = unparser.expr_to_sql(&expr)?;
 
         let actual = format!("{}", ast);

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1511,7 +1511,7 @@ mod tests {
     use datafusion_common::TableReference;
     use datafusion_expr::expr::WildcardOptions;
     use datafusion_expr::{
-        case, col, cube, exists, grouping_set, interval_datetime_lit,
+        case, cast, col, cube, exists, grouping_set, interval_datetime_lit,
         interval_year_month_lit, lit, not, not_exists, out_ref_col, placeholder, rollup,
         table_scan, try_cast, when, wildcard, ColumnarValue, ScalarUDF, ScalarUDFImpl,
         Signature, Volatility, WindowFrame, WindowFunctionDefinition,

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -2526,6 +2526,22 @@ mod tests {
 
         assert_eq!(actual, expected);
 
+        let expr = col("a").is_not_null();
+
+        let ast = unparser.expr_to_sql(&expr)?;
+        let actual = format!("{}", ast);
+        let expected = r#"a IS NOT NULL"#.to_string();
+
+        assert_eq!(actual, expected);
+
+        let expr = col("a").is_null();
+
+        let ast = unparser.expr_to_sql(&expr)?;
+        let actual = format!("{}", ast);
+        let expected = r#"a IS NULL"#.to_string();
+
+        assert_eq!(actual, expected);
+
         Ok(())
     }
 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -2500,7 +2500,7 @@ mod tests {
     }
 
     #[test]
-    fn test_utf8_view_to_ast_dtype() -> Result<()> {
+    fn test_utf8_view_to_sql() -> Result<()> {
         let dialect = CustomDialectBuilder::new()
             .with_utf8_cast_dtype(ast::DataType::Char(None))
             .build();
@@ -2518,6 +2518,20 @@ mod tests {
 
         let actual = format!("{}", ast);
         let expected = r#"CAST(a AS CHAR)"#.to_string();
+
+        assert_eq!(actual, expected);
+
+        let expr = Expr::Column(Column {
+            name: "a".to_string(),
+            relation: None,
+        });
+        let expr = expr.eq(Expr::Literal(ScalarValue::Utf8View(Some(
+            "hello".to_string(),
+        ))));
+        let ast = unparser.expr_to_sql(&expr)?;
+
+        let actual = format!("{}", ast);
+        let expected = r#"(a = 'hello')"#.to_string();
 
         assert_eq!(actual, expected);
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13461

## Rationale for this change

Now that Utf8View is being returned by DataFusion, we need to ensure that when we encounter it as part of unparsing an expression, we support it properly.

## What changes are included in this PR?

Correctly maps the Utf8View Arrow data type to the existing Utf8 type for unparsing.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No API changes.
