### PR TITLE
Improve unsupported compound identifier message

### DIFF
--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -70,7 +70,7 @@ SELECT COUNT(*) FROM nonexistentschema.aggregate_test_100
 statement error Error during planning: table 'nonexistentcatalog\.public\.aggregate_test_100' not found
 SELECT COUNT(*) FROM nonexistentcatalog.public.aggregate_test_100
 
-statement error Error during planning: Unsupported compound identifier '\[Ident \{ value: "way", quote_style: None \}, Ident \{ value: "too", quote_style: None \}, Ident \{ value: "many", quote_style: None \}, Ident \{ value: "namespaces", quote_style: None \}, Ident \{ value: "as", quote_style: None \}, Ident \{ value: "ident", quote_style: None \}, Ident \{ value: "prefixes", quote_style: None \}, Ident \{ value: "aggregate_test_100", quote_style: None \}\]'
+statement error DataFusion error: Error during planning: Unsupported compound identifier 'way\.too\.many\.namespaces\.as\.ident\.prefixes\.aggregate_test_100'\. Expected 1, 2 or 3 parts, got 8
 SELECT COUNT(*) FROM way.too.many.namespaces.as.ident.prefixes.aggregate_test_100
 
 


### PR DESCRIPTION
## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/pull/13546

## Rationale for this change

While working on the upgrade of sqlparser, the structure has changed and thus the debug formatting has changed (so I needed to change this error message anyways)

The error message was hard to understand anyways, so I spent a few moments improving it to show the actual indentifers rather than a debug version

## What changes are included in this PR?
1. Improve error message and test

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
