### PR TITLE
Replace is_sorted helper with standard one.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ homepage = "https://datafusion.apache.org"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/datafusion"
-rust-version = "1.79"
+rust-version = "1.82"
 version = "43.0.0"
 
 [workspace.dependencies]

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 homepage = "https://datafusion.apache.org"
 repository = "https://github.com/apache/datafusion"
 # Specify MSRV here as `cargo msrv` doesn't support workspace version
-rust-version = "1.79"
+rust-version = "1.82"
 readme = "README.md"
 
 [dependencies]

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -657,20 +657,6 @@ pub fn set_difference<T: Borrow<usize>, S: Borrow<usize>>(
         .collect()
 }
 
-/// Checks whether the given index sequence is monotonically non-decreasing.
-pub fn is_sorted<T: Borrow<usize>>(sequence: impl IntoIterator<Item = T>) -> bool {
-    // TODO: Remove this function when `is_sorted` graduates from Rust nightly.
-    let mut previous = 0;
-    for item in sequence.into_iter() {
-        let current = *item.borrow();
-        if current < previous {
-            return false;
-        }
-        previous = current;
-    }
-    true
-}
-
 /// Find indices of each element in `targets` inside `items`. If one of the
 /// elements is absent in `items`, returns an error.
 pub fn find_indices<T: PartialEq, S: Borrow<T>>(
@@ -1056,18 +1042,6 @@ mod tests {
         assert_eq!(set_difference([3, 4, 0], [1, 2, 4]), vec![3, 0]);
         assert_eq!(set_difference([0, 3, 4], [4, 1, 2]), vec![0, 3]);
         assert_eq!(set_difference([3, 4, 0], [4, 1, 2]), vec![3, 0]);
-    }
-
-    #[test]
-    fn test_is_sorted() {
-        assert!(is_sorted::<usize>([]));
-        assert!(is_sorted([0]));
-        assert!(is_sorted([0, 3, 4]));
-        assert!(is_sorted([0, 1, 2]));
-        assert!(is_sorted([0, 1, 4]));
-        assert!(is_sorted([0usize; 0]));
-        assert!(is_sorted([1, 2]));
-        assert!(!is_sorted([3, 2]));
     }
 
     #[test]

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -30,7 +30,7 @@ authors = { workspace = true }
 # Specify MSRV here as `cargo msrv` doesn't support workspace version and fails with
 # "Unable to find key 'package.rust-version' (or 'package.metadata.msrv') in 'arrow-datafusion/Cargo.toml'"
 # https://github.com/foresterre/cargo-msrv/issues/590
-rust-version = "1.79"
+rust-version = "1.82"
 
 [lints]
 workspace = true

--- a/datafusion/ffi/Cargo.toml
+++ b/datafusion/ffi/Cargo.toml
@@ -26,7 +26,7 @@ repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
 # Specify MSRV here as `cargo msrv` doesn't support workspace version
-rust-version = "1.76"
+rust-version = "1.82"
 
 [lints]
 workspace = true

--- a/datafusion/functions-aggregate-common/src/tdigest.rs
+++ b/datafusion/functions-aggregate-common/src/tdigest.rs
@@ -250,7 +250,7 @@ impl TDigest {
 
     pub fn merge_sorted_f64(&self, sorted_values: &[f64]) -> TDigest {
         #[cfg(debug_assertions)]
-        debug_assert!(is_sorted(sorted_values), "unsorted input to TDigest");
+        debug_assert!(is_total_ordered(sorted_values), "unsorted input to TDigest");
 
         if sorted_values.is_empty() {
             return self.clone();
@@ -662,8 +662,8 @@ impl TDigest {
 }
 
 #[cfg(debug_assertions)]
-fn is_sorted(values: &[f64]) -> bool {
-    values.windows(2).all(|w| w[0].total_cmp(&w[1]).is_le())
+fn is_total_ordered(values: &[f64]) -> bool {
+    values.is_sorted_by(|a, b| a.total_cmp(b).is_le())
 }
 
 #[cfg(test)]

--- a/datafusion/functions-aggregate-common/src/tdigest.rs
+++ b/datafusion/functions-aggregate-common/src/tdigest.rs
@@ -250,7 +250,7 @@ impl TDigest {
 
     pub fn merge_sorted_f64(&self, sorted_values: &[f64]) -> TDigest {
         #[cfg(debug_assertions)]
-        debug_assert!(is_sorted(sorted_values), "unsorted input to TDigest");
+        debug_assert!(sorted_values.is_sorted(), "unsorted input to TDigest");
 
         if sorted_values.is_empty() {
             return self.clone();
@@ -659,11 +659,6 @@ impl TDigest {
             centroids,
         }
     }
-}
-
-#[cfg(debug_assertions)]
-fn is_sorted(values: &[f64]) -> bool {
-    values.windows(2).all(|w| w[0].total_cmp(&w[1]).is_le())
 }
 
 #[cfg(test)]

--- a/datafusion/functions-aggregate-common/src/tdigest.rs
+++ b/datafusion/functions-aggregate-common/src/tdigest.rs
@@ -250,7 +250,7 @@ impl TDigest {
 
     pub fn merge_sorted_f64(&self, sorted_values: &[f64]) -> TDigest {
         #[cfg(debug_assertions)]
-        debug_assert!(sorted_values.is_sorted(), "unsorted input to TDigest");
+        debug_assert!(is_sorted(sorted_values), "unsorted input to TDigest");
 
         if sorted_values.is_empty() {
             return self.clone();
@@ -659,6 +659,11 @@ impl TDigest {
             centroids,
         }
     }
+}
+
+#[cfg(debug_assertions)]
+fn is_sorted(values: &[f64]) -> bool {
+    values.windows(2).all(|w| w[0].total_cmp(&w[1]).is_le())
 }
 
 #[cfg(test)]

--- a/datafusion/proto-common/Cargo.toml
+++ b/datafusion/proto-common/Cargo.toml
@@ -26,7 +26,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
-rust-version = "1.79"
+rust-version = "1.82"
 
 # Exclude proto files so crates.io consumers don't need protoc
 exclude = ["*.proto"]

--- a/datafusion/proto-common/gen/Cargo.toml
+++ b/datafusion/proto-common/gen/Cargo.toml
@@ -20,7 +20,7 @@ name = "gen-common"
 description = "Code generation for proto"
 version = "0.1.0"
 edition = { workspace = true }
-rust-version = "1.79"
+rust-version = "1.82"
 authors = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -27,7 +27,7 @@ repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
 # Specify MSRV here as `cargo msrv` doesn't support workspace version
-rust-version = "1.79"
+rust-version = "1.82"
 
 # Exclude proto files so crates.io consumers don't need protoc
 exclude = ["*.proto"]

--- a/datafusion/proto/gen/Cargo.toml
+++ b/datafusion/proto/gen/Cargo.toml
@@ -20,7 +20,7 @@ name = "gen"
 description = "Code generation for proto"
 version = "0.1.0"
 edition = { workspace = true }
-rust-version = "1.79"
+rust-version = "1.82"
 authors = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -26,7 +26,7 @@ repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
 # Specify MSRV here as `cargo msrv` doesn't support workspace version
-rust-version = "1.79"
+rust-version = "1.82"
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
With rust release `1.82.0` `is_sorted` util is available for iterators. This PR replaces existing util with standard version. However, it makes MSRV `1.82.0` (latest stable version is `1.83.0`). If this is not desirable, we can delay this PR to future.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
