### PR TITLE
Test for string / numeric coercion

### DIFF
--- a/datafusion/sqllogictest/test_files/string/string_query.slt.part
+++ b/datafusion/sqllogictest/test_files/string/string_query.slt.part
@@ -19,6 +19,10 @@
 # with standard values, but different types in string columns
 # (String, StringView, etc.)
 
+# --------------------------------------
+# Show the input data
+# --------------------------------------
+
 # select
 query TTTT
 SELECT ascii_1, ascii_2, unicode_1, unicode_2 FROM test_basic_operator
@@ -34,6 +38,41 @@ percent p%t pan Tadeusz ma iść w kąt Pan Tadeusz ma frunąć stąd w kąt
 _ \_ (empty) (empty)
 NULL % NULL NULL
 NULL R NULL 🔥
+
+# --------------------------------------
+# test type coercion (compare to int)
+# queries should not error
+# --------------------------------------
+
+query BB
+select ascii_1 = 1 as col1, ascii_1 = 1 as col2 from test_basic_operator;
+----
+false false
+false false
+false false
+false false
+false false
+false false
+false false
+false false
+false false
+NULL NULL
+NULL NULL
+
+query BB
+select ascii_1 <> 1 as col1, ascii_1 <> 1 as col2 from test_basic_operator;
+----
+true true
+true true
+true true
+true true
+true true
+true true
+true true
+true true
+true true
+NULL NULL
+NULL NULL
 
 # --------------------------------------
 # column comparison as filters


### PR DESCRIPTION
## Which issue does this PR close?


- Part of https://github.com/apache/datafusion/issues/13359
- closes https://github.com/apache/datafusion/pull/13366

## Rationale for this change

While testing https://github.com/apache/datafusion/pull/13366 I found there are still some gaps with StringView:

## What changes are included in this PR?

Add tests for string coercsion to integer. They currently fail as arrow-rs doesn't suport int --> StringView casting at the moment

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
