### PR TITLE
Avoid pushdown of volatile functions to tablescan

### DIFF
--- a/datafusion/expr/src/table_source.rs
+++ b/datafusion/expr/src/table_source.rs
@@ -99,7 +99,7 @@ pub trait TableSource: Sync + Send {
     }
 
     /// Tests whether the table provider can make use of any or all filter expressions
-    /// to optimise data retrieval.
+    /// to optimise data retrieval. Only non-volatile expressions are passed to this function.
     fn supports_filters_pushdown(
         &self,
         filters: &[&Expr],

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1002,7 +1002,7 @@ impl OptimizerRule for PushDownFilter {
                     filter_predicates
                         .into_iter()
                         .zip(results)
-                        .map(|(&ref expr, res)| {
+                        .map(|(expr, res)| {
                             let filter_pushdown_type = if expr.is_volatile() {
                                 // Do not push down predicate with volatile functions to scan
                                 TableProviderFilterPushDown::Unsupported
@@ -1011,7 +1011,6 @@ impl OptimizerRule for PushDownFilter {
                             };
                             (expr, filter_pushdown_type)
                         });
-
 
                 let new_scan_filters = zip
                     .clone()
@@ -3422,5 +3421,4 @@ Projection: a, b
         \n    TableScan: test";
         assert_optimized_plan_eq(plan, expected_after)
     }
-
 }

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -2529,23 +2529,31 @@ mod tests {
         }
     }
 
-    fn table_scan_with_pushdown_provider(
+    fn table_scan_with_pushdown_provider_builder(
         filter_support: TableProviderFilterPushDown,
-    ) -> Result<LogicalPlan> {
+        filters: Vec<Expr>,
+        projection: Option<Vec<usize>>,
+    ) -> Result<LogicalPlanBuilder> {
         let test_provider = PushDownProvider { filter_support };
 
         let table_scan = LogicalPlan::TableScan(TableScan {
             table_name: "test".into(),
-            filters: vec![],
+            filters,
             projected_schema: Arc::new(DFSchema::try_from(
                 (*test_provider.schema()).clone(),
             )?),
-            projection: None,
+            projection,
             source: Arc::new(test_provider),
             fetch: None,
         });
 
-        LogicalPlanBuilder::from(table_scan)
+        Ok(LogicalPlanBuilder::from(table_scan))
+    }
+
+    fn table_scan_with_pushdown_provider(
+        filter_support: TableProviderFilterPushDown,
+    ) -> Result<LogicalPlan> {
+        table_scan_with_pushdown_provider_builder(filter_support, vec![], None)?
             .filter(col("a").eq(lit(1i64)))?
             .build()
     }
@@ -2602,25 +2610,14 @@ mod tests {
 
     #[test]
     fn multi_combined_filter() -> Result<()> {
-        let test_provider = PushDownProvider {
-            filter_support: TableProviderFilterPushDown::Inexact,
-        };
-
-        let table_scan = LogicalPlan::TableScan(TableScan {
-            table_name: "test".into(),
-            filters: vec![col("a").eq(lit(10i64)), col("b").gt(lit(11i64))],
-            projected_schema: Arc::new(DFSchema::try_from(
-                (*test_provider.schema()).clone(),
-            )?),
-            projection: Some(vec![0]),
-            source: Arc::new(test_provider),
-            fetch: None,
-        });
-
-        let plan = LogicalPlanBuilder::from(table_scan)
-            .filter(and(col("a").eq(lit(10i64)), col("b").gt(lit(11i64))))?
-            .project(vec![col("a"), col("b")])?
-            .build()?;
+        let plan = table_scan_with_pushdown_provider_builder(
+            TableProviderFilterPushDown::Inexact,
+            vec![col("a").eq(lit(10i64)), col("b").gt(lit(11i64))],
+            Some(vec![0]),
+        )?
+        .filter(and(col("a").eq(lit(10i64)), col("b").gt(lit(11i64))))?
+        .project(vec![col("a"), col("b")])?
+        .build()?;
 
         let expected = "Projection: a, b\
             \n  Filter: a = Int64(10) AND b > Int64(11)\
@@ -2631,25 +2628,14 @@ mod tests {
 
     #[test]
     fn multi_combined_filter_exact() -> Result<()> {
-        let test_provider = PushDownProvider {
-            filter_support: TableProviderFilterPushDown::Exact,
-        };
-
-        let table_scan = LogicalPlan::TableScan(TableScan {
-            table_name: "test".into(),
-            filters: vec![],
-            projected_schema: Arc::new(DFSchema::try_from(
-                (*test_provider.schema()).clone(),
-            )?),
-            projection: Some(vec![0]),
-            source: Arc::new(test_provider),
-            fetch: None,
-        });
-
-        let plan = LogicalPlanBuilder::from(table_scan)
-            .filter(and(col("a").eq(lit(10i64)), col("b").gt(lit(11i64))))?
-            .project(vec![col("a"), col("b")])?
-            .build()?;
+        let plan = table_scan_with_pushdown_provider_builder(
+            TableProviderFilterPushDown::Exact,
+            vec![],
+            Some(vec![0]),
+        )?
+        .filter(and(col("a").eq(lit(10i64)), col("b").gt(lit(11i64))))?
+        .project(vec![col("a"), col("b")])?
+        .build()?;
 
         let expected = r#"
 Projection: a, b

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1002,14 +1002,18 @@ impl OptimizerRule for PushDownFilter {
                     filter_predicates
                         .into_iter()
                         .zip(results)
-                        .map(|(expr, res)| {
-                            let filter_pushdown_type = if expr.is_volatile() {
+                        .map(|(pred, res)| {
+                            let filter_pushdown_type = if !matches!(
+                                res,
+                                TableProviderFilterPushDown::Unsupported
+                            ) && pred.is_volatile()
+                            {
                                 // Do not push down predicate with volatile functions to scan
                                 TableProviderFilterPushDown::Unsupported
                             } else {
                                 res
                             };
-                            (expr, filter_pushdown_type)
+                            (pred, filter_pushdown_type)
                         });
 
                 let new_scan_filters = zip


### PR DESCRIPTION
## Which issue does this PR close?

When using pushdown filters, the planner pushes the volatile `random()` filter to the table source, so it executes in scan (for example, in parquet) and in the query engine, which leads to weird results.

Closes #13268.

## Rationale for this change

It's impossible to evaluate volatile filters in different layers.

## What changes are included in this PR?

- Improvement for rule optimiser to avoid passing volatile filters to scan
- Unit test

## Are these changes tested?

- Unit tests
- Regression tests
- Manual test

As proposed in the original issue, I tried `alltypes_tiny_pages_plain.parquet` sample file containing 7300 lines:

```sql
set datafusion.execution.parquet.pushdown_filters=true;
create external table data stored as parquet location 'alltypes_tiny_pages_plain.parquet';
```

Running a query 
```sql
select COUNT(*) from data WHERE RANDOM() < 0.1;
```
with `datafusion-cli` gives an answer of 726, which is pretty close to the expected 730.

New plan
```
+---------------+---------------------------------------------------------------------------------+
| plan_type     | plan                                                                            |
+---------------+---------------------------------------------------------------------------------+
| logical_plan  | Aggregate: groupBy=[[]], aggr=[[count(Int64(1)) AS count(*)]]                   |
|               |   Filter: random() < Float64(0.1)                                               |
|               |     TableScan: data projection=[]                                               |
| physical_plan | AggregateExec: mode=Final, gby=[], aggr=[count(*)]                              |
|               |   CoalescePartitionsExec                                                        |
|               |     AggregateExec: mode=Partial, gby=[], aggr=[count(*)]                        |
|               |       CoalesceBatchesExec: target_batch_size=8192                               |
|               |         FilterExec: random() < 0.1                                              |
|               |           RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1  |
|               |             ParquetExec: file_groups={1 group: [[sample.parquet]]} 							|
|               |                                                                                 |
+---------------+---------------------------------------------------------------------------------+
```

Before the change plan was
```
| ParquetExec: file_groups={1 group: [[alltypes_tiny_pages_plain.parquet]]}, predicate=random() < 0.1 |
```
## Are there any user-facing changes?

No breaking changes.