### PR TITLE
Minor: Add example of backporting / `cherry-pick`ing to release branch

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -48,6 +48,7 @@ git cherry-pick 12345
 git push -u <your fork>
 # make a PR as normal
 ```
+
 [example release issue]: https://github.com/apache/datafusion/issues/9904
 [example backport pr]: https://github.com/apache/datafusion/pull/10123
 

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -30,7 +30,7 @@ Patch releases are made on an adhoc basis, but we try and avoid them given the f
 - Once the PR is approved and merged, we tag the rc in the release branch, and release from the release branch
 - Bug fixes can be merged to the release branch and patch releases can be created from the release branch
 
-#### How to add changes to `branch-*` branch?
+#### How to backport (add changes) to `branch-*` branch
 
 If you would like to propose your change for inclusion in a release branch for a
 patch release:
@@ -39,6 +39,15 @@ patch release:
 1. Follow normal workflow to create PR to `main` branch and wait for its approval and merge.
 1. After PR is squash merged to `main`, branch from most recent release branch (e.g. `branch-37`), cherry-pick the commit and create a PR targeting the release branch [example backport PR].
 
+For example, to backport commit `12345` from `main` to `branch-43`:
+
+```shell
+git checkout branch-43
+git checkout -b backport_to_43
+git cherry-pick 12345
+git push -u <your fork>
+# make a PR as normal
+```
 [example release issue]: https://github.com/apache/datafusion/issues/9904
 [example backport pr]: https://github.com/apache/datafusion/pull/10123
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to 
- https://github.com/apache/datafusion/issues/13499

## Rationale for this change

If we are going to do backports more frequently, let's add an example of doing so
## What changes are included in this PR?
add an example of how to `cherry-pick` / backport to release instructions
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
