### PR TITLE
Unparse map to sql

### DIFF
--- a/datafusion/functions-nested/src/map.rs
+++ b/datafusion/functions-nested/src/map.rs
@@ -214,9 +214,9 @@ impl ScalarUDFImpl for MapFunc {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        if arg_types.len() % 2 != 0 {
+        if arg_types.len() != 2 {
             return exec_err!(
-                "map requires an even number of arguments, got {} instead",
+                "map requires exactly 2 arguments, got {} instead",
                 arg_types.len()
             );
         }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -573,24 +573,20 @@ impl Unparser<'_> {
             return internal_err!("map must have exactly 2 arguments");
         }
 
-        let keys = match self.expr_to_sql(&args[0])? {
-            ast::Expr::Array(Array { elem, .. }) => elem,
-            other => {
-                return internal_err!(
-                    "map expects first argument to be an array, but received: {:?}",
-                    other
-                )
-            }
+        let ast::Expr::Array(Array { elem: keys, .. }) = self.expr_to_sql(&args[0])?
+        else {
+            return internal_err!(
+                "map expects first argument to be an array, but received: {:?}",
+                &args[0]
+            );
         };
 
-        let values = match self.expr_to_sql(&args[1])? {
-            ast::Expr::Array(Array { elem, .. }) => elem,
-            other => {
-                return internal_err!(
-                    "map expects second argument to be an array, but received: {:?}",
-                    other
-                )
-            }
+        let ast::Expr::Array(Array { elem: values, .. }) = self.expr_to_sql(&args[1])?
+        else {
+            return internal_err!(
+                "map expects second argument to be an array, but received: {:?}",
+                &args[1]
+            );
         };
 
         let entries = keys

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -464,6 +464,7 @@ impl Unparser<'_> {
             "array_element" => self.array_element_to_sql(args),
             "named_struct" => self.named_struct_to_sql(args),
             "get_field" => self.get_field_to_sql(args),
+            "map" => self.map_to_sql(args),
             // TODO: support for the construct and access functions of the `map` type
             _ => self.scalar_function_to_sql_internal(func_name, args),
         }
@@ -565,6 +566,43 @@ impl Unparser<'_> {
         id.push(field);
 
         Ok(ast::Expr::CompoundIdentifier(id))
+    }
+
+    fn map_to_sql(&self, args: &[Expr]) -> Result<ast::Expr> {
+        if args.len() != 2 {
+            return internal_err!("map must have exactly 2 arguments");
+        }
+
+        let keys = match self.expr_to_sql(&args[0])? {
+            ast::Expr::Array(Array { elem, .. }) => elem,
+            other => {
+                return internal_err!(
+                    "map expects first argument to be an array, but received: {:?}",
+                    other
+                )
+            }
+        };
+
+        let values = match self.expr_to_sql(&args[1])? {
+            ast::Expr::Array(Array { elem, .. }) => elem,
+            other => {
+                return internal_err!(
+                    "map expects second argument to be an array, but received: {:?}",
+                    other
+                )
+            }
+        };
+
+        let entries = keys
+            .into_iter()
+            .zip(values)
+            .map(|(key, value)| ast::MapEntry {
+                key: Box::new(key),
+                value: Box::new(value),
+            })
+            .collect();
+
+        Ok(ast::Expr::Map(ast::Map { entries }))
     }
 
     pub fn sort_to_sql(&self, sort: &Sort) -> Result<ast::OrderByExpr> {
@@ -1581,6 +1619,7 @@ mod tests {
     use datafusion_functions_aggregate::count::count_udaf;
     use datafusion_functions_aggregate::expr_fn::sum;
     use datafusion_functions_nested::expr_fn::{array_element, make_array};
+    use datafusion_functions_nested::map::map;
     use datafusion_functions_window::row_number::row_number_udwf;
 
     use crate::unparser::dialect::{
@@ -1996,6 +2035,10 @@ mod tests {
                 "{a: '1', b: 2}",
             ),
             (get_field(col("a.b"), "c"), "a.b.c"),
+            (
+                map(vec![lit("a"), lit("b")], vec![lit(1), lit(2)]),
+                "MAP {'a': 1, 'b': 2}",
+            ),
         ];
 
         for (expr, expected) in tests {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -27,6 +27,7 @@ use datafusion_expr::{col, lit, table_scan, wildcard, LogicalPlanBuilder};
 use datafusion_functions::unicode;
 use datafusion_functions_aggregate::grouping::grouping_udaf;
 use datafusion_functions_nested::make_array::make_array_udf;
+use datafusion_functions_nested::map::map_udf;
 use datafusion_functions_window::rank::rank_udwf;
 use datafusion_sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_sql::unparser::dialect::{
@@ -190,7 +191,8 @@ fn roundtrip_statement() -> Result<()> {
             "SELECT [1, 2, 3][1]",
             "SELECT left[1] FROM array",
             "SELECT {a:1, b:2}",
-            "SELECT s.a FROM (SELECT {a:1, b:2} AS s)"
+            "SELECT s.a FROM (SELECT {a:1, b:2} AS s)",
+            "SELECT MAP {'a': 1, 'b': 2}"
     ];
 
     // For each test sql string, we transform as follows:
@@ -206,6 +208,7 @@ fn roundtrip_statement() -> Result<()> {
         let state = MockSessionState::default()
             .with_scalar_function(make_array_udf())
             .with_scalar_function(array_element_udf())
+            .with_scalar_function(map_udf())
             .with_aggregate_function(sum_udaf())
             .with_aggregate_function(count_udaf())
             .with_aggregate_function(max_udaf())

--- a/datafusion/sqllogictest/test_files/map.slt
+++ b/datafusion/sqllogictest/test_files/map.slt
@@ -185,7 +185,7 @@ SELECT MAP([[1,2], [3,4]], ['a', 'b']);
 query error
 SELECT MAP()
 
-query error DataFusion error: Execution error: map requires an even number of arguments, got 1 instead
+query error DataFusion error: Execution error: map requires exactly 2 arguments, got 1 instead
 SELECT MAP(['POST', 'HEAD'])
 
 query error DataFusion error: Execution error: Expected list, large_list or fixed_size_list, got Null


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Implements `map` for #13478. For `get_field` it doesn't look like there is a way to distinguish if it is a map access from the expression.

## Rationale for this change

Support roundtrip for statements containing `map`
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Implement `expr_to_sql` for `map`. 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
