### PR TITLE
Add csv loading benchmarks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ datafusion/sqllogictest/test_files/scratch*
 # temp file for core
 datafusion/core/*.parquet
 
+# Generated core benchmark data
+datafusion/core/benches/data/*
+
 # rat
 filtered_rat.txt
 rat.txt

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -161,6 +161,10 @@ name = "aggregate_query_sql"
 
 [[bench]]
 harness = false
+name = "csv_load"
+
+[[bench]]
+harness = false
 name = "distinct_query_sql"
 
 [[bench]]

--- a/datafusion/core/benches/csv_load.rs
+++ b/datafusion/core/benches/csv_load.rs
@@ -27,20 +27,14 @@ use datafusion::execution::context::SessionContext;
 use datafusion::prelude::CsvReadOptions;
 use datafusion::test_util::csv::TestCsvFile;
 use parking_lot::Mutex;
-use test_utils::AccessLogGenerator;
 use std::sync::Arc;
 use std::time::Duration;
+use test_utils::AccessLogGenerator;
 use tokio::runtime::Runtime;
 
-fn load_csv(ctx: Arc<Mutex<SessionContext>>, path: &str, options: CsvReadOptions) {    
+fn load_csv(ctx: Arc<Mutex<SessionContext>>, path: &str, options: CsvReadOptions) {
     let rt = Runtime::new().unwrap();
-    let df = rt.block_on(
-        ctx.lock()
-            .read_csv(
-                path,
-                options,
-            )
-        ).unwrap();
+    let df = rt.block_on(ctx.lock().read_csv(path, options)).unwrap();
     criterion::black_box(rt.block_on(df.collect()).unwrap());
 }
 
@@ -61,10 +55,9 @@ fn generate_test_file() -> TestCsvFile {
 
     let generator = AccessLogGenerator::new().with_include_nulls(true);
     let num_batches = 2;
-    let test_file = TestCsvFile::try_new(
-        file_path.clone(),
-        generator.take(num_batches as usize)
-    ).expect("Failed to create the test file.");
+    let test_file =
+        TestCsvFile::try_new(file_path.clone(), generator.take(num_batches as usize))
+            .expect("Failed to create the test file.");
 
     test_file
 }

--- a/datafusion/core/benches/csv_load.rs
+++ b/datafusion/core/benches/csv_load.rs
@@ -55,11 +55,8 @@ fn generate_test_file() -> TestCsvFile {
 
     let generator = AccessLogGenerator::new().with_include_nulls(true);
     let num_batches = 2;
-    let test_file =
-        TestCsvFile::try_new(file_path.clone(), generator.take(num_batches as usize))
-            .expect("Failed to create the test file.");
-
-    test_file
+    TestCsvFile::try_new(file_path.clone(), generator.take(num_batches as usize))
+        .expect("Failed to create test file.")
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/datafusion/core/benches/csv_load.rs
+++ b/datafusion/core/benches/csv_load.rs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+extern crate arrow;
+extern crate datafusion;
+
+mod data_utils;
+use crate::criterion::Criterion;
+use datafusion::error::Result;
+use datafusion::execution::context::SessionContext;
+use datafusion::prelude::CsvReadOptions;
+use datafusion::test_util::csv::TestCsvFile;
+use parking_lot::Mutex;
+use test_utils::AccessLogGenerator;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+
+fn load_csv(ctx: Arc<Mutex<SessionContext>>, path: &str, options: CsvReadOptions) {    
+    let rt = Runtime::new().unwrap();
+    let df = rt.block_on(
+        ctx.lock()
+            .read_csv(
+                path,
+                options,
+            )
+        ).unwrap();
+    criterion::black_box(rt.block_on(df.collect()).unwrap());
+}
+
+fn create_context() -> Result<Arc<Mutex<SessionContext>>> {
+    let ctx = SessionContext::new();
+    Ok(Arc::new(Mutex::new(ctx)))
+}
+
+fn generate_test_file() -> TestCsvFile {
+    let write_location = std::env::current_dir()
+        .unwrap()
+        .join("benches")
+        .join("data");
+
+    // Make sure the write directory exists.
+    std::fs::create_dir_all(&write_location).unwrap();
+    let file_path = write_location.join("logs.csv");
+
+    let generator = AccessLogGenerator::new().with_include_nulls(true);
+    let num_batches = 2;
+    let test_file = TestCsvFile::try_new(
+        file_path.clone(),
+        generator.take(num_batches as usize)
+    ).expect("Failed to create the test file.");
+
+    test_file
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let ctx = create_context().unwrap();
+    let test_file = generate_test_file();
+
+    let mut group = c.benchmark_group("load csv testing");
+    group.measurement_time(Duration::from_secs(20));
+
+    group.bench_function("default csv read options", |b| {
+        b.iter(|| {
+            load_csv(
+                ctx.clone(),
+                test_file.path().to_str().unwrap(),
+                CsvReadOptions::default(),
+            )
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/core/src/test_util/csv.rs
+++ b/datafusion/core/src/test_util/csv.rs
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Helpers for writing csv files and reading them back
+
+use std::fs::File;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use crate::error::Result;
+
+use arrow::csv::WriterBuilder;
+
+///  a CSV file that has been created for testing.
+pub struct TestCsvFile {
+    path: PathBuf,
+    schema: SchemaRef,
+}
+
+impl TestCsvFile {
+    /// Creates a new csv file at the specified location
+    pub fn try_new(
+        path: PathBuf,
+        batches: impl IntoIterator<Item = RecordBatch>,
+    ) -> Result<Self> {
+        let file = File::create(&path).unwrap();
+        let builder = WriterBuilder::new().with_header(true);
+        let mut writer = builder.build(file);
+
+        let mut batches = batches.into_iter();
+        let first_batch = batches.next().expect("need at least one record batch");
+        let schema = first_batch.schema();
+
+        let mut num_rows = 0;
+        for batch in batches {
+            writer.write(&batch)?;
+            num_rows += batch.num_rows();
+        }
+
+        println!("Generated test dataset with {num_rows} rows");
+
+        Ok(Self { path, schema })
+    }
+
+    /// The schema of this csv file
+    pub fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    /// The path to the csv file
+    pub fn path(&self) -> &std::path::Path {
+        self.path.as_path()
+    }
+}

--- a/datafusion/core/src/test_util/mod.rs
+++ b/datafusion/core/src/test_util/mod.rs
@@ -20,6 +20,8 @@
 #[cfg(feature = "parquet")]
 pub mod parquet;
 
+pub mod csv;
+
 use std::any::Any;
 use std::collections::HashMap;
 use std::fs::File;


### PR DESCRIPTION
## Which issue does this PR close?


Related to #12904

## Rationale for this change

Requested in comments for `https://github.com/apache/datafusion/pull/13228`

A direct testing on loading csv files was identified as a gap in the benchmarking suite.

## What changes are included in this PR?

Basic benchmarks related to loading csv files.

## Are these changes tested?

Tested via `./bench.sh run csv`

Logged output:
```
Running csv load benchmarks.
Generated test dataset with 10240283 rows
Executing 'CSV Load Speed Test.'
Iteration 0 finished in 7.079167 ms.
Iteration 1 finished in 3.3643750000000003 ms.
Iteration 2 finished in 3.2645 ms.
Iteration 3 finished in 3.311208 ms.
Iteration 4 finished in 3.319 ms.
Done
```

results file:
[csv.json](https://github.com/user-attachments/files/17891638/csv.json)

Curious result is the first iteration is consistently 6-7 ms vs ~3ms on future iterations.  Is a new `SessionContext` not sufficient to remove any cache in loading?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
