### PR TITLE
chore(deps): update bigdecimal from 0.4.1 to 0.4.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ arrow-ipc = { version = "53.3.0", default-features = false, features = [
 arrow-ord = { version = "53.3.0", default-features = false }
 arrow-schema = { version = "53.3.0", default-features = false }
 async-trait = "0.1.73"
-bigdecimal = "=0.4.1"
+bigdecimal = "0.4.6"
 bytes = "1.4"
 chrono = { version = "0.4.38", default-features = false }
 ctor = "0.2.0"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #10001.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
We use the bigdecimal crate to format decimal values to strings and display them in sqllogical tests(SLTs).
The new version of bigdecimal formats certain decimals in scientific notation, which will break many SLT tests.

There are two possible solutions:
1. Set the compile-time environment variables for bigdecimal, such as `RUST_BIGDECIMAL_FMT_EXPONENTIAL_LOWER_THRESHOLD`. However, I'm a bit concerned about whether it's appropriate to operate environment variables in a library like DataFusion. Additionally, we might need to introduce a separate Cargo config.toml into the project root directory so that `cargo test --test sqllogictests` can work.
2. Implement our own method for formatting decimals.

This PR takes the latter approach.
## What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. By new UTs and existing SLT tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No. Only modified the test engine.