### PR TITLE
Deprecate `adjust_output_array` in favor of `PrimitiveArray::with_data_type`

### DIFF
--- a/datafusion/functions-aggregate-common/src/utils.rs
+++ b/datafusion/functions-aggregate-common/src/utils.rs
@@ -48,6 +48,7 @@ pub fn get_accum_scalar_values_as_arrays(
 /// Since `Decimal128Arrays` created from `Vec<NativeType>` have
 /// default precision and scale, this function adjusts the output to
 /// match `data_type`, if necessary
+#[deprecated(since = "44.0.0", note = "use PrimitiveArray::with_datatype")]
 pub fn adjust_output_array(data_type: &DataType, array: ArrayRef) -> Result<ArrayRef> {
     let array = match data_type {
         DataType::Decimal128(p, s) => Arc::new(

--- a/datafusion/physical-expr/src/aggregate.rs
+++ b/datafusion/physical-expr/src/aggregate.rs
@@ -28,6 +28,7 @@ pub(crate) mod stats {
     pub use datafusion_functions_aggregate_common::stats::StatsType;
 }
 pub mod utils {
+    #[allow(deprecated)] // allow adjust_output_array
     pub use datafusion_functions_aggregate_common::utils::{
         adjust_output_array, get_accum_scalar_values_as_arrays, get_sort_options,
         ordering_fields, DecimalAverager, Hashable,

--- a/datafusion/physical-plan/src/aggregates/topk/heap.rs
+++ b/datafusion/physical-plan/src/aggregates/topk/heap.rs
@@ -20,11 +20,11 @@
 use arrow::datatypes::i256;
 use arrow_array::cast::AsArray;
 use arrow_array::{downcast_primitive, ArrayRef, ArrowPrimitiveType, PrimitiveArray};
-use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
+use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano, ScalarBuffer};
 use arrow_schema::DataType;
 use datafusion_common::DataFusionError;
 use datafusion_common::Result;
-use datafusion_physical_expr::aggregate::utils::adjust_output_array;
+
 use half::f16;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter};
@@ -151,10 +151,11 @@ where
     }
 
     fn drain(&mut self) -> (ArrayRef, Vec<usize>) {
+        let nulls = None;
         let (vals, map_idxs) = self.heap.drain();
-        let vals = Arc::new(PrimitiveArray::<VAL>::from_iter_values(vals));
-        let vals = adjust_output_array(&self.data_type, vals).expect("Type is incorrect");
-        (vals, map_idxs)
+        let arr = PrimitiveArray::<VAL>::new(ScalarBuffer::from(vals), nulls)
+            .with_data_type(self.data_type.clone());
+        (Arc::new(arr), map_idxs)
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/13505
- Related to https://github.com/apache/datafusion/pull/13564

## Rationale for this change

While reviewing https://github.com/apache/datafusion/pull/13564#pullrequestreview-2465814062 @jayzhan211  pointed out this function wasn't necessary as there is now equivalent functionality in arrow-rs

It is confusing there are two patterns to do the same thing, so let's remove the DataFusion specific pattern

## What changes are included in this PR?
1. Change code to use `PrimitiveArray::with_data_type` instead
2. Deprecate adjust_output_array


## Are these changes tested?
By CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
