### PR TITLE
Chore: exposing ArraySize and ArrayFlatten

### DIFF
--- a/datafusion/functions-nested/src/flatten.rs
+++ b/datafusion/functions-nested/src/flatten.rs
@@ -42,10 +42,17 @@ make_udf_expr_and_func!(
 );
 
 #[derive(Debug)]
-pub(super) struct Flatten {
+pub struct Flatten {
     signature: Signature,
     aliases: Vec<String>,
 }
+
+impl Default for Flatten {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Flatten {
     pub fn new() -> Self {
         Self {

--- a/datafusion/functions-nested/src/length.rs
+++ b/datafusion/functions-nested/src/length.rs
@@ -43,10 +43,17 @@ make_udf_expr_and_func!(
 );
 
 #[derive(Debug)]
-pub(super) struct ArrayLength {
+pub struct ArrayLength {
     signature: Signature,
     aliases: Vec<String>,
 }
+
+impl Default for ArrayLength {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ArrayLength {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
Want to able to call these functions in apache comet. But cannot create the expression because of pub(super)

## What changes are included in this PR?
Exposing ArraySize and ArrayFlatten, so these functions can be implemented in comet

## Are these changes tested?
No changes are tested

## Are there any user-facing changes?

