### PR TITLE
Minor: Simplify `IdentTaker`

### DIFF
--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -259,7 +259,7 @@ pub(crate) fn make_decimal_type(
     }
 }
 
-// Normalize an owned identifier to a lowercase string unless the identifier is quoted.
+/// Normalize an owned identifier to a lowercase string, unless the identifier is quoted.
 pub(crate) fn normalize_ident(id: Ident) -> String {
     match id.quote_style {
         Some(_) => id.value,


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to https://github.com/apache/datafusion/pull/13605


## Rationale for this change


As suggested by @jonahgao on https://github.com/apache/datafusion/pull/13605/files#r1863695929

> Not related to the current PR, maybe we can move IdentNormalizer into IdentTaker to simplify take() and avoid creating normalizer every time.



## What changes are included in this PR?
1. Move IdentNormalizer into IdentTaker


## Are these changes tested?
Yes, by CI

## Are there any user-facing changes?
No, these are all internal apis

