### PR TITLE
Fix panic when hashing empty FixedSizeList Array

### DIFF
--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -322,7 +322,11 @@ fn hash_fixed_list_array(
 ) -> Result<()> {
     let values = Arc::clone(array.values());
     let value_len = array.value_length();
-    let offset_size = value_len as usize / array.len();
+    let offset_size = if array.len() == 0 {
+        0
+    } else {
+        value_len as usize / array.len()
+    };
     let nulls = array.nulls();
     let mut values_hashes = vec![0u64; values.len()];
     create_hashes(&[values], random_state, &mut values_hashes)?;
@@ -451,6 +455,16 @@ mod tests {
         let hashes_buff = &mut vec![0; array_ref.len()];
         let hashes = create_hashes(&[array_ref], &random_state, hashes_buff)?;
         assert_eq!(hashes.len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn create_hashes_for_empty_fixed_size_lit() -> Result<()> {
+        let empty_array = FixedSizeListBuilder::new(StringBuilder::new(), 1).finish();
+        let random_state = RandomState::with_seeds(0, 0, 0, 0);
+        let hashes_buff = &mut vec![0; 0];
+        let hashes = create_hashes(&[Arc::new(empty_array)], &random_state, hashes_buff)?;
+        assert_eq!(hashes, &Vec::<u64>::new());
         Ok(())
     }
 

--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -321,12 +321,7 @@ fn hash_fixed_list_array(
     hashes_buffer: &mut [u64],
 ) -> Result<()> {
     let values = Arc::clone(array.values());
-    let value_len = array.value_length();
-    let offset_size = if array.len() == 0 {
-        0
-    } else {
-        value_len as usize / array.len()
-    };
+    let value_length = array.value_length() as usize;
     let nulls = array.nulls();
     let mut values_hashes = vec![0u64; values.len()];
     create_hashes(&[values], random_state, &mut values_hashes)?;
@@ -334,7 +329,8 @@ fn hash_fixed_list_array(
         for i in 0..array.len() {
             if nulls.is_valid(i) {
                 let hash = &mut hashes_buffer[i];
-                for values_hash in &values_hashes[i * offset_size..(i + 1) * offset_size]
+                for values_hash in
+                    &values_hashes[i * value_length..(i + 1) * value_length]
                 {
                     *hash = combine_hashes(*hash, *values_hash);
                 }
@@ -343,7 +339,7 @@ fn hash_fixed_list_array(
     } else {
         for i in 0..array.len() {
             let hash = &mut hashes_buffer[i];
-            for values_hash in &values_hashes[i * offset_size..(i + 1) * offset_size] {
+            for values_hash in &values_hashes[i * value_length..(i + 1) * value_length] {
                 *hash = combine_hashes(*hash, *values_hash);
             }
         }


### PR DESCRIPTION
Previously it would panic due to division by zero.
