### PR TITLE
MINOR: remove one duplicated inparam in TopK

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -911,7 +911,6 @@ impl ExecutionPlan for SortExec {
                     context.session_config().batch_size(),
                     context.runtime_env(),
                     &self.metrics_set,
-                    partition,
                 )?;
                 Ok(Box::pin(RecordBatchStreamAdapter::new(
                     self.schema(),

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -95,9 +95,7 @@ pub struct TopK {
 impl TopK {
     /// Create a new [`TopK`] that stores the top `k` values, as
     /// defined by the sort expressions in `expr`.
-    // TODO: make a builder or some other nicer API to avoid the
-    // clippy warning
-    #[allow(clippy::too_many_arguments)]
+    // TODO: make a builder or some other nicer API
     pub fn try_new(
         partition_id: usize,
         schema: SchemaRef,
@@ -106,7 +104,6 @@ impl TopK {
         batch_size: usize,
         runtime: Arc<RuntimeEnv>,
         metrics: &ExecutionPlanMetricsSet,
-        partition: usize,
     ) -> Result<Self> {
         let reservation = MemoryConsumer::new(format!("TopK[{partition_id}]"))
             .register(&runtime.memory_pool);
@@ -133,7 +130,7 @@ impl TopK {
 
         Ok(Self {
             schema: Arc::clone(&schema),
-            metrics: TopKMetrics::new(metrics, partition),
+            metrics: TopKMetrics::new(metrics, partition_id),
             reservation,
             batch_size,
             expr,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I came across this when writing https://github.com/GreptimeTeam/greptimedb/pull/5018. `partition` and `partition_id` are the same things.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

A minor refactor to remove the unnecessary inparam.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No need

## Are there any user-facing changes?

API change for those who use `TopK` directly like me in https://github.com/GreptimeTeam/greptimedb/pull/5018

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
