### PR TITLE
Add `Container` trait and to simplify `Expr` and `LogicalPlan` apply and map methods

### DIFF
--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -17,10 +17,11 @@
 
 //! [`TreeNode`] for visiting and rewriting expression and plan trees
 
-use recursive::recursive;
-use std::sync::Arc;
-
 use crate::Result;
+use recursive::recursive;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::Arc;
 
 /// These macros are used to determine continuation during transforming traversals.
 macro_rules! handle_transform_recursion {
@@ -769,6 +770,263 @@ impl<T> Transformed<T> {
     }
 }
 
+/// [`Container`] contains elements that a function can be applied on or mapped. The
+/// elements of the container are siblings so the continuation rules are similar to
+/// [`TreeNodeRecursion::visit_sibling`] / [`Transformed::transform_sibling`].
+pub trait Container<'a, T: 'a>: Sized {
+    fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        f: F,
+    ) -> Result<TreeNodeRecursion>;
+
+    fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
+        self,
+        f: F,
+    ) -> Result<Transformed<Self>>;
+}
+
+impl<'a, T: 'a, C: Container<'a, T>> Container<'a, T> for Box<C> {
+    fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        f: F,
+    ) -> Result<TreeNodeRecursion> {
+        self.as_ref().apply_elements(f)
+    }
+
+    fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
+        self,
+        f: F,
+    ) -> Result<Transformed<Self>> {
+        (*self).map_elements(f)?.map_data(|c| Ok(Self::new(c)))
+    }
+}
+
+impl<'a, T: 'a, C: Container<'a, T> + Clone> Container<'a, T> for Arc<C> {
+    fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        f: F,
+    ) -> Result<TreeNodeRecursion> {
+        self.as_ref().apply_elements(f)
+    }
+
+    fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
+        self,
+        f: F,
+    ) -> Result<Transformed<Self>> {
+        Arc::unwrap_or_clone(self)
+            .map_elements(f)?
+            .map_data(|c| Ok(Arc::new(c)))
+    }
+}
+
+impl<'a, T: 'a, C: Container<'a, T>> Container<'a, T> for Option<C> {
+    fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        f: F,
+    ) -> Result<TreeNodeRecursion> {
+        match self {
+            Some(t) => t.apply_elements(f),
+            None => Ok(TreeNodeRecursion::Continue),
+        }
+    }
+
+    fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
+        self,
+        f: F,
+    ) -> Result<Transformed<Self>> {
+        self.map_or(Ok(Transformed::no(None)), |c| {
+            c.map_elements(f)?.map_data(|c| Ok(Some(c)))
+        })
+    }
+}
+
+impl<'a, T: 'a, C: Container<'a, T>> Container<'a, T> for Vec<C> {
+    fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        mut f: F,
+    ) -> Result<TreeNodeRecursion> {
+        let mut tnr = TreeNodeRecursion::Continue;
+        for c in self {
+            tnr = c.apply_elements(&mut f)?;
+            match tnr {
+                TreeNodeRecursion::Continue | TreeNodeRecursion::Jump => {}
+                TreeNodeRecursion::Stop => return Ok(TreeNodeRecursion::Stop),
+            }
+        }
+        Ok(tnr)
+    }
+
+    fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
+        self,
+        mut f: F,
+    ) -> Result<Transformed<Self>> {
+        let mut tnr = TreeNodeRecursion::Continue;
+        let mut transformed = false;
+        self.into_iter()
+            .map(|c| match tnr {
+                TreeNodeRecursion::Continue | TreeNodeRecursion::Jump => {
+                    c.map_elements(&mut f).map(|result| {
+                        tnr = result.tnr;
+                        transformed |= result.transformed;
+                        result.data
+                    })
+                }
+                TreeNodeRecursion::Stop => Ok(c),
+            })
+            .collect::<Result<Vec<_>>>()
+            .map(|data| Transformed::new(data, transformed, tnr))
+    }
+}
+
+impl<'a, T: 'a, K: Eq + Hash, C: Container<'a, T>> Container<'a, T> for HashMap<K, C> {
+    fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        mut f: F,
+    ) -> Result<TreeNodeRecursion> {
+        let mut tnr = TreeNodeRecursion::Continue;
+        for c in self.values() {
+            tnr = c.apply_elements(&mut f)?;
+            match tnr {
+                TreeNodeRecursion::Continue | TreeNodeRecursion::Jump => {}
+                TreeNodeRecursion::Stop => return Ok(TreeNodeRecursion::Stop),
+            }
+        }
+        Ok(tnr)
+    }
+
+    fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
+        self,
+        mut f: F,
+    ) -> Result<Transformed<Self>> {
+        let mut tnr = TreeNodeRecursion::Continue;
+        let mut transformed = false;
+        self.into_iter()
+            .map(|(k, c)| match tnr {
+                TreeNodeRecursion::Continue | TreeNodeRecursion::Jump => {
+                    c.map_elements(&mut f).map(|result| {
+                        tnr = result.tnr;
+                        transformed |= result.transformed;
+                        (k, result.data)
+                    })
+                }
+                TreeNodeRecursion::Stop => Ok((k, c)),
+            })
+            .collect::<Result<HashMap<_, _>>>()
+            .map(|data| Transformed::new(data, transformed, tnr))
+    }
+}
+
+impl<'a, T: 'a, C0: Container<'a, T>, C1: Container<'a, T>> Container<'a, T>
+    for (C0, C1)
+{
+    fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        mut f: F,
+    ) -> Result<TreeNodeRecursion> {
+        self.0
+            .apply_elements(&mut f)?
+            .visit_sibling(|| self.1.apply_elements(&mut f))
+    }
+
+    fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
+        self,
+        mut f: F,
+    ) -> Result<Transformed<Self>> {
+        self.0
+            .map_elements(&mut f)?
+            .map_data(|new_c0| Ok((new_c0, self.1)))?
+            .transform_sibling(|(new_c0, c1)| {
+                c1.map_elements(&mut f)?
+                    .map_data(|new_c1| Ok((new_c0, new_c1)))
+            })
+    }
+}
+
+impl<'a, T: 'a, C0: Container<'a, T>, C1: Container<'a, T>, C2: Container<'a, T>>
+    Container<'a, T> for (C0, C1, C2)
+{
+    fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        mut f: F,
+    ) -> Result<TreeNodeRecursion> {
+        self.0
+            .apply_elements(&mut f)?
+            .visit_sibling(|| self.1.apply_elements(&mut f))?
+            .visit_sibling(|| self.2.apply_elements(&mut f))
+    }
+
+    fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
+        self,
+        mut f: F,
+    ) -> Result<Transformed<Self>> {
+        self.0
+            .map_elements(&mut f)?
+            .map_data(|new_c0| Ok((new_c0, self.1, self.2)))?
+            .transform_sibling(|(new_c0, c1, c2)| {
+                c1.map_elements(&mut f)?
+                    .map_data(|new_c1| Ok((new_c0, new_c1, c2)))
+            })?
+            .transform_sibling(|(new_c0, new_c1, c2)| {
+                c2.map_elements(&mut f)?
+                    .map_data(|new_c2| Ok((new_c0, new_c1, new_c2)))
+            })
+    }
+}
+
+/// [`RefContainer`] contains references to elements that a function can be applied on.
+/// The elements of the container are siblings so the continuation rules are similar to
+/// [`TreeNodeRecursion::visit_sibling`].
+pub trait RefContainer<'a, T: 'a>: Sized {
+    fn apply_ref_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &self,
+        f: F,
+    ) -> Result<TreeNodeRecursion>;
+}
+
+impl<'a, T: 'a, C: Container<'a, T>> RefContainer<'a, T> for Vec<&'a C> {
+    fn apply_ref_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &self,
+        mut f: F,
+    ) -> Result<TreeNodeRecursion> {
+        let mut tnr = TreeNodeRecursion::Continue;
+        for c in self {
+            tnr = c.apply_elements(&mut f)?;
+            match tnr {
+                TreeNodeRecursion::Continue | TreeNodeRecursion::Jump => {}
+                TreeNodeRecursion::Stop => return Ok(TreeNodeRecursion::Stop),
+            }
+        }
+        Ok(tnr)
+    }
+}
+
+impl<'a, T: 'a, C0: Container<'a, T>, C1: Container<'a, T>> RefContainer<'a, T>
+    for (&'a C0, &'a C1)
+{
+    fn apply_ref_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &self,
+        mut f: F,
+    ) -> Result<TreeNodeRecursion> {
+        self.0
+            .apply_elements(&mut f)?
+            .visit_sibling(|| self.1.apply_elements(&mut f))
+    }
+}
+
+impl<'a, T: 'a, C0: Container<'a, T>, C1: Container<'a, T>, C2: Container<'a, T>>
+    RefContainer<'a, T> for (&'a C0, &'a C1, &'a C2)
+{
+    fn apply_ref_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
+        &self,
+        mut f: F,
+    ) -> Result<TreeNodeRecursion> {
+        self.0
+            .apply_elements(&mut f)?
+            .visit_sibling(|| self.1.apply_elements(&mut f))?
+            .visit_sibling(|| self.2.apply_elements(&mut f))
+    }
+}
+
 /// Transformation helper to process a sequence of iterable tree nodes that are siblings.
 pub trait TreeNodeIterator: Iterator {
     /// Apples `f` to each item in this iterator
@@ -841,50 +1099,6 @@ impl<I: Iterator> TreeNodeIterator for I {
         .collect::<Result<Vec<_>>>()
         .map(|data| Transformed::new(data, transformed, tnr))
     }
-}
-
-/// Transformation helper to process a heterogeneous sequence of tree node containing
-/// expressions.
-///
-/// This macro is very similar to [TreeNodeIterator::map_until_stop_and_collect] to
-/// process nodes that are siblings, but it accepts an initial transformation (`F0`) and
-/// a sequence of pairs. Each pair is made of an expression (`EXPR`) and its
-/// transformation (`F`).
-///
-/// The macro builds up a tuple that contains `Transformed.data` result of `F0` as the
-/// first element and further elements from the sequence of pairs. An element from a pair
-/// is either the value of `EXPR` or the `Transformed.data` result of `F`, depending on
-/// the `Transformed.tnr` result of previous `F`s (`F0` initially).
-///
-/// # Returns
-/// Error if any of the transformations returns an error
-///
-/// Ok(Transformed<(data0, ..., dataN)>) such that:
-/// 1. `transformed` is true if any of the transformations had transformed true
-/// 2. `(data0, ..., dataN)`, where `data0` is the `Transformed.data` from `F0` and
-///     `data1` ... `dataN` are from either `EXPR` or the `Transformed.data` of `F`
-/// 3. `tnr` from `F0` or the last invocation of `F`
-#[macro_export]
-macro_rules! map_until_stop_and_collect {
-    ($F0:expr, $($EXPR:expr, $F:expr),*) => {{
-        $F0.and_then(|Transformed { data: data0, mut transformed, mut tnr }| {
-            let all_datas = (
-                data0,
-                $(
-                    if tnr == TreeNodeRecursion::Continue || tnr == TreeNodeRecursion::Jump {
-                        $F.map(|result| {
-                            tnr = result.tnr;
-                            transformed |= result.transformed;
-                            result.data
-                        })?
-                    } else {
-                        $EXPR
-                    },
-                )*
-            );
-            Ok(Transformed::new(all_datas, transformed, tnr))
-        })
-    }}
 }
 
 /// Transformation helper to access [`Transformed`] fields in a [`Result`] easily.
