### PR TITLE
chore: try make Setup Rust CI step immune to network hang

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -28,18 +28,18 @@ runs:
     - name: Install Build Dependencies
       shell: bash
       run: |
-        RETRY="ci/scripts/retry"
-        "${RETRY}" apt-get update
-        "${RETRY}" apt-get install -y protobuf-compiler
+        RETRY=("ci/scripts/retry" timeout 120)
+        "${RETRY[@]}" apt-get update
+        "${RETRY[@]}" apt-get install -y protobuf-compiler
     - name: Setup Rust toolchain
       shell: bash
       # rustfmt is needed for the substrait build script
       run: |
-        RETRY="ci/scripts/retry"
+        RETRY=("ci/scripts/retry" timeout 120)
         echo "Installing ${{ inputs.rust-version }}"
-        "${RETRY}" rustup toolchain install ${{ inputs.rust-version }}
-        "${RETRY}" rustup default ${{ inputs.rust-version }}
-        "${RETRY}" rustup component add rustfmt
+        "${RETRY[@]}" rustup toolchain install ${{ inputs.rust-version }}
+        "${RETRY[@]}" rustup default ${{ inputs.rust-version }}
+        "${RETRY[@]}" rustup component add rustfmt
     - name: Configure rust runtime env
       uses: ./.github/actions/setup-rust-runtime
     - name: Fixup git permissions

--- a/ci/scripts/retry
+++ b/ci/scripts/retry
@@ -7,7 +7,7 @@ x() {
     "$@"
 }
 
-max_retry_time_seconds=$(( 3 * 60 ))
+max_retry_time_seconds=$(( 5 * 60 ))
 retry_delay_seconds=10
 
 END=$(( $(date +%s) + ${max_retry_time_seconds} ))


### PR DESCRIPTION


## Which issue does this PR close?

hopefully fixes  https://github.com/apache/datafusion/issues/13494

## Rationale for this change

Try to fix CI stability issue.
Try add a timeout to the apt-get invocation so that retry can kick in.

## What changes are included in this PR?

CI script hange

## Are these changes tested?

no

## Are there any user-facing changes?

no