### PR TITLE
chore: Remove redundant assert_starts_with test helper

### DIFF
--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -1098,9 +1098,9 @@ mod tests {
             &vec![0],
         );
         assert!(result.is_err());
-        assert_starts_with(
-            result.err().unwrap().message().as_ref(),
-            "Invalid batch column at '0' has null but schema specifies non-nullable",
+        assert_eq!(
+            result.err().unwrap().strip_backtrace(),
+            "Execution error: Invalid batch column at '0' has null but schema specifies non-nullable",
         );
         Ok(())
     }
@@ -1123,9 +1123,9 @@ mod tests {
             &vec![0],
         );
         assert!(result.is_err());
-        assert_starts_with(
-            result.err().unwrap().message().as_ref(),
-            "Invalid batch column at '0' has null but schema specifies non-nullable",
+        assert_eq!(
+            result.err().unwrap().strip_backtrace(),
+            "Execution error: Invalid batch column at '0' has null but schema specifies non-nullable",
         );
         Ok(())
     }
@@ -1147,9 +1147,9 @@ mod tests {
             &vec![0],
         );
         assert!(result.is_err());
-        assert_starts_with(
-            result.err().unwrap().message().as_ref(),
-            "Invalid batch column at '0' has null but schema specifies non-nullable",
+        assert_eq!(
+            result.err().unwrap().strip_backtrace(),
+            "Execution error: Invalid batch column at '0' has null but schema specifies non-nullable",
         );
         Ok(())
     }
@@ -1190,21 +1190,10 @@ mod tests {
             &vec![0],
         );
         assert!(result.is_err());
-        assert_starts_with(
-            result.err().unwrap().message().as_ref(),
-            "Invalid batch column at '0' has null but schema specifies non-nullable",
+        assert_eq!(
+            result.err().unwrap().strip_backtrace(),
+            "Execution error: Invalid batch column at '0' has null but schema specifies non-nullable",
         );
         Ok(())
-    }
-
-    fn assert_starts_with(actual: impl AsRef<str>, expected_prefix: impl AsRef<str>) {
-        let actual = actual.as_ref();
-        let expected_prefix = expected_prefix.as_ref();
-        assert!(
-            actual.starts_with(expected_prefix),
-            "Expected '{}' to start with '{}'",
-            actual,
-            expected_prefix
-        );
     }
 }


### PR DESCRIPTION
Replace with usage of `DataFusionError::strip_backtrace`.
