### PR TITLE
Fix DataFusionError use in schema_err macro

### DIFF
--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -21,7 +21,7 @@ use arrow_schema::{Field, FieldRef};
 
 use crate::error::_schema_err;
 use crate::utils::{parse_identifiers_normalized, quote_identifier};
-use crate::{DFSchema, DataFusionError, Result, SchemaError, TableReference};
+use crate::{DFSchema, Result, SchemaError, TableReference};
 use std::collections::HashSet;
 use std::convert::Infallible;
 use std::fmt;

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -598,9 +598,9 @@ macro_rules! arrow_err {
 #[macro_export]
 macro_rules! schema_datafusion_err {
     ($ERR:expr) => {
-        DataFusionError::SchemaError(
+        $crate::error::DataFusionError::SchemaError(
             $ERR,
-            Box::new(Some(DataFusionError::get_back_trace())),
+            Box::new(Some($crate::error::DataFusionError::get_back_trace())),
         )
     };
 }
@@ -609,9 +609,9 @@ macro_rules! schema_datafusion_err {
 #[macro_export]
 macro_rules! schema_err {
     ($ERR:expr) => {
-        Err(DataFusionError::SchemaError(
+        Err($crate::error::DataFusionError::SchemaError(
             $ERR,
-            Box::new(Some(DataFusionError::get_back_trace())),
+            Box::new(Some($crate::error::DataFusionError::get_back_trace())),
         ))
     };
 }


### PR DESCRIPTION

## Which issue does this PR close?

none

## Rationale for this change

Use declaring-crate-relative references so that macro use place does not need to import symbols it doesn't use.


## What changes are included in this PR?

Improve schema_err macro

## Are these changes tested?

by the compiler

## Are there any user-facing changes?

no
