### PR TITLE
Clarify documentation about use of tokio tasks

### DIFF
--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -475,10 +475,12 @@
 //!
 //! The number of cores used is determined by the `target_partitions`
 //! configuration setting, which defaults to the number of CPU cores.
-//! During execution, DataFusion creates this many distinct `async` [`Stream`]s and
-//! this many distinct [Tokio] [`task`]s, which drive the `Stream`s
-//! using threads managed by the `Runtime`. Many DataFusion `Stream`s  perform
-//! CPU intensive processing.
+//! While preparing for execution, DataFusion tries to create this many distinct
+//! `async` [`Stream`]s for each `ExecutionPlan`.
+//! The `Stream`s for certain `ExecutionPlans`, such as as [`RepartitionExec`]
+//! and [`CoalescePartitionsExec`], spawn [Tokio] [`task`]s, that are run by
+//! threads managed by the `Runtime`.
+//! Many DataFusion `Stream`s perform CPU intensive processing.
 //!
 //! Using `async` for CPU intensive tasks makes it easy for [`TableProvider`]s
 //! to perform network I/O using standard Rust `async` during execution.
@@ -582,6 +584,8 @@
 //! [`Runtime`]: tokio::runtime::Runtime
 //! [`task`]: tokio::task
 //! [Using Rustlang’s Async Tokio Runtime for CPU-Bound Tasks]: https://thenewstack.io/using-rustlangs-async-tokio-runtime-for-cpu-bound-tasks/
+//! [`RepartitionExec`]: physical_plan::repartition::RepartitionExec
+//! [`CoalescePartitionsExec`]: physical_plan::coalesce_partitions::CoalescePartitionsExec
 //!
 //! ## State Management and Configuration
 //!


### PR DESCRIPTION
## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/12393
- Follow on to https://github.com/apache/datafusion/pull/13423

## Rationale for this change

@matthewmturner  noted on https://github.com/apache/datafusion/pull/13423#discussion_r1846635429 that the  discussion about how tasks were launched was confusion

## What changes are included in this PR?
Try to clarify what happens with  the tasks

## Are these changes tested?
By docs CI
## Are there any user-facing changes?
Just docs, no functional changes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
