### PR TITLE
feat!: change catalog provider and schema provider methods to be asynchronous

### DIFF
--- a/benchmarks/src/bin/dfbench.rs
+++ b/benchmarks/src/bin/dfbench.rs
@@ -53,12 +53,12 @@ pub async fn main() -> Result<()> {
     env_logger::init();
 
     match Options::from_args() {
-        Options::Tpch(opt) => opt.run().await,
+        Options::Tpch(opt) => Box::pin(opt.run()).await,
         Options::TpchConvert(opt) => opt.run().await,
         Options::Clickbench(opt) => opt.run().await,
         Options::ParquetFilter(opt) => opt.run().await,
         Options::Sort(opt) => opt.run().await,
         Options::SortTpch(opt) => opt.run().await,
-        Options::Imdb(opt) => opt.run().await,
+        Options::Imdb(opt) => Box::pin(opt.run()).await,
     }
 }

--- a/benchmarks/src/bin/external_aggr.rs
+++ b/benchmarks/src/bin/external_aggr.rs
@@ -245,9 +245,9 @@ impl ExternalAggrConfig {
                     table,
                     start.elapsed().as_millis()
                 );
-                ctx.register_table(table, Arc::new(memtable))?;
+                ctx.register_table(table, Arc::new(memtable)).await?;
             } else {
-                ctx.register_table(table, table_provider)?;
+                ctx.register_table(table, table_provider).await?;
             }
         }
         Ok(())

--- a/benchmarks/src/bin/h2o.rs
+++ b/benchmarks/src/bin/h2o.rs
@@ -94,7 +94,7 @@ async fn group_by(opt: &GroupBy) -> Result<()> {
         let partition_size = num_cpus::get();
         let memtable =
             MemTable::load(Arc::new(csv), Some(partition_size), &ctx.state()).await?;
-        ctx.register_table("x", Arc::new(memtable))?;
+        ctx.register_table("x", Arc::new(memtable)).await?;
     } else {
         ctx.register_csv("x", path, CsvReadOptions::default().schema(&schema))
             .await?;

--- a/benchmarks/src/bin/imdb.rs
+++ b/benchmarks/src/bin/imdb.rs
@@ -53,7 +53,7 @@ pub async fn main() -> Result<()> {
     env_logger::init();
     match ImdbOpt::from_args() {
         ImdbOpt::Benchmark(BenchmarkSubCommandOpt::DataFusionBenchmark(opt)) => {
-            opt.run().await
+            Box::pin(opt.run()).await
         }
         ImdbOpt::Convert(opt) => opt.run().await,
     }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
     env_logger::init();
     match TpchOpt::from_args() {
         TpchOpt::Benchmark(BenchmarkSubCommandOpt::DataFusionBenchmark(opt)) => {
-            opt.run().await
+            Box::pin(opt.run()).await
         }
         TpchOpt::Convert(opt) => opt.run().await,
     }

--- a/benchmarks/src/imdb/run.rs
+++ b/benchmarks/src/imdb/run.rs
@@ -358,9 +358,9 @@ impl RunOpt {
                     table,
                     start.elapsed().as_millis()
                 );
-                ctx.register_table(*table, Arc::new(memtable))?;
+                ctx.register_table(*table, Arc::new(memtable)).await?;
             } else {
-                ctx.register_table(*table, table_provider)?;
+                ctx.register_table(*table, table_provider).await?;
             }
         }
         Ok(())

--- a/benchmarks/src/sort_tpch.rs
+++ b/benchmarks/src/sort_tpch.rs
@@ -236,9 +236,9 @@ impl RunOpt {
                     table,
                     start.elapsed().as_millis()
                 );
-                ctx.register_table(table, Arc::new(memtable))?;
+                ctx.register_table(table, Arc::new(memtable)).await?;
             } else {
-                ctx.register_table(table, table_provider)?;
+                ctx.register_table(table, table_provider).await?;
             }
         }
         Ok(())

--- a/benchmarks/src/tpch/run.rs
+++ b/benchmarks/src/tpch/run.rs
@@ -182,9 +182,9 @@ impl RunOpt {
                     table,
                     start.elapsed().as_millis()
                 );
-                ctx.register_table(*table, Arc::new(memtable))?;
+                ctx.register_table(*table, Arc::new(memtable)).await?;
             } else {
-                ctx.register_table(*table, table_provider)?;
+                ctx.register_table(*table, table_provider).await?;
             }
         }
         Ok(())

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-physical-plan",
+ "futures",
  "parking_lot",
 ]
 

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -176,7 +176,8 @@ async fn main_inner() -> Result<()> {
     // enable dynamic file query
     let ctx =
         SessionContext::new_with_config_rt(session_config.clone(), Arc::new(runtime_env))
-            .enable_url_table();
+            .enable_url_table()
+            .await;
     ctx.refresh_catalogs().await?;
     // install dynamic catalog provider that can register required object stores
     ctx.register_catalog_list(Arc::new(DynamicObjectStoreCatalog::new(

--- a/datafusion-examples/examples/advanced_parquet_index.rs
+++ b/datafusion-examples/examples/advanced_parquet_index.rs
@@ -168,7 +168,8 @@ async fn main() -> Result<()> {
     // SessionContext for running queries that has the table provider
     // registered as "index_table"
     let ctx = SessionContext::new();
-    ctx.register_table("index_table", Arc::clone(&provider) as _)?;
+    ctx.register_table("index_table", Arc::clone(&provider) as _)
+        .await?;
 
     // register object store provider for urls like `file://` work
     let url = Url::try_from("file://").unwrap();

--- a/datafusion-examples/examples/advanced_udaf.rs
+++ b/datafusion-examples/examples/advanced_udaf.rs
@@ -198,7 +198,7 @@ impl Accumulator for GeometricMean {
 }
 
 // create local session context with an in-memory table
-fn create_context() -> Result<SessionContext> {
+async fn create_context() -> Result<SessionContext> {
     use datafusion::datasource::MemTable;
     // define a schema.
     let schema = Arc::new(Schema::new(vec![
@@ -227,7 +227,7 @@ fn create_context() -> Result<SessionContext> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch1], vec![batch2]])?;
-    ctx.register_table("t", Arc::new(provider))?;
+    ctx.register_table("t", Arc::new(provider)).await?;
     Ok(ctx)
 }
 
@@ -401,7 +401,7 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let ctx = create_context()?;
+    let ctx = create_context().await?;
 
     // create the AggregateUDF
     let geometric_mean = AggregateUDF::from(GeoMeanUdaf::new());

--- a/datafusion-examples/examples/advanced_udf.rs
+++ b/datafusion-examples/examples/advanced_udf.rs
@@ -195,7 +195,7 @@ impl ScalarUDFImpl for PowUdf {
 /// and invoke it via the DataFrame API and SQL
 #[tokio::main]
 async fn main() -> Result<()> {
-    let ctx = create_context()?;
+    let ctx = create_context().await?;
 
     // create the UDF
     let pow = ScalarUDF::from(PowUdf::new());
@@ -234,7 +234,7 @@ async fn main() -> Result<()> {
 /// | 5.1 | 4.0 |
 /// +-----+-----+
 /// ```
-fn create_context() -> Result<SessionContext> {
+async fn create_context() -> Result<SessionContext> {
     // define data.
     let a: ArrayRef = Arc::new(Float32Array::from(vec![2.1, 3.1, 4.1, 5.1]));
     let b: ArrayRef = Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0, 4.0]));
@@ -244,6 +244,6 @@ fn create_context() -> Result<SessionContext> {
     let ctx = SessionContext::new();
 
     // declare a table in memory. In Spark API, this corresponds to createDataFrame(...).
-    ctx.register_batch("t", batch)?;
+    ctx.register_batch("t", batch).await?;
     Ok(ctx)
 }

--- a/datafusion-examples/examples/analyzer_rule.rs
+++ b/datafusion-examples/examples/analyzer_rule.rs
@@ -46,7 +46,7 @@ pub async fn main() -> Result<()> {
     let ctx = SessionContext::new();
     ctx.add_analyzer_rule(Arc::clone(&rule) as _);
 
-    ctx.register_batch("employee", employee_batch())?;
+    ctx.register_batch("employee", employee_batch()).await?;
 
     // Now, planning any SQL statement also invokes the AnalyzerRule
     let plan = ctx

--- a/datafusion-examples/examples/custom_file_format.rs
+++ b/datafusion-examples/examples/custom_file_format.rs
@@ -179,7 +179,10 @@ impl GetExt for TSVFileFactory {
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create a new context with the default configuration
-    let mut state = SessionStateBuilder::new().with_default_features().build();
+    let mut state = SessionStateBuilder::new()
+        .with_default_features()
+        .build()
+        .await;
 
     // Register the custom file format
     let file_format = Arc::new(TSVFileFactory::new());
@@ -189,7 +192,7 @@ async fn main() -> Result<()> {
     let ctx = SessionContext::new_with_state(state);
 
     let mem_table = create_mem_table();
-    ctx.register_table("mem_table", mem_table).unwrap();
+    ctx.register_table("mem_table", mem_table).await.unwrap();
 
     let temp_dir = tempdir().unwrap();
     let table_save_path = temp_dir.path().join("mem_table.tsv");

--- a/datafusion-examples/examples/dataframe.rs
+++ b/datafusion-examples/examples/dataframe.rs
@@ -109,7 +109,7 @@ async fn read_csv(ctx: &SessionContext) -> Result<()> {
 
     // You can also create DataFrames from the result of sql queries
     // and using the `enable_url_table` refer to local files directly
-    let dyn_ctx = ctx.clone().enable_url_table();
+    let dyn_ctx = ctx.clone().enable_url_table().await;
     let csv_df = dyn_ctx
         .sql(&format!("SELECT rating, unixtime FROM '{}'", file_path))
         .await?;
@@ -127,7 +127,7 @@ async fn read_memory(ctx: &SessionContext) -> Result<()> {
     let batch = RecordBatch::try_from_iter(vec![("a", a), ("b", b)])?;
 
     // declare a table in memory. In Apache Spark API, this corresponds to createDataFrame(...).
-    ctx.register_batch("t", batch)?;
+    ctx.register_batch("t", batch).await?;
     let df = ctx.table("t").await?;
 
     // construct an expression corresponding to "SELECT a, b FROM t WHERE b = 10" in SQL

--- a/datafusion-examples/examples/external_dependency/query-aws-s3.rs
+++ b/datafusion-examples/examples/external_dependency/query-aws-s3.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
     df.show().await?;
 
     // dynamic query by the file path
-    let ctx = ctx.enable_url_table();
+    let ctx = ctx.enable_url_table().await;
     let df = ctx
         .sql(format!(r#"SELECT * FROM '{}' LIMIT 10"#, &path).as_str())
         .await?;

--- a/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
@@ -55,7 +55,8 @@ async fn main() -> Result<()> {
     let ctx = SessionContext::new();
 
     // Display the data to show the full cycle works.
-    ctx.register_table("external_table", Arc::new(foreign_table_provider))?;
+    ctx.register_table("external_table", Arc::new(foreign_table_provider))
+        .await?;
     let df = ctx.table("external_table").await?;
     df.show().await?;
 

--- a/datafusion-examples/examples/file_stream_provider.rs
+++ b/datafusion-examples/examples/file_stream_provider.rs
@@ -160,7 +160,7 @@ mod non_windows {
         let order = vec![vec![datafusion_expr::col("a1").sort(true, false)]];
 
         let provider = fifo_table(schema.clone(), fifo_path, order.clone());
-        ctx.register_table("fifo", provider)?;
+        ctx.register_table("fifo", provider).await?;
 
         let df = ctx.sql("SELECT * FROM fifo").await.unwrap();
         let mut stream = df.execute_stream().await.unwrap();

--- a/datafusion-examples/examples/flight/flight_sql_server.rs
+++ b/datafusion-examples/examples/flight/flight_sql_server.rs
@@ -170,11 +170,11 @@ impl FlightSqlServiceImpl {
         let mut schemas = vec![];
         let mut names = vec![];
         let mut types = vec![];
-        for catalog in ctx.catalog_names() {
-            let catalog_provider = ctx.catalog(&catalog).unwrap();
-            for schema in catalog_provider.schema_names() {
-                let schema_provider = catalog_provider.schema(&schema).unwrap();
-                for table in schema_provider.table_names() {
+        for catalog in ctx.catalog_names().await {
+            let catalog_provider = ctx.catalog(&catalog).await.unwrap();
+            for schema in catalog_provider.schema_names().await {
+                let schema_provider = catalog_provider.schema(&schema).await.unwrap();
+                for table in schema_provider.table_names().await {
                     let table_provider =
                         schema_provider.table(&table).await.unwrap().unwrap();
                     catalogs.push(catalog.clone());

--- a/datafusion-examples/examples/make_date.rs
+++ b/datafusion-examples/examples/make_date.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
     let ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    ctx.register_batch("t", batch)?;
+    ctx.register_batch("t", batch).await?;
     let df = ctx.table("t").await?;
 
     // use make_date function to convert col 'y', 'm' & 'd' to a date

--- a/datafusion-examples/examples/memtable.rs
+++ b/datafusion-examples/examples/memtable.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     let ctx = SessionContext::new();
 
     // Register the in-memory table containing the data
-    ctx.register_table("users", Arc::new(mem_table))?;
+    ctx.register_table("users", Arc::new(mem_table)).await?;
 
     let dataframe = ctx.sql("SELECT * FROM users;").await?;
 

--- a/datafusion-examples/examples/optimizer_rule.rs
+++ b/datafusion-examples/examples/optimizer_rule.rs
@@ -48,7 +48,7 @@ pub async fn main() -> Result<()> {
     ctx.add_optimizer_rule(Arc::new(MyOptimizerRule {}));
 
     // Now, let's plan and run queries with the new rule
-    ctx.register_batch("person", person_batch())?;
+    ctx.register_batch("person", person_batch()).await?;
     let sql = "SELECT * FROM person WHERE age = 22";
     let plan = ctx.sql(sql).await?.into_optimized_plan()?;
 

--- a/datafusion-examples/examples/parquet_index.rs
+++ b/datafusion-examples/examples/parquet_index.rs
@@ -121,7 +121,8 @@ async fn main() -> Result<()> {
     // Create a SessionContext for running queries that has the table provider
     // registered as "index_table"
     let ctx = SessionContext::new();
-    ctx.register_table("index_table", Arc::clone(&provider) as _)?;
+    ctx.register_table("index_table", Arc::clone(&provider) as _)
+        .await?;
 
     // register object store provider for urls like `file://` work
     let url = Url::try_from("file://").unwrap();

--- a/datafusion-examples/examples/simple_udaf.rs
+++ b/datafusion-examples/examples/simple_udaf.rs
@@ -26,7 +26,7 @@ use datafusion_common::cast::as_float64_array;
 use std::sync::Arc;
 
 // create local session context with an in-memory table
-fn create_context() -> Result<SessionContext> {
+async fn create_context() -> Result<SessionContext> {
     use datafusion::arrow::datatypes::{Field, Schema};
     use datafusion::datasource::MemTable;
     // define a schema.
@@ -47,7 +47,7 @@ fn create_context() -> Result<SessionContext> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch1], vec![batch2]])?;
-    ctx.register_table("t", Arc::new(provider))?;
+    ctx.register_table("t", Arc::new(provider)).await?;
     Ok(ctx)
 }
 
@@ -137,7 +137,7 @@ impl Accumulator for GeometricMean {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let ctx = create_context()?;
+    let ctx = create_context().await?;
 
     // here is where we define the UDAF. We also declare its signature:
     let geometric_mean = create_udaf(

--- a/datafusion-examples/examples/simple_udf.rs
+++ b/datafusion-examples/examples/simple_udf.rs
@@ -42,7 +42,7 @@ use std::sync::Arc;
 /// | 5.1 | 4.0 |
 /// +-----+-----+
 /// ```
-fn create_context() -> Result<SessionContext> {
+async fn create_context() -> Result<SessionContext> {
     // define data.
     let a: ArrayRef = Arc::new(Float32Array::from(vec![2.1, 3.1, 4.1, 5.1]));
     let b: ArrayRef = Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0, 4.0]));
@@ -52,14 +52,14 @@ fn create_context() -> Result<SessionContext> {
     let ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    ctx.register_batch("t", batch)?;
+    ctx.register_batch("t", batch).await?;
     Ok(ctx)
 }
 
 /// In this example we will declare a single-type, single return type UDF that exponentiates f64, a^b
 #[tokio::main]
 async fn main() -> Result<()> {
-    let ctx = create_context()?;
+    let ctx = create_context().await?;
 
     // First, declare the actual implementation of the calculation
     let pow = Arc::new(|args: &[ColumnarValue]| {

--- a/datafusion-examples/examples/simplify_udaf_expression.rs
+++ b/datafusion-examples/examples/simplify_udaf_expression.rs
@@ -108,7 +108,7 @@ impl AggregateUDFImpl for BetterAvgUdaf {
 }
 
 // create local session context with an in-memory table
-fn create_context() -> Result<SessionContext> {
+async fn create_context() -> Result<SessionContext> {
     use datafusion::datasource::MemTable;
     // define a schema.
     let schema = Arc::new(Schema::new(vec![
@@ -136,13 +136,13 @@ fn create_context() -> Result<SessionContext> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch1], vec![batch2]])?;
-    ctx.register_table("t", Arc::new(provider))?;
+    ctx.register_table("t", Arc::new(provider)).await?;
     Ok(ctx)
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let ctx = create_context()?;
+    let ctx = create_context().await?;
 
     let better_avg = AggregateUDF::from(BetterAvgUdaf::new());
     ctx.register_udaf(better_avg.clone());

--- a/datafusion-examples/examples/sql_analysis.rs
+++ b/datafusion-examples/examples/sql_analysis.rs
@@ -275,7 +275,8 @@ from
         ctx.register_table(
             table.name,
             Arc::new(MemTable::try_new(Arc::new(table.schema.clone()), vec![])?),
-        )?;
+        )
+        .await?;
     }
     // We can create a LogicalPlan from a SQL query like this
     let logical_plan = ctx.sql(tpcds_query_88).await?.into_optimized_plan()?;

--- a/datafusion-examples/examples/to_char.rs
+++ b/datafusion-examples/examples/to_char.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
     let ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    ctx.register_batch("t", batch)?;
+    ctx.register_batch("t", batch).await?;
     let _ = ctx.table("t").await?;
 
     // use to_char function to convert col 'values' to timestamp type using

--- a/datafusion-examples/examples/to_date.rs
+++ b/datafusion-examples/examples/to_date.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     let ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    ctx.register_batch("t", batch)?;
+    ctx.register_batch("t", batch).await?;
     let df = ctx.table("t").await?;
 
     // use to_date function to convert col 'a' to timestamp type using the default parsing

--- a/datafusion-examples/examples/to_timestamp.rs
+++ b/datafusion-examples/examples/to_timestamp.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
     let ctx = SessionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    ctx.register_batch("t", batch)?;
+    ctx.register_batch("t", batch).await?;
     let df = ctx.table("t").await?;
 
     // use to_timestamp function to convert col 'a' to timestamp type using the default parsing

--- a/datafusion/catalog/Cargo.toml
+++ b/datafusion/catalog/Cargo.toml
@@ -34,6 +34,7 @@ datafusion-common = { workspace = true }
 datafusion-execution = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-physical-plan = { workspace = true }
+futures = { workspace = true }
 parking_lot = { workspace = true }
 
 [lints]

--- a/datafusion/catalog/src/catalog.rs
+++ b/datafusion/catalog/src/catalog.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 pub use crate::schema::SchemaProvider;
+use async_trait::async_trait;
 use datafusion_common::not_impl_err;
 use datafusion_common::Result;
 
@@ -102,16 +103,17 @@ use datafusion_common::Result;
 ///
 /// [`TableProvider`]: crate::TableProvider
 
+#[async_trait]
 pub trait CatalogProvider: Debug + Sync + Send {
     /// Returns the catalog provider as [`Any`]
     /// so that it can be downcast to a specific implementation.
     fn as_any(&self) -> &dyn Any;
 
     /// Retrieves the list of available schema names in this catalog.
-    fn schema_names(&self) -> Vec<String>;
+    async fn schema_names(&self) -> Vec<String>;
 
     /// Retrieves a specific schema from the catalog by name, provided it exists.
-    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>>;
+    async fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>>;
 
     /// Adds a new schema to this catalog.
     ///
@@ -119,7 +121,7 @@ pub trait CatalogProvider: Debug + Sync + Send {
     /// the catalog and returned.
     ///
     /// By default returns a "Not Implemented" error
-    fn register_schema(
+    async fn register_schema(
         &self,
         name: &str,
         schema: Arc<dyn SchemaProvider>,
@@ -140,7 +142,7 @@ pub trait CatalogProvider: Debug + Sync + Send {
     /// does not exist.
     ///
     /// By default returns a "Not Implemented" error
-    fn deregister_schema(
+    async fn deregister_schema(
         &self,
         _name: &str,
         _cascade: bool,
@@ -153,6 +155,7 @@ pub trait CatalogProvider: Debug + Sync + Send {
 ///
 /// Please see the documentation on `CatalogProvider` for details of
 /// implementing a custom catalog.
+#[async_trait]
 pub trait CatalogProviderList: Debug + Sync + Send {
     /// Returns the catalog list as [`Any`]
     /// so that it can be downcast to a specific implementation.
@@ -160,15 +163,15 @@ pub trait CatalogProviderList: Debug + Sync + Send {
 
     /// Adds a new catalog to this catalog list
     /// If a catalog of the same name existed before, it is replaced in the list and returned.
-    fn register_catalog(
+    async fn register_catalog(
         &self,
         name: String,
         catalog: Arc<dyn CatalogProvider>,
     ) -> Option<Arc<dyn CatalogProvider>>;
 
     /// Retrieves the list of available catalog names
-    fn catalog_names(&self) -> Vec<String>;
+    async fn catalog_names(&self) -> Vec<String>;
 
     /// Retrieves a specific catalog by name, provided it exists.
-    fn catalog(&self, name: &str) -> Option<Arc<dyn CatalogProvider>>;
+    async fn catalog(&self, name: &str) -> Option<Arc<dyn CatalogProvider>>;
 }

--- a/datafusion/catalog/src/catalog.rs
+++ b/datafusion/catalog/src/catalog.rs
@@ -23,6 +23,7 @@ pub use crate::schema::SchemaProvider;
 use async_trait::async_trait;
 use datafusion_common::not_impl_err;
 use datafusion_common::Result;
+use futures::stream::BoxStream;
 
 /// Represents a catalog, comprising a number of named schemas.
 ///
@@ -110,10 +111,10 @@ pub trait CatalogProvider: Debug + Sync + Send {
     fn as_any(&self) -> &dyn Any;
 
     /// Retrieves the list of available schema names in this catalog.
-    async fn schema_names(&self) -> Vec<String>;
+    async fn schema_names(&self) -> BoxStream<'static, Result<String>>;
 
     /// Retrieves a specific schema from the catalog by name, provided it exists.
-    async fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>>;
+    async fn schema(&self, name: &str) -> Result<Option<Arc<dyn SchemaProvider>>>;
 
     /// Adds a new schema to this catalog.
     ///
@@ -167,11 +168,11 @@ pub trait CatalogProviderList: Debug + Sync + Send {
         &self,
         name: String,
         catalog: Arc<dyn CatalogProvider>,
-    ) -> Option<Arc<dyn CatalogProvider>>;
+    ) -> Result<Option<Arc<dyn CatalogProvider>>>;
 
     /// Retrieves the list of available catalog names
-    async fn catalog_names(&self) -> Vec<String>;
+    async fn catalog_names(&self) -> BoxStream<'static, Result<String>>;
 
     /// Retrieves a specific catalog by name, provided it exists.
-    async fn catalog(&self, name: &str) -> Option<Arc<dyn CatalogProvider>>;
+    async fn catalog(&self, name: &str) -> Result<Option<Arc<dyn CatalogProvider>>>;
 }

--- a/datafusion/catalog/src/dynamic_file/catalog.rs
+++ b/datafusion/catalog/src/dynamic_file/catalog.rs
@@ -41,25 +41,26 @@ impl DynamicFileCatalog {
     }
 }
 
+#[async_trait]
 impl CatalogProviderList for DynamicFileCatalog {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
-    fn register_catalog(
+    async fn register_catalog(
         &self,
         name: String,
         catalog: Arc<dyn CatalogProvider>,
     ) -> Option<Arc<dyn CatalogProvider>> {
-        self.inner.register_catalog(name, catalog)
+        self.inner.register_catalog(name, catalog).await
     }
 
-    fn catalog_names(&self) -> Vec<String> {
-        self.inner.catalog_names()
+    async fn catalog_names(&self) -> Vec<String> {
+        self.inner.catalog_names().await
     }
 
-    fn catalog(&self, name: &str) -> Option<Arc<dyn CatalogProvider>> {
-        self.inner.catalog(name).map(|catalog| {
+    async fn catalog(&self, name: &str) -> Option<Arc<dyn CatalogProvider>> {
+        self.inner.catalog(name).await.map(|catalog| {
             Arc::new(DynamicFileCatalogProvider::new(
                 catalog,
                 Arc::clone(&self.factory),
@@ -86,17 +87,18 @@ impl DynamicFileCatalogProvider {
     }
 }
 
+#[async_trait]
 impl CatalogProvider for DynamicFileCatalogProvider {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
-    fn schema_names(&self) -> Vec<String> {
-        self.inner.schema_names()
+    async fn schema_names(&self) -> Vec<String> {
+        self.inner.schema_names().await
     }
 
-    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
-        self.inner.schema(name).map(|schema| {
+    async fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        self.inner.schema(name).await.map(|schema| {
             Arc::new(DynamicFileSchemaProvider::new(
                 schema,
                 Arc::clone(&self.factory),
@@ -104,12 +106,12 @@ impl CatalogProvider for DynamicFileCatalogProvider {
         })
     }
 
-    fn register_schema(
+    async fn register_schema(
         &self,
         name: &str,
         schema: Arc<dyn SchemaProvider>,
     ) -> datafusion_common::Result<Option<Arc<dyn SchemaProvider>>> {
-        self.inner.register_schema(name, schema)
+        self.inner.register_schema(name, schema).await
     }
 }
 
@@ -141,8 +143,8 @@ impl SchemaProvider for DynamicFileSchemaProvider {
         self
     }
 
-    fn table_names(&self) -> Vec<String> {
-        self.inner.table_names()
+    async fn table_names(&self) -> Vec<String> {
+        self.inner.table_names().await
     }
 
     async fn table(
@@ -156,23 +158,23 @@ impl SchemaProvider for DynamicFileSchemaProvider {
         self.factory.try_new(name).await
     }
 
-    fn register_table(
+    async fn register_table(
         &self,
         name: String,
         table: Arc<dyn TableProvider>,
     ) -> datafusion_common::Result<Option<Arc<dyn TableProvider>>> {
-        self.inner.register_table(name, table)
+        self.inner.register_table(name, table).await
     }
 
-    fn deregister_table(
+    async fn deregister_table(
         &self,
         name: &str,
     ) -> datafusion_common::Result<Option<Arc<dyn TableProvider>>> {
-        self.inner.deregister_table(name)
+        self.inner.deregister_table(name).await
     }
 
-    fn table_exist(&self, name: &str) -> bool {
-        self.inner.table_exist(name)
+    async fn table_exist(&self, name: &str) -> bool {
+        self.inner.table_exist(name).await
     }
 }
 

--- a/datafusion/catalog/src/schema.rs
+++ b/datafusion/catalog/src/schema.rs
@@ -36,7 +36,7 @@ use datafusion_common::Result;
 pub trait SchemaProvider: Debug + Sync + Send {
     /// Returns the owner of the Schema, default is None. This value is reported
     /// as part of `information_tables.schemata
-    fn owner_name(&self) -> Option<&str> {
+    async fn owner_name(&self) -> Option<&str> {
         None
     }
 
@@ -45,7 +45,7 @@ pub trait SchemaProvider: Debug + Sync + Send {
     fn as_any(&self) -> &dyn Any;
 
     /// Retrieves the list of available table names in this schema.
-    fn table_names(&self) -> Vec<String>;
+    async fn table_names(&self) -> Vec<String>;
 
     /// Retrieves a specific table from the schema by name, if it exists,
     /// otherwise returns `None`.
@@ -60,7 +60,7 @@ pub trait SchemaProvider: Debug + Sync + Send {
     /// If a table of the same name was already registered, returns "Table
     /// already exists" error.
     #[allow(unused_variables)]
-    fn register_table(
+    async fn register_table(
         &self,
         name: String,
         table: Arc<dyn TableProvider>,
@@ -73,10 +73,13 @@ pub trait SchemaProvider: Debug + Sync + Send {
     ///
     /// If no `name` table exists, returns Ok(None).
     #[allow(unused_variables)]
-    fn deregister_table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
+    async fn deregister_table(
+        &self,
+        name: &str,
+    ) -> Result<Option<Arc<dyn TableProvider>>> {
         exec_err!("schema provider does not support deregistering tables")
     }
 
     /// Returns true if table exist in the schema provider, false otherwise.
-    fn table_exist(&self, name: &str) -> bool;
+    async fn table_exist(&self, name: &str) -> bool;
 }

--- a/datafusion/catalog/src/schema.rs
+++ b/datafusion/catalog/src/schema.rs
@@ -20,6 +20,7 @@
 
 use async_trait::async_trait;
 use datafusion_common::{exec_err, DataFusionError};
+use futures::stream::BoxStream;
 use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -45,7 +46,7 @@ pub trait SchemaProvider: Debug + Sync + Send {
     fn as_any(&self) -> &dyn Any;
 
     /// Retrieves the list of available table names in this schema.
-    async fn table_names(&self) -> Vec<String>;
+    async fn table_names(&self) -> BoxStream<'static, Result<String>>;
 
     /// Retrieves a specific table from the schema by name, if it exists,
     /// otherwise returns `None`.

--- a/datafusion/core/benches/aggregate_query_sql.rs
+++ b/datafusion/core/benches/aggregate_query_sql.rs
@@ -25,6 +25,7 @@ use crate::criterion::Criterion;
 use data_utils::create_table_provider;
 use datafusion::error::Result;
 use datafusion::execution::context::SessionContext;
+use futures::FutureExt;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -42,7 +43,7 @@ fn create_context(
 ) -> Result<Arc<Mutex<SessionContext>>> {
     let ctx = SessionContext::new();
     let provider = create_table_provider(partitions_len, array_len, batch_size)?;
-    ctx.register_table("t", provider)?;
+    ctx.register_table("t", provider).now_or_never().unwrap()?;
     Ok(Arc::new(Mutex::new(ctx)))
 }
 

--- a/datafusion/core/benches/filter_query_sql.rs
+++ b/datafusion/core/benches/filter_query_sql.rs
@@ -23,7 +23,7 @@ use arrow::{
 use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::prelude::SessionContext;
 use datafusion::{datasource::MemTable, error::Result};
-use futures::executor::block_on;
+use futures::{executor::block_on, FutureExt};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
@@ -60,7 +60,9 @@ fn create_context(array_len: usize, batch_size: usize) -> Result<SessionContext>
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![batches])?;
-    ctx.register_table("t", Arc::new(provider))?;
+    ctx.register_table("t", Arc::new(provider))
+        .now_or_never()
+        .unwrap()?;
 
     Ok(ctx)
 }

--- a/datafusion/core/benches/map_query_sql.rs
+++ b/datafusion/core/benches/map_query_sql.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, Int32Array, RecordBatch};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use futures::FutureExt;
 use parking_lot::Mutex;
 use rand::prelude::ThreadRng;
 use rand::Rng;
@@ -55,7 +56,9 @@ fn t_batch(num: i32) -> RecordBatch {
 
 fn create_context(num: i32) -> datafusion_common::Result<Arc<Mutex<SessionContext>>> {
     let ctx = SessionContext::new();
-    ctx.register_batch("t", t_batch(num))?;
+    ctx.register_batch("t", t_batch(num))
+        .now_or_never()
+        .expect("default context should use synchronous in-memory catalog")?;
     Ok(Arc::new(Mutex::new(ctx)))
 }
 

--- a/datafusion/core/benches/math_query_sql.rs
+++ b/datafusion/core/benches/math_query_sql.rs
@@ -19,6 +19,7 @@
 extern crate criterion;
 use criterion::Criterion;
 
+use futures::FutureExt;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -72,7 +73,9 @@ fn create_context(
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![batches])?;
-    ctx.register_table("t", Arc::new(provider))?;
+    ctx.register_table("t", Arc::new(provider))
+        .now_or_never()
+        .expect("default context should use synchronous in-memory catalog")?;
 
     Ok(Arc::new(Mutex::new(ctx)))
 }

--- a/datafusion/core/benches/sort_limit_query_sql.rs
+++ b/datafusion/core/benches/sort_limit_query_sql.rs
@@ -24,6 +24,7 @@ use datafusion::datasource::listing::{
 };
 
 use datafusion::prelude::SessionConfig;
+use futures::FutureExt;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -95,6 +96,8 @@ fn create_context() -> Arc<Mutex<SessionContext>> {
             .await
             .unwrap();
         ctx.register_table("aggregate_test_100", Arc::new(mem_table))
+            .now_or_never()
+            .expect("default context should use synchronous in-memory catalog")
             .unwrap();
         ctx_holder.lock().push(Arc::new(Mutex::new(ctx)))
     });

--- a/datafusion/core/benches/window_query_sql.rs
+++ b/datafusion/core/benches/window_query_sql.rs
@@ -25,6 +25,7 @@ use crate::criterion::Criterion;
 use data_utils::create_table_provider;
 use datafusion::error::Result;
 use datafusion::execution::context::SessionContext;
+use futures::FutureExt;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -42,7 +43,9 @@ fn create_context(
 ) -> Result<Arc<Mutex<SessionContext>>> {
     let ctx = SessionContext::new();
     let provider = create_table_provider(partitions_len, array_len, batch_size)?;
-    ctx.register_table("t", provider)?;
+    ctx.register_table("t", provider)
+        .now_or_never()
+        .expect("default context should use synchronous in-memory catalog")?;
     Ok(Arc::new(Mutex::new(ctx)))
 }
 

--- a/datafusion/core/src/catalog_common/information_schema.rs
+++ b/datafusion/core/src/catalog_common/information_schema.rs
@@ -96,14 +96,14 @@ impl InformationSchemaConfig {
     ) -> Result<(), DataFusionError> {
         // create a mem table with the names of tables
 
-        for catalog_name in self.catalog_list.catalog_names() {
-            let catalog = self.catalog_list.catalog(&catalog_name).unwrap();
+        for catalog_name in self.catalog_list.catalog_names().await {
+            let catalog = self.catalog_list.catalog(&catalog_name).await.unwrap();
 
-            for schema_name in catalog.schema_names() {
+            for schema_name in catalog.schema_names().await {
                 if schema_name != INFORMATION_SCHEMA {
                     // schema name may not exist in the catalog, so we need to check
-                    if let Some(schema) = catalog.schema(&schema_name) {
-                        for table_name in schema.table_names() {
+                    if let Some(schema) = catalog.schema(&schema_name).await {
+                        for table_name in schema.table_names().await {
                             if let Some(table) = schema.table(&table_name).await? {
                                 builder.add_table(
                                     &catalog_name,
@@ -132,13 +132,13 @@ impl InformationSchemaConfig {
     }
 
     async fn make_schemata(&self, builder: &mut InformationSchemataBuilder) {
-        for catalog_name in self.catalog_list.catalog_names() {
-            let catalog = self.catalog_list.catalog(&catalog_name).unwrap();
+        for catalog_name in self.catalog_list.catalog_names().await {
+            let catalog = self.catalog_list.catalog(&catalog_name).await.unwrap();
 
-            for schema_name in catalog.schema_names() {
+            for schema_name in catalog.schema_names().await {
                 if schema_name != INFORMATION_SCHEMA {
-                    if let Some(schema) = catalog.schema(&schema_name) {
-                        let schema_owner = schema.owner_name();
+                    if let Some(schema) = catalog.schema(&schema_name).await {
+                        let schema_owner = schema.owner_name().await;
                         builder.add_schemata(&catalog_name, &schema_name, schema_owner);
                     }
                 }
@@ -150,14 +150,14 @@ impl InformationSchemaConfig {
         &self,
         builder: &mut InformationSchemaViewBuilder,
     ) -> Result<(), DataFusionError> {
-        for catalog_name in self.catalog_list.catalog_names() {
-            let catalog = self.catalog_list.catalog(&catalog_name).unwrap();
+        for catalog_name in self.catalog_list.catalog_names().await {
+            let catalog = self.catalog_list.catalog(&catalog_name).await.unwrap();
 
-            for schema_name in catalog.schema_names() {
+            for schema_name in catalog.schema_names().await {
                 if schema_name != INFORMATION_SCHEMA {
                     // schema name may not exist in the catalog, so we need to check
-                    if let Some(schema) = catalog.schema(&schema_name) {
-                        for table_name in schema.table_names() {
+                    if let Some(schema) = catalog.schema(&schema_name).await {
+                        for table_name in schema.table_names().await {
                             if let Some(table) = schema.table(&table_name).await? {
                                 builder.add_view(
                                     &catalog_name,
@@ -180,14 +180,14 @@ impl InformationSchemaConfig {
         &self,
         builder: &mut InformationSchemaColumnsBuilder,
     ) -> Result<(), DataFusionError> {
-        for catalog_name in self.catalog_list.catalog_names() {
-            let catalog = self.catalog_list.catalog(&catalog_name).unwrap();
+        for catalog_name in self.catalog_list.catalog_names().await {
+            let catalog = self.catalog_list.catalog(&catalog_name).await.unwrap();
 
-            for schema_name in catalog.schema_names() {
+            for schema_name in catalog.schema_names().await {
                 if schema_name != INFORMATION_SCHEMA {
                     // schema name may not exist in the catalog, so we need to check
-                    if let Some(schema) = catalog.schema(&schema_name) {
-                        for table_name in schema.table_names() {
+                    if let Some(schema) = catalog.schema(&schema_name).await {
+                        for table_name in schema.table_names().await {
                             if let Some(table) = schema.table(&table_name).await? {
                                 for (field_position, field) in
                                     table.schema().fields().iter().enumerate()
@@ -469,7 +469,7 @@ impl SchemaProvider for InformationSchemaProvider {
         self
     }
 
-    fn table_names(&self) -> Vec<String> {
+    async fn table_names(&self) -> Vec<String> {
         INFORMATION_SCHEMA_TABLES
             .iter()
             .map(|t| t.to_string())
@@ -497,7 +497,7 @@ impl SchemaProvider for InformationSchemaProvider {
         )))
     }
 
-    fn table_exist(&self, name: &str) -> bool {
+    async fn table_exist(&self, name: &str) -> bool {
         INFORMATION_SCHEMA_TABLES.contains(&name.to_ascii_lowercase().as_str())
     }
 }

--- a/datafusion/core/src/catalog_common/listing_schema.rs
+++ b/datafusion/core/src/catalog_common/listing_schema.rs
@@ -123,7 +123,7 @@ impl ListingSchemaProvider {
                 DataFusionError::Internal("Cannot parse file name!".to_string())
             })?;
 
-            if !self.table_exist(table_name) {
+            if !self.table_exist(table_name).await {
                 let table_url = format!("{}/{}", self.authority, table_path);
 
                 let name = TableReference::bare(table_name);
@@ -148,8 +148,9 @@ impl ListingSchemaProvider {
                         },
                     )
                     .await?;
-                let _ =
-                    self.register_table(table_name.to_string(), Arc::clone(&provider))?;
+                let _ = self
+                    .register_table(table_name.to_string(), Arc::clone(&provider))
+                    .await?;
             }
         }
         Ok(())
@@ -162,7 +163,7 @@ impl SchemaProvider for ListingSchemaProvider {
         self
     }
 
-    fn table_names(&self) -> Vec<String> {
+    async fn table_names(&self) -> Vec<String> {
         self.tables
             .lock()
             .expect("Can't lock tables")
@@ -183,7 +184,7 @@ impl SchemaProvider for ListingSchemaProvider {
             .cloned())
     }
 
-    fn register_table(
+    async fn register_table(
         &self,
         name: String,
         table: Arc<dyn TableProvider>,
@@ -195,14 +196,14 @@ impl SchemaProvider for ListingSchemaProvider {
         Ok(Some(table))
     }
 
-    fn deregister_table(
+    async fn deregister_table(
         &self,
         name: &str,
     ) -> datafusion_common::Result<Option<Arc<dyn TableProvider>>> {
         Ok(self.tables.lock().expect("Can't lock tables").remove(name))
     }
 
-    fn table_exist(&self, name: &str) -> bool {
+    async fn table_exist(&self, name: &str) -> bool {
         self.tables
             .lock()
             .expect("Can't lock tables")

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -2201,7 +2201,7 @@ mod tests {
         let batch = RecordBatch::try_from_iter(vec![("f.c1", Arc::new(array) as _)])?;
 
         let ctx = SessionContext::new();
-        ctx.register_batch("t", batch)?;
+        ctx.register_batch("t", batch).await?;
 
         let df = ctx.table("t").await?.select_columns(&["f.c1"])?;
 
@@ -2302,7 +2302,7 @@ mod tests {
         ])?;
 
         let ctx = SessionContext::new();
-        ctx.register_batch("t", batch)?;
+        ctx.register_batch("t", batch).await?;
 
         let df = ctx.table("t").await?.drop_columns(&["f\"c1"])?;
 
@@ -2334,7 +2334,7 @@ mod tests {
         ])?;
 
         let ctx = SessionContext::new();
-        ctx.register_batch("t", batch)?;
+        ctx.register_batch("t", batch).await?;
 
         let df = ctx.table("t").await?.drop_columns(&["f.c1"])?;
 
@@ -3166,7 +3166,8 @@ mod tests {
         let df_impl = DataFrame::new(ctx.state(), df.plan.clone());
 
         // register a dataframe as a table
-        ctx.register_table("test_table", df_impl.clone().into_view())?;
+        ctx.register_table("test_table", df_impl.clone().into_view())
+            .await?;
 
         // pull the table out
         let table = ctx.table("test_table").await?;
@@ -3347,8 +3348,8 @@ mod tests {
         let ctx = SessionContext::new();
 
         let table = df.into_view();
-        ctx.register_table("t1", table.clone())?;
-        ctx.register_table("t2", table)?;
+        ctx.register_table("t1", table.clone()).await?;
+        ctx.register_table("t2", table).await?;
         let df = ctx
             .table("t1")
             .await?
@@ -3463,8 +3464,8 @@ mod tests {
         let ctx = SessionContext::new();
 
         let table = df.into_view();
-        ctx.register_table("t1", table.clone())?;
-        ctx.register_table("t2", table)?;
+        ctx.register_table("t1", table.clone()).await?;
+        ctx.register_table("t2", table).await?;
 
         let actual_err = ctx
             .table("t1")
@@ -3491,8 +3492,8 @@ mod tests {
         let ctx = SessionContext::new();
 
         let table = df.into_view();
-        ctx.register_table("t1", table.clone())?;
-        ctx.register_table("t2", table)?;
+        ctx.register_table("t1", table.clone()).await?;
+        ctx.register_table("t2", table).await?;
         let df = ctx
             .table("t1")
             .await?
@@ -3659,7 +3660,7 @@ mod tests {
         )?;
 
         let ctx = SessionContext::new();
-        ctx.register_batch("test", data)?;
+        ctx.register_batch("test", data).await?;
 
         let sql = r#"
         SELECT
@@ -3682,7 +3683,7 @@ mod tests {
         let batch = RecordBatch::try_from_iter(vec![("f.c1", Arc::new(array) as _)])?;
 
         let ctx = SessionContext::new();
-        ctx.register_batch("t", batch)?;
+        ctx.register_batch("t", batch).await?;
 
         let df = ctx
             .table("t")

--- a/datafusion/core/src/dataframe/parquet.rs
+++ b/datafusion/core/src/dataframe/parquet.rs
@@ -126,7 +126,8 @@ mod tests {
         )
         .await?;
 
-        ctx.register_table("t1", ctx.table("test").await?.into_view())?;
+        ctx.register_table("t1", ctx.table("test").await?.into_view())
+            .await?;
 
         let df = ctx
             .table("t1")

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -991,7 +991,8 @@ mod tests {
             .with_config(cfg)
             .with_runtime_env(runtime)
             .with_default_features()
-            .build();
+            .build()
+            .await;
         let integration = LocalFileSystem::new_with_prefix(arrow_test_data()).unwrap();
         let path = Path::from("csv/aggregate_test_100.csv");
         let csv = CsvFormat::default().with_has_header(true);

--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -567,7 +567,8 @@ mod tests {
         let (store, state) = make_test_store_and_state(&[
             ("tablepath/mypartition=val1/notparquetfile", 100),
             ("tablepath/file.parquet", 100),
-        ]);
+        ])
+        .await;
         let filter = Expr::eq(col("mypartition"), lit("val1"));
         let pruned = pruned_partition_list(
             &state,
@@ -591,7 +592,8 @@ mod tests {
             ("tablepath/mypartition=val1/file.parquet", 100),
             ("tablepath/mypartition=val2/file.parquet", 100),
             ("tablepath/mypartition=val1/other=val3/file.parquet", 100),
-        ]);
+        ])
+        .await;
         let filter = Expr::eq(col("mypartition"), lit("val1"));
         let pruned = pruned_partition_list(
             &state,
@@ -630,7 +632,8 @@ mod tests {
             ("tablepath/part1=p1v2/part2=p2v1/file2.parquet", 100),
             ("tablepath/part1=p1v3/part2=p2v1/file2.parquet", 100),
             ("tablepath/part1=p1v2/part2=p2v2/file2.parquet", 100),
-        ]);
+        ])
+        .await;
         let filter1 = Expr::eq(col("part1"), lit("p1v2"));
         let filter2 = Expr::eq(col("part2"), lit("p2v1"));
         let pruned = pruned_partition_list(

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1348,7 +1348,7 @@ mod tests {
     async fn read_empty_table() -> Result<()> {
         let ctx = SessionContext::new();
         let path = String::from("table/p1=v1/file.avro");
-        register_test_store(&ctx, &[(&path, 100)]);
+        register_test_store(&ctx, &[(&path, 100)]).await;
 
         let opt = ListingOptions::new(Arc::new(AvroFormat {}))
             .with_file_extension(AvroFormat.get_ext())
@@ -1592,7 +1592,8 @@ mod tests {
         file_ext: Option<&str>,
     ) -> Result<()> {
         let ctx = SessionContext::new();
-        register_test_store(&ctx, &files.iter().map(|f| (*f, 10)).collect::<Vec<_>>());
+        register_test_store(&ctx, &files.iter().map(|f| (*f, 10)).collect::<Vec<_>>())
+            .await;
 
         let format = AvroFormat {};
 
@@ -1626,7 +1627,8 @@ mod tests {
         file_ext: Option<&str>,
     ) -> Result<()> {
         let ctx = SessionContext::new();
-        register_test_store(&ctx, &files.iter().map(|f| (*f, 10)).collect::<Vec<_>>());
+        register_test_store(&ctx, &files.iter().map(|f| (*f, 10)).collect::<Vec<_>>())
+            .await;
 
         let format = AvroFormat {};
 
@@ -2028,7 +2030,9 @@ mod tests {
             schema.clone(),
             vec![vec![batch.clone(), batch.clone()]],
         )?);
-        session_ctx.register_table("source", source_table.clone())?;
+        session_ctx
+            .register_table("source", source_table.clone())
+            .await?;
         // Convert the source table into a provider so that it can be used in a query
         let source = provider_as_source(source_table);
         // Create a table scan logical plan to read from the source table

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -629,10 +629,14 @@ mod tests {
         let session_ctx = SessionContext::new();
         // Create and register the initial table with the provided schema and data
         let initial_table = Arc::new(MemTable::try_new(schema.clone(), initial_data)?);
-        session_ctx.register_table("t", initial_table.clone())?;
+        session_ctx
+            .register_table("t", initial_table.clone())
+            .await?;
         // Create and register the source table with the provided schema and inserted data
         let source_table = Arc::new(MemTable::try_new(schema.clone(), inserted_data)?);
-        session_ctx.register_table("source", source_table.clone())?;
+        session_ctx
+            .register_table("source", source_table.clone())
+            .await?;
         // Convert the source table into a provider so that it can be used in a query
         let source = provider_as_source(source_table);
         // Create a table scan logical plan to read from the source table

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -636,7 +636,7 @@ mod tests {
                 .map(|(name, size)| (name.as_str(), *size))
                 .collect();
 
-            register_test_store(&ctx, &mock_files_ref);
+            register_test_store(&ctx, &mock_files_ref).await;
 
             let file_group = mock_files
                 .into_iter()

--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -461,7 +461,8 @@ mod tests {
         )
         .await?;
 
-        ctx.register_table("t1", ctx.table("test").await?.into_view())?;
+        ctx.register_table("t1", ctx.table("test").await?.into_view())
+            .await?;
 
         ctx.sql("CREATE VIEW t2 as SELECT * FROM t1").await?;
 
@@ -492,7 +493,8 @@ mod tests {
         )
         .await?;
 
-        ctx.register_table("t1", ctx.table("test").await?.into_view())?;
+        ctx.register_table("t1", ctx.table("test").await?.into_view())
+            .await?;
 
         ctx.sql("CREATE VIEW t2 as SELECT * FROM t1").await?;
 

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -308,7 +308,7 @@ impl SessionState {
         table_ref: impl Into<TableReference>,
     ) -> BoxFuture<'static, datafusion_common::Result<Arc<dyn SchemaProvider>>> {
         let resolved_ref = self.resolve_table_ref(table_ref);
-        let catalog_list = self.catalog_list.clone();
+        let catalog_list = Arc::clone(&self.catalog_list);
         if self.config.information_schema() && *resolved_ref.schema == *INFORMATION_SCHEMA
         {
             return std::future::ready(Ok(Arc::new(InformationSchemaProvider::new(

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -323,7 +323,7 @@ impl SessionState {
         async move {
             catalog_list
                 .catalog(&resolved_ref.catalog)
-                .await
+                .await?
                 .ok_or_else(|| {
                     plan_datafusion_err!(
                         "failed to resolve catalog: {}",
@@ -331,7 +331,7 @@ impl SessionState {
                     )
                 })?
                 .schema(&resolved_ref.schema)
-                .await
+                .await?
                 .ok_or_else(|| {
                     plan_datafusion_err!(
                         "failed to resolve schema: {}",
@@ -1042,6 +1042,7 @@ impl SessionStateBuilder {
             .catalog_list()
             .catalog(&existing.config.options().catalog.default_catalog)
             .await
+            .unwrap()
             .is_some();
         // The new `with_create_default_catalog_and_schema` should be false if the default catalog exists
         let create_default_catalog_and_schema = existing
@@ -1452,7 +1453,8 @@ impl SessionStateBuilder {
                     state.config.options().catalog.default_catalog.clone(),
                     Arc::new(default_catalog),
                 )
-                .await;
+                .await
+                .unwrap();
         }
 
         if let Some(analyzer_rules) = analyzer_rules {
@@ -2062,8 +2064,10 @@ mod tests {
             .catalog(default_catalog.as_str())
             .await
             .unwrap()
+            .unwrap()
             .schema(default_schema.as_str())
             .await
+            .unwrap()
             .unwrap()
             .table_exist("employee")
             .await;
@@ -2078,8 +2082,10 @@ mod tests {
                 .catalog(default_catalog.as_str())
                 .await
                 .unwrap()
+                .unwrap()
                 .schema(default_schema.as_str())
                 .await
+                .unwrap()
                 .unwrap()
                 .table_exist("employee")
                 .await
@@ -2096,6 +2102,7 @@ mod tests {
             .catalog_list()
             .catalog(&default_catalog)
             .await
+            .unwrap()
             .is_none());
         let new_state = SessionStateBuilder::new_from_existing(without_default_state)
             .await
@@ -2105,6 +2112,7 @@ mod tests {
             .catalog_list()
             .catalog(&default_catalog)
             .await
+            .unwrap()
             .is_none());
         Ok(())
     }

--- a/datafusion/core/src/execution/session_state_defaults.rs
+++ b/datafusion/core/src/execution/session_state_defaults.rs
@@ -35,6 +35,7 @@ use datafusion_execution::object_store::ObjectStoreUrl;
 use datafusion_execution::runtime_env::RuntimeEnv;
 use datafusion_expr::planner::ExprPlanner;
 use datafusion_expr::{AggregateUDF, ScalarUDF, WindowUDF};
+use futures::FutureExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use url::Url;
@@ -72,6 +73,8 @@ impl SessionStateDefaults {
                 &config.options().catalog.default_schema,
                 Arc::new(MemorySchemaProvider::new()),
             )
+            .now_or_never()
+            .expect("memory catalog provider is synchronous")
             .expect("memory catalog provider can register schema");
 
         Self::register_default_schema(config, table_factories, runtime, &default_catalog);
@@ -202,6 +205,8 @@ impl SessionStateDefaults {
         );
         let _ = default_catalog
             .register_schema("default", Arc::new(schema))
+            .now_or_never()
+            .expect("memory catalog provider is synchronous")
             .expect("Failed to register default schema");
     }
 

--- a/datafusion/core/src/physical_optimizer/test_utils.rs
+++ b/datafusion/core/src/physical_optimizer/test_utils.rs
@@ -71,7 +71,8 @@ async fn register_current_csv(
         true => {
             let source = FileStreamProvider::new_file(schema, path.into());
             let config = StreamConfig::new(Arc::new(source));
-            ctx.register_table(table_name, Arc::new(StreamTable::new(Arc::new(config))))?;
+            ctx.register_table(table_name, Arc::new(StreamTable::new(Arc::new(config))))
+                .await?;
         }
         false => {
             ctx.register_csv(table_name, &path, CsvReadOptions::new().schema(&schema))

--- a/datafusion/core/src/test/object_store.rs
+++ b/datafusion/core/src/test/object_store.rs
@@ -26,13 +26,15 @@ use std::sync::Arc;
 use url::Url;
 
 /// Returns a test object store with the provided `ctx`
-pub fn register_test_store(ctx: &SessionContext, files: &[(&str, u64)]) {
+pub async fn register_test_store(ctx: &SessionContext, files: &[(&str, u64)]) {
     let url = Url::parse("test://").unwrap();
-    ctx.register_object_store(&url, make_test_store_and_state(files).0);
+    ctx.register_object_store(&url, make_test_store_and_state(files).await.0);
 }
 
 /// Create a test object store with the provided files
-pub fn make_test_store_and_state(files: &[(&str, u64)]) -> (Arc<InMemory>, SessionState) {
+pub async fn make_test_store_and_state(
+    files: &[(&str, u64)],
+) -> (Arc<InMemory>, SessionState) {
     let memory = InMemory::new();
 
     for (name, size) in files {
@@ -45,7 +47,10 @@ pub fn make_test_store_and_state(files: &[(&str, u64)]) -> (Arc<InMemory>, Sessi
 
     (
         Arc::new(memory),
-        SessionStateBuilder::new().with_default_features().build(),
+        SessionStateBuilder::new()
+            .with_default_features()
+            .build()
+            .await,
     )
 }
 

--- a/datafusion/core/src/test_util/mod.rs
+++ b/datafusion/core/src/test_util/mod.rs
@@ -357,7 +357,7 @@ impl RecordBatchStream for UnboundedStream {
 }
 
 /// This function creates an unbounded sorted file for testing purposes.
-pub fn register_unbounded_file_with_ordering(
+pub async fn register_unbounded_file_with_ordering(
     ctx: &SessionContext,
     schema: SchemaRef,
     file_path: &Path,
@@ -368,7 +368,8 @@ pub fn register_unbounded_file_with_ordering(
     let config = StreamConfig::new(Arc::new(source)).with_order(file_sort_order);
 
     // Register table:
-    ctx.register_table(table_name, Arc::new(StreamTable::new(Arc::new(config))))?;
+    ctx.register_table(table_name, Arc::new(StreamTable::new(Arc::new(config))))
+        .await?;
     Ok(())
 }
 

--- a/datafusion/core/tests/custom_sources_cases/mod.rs
+++ b/datafusion/core/tests/custom_sources_cases/mod.rs
@@ -268,6 +268,7 @@ async fn custom_source_dataframe() -> Result<()> {
 async fn optimizers_catch_all_statistics() {
     let ctx = SessionContext::new();
     ctx.register_table("test", Arc::new(CustomTableProvider))
+        .await
         .unwrap();
 
     let df = ctx

--- a/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
@@ -245,7 +245,7 @@ async fn assert_provider_row_count(value: i64, expected_count: i64) -> Result<()
     let result_col: &Int64Array = as_primitive_array(results[0].column(0))?;
     assert_eq!(result_col.value(0), expected_count);
 
-    ctx.register_table("data", Arc::new(provider))?;
+    ctx.register_table("data", Arc::new(provider)).await?;
     let sql_results = ctx
         .sql(&format!("select count(*) from data where flag = {value}"))
         .await?

--- a/datafusion/core/tests/dataframe/dataframe_functions.rs
+++ b/datafusion/core/tests/dataframe/dataframe_functions.rs
@@ -69,7 +69,7 @@ async fn create_test_table() -> Result<DataFrame> {
 
     let ctx = SessionContext::new();
 
-    ctx.register_batch("test", batch)?;
+    ctx.register_batch("test", batch).await?;
 
     ctx.table("test").await
 }

--- a/datafusion/core/tests/execution/logical_plan.rs
+++ b/datafusion/core/tests/execution/logical_plan.rs
@@ -68,7 +68,7 @@ async fn count_only_nulls() -> Result<()> {
     )?);
 
     // Execute and verify results
-    let session_state = SessionStateBuilder::new().build();
+    let session_state = SessionStateBuilder::new().build().await;
     let physical_plan = session_state.create_physical_plan(&aggregate).await?;
     let result =
         collect(physical_plan, Arc::new(TaskContext::from(&session_state))).await?;

--- a/datafusion/core/tests/fifo/mod.rs
+++ b/datafusion/core/tests/fifo/mod.rs
@@ -189,7 +189,7 @@ mod unix_test {
         ]));
 
         let provider = fifo_table(schema, fifo_path, vec![]);
-        ctx.register_table("left", provider).unwrap();
+        ctx.register_table("left", provider).await.unwrap();
 
         // Register right table
         let schema = aggr_test_schema();
@@ -251,10 +251,10 @@ mod unix_test {
 
         // Set unbounded sorted files read configuration
         let provider = fifo_table(schema.clone(), left_fifo.clone(), order.clone());
-        ctx.register_table("left", provider)?;
+        ctx.register_table("left", provider).await?;
 
         let provider = fifo_table(schema.clone(), right_fifo.clone(), order);
-        ctx.register_table("right", provider)?;
+        ctx.register_table("right", provider).await?;
 
         // Execute the query, with no matching rows. (since key is modulus 10)
         let df = ctx

--- a/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
@@ -508,7 +508,7 @@ async fn group_by_string_test(
         provider
     };
 
-    ctx.register_table("t", Arc::new(provider)).unwrap();
+    ctx.register_table("t", Arc::new(provider)).await.unwrap();
 
     let df = ctx
         .sql("SELECT a, COUNT(*) FROM t GROUP BY a")

--- a/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/fuzzer.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/fuzzer.rs
@@ -233,6 +233,7 @@ impl AggregationFuzzer {
             // Generate the baseline context, and get the baseline result firstly
             let baseline_ctx_with_params = ctx_generator
                 .generate_baseline()
+                .await
                 .expect("should success to generate baseline session context");
             let baseline_result = run_sql(&sql, &baseline_ctx_with_params.ctx)
                 .await
@@ -242,6 +243,7 @@ impl AggregationFuzzer {
             for _ in 0..CTX_GEN_ROUNDS {
                 let ctx_with_params = ctx_generator
                     .generate()
+                    .await
                     .expect("should success to generate session context");
                 let task = AggregationFuzzTestTask {
                     dataset_ref: dataset_ref.clone(),

--- a/datafusion/core/tests/fuzz_cases/distinct_count_string_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/distinct_count_string_fuzz.rs
@@ -59,7 +59,7 @@ async fn run_distinct_count_test(mut generator: StringBatchGenerator) {
     ];
 
     let provider = MemTable::try_new(schema, partitions).unwrap();
-    ctx.register_table("t", Arc::new(provider)).unwrap();
+    ctx.register_table("t", Arc::new(provider)).await.unwrap();
     // input has two columns, a and b.  The result is the number of distinct
     // values in each column.
     //

--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -534,8 +534,10 @@ impl TestCase {
             None => builder,
         };
 
-        let ctx = SessionContext::new_with_state(builder.build());
-        ctx.register_table("t", table).expect("registering table");
+        let ctx = SessionContext::new_with_state(builder.build().await);
+        ctx.register_table("t", table)
+            .await
+            .expect("registering table");
 
         let query = query.expect("Test error: query not specified");
         let df = ctx.sql(&query).await.expect("Planning query");

--- a/datafusion/core/tests/parquet/file_statistics.rs
+++ b/datafusion/core/tests/parquet/file_statistics.rs
@@ -188,7 +188,10 @@ async fn get_listing_table(
 ) -> ListingTable {
     let schema = opt
         .infer_schema(
-            &SessionStateBuilder::new().with_default_features().build(),
+            &SessionStateBuilder::new()
+                .with_default_features()
+                .build()
+                .await,
             table_path,
         )
         .await

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -210,8 +210,8 @@ impl ContextWithParquet {
         ctx.register_parquet("t", &parquet_path, ParquetReadOptions::default())
             .await
             .unwrap();
-        let provider = ctx.deregister_table("t").unwrap().unwrap();
-        ctx.register_table("t", provider.clone()).unwrap();
+        let provider = ctx.deregister_table("t").await.unwrap().unwrap();
+        ctx.register_table("t", provider.clone()).await.unwrap();
 
         Self {
             _file: file,

--- a/datafusion/core/tests/sql/create_drop.rs
+++ b/datafusion/core/tests/sql/create_drop.rs
@@ -22,7 +22,10 @@ use super::*;
 
 #[tokio::test]
 async fn create_custom_table() -> Result<()> {
-    let mut state = SessionStateBuilder::new().with_default_features().build();
+    let mut state = SessionStateBuilder::new()
+        .with_default_features()
+        .build()
+        .await;
     state
         .table_factories_mut()
         .insert("DELTATABLE".to_string(), Arc::new(TestTableFactory {}));
@@ -31,9 +34,9 @@ async fn create_custom_table() -> Result<()> {
     let sql = "CREATE EXTERNAL TABLE dt STORED AS DELTATABLE LOCATION 's3://bucket/schema/table';";
     ctx.sql(sql).await.unwrap();
 
-    let cat = ctx.catalog("datafusion").unwrap();
-    let schema = cat.schema("public").unwrap();
-    let exists = schema.table_exist("dt");
+    let cat = ctx.catalog("datafusion").await.unwrap();
+    let schema = cat.schema("public").await.unwrap();
+    let exists = schema.table_exist("dt").await;
     assert!(exists, "Table should have been created!");
 
     Ok(())
@@ -41,7 +44,10 @@ async fn create_custom_table() -> Result<()> {
 
 #[tokio::test]
 async fn create_external_table_with_ddl() -> Result<()> {
-    let mut state = SessionStateBuilder::new().with_default_features().build();
+    let mut state = SessionStateBuilder::new()
+        .with_default_features()
+        .build()
+        .await;
     state
         .table_factories_mut()
         .insert("MOCKTABLE".to_string(), Arc::new(TestTableFactory {}));
@@ -50,10 +56,10 @@ async fn create_external_table_with_ddl() -> Result<()> {
     let sql = "CREATE EXTERNAL TABLE dt (a_id integer, a_str string, a_bool boolean) STORED AS MOCKTABLE LOCATION 'mockprotocol://path/to/table';";
     ctx.sql(sql).await.unwrap();
 
-    let cat = ctx.catalog("datafusion").unwrap();
-    let schema = cat.schema("public").unwrap();
+    let cat = ctx.catalog("datafusion").await.unwrap();
+    let schema = cat.schema("public").await.unwrap();
 
-    let exists = schema.table_exist("dt");
+    let exists = schema.table_exist("dt").await;
     assert!(exists, "Table should have been created!");
 
     let table_schema = schema.table("dt").await.unwrap().unwrap().schema();

--- a/datafusion/core/tests/sql/create_drop.rs
+++ b/datafusion/core/tests/sql/create_drop.rs
@@ -34,8 +34,8 @@ async fn create_custom_table() -> Result<()> {
     let sql = "CREATE EXTERNAL TABLE dt STORED AS DELTATABLE LOCATION 's3://bucket/schema/table';";
     ctx.sql(sql).await.unwrap();
 
-    let cat = ctx.catalog("datafusion").await.unwrap();
-    let schema = cat.schema("public").await.unwrap();
+    let cat = ctx.catalog("datafusion").await.unwrap().unwrap();
+    let schema = cat.schema("public").await.unwrap().unwrap();
     let exists = schema.table_exist("dt").await;
     assert!(exists, "Table should have been created!");
 
@@ -56,8 +56,8 @@ async fn create_external_table_with_ddl() -> Result<()> {
     let sql = "CREATE EXTERNAL TABLE dt (a_id integer, a_str string, a_bool boolean) STORED AS MOCKTABLE LOCATION 'mockprotocol://path/to/table';";
     ctx.sql(sql).await.unwrap();
 
-    let cat = ctx.catalog("datafusion").await.unwrap();
-    let schema = cat.schema("public").await.unwrap();
+    let cat = ctx.catalog("datafusion").await.unwrap().unwrap();
+    let schema = cat.schema("public").await.unwrap().unwrap();
 
     let exists = schema.table_exist("dt").await;
     assert!(exists, "Table should have been created!");

--- a/datafusion/core/tests/sql/joins.rs
+++ b/datafusion/core/tests/sql/joins.rs
@@ -47,7 +47,8 @@ async fn join_change_in_planner() -> Result<()> {
         &left_file_path,
         "left",
         file_sort_order.clone(),
-    )?;
+    )
+    .await?;
     let right_file_path = tmp_dir.path().join("right.csv");
     File::create(right_file_path.clone()).unwrap();
     register_unbounded_file_with_ordering(
@@ -56,7 +57,8 @@ async fn join_change_in_planner() -> Result<()> {
         &right_file_path,
         "right",
         file_sort_order,
-    )?;
+    )
+    .await?;
     let sql = "SELECT t1.a1, t1.a2, t2.a1, t2.a2 FROM left as t1 FULL JOIN right as t2 ON t1.a2 = t2.a2 AND t1.a1 > t2.a1 + 3 AND t1.a1 < t2.a1 + 10";
     let dataframe = ctx.sql(sql).await?;
     let physical_plan = dataframe.create_physical_plan().await?;
@@ -115,7 +117,8 @@ async fn join_no_order_on_filter() -> Result<()> {
         &left_file_path,
         "left",
         file_sort_order.clone(),
-    )?;
+    )
+    .await?;
     let right_file_path = tmp_dir.path().join("right.csv");
     File::create(right_file_path.clone()).unwrap();
     register_unbounded_file_with_ordering(
@@ -124,7 +127,8 @@ async fn join_no_order_on_filter() -> Result<()> {
         &right_file_path,
         "right",
         file_sort_order,
-    )?;
+    )
+    .await?;
     let sql = "SELECT * FROM left as t1 FULL JOIN right as t2 ON t1.a2 = t2.a2 AND t1.a3 > t2.a3 + 3 AND t1.a3 < t2.a3 + 10";
     let dataframe = ctx.sql(sql).await?;
     let physical_plan = dataframe.create_physical_plan().await?;
@@ -168,13 +172,15 @@ async fn join_change_in_planner_without_sort() -> Result<()> {
     ]));
     let left_source = FileStreamProvider::new_file(schema.clone(), left_file_path);
     let left = StreamConfig::new(Arc::new(left_source));
-    ctx.register_table("left", Arc::new(StreamTable::new(Arc::new(left))))?;
+    ctx.register_table("left", Arc::new(StreamTable::new(Arc::new(left))))
+        .await?;
 
     let right_file_path = tmp_dir.path().join("right.csv");
     File::create(right_file_path.clone())?;
     let right_source = FileStreamProvider::new_file(schema, right_file_path);
     let right = StreamConfig::new(Arc::new(right_source));
-    ctx.register_table("right", Arc::new(StreamTable::new(Arc::new(right))))?;
+    ctx.register_table("right", Arc::new(StreamTable::new(Arc::new(right))))
+        .await?;
     let sql = "SELECT t1.a1, t1.a2, t2.a1, t2.a2 FROM left as t1 FULL JOIN right as t2 ON t1.a2 = t2.a2 AND t1.a1 > t2.a1 + 3 AND t1.a1 < t2.a1 + 10";
     let dataframe = ctx.sql(sql).await?;
     let physical_plan = dataframe.create_physical_plan().await?;
@@ -220,12 +226,14 @@ async fn join_change_in_planner_without_sort_not_allowed() -> Result<()> {
     ]));
     let left_source = FileStreamProvider::new_file(schema.clone(), left_file_path);
     let left = StreamConfig::new(Arc::new(left_source));
-    ctx.register_table("left", Arc::new(StreamTable::new(Arc::new(left))))?;
+    ctx.register_table("left", Arc::new(StreamTable::new(Arc::new(left))))
+        .await?;
     let right_file_path = tmp_dir.path().join("right.csv");
     File::create(right_file_path.clone())?;
     let right_source = FileStreamProvider::new_file(schema.clone(), right_file_path);
     let right = StreamConfig::new(Arc::new(right_source));
-    ctx.register_table("right", Arc::new(StreamTable::new(Arc::new(right))))?;
+    ctx.register_table("right", Arc::new(StreamTable::new(Arc::new(right))))
+        .await?;
     let df = ctx.sql("SELECT t1.a1, t1.a2, t2.a1, t2.a2 FROM left as t1 FULL JOIN right as t2 ON t1.a2 = t2.a2 AND t1.a1 > t2.a1 + 3 AND t1.a1 < t2.a1 + 10").await?;
     match df.create_physical_plan().await {
         Ok(_) => panic!("Expecting error."),

--- a/datafusion/core/tests/sql/path_partition.rs
+++ b/datafusion/core/tests/sql/path_partition.rs
@@ -264,7 +264,8 @@ async fn csv_filter_with_file_col() -> Result<()> {
         ],
         &[("date", DataType::Utf8)],
         "mirror:///mytable/",
-    );
+    )
+    .await;
 
     let result = ctx
         .sql("SELECT c1, c2 FROM t WHERE date='2021-10-27' and c1!='2021-10-27' LIMIT 5")
@@ -302,7 +303,8 @@ async fn csv_filter_with_file_nonstring_col() -> Result<()> {
         ],
         &[("date", DataType::Date32)],
         "mirror:///mytable/",
-    );
+    )
+    .await;
 
     let result = ctx
         .sql("SELECT c1, c2, date FROM t WHERE date > '2021-10-27' LIMIT 5")
@@ -340,7 +342,8 @@ async fn csv_projection_on_partition() -> Result<()> {
         ],
         &[("date", DataType::Date32)],
         "mirror:///mytable/",
-    );
+    )
+    .await;
 
     let result = ctx
         .sql("SELECT c1, date FROM t WHERE date='2021-10-27' LIMIT 5")
@@ -379,7 +382,8 @@ async fn csv_grouping_by_partition() -> Result<()> {
         ],
         &[("date", DataType::Date32)],
         "mirror:///mytable/",
-    );
+    )
+    .await;
 
     let result = ctx
         .sql("SELECT date, count(*), count(distinct(c1)) FROM t WHERE date<='2021-10-27' GROUP BY date")
@@ -573,7 +577,7 @@ async fn parquet_overlapping_columns() -> Result<()> {
     Ok(())
 }
 
-fn register_partitioned_aggregate_csv(
+async fn register_partitioned_aggregate_csv(
     ctx: &SessionContext,
     store_paths: &[&str],
     partition_cols: &[(&str, DataType)],
@@ -603,6 +607,7 @@ fn register_partitioned_aggregate_csv(
     let table = ListingTable::try_new(config).unwrap();
 
     ctx.register_table("t", Arc::new(table))
+        .await
         .expect("registering listing table failed");
 }
 
@@ -622,6 +627,7 @@ async fn register_partitioned_alltypes_parquet(
     )
     .await;
     ctx.register_table("t", table)
+        .await
         .expect("registering listing table failed");
 }
 

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -154,7 +154,7 @@ async fn prepared_statement_type_coercion() -> Result<()> {
         ("signed", Arc::new(signed_ints) as ArrayRef),
         ("unsigned", Arc::new(unsigned_ints) as ArrayRef),
     ])?;
-    ctx.register_batch("test", batch)?;
+    ctx.register_batch("test", batch).await?;
     let results = ctx.sql("SELECT signed, unsigned FROM test WHERE $1 >= signed AND signed <= $2 AND unsigned = $3")
         .await?
         .with_param_values(vec![
@@ -184,7 +184,7 @@ async fn test_parameter_type_coercion() -> Result<()> {
         ("signed", Arc::new(signed_ints) as ArrayRef),
         ("unsigned", Arc::new(unsigned_ints) as ArrayRef),
     ])?;
-    ctx.register_batch("test", batch)?;
+    ctx.register_batch("test", batch).await?;
     let results = ctx.sql("SELECT signed, unsigned FROM test WHERE $foo >= signed AND signed <= $bar AND unsigned <= $baz AND unsigned = $str")
         .await?
         .with_param_values(vec![
@@ -215,7 +215,7 @@ async fn test_parameter_invalid_types() -> Result<()> {
     ])]);
     let batch =
         RecordBatch::try_from_iter(vec![("list", Arc::new(list_array) as ArrayRef)])?;
-    ctx.register_batch("test", batch)?;
+    ctx.register_batch("test", batch).await?;
     let results = ctx
         .sql("SELECT list FROM test WHERE list = $1")
         .await?

--- a/datafusion/core/tests/tpcds_planning.rs
+++ b/datafusion/core/tests/tpcds_planning.rs
@@ -1040,7 +1040,8 @@ async fn regression_test(query_no: u8, create_physical: bool) -> Result<()> {
                 Arc::new(table.schema.clone()),
                 vec![vec![]],
             )?),
-        )?;
+        )
+        .await?;
     }
 
     // some queries have multiple statements

--- a/datafusion/core/tests/user_defined/insert_operation.rs
+++ b/datafusion/core/tests/user_defined/insert_operation.rs
@@ -34,6 +34,7 @@ async fn insert_operation_is_passed_correctly_to_table_provider() {
     let ctx = session_ctx_with_dialect("SQLite");
     let table_provider = Arc::new(TestInsertTableProvider::new());
     ctx.register_table("testing", table_provider.clone())
+        .await
         .unwrap();
 
     let sql = "INSERT INTO testing (column) VALUES (1)";

--- a/datafusion/core/tests/user_defined/user_defined_window_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_window_functions.rs
@@ -63,7 +63,7 @@ const BOUNDED_WINDOW_QUERY:  &str  =
 #[tokio::test]
 async fn test_setup() {
     let test_state = TestState::new();
-    let TestContext { ctx, test_state: _ } = TestContext::new(test_state);
+    let TestContext { ctx, test_state: _ } = TestContext::new(test_state).await;
 
     let sql = "SELECT * from t order by x, y";
     let expected = vec![
@@ -89,7 +89,7 @@ async fn test_setup() {
 #[tokio::test]
 async fn test_udwf() {
     let test_state = TestState::new();
-    let TestContext { ctx, test_state } = TestContext::new(test_state);
+    let TestContext { ctx, test_state } = TestContext::new(test_state).await;
 
     let expected = vec![
     "+---+---+-----+-----------------------------------------------------------------------------------------------------------------------+",
@@ -133,7 +133,7 @@ async fn test_deregister_udwf() -> Result<()> {
 #[tokio::test]
 async fn test_udwf_with_alias() {
     let test_state = TestState::new();
-    let TestContext { ctx, .. } = TestContext::new(test_state);
+    let TestContext { ctx, .. } = TestContext::new(test_state).await;
 
     let expected = vec![
         "+---+---+-----+-----------------------------------------------------------------------------------------------------------------------+",
@@ -163,7 +163,7 @@ async fn test_udwf_with_alias() {
 #[tokio::test]
 async fn test_udwf_bounded_window_ignores_frame() {
     let test_state = TestState::new();
-    let TestContext { ctx, test_state } = TestContext::new(test_state);
+    let TestContext { ctx, test_state } = TestContext::new(test_state).await;
 
     // Since the UDWF doesn't say it needs the window frame, the frame is ignored
     let expected = vec![
@@ -195,7 +195,7 @@ async fn test_udwf_bounded_window_ignores_frame() {
 #[tokio::test]
 async fn test_udwf_bounded_window() {
     let test_state = TestState::new().with_uses_window_frame();
-    let TestContext { ctx, test_state } = TestContext::new(test_state);
+    let TestContext { ctx, test_state } = TestContext::new(test_state).await;
 
     let expected = vec![
     "+---+---+-----+--------------------------------------------------------------------------------------------------------------+",
@@ -228,7 +228,7 @@ async fn test_stateful_udwf() {
     let test_state = TestState::new()
         .with_supports_bounded_execution()
         .with_uses_window_frame();
-    let TestContext { ctx, test_state } = TestContext::new(test_state);
+    let TestContext { ctx, test_state } = TestContext::new(test_state).await;
 
     let expected = vec![
     "+---+---+-----+-----------------------------------------------------------------------------------------------------------------------+",
@@ -260,7 +260,7 @@ async fn test_stateful_udwf_bounded_window() {
     let test_state = TestState::new()
         .with_supports_bounded_execution()
         .with_uses_window_frame();
-    let TestContext { ctx, test_state } = TestContext::new(test_state);
+    let TestContext { ctx, test_state } = TestContext::new(test_state).await;
 
     let expected = vec![
     "+---+---+-----+--------------------------------------------------------------------------------------------------------------+",
@@ -291,7 +291,7 @@ async fn test_stateful_udwf_bounded_window() {
 #[tokio::test]
 async fn test_udwf_query_include_rank() {
     let test_state = TestState::new().with_include_rank();
-    let TestContext { ctx, test_state } = TestContext::new(test_state);
+    let TestContext { ctx, test_state } = TestContext::new(test_state).await;
 
     let expected = vec![
     "+---+---+-----+-----------------------------------------------------------------------------------------------------------------------+",
@@ -323,7 +323,7 @@ async fn test_udwf_query_include_rank() {
 #[tokio::test]
 async fn test_udwf_bounded_query_include_rank() {
     let test_state = TestState::new().with_include_rank();
-    let TestContext { ctx, test_state } = TestContext::new(test_state);
+    let TestContext { ctx, test_state } = TestContext::new(test_state).await;
 
     let expected = vec![
     "+---+---+-----+--------------------------------------------------------------------------------------------------------------+",
@@ -357,7 +357,7 @@ async fn test_udwf_bounded_window_returns_null() {
     let test_state = TestState::new()
         .with_uses_window_frame()
         .with_null_for_zero();
-    let TestContext { ctx, test_state } = TestContext::new(test_state);
+    let TestContext { ctx, test_state } = TestContext::new(test_state).await;
 
     let expected = vec![
     "+---+---+-----+--------------------------------------------------------------------------------------------------------------+",
@@ -412,7 +412,7 @@ struct TestContext {
 }
 
 impl TestContext {
-    fn new(test_state: TestState) -> Self {
+    async fn new(test_state: TestState) -> Self {
         let test_state = Arc::new(test_state);
         let x = Int64Array::from(vec![1, 1, 1, 2, 2, 2, 2, 2, 2, 2]);
         let y = StringArray::from(vec!["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]);
@@ -427,7 +427,7 @@ impl TestContext {
 
         let mut ctx = SessionContext::new();
 
-        ctx.register_batch("t", batch).unwrap();
+        ctx.register_batch("t", batch).await.unwrap();
 
         // Tell DataFusion about the window function
         OddCounter::register(&mut ctx, Arc::clone(&test_state));

--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -225,7 +225,8 @@ unsafe extern "C" fn scan_fn_wrapper(
         let session = SessionStateBuilder::new()
             .with_default_features()
             .with_config(config.0)
-            .build();
+            .build()
+            .await;
         let ctx = SessionContext::new_with_state(session);
 
         let filters = match filters_serialized.is_empty() {
@@ -467,7 +468,8 @@ mod tests {
 
         let foreign_table_provider: ForeignTableProvider = (&ffi_provider).into();
 
-        ctx.register_table("t", Arc::new(foreign_table_provider))?;
+        ctx.register_table("t", Arc::new(foreign_table_provider))
+            .await?;
 
         let df = ctx.table("t").await?;
 

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -215,7 +215,10 @@ async fn roundtrip_custom_tables() -> Result<()> {
     let mut table_factories: HashMap<String, Arc<dyn TableProviderFactory>> =
         HashMap::new();
     table_factories.insert("TESTTABLE".to_string(), Arc::new(TestTableFactory {}));
-    let mut state = SessionStateBuilder::new().with_default_features().build();
+    let mut state = SessionStateBuilder::new()
+        .with_default_features()
+        .build()
+        .await;
     // replace factories
     *state.table_factories_mut() = table_factories;
     let ctx = SessionContext::new_with_state(state);

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -253,7 +253,9 @@ pub async fn register_table_with_many_types(ctx: &SessionContext) {
         .register_schema("my_schema", Arc::new(schema))
         .await
         .unwrap();
-    ctx.register_catalog("my_catalog", Arc::new(catalog)).await;
+    ctx.register_catalog("my_catalog", Arc::new(catalog))
+        .await
+        .unwrap();
 
     ctx.register_table(
         "my_catalog.my_schema.table_with_many_types",

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -99,7 +99,7 @@ impl TestContext {
                 }
             }
             "dynamic_file.slt" => {
-                test_ctx.ctx = test_ctx.ctx.enable_url_table();
+                test_ctx.ctx = test_ctx.ctx.enable_url_table().await;
             }
             "joins.slt" => {
                 info!("Registering partition table tables");
@@ -241,6 +241,7 @@ pub async fn register_temp_table(ctx: &SessionContext) {
         "datafusion.public.temp",
         Arc::new(TestTable(TableType::Temporary)),
     )
+    .await
     .unwrap();
 }
 
@@ -250,13 +251,15 @@ pub async fn register_table_with_many_types(ctx: &SessionContext) {
 
     catalog
         .register_schema("my_schema", Arc::new(schema))
+        .await
         .unwrap();
-    ctx.register_catalog("my_catalog", Arc::new(catalog));
+    ctx.register_catalog("my_catalog", Arc::new(catalog)).await;
 
     ctx.register_table(
         "my_catalog.my_schema.table_with_many_types",
         table_with_many_types(),
     )
+    .await
     .unwrap();
 }
 
@@ -274,6 +277,7 @@ pub async fn register_table_with_map(ctx: &SessionContext) {
     let memory_table = MemTable::try_new(schema.into(), vec![vec![]]).unwrap();
 
     ctx.register_table("table_with_map", Arc::new(memory_table))
+        .await
         .unwrap();
 }
 
@@ -366,7 +370,9 @@ pub async fn register_metadata_tables(ctx: &SessionContext) {
     )
     .unwrap();
 
-    ctx.register_batch("table_with_metadata", batch).unwrap();
+    ctx.register_batch("table_with_metadata", batch)
+        .await
+        .unwrap();
 }
 
 /// Create a UDF function named "example". See the `sample_udf.rs` example

--- a/datafusion/substrait/src/lib.rs
+++ b/datafusion/substrait/src/lib.rs
@@ -59,7 +59,7 @@
 //! // Create a plan that scans table 't'
 //!  let ctx = SessionContext::new();
 //!  let batch = RecordBatch::try_from_iter(vec![("x", Arc::new(Int32Array::from(vec![42])) as _)])?;
-//!  ctx.register_batch("t", batch)?;
+//!  ctx.register_batch("t", batch).await?;
 //!  let df = ctx.sql("SELECT x from t").await?;
 //!  let plan = df.into_optimized_plan()?;
 //!

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -2441,7 +2441,7 @@ mod test {
 
     #[tokio::test]
     async fn extended_expressions() -> Result<()> {
-        let state = SessionStateBuilder::default().build();
+        let state = SessionStateBuilder::default().build().await;
 
         // One expression, empty input schema
         let expr = Expr::Literal(ScalarValue::Int32(Some(42)));
@@ -2493,7 +2493,7 @@ mod test {
 
     #[tokio::test]
     async fn invalid_extended_expression() {
-        let state = SessionStateBuilder::default().build();
+        let state = SessionStateBuilder::default().build().await;
 
         // Not ok if input schema is missing field referenced by expr
         let expr = Expr::Column("missing".into());

--- a/datafusion/substrait/src/logical_plan/state.rs
+++ b/datafusion/substrait/src/logical_plan/state.rs
@@ -56,7 +56,7 @@ impl SubstraitPlanningState for SessionState {
         reference: &TableReference,
     ) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
         let table = reference.table().to_string();
-        let schema = self.schema_for_ref(reference.clone())?;
+        let schema = self.schema_for_ref(reference.clone()).await?;
         let table_provider = schema.table(&table).await?;
         Ok(table_provider)
     }

--- a/datafusion/substrait/tests/cases/consumer_integration.rs
+++ b/datafusion/substrait/tests/cases/consumer_integration.rs
@@ -40,7 +40,7 @@ mod tests {
         ))
         .expect("failed to parse json");
 
-        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto)?;
+        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto).await?;
         let plan = from_substrait_plan(&ctx.state(), &proto).await?;
         Ok(format!("{}", plan))
     }

--- a/datafusion/substrait/tests/cases/emit_kind_tests.rs
+++ b/datafusion/substrait/tests/cases/emit_kind_tests.rs
@@ -32,7 +32,7 @@ mod tests {
         let proto_plan = read_json(
             "tests/testdata/test_plans/emit_kind/direct_on_project.substrait.json",
         );
-        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan)?;
+        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan).await?;
         let plan = from_substrait_plan(&ctx.state(), &proto_plan).await?;
 
         let plan_str = format!("{}", plan);
@@ -50,7 +50,7 @@ mod tests {
         let proto_plan = read_json(
             "tests/testdata/test_plans/emit_kind/emit_on_filter.substrait.json",
         );
-        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan)?;
+        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan).await?;
         let plan = from_substrait_plan(&ctx.state(), &proto_plan).await?;
 
         let plan_str = format!("{}", plan);
@@ -69,7 +69,8 @@ mod tests {
         let state = SessionStateBuilder::new()
             .with_config(SessionConfig::default())
             .with_default_features()
-            .build();
+            .build()
+            .await;
         let ctx = SessionContext::new_with_state(state);
         ctx.register_csv("data", "tests/testdata/data.csv", CsvReadOptions::default())
             .await?;

--- a/datafusion/substrait/tests/cases/function_test.rs
+++ b/datafusion/substrait/tests/cases/function_test.rs
@@ -28,7 +28,7 @@ mod tests {
     #[tokio::test]
     async fn contains_function_test() -> Result<()> {
         let proto_plan = read_json("tests/testdata/contains_plan.substrait.json");
-        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan)?;
+        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan).await?;
         let plan = from_substrait_plan(&ctx.state(), &proto_plan).await?;
 
         let plan_str = format!("{}", plan);

--- a/datafusion/substrait/tests/cases/logical_plans.rs
+++ b/datafusion/substrait/tests/cases/logical_plans.rs
@@ -37,7 +37,7 @@ mod tests {
         // ./isthmus-cli/build/graal/isthmus --create "create table data (d boolean)" "select not d from data"
         let proto_plan =
             read_json("tests/testdata/test_plans/select_not_bool.substrait.json");
-        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan)?;
+        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan).await?;
         let plan = from_substrait_plan(&ctx.state(), &proto_plan).await?;
 
         assert_eq!(
@@ -62,7 +62,7 @@ mod tests {
         // ./isthmus-cli/build/graal/isthmus --create "create table data (d int, part int, ord int)" "select sum(d) OVER (PARTITION BY part ORDER BY ord ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING) AS lead_expr from data"
         let proto_plan =
             read_json("tests/testdata/test_plans/select_window.substrait.json");
-        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan)?;
+        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan).await?;
         let plan = from_substrait_plan(&ctx.state(), &proto_plan).await?;
 
         assert_eq!(
@@ -81,7 +81,7 @@ mod tests {
         // This test confirms that reading a plan with non-nullable lists works as expected.
         let proto_plan =
             read_json("tests/testdata/test_plans/non_nullable_lists.substrait.json");
-        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan)?;
+        let ctx = add_plan_schemas_to_ctx(SessionContext::new(), &proto_plan).await?;
         let plan = from_substrait_plan(&ctx.state(), &proto_plan).await?;
 
         assert_eq!(format!("{}", &plan), "Values: (List([1, 2]))");

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -1372,7 +1372,8 @@ async fn create_context() -> Result<SessionContext> {
         .with_runtime_env(Arc::new(RuntimeEnv::default()))
         .with_default_features()
         .with_serializer_registry(Arc::new(MockSerializerRegistry))
-        .build();
+        .build()
+        .await;
 
     // register udaf for test, e.g. `sum()`
     datafusion_functions_aggregate::register_all(&mut state)

--- a/datafusion/substrait/tests/cases/substrait_validations.rs
+++ b/datafusion/substrait/tests/cases/substrait_validations.rs
@@ -30,7 +30,7 @@ mod tests {
         use std::collections::HashMap;
         use std::sync::Arc;
 
-        fn generate_context_with_table(
+        async fn generate_context_with_table(
             table_name: &str,
             fields: Vec<(&str, DataType, bool)>,
         ) -> Result<SessionContext> {
@@ -52,7 +52,8 @@ mod tests {
             ctx.register_table(
                 table_ref,
                 Arc::new(EmptyTable::new(df_schema.inner().clone())),
-            )?;
+            )
+            .await?;
             Ok(ctx)
         }
 
@@ -64,7 +65,7 @@ mod tests {
             let df_schema =
                 vec![("a", DataType::Int32, false), ("b", DataType::Int32, true)];
 
-            let ctx = generate_context_with_table("DATA", df_schema)?;
+            let ctx = generate_context_with_table("DATA", df_schema).await?;
             let plan = from_substrait_plan(&ctx.state(), &proto_plan).await?;
 
             assert_eq!(
@@ -85,7 +86,7 @@ mod tests {
                 ("a", DataType::Int32, false),
                 ("c", DataType::Int32, false),
             ];
-            let ctx = generate_context_with_table("DATA", df_schema)?;
+            let ctx = generate_context_with_table("DATA", df_schema).await?;
             let plan = from_substrait_plan(&ctx.state(), &proto_plan).await?;
 
             assert_eq!(
@@ -108,7 +109,7 @@ mod tests {
                 ("c", DataType::Int32, false),
                 ("b", DataType::Int32, false),
             ];
-            let ctx = generate_context_with_table("DATA", df_schema)?;
+            let ctx = generate_context_with_table("DATA", df_schema).await?;
             let plan = from_substrait_plan(&ctx.state(), &proto_plan).await?;
 
             assert_eq!(
@@ -127,7 +128,7 @@ mod tests {
             let df_schema =
                 vec![("a", DataType::Int32, false), ("c", DataType::Int32, true)];
 
-            let ctx = generate_context_with_table("DATA", df_schema)?;
+            let ctx = generate_context_with_table("DATA", df_schema).await?;
             let res = from_substrait_plan(&ctx.state(), &proto_plan).await;
             assert!(res.is_err());
             Ok(())
@@ -139,7 +140,8 @@ mod tests {
                 read_json("tests/testdata/test_plans/simple_select.substrait.json");
 
             let ctx =
-                generate_context_with_table("DATA", vec![("a", DataType::Date32, true)])?;
+                generate_context_with_table("DATA", vec![("a", DataType::Date32, true)])
+                    .await?;
             let res = from_substrait_plan(&ctx.state(), &proto_plan).await;
             assert!(res.is_err());
             Ok(())

--- a/datafusion/substrait/tests/utils.rs
+++ b/datafusion/substrait/tests/utils.rs
@@ -46,7 +46,7 @@ pub mod test {
         .expect("failed to parse json")
     }
 
-    pub fn add_plan_schemas_to_ctx(
+    pub async fn add_plan_schemas_to_ctx(
         ctx: SessionContext,
         plan: &Plan,
     ) -> Result<SessionContext> {
@@ -66,7 +66,7 @@ pub mod test {
             }
         }
         for (table_reference, table) in schema_map.into_iter() {
-            ctx.register_table(table_reference, table)?;
+            ctx.register_table(table_reference, table).await?;
         }
         Ok(ctx)
     }

--- a/docs/source/library-user-guide/using-the-dataframe-api.md
+++ b/docs/source/library-user-guide/using-the-dataframe-api.md
@@ -88,7 +88,7 @@ async fn main() -> Result<()> {
         ("id", Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef),
         ("bank_account", Arc::new(Int32Array::from(vec![9000, 8000, 7000]))),
     ])?;
-    ctx.register_batch("users", data)?;
+    ctx.register_batch("users", data).await?;
     // Create a DataFrame using SQL
     let dataframe = ctx.sql("SELECT * FROM users;")
         .await?


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10339 

## Rationale for this change

Many catalogs are remote (and/or disk based) and offer only asynchronous APIs.  For example, [Polaris](https://github.com/apache/polaris), [Unity](https://github.com/unitycatalog/unitycatalog), and [Hive](https://hive.apache.org/).  Integrating with this catalogs is impossible since something like `ctx.sql("SELECT * FROM db.schm.tbl")` first enters an async context (`sql`) then a synchronous context (calling the catalog provider to resolve `db`) and then we need to go into an asynchronous context to interact with the catalog and this async -> sync -> async path is generally forbidden.

## What changes are included in this PR?

The heart of the change is making all non-trivial methods async in `CatalogProvider`, `SchemaProvider`, and `CatalogProviderList`.

These changes had rather far-reaching ramifications discussed more below.

## Are these changes tested?

Yes, in the sense that these traits were all tested previously.  I did not add any new testing.

## Are there any user-facing changes?

Yes, there are significant **user-facing breaking changes** beyond the obvious change that these public traits are now async.

### Notable but expected

The following methods are now async and were previously sync

```
SessionContext::register_catalog
SessionContext::catalog_names
SessionContext::catalog
SessionContext::register_table
SessionContext::deregister_table
SessionContext::table_exist
```

### Perhaps surprising

The `SessionStateBuilder::build` method and `SessionStateBuilder::new_from_existing` methods are now async and the `From` impls to go between `SessionState` and `SessionStateBuilder` were removed.

The `new_from_existing` change is because the method does a (now async) lookup into the existing catalog list (which may be remote) to determine if a default catalog exists so that it knows if it needs to create a new one or not.

The `build` change is because, if no default catalog exists, then a default catalog is created and registered with the (potentially remote) catalog list.

The `SessionContext::register_batch` and `SessionContext::register_table` methods are used frequently and it may make sense to think of them as synchronous since in-memory tables and batches are not typically thought of as something a "catalog" provides.  It would be possible for `SessionContext` to have both "a catalog" (which is async) and "a collection of in-memory session-specific tables" (which is sync) and thus keep these methods synchronous.  However, that felt like more complexity than justified by this change.

### Caveats

In most cases I simply propagated the async.  In some benchmarks I am using `now_or_never().expect()` to avoid the need to create a tokio runtime.

In a few of the `SessionContext` factory functions, where a custom catalog cannot possibly be provided (e.g. `SessionContext::default`) I use `now_or_never` since it is safe to assume the default in-memory catalog is synchronous.

### Details for review

The only non-trivial implementation changes were in `SessionState`.  There is a `RwLock` there and it required some fiddling (and a few Arc clones of the catalog list) to avoid holding the lock across an await boundary.  This could be potentially simplified by changing the `RwLock` to an async lock but I'm not sure that's justified yet.