### PR TITLE
Add zero-`decimal`-cast test

### DIFF
--- a/datafusion/sqllogictest/test_files/decimal.slt
+++ b/datafusion/sqllogictest/test_files/decimal.slt
@@ -733,3 +733,10 @@ true 2
 
 statement ok
 drop table decimal256_simple;
+
+
+# https://github.com/apache/datafusion/issues/12870
+query R
+SELECT CAST('0' AS decimal(38,0));
+----
+0


### PR DESCRIPTION

## Which issue does this PR close?

closes https://github.com/apache/datafusion/issues/12870



## Rationale for this change

Bug for fixed in https://github.com/apache/arrow-rs/pull/6547, this pr just adds a test for it

## Are there any user-facing changes?

No