### PR TITLE
[refactor]: Convert Vec<PhysicalExpr> to HashSet<PhysicalExpr>

### DIFF
--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -93,6 +93,8 @@ pub use error::{
 pub type HashMap<K, V, S = DefaultHashBuilder> = hashbrown::HashMap<K, V, S>;
 pub type HashSet<T, S = DefaultHashBuilder> = hashbrown::HashSet<T, S>;
 
+pub type IndexSet<T, S = std::hash::RandomState> = indexmap::IndexSet<T, S>;
+
 /// Downcast an Arrow Array to a concrete type, return an `DataFusionError::Internal` if the cast is
 /// not possible. In normal usage of DataFusion the downcast should always succeed.
 ///

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -26,7 +26,7 @@ use arrow::array::BooleanArray;
 use arrow::compute::filter_record_batch;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
-use datafusion_common::{internal_err, not_impl_err, IndexSet, Result};
+use datafusion_common::{internal_err, not_impl_err, Result};
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use datafusion_expr_common::interval_arithmetic::Interval;
 use datafusion_expr_common::sort_properties::ExprProperties;
@@ -217,35 +217,24 @@ pub fn with_new_children_if_necessary(
 /// Returns [`Display`] able a list of [`PhysicalExpr`]
 ///
 /// Example output: `[a + 1, b]`
-pub fn format_physical_expr_list(exprs: &[Arc<dyn PhysicalExpr>]) -> impl Display + '_ {
-    struct DisplayWrapper<'a>(&'a [Arc<dyn PhysicalExpr>]);
-    impl Display for DisplayWrapper<'_> {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            let mut iter = self.0.iter();
-            write!(f, "[")?;
-            if let Some(expr) = iter.next() {
-                write!(f, "{}", expr)?;
-            }
-            for expr in iter {
-                write!(f, ", {}", expr)?;
-            }
-            write!(f, "]")?;
-            Ok(())
-        }
-    }
-    DisplayWrapper(exprs)
-}
+pub fn format_physical_expr_list<T>(exprs: T) -> impl Display
+where
+    T: IntoIterator,
+    T::Item: Display,
+    T::IntoIter: Clone,
+{
+    struct DisplayWrapper<I>(I)
+    where
+        I: Iterator + Clone,
+        I::Item: Display;
 
-/// Returns [`Display`] able a list of [`PhysicalExpr`]
-///
-/// Example output: `[a + 1, b]`
-pub fn format_physical_expr_list2(
-    exprs: &IndexSet<Arc<dyn PhysicalExpr>>,
-) -> impl Display + '_ {
-    struct DisplayWrapper<'a>(&'a IndexSet<Arc<dyn PhysicalExpr>>);
-    impl Display for DisplayWrapper<'_> {
+    impl<I> Display for DisplayWrapper<I>
+    where
+        I: Iterator + Clone,
+        I::Item: Display,
+    {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            let mut iter = self.0.iter();
+            let mut iter = self.0.clone();
             write!(f, "[")?;
             if let Some(expr) = iter.next() {
                 write!(f, "{}", expr)?;
@@ -257,5 +246,6 @@ pub fn format_physical_expr_list2(
             Ok(())
         }
     }
-    DisplayWrapper(exprs)
+
+    DisplayWrapper(exprs.into_iter())
 }

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -26,7 +26,7 @@ use arrow::array::BooleanArray;
 use arrow::compute::filter_record_batch;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
-use datafusion_common::{internal_err, not_impl_err, Result};
+use datafusion_common::{internal_err, not_impl_err, IndexSet, Result};
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use datafusion_expr_common::interval_arithmetic::Interval;
 use datafusion_expr_common::sort_properties::ExprProperties;
@@ -219,6 +219,30 @@ pub fn with_new_children_if_necessary(
 /// Example output: `[a + 1, b]`
 pub fn format_physical_expr_list(exprs: &[Arc<dyn PhysicalExpr>]) -> impl Display + '_ {
     struct DisplayWrapper<'a>(&'a [Arc<dyn PhysicalExpr>]);
+    impl Display for DisplayWrapper<'_> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            let mut iter = self.0.iter();
+            write!(f, "[")?;
+            if let Some(expr) = iter.next() {
+                write!(f, "{}", expr)?;
+            }
+            for expr in iter {
+                write!(f, ", {}", expr)?;
+            }
+            write!(f, "]")?;
+            Ok(())
+        }
+    }
+    DisplayWrapper(exprs)
+}
+
+/// Returns [`Display`] able a list of [`PhysicalExpr`]
+///
+/// Example output: `[a + 1, b]`
+pub fn format_physical_expr_list2(
+    exprs: &IndexSet<Arc<dyn PhysicalExpr>>,
+) -> impl Display + '_ {
+    struct DisplayWrapper<'a>(&'a IndexSet<Arc<dyn PhysicalExpr>>);
     impl Display for DisplayWrapper<'_> {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             let mut iter = self.0.iter();

--- a/datafusion/physical-expr/src/equivalence/class.rs
+++ b/datafusion/physical-expr/src/equivalence/class.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::JoinType;
-use datafusion_physical_expr_common::physical_expr::format_physical_expr_list2;
+use datafusion_physical_expr_common::physical_expr::format_physical_expr_list;
 
 /// A structure representing a expression known to be constant in a physical execution plan.
 ///
@@ -282,7 +282,7 @@ impl EquivalenceClass {
 
 impl Display for EquivalenceClass {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "[{}]", format_physical_expr_list2(&self.exprs))
+        write!(f, "[{}]", format_physical_expr_list(&self.exprs))
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

`Vec<Arc<dynPhysicalExpr>>`s inside `EquivalenceClass` is conceptually set. Previously, since `Arc<dyn PhysicalExpr>` didnot support `Eq`, we couldn't use it inside`HashSet` (or `IndexSet`). With recent changes in Datafusion, we can do so now. This PR converts `Vec<Arc<dynPhysicalExpr>>` into `IndexSet<Arc<dynPhysicalExpr>>` to make implementation simpler. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
