### PR TITLE
feat: Wrap `TableScan` with `Filter` in Join Unparsing

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -518,10 +518,7 @@ impl Unparser<'_> {
                     return internal_err!("Failed to build right relation");
                 };
 
-                let join_filters = match &join.filter {
-                    Some(filter) => Some(filter.clone()),
-                    None => None,
-                };
+                let join_filters = join.filter.as_ref().map(|filter| filter.clone());
 
                 let join_constraint = self.join_constraint_to_sql(
                     join.join_constraint,

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -518,7 +518,7 @@ impl Unparser<'_> {
                     return internal_err!("Failed to build right relation");
                 };
 
-                let join_filters = join.filter.as_ref().map(|filter| filter.clone());
+                let join_filters = join.filter.clone();
 
                 let join_constraint = self.join_constraint_to_sql(
                     join.join_constraint,

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1113,7 +1113,7 @@ fn test_join_with_table_scan_filters() -> Result<()> {
 
     let sql = plan_to_sql(&join_plan_with_filter)?;
 
-    let expected_sql = r#"SELECT * FROM left_table AS "left" JOIN right_table ON "left".id = right_table.id AND (("left".id > 5) AND ("left"."name" LIKE 'some_name' AND (age > 10)))"#;
+    let expected_sql = r#"SELECT * FROM left_table AS "left" JOIN right_table ON "left".id = right_table.id AND ("left".id > 5) WHERE "left"."name" LIKE 'some_name' AND (right_table.age > 10)"#;
 
     assert_eq!(sql.to_string(), expected_sql);
 
@@ -1128,7 +1128,7 @@ fn test_join_with_table_scan_filters() -> Result<()> {
 
     let sql = plan_to_sql(&join_plan_no_filter)?;
 
-    let expected_sql = r#"SELECT * FROM left_table AS "left" JOIN right_table ON "left".id = right_table.id AND ("left"."name" LIKE 'some_name' AND (age > 10))"#;
+    let expected_sql = r#"SELECT * FROM left_table AS "left" JOIN right_table ON "left".id = right_table.id WHERE "left"."name" LIKE 'some_name' AND (right_table.age > 10)"#;
 
     assert_eq!(sql.to_string(), expected_sql);
 
@@ -1153,7 +1153,7 @@ fn test_join_with_table_scan_filters() -> Result<()> {
 
     let sql = plan_to_sql(&join_plan_multiple_filters)?;
 
-    let expected_sql = r#"SELECT * FROM left_table AS "left" JOIN right_table ON "left".id = right_table.id AND (("left".id > 5) AND (("left"."name" LIKE 'some_name' AND (right_table."name" = 'before_join_filter_val')) AND (age > 10))) WHERE ("left"."name" = 'after_join_filter_val')"#;
+    let expected_sql = r#"SELECT * FROM left_table AS "left" JOIN right_table ON "left".id = right_table.id AND ("left".id > 5) WHERE ("left"."name" = 'after_join_filter_val') AND "left"."name" LIKE 'some_name' AND ((right_table."name" = 'before_join_filter_val') AND (right_table.age > 10))"#;
 
     assert_eq!(sql.to_string(), expected_sql);
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13156 .

## Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Pushes down filter to tablescan instead of having it apply on the join in unparsing.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Changed the previous test
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
