### PR TITLE
Reject CREATE TABLE/VIEW with duplicate column names 

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -150,6 +150,13 @@ pub enum SchemaError {
         qualifier: Box<TableReference>,
         name: String,
     },
+    /// Schema duplicate qualified fields with duplicate unqualified names. This is an error
+    /// for schema in CREATE TABLE/VIEW statements, because the final object is going to retain
+    /// and return the unqualified names only.
+    QualifiedFieldWithDuplicateName {
+        qualifier: Box<TableReference>,
+        name: String,
+    },
     /// Schema contains duplicate unqualified field name
     DuplicateUnqualifiedField { name: String },
     /// No field with this name
@@ -184,6 +191,14 @@ impl Display for SchemaError {
                 write!(
                     f,
                     "Schema contains duplicate qualified field name {}.{}",
+                    qualifier.to_quoted_string(),
+                    quote_identifier(name)
+                )
+            }
+            Self::QualifiedFieldWithDuplicateName { qualifier, name } => {
+                write!(
+                    f,
+                    "Schema contains qualified fields with duplicate unqualified names {}.{}",
                     qualifier.to_quoted_string(),
                     quote_identifier(name)
                 )

--- a/datafusion/core/src/catalog_common/listing_schema.rs
+++ b/datafusion/core/src/catalog_common/listing_schema.rs
@@ -25,9 +25,7 @@ use std::sync::{Arc, Mutex};
 use crate::catalog::{SchemaProvider, TableProvider, TableProviderFactory};
 use crate::execution::context::SessionState;
 
-use datafusion_common::{
-    Constraints, DFSchema, DataFusionError, HashMap, TableReference,
-};
+use datafusion_common::{DFSchema, DataFusionError, HashMap, TableReference};
 use datafusion_expr::CreateExternalTable;
 
 use async_trait::async_trait;
@@ -131,21 +129,12 @@ impl ListingSchemaProvider {
                     .factory
                     .create(
                         state,
-                        &CreateExternalTable {
-                            schema: Arc::new(DFSchema::empty()),
-                            name,
-                            location: table_url,
-                            file_type: self.format.clone(),
-                            table_partition_cols: vec![],
-                            if_not_exists: false,
-                            temporary: false,
-                            definition: None,
-                            order_exprs: vec![],
-                            unbounded: false,
-                            options: Default::default(),
-                            constraints: Constraints::empty(),
-                            column_defaults: Default::default(),
-                        },
+                        &CreateExternalTable::builder()
+                            .schema(Arc::new(DFSchema::empty()))
+                            .name(name)
+                            .location(table_url)
+                            .file_type(self.format.clone())
+                            .build()?,
                     )
                     .await?;
                 let _ =

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -41,9 +41,9 @@ use crate::{
     logical_expr::ScalarUDF,
     logical_expr::{
         CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateFunction,
-        CreateMemoryTable, CreateView, DropCatalogSchema, DropFunction, DropTable,
-        DropView, Execute, LogicalPlan, LogicalPlanBuilder, Prepare, SetVariable,
-        TableType, UNNAMED_TABLE,
+        CreateMemoryTable, CreateMemoryTableFields, CreateView, CreateViewFields,
+        DropCatalogSchema, DropFunction, DropTable, DropView, Execute, LogicalPlan,
+        LogicalPlanBuilder, Prepare, SetVariable, TableType, UNNAMED_TABLE,
     },
     physical_expr::PhysicalExpr,
     physical_plan::ExecutionPlan,
@@ -792,7 +792,7 @@ impl SessionContext {
     }
 
     async fn create_memory_table(&self, cmd: CreateMemoryTable) -> Result<DataFrame> {
-        let CreateMemoryTable {
+        let CreateMemoryTableFields {
             name,
             input,
             if_not_exists,
@@ -800,7 +800,7 @@ impl SessionContext {
             constraints,
             column_defaults,
             temporary,
-        } = cmd;
+        } = cmd.into_fields();
 
         let input = Arc::unwrap_or_clone(input);
         let input = self.state().optimize(&input)?;
@@ -852,13 +852,13 @@ impl SessionContext {
     }
 
     async fn create_view(&self, cmd: CreateView) -> Result<DataFrame> {
-        let CreateView {
+        let CreateViewFields {
             name,
             input,
             or_replace,
             definition,
             temporary,
-        } = cmd;
+        } = cmd.into_fields();
 
         let view = self.table(name.clone()).await;
 

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -291,7 +291,7 @@ impl PartialOrd for CreateExternalTable {
 }
 
 impl CreateExternalTable {
-    pub fn new(fields: CreateExternalTableFields) -> Result<Self> {
+    pub fn try_new(fields: CreateExternalTableFields) -> Result<Self> {
         let CreateExternalTableFields {
             name,
             schema,
@@ -365,7 +365,7 @@ impl CreateExternalTable {
 
 /// A struct with same fields as [`CreateExternalTable`] struct so that the DDL can be conveniently
 /// destructed with validation that each field is handled, while still requiring that all
-/// construction goes through the [`CreateExternalTable::new`] constructor or the builder.
+/// construction goes through the [`CreateExternalTable::try_new`] constructor or the builder.
 pub struct CreateExternalTableFields {
     /// The table name
     pub name: TableReference,
@@ -497,7 +497,7 @@ impl CreateExternalTableBuilder {
     }
 
     pub fn build(self) -> Result<CreateExternalTable> {
-        CreateExternalTable::new(CreateExternalTableFields {
+        CreateExternalTable::try_new(CreateExternalTableFields {
             name: self.name.expect("name is required"),
             schema: self.schema.expect("schema is required"),
             location: self.location.expect("location is required"),
@@ -536,7 +536,7 @@ pub struct CreateMemoryTable {
 }
 
 impl CreateMemoryTable {
-    pub fn new(fields: CreateMemoryTableFields) -> Result<Self> {
+    pub fn try_new(fields: CreateMemoryTableFields) -> Result<Self> {
         let CreateMemoryTableFields {
             name,
             constraints,
@@ -586,7 +586,7 @@ impl CreateMemoryTable {
 
 /// A struct with same fields as [`CreateMemoryTable`] struct so that the DDL can be conveniently
 /// destructed with validation that each field is handled, while still requiring that all
-/// construction goes through the [`CreateMemoryTable::new`] constructor or the builder.
+/// construction goes through the [`CreateMemoryTable::try_new`] constructor or the builder.
 pub struct CreateMemoryTableFields {
     /// The table name
     pub name: TableReference,
@@ -664,7 +664,7 @@ impl CreateMemoryTableBuilder {
     }
 
     pub fn build(self) -> Result<CreateMemoryTable> {
-        CreateMemoryTable::new(CreateMemoryTableFields {
+        CreateMemoryTable::try_new(CreateMemoryTableFields {
             name: self.name.expect("name is required"),
             constraints: self.constraints,
             input: self.input.expect("input is required"),
@@ -693,7 +693,7 @@ pub struct CreateView {
 }
 
 impl CreateView {
-    pub fn new(fields: CreateViewFields) -> Result<Self> {
+    pub fn try_new(fields: CreateViewFields) -> Result<Self> {
         let CreateViewFields {
             name,
             input,
@@ -735,7 +735,7 @@ impl CreateView {
 
 /// A struct with same fields as [`CreateView`] struct so that the DDL can be conveniently
 /// destructed with validation that each field is handled, while still requiring that all
-/// construction goes through the [`CreateView::new`] constructor or the builder.
+/// construction goes through the [`CreateView::try_new`] constructor or the builder.
 pub struct CreateViewFields {
     /// The table name
     pub name: TableReference,
@@ -795,7 +795,7 @@ impl CreateViewBuilder {
     }
 
     pub fn build(self) -> Result<CreateView> {
-        CreateView::new(CreateViewFields {
+        CreateView::try_new(CreateViewFields {
             name: self.name.expect("name is required"),
             input: self.input.expect("input is required"),
             or_replace: self.or_replace,

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -28,8 +28,8 @@ use crate::expr::Sort;
 use arrow::datatypes::DataType;
 use datafusion_common::tree_node::{Transformed, TreeNodeContainer, TreeNodeRecursion};
 use datafusion_common::{
-    schema_err, Column, Constraints, DFSchema, DFSchemaRef, Result,
-    SchemaError, SchemaReference, TableReference,
+    schema_err, Column, Constraints, DFSchema, DFSchemaRef, Result, SchemaError,
+    SchemaReference, TableReference,
 };
 use sqlparser::ast::Ident;
 

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -17,7 +17,7 @@
 
 use crate::{Expr, LogicalPlan, SortExpr, Volatility};
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::{
     fmt::{self, Display},
@@ -28,7 +28,8 @@ use crate::expr::Sort;
 use arrow::datatypes::DataType;
 use datafusion_common::tree_node::{Transformed, TreeNodeContainer, TreeNodeRecursion};
 use datafusion_common::{
-    Constraints, DFSchemaRef, Result, SchemaReference, TableReference,
+    schema_err, Column, Constraints, DFSchema, DFSchemaRef, Result,
+    SchemaError, SchemaReference, TableReference,
 };
 use sqlparser::ast::Ident;
 
@@ -306,6 +307,7 @@ impl CreateExternalTable {
             constraints,
             column_defaults,
         } = fields;
+        check_fields_unique(&schema)?;
         Ok(Self {
             name,
             schema,
@@ -544,6 +546,7 @@ impl CreateMemoryTable {
             column_defaults,
             temporary,
         } = fields;
+        check_fields_unique(input.schema())?;
         Ok(Self {
             name,
             constraints,
@@ -698,6 +701,7 @@ impl CreateView {
             definition,
             temporary,
         } = fields;
+        check_fields_unique(input.schema())?;
         Ok(Self {
             name,
             input,
@@ -799,6 +803,48 @@ impl CreateViewBuilder {
             temporary: self.temporary,
         })
     }
+}
+fn check_fields_unique(schema: &DFSchema) -> Result<()> {
+    // Use tree set for deterministic error messages
+    let mut qualified_names = BTreeSet::new();
+    let mut unqualified_names = HashSet::new();
+    let mut name_occurrences: HashMap<&String, usize> = HashMap::new();
+
+    for (qualifier, field) in schema.iter() {
+        if let Some(qualifier) = qualifier {
+            // Check for duplicate qualified field names
+            if !qualified_names.insert((qualifier, field.name())) {
+                return schema_err!(SchemaError::DuplicateQualifiedField {
+                    qualifier: Box::new(qualifier.clone()),
+                    name: field.name().to_string(),
+                });
+            }
+        // Check for duplicate unqualified field names
+        } else if !unqualified_names.insert(field.name()) {
+            return schema_err!(SchemaError::DuplicateUnqualifiedField {
+                name: field.name().to_string()
+            });
+        }
+        *name_occurrences.entry(field.name()).or_default() += 1;
+    }
+
+    for (qualifier, name) in qualified_names {
+        // Check for duplicate between qualified and unqualified field names
+        if unqualified_names.contains(name) {
+            return schema_err!(SchemaError::AmbiguousReference {
+                field: Column::new(Some(qualifier.clone()), name)
+            });
+        }
+        // Check for duplicates between qualified names as the qualification will be stripped off
+        if name_occurrences[name] > 1 {
+            return schema_err!(SchemaError::QualifiedFieldWithDuplicateName {
+                qualifier: Box::new(qualifier.clone()),
+                name: name.to_owned(),
+            });
+        }
+    }
+
+    Ok(())
 }
 
 /// Creates a catalog (aka "Database").
@@ -1085,7 +1131,9 @@ impl PartialOrd for CreateIndex {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::{CreateCatalog, DdlStatement, DropView};
+    use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::{DFSchema, DFSchemaRef, TableReference};
     use std::cmp::Ordering;
 
@@ -1111,5 +1159,88 @@ mod test {
         });
 
         assert_eq!(drop_view.partial_cmp(&catalog), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_check_fields_unique() -> Result<()> {
+        // no duplicate fields, unqualified schema
+        check_fields_unique(&DFSchema::try_from(Schema::new(vec![
+            Field::new("c100", DataType::Boolean, true),
+            Field::new("c101", DataType::Boolean, true),
+        ]))?)?;
+
+        // no duplicate fields, qualified schema
+        check_fields_unique(&DFSchema::try_from_qualified_schema(
+            "t1",
+            &Schema::new(vec![
+                Field::new("c100", DataType::Boolean, true),
+                Field::new("c101", DataType::Boolean, true),
+            ]),
+        )?)?;
+
+        // duplicate unqualified field name
+        assert_eq!(
+            check_fields_unique(&DFSchema::try_from(Schema::new(vec![
+                Field::new("c0", DataType::Boolean, true),
+                Field::new("c1", DataType::Boolean, true),
+                Field::new("c1", DataType::Boolean, true),
+                Field::new("c2", DataType::Boolean, true),
+            ]))?)
+            .unwrap_err()
+            .strip_backtrace()
+            .to_string(),
+            "Schema error: Schema contains duplicate unqualified field name c1"
+        );
+
+        // duplicate qualified field with same qualifier
+        assert_eq!(
+            DFSchema::try_from_qualified_schema(
+                "t1",
+                &Schema::new(vec![
+                    Field::new("c1", DataType::Boolean, true),
+                    Field::new("c1", DataType::Boolean, true),
+                ])
+            )
+            // if schema construction succeeds (due to future changes in DFSchema), call check_fields_unique on it
+            .unwrap_err()
+            .strip_backtrace()
+            .to_string(),
+            "Schema error: Schema contains duplicate qualified field name t1.c1"
+        );
+
+        // duplicate qualified and unqualified field
+        assert_eq!(
+            DFSchema::from_field_specific_qualified_schema(
+                vec![
+                    None,
+                    Some(TableReference::from("t1")),
+                ],
+                &Arc::new(Schema::new(vec![
+                    Field::new("c1", DataType::Boolean, true),
+                    Field::new("c1", DataType::Boolean, true),
+                ]))
+            )
+                 // if schema construction succeeds (due to future changes in DFSchema), call check_fields_unique on it
+                .unwrap_err().strip_backtrace().to_string(),
+            "Schema error: Schema contains qualified field name t1.c1 and unqualified field name c1 which would be ambiguous"
+        );
+
+        // qualified fields with duplicate unqualified names
+        assert_eq!(
+            check_fields_unique(&DFSchema::from_field_specific_qualified_schema(
+                vec![
+                    Some(TableReference::from("t1")),
+                    Some(TableReference::from("t2")),
+                ],
+                &Arc::new(Schema::new(vec![
+                    Field::new("c1", DataType::Boolean, true),
+                    Field::new("c1", DataType::Boolean, true),
+                ]))
+            )?)
+                .unwrap_err().strip_backtrace().to_string(),
+             "Schema error: Schema contains qualified fields with duplicate unqualified names t1.c1"
+        );
+
+        Ok(())
     }
 }

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -29,9 +29,11 @@ pub use builder::{
     LogicalPlanBuilder, LogicalTableSource, UNNAMED_TABLE,
 };
 pub use ddl::{
-    CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateFunction,
-    CreateFunctionBody, CreateIndex, CreateMemoryTable, CreateView, DdlStatement,
-    DropCatalogSchema, DropFunction, DropTable, DropView, OperateFunctionArg,
+    CreateCatalog, CreateCatalogSchema, CreateExternalTable, CreateExternalTableBuilder,
+    CreateExternalTableFields, CreateFunction, CreateFunctionBody, CreateIndex,
+    CreateMemoryTable, CreateMemoryTableBuilder, CreateMemoryTableFields, CreateView,
+    CreateViewBuilder, CreateViewFields, DdlStatement, DropCatalogSchema, DropFunction,
+    DropTable, DropView, OperateFunctionArg,
 };
 pub use dml::{DmlStatement, WriteOp};
 pub use plan::{

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -568,7 +568,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                 }
 
                 Ok(LogicalPlan::Ddl(DdlStatement::CreateExternalTable(
-                    CreateExternalTable::new(CreateExternalTableFields {
+                    CreateExternalTable::try_new(CreateExternalTableFields {
                         schema: pb_schema.try_into()?,
                         name: from_table_reference(
                             create_extern_table.name.as_ref(),
@@ -602,8 +602,8 @@ impl AsLogicalPlan for LogicalPlanNode {
                     None
                 };
 
-                Ok(LogicalPlan::Ddl(DdlStatement::CreateView(CreateView::new(
-                    CreateViewFields {
+                Ok(LogicalPlan::Ddl(DdlStatement::CreateView(
+                    CreateView::try_new(CreateViewFields {
                         name: from_table_reference(
                             create_view.name.as_ref(),
                             "CreateView",
@@ -612,8 +612,8 @@ impl AsLogicalPlan for LogicalPlanNode {
                         input: Arc::new(plan),
                         or_replace: create_view.or_replace,
                         definition,
-                    },
-                )?)))
+                    })?,
+                )))
             }
             LogicalPlanType::CreateCatalogSchema(create_catalog_schema) => {
                 let pb_schema = (create_catalog_schema.schema.clone()).ok_or_else(|| {

--- a/datafusion/sql/src/query.rs
+++ b/datafusion/sql/src/query.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 
-use datafusion_common::{not_impl_err, Constraints, DFSchema, Result};
+use datafusion_common::{not_impl_err, DFSchema, Result};
 use datafusion_expr::expr::Sort;
 use datafusion_expr::{
     CreateMemoryTable, DdlStatement, Distinct, LogicalPlan, LogicalPlanBuilder,
@@ -134,15 +134,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     ) -> Result<LogicalPlan> {
         match select_into {
             Some(into) => Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
-                CreateMemoryTable {
-                    name: self.object_name_to_table_reference(into.name)?,
-                    constraints: Constraints::empty(),
-                    input: Arc::new(plan),
-                    if_not_exists: false,
-                    or_replace: false,
-                    temporary: false,
-                    column_defaults: vec![],
-                },
+                CreateMemoryTable::builder()
+                    .name(self.object_name_to_table_reference(into.name)?)
+                    .input(Arc::new(plan))
+                    .build()?,
             ))),
             _ => Ok(plan),
         }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -444,15 +444,15 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         )?;
 
                         Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
-                            CreateMemoryTable {
-                                name: self.object_name_to_table_reference(name)?,
-                                constraints,
-                                input: Arc::new(plan),
-                                if_not_exists,
-                                or_replace,
-                                column_defaults,
-                                temporary,
-                            },
+                            CreateMemoryTable::builder()
+                                .name(self.object_name_to_table_reference(name)?)
+                                .constraints(constraints)
+                                .input(Arc::new(plan))
+                                .if_not_exists(if_not_exists)
+                                .or_replace(or_replace)
+                                .column_defaults(column_defaults)
+                                .temporary(temporary)
+                                .build()?,
                         )))
                     }
 
@@ -467,15 +467,15 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                             plan.schema(),
                         )?;
                         Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
-                            CreateMemoryTable {
-                                name: self.object_name_to_table_reference(name)?,
-                                constraints,
-                                input: Arc::new(plan),
-                                if_not_exists,
-                                or_replace,
-                                column_defaults,
-                                temporary,
-                            },
+                            CreateMemoryTable::builder()
+                                .name(self.object_name_to_table_reference(name)?)
+                                .constraints(constraints)
+                                .input(Arc::new(plan))
+                                .if_not_exists(if_not_exists)
+                                .or_replace(or_replace)
+                                .column_defaults(column_defaults)
+                                .temporary(temporary)
+                                .build()?,
                         )))
                     }
                 }
@@ -530,13 +530,15 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 let mut plan = self.query_to_plan(*query, &mut PlannerContext::new())?;
                 plan = self.apply_expr_alias(plan, columns)?;
 
-                Ok(LogicalPlan::Ddl(DdlStatement::CreateView(CreateView {
-                    name: self.object_name_to_table_reference(name)?,
-                    input: Arc::new(plan),
-                    or_replace,
-                    definition: sql,
-                    temporary,
-                })))
+                Ok(LogicalPlan::Ddl(DdlStatement::CreateView(
+                    CreateView::builder()
+                        .name(self.object_name_to_table_reference(name)?)
+                        .input(Arc::new(plan))
+                        .or_replace(or_replace)
+                        .definition(sql)
+                        .temporary(temporary)
+                        .build()?,
+                )))
             }
             Statement::ShowCreate { obj_type, obj_name } => match obj_type {
                 ShowCreateObject::Table => self.show_create_table_to_plan(obj_name),
@@ -1289,21 +1291,21 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let constraints =
             Self::new_constraint_from_table_constraints(&all_constraints, &df_schema)?;
         Ok(LogicalPlan::Ddl(DdlStatement::CreateExternalTable(
-            PlanCreateExternalTable {
-                schema: df_schema,
-                name,
-                location,
-                file_type,
-                table_partition_cols,
-                if_not_exists,
-                temporary,
-                definition,
-                order_exprs: ordered_exprs,
-                unbounded,
-                options: options_map,
-                constraints,
-                column_defaults,
-            },
+            PlanCreateExternalTable::builder()
+                .schema(df_schema)
+                .name(name)
+                .location(location)
+                .file_type(file_type)
+                .table_partition_cols(table_partition_cols)
+                .if_not_exists(if_not_exists)
+                .temporary(temporary)
+                .definition(definition)
+                .order_exprs(ordered_exprs)
+                .unbounded(unbounded)
+                .options(options_map)
+                .constraints(constraints)
+                .column_defaults(column_defaults)
+                .build()?,
         )))
     }
 

--- a/datafusion/sqllogictest/test_files/create_table.slt
+++ b/datafusion/sqllogictest/test_files/create_table.slt
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Issue https://github.com/apache/datafusion/issues/13487
+statement error DataFusion error: Schema error: Schema contains qualified fields with duplicate unqualified names l\.id
+CREATE TABLE t AS SELECT * FROM (SELECT 1 AS id, 'Foo' AS name) l JOIN (SELECT 1 AS id, 'Bar' as name) r ON l.id = r.id;


### PR DESCRIPTION
Reject CREATE TABLE/VIEW with duplicate column names 

DFSchema checks column for uniqueness, but allows duplicate column names
when they are qualified differently. This is because DFSchema plays
central role during query planning as a identifier resolution scope.

Those checks in their current form should not be there, since they
prevent execution of queries with duplicate column aliases, which is
legal in SQL. But even with these checks present, they are not
sufficient to ensure CREATE TABLE/VIEW is well structured. Table or
view columns need to have unique names and there is no qualification
involved.

This commit adds necessary checks in CREATE TABLE/VIEW DDL structs,
ensuring that CREATE TABLE/VIEW logical plans are valid in that regard.

This PR includes

- Encapsulate create table/view construction (to be able to add these checks)
- Checks in  create table/view construction to validate schema has no duplicate names



- fixes https://github.com/apache/datafusion/issues/13487
- extracted from https://github.com/apache/datafusion/pull/13489