### PR TITLE
feat(substrait): remove dependency on datafusion default features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,8 +80,11 @@ jobs:
       - name: Check datafusion-common without default features
         run: cargo check --all-targets --no-default-features -p datafusion-common
 
-      - name: Check datafusion-functions
+      - name: Check datafusion-functions without default features
         run: cargo check --all-targets --no-default-features -p datafusion-functions
+
+      - name: Check datafusion-substrait without default features
+        run: cargo check --all-targets --no-default-features -p datafusion-substrait
 
       - name: Check workspace in debug mode
         run: cargo check --all-targets --workspace

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -36,7 +36,7 @@ arrow-buffer = { workspace = true }
 async-recursion = "1.0"
 async-trait = { workspace = true }
 chrono = { workspace = true }
-datafusion = { workspace = true, default-features = true }
+datafusion = { workspace = true }
 itertools = { workspace = true }
 object_store = { workspace = true }
 pbjson-types = "0.7"
@@ -51,4 +51,6 @@ serde_json = "1.0"
 tokio = { workspace = true }
 
 [features]
+default = ["physical"]
+physical = ["datafusion/parquet"]
 protoc = ["substrait/protoc"]

--- a/datafusion/substrait/src/lib.rs
+++ b/datafusion/substrait/src/lib.rs
@@ -75,6 +75,7 @@
 //! ```
 pub mod extensions;
 pub mod logical_plan;
+#[cfg(feature = "physical")]
 pub mod physical_plan;
 pub mod serializer;
 pub mod variation_const;

--- a/datafusion/substrait/tests/cases/mod.rs
+++ b/datafusion/substrait/tests/cases/mod.rs
@@ -20,6 +20,7 @@ mod emit_kind_tests;
 mod function_test;
 mod logical_plans;
 mod roundtrip_logical_plan;
+#[cfg(feature = "physical")]
 mod roundtrip_physical_plan;
 mod serialize;
 mod substrait_validations;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13593 

## What changes are included in this PR?

- `physical` feature, which enables production and consumption of physical substrait plans.

## Are these changes tested?

Yes, running `cargo tree -p datafusion-substrait` with and without the `--no-default-features` shows that `parquet` and many other dependencies are not included.

## Are there any user-facing changes?

No, the new feature is enabled by default. Users who might want to benefit from this change will have to use `default-features = false` when including the `datafusion-substrait` crate.