### PR TITLE
Minor: Fix two test cases causing CI failures by adding `rowsort`

### DIFF
--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -766,13 +766,13 @@ SELECT NULL WHERE FALSE;
 query error DataFusion error: type_coercion\ncaused by\nError during planning: Incompatible inputs for Union: Previous inputs were of type List(.*), but got incompatible type List(.*) on column 'x'
 SELECT make_array(2) x UNION ALL SELECT make_array(now()) x;
 
-query ?
+query ? rowsort
 select make_array(arrow_cast(2, 'UInt8')) x UNION ALL SELECT make_array(arrow_cast(-2, 'Int8')) x;
 ----
 [-2]
 [2]
 
-query ?
+query ? rowsort
 select make_array(make_array(1)) x UNION ALL SELECT make_array(arrow_cast(make_array(-1), 'LargeList(Int8)')) x;
 ----
 [[-1]]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
I encountered a CI failure in https://github.com/apache/datafusion/actions/runs/11995648362/job/33439273622?pr=13540
```
External error: query result mismatch:
[SQL] select make_array(make_array(1)) x UNION ALL SELECT make_array(arrow_cast(make_array(-1), 'LargeList(Int8)')) x;
[Diff] (-expected|+actual)
-   [[-1]]
-   [[1]]
+   [[1]]
+   [[-1]]
at test_files/union.slt:775
```

I think for `UNION ALL` statements, output order is not deterministic
So this PR specified the output order in failed test cases.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
