### PR TITLE
refactor: change some `hashbrown` `RawTable` uses to `HashTable`

### DIFF
--- a/datafusion/execution/src/memory_pool/mod.rs
+++ b/datafusion/execution/src/memory_pool/mod.rs
@@ -23,7 +23,9 @@ use std::{cmp::Ordering, sync::Arc};
 
 mod pool;
 pub mod proxy {
-    pub use datafusion_common::utils::proxy::{RawTableAllocExt, VecAllocExt};
+    pub use datafusion_common::utils::proxy::{
+        HashTableAllocExt, RawTableAllocExt, VecAllocExt,
+    };
 }
 
 pub use pool::*;

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -24,7 +24,7 @@ use arrow::array::cast::AsArray;
 use arrow::array::{Array, ArrayBuilder, ArrayRef, GenericByteViewBuilder};
 use arrow::datatypes::{BinaryViewType, ByteViewType, DataType, StringViewType};
 use datafusion_common::hash_utils::create_hashes;
-use datafusion_common::utils::proxy::{RawTableAllocExt, VecAllocExt};
+use datafusion_common::utils::proxy::{HashTableAllocExt, VecAllocExt};
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -122,7 +122,7 @@ where
     /// Should the output be StringView or BinaryView?
     output_type: OutputType,
     /// Underlying hash set for each distinct value
-    map: hashbrown::raw::RawTable<Entry<V>>,
+    map: hashbrown::hash_table::HashTable<Entry<V>>,
     /// Total size of the map in bytes
     map_size: usize,
 
@@ -148,7 +148,7 @@ where
     pub fn new(output_type: OutputType) -> Self {
         Self {
             output_type,
-            map: hashbrown::raw::RawTable::with_capacity(INITIAL_MAP_CAPACITY),
+            map: hashbrown::hash_table::HashTable::with_capacity(INITIAL_MAP_CAPACITY),
             map_size: 0,
             builder: GenericByteViewBuilder::new(),
             random_state: RandomState::new(),
@@ -274,7 +274,7 @@ where
             // get the value as bytes
             let value: &[u8] = value.as_ref();
 
-            let entry = self.map.get_mut(hash, |header| {
+            let entry = self.map.find_mut(hash, |header| {
                 let v = self.builder.get_value(header.view_idx);
 
                 if v.len() != value.len() {


### PR DESCRIPTION
## Which issue does this PR close?
For #13256, but only parts of it.

## Rationale for this change
Prepare `hashbrown` 0.15 upgrade.

## What changes are included in this PR?
- `HashTableAllocExt`
- a few migrations

## Are these changes tested?
Existing tests pass.

## Are there any user-facing changes?
No.