### PR TITLE
Support duplicate column aliases in queries 

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -150,6 +150,11 @@ pub enum SchemaError {
         qualifier: Box<TableReference>,
         name: String,
     },
+    /// Schema duplicate qualified fields with duplicate unqualified names
+    QualifiedFieldWithDuplicateName {
+        qualifier: Box<TableReference>,
+        name: String,
+    },
     /// Schema contains duplicate unqualified field name
     DuplicateUnqualifiedField { name: String },
     /// No field with this name
@@ -184,6 +189,14 @@ impl Display for SchemaError {
                 write!(
                     f,
                     "Schema contains duplicate qualified field name {}.{}",
+                    qualifier.to_quoted_string(),
+                    quote_identifier(name)
+                )
+            }
+            Self::QualifiedFieldWithDuplicateName { qualifier, name } => {
+                write!(
+                    f,
+                    "Schema contains qualified fields with duplicate unqualified names {}.{}",
                     qualifier.to_quoted_string(),
                     quote_identifier(name)
                 )

--- a/datafusion/core/src/catalog_common/listing_schema.rs
+++ b/datafusion/core/src/catalog_common/listing_schema.rs
@@ -25,9 +25,7 @@ use std::sync::{Arc, Mutex};
 use crate::catalog::{SchemaProvider, TableProvider, TableProviderFactory};
 use crate::execution::context::SessionState;
 
-use datafusion_common::{
-    Constraints, DFSchema, DataFusionError, HashMap, TableReference,
-};
+use datafusion_common::{DFSchema, DataFusionError, HashMap, TableReference};
 use datafusion_expr::CreateExternalTable;
 
 use async_trait::async_trait;
@@ -131,21 +129,12 @@ impl ListingSchemaProvider {
                     .factory
                     .create(
                         state,
-                        &CreateExternalTable {
-                            schema: Arc::new(DFSchema::empty()),
-                            name,
-                            location: table_url,
-                            file_type: self.format.clone(),
-                            table_partition_cols: vec![],
-                            if_not_exists: false,
-                            temporary: false,
-                            definition: None,
-                            order_exprs: vec![],
-                            unbounded: false,
-                            options: Default::default(),
-                            constraints: Constraints::empty(),
-                            column_defaults: Default::default(),
-                        },
+                        &CreateExternalTable::builder()
+                            .schema(Arc::new(DFSchema::empty()))
+                            .name(name)
+                            .location(table_url)
+                            .file_type(self.format.clone())
+                            .build()?,
                     )
                     .await?;
                 let _ =

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -41,9 +41,9 @@ use crate::{
     logical_expr::ScalarUDF,
     logical_expr::{
         CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateFunction,
-        CreateMemoryTable, CreateView, DropCatalogSchema, DropFunction, DropTable,
-        DropView, Execute, LogicalPlan, LogicalPlanBuilder, Prepare, SetVariable,
-        TableType, UNNAMED_TABLE,
+        CreateMemoryTable, CreateMemoryTableFields, CreateView, CreateViewFields,
+        DropCatalogSchema, DropFunction, DropTable, DropView, Execute, LogicalPlan,
+        LogicalPlanBuilder, Prepare, SetVariable, TableType, UNNAMED_TABLE,
     },
     physical_expr::PhysicalExpr,
     physical_plan::ExecutionPlan,
@@ -792,7 +792,7 @@ impl SessionContext {
     }
 
     async fn create_memory_table(&self, cmd: CreateMemoryTable) -> Result<DataFrame> {
-        let CreateMemoryTable {
+        let CreateMemoryTableFields {
             name,
             input,
             if_not_exists,
@@ -800,7 +800,7 @@ impl SessionContext {
             constraints,
             column_defaults,
             temporary,
-        } = cmd;
+        } = cmd.into_fields();
 
         let input = Arc::unwrap_or_clone(input);
         let input = self.state().optimize(&input)?;
@@ -852,13 +852,13 @@ impl SessionContext {
     }
 
     async fn create_view(&self, cmd: CreateView) -> Result<DataFrame> {
-        let CreateView {
+        let CreateViewFields {
             name,
             input,
             or_replace,
             definition,
             temporary,
-        } = cmd;
+        } = cmd.into_fields();
 
         let view = self.table(name.clone()).await;
 

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -29,9 +29,11 @@ pub use builder::{
     LogicalPlanBuilder, LogicalTableSource, UNNAMED_TABLE,
 };
 pub use ddl::{
-    CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateFunction,
-    CreateFunctionBody, CreateIndex, CreateMemoryTable, CreateView, DdlStatement,
-    DropCatalogSchema, DropFunction, DropTable, DropView, OperateFunctionArg,
+    CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateExternalTableBuilder,
+    CreateExternalTableFields, CreateFunction, CreateFunctionBody, CreateIndex,
+    CreateMemoryTable, CreateMemoryTableBuilder, CreateMemoryTableFields, CreateView,
+    CreateViewBuilder, CreateViewFields, DdlStatement, DropCatalogSchema, DropFunction,
+    DropTable, DropView, OperateFunctionArg,
 };
 pub use dml::{DmlStatement, WriteOp};
 pub use plan::{

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -25,7 +25,7 @@ use std::sync::{Arc, OnceLock};
 
 use super::dml::CopyTo;
 use super::DdlStatement;
-use crate::builder::{change_redundant_column, unnest_with_options};
+use crate::builder::unnest_with_options;
 use crate::expr::{Placeholder, Sort as SortExpr, WindowFunction};
 use crate::expr_rewriter::{
     create_col_from_scalar_expr, normalize_cols, normalize_sorts, NamePreserver,
@@ -2193,7 +2193,7 @@ impl SubqueryAlias {
         alias: impl Into<TableReference>,
     ) -> Result<Self> {
         let alias = alias.into();
-        let fields = change_redundant_column(plan.schema().fields());
+        let fields = plan.schema().fields().clone();
         let meta_data = plan.schema().as_ref().metadata().clone();
         let schema: Schema =
             DFSchema::from_unqualified_fields(fields.into(), meta_data)?.into();

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -1012,7 +1012,7 @@ pub fn check_all_columns_from_schema(
     schema: &DFSchema,
 ) -> Result<bool> {
     for col in columns.iter() {
-        let exist = schema.is_column_from_schema(col);
+        let exist = schema.is_column_from_schema(col)?;
         if !exist {
             return Ok(false);
         }

--- a/datafusion/optimizer/src/analyzer/expand_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/expand_wildcard_rule.rs
@@ -55,7 +55,6 @@ fn expand_internal(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
     match plan {
         LogicalPlan::Projection(Projection { expr, input, .. }) => {
             let projected_expr = expand_exprlist(&input, expr)?;
-            validate_unique_names("Projections", projected_expr.iter())?;
             Ok(Transformed::yes(
                 Projection::try_new(projected_expr, Arc::clone(&input))
                     .map(LogicalPlan::Projection)?,

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -177,7 +177,7 @@ fn optimize_projections(
             let all_exprs_iter = new_group_bys.iter().chain(new_aggr_expr.iter());
             let schema = aggregate.input.schema();
             let necessary_indices =
-                RequiredIndicies::new().with_exprs(schema, all_exprs_iter);
+                RequiredIndicies::new().with_exprs(schema, all_exprs_iter)?;
             let necessary_exprs = necessary_indices.get_required_exprs(schema);
 
             return optimize_projections(
@@ -217,7 +217,8 @@ fn optimize_projections(
 
             // Get all the required column indices at the input, either by the
             // parent or window expression requirements.
-            let required_indices = child_reqs.with_exprs(&input_schema, &new_window_expr);
+            let required_indices =
+                child_reqs.with_exprs(&input_schema, &new_window_expr)?;
 
             return optimize_projections(
                 Arc::unwrap_or_clone(window.input),
@@ -753,7 +754,7 @@ fn rewrite_projection_given_requirements(
     let exprs_used = indices.get_at_indices(&expr);
 
     let required_indices =
-        RequiredIndicies::new().with_exprs(input.schema(), exprs_used.iter());
+        RequiredIndicies::new().with_exprs(input.schema(), exprs_used.iter())?;
 
     // rewrite the children projection, and if they are changed rewrite the
     // projection down

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -343,11 +343,11 @@ fn test_propagate_empty_relation_inner_join_and_unions() {
 #[test]
 fn select_wildcard_with_repeated_column() {
     let sql = "SELECT *, col_int32 FROM test";
-    let err = test_sql(sql).expect_err("query should have failed");
-    assert_eq!(
-        "Schema error: Schema contains duplicate qualified field name test.col_int32",
-        err.strip_backtrace()
-    );
+    let plan = test_sql(sql).unwrap();
+    let expected = "\
+        Projection: test.col_int32, test.col_uint32, test.col_utf8, test.col_date32, test.col_date64, test.col_ts_nano_none, test.col_ts_nano_utc, test.col_int32\
+        \n  TableScan: test projection=[col_int32, col_uint32, col_utf8, col_date32, col_date64, col_ts_nano_none, col_ts_nano_utc]";
+    assert_eq!(expected, format!("{plan}"));
 }
 
 #[test]

--- a/datafusion/sql/src/query.rs
+++ b/datafusion/sql/src/query.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 
-use datafusion_common::{not_impl_err, Constraints, DFSchema, Result};
+use datafusion_common::{not_impl_err, DFSchema, Result};
 use datafusion_expr::expr::Sort;
 use datafusion_expr::{
     CreateMemoryTable, DdlStatement, Distinct, LogicalPlan, LogicalPlanBuilder,
@@ -134,15 +134,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     ) -> Result<LogicalPlan> {
         match select_into {
             Some(into) => Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
-                CreateMemoryTable {
-                    name: self.object_name_to_table_reference(into.name)?,
-                    constraints: Constraints::empty(),
-                    input: Arc::new(plan),
-                    if_not_exists: false,
-                    or_replace: false,
-                    temporary: false,
-                    column_defaults: vec![],
-                },
+                CreateMemoryTable::builder()
+                    .name(self.object_name_to_table_reference(into.name)?)
+                    .input(Arc::new(plan))
+                    .build()?,
             ))),
             _ => Ok(plan),
         }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -444,15 +444,15 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         )?;
 
                         Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
-                            CreateMemoryTable {
-                                name: self.object_name_to_table_reference(name)?,
-                                constraints,
-                                input: Arc::new(plan),
-                                if_not_exists,
-                                or_replace,
-                                column_defaults,
-                                temporary,
-                            },
+                            CreateMemoryTable::builder()
+                                .name(self.object_name_to_table_reference(name)?)
+                                .constraints(constraints)
+                                .input(Arc::new(plan))
+                                .if_not_exists(if_not_exists)
+                                .or_replace(or_replace)
+                                .column_defaults(column_defaults)
+                                .temporary(temporary)
+                                .build()?,
                         )))
                     }
 
@@ -467,15 +467,15 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             plan.schema(),
                         )?;
                         Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
-                            CreateMemoryTable {
-                                name: self.object_name_to_table_reference(name)?,
-                                constraints,
-                                input: Arc::new(plan),
-                                if_not_exists,
-                                or_replace,
-                                column_defaults,
-                                temporary,
-                            },
+                            CreateMemoryTable::builder()
+                                .name(self.object_name_to_table_reference(name)?)
+                                .constraints(constraints)
+                                .input(Arc::new(plan))
+                                .if_not_exists(if_not_exists)
+                                .or_replace(or_replace)
+                                .column_defaults(column_defaults)
+                                .temporary(temporary)
+                                .build()?,
                         )))
                     }
                 }
@@ -530,13 +530,15 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 let mut plan = self.query_to_plan(*query, &mut PlannerContext::new())?;
                 plan = self.apply_expr_alias(plan, columns)?;
 
-                Ok(LogicalPlan::Ddl(DdlStatement::CreateView(CreateView {
-                    name: self.object_name_to_table_reference(name)?,
-                    input: Arc::new(plan),
-                    or_replace,
-                    definition: sql,
-                    temporary,
-                })))
+                Ok(LogicalPlan::Ddl(DdlStatement::CreateView(
+                    CreateView::builder()
+                        .name(self.object_name_to_table_reference(name)?)
+                        .input(Arc::new(plan))
+                        .or_replace(or_replace)
+                        .definition(sql)
+                        .temporary(temporary)
+                        .build()?,
+                )))
             }
             Statement::ShowCreate { obj_type, obj_name } => match obj_type {
                 ShowCreateObject::Table => self.show_create_table_to_plan(obj_name),
@@ -1289,21 +1291,21 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let constraints =
             Self::new_constraint_from_table_constraints(&all_constraints, &df_schema)?;
         Ok(LogicalPlan::Ddl(DdlStatement::CreateExternalTable(
-            PlanCreateExternalTable {
-                schema: df_schema,
-                name,
-                location,
-                file_type,
-                table_partition_cols,
-                if_not_exists,
-                temporary,
-                definition,
-                order_exprs: ordered_exprs,
-                unbounded,
-                options: options_map,
-                constraints,
-                column_defaults,
-            },
+            PlanCreateExternalTable::builder()
+                .schema(df_schema)
+                .name(name)
+                .location(location)
+                .file_type(file_type)
+                .table_partition_cols(table_partition_cols)
+                .if_not_exists(if_not_exists)
+                .temporary(temporary)
+                .definition(definition)
+                .order_exprs(ordered_exprs)
+                .unbounded(unbounded)
+                .options(options_map)
+                .constraints(constraints)
+                .column_defaults(column_defaults)
+                .build()?,
         )))
     }
 

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1750,7 +1750,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 .enumerate()
                 .map(|(i, c)| {
                     let column_index = table_schema
-                        .index_of_column_by_name(None, &c)
+                        .index_of_column_by_name(None, &c)?
                         .ok_or_else(|| unqualified_field_not_found(&c, &table_schema))?;
                     if value_indices[column_index].is_some() {
                         return schema_err!(SchemaError::DuplicateUnqualifiedField {

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1282,7 +1282,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         let schema = self.build_schema(columns)?;
         let df_schema = schema.to_dfschema_ref()?;
-        df_schema.check_names()?;
 
         let ordered_exprs =
             self.build_order_by(order_exprs, &df_schema, &mut planner_context)?;

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -269,7 +269,7 @@ pub(crate) fn unproject_sort_expr(
 
     // In case of aggregation there could be columns containing aggregation functions we need to unproject
     if let Some(agg) = agg {
-        if agg.schema.is_column_from_schema(col_ref) {
+        if agg.schema.is_column_from_schema(col_ref)? {
             let new_expr = unproject_agg_exprs(sort_expr.expr, agg, None)?;
             sort_expr.expr = new_expr;
             return Ok(sort_expr);

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -631,11 +631,10 @@ fn select_column_does_not_exist() {
 
 #[test]
 fn select_repeated_column() {
-    let sql = "SELECT age, age FROM person";
-    let err = logical_plan(sql).expect_err("query should have failed");
-    assert_eq!(
-        "Error during planning: Projections require unique expression names but the expression \"person.age\" at position 0 and \"person.age\" at position 1 have the same name. Consider aliasing (\"AS\") one of them.",
-        err.strip_backtrace()
+    quick_test(
+        "SELECT age, age FROM person",
+        "Projection: person.age, person.age\
+        \n  TableScan: person",
     );
 }
 
@@ -1334,11 +1333,11 @@ fn select_simple_aggregate_column_does_not_exist() {
 
 #[test]
 fn select_simple_aggregate_repeated_aggregate() {
-    let sql = "SELECT MIN(age), MIN(age) FROM person";
-    let err = logical_plan(sql).expect_err("query should have failed");
-    assert_eq!(
-        "Error during planning: Projections require unique expression names but the expression \"min(person.age)\" at position 0 and \"min(person.age)\" at position 1 have the same name. Consider aliasing (\"AS\") one of them.",
-        err.strip_backtrace()
+    quick_test(
+        "SELECT MIN(age), MIN(age) FROM person",
+        "Projection: min(person.age), min(person.age)\
+        \n  Aggregate: groupBy=[[]], aggr=[[min(person.age)]]\
+        \n    TableScan: person",
     );
 }
 
@@ -1375,11 +1374,11 @@ fn select_from_typed_string_values() {
 
 #[test]
 fn select_simple_aggregate_repeated_aggregate_with_repeated_aliases() {
-    let sql = "SELECT MIN(age) AS a, MIN(age) AS a FROM person";
-    let err = logical_plan(sql).expect_err("query should have failed");
-    assert_eq!(
-        "Error during planning: Projections require unique expression names but the expression \"min(person.age) AS a\" at position 0 and \"min(person.age) AS a\" at position 1 have the same name. Consider aliasing (\"AS\") one of them.",
-        err.strip_backtrace()
+    quick_test(
+        "SELECT MIN(age) AS a, MIN(age) AS a FROM person",
+        "Projection: min(person.age) AS a, min(person.age) AS a\
+        \n  Aggregate: groupBy=[[]], aggr=[[min(person.age)]]\
+        \n    TableScan: person",
     );
 }
 
@@ -1405,11 +1404,11 @@ fn select_simple_aggregate_with_groupby_with_aliases() {
 
 #[test]
 fn select_simple_aggregate_with_groupby_with_aliases_repeated() {
-    let sql = "SELECT state AS a, MIN(age) AS a FROM person GROUP BY state";
-    let err = logical_plan(sql).expect_err("query should have failed");
-    assert_eq!(
-        "Error during planning: Projections require unique expression names but the expression \"person.state AS a\" at position 0 and \"min(person.age) AS a\" at position 1 have the same name. Consider aliasing (\"AS\") one of them.",
-        err.strip_backtrace()
+    quick_test(
+        "SELECT state AS a, MIN(age) AS a FROM person GROUP BY state",
+        "Projection: person.state AS a, min(person.age) AS a\
+        \n  Aggregate: groupBy=[[person.state]], aggr=[[min(person.age)]]\
+        \n    TableScan: person",
     );
 }
 
@@ -1554,11 +1553,11 @@ fn select_simple_aggregate_with_groupby_can_use_alias() {
 
 #[test]
 fn select_simple_aggregate_with_groupby_aggregate_repeated() {
-    let sql = "SELECT state, MIN(age), MIN(age) FROM person GROUP BY state";
-    let err = logical_plan(sql).expect_err("query should have failed");
-    assert_eq!(
-        "Error during planning: Projections require unique expression names but the expression \"min(person.age)\" at position 1 and \"min(person.age)\" at position 2 have the same name. Consider aliasing (\"AS\") one of them.",
-        err.strip_backtrace()
+    quick_test(
+        "SELECT state, MIN(age), MIN(age) FROM person GROUP BY state",
+        "Projection: person.state, min(person.age), min(person.age)\
+        \n  Aggregate: groupBy=[[person.state]], aggr=[[min(person.age)]]\
+        \n    TableScan: person",
     );
 }
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -72,7 +72,7 @@ CREATE TABLE test (c1 BIGINT,c2 BIGINT) as values
 #######
 
 # https://github.com/apache/datafusion/issues/3353
-statement error DataFusion error: Schema error: Schema contains duplicate unqualified field name "approx_distinct\(aggregate_test_100\.c9\)"
+statement error DataFusion error: Schema error: Ambiguous reference to unqualified field "approx_distinct\(aggregate_test_100\.c9\)"
 SELECT approx_distinct(c9) count_c9, approx_distinct(cast(c9 as varchar)) count_c9_str FROM aggregate_test_100
 
 # csv_query_approx_percentile_cont_with_weight
@@ -5943,9 +5943,10 @@ logical_plan
 02)--Aggregate: groupBy=[[employee_csv.state]], aggr=[[sum(employee_csv.salary)]]
 03)----TableScan: employee_csv projection=[state, salary]
 
-# fail if there is duplicate name
-query error DataFusion error: Schema error: Schema contains qualified field name employee_csv\.state and unqualified field name state which would be ambiguous
+query TI
 select state, sum(salary) as state from employee_csv group by state;
+----
+unemployed 10
 
 statement ok
 set datafusion.explain.logical_plan_only = false;

--- a/datafusion/sqllogictest/test_files/create_external_table.slt
+++ b/datafusion/sqllogictest/test_files/create_external_table.slt
@@ -84,6 +84,10 @@ CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV FOOBAR BARBAR BARFOO LOCATION 'foo
 statement error DataFusion error: Arrow error: Schema error: Unable to get field named "c2". Valid fields: \["c1"\]
 create EXTERNAL TABLE t(c1 int) STORED AS CSV PARTITIONED BY (c2) LOCATION 'foo.csv'
 
+# Duplicate Column
+statement error DataFusion error: Schema error: Schema contains duplicate unqualified field name c1
+create EXTERNAL TABLE t(c1 int, c1 int) STORED AS CSV LOCATION 'foo.csv'
+
 # Duplicate Column in `PARTITIONED BY` clause
 statement error DataFusion error: Schema error: Schema contains duplicate unqualified field name c1
 create EXTERNAL TABLE t(c1 int, c2 int) STORED AS CSV PARTITIONED BY (c1 int) LOCATION 'foo.csv'

--- a/datafusion/sqllogictest/test_files/create_table.slt
+++ b/datafusion/sqllogictest/test_files/create_table.slt
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Issue https://github.com/apache/datafusion/issues/13487
+statement error DataFusion error: Schema error: Schema contains qualified fields with duplicate unqualified names l\.id
+CREATE TABLE t AS SELECT * FROM (SELECT 1 AS id, 'Foo' AS name) l JOIN (SELECT 1 AS id, 'Bar' as name) r ON l.id = r.id;

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -1215,14 +1215,18 @@ statement ok
 create table t1(v1 int) as values(100);
 
 ## Query with Ambiguous column reference
-query error DataFusion error: Schema error: Schema contains duplicate qualified field name t1\.v1
+query I
 select count(*)
 from t1
 right outer join t1
 on t1.v1 > 0;
+----
+1
 
-query error DataFusion error: Schema error: Schema contains duplicate qualified field name t1\.v1
+query I
 select t1.v1 from t1 join t1 using(v1) cross join (select struct('foo' as v1) as t1);
+----
+100
 
 statement ok
 drop table t1;

--- a/datafusion/sqllogictest/test_files/join.slt
+++ b/datafusion/sqllogictest/test_files/join.slt
@@ -1215,18 +1215,19 @@ statement ok
 create table t1(v1 int) as values(100);
 
 ## Query with Ambiguous column reference
-query I
+query error DataFusion error: Schema error: Schema contains duplicate qualified field name t1\.v1
 select count(*)
 from t1
 right outer join t1
 on t1.v1 > 0;
-----
-1
 
-query I
+query error
 select t1.v1 from t1 join t1 using(v1) cross join (select struct('foo' as v1) as t1);
 ----
-100
+DataFusion error: Optimizer rule 'eliminate_cross_join' failed
+caused by
+Schema error: Schema contains duplicate qualified field name t1.v1
+
 
 statement ok
 drop table t1;

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -1777,6 +1777,42 @@ create table users (id int, name varchar);
 statement ok
 insert into users values (1, 'Tom');
 
+query II
+SELECT id, id FROM users
+----
+1 1
+
+query II
+SELECT users.id, users.id FROM users
+----
+1 1
+
+query ITI
+SELECT *, id FROM users
+----
+1 Tom 1
+
+query ITIT
+SELECT *, * FROM users
+----
+1 Tom 1 Tom
+
+query ITITIIII
+SELECT *, *, id, id, -id AS id, id*3 AS id FROM users
+----
+1 Tom 1 Tom 1 1 -1 3
+
+query II
+SELECT id AS col, id+1 AS col FROM users
+----
+1 2
+
+# TODO When joining using USING, the condition columns should appear once in the output, and should be selectible using unqualified name only
+query ITIT
+SELECT * FROM users JOIN users USING (id);
+----
+1 Tom 1 Tom
+
 statement ok
 create view v as select count(id) from users;
 

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -1807,11 +1807,23 @@ SELECT id AS col, id+1 AS col FROM users
 ----
 1 2
 
+# a reference is ambiguous
+query error DataFusion error: Schema error: Ambiguous reference to unqualified field a
+select a from (select 1 as a, 2 as a) t;
+
+# t.a reference is ambiguous
+query error DataFusion error: Schema error: Schema contains duplicate qualified field name t\.a
+select t.a from (select 1 as a, 2 as a) t;
+
+# TODO PostgreSQL disallows self-join without giving tables distinct aliases, but some other databases, e.g. Trino, do allow this, so this could work
 # TODO When joining using USING, the condition columns should appear once in the output, and should be selectible using unqualified name only
-query ITIT
+query error
 SELECT * FROM users JOIN users USING (id);
 ----
-1 Tom 1 Tom
+DataFusion error: expand_wildcard_rule
+caused by
+Schema error: Schema contains duplicate qualified field name users.id
+
 
 statement ok
 create view v as select count(id) from users;

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -533,8 +533,16 @@ select unnest(column1) from (select * from (values([1,2,3]), ([4,5,6])) limit 1 
 5
 6
 
-query error DataFusion error: Error during planning: Projections require unique expression names but the expression "UNNEST\(unnest_table.column1\)" at position 0 and "UNNEST\(unnest_table.column1\)" at position 1 have the same name. Consider aliasing \("AS"\) one of them.
+query II
 select unnest(column1), unnest(column1) from unnest_table;
+----
+1 1
+2 2
+3 3
+4 4
+5 5
+6 6
+12 12
 
 query II
 select unnest(column1), unnest(column1) u1 from unnest_table;

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -1270,7 +1270,7 @@ fn apply_projection(table: DataFrame, substrait_schema: DFSchema) -> Result<Logi
                 .iter()
                 .map(|substrait_field| {
                     Ok(df_schema
-                        .index_of_column_by_name(None, substrait_field.name().as_str())
+                        .index_of_column_by_name(None, substrait_field.name().as_str())?
                         .unwrap())
                 })
                 .collect::<Result<_>>()?;


### PR DESCRIPTION
## Which issue does this PR close?

- fixes https://github.com/apache/datafusion/issues/13476
- fixes https://github.com/apache/datafusion/issues/13487
- fixes https://github.com/apache/datafusion/issues/6543 


## Rationale for this change

In SQL, selecting single column multiple times is legal and most modern
databases support this. This commit adds such support to DataFusion too.

## What changes are included in this PR?

- allow creation of schemas for duplicated names. DFSchema is used in logical plan to describe output of a relational operator, and In SQL, this is totally valid to have duplicated names
  - a better long term fix would be to limit Schema use for field resolution during initial query plan building and use unambiguous "symbols" or "variables" in the logical plan. This would fall under https://github.com/apache/datafusion/issues/12723
- add checks for CREATE TABLE and CREATE VIEW to disallow creation of tables with duplicate field names
  - previously this was taken care of by schema construction checks, but only partially, as witnessed by https://github.com/apache/datafusion/issues/13487

## Are these changes tested?

yes

## Are there any user-facing changes?

yes, more valid queries are supported
