### PR TITLE
Implement GroupsAccumulator for corr(x,y) aggregate function

### DIFF
--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/accumulate.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/accumulate.rs
@@ -394,8 +394,10 @@ pub fn accumulate_multiple<T, F>(
     // Take AND from all null buffers of `value_columns`.
     let combined_nulls = value_columns
         .iter()
-        .map(|arr| arr.nulls())
-        .fold(None, |acc, nulls| NullBuffer::union(acc.as_ref(), nulls));
+        .map(|arr| arr.logical_nulls())
+        .fold(None, |acc, nulls| {
+            NullBuffer::union(acc.as_ref(), nulls.as_ref())
+        });
 
     // Take AND from previous combined nulls and `opt_filter`.
     let valid_indices = match (combined_nulls, opt_filter) {
@@ -409,7 +411,7 @@ pub fn accumulate_multiple<T, F>(
     };
 
     for col in value_columns.iter() {
-        assert_eq!(col.len(), group_indices.len());
+        debug_assert_eq!(col.len(), group_indices.len());
     }
 
     match valid_indices {

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -390,9 +390,9 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
             group_indices,
             &[&array_x, &array_y],
             opt_filter,
-            |group_index, values| {
-                let x = values[0];
-                let y = values[1];
+            |group_index, batch_index, columns| {
+                let x = columns[0].value(batch_index);
+                let y = columns[1].value(batch_index);
                 self.count[group_index] += 1;
                 self.sum_x[group_index] += x;
                 self.sum_y[group_index] += y;

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -22,11 +22,19 @@ use std::fmt::Debug;
 use std::mem::size_of_val;
 use std::sync::{Arc, OnceLock};
 
-use arrow::compute::{and, filter, is_not_null};
+use arrow::array::{
+    downcast_array, Array, AsArray, BooleanArray, BooleanBufferBuilder, Float64Array,
+    UInt64Array,
+};
+use arrow::compute::{and, filter, is_not_null, kernels::cast};
+use arrow::datatypes::{Float64Type, UInt64Type};
 use arrow::{
     array::ArrayRef,
     datatypes::{DataType, Field},
 };
+use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_functions_aggregate_common::aggregate::groups_accumulator::accumulate::accumulate_multiple;
+use log::debug;
 
 use crate::covariance::CovarianceAccumulator;
 use crate::stddev::StddevAccumulator;
@@ -112,6 +120,18 @@ impl AggregateUDFImpl for Correlation {
 
     fn documentation(&self) -> Option<&Documentation> {
         Some(get_corr_doc())
+    }
+
+    fn groups_accumulator_supported(&self, _args: AccumulatorArgs) -> bool {
+        true
+    }
+
+    fn create_groups_accumulator(
+        &self,
+        _args: AccumulatorArgs,
+    ) -> Result<Box<dyn GroupsAccumulator>> {
+        debug!("GroupsAccumulator is created for aggregate function `corr(c1, c2)`");
+        Ok(Box::new(CorrelationGroupsAccumulator::new()))
     }
 }
 
@@ -261,5 +281,316 @@ impl Accumulator for CorrelationAccumulator {
         self.stddev1.retract_batch(&values[0..1])?;
         self.stddev2.retract_batch(&values[1..2])?;
         Ok(())
+    }
+}
+
+pub struct CorrelationGroupsAccumulator {
+    // Number of elements for each group
+    // This is also used to track nulls: if a group has 0 valid values accumulated,
+    // final aggregation result will be null.
+    count: Vec<u64>,
+    // Sum of x values for each group
+    sum_x: Vec<f64>,
+    // Sum of y
+    sum_y: Vec<f64>,
+    // Sum of x*y
+    sum_xy: Vec<f64>,
+    // Sum of x^2
+    sum_xx: Vec<f64>,
+    // Sum of y^2
+    sum_yy: Vec<f64>,
+}
+
+impl CorrelationGroupsAccumulator {
+    pub fn new() -> Self {
+        Self {
+            count: Vec::new(),
+            sum_x: Vec::new(),
+            sum_y: Vec::new(),
+            sum_xy: Vec::new(),
+            sum_xx: Vec::new(),
+            sum_yy: Vec::new(),
+        }
+    }
+}
+
+/// Specialized version of `accumulate_multiple` for correlation's merge_batch
+///
+/// Note: Arrays in `state_arrays` should not have null values, because they are all
+/// intermediate states created within the accumulator, instead of inputs from
+/// outside.
+fn accumulate_correlation_states(
+    group_indices: &[usize],
+    state_arrays: (
+        &UInt64Array,  // count
+        &Float64Array, // sum_x
+        &Float64Array, // sum_y
+        &Float64Array, // sum_xy
+        &Float64Array, // sum_xx
+        &Float64Array, // sum_yy
+    ),
+    mut value_fn: impl FnMut(usize, u64, &[f64]),
+) {
+    let (counts, sum_x, sum_y, sum_xy, sum_xx, sum_yy) = state_arrays;
+
+    assert_eq!(counts.null_count(), 0);
+    assert_eq!(sum_x.null_count(), 0);
+    assert_eq!(sum_y.null_count(), 0);
+    assert_eq!(sum_xy.null_count(), 0);
+    assert_eq!(sum_xx.null_count(), 0);
+    assert_eq!(sum_yy.null_count(), 0);
+
+    let counts_values = counts.values().as_ref();
+    let sum_x_values = sum_x.values().as_ref();
+    let sum_y_values = sum_y.values().as_ref();
+    let sum_xy_values = sum_xy.values().as_ref();
+    let sum_xx_values = sum_xx.values().as_ref();
+    let sum_yy_values = sum_yy.values().as_ref();
+
+    let mut row = [0.0; 5];
+    for (idx, &group_idx) in group_indices.iter().enumerate() {
+        row[0] = sum_x_values[idx];
+        row[1] = sum_y_values[idx];
+        row[2] = sum_xy_values[idx];
+        row[3] = sum_xx_values[idx];
+        row[4] = sum_yy_values[idx];
+        value_fn(group_idx, counts_values[idx], &row);
+    }
+}
+
+/// GroupsAccumulator implementation for `corr(x, y)` that computes the Pearson correlation coefficient
+/// between two numeric columns.
+///
+/// Online algorithm for correlation:
+///
+/// r = (n * sum_xy - sum_x * sum_y) / sqrt((n * sum_xx - sum_x^2) * (n * sum_yy - sum_y^2))
+/// where:
+/// n = number of observations
+/// sum_x = sum of x values
+/// sum_y = sum of y values  
+/// sum_xy = sum of (x * y)
+/// sum_xx = sum of x^2 values
+/// sum_yy = sum of y^2 values
+///
+/// Reference: <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient#For_a_sample>
+impl GroupsAccumulator for CorrelationGroupsAccumulator {
+    fn update_batch(
+        &mut self,
+        values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> Result<()> {
+        self.count.resize(total_num_groups, 0);
+        self.sum_x.resize(total_num_groups, 0.0);
+        self.sum_y.resize(total_num_groups, 0.0);
+        self.sum_xy.resize(total_num_groups, 0.0);
+        self.sum_xx.resize(total_num_groups, 0.0);
+        self.sum_yy.resize(total_num_groups, 0.0);
+
+        let array_x = &cast(&values[0], &DataType::Float64)?;
+        let array_x = downcast_array::<Float64Array>(array_x);
+        let array_y = &cast(&values[1], &DataType::Float64)?;
+        let array_y = downcast_array::<Float64Array>(array_y);
+
+        accumulate_multiple(
+            group_indices,
+            &[&array_x, &array_y],
+            opt_filter,
+            |group_index, values| {
+                let x = values[0];
+                let y = values[1];
+                self.count[group_index] += 1;
+                self.sum_x[group_index] += x;
+                self.sum_y[group_index] += y;
+                self.sum_xy[group_index] += x * y;
+                self.sum_xx[group_index] += x * x;
+                self.sum_yy[group_index] += y * y;
+            },
+        );
+
+        Ok(())
+    }
+
+    fn merge_batch(
+        &mut self,
+        values: &[ArrayRef],
+        group_indices: &[usize],
+        opt_filter: Option<&BooleanArray>,
+        total_num_groups: usize,
+    ) -> Result<()> {
+        // Resize vectors to accommodate total number of groups
+        self.count.resize(total_num_groups, 0);
+        self.sum_x.resize(total_num_groups, 0.0);
+        self.sum_y.resize(total_num_groups, 0.0);
+        self.sum_xy.resize(total_num_groups, 0.0);
+        self.sum_xx.resize(total_num_groups, 0.0);
+        self.sum_yy.resize(total_num_groups, 0.0);
+
+        // Extract arrays from input values
+        let partial_counts = values[0].as_primitive::<UInt64Type>();
+        let partial_sum_x = values[1].as_primitive::<Float64Type>();
+        let partial_sum_y = values[2].as_primitive::<Float64Type>();
+        let partial_sum_xy = values[3].as_primitive::<Float64Type>();
+        let partial_sum_xx = values[4].as_primitive::<Float64Type>();
+        let partial_sum_yy = values[5].as_primitive::<Float64Type>();
+
+        assert!(opt_filter.is_none(), "aggregate filter should be applied in partial stage, there should be no filter in final stage");
+
+        accumulate_correlation_states(
+            group_indices,
+            (
+                partial_counts,
+                partial_sum_x,
+                partial_sum_y,
+                partial_sum_xy,
+                partial_sum_xx,
+                partial_sum_yy,
+            ),
+            |group_index, count, values| {
+                self.count[group_index] += count;
+                self.sum_x[group_index] += values[0];
+                self.sum_y[group_index] += values[1];
+                self.sum_xy[group_index] += values[2];
+                self.sum_xx[group_index] += values[3];
+                self.sum_yy[group_index] += values[4];
+            },
+        );
+
+        Ok(())
+    }
+
+    fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
+        let n = match emit_to {
+            EmitTo::All => self.count.len(),
+            EmitTo::First(n) => n,
+        };
+
+        let mut values = Vec::with_capacity(n);
+        let mut nulls = BooleanBufferBuilder::new(n);
+
+        // Notes for `Null` handling:
+        // - If the `count` state of a group is 0, no valid records are accumulated
+        //   for this group, so the aggregation result is `Null`.
+        // - Correlation can't be calculated when a group only has 1 record, or when
+        //   the `denominator` state is 0. In these cases, the final aggregation
+        //   result should be `Null` (according to PostgreSQL's behavior).
+        //
+        // TODO: Old datafusion implementation returns 0.0 for these invalid cases.
+        // Update this to match PostgreSQL's behavior.
+        for i in 0..n {
+            if self.count[i] < 2 {
+                // TODO: Evaluate as `Null` (see notes above)
+                values.push(0.0);
+                nulls.append(false);
+                continue;
+            }
+
+            let count = self.count[i];
+            let sum_x = self.sum_x[i];
+            let sum_y = self.sum_y[i];
+            let sum_xy = self.sum_xy[i];
+            let sum_xx = self.sum_xx[i];
+            let sum_yy = self.sum_yy[i];
+
+            let mean_x = sum_x / count as f64;
+            let mean_y = sum_y / count as f64;
+
+            let numerator = sum_xy - sum_x * mean_y;
+            let denominator =
+                ((sum_xx - sum_x * mean_x) * (sum_yy - sum_y * mean_y)).sqrt();
+
+            if denominator == 0.0 {
+                // TODO: Evaluate as `Null` (see notes above)
+                values.push(0.0);
+                nulls.append(false);
+            } else {
+                values.push(numerator / denominator);
+                nulls.append(true);
+            }
+        }
+
+        Ok(Arc::new(Float64Array::new(
+            values.into(),
+            Some(nulls.finish().into()),
+        )))
+    }
+
+    fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
+        let n = match emit_to {
+            EmitTo::All => self.count.len(),
+            EmitTo::First(n) => n,
+        };
+
+        Ok(vec![
+            Arc::new(UInt64Array::from(self.count[0..n].to_vec())),
+            Arc::new(Float64Array::from(self.sum_x[0..n].to_vec())),
+            Arc::new(Float64Array::from(self.sum_y[0..n].to_vec())),
+            Arc::new(Float64Array::from(self.sum_xy[0..n].to_vec())),
+            Arc::new(Float64Array::from(self.sum_xx[0..n].to_vec())),
+            Arc::new(Float64Array::from(self.sum_yy[0..n].to_vec())),
+        ])
+    }
+
+    fn size(&self) -> usize {
+        size_of::<f64>()
+            * (self.count.capacity()
+                + self.sum_x.capacity()
+                + self.sum_y.capacity()
+                + self.sum_xy.capacity()
+                + self.sum_xx.capacity()
+                + self.sum_yy.capacity())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, UInt64Array};
+
+    #[test]
+    fn test_accumulate_correlation_states() {
+        // Test data
+        let group_indices = vec![0, 1, 0, 1];
+        let counts = UInt64Array::from(vec![1, 2, 3, 4]);
+        let sum_x = Float64Array::from(vec![10.0, 20.0, 30.0, 40.0]);
+        let sum_y = Float64Array::from(vec![1.0, 2.0, 3.0, 4.0]);
+        let sum_xy = Float64Array::from(vec![10.0, 40.0, 90.0, 160.0]);
+        let sum_xx = Float64Array::from(vec![100.0, 400.0, 900.0, 1600.0]);
+        let sum_yy = Float64Array::from(vec![1.0, 4.0, 9.0, 16.0]);
+
+        let mut accumulated = vec![];
+        accumulate_correlation_states(
+            &group_indices,
+            (&counts, &sum_x, &sum_y, &sum_xy, &sum_xx, &sum_yy),
+            |group_idx, count, values| {
+                accumulated.push((group_idx, count, values.to_vec()));
+            },
+        );
+
+        let expected = vec![
+            (0, 1, vec![10.0, 1.0, 10.0, 100.0, 1.0]),
+            (1, 2, vec![20.0, 2.0, 40.0, 400.0, 4.0]),
+            (0, 3, vec![30.0, 3.0, 90.0, 900.0, 9.0]),
+            (1, 4, vec![40.0, 4.0, 160.0, 1600.0, 16.0]),
+        ];
+        assert_eq!(accumulated, expected);
+
+        // Test that function panics with null values
+        let counts = UInt64Array::from(vec![Some(1), None, Some(3), Some(4)]);
+        let sum_x = Float64Array::from(vec![10.0, 20.0, 30.0, 40.0]);
+        let sum_y = Float64Array::from(vec![1.0, 2.0, 3.0, 4.0]);
+        let sum_xy = Float64Array::from(vec![10.0, 40.0, 90.0, 160.0]);
+        let sum_xx = Float64Array::from(vec![100.0, 400.0, 900.0, 1600.0]);
+        let sum_yy = Float64Array::from(vec![1.0, 4.0, 9.0, 16.0]);
+
+        let result = std::panic::catch_unwind(|| {
+            accumulate_correlation_states(
+                &group_indices,
+                (&counts, &sum_x, &sum_y, &sum_xy, &sum_xx, &sum_yy),
+                |_, _, _| {},
+            )
+        });
+        assert!(result.is_err());
     }
 }

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -527,13 +527,12 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
     }
 
     fn size(&self) -> usize {
-        size_of::<f64>()
-            * (self.count.capacity()
-                + self.sum_x.capacity()
-                + self.sum_y.capacity()
-                + self.sum_xy.capacity()
-                + self.sum_xx.capacity()
-                + self.sum_yy.capacity())
+        size_of_val(&self.count)
+            + size_of_val(&self.sum_x)
+            + size_of_val(&self.sum_y)
+            + size_of_val(&self.sum_xy)
+            + size_of_val(&self.sum_xx)
+            + size_of_val(&self.sum_yy)
     }
 }
 

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -284,6 +284,7 @@ impl Accumulator for CorrelationAccumulator {
     }
 }
 
+#[derive(Default)]
 pub struct CorrelationGroupsAccumulator {
     // Number of elements for each group
     // This is also used to track nulls: if a group has 0 valid values accumulated,
@@ -303,14 +304,7 @@ pub struct CorrelationGroupsAccumulator {
 
 impl CorrelationGroupsAccumulator {
     pub fn new() -> Self {
-        Self {
-            count: Vec::new(),
-            sum_x: Vec::new(),
-            sum_y: Vec::new(),
-            sum_xy: Vec::new(),
-            sum_xx: Vec::new(),
-            sum_yy: Vec::new(),
-        }
+        Default::default()
     }
 }
 

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -26,7 +26,7 @@ use arrow::array::{
     downcast_array, Array, AsArray, BooleanArray, BooleanBufferBuilder, Float64Array,
     UInt64Array,
 };
-use arrow::compute::{and, filter, is_not_null};
+use arrow::compute::{and, filter, is_not_null, kernels::cast};
 use arrow::datatypes::{Float64Type, UInt64Type};
 use arrow::{
     array::ArrayRef,
@@ -383,8 +383,10 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
         self.sum_xx.resize(total_num_groups, 0.0);
         self.sum_yy.resize(total_num_groups, 0.0);
 
-        let array_x = downcast_array::<Float64Array>(&values[0]);
-        let array_y = downcast_array::<Float64Array>(&values[1]);
+        let array_x = &cast(&values[0], &DataType::Float64)?;
+        let array_x = downcast_array::<Float64Array>(array_x);
+        let array_y = &cast(&values[1], &DataType::Float64)?;
+        let array_y = downcast_array::<Float64Array>(array_y);
 
         accumulate_multiple(
             group_indices,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/13549

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Implement `GroupsAccumulator` for `corr` aggregation function, for better performance when group cardinality is high

I rerun the H2o benchmark:
### Data Generation
`falsa groupby --path-prefix=/Users/yongting/data/ --size MEDIUM --data-format PARQUET`
https://github.com/mrpowers-io/falsa
### Run benchmark in datafusion-cli
```
CREATE EXTERNAL TABLE IF NOT EXISTS h2o_100m (
    id1 VARCHAR NOT NULL,
    id2 VARCHAR NOT NULL,
    id3 VARCHAR NOT NULL,
    id4 INTEGER NOT NULL,
    id5 INTEGER NOT NULL,
    id6 INTEGER NOT NULL,
    v1 INTEGER NOT NULL,
    v2 INTEGER NOT NULL,
    v3 DOUBLE PRECISION NOT NULL
)
STORED AS parquet
LOCATION '/Users/yongting/data/G1_1e8_1e8_100_0.parquet';

select id2, id4, power(corr(v1, v2), 2) as r2 from h2o_100m group by id2, id4;
```
### Result
Main: 12s
This PR: 4s
(On my MacBook with m4 pro)

----

Remaining tasks
~~Implement `convert_to_states()`~~ This requires changes in aggregate fuzzer for test coverage, which can be done later to keep this PR small

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Implement two utility functions: `accumulate_multiple` and `accumulate_correlation_states` to accumulate states in correlation function. (existing util functions is for aggregate functions with 1 input expr `avg(expr1) v.s. corr(expr1, expr2)`)
2. Implement `GroupsAccumulator` for `corr()`

## Are these changes tested?

Unit tests for util functions
`corr()` is covered by existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