@@ -1021,7 +1235,7 @@ pub(crate) mod tests {
     use std::fmt::Display;
 
     use crate::tree_node::{
-        Transformed, TreeNode, TreeNodeIterator, TreeNodeRecursion, TreeNodeRewriter,
+        Container, Transformed, TreeNode, TreeNodeRecursion, TreeNodeRewriter,
         TreeNodeVisitor,
     };
     use crate::Result;
@@ -1054,7 +1268,7 @@ pub(crate) mod tests {
             &'n self,
             f: F,
         ) -> Result<TreeNodeRecursion> {
-            self.children.iter().apply_until_stop(f)
+            self.children.apply_elements(f)
         }
 
         fn map_children<F: FnMut(Self) -> Result<Transformed<Self>>>(
@@ -1063,12 +1277,27 @@ pub(crate) mod tests {
         ) -> Result<Transformed<Self>> {
             Ok(self
                 .children
-                .into_iter()
-                .map_until_stop_and_collect(f)?
+                .map_elements(f)?
                 .update_data(|new_children| Self {
                     children: new_children,
                     ..self
                 }))
+        }
+    }
+
+    impl<'a, T: 'a> Container<'a, Self> for TestTreeNode<T> {
+        fn apply_elements<F: FnMut(&'a Self) -> Result<TreeNodeRecursion>>(
+            &'a self,
+            mut f: F,
+        ) -> Result<TreeNodeRecursion> {
+            f(self)
+        }
+
+        fn map_elements<F: FnMut(Self) -> Result<Transformed<Self>>>(
+            self,
+            mut f: F,
+        ) -> Result<Transformed<Self>> {
+            f(self)
         }
     }
 

--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -996,12 +996,12 @@ impl<
 /// construct a temporary container to be able to call `apply_ref_elements` on a
 /// collection of tree node references. But in that case the container's temporary
 /// lifetime is different to the lifetime of tree nodes that we put into it.
-/// Please find an example usecase in case in `Expr::apply_children` in `Expr::Case` case.
+/// Please find an example usecase in `Expr::apply_children` with the `Expr::Case` case.
 ///
 /// Most of the cases we don't need to create a temporary container with
 /// `TreeNodeRefContainer`, but we can just call `TreeNodeContainer::apply_elements`.
-/// Please find an example usecase in case in `Expr::apply_children` in
-/// `Expr::GroupingSet` case.
+/// Please find an example usecase in `Expr::apply_children` with the `Expr::GroupingSet`
+/// case.
 pub trait TreeNodeRefContainer<'a, T: 'a>: Sized {
     /// Applies `f` to all elements of the container.
     /// This method is usually called from [`TreeNode::apply_children`] implementations as

--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -989,6 +989,19 @@ impl<
 /// [`TreeNodeRefContainer`] contains references to elements that a function can be
 /// applied on. The elements of the container are siblings so the continuation rules are
 /// similar to [`TreeNodeRecursion::visit_sibling`].
+///
+/// This container is similar to [`TreeNodeContainer`], but the lifetime of the reference
+/// elements (`T`) are not derived from the container's lifetime.
+/// A typical usage of this container is in `Expr::apply_children` when we need to
+/// construct a temporary container to be able to call `apply_ref_elements` on a
+/// collection of tree node references. But in that case the container's temporary
+/// lifetime is different to the lifetime of tree nodes that we put into it.
+/// Please find an example usecase in case in `Expr::apply_children` in `Expr::Case` case.
+///
+/// Most of the cases we don't need to create a temporary container with
+/// `TreeNodeRefContainer`, but we can just call `TreeNodeContainer::apply_elements`.
+/// Please find an example usecase in case in `Expr::apply_children` in
+/// `Expr::GroupingSet` case.
 pub trait TreeNodeRefContainer<'a, T: 'a>: Sized {
     /// Applies `f` to all elements of the container.
     /// This method is usually called from [`TreeNode::apply_children`] implementations as

--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -774,11 +774,17 @@ impl<T> Transformed<T> {
 /// The elements of the container are siblings so the continuation rules are similar to
 /// [`TreeNodeRecursion::visit_sibling`] / [`Transformed::transform_sibling`].
 pub trait TreeNodeContainer<'a, T: 'a>: Sized {
+    /// Applies `f` to all elements of the container.
+    /// This method is usually called from [`TreeNode::apply_children`] implementations as
+    /// a node is actually a container of the node's children.
     fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
         &'a self,
         f: F,
     ) -> Result<TreeNodeRecursion>;
 
+    /// Maps all elements of the container with `f`.
+    /// This method is usually called from [`TreeNode::map_children`] implementations as
+    /// a node is actually a container of the node's children.
     fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
         self,
         f: F,
@@ -984,6 +990,9 @@ impl<
 /// applied on. The elements of the container are siblings so the continuation rules are
 /// similar to [`TreeNodeRecursion::visit_sibling`].
 pub trait TreeNodeRefContainer<'a, T: 'a>: Sized {
+    /// Applies `f` to all elements of the container.
+    /// This method is usually called from [`TreeNode::apply_children`] implementations as
+    /// a node is actually a container of the node's children.
     fn apply_ref_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
         &self,
         f: F,

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -32,7 +32,7 @@ use crate::{udaf, ExprSchemable, Operator, Signature, WindowFrame, WindowUDF};
 use arrow::datatypes::{DataType, FieldRef};
 use datafusion_common::cse::HashNode;
 use datafusion_common::tree_node::{
-    Container, Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
+    Transformed, TransformedResult, TreeNode, TreeNodeContainer, TreeNodeRecursion,
 };
 use datafusion_common::{
     plan_err, Column, DFSchema, HashMap, Result, ScalarValue, TableReference,
@@ -351,7 +351,7 @@ impl<'a> From<(Option<&'a TableReference>, &'a FieldRef)> for Expr {
     }
 }
 
-impl<'a> Container<'a, Self> for Expr {
+impl<'a> TreeNodeContainer<'a, Self> for Expr {
     fn apply_elements<F: FnMut(&'a Self) -> Result<TreeNodeRecursion>>(
         &'a self,
         mut f: F,
@@ -669,7 +669,7 @@ impl Display for Sort {
     }
 }
 
-impl<'a> Container<'a, Expr> for Sort {
+impl<'a> TreeNodeContainer<'a, Expr> for Sort {
     fn apply_elements<F: FnMut(&'a Expr) -> Result<TreeNodeRecursion>>(
         &'a self,
         f: F,

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -32,7 +32,7 @@ use crate::{udaf, ExprSchemable, Operator, Signature, WindowFrame, WindowUDF};
 use arrow::datatypes::{DataType, FieldRef};
 use datafusion_common::cse::HashNode;
 use datafusion_common::tree_node::{
-    Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
+    Container, Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
 };
 use datafusion_common::{
     plan_err, Column, DFSchema, HashMap, Result, ScalarValue, TableReference,
@@ -351,6 +351,22 @@ impl<'a> From<(Option<&'a TableReference>, &'a FieldRef)> for Expr {
     }
 }
 
+impl<'a> Container<'a, Self> for Expr {
+    fn apply_elements<F: FnMut(&'a Self) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        mut f: F,
+    ) -> Result<TreeNodeRecursion> {
+        f(self)
+    }
+
+    fn map_elements<F: FnMut(Self) -> Result<Transformed<Self>>>(
+        self,
+        mut f: F,
+    ) -> Result<Transformed<Self>> {
+        f(self)
+    }
+}
+
 /// UNNEST expression.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
 pub struct Unnest {
@@ -650,6 +666,24 @@ impl Display for Sort {
             write!(f, " NULLS LAST")?;
         }
         Ok(())
+    }
+}
+
+impl<'a> Container<'a, Expr> for Sort {
+    fn apply_elements<F: FnMut(&'a Expr) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        f: F,
+    ) -> Result<TreeNodeRecursion> {
+        self.expr.apply_elements(f)
+    }
+
+    fn map_elements<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
+        self,
+        f: F,
+    ) -> Result<Transformed<Self>> {
+        self.expr
+            .map_elements(f)?
+            .map_data(|expr| Ok(Self { expr, ..self }))
     }
 }
 

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -26,7 +26,7 @@ use std::{
 
 use crate::expr::Sort;
 use arrow::datatypes::DataType;
-use datafusion_common::tree_node::{Container, Transformed, TreeNodeRecursion};
+use datafusion_common::tree_node::{Transformed, TreeNodeContainer, TreeNodeRecursion};
 use datafusion_common::{
     Constraints, DFSchemaRef, Result, SchemaReference, TableReference,
 };
@@ -491,7 +491,7 @@ pub struct OperateFunctionArg {
     pub default_expr: Option<Expr>,
 }
 
-impl<'a> Container<'a, Expr> for OperateFunctionArg {
+impl<'a> TreeNodeContainer<'a, Expr> for OperateFunctionArg {
     fn apply_elements<F: FnMut(&'a Expr) -> Result<TreeNodeRecursion>>(
         &'a self,
         f: F,
@@ -522,7 +522,7 @@ pub struct CreateFunctionBody {
     pub function_body: Option<Expr>,
 }
 
-impl<'a> Container<'a, Expr> for CreateFunctionBody {
+impl<'a> TreeNodeContainer<'a, Expr> for CreateFunctionBody {
     fn apply_elements<F: FnMut(&'a Expr) -> Result<TreeNodeRecursion>>(
         &'a self,
         f: F,

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -26,7 +26,10 @@ use std::{
 
 use crate::expr::Sort;
 use arrow::datatypes::DataType;
-use datafusion_common::{Constraints, DFSchemaRef, SchemaReference, TableReference};
+use datafusion_common::tree_node::{Container, Transformed, TreeNodeRecursion};
+use datafusion_common::{
+    Constraints, DFSchemaRef, Result, SchemaReference, TableReference,
+};
 use sqlparser::ast::Ident;
 
 /// Various types of DDL  (CREATE / DROP) catalog manipulation
@@ -487,6 +490,28 @@ pub struct OperateFunctionArg {
     pub data_type: DataType,
     pub default_expr: Option<Expr>,
 }
+
+impl<'a> Container<'a, Expr> for OperateFunctionArg {
+    fn apply_elements<F: FnMut(&'a Expr) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        f: F,
+    ) -> Result<TreeNodeRecursion> {
+        self.default_expr.apply_elements(f)
+    }
+
+    fn map_elements<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
+        self,
+        f: F,
+    ) -> Result<Transformed<Self>> {
+        self.default_expr.map_elements(f)?.map_data(|default_expr| {
+            Ok(Self {
+                default_expr,
+                ..self
+            })
+        })
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
 pub struct CreateFunctionBody {
     /// LANGUAGE lang_name
@@ -495,6 +520,29 @@ pub struct CreateFunctionBody {
     pub behavior: Option<Volatility>,
     /// RETURN or AS function body
     pub function_body: Option<Expr>,
+}
+
+impl<'a> Container<'a, Expr> for CreateFunctionBody {
+    fn apply_elements<F: FnMut(&'a Expr) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        f: F,
+    ) -> Result<TreeNodeRecursion> {
+        self.function_body.apply_elements(f)
+    }
+
+    fn map_elements<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
+        self,
+        f: F,
+    ) -> Result<Transformed<Self>> {
+        self.function_body
+            .map_elements(f)?
+            .map_data(|function_body| {
+                Ok(Self {
+                    function_body,
+                    ..self
+                })
+            })
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -45,7 +45,7 @@ use crate::{
 };
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion_common::tree_node::{Container, Transformed, TreeNode, TreeNodeRecursion};
 use datafusion_common::{
     aggregate_functional_dependencies, internal_err, plan_err, Column, Constraints,
     DFSchema, DFSchemaRef, DataFusionError, Dependency, FunctionalDependence,
@@ -284,6 +284,22 @@ impl Default for LogicalPlan {
             produce_one_row: false,
             schema: Arc::new(DFSchema::empty()),
         })
+    }
+}
+
+impl<'a> Container<'a, Self> for LogicalPlan {
+    fn apply_elements<F: FnMut(&'a Self) -> Result<TreeNodeRecursion>>(
+        &'a self,
+        mut f: F,
+    ) -> Result<TreeNodeRecursion> {
+        f(self)
+    }
+
+    fn map_elements<F: FnMut(Self) -> Result<Transformed<Self>>>(
+        self,
+        mut f: F,
+    ) -> Result<Transformed<Self>> {
+        f(self)
     }
 }
 

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -45,7 +45,9 @@ use crate::{
 };
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion_common::tree_node::{Container, Transformed, TreeNode, TreeNodeRecursion};
+use datafusion_common::tree_node::{
+    Transformed, TreeNode, TreeNodeContainer, TreeNodeRecursion,
+};
 use datafusion_common::{
     aggregate_functional_dependencies, internal_err, plan_err, Column, Constraints,
     DFSchema, DFSchemaRef, DataFusionError, Dependency, FunctionalDependence,
@@ -287,7 +289,7 @@ impl Default for LogicalPlan {
     }
 }
 
-impl<'a> Container<'a, Self> for LogicalPlan {
+impl<'a> TreeNodeContainer<'a, Self> for LogicalPlan {
     fn apply_elements<F: FnMut(&'a Self) -> Result<TreeNodeRecursion>>(
         &'a self,
         mut f: F,

--- a/datafusion/expr/src/logical_plan/statement.rs
+++ b/datafusion/expr/src/logical_plan/statement.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 use arrow::datatypes::DataType;
-use datafusion_common::tree_node::{Container, Transformed};
-use datafusion_common::{DFSchema, DFSchemaRef, Result};
+use datafusion_common::{DFSchema, DFSchemaRef};
 use std::fmt::{self, Display};
 use std::sync::{Arc, OnceLock};
 

--- a/datafusion/expr/src/logical_plan/statement.rs
+++ b/datafusion/expr/src/logical_plan/statement.rs
@@ -16,12 +16,11 @@
 // under the License.
 
 use arrow::datatypes::DataType;
-use datafusion_common::tree_node::{Transformed, TreeNodeIterator};
+use datafusion_common::tree_node::{Container, Transformed};
 use datafusion_common::{DFSchema, DFSchemaRef, Result};
 use std::fmt::{self, Display};
 use std::sync::{Arc, OnceLock};
 
-use super::tree_node::rewrite_arc;
 use crate::{expr_vec_fmt, Expr, LogicalPlan};
 
 /// Statements have a unchanging empty schema.
@@ -77,53 +76,6 @@ impl Statement {
         match self {
             Statement::Prepare(Prepare { input, .. }) => vec![input.as_ref()],
             _ => vec![],
-        }
-    }
-
-    /// Rewrites input LogicalPlans in the current `Statement` using `f`.
-    pub(super) fn map_inputs<
-        F: FnMut(LogicalPlan) -> Result<Transformed<LogicalPlan>>,
-    >(
-        self,
-        f: F,
-    ) -> Result<Transformed<Self>> {
-        match self {
-            Statement::Prepare(Prepare {
-                input,
-                name,
-                data_types,
-            }) => Ok(rewrite_arc(input, f)?.update_data(|input| {
-                Statement::Prepare(Prepare {
-                    input,
-                    name,
-                    data_types,
-                })
-            })),
-            _ => Ok(Transformed::no(self)),
-        }
-    }
-
-    /// Returns a iterator over all expressions in the current `Statement`.
-    pub(super) fn expression_iter(&self) -> impl Iterator<Item = &Expr> {
-        match self {
-            Statement::Execute(Execute { parameters, .. }) => parameters.iter(),
-            _ => [].iter(),
-        }
-    }
-
-    /// Rewrites all expressions in the current `Statement` using `f`.
-    pub(super) fn map_expressions<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
-        self,
-        f: F,
-    ) -> Result<Transformed<Self>> {
-        match self {
-            Statement::Execute(Execute { name, parameters }) => Ok(parameters
-                .into_iter()
-                .map_until_stop_and_collect(f)?
-                .update_data(|parameters| {
-                    Statement::Execute(Execute { parameters, name })
-                })),
-            _ => Ok(Transformed::no(self)),
         }
     }
 

--- a/datafusion/expr/src/logical_plan/tree_node.rs
+++ b/datafusion/expr/src/logical_plan/tree_node.rs
@@ -44,12 +44,12 @@ use crate::{
     Sort, Statement, Subquery, SubqueryAlias, TableScan, Union, Unnest,
     UserDefinedLogicalNode, Values, Window,
 };
-use datafusion_common::tree_node::RefContainer;
+use datafusion_common::tree_node::TreeNodeRefContainer;
 use recursive::recursive;
 
 use crate::expr::{Exists, InSubquery};
 use datafusion_common::tree_node::{
-    Container, Transformed, TreeNode, TreeNodeIterator, TreeNodeRecursion,
+    Transformed, TreeNode, TreeNodeContainer, TreeNodeIterator, TreeNodeRecursion,
     TreeNodeRewriter, TreeNodeVisitor,
 };
 use datafusion_common::{internal_err, Result};

--- a/datafusion/expr/src/tree_node.rs
+++ b/datafusion/expr/src/tree_node.rs
@@ -19,14 +19,14 @@
 
 use crate::expr::{
     AggregateFunction, Alias, Between, BinaryExpr, Case, Cast, GroupingSet, InList,
-    InSubquery, Like, Placeholder, ScalarFunction, Sort, TryCast, Unnest, WindowFunction,
+    InSubquery, Like, Placeholder, ScalarFunction, TryCast, Unnest, WindowFunction,
 };
 use crate::{Expr, ExprFunctionExt};
 
 use datafusion_common::tree_node::{
-    Transformed, TreeNode, TreeNodeIterator, TreeNodeRecursion,
+    Container, RefContainer, Transformed, TreeNode, TreeNodeRecursion,
 };
-use datafusion_common::{map_until_stop_and_collect, Result};
+use datafusion_common::Result;
 
 /// Implementation of the [`TreeNode`] trait
 ///
@@ -42,9 +42,9 @@ impl TreeNode for Expr {
         &'n self,
         f: F,
     ) -> Result<TreeNodeRecursion> {
-        let children = match self {
-            Expr::Alias(Alias{expr,..})
-            | Expr::Unnest(Unnest{expr})
+        match self {
+            Expr::Alias(Alias { expr, .. })
+            | Expr::Unnest(Unnest { expr })
             | Expr::Not(expr)
             | Expr::IsNotNull(expr)
             | Expr::IsTrue(expr)
@@ -57,78 +57,50 @@ impl TreeNode for Expr {
             | Expr::Negative(expr)
             | Expr::Cast(Cast { expr, .. })
             | Expr::TryCast(TryCast { expr, .. })
-            | Expr::InSubquery(InSubquery{ expr, .. }) => vec![expr.as_ref()],
+            | Expr::InSubquery(InSubquery { expr, .. }) => expr.apply_elements(f),
             Expr::GroupingSet(GroupingSet::Rollup(exprs))
-            | Expr::GroupingSet(GroupingSet::Cube(exprs)) => exprs.iter().collect(),
-            Expr::ScalarFunction (ScalarFunction{ args, .. } )  => {
-                args.iter().collect()
+            | Expr::GroupingSet(GroupingSet::Cube(exprs)) => exprs.apply_elements(f),
+            Expr::ScalarFunction(ScalarFunction { args, .. }) => {
+                args.apply_elements(f)
             }
             Expr::GroupingSet(GroupingSet::GroupingSets(lists_of_exprs)) => {
-                lists_of_exprs.iter().flatten().collect()
+                lists_of_exprs.apply_elements(f)
             }
             Expr::Column(_)
             // Treat OuterReferenceColumn as a leaf expression
             | Expr::OuterReferenceColumn(_, _)
             | Expr::ScalarVariable(_, _)
             | Expr::Literal(_)
-            | Expr::Exists {..}
+            | Expr::Exists { .. }
             | Expr::ScalarSubquery(_)
-            | Expr::Wildcard {..}
-            | Expr::Placeholder (_) => vec![],
+            | Expr::Wildcard { .. }
+            | Expr::Placeholder(_) => Ok(TreeNodeRecursion::Continue),
             Expr::BinaryExpr(BinaryExpr { left, right, .. }) => {
-                vec![left.as_ref(), right.as_ref()]
+                (left, right).apply_ref_elements(f)
             }
             Expr::Like(Like { expr, pattern, .. })
             | Expr::SimilarTo(Like { expr, pattern, .. }) => {
-                vec![expr.as_ref(), pattern.as_ref()]
+                (expr, pattern).apply_ref_elements(f)
             }
             Expr::Between(Between {
-                expr, low, high, ..
-            }) => vec![expr.as_ref(), low.as_ref(), high.as_ref()],
-            Expr::Case(case) => {
-                let mut expr_vec = vec![];
-                if let Some(expr) = case.expr.as_ref() {
-                    expr_vec.push(expr.as_ref());
-                };
-                for (when, then) in case.when_then_expr.iter() {
-                    expr_vec.push(when.as_ref());
-                    expr_vec.push(then.as_ref());
-                }
-                if let Some(else_expr) = case.else_expr.as_ref() {
-                    expr_vec.push(else_expr.as_ref());
-                }
-                expr_vec
-            }
-            Expr::AggregateFunction(AggregateFunction { args, filter, order_by, .. })
-             => {
-                let mut expr_vec = args.iter().collect::<Vec<_>>();
-                if let Some(f) = filter {
-                    expr_vec.push(f.as_ref());
-                }
-                if let Some(order_by) = order_by {
-                    expr_vec.extend(order_by.iter().map(|sort| &sort.expr));
-                }
-                expr_vec
-            }
+                              expr, low, high, ..
+                          }) => (expr, low, high).apply_ref_elements(f),
+            Expr::Case(Case { expr, when_then_expr, else_expr }) =>
+                (expr, when_then_expr, else_expr).apply_ref_elements(f),
+            Expr::AggregateFunction(AggregateFunction { args, filter, order_by, .. }) =>
+                (args, filter, order_by).apply_ref_elements(f),
             Expr::WindowFunction(WindowFunction {
-                args,
-                partition_by,
-                order_by,
-                ..
-            }) => {
-                let mut expr_vec = args.iter().collect::<Vec<_>>();
-                expr_vec.extend(partition_by);
-                expr_vec.extend(order_by.iter().map(|sort| &sort.expr));
-                expr_vec
+                                     args,
+                                     partition_by,
+                                     order_by,
+                                     ..
+                                 }) => {
+                (args, partition_by, order_by).apply_ref_elements(f)
             }
             Expr::InList(InList { expr, list, .. }) => {
-                let mut expr_vec = vec![expr.as_ref()];
-                expr_vec.extend(list);
-                expr_vec
+                (expr, list).apply_ref_elements(f)
             }
-        };
-
-        children.into_iter().apply_until_stop(f)
+        }
     }
 
     /// Maps each child of `self` using the provided closure `f`.
@@ -148,137 +120,109 @@ impl TreeNode for Expr {
             | Expr::ScalarSubquery(_)
             | Expr::ScalarVariable(_, _)
             | Expr::Literal(_) => Transformed::no(self),
-            Expr::Unnest(Unnest { expr, .. }) => transform_box(expr, &mut f)?
-                .update_data(|be| Expr::Unnest(Unnest::new_boxed(be))),
+            Expr::Unnest(Unnest { expr, .. }) => expr
+                .map_elements(&mut f)?
+                .update_data(|expr| Expr::Unnest(Unnest { expr })),
             Expr::Alias(Alias {
                 expr,
                 relation,
                 name,
-            }) => f(*expr)?.update_data(|e| Expr::Alias(Alias::new(e, relation, name))),
+            }) => f(*expr)?.update_data(|e| e.alias_qualified(relation, name)),
             Expr::InSubquery(InSubquery {
                 expr,
                 subquery,
                 negated,
-            }) => transform_box(expr, &mut f)?.update_data(|be| {
+            }) => expr.map_elements(&mut f)?.update_data(|be| {
                 Expr::InSubquery(InSubquery::new(be, subquery, negated))
             }),
-            Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
-                map_until_stop_and_collect!(
-                    transform_box(left, &mut f),
-                    right,
-                    transform_box(right, &mut f)
-                )?
+            Expr::BinaryExpr(BinaryExpr { left, op, right }) => (left, right)
+                .map_elements(&mut f)?
                 .update_data(|(new_left, new_right)| {
                     Expr::BinaryExpr(BinaryExpr::new(new_left, op, new_right))
-                })
-            }
+                }),
             Expr::Like(Like {
                 negated,
                 expr,
                 pattern,
                 escape_char,
                 case_insensitive,
-            }) => map_until_stop_and_collect!(
-                transform_box(expr, &mut f),
-                pattern,
-                transform_box(pattern, &mut f)
-            )?
-            .update_data(|(new_expr, new_pattern)| {
-                Expr::Like(Like::new(
-                    negated,
-                    new_expr,
-                    new_pattern,
-                    escape_char,
-                    case_insensitive,
-                ))
-            }),
+            }) => (expr, pattern).map_elements(&mut f)?.update_data(
+                |(new_expr, new_pattern)| {
+                    Expr::Like(Like::new(
+                        negated,
+                        new_expr,
+                        new_pattern,
+                        escape_char,
+                        case_insensitive,
+                    ))
+                },
+            ),
             Expr::SimilarTo(Like {
                 negated,
                 expr,
                 pattern,
                 escape_char,
                 case_insensitive,
-            }) => map_until_stop_and_collect!(
-                transform_box(expr, &mut f),
-                pattern,
-                transform_box(pattern, &mut f)
-            )?
-            .update_data(|(new_expr, new_pattern)| {
-                Expr::SimilarTo(Like::new(
-                    negated,
-                    new_expr,
-                    new_pattern,
-                    escape_char,
-                    case_insensitive,
-                ))
-            }),
-            Expr::Not(expr) => transform_box(expr, &mut f)?.update_data(Expr::Not),
+            }) => (expr, pattern).map_elements(&mut f)?.update_data(
+                |(new_expr, new_pattern)| {
+                    Expr::SimilarTo(Like::new(
+                        negated,
+                        new_expr,
+                        new_pattern,
+                        escape_char,
+                        case_insensitive,
+                    ))
+                },
+            ),
+            Expr::Not(expr) => expr.map_elements(&mut f)?.update_data(Expr::Not),
             Expr::IsNotNull(expr) => {
-                transform_box(expr, &mut f)?.update_data(Expr::IsNotNull)
+                expr.map_elements(&mut f)?.update_data(Expr::IsNotNull)
             }
-            Expr::IsNull(expr) => transform_box(expr, &mut f)?.update_data(Expr::IsNull),
-            Expr::IsTrue(expr) => transform_box(expr, &mut f)?.update_data(Expr::IsTrue),
-            Expr::IsFalse(expr) => {
-                transform_box(expr, &mut f)?.update_data(Expr::IsFalse)
-            }
+            Expr::IsNull(expr) => expr.map_elements(&mut f)?.update_data(Expr::IsNull),
+            Expr::IsTrue(expr) => expr.map_elements(&mut f)?.update_data(Expr::IsTrue),
+            Expr::IsFalse(expr) => expr.map_elements(&mut f)?.update_data(Expr::IsFalse),
             Expr::IsUnknown(expr) => {
-                transform_box(expr, &mut f)?.update_data(Expr::IsUnknown)
+                expr.map_elements(&mut f)?.update_data(Expr::IsUnknown)
             }
             Expr::IsNotTrue(expr) => {
-                transform_box(expr, &mut f)?.update_data(Expr::IsNotTrue)
+                expr.map_elements(&mut f)?.update_data(Expr::IsNotTrue)
             }
             Expr::IsNotFalse(expr) => {
-                transform_box(expr, &mut f)?.update_data(Expr::IsNotFalse)
+                expr.map_elements(&mut f)?.update_data(Expr::IsNotFalse)
             }
             Expr::IsNotUnknown(expr) => {
-                transform_box(expr, &mut f)?.update_data(Expr::IsNotUnknown)
+                expr.map_elements(&mut f)?.update_data(Expr::IsNotUnknown)
             }
             Expr::Negative(expr) => {
-                transform_box(expr, &mut f)?.update_data(Expr::Negative)
+                expr.map_elements(&mut f)?.update_data(Expr::Negative)
             }
             Expr::Between(Between {
                 expr,
                 negated,
                 low,
                 high,
-            }) => map_until_stop_and_collect!(
-                transform_box(expr, &mut f),
-                low,
-                transform_box(low, &mut f),
-                high,
-                transform_box(high, &mut f)
-            )?
-            .update_data(|(new_expr, new_low, new_high)| {
-                Expr::Between(Between::new(new_expr, negated, new_low, new_high))
-            }),
+            }) => (expr, low, high).map_elements(&mut f)?.update_data(
+                |(new_expr, new_low, new_high)| {
+                    Expr::Between(Between::new(new_expr, negated, new_low, new_high))
+                },
+            ),
             Expr::Case(Case {
                 expr,
                 when_then_expr,
                 else_expr,
-            }) => map_until_stop_and_collect!(
-                transform_option_box(expr, &mut f),
-                when_then_expr,
-                when_then_expr
-                    .into_iter()
-                    .map_until_stop_and_collect(|(when, then)| {
-                        map_until_stop_and_collect!(
-                            transform_box(when, &mut f),
-                            then,
-                            transform_box(then, &mut f)
-                        )
-                    }),
-                else_expr,
-                transform_option_box(else_expr, &mut f)
-            )?
-            .update_data(|(new_expr, new_when_then_expr, new_else_expr)| {
-                Expr::Case(Case::new(new_expr, new_when_then_expr, new_else_expr))
-            }),
-            Expr::Cast(Cast { expr, data_type }) => transform_box(expr, &mut f)?
+            }) => (expr, when_then_expr, else_expr)
+                .map_elements(&mut f)?
+                .update_data(|(new_expr, new_when_then_expr, new_else_expr)| {
+                    Expr::Case(Case::new(new_expr, new_when_then_expr, new_else_expr))
+                }),
+            Expr::Cast(Cast { expr, data_type }) => expr
+                .map_elements(&mut f)?
                 .update_data(|be| Expr::Cast(Cast::new(be, data_type))),
-            Expr::TryCast(TryCast { expr, data_type }) => transform_box(expr, &mut f)?
+            Expr::TryCast(TryCast { expr, data_type }) => expr
+                .map_elements(&mut f)?
                 .update_data(|be| Expr::TryCast(TryCast::new(be, data_type))),
             Expr::ScalarFunction(ScalarFunction { func, args }) => {
-                transform_vec(args, &mut f)?.map_data(|new_args| {
+                args.map_elements(&mut f)?.map_data(|new_args| {
                     Ok(Expr::ScalarFunction(ScalarFunction::new_udf(
                         func, new_args,
                     )))
@@ -291,22 +235,17 @@ impl TreeNode for Expr {
                 order_by,
                 window_frame,
                 null_treatment,
-            }) => map_until_stop_and_collect!(
-                transform_vec(args, &mut f),
-                partition_by,
-                transform_vec(partition_by, &mut f),
-                order_by,
-                transform_sort_vec(order_by, &mut f)
-            )?
-            .update_data(|(new_args, new_partition_by, new_order_by)| {
-                Expr::WindowFunction(WindowFunction::new(fun, new_args))
-                    .partition_by(new_partition_by)
-                    .order_by(new_order_by)
-                    .window_frame(window_frame)
-                    .null_treatment(null_treatment)
-                    .build()
-                    .unwrap()
-            }),
+            }) => (args, partition_by, order_by)
+                .map_elements(&mut f)?
+                .update_data(|(new_args, new_partition_by, new_order_by)| {
+                    Expr::WindowFunction(WindowFunction::new(fun, new_args))
+                        .partition_by(new_partition_by)
+                        .order_by(new_order_by)
+                        .window_frame(window_frame)
+                        .null_treatment(null_treatment)
+                        .build()
+                        .unwrap()
+                }),
             Expr::AggregateFunction(AggregateFunction {
                 args,
                 func,
@@ -314,31 +253,27 @@ impl TreeNode for Expr {
                 filter,
                 order_by,
                 null_treatment,
-            }) => map_until_stop_and_collect!(
-                transform_vec(args, &mut f),
-                filter,
-                transform_option_box(filter, &mut f),
-                order_by,
-                transform_sort_option_vec(order_by, &mut f)
-            )?
-            .map_data(|(new_args, new_filter, new_order_by)| {
-                Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
-                    func,
-                    new_args,
-                    distinct,
-                    new_filter,
-                    new_order_by,
-                    null_treatment,
-                )))
-            })?,
+            }) => (args, filter, order_by).map_elements(&mut f)?.map_data(
+                |(new_args, new_filter, new_order_by)| {
+                    Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
+                        func,
+                        new_args,
+                        distinct,
+                        new_filter,
+                        new_order_by,
+                        null_treatment,
+                    )))
+                },
+            )?,
             Expr::GroupingSet(grouping_set) => match grouping_set {
-                GroupingSet::Rollup(exprs) => transform_vec(exprs, &mut f)?
+                GroupingSet::Rollup(exprs) => exprs
+                    .map_elements(&mut f)?
                     .update_data(|ve| Expr::GroupingSet(GroupingSet::Rollup(ve))),
-                GroupingSet::Cube(exprs) => transform_vec(exprs, &mut f)?
+                GroupingSet::Cube(exprs) => exprs
+                    .map_elements(&mut f)?
                     .update_data(|ve| Expr::GroupingSet(GroupingSet::Cube(ve))),
                 GroupingSet::GroupingSets(lists_of_exprs) => lists_of_exprs
-                    .into_iter()
-                    .map_until_stop_and_collect(|exprs| transform_vec(exprs, &mut f))?
+                    .map_elements(f)?
                     .update_data(|new_lists_of_exprs| {
                         Expr::GroupingSet(GroupingSet::GroupingSets(new_lists_of_exprs))
                     }),
@@ -347,70 +282,13 @@ impl TreeNode for Expr {
                 expr,
                 list,
                 negated,
-            }) => map_until_stop_and_collect!(
-                transform_box(expr, &mut f),
-                list,
-                transform_vec(list, &mut f)
-            )?
-            .update_data(|(new_expr, new_list)| {
-                Expr::InList(InList::new(new_expr, new_list, negated))
-            }),
+            }) => {
+                (expr, list)
+                    .map_elements(&mut f)?
+                    .update_data(|(new_expr, new_list)| {
+                        Expr::InList(InList::new(new_expr, new_list, negated))
+                    })
+            }
         })
     }
-}
-
-/// Transforms a boxed expression by applying the provided closure `f`.
-fn transform_box<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
-    be: Box<Expr>,
-    f: &mut F,
-) -> Result<Transformed<Box<Expr>>> {
-    Ok(f(*be)?.update_data(Box::new))
-}
-
-/// Transforms an optional boxed expression by applying the provided closure `f`.
-fn transform_option_box<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
-    obe: Option<Box<Expr>>,
-    f: &mut F,
-) -> Result<Transformed<Option<Box<Expr>>>> {
-    obe.map_or(Ok(Transformed::no(None)), |be| {
-        Ok(transform_box(be, f)?.update_data(Some))
-    })
-}
-
-/// &mut transform a Option<`Vec` of `Expr`s>
-pub fn transform_option_vec<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
-    ove: Option<Vec<Expr>>,
-    f: &mut F,
-) -> Result<Transformed<Option<Vec<Expr>>>> {
-    ove.map_or(Ok(Transformed::no(None)), |ve| {
-        Ok(transform_vec(ve, f)?.update_data(Some))
-    })
-}
-
-/// &mut transform a `Vec` of `Expr`s
-fn transform_vec<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
-    ve: Vec<Expr>,
-    f: &mut F,
-) -> Result<Transformed<Vec<Expr>>> {
-    ve.into_iter().map_until_stop_and_collect(f)
-}
-
-/// Transforms an optional vector of sort expressions by applying the provided closure `f`.
-pub fn transform_sort_option_vec<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
-    sorts_option: Option<Vec<Sort>>,
-    f: &mut F,
-) -> Result<Transformed<Option<Vec<Sort>>>> {
-    sorts_option.map_or(Ok(Transformed::no(None)), |sorts| {
-        Ok(transform_sort_vec(sorts, f)?.update_data(Some))
-    })
-}
-
-/// Transforms an vector of sort expressions by applying the provided closure `f`.
-pub fn transform_sort_vec<F: FnMut(Expr) -> Result<Transformed<Expr>>>(
-    sorts: Vec<Sort>,
-    f: &mut F,
-) -> Result<Transformed<Vec<Sort>>> {
-    sorts.into_iter().map_until_stop_and_collect(|s| {
-        Ok(f(s.expr)?.update_data(|e| Sort { expr: e, ..s }))
-    })
 }

--- a/datafusion/expr/src/tree_node.rs
+++ b/datafusion/expr/src/tree_node.rs
@@ -121,7 +121,7 @@ impl TreeNode for Expr {
             | Expr::ScalarVariable(_, _)
             | Expr::Literal(_) => Transformed::no(self),
             Expr::Unnest(Unnest { expr, .. }) => expr
-                .map_elements(&mut f)?
+                .map_elements(f)?
                 .update_data(|expr| Expr::Unnest(Unnest { expr })),
             Expr::Alias(Alias {
                 expr,
@@ -132,11 +132,11 @@ impl TreeNode for Expr {
                 expr,
                 subquery,
                 negated,
-            }) => expr.map_elements(&mut f)?.update_data(|be| {
+            }) => expr.map_elements(f)?.update_data(|be| {
                 Expr::InSubquery(InSubquery::new(be, subquery, negated))
             }),
             Expr::BinaryExpr(BinaryExpr { left, op, right }) => (left, right)
-                .map_elements(&mut f)?
+                .map_elements(f)?
                 .update_data(|(new_left, new_right)| {
                     Expr::BinaryExpr(BinaryExpr::new(new_left, op, new_right))
                 }),
@@ -146,62 +146,56 @@ impl TreeNode for Expr {
                 pattern,
                 escape_char,
                 case_insensitive,
-            }) => (expr, pattern).map_elements(&mut f)?.update_data(
-                |(new_expr, new_pattern)| {
-                    Expr::Like(Like::new(
-                        negated,
-                        new_expr,
-                        new_pattern,
-                        escape_char,
-                        case_insensitive,
-                    ))
-                },
-            ),
+            }) => {
+                (expr, pattern)
+                    .map_elements(f)?
+                    .update_data(|(new_expr, new_pattern)| {
+                        Expr::Like(Like::new(
+                            negated,
+                            new_expr,
+                            new_pattern,
+                            escape_char,
+                            case_insensitive,
+                        ))
+                    })
+            }
             Expr::SimilarTo(Like {
                 negated,
                 expr,
                 pattern,
                 escape_char,
                 case_insensitive,
-            }) => (expr, pattern).map_elements(&mut f)?.update_data(
-                |(new_expr, new_pattern)| {
-                    Expr::SimilarTo(Like::new(
-                        negated,
-                        new_expr,
-                        new_pattern,
-                        escape_char,
-                        case_insensitive,
-                    ))
-                },
-            ),
-            Expr::Not(expr) => expr.map_elements(&mut f)?.update_data(Expr::Not),
-            Expr::IsNotNull(expr) => {
-                expr.map_elements(&mut f)?.update_data(Expr::IsNotNull)
+            }) => {
+                (expr, pattern)
+                    .map_elements(f)?
+                    .update_data(|(new_expr, new_pattern)| {
+                        Expr::SimilarTo(Like::new(
+                            negated,
+                            new_expr,
+                            new_pattern,
+                            escape_char,
+                            case_insensitive,
+                        ))
+                    })
             }
-            Expr::IsNull(expr) => expr.map_elements(&mut f)?.update_data(Expr::IsNull),
-            Expr::IsTrue(expr) => expr.map_elements(&mut f)?.update_data(Expr::IsTrue),
-            Expr::IsFalse(expr) => expr.map_elements(&mut f)?.update_data(Expr::IsFalse),
-            Expr::IsUnknown(expr) => {
-                expr.map_elements(&mut f)?.update_data(Expr::IsUnknown)
-            }
-            Expr::IsNotTrue(expr) => {
-                expr.map_elements(&mut f)?.update_data(Expr::IsNotTrue)
-            }
-            Expr::IsNotFalse(expr) => {
-                expr.map_elements(&mut f)?.update_data(Expr::IsNotFalse)
-            }
+            Expr::Not(expr) => expr.map_elements(f)?.update_data(Expr::Not),
+            Expr::IsNotNull(expr) => expr.map_elements(f)?.update_data(Expr::IsNotNull),
+            Expr::IsNull(expr) => expr.map_elements(f)?.update_data(Expr::IsNull),
+            Expr::IsTrue(expr) => expr.map_elements(f)?.update_data(Expr::IsTrue),
+            Expr::IsFalse(expr) => expr.map_elements(f)?.update_data(Expr::IsFalse),
+            Expr::IsUnknown(expr) => expr.map_elements(f)?.update_data(Expr::IsUnknown),
+            Expr::IsNotTrue(expr) => expr.map_elements(f)?.update_data(Expr::IsNotTrue),
+            Expr::IsNotFalse(expr) => expr.map_elements(f)?.update_data(Expr::IsNotFalse),
             Expr::IsNotUnknown(expr) => {
-                expr.map_elements(&mut f)?.update_data(Expr::IsNotUnknown)
+                expr.map_elements(f)?.update_data(Expr::IsNotUnknown)
             }
-            Expr::Negative(expr) => {
-                expr.map_elements(&mut f)?.update_data(Expr::Negative)
-            }
+            Expr::Negative(expr) => expr.map_elements(f)?.update_data(Expr::Negative),
             Expr::Between(Between {
                 expr,
                 negated,
                 low,
                 high,
-            }) => (expr, low, high).map_elements(&mut f)?.update_data(
+            }) => (expr, low, high).map_elements(f)?.update_data(
                 |(new_expr, new_low, new_high)| {
                     Expr::Between(Between::new(new_expr, negated, new_low, new_high))
                 },
@@ -211,18 +205,18 @@ impl TreeNode for Expr {
                 when_then_expr,
                 else_expr,
             }) => (expr, when_then_expr, else_expr)
-                .map_elements(&mut f)?
+                .map_elements(f)?
                 .update_data(|(new_expr, new_when_then_expr, new_else_expr)| {
                     Expr::Case(Case::new(new_expr, new_when_then_expr, new_else_expr))
                 }),
             Expr::Cast(Cast { expr, data_type }) => expr
-                .map_elements(&mut f)?
+                .map_elements(f)?
                 .update_data(|be| Expr::Cast(Cast::new(be, data_type))),
             Expr::TryCast(TryCast { expr, data_type }) => expr
-                .map_elements(&mut f)?
+                .map_elements(f)?
                 .update_data(|be| Expr::TryCast(TryCast::new(be, data_type))),
             Expr::ScalarFunction(ScalarFunction { func, args }) => {
-                args.map_elements(&mut f)?.map_data(|new_args| {
+                args.map_elements(f)?.map_data(|new_args| {
                     Ok(Expr::ScalarFunction(ScalarFunction::new_udf(
                         func, new_args,
                     )))
@@ -235,9 +229,8 @@ impl TreeNode for Expr {
                 order_by,
                 window_frame,
                 null_treatment,
-            }) => (args, partition_by, order_by)
-                .map_elements(&mut f)?
-                .update_data(|(new_args, new_partition_by, new_order_by)| {
+            }) => (args, partition_by, order_by).map_elements(f)?.update_data(
+                |(new_args, new_partition_by, new_order_by)| {
                     Expr::WindowFunction(WindowFunction::new(fun, new_args))
                         .partition_by(new_partition_by)
                         .order_by(new_order_by)
@@ -245,7 +238,8 @@ impl TreeNode for Expr {
                         .null_treatment(null_treatment)
                         .build()
                         .unwrap()
-                }),
+                },
+            ),
             Expr::AggregateFunction(AggregateFunction {
                 args,
                 func,
@@ -253,7 +247,7 @@ impl TreeNode for Expr {
                 filter,
                 order_by,
                 null_treatment,
-            }) => (args, filter, order_by).map_elements(&mut f)?.map_data(
+            }) => (args, filter, order_by).map_elements(f)?.map_data(
                 |(new_args, new_filter, new_order_by)| {
                     Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
                         func,
@@ -267,10 +261,10 @@ impl TreeNode for Expr {
             )?,
             Expr::GroupingSet(grouping_set) => match grouping_set {
                 GroupingSet::Rollup(exprs) => exprs
-                    .map_elements(&mut f)?
+                    .map_elements(f)?
                     .update_data(|ve| Expr::GroupingSet(GroupingSet::Rollup(ve))),
                 GroupingSet::Cube(exprs) => exprs
-                    .map_elements(&mut f)?
+                    .map_elements(f)?
                     .update_data(|ve| Expr::GroupingSet(GroupingSet::Cube(ve))),
                 GroupingSet::GroupingSets(lists_of_exprs) => lists_of_exprs
                     .map_elements(f)?
@@ -282,13 +276,11 @@ impl TreeNode for Expr {
                 expr,
                 list,
                 negated,
-            }) => {
-                (expr, list)
-                    .map_elements(&mut f)?
-                    .update_data(|(new_expr, new_list)| {
-                        Expr::InList(InList::new(new_expr, new_list, negated))
-                    })
-            }
+            }) => (expr, list)
+                .map_elements(f)?
+                .update_data(|(new_expr, new_list)| {
+                    Expr::InList(InList::new(new_expr, new_list, negated))
+                }),
         })
     }
 }

--- a/datafusion/expr/src/tree_node.rs
+++ b/datafusion/expr/src/tree_node.rs
@@ -24,7 +24,7 @@ use crate::expr::{
 use crate::{Expr, ExprFunctionExt};
 
 use datafusion_common::tree_node::{
-    Container, RefContainer, Transformed, TreeNode, TreeNodeRecursion,
+    Transformed, TreeNode, TreeNodeContainer, TreeNodeRecursion, TreeNodeRefContainer,
 };
 use datafusion_common::Result;
 

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -38,7 +38,9 @@ use datafusion_expr::{
 
 use crate::optimize_projections::required_indices::RequiredIndicies;
 use crate::utils::NamePreserver;
-use datafusion_common::tree_node::{Container, Transformed, TreeNode, TreeNodeRecursion};
+use datafusion_common::tree_node::{
+    Transformed, TreeNode, TreeNodeContainer, TreeNodeRecursion,
+};
 
 /// Optimizer rule to prune unnecessary columns from intermediate schemas
 /// inside the [`LogicalPlan`]. This rule:

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -38,9 +38,7 @@ use datafusion_expr::{
 
 use crate::optimize_projections::required_indices::RequiredIndicies;
 use crate::utils::NamePreserver;
-use datafusion_common::tree_node::{
-    Transformed, TreeNode, TreeNodeIterator, TreeNodeRecursion,
-};
+use datafusion_common::tree_node::{Container, Transformed, TreeNode, TreeNodeRecursion};
 
 /// Optimizer rule to prune unnecessary columns from intermediate schemas
 /// inside the [`LogicalPlan`]. This rule:
@@ -484,7 +482,7 @@ fn merge_consecutive_projections(proj: Projection) -> Result<Transformed<Project
     // previous projection as input:
     let name_preserver = NamePreserver::new_for_projection();
     let mut original_names = vec![];
-    let new_exprs = expr.into_iter().map_until_stop_and_collect(|expr| {
+    let new_exprs = expr.map_elements(|expr| {
         original_names.push(name_preserver.save(&expr));
 
         // do not rewrite top level Aliases (rewriter will remove all aliases within exprs)

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -18,7 +18,7 @@
 use std::{collections::HashSet, sync::Arc};
 
 use arrow_schema::Schema;
-use datafusion_common::tree_node::Container;
+use datafusion_common::tree_node::TreeNodeContainer;
 use datafusion_common::{
     tree_node::{Transformed, TransformedResult, TreeNode, TreeNodeRewriter},
     Column, HashMap, Result, TableReference,

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -18,11 +18,12 @@
 use std::{collections::HashSet, sync::Arc};
 
 use arrow_schema::Schema;
+use datafusion_common::tree_node::Container;
 use datafusion_common::{
     tree_node::{Transformed, TransformedResult, TreeNode, TreeNodeRewriter},
     Column, HashMap, Result, TableReference,
 };
-use datafusion_expr::{expr::Alias, tree_node::transform_sort_vec};
+use datafusion_expr::expr::Alias;
 use datafusion_expr::{Expr, LogicalPlan, Projection, Sort, SortExpr};
 use sqlparser::ast::Ident;
 
@@ -83,17 +84,18 @@ pub(super) fn normalize_union_schema(plan: &LogicalPlan) -> Result<LogicalPlan> 
 
 /// Rewrite sort expressions that have a UNION plan as their input to remove the table reference.
 fn rewrite_sort_expr_for_union(exprs: Vec<SortExpr>) -> Result<Vec<SortExpr>> {
-    let sort_exprs = transform_sort_vec(exprs, &mut |expr| {
-        expr.transform_up(|expr| {
-            if let Expr::Column(mut col) = expr {
-                col.relation = None;
-                Ok(Transformed::yes(Expr::Column(col)))
-            } else {
-                Ok(Transformed::no(expr))
-            }
+    let sort_exprs = exprs
+        .map_elements(&mut |expr: Expr| {
+            expr.transform_up(|expr| {
+                if let Expr::Column(mut col) = expr {
+                    col.relation = None;
+                    Ok(Transformed::yes(Expr::Column(col)))
+                } else {
+                    Ok(Transformed::no(expr))
+                }
+            })
         })
-    })
-    .data()?;
+        .data()?;
 
     Ok(sort_exprs)
 }


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/8913.

## Rationale for this change

The current implementation of `LogicalPlan:apply_children()`, `LogicalPlan::map_children()`, `LogicalPlan::apply_expressions()`, `LogicalPlan::map_expressions()`, `Expr::apply_children()` and `Expr::map_children()` are confusing due the `map_until_stop_and_collect` macro. I think we can introduce a trait that can contain arbitrary sibling elements that functions can be applied on and mapped:
```rust
/// [`TreeNodeContainer`] contains elements that a function can be applied on or mapped. The
/// elements of the container are siblings so the continuation rules are similar to
/// [`TreeNodeRecursion::visit_sibling`] / [`Transformed::transform_sibling`].
pub trait TreeNodeContainer<'a, T: 'a>: Sized {
    fn apply_elements<F: FnMut(&'a T) -> Result<TreeNodeRecursion>>(
        &'a self,
        f: F,
    ) -> Result<TreeNodeRecursion>;

    fn map_elements<F: FnMut(T) -> Result<Transformed<T>>>(
        self,
        f: F,
    ) -> Result<Transformed<Self>>;
}
```
As example for the new trait usage, this is how `Expr::map_children()` handled `Expr::Case` before this PR:
```rust
Expr::Case(Case {
    expr,           // Option<Box<Expr>>,
    when_then_expr, // Vec<(Box<Expr>, Box<Expr>)>
    else_expr,      // Option<Box<Expr>>,
}) => map_until_stop_and_collect!(
    transform_option_box(expr, &mut f),
    when_then_expr,
    when_then_expr
        .into_iter()
        .map_until_stop_and_collect(|(when, then)| {
            map_until_stop_and_collect!(
                transform_box(when, &mut f),
                then,
                transform_box(then, &mut f)
            )
        }),
        else_expr,
        transform_option_box(else_expr, &mut f)
)?...
```
and this is how it is handled with this PR:
```rust
Expr::Case(Case {
    expr,           // Option<Box<Expr>>,
    when_then_expr, // Vec<(Box<Expr>, Box<Expr>)>
    else_expr,      // Option<Box<Expr>>,
}) => (expr, when_then_expr, else_expr).map_elements(f)?...
```
Please see the type of the `Case` struct fields in comments.
Let's focus on `when_then_expr: Vec<(Box<Expr>, Box<Expr>)>` first. The composable nature of `TreeNodeContainer` and the blanket implementation we provide for `Box`, 2-tuple and `Vec` makes it possible to just call `when_then_expr. map_elements(f)` to map all the expressions in `when_then_expr`.
But we can go further and replace the `map_until_stop_and_collect` macro to deal with all 3 fields of `Case`. We can put them into a 3-tuple and can call `.map_elements()` as we have blanket implementation for 3-tuple as well. (Note that we can't use `Vec` for this as the type of the 3 fields differ.)

## What changes are included in this PR?

This PR:
- Gets rid of `map_until_stop_and_collect` macro and many `transform` and `rewrite` helper methods.
- Adds the `TreeNodeContainer` trait and blanket implementations for `Box`, `Option`, `Vec`, tuples, ...
- Defines the trivial `TreeNodeContainer` implementation for `Expr` and `LogicalPlan`.
- Simplifies the above mentioned `apply...` and `map...` methods.

## Are these changes tested?

Yes, with exitsing UTs.

## Are there any user-facing changes?

No.
