### PR TITLE
Minor: Add debug log message for creating GroupValuesRows

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/row.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/row.rs
@@ -29,6 +29,7 @@ use datafusion_expr::EmitTo;
 use hashbrown::raw::RawTable;
 use std::mem::size_of;
 use std::sync::Arc;
+use log::debug;
 
 /// A [`GroupValues`] making use of [`Rows`]
 ///
@@ -80,6 +81,9 @@ pub struct GroupValuesRows {
 
 impl GroupValuesRows {
     pub fn try_new(schema: SchemaRef) -> Result<Self> {
+        // Print a debugging message, so it is clear when the (slower) fallback
+        // GroupValuesRows is used.
+        debug!("Creating GroupValuesRows for schema: {}", schema);
         let row_converter = RowConverter::new(
             schema
                 .fields()

--- a/datafusion/physical-plan/src/aggregates/group_values/row.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/row.rs
@@ -27,9 +27,9 @@ use datafusion_common::Result;
 use datafusion_execution::memory_pool::proxy::{RawTableAllocExt, VecAllocExt};
 use datafusion_expr::EmitTo;
 use hashbrown::raw::RawTable;
+use log::debug;
 use std::mem::size_of;
 use std::sync::Arc;
-use log::debug;
 
 /// A [`GroupValues`] making use of [`Rows`]
 ///


### PR DESCRIPTION
## Which issue does this PR close?

related to
- https://github.com/apache/datafusion/issues/13505

## Rationale for this change

I want to know when the aggregation path is using the slower (but general) `GroupValuesRows` so we can verify that work like https://github.com/apache/datafusion/issues/13505 has been completed


## What changes are included in this PR?

Add a `debug` log message with some comments

## Are these changes tested?
N/A

## Are there any user-facing changes?

No