### PR TITLE
refactor: use `std::slice::from_ref` to remove some clones

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1671,7 +1671,7 @@ impl DataFrame {
     /// # }
     /// ```
     pub fn with_column(self, name: &str, expr: Expr) -> Result<DataFrame> {
-        let window_func_exprs = find_window_exprs(&[expr.clone()]);
+        let window_func_exprs = find_window_exprs(std::slice::from_ref(&expr));
 
         let (window_fn_str, plan) = if window_func_exprs.is_empty() {
             (None, self.plan)

--- a/datafusion/core/src/datasource/file_format/arrow.rs
+++ b/datafusion/core/src/datasource/file_format/arrow.rs
@@ -476,7 +476,7 @@ mod tests {
                 .infer_schema(
                     &state,
                     &(store.clone() as Arc<dyn ObjectStore>),
-                    &[object_meta.clone()],
+                    std::slice::from_ref(&object_meta),
                 )
                 .await?;
             let actual_fields = inferred_schema
@@ -515,7 +515,7 @@ mod tests {
             .infer_schema(
                 &state,
                 &(store.clone() as Arc<dyn ObjectStore>),
-                &[object_meta.clone()],
+                std::slice::from_ref(&object_meta),
             )
             .await;
 

--- a/datafusion/core/src/datasource/file_format/mod.rs
+++ b/datafusion/core/src/datasource/file_format/mod.rs
@@ -573,7 +573,9 @@ pub(crate) mod test_util {
         let store = Arc::new(LocalFileSystem::new()) as _;
         let meta = local_unpartitioned_file(format!("{store_root}/{file_name}"));
 
-        let file_schema = format.infer_schema(state, &store, &[meta.clone()]).await?;
+        let file_schema = format
+            .infer_schema(state, &store, std::slice::from_ref(&meta))
+            .await?;
 
         let statistics = format
             .infer_stats(state, &store, file_schema.clone(), &meta)

--- a/datafusion/core/src/datasource/physical_plan/avro.rs
+++ b/datafusion/core/src/datasource/physical_plan/avro.rs
@@ -284,7 +284,7 @@ mod tests {
         let meta = local_unpartitioned_file(filename);
 
         let file_schema = AvroFormat {}
-            .infer_schema(&state, &store, &[meta.clone()])
+            .infer_schema(&state, &store, std::slice::from_ref(&meta))
             .await?;
 
         let avro_exec = AvroExec::new(
@@ -349,7 +349,7 @@ mod tests {
         let object_store_url = ObjectStoreUrl::local_filesystem();
         let meta = local_unpartitioned_file(filename);
         let actual_schema = AvroFormat {}
-            .infer_schema(&state, &object_store, &[meta.clone()])
+            .infer_schema(&state, &object_store, std::slice::from_ref(&meta))
             .await?;
 
         let mut builder = SchemaBuilder::from(actual_schema.fields());
@@ -422,7 +422,7 @@ mod tests {
         let object_store_url = ObjectStoreUrl::local_filesystem();
         let meta = local_unpartitioned_file(filename);
         let file_schema = AvroFormat {}
-            .infer_schema(&state, &object_store, &[meta.clone()])
+            .infer_schema(&state, &object_store, std::slice::from_ref(&meta))
             .await?;
 
         let mut partitioned_file = PartitionedFile::from(meta);

--- a/datafusion/core/src/datasource/physical_plan/json.rs
+++ b/datafusion/core/src/datasource/physical_plan/json.rs
@@ -430,7 +430,7 @@ mod tests {
             .object_meta;
         let schema = JsonFormat::default()
             .with_file_compression_type(file_compression_type.to_owned())
-            .infer_schema(state, &store, &[meta.clone()])
+            .infer_schema(state, &store, std::slice::from_ref(&meta))
             .await
             .unwrap();
 

--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -1702,7 +1702,7 @@ mod tests {
 
         let store = Arc::new(LocalFileSystem::new()) as _;
         let file_schema = ParquetFormat::default()
-            .infer_schema(&state, &store, &[meta.clone()])
+            .infer_schema(&state, &store, std::slice::from_ref(&meta))
             .await?;
 
         let group_empty = vec![vec![file_range(&meta, 0, 2)]];
@@ -1734,7 +1734,7 @@ mod tests {
         let meta = local_unpartitioned_file(filename);
 
         let schema = ParquetFormat::default()
-            .infer_schema(&state, &store, &[meta.clone()])
+            .infer_schema(&state, &store, std::slice::from_ref(&meta))
             .await
             .unwrap();
 

--- a/datafusion/core/tests/parquet/page_pruning.rs
+++ b/datafusion/core/tests/parquet/page_pruning.rs
@@ -54,7 +54,7 @@ async fn get_parquet_exec(state: &SessionState, filter: Expr) -> ParquetExec {
     };
 
     let schema = ParquetFormat::default()
-        .infer_schema(state, &store, &[meta.clone()])
+        .infer_schema(state, &store, std::slice::from_ref(&meta))
         .await
         .unwrap();
 

--- a/datafusion/physical-plan/src/aggregates/topk_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/topk_stream.rs
@@ -123,7 +123,7 @@ impl Stream for GroupedTopKAggregateStream {
                         batch.num_rows()
                     );
                     if log::log_enabled!(Level::Trace) && batch.num_rows() < 20 {
-                        print_batches(&[batch.clone()])?;
+                        print_batches(std::slice::from_ref(&batch))?;
                     }
                     self.row_count += batch.num_rows();
                     let batches = &[batch];
@@ -165,7 +165,7 @@ impl Stream for GroupedTopKAggregateStream {
                         batch.num_rows()
                     );
                     if log::log_enabled!(Level::Trace) {
-                        print_batches(&[batch.clone()])?;
+                        print_batches(std::slice::from_ref(&batch))?;
                     }
                     return Poll::Ready(Some(Ok(batch)));
                 }

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -140,7 +140,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     ) -> Result<Expr> {
         let mut expr = self.sql_expr_to_logical_expr(sql, schema, planner_context)?;
         expr = self.rewrite_partial_qualifier(expr, schema);
-        self.validate_schema_satisfies_exprs(schema, &[expr.clone()])?;
+        self.validate_schema_satisfies_exprs(schema, std::slice::from_ref(&expr))?;
         let (expr, _) = expr.infer_placeholder_types(schema)?;
         Ok(expr)
     }

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -167,7 +167,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     let group_by_expr = normalize_col(group_by_expr, &projected_plan)?;
                     self.validate_schema_satisfies_exprs(
                         base_plan.schema(),
-                        &[group_by_expr.clone()],
+                        std::slice::from_ref(&group_by_expr),
                     )?;
                     Ok(group_by_expr)
                 })
@@ -815,7 +815,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
             check_columns_satisfy_exprs(
                 &column_exprs_post_aggr,
-                &[having_expr_post_aggr.clone()],
+                std::slice::from_ref(&having_expr_post_aggr),
                 "HAVING clause references non-aggregate values",
             )?;
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change
Replace `&[T.clone()]` with `std::slice::from_ref(&T)` to avoid cloning of T.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. By existing tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
