### PR TITLE
Add `LogicalPlanStats` to logical plan nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ datafusion-proto = { path = "datafusion/proto", version = "43.0.0" }
 datafusion-proto-common = { path = "datafusion/proto-common", version = "43.0.0" }
 datafusion-sql = { path = "datafusion/sql", version = "43.0.0" }
 doc-comment = "0.3"
+enumset = "1.1.5"
 env_logger = "0.11"
 futures = "0.3"
 half = { version = "2.2.1", default-features = false }

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
  "num",
 ]
 
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
 dependencies = [
  "bzip2",
  "flate2",
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -880,9 +880,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bytes-utils"
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1081,6 +1081,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -1167,6 +1177,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dary_heap"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1260,7 @@ dependencies = [
  "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-sql",
+ "enumset",
  "flate2",
  "futures",
  "glob",
@@ -1349,6 +1394,7 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
+ "enumset",
  "indexmap",
  "paste",
  "recursive",
@@ -1487,6 +1533,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
+ "enumset",
  "indexmap",
  "itertools",
  "log",
@@ -1670,6 +1717,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "enumset"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a4b049558765cef5f0c1a273c3fc57084d768b44d2f98127aef4cceb17293"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c3b24c345d8c314966bdc1832f6c2635bfcce8e7cf363bd115987bba2ee242"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,12 +1768,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1972,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -1987,12 +2055,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2162,8 +2224,8 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.5.1",
  "hyper-util",
- "rustls 0.23.17",
- "rustls-native-certs 0.8.0",
+ "rustls 0.23.19",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2331,6 +2393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,7 +2426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2390,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -2405,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "fb15147158e79fd8b8afd0252522769c4f48725460b37338544d8379d94fc8f9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2484,9 +2552,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libflate"
@@ -2546,9 +2614,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -2628,11 +2696,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -2862,7 +2929,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
  "lz4_flex",
  "num",
  "num-bigint",
@@ -3020,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -3063,7 +3130,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.17",
+ "rustls 0.23.19",
  "socket2",
  "thiserror 2.0.3",
  "tokio",
@@ -3081,7 +3148,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.17",
+ "rustls 0.23.19",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.3",
@@ -3259,8 +3326,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.17",
- "rustls-native-certs 0.8.0",
+ "rustls 0.23.19",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -3378,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "once_cell",
  "ring",
@@ -3399,20 +3466,19 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.0.1",
 ]
 
 [[package]]
@@ -3538,7 +3604,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3686,9 +3765,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3801,9 +3880,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4009,7 +4088,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.17",
+ "rustls 0.23.19",
  "rustls-pki-types",
  "tokio",
 ]
@@ -4052,9 +4131,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4063,9 +4142,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4074,9 +4153,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -4155,9 +4234,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4246,9 +4325,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "21d3b25c3ea1126a2ad5f4f9068483c2af1e64168f847abe863a526b8dbfe00b"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4257,9 +4336,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "52857d4c32e496dc6537646b5b117081e71fd2ff06de792e3577a150627db283"
 dependencies = [
  "bumpalo",
  "log",
@@ -4272,21 +4351,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "951fe82312ed48443ac78b66fa43eded9999f738f6022e67aead7b708659e49a"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "920b0ffe069571ebbfc9ddc0b36ba305ef65577c94b06262ed793716a1afd981"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4294,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "bf59002391099644be3524e23b781fa43d2be0c5aa0719a18c0731b9d195cab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4307,9 +4387,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "e5047c5392700766601942795a436d7d2599af60dcc3cc1248c9120bfb0827b0"
 
 [[package]]
 name = "wasm-streams"
@@ -4326,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "476364ff87d0ae6bfb661053a9104ab312542658c3d8f963b7ace80b6f9b26b9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4578,9 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4590,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4623,18 +4703,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/datafusion-cli/src/functions.rs
+++ b/datafusion-cli/src/functions.rs
@@ -321,8 +321,8 @@ pub struct ParquetMetadataFunc {}
 impl TableFunctionImpl for ParquetMetadataFunc {
     fn call(&self, exprs: &[Expr]) -> Result<Arc<dyn TableProvider>> {
         let filename = match exprs.first() {
-            Some(Expr::Literal(ScalarValue::Utf8(Some(s)))) => s, // single quote: parquet_metadata('x.parquet')
-            Some(Expr::Column(Column { name, .. })) => name, // double quote: parquet_metadata("x.parquet")
+            Some(Expr::Literal(ScalarValue::Utf8(Some(s)), _)) => s, // single quote: parquet_metadata('x.parquet')
+            Some(Expr::Column(Column { name, .. }, _)) => name, // double quote: parquet_metadata("x.parquet")
             _ => {
                 return plan_err!(
                     "parquet_metadata requires string argument as its input"

--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -493,7 +493,7 @@ mod tests {
         let ctx = SessionContext::new();
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
-        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd), _) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;
@@ -538,7 +538,7 @@ mod tests {
         let ctx = SessionContext::new();
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
-        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd), _) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;
@@ -564,7 +564,7 @@ mod tests {
 
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
-        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd), _) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;
@@ -592,7 +592,7 @@ mod tests {
         let ctx = SessionContext::new();
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
-        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd), _) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;
@@ -629,7 +629,7 @@ mod tests {
         let ctx = SessionContext::new();
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
-        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd), _) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;

--- a/datafusion-examples/examples/analyzer_rule.rs
+++ b/datafusion-examples/examples/analyzer_rule.rs
@@ -175,7 +175,7 @@ impl AnalyzerRule for RowLevelAccessControl {
 }
 
 fn is_employee_table_scan(plan: &LogicalPlan) -> bool {
-    if let LogicalPlan::TableScan(scan) = plan {
+    if let LogicalPlan::TableScan(scan, _) = plan {
         scan.table_name.table() == "employee"
     } else {
         false

--- a/datafusion-examples/examples/expr_api.rs
+++ b/datafusion-examples/examples/expr_api.rs
@@ -61,10 +61,10 @@ async fn main() -> Result<()> {
     let expr = col("a") + lit(5);
 
     // The same same expression can be created directly, with much more code:
-    let expr2 = Expr::BinaryExpr(BinaryExpr::new(
+    let expr2 = Expr::binary_expr(BinaryExpr::new(
         Box::new(col("a")),
         Operator::Plus,
-        Box::new(Expr::Literal(ScalarValue::Int32(Some(5)))),
+        Box::new(Expr::literal(ScalarValue::Int32(Some(5)))),
     ));
     assert_eq!(expr, expr2);
 
@@ -396,20 +396,20 @@ fn type_coercion_demo() -> Result<()> {
     let coerced_expr = expr
         .transform(|e| {
             // Only type coerces binary expressions.
-            let Expr::BinaryExpr(e) = e else {
+            let Expr::BinaryExpr(e, _) = e else {
                 return Ok(Transformed::no(e));
             };
-            if let Expr::Column(ref col_expr) = *e.left {
+            if let Expr::Column(ref col_expr, _) = *e.left {
                 let field = df_schema.field_with_name(None, col_expr.name())?;
                 let cast_to_type = field.data_type();
                 let coerced_right = e.right.cast_to(cast_to_type, &df_schema)?;
-                Ok(Transformed::yes(Expr::BinaryExpr(BinaryExpr::new(
+                Ok(Transformed::yes(Expr::binary_expr(BinaryExpr::new(
                     e.left,
                     e.op,
                     Box::new(coerced_right),
                 ))))
             } else {
-                Ok(Transformed::no(Expr::BinaryExpr(e)))
+                Ok(Transformed::no(Expr::binary_expr(e)))
             }
         })?
         .data;

--- a/datafusion-examples/examples/function_factory.rs
+++ b/datafusion-examples/examples/function_factory.rs
@@ -169,7 +169,7 @@ impl ScalarFunctionWrapper {
     fn replacement(expr: &Expr, args: &[Expr]) -> Result<Expr> {
         let result = expr.clone().transform(|e| {
             let r = match e {
-                Expr::Placeholder(placeholder) => {
+                Expr::Placeholder(placeholder, _) => {
                     let placeholder_position =
                         Self::parse_placeholder_identifier(&placeholder.id)?;
                     if placeholder_position < args.len() {

--- a/datafusion-examples/examples/optimizer_rule.rs
+++ b/datafusion-examples/examples/optimizer_rule.rs
@@ -145,7 +145,7 @@ impl MyOptimizerRule {
         expr.transform_up(|expr| {
             // Closure called for each sub tree
             match expr {
-                Expr::BinaryExpr(binary_expr) if is_binary_eq(&binary_expr) => {
+                Expr::BinaryExpr(binary_expr, _) if is_binary_eq(&binary_expr) => {
                     // destruture the expression
                     let BinaryExpr { left, op: _, right } = binary_expr;
                     // rewrite to `my_eq(left, right)`
@@ -171,7 +171,7 @@ fn is_binary_eq(binary_expr: &BinaryExpr) -> bool {
 
 /// Return true if the expression is a literal or column reference
 fn is_lit_or_col(expr: &Expr) -> bool {
-    matches!(expr, Expr::Column(_) | Expr::Literal(_))
+    matches!(expr, Expr::Column(_, _) | Expr::Literal(_, _))
 }
 
 /// A simple user defined filter function

--- a/datafusion-examples/examples/simple_udtf.rs
+++ b/datafusion-examples/examples/simple_udtf.rs
@@ -133,7 +133,8 @@ struct LocalCsvTableFunc {}
 
 impl TableFunctionImpl for LocalCsvTableFunc {
     fn call(&self, exprs: &[Expr]) -> Result<Arc<dyn TableProvider>> {
-        let Some(Expr::Literal(ScalarValue::Utf8(Some(ref path)))) = exprs.first() else {
+        let Some(Expr::Literal(ScalarValue::Utf8(Some(ref path)), _)) = exprs.first()
+        else {
             return plan_err!("read_csv requires at least one string argument");
         };
 
@@ -145,7 +146,7 @@ impl TableFunctionImpl for LocalCsvTableFunc {
                 let info = SimplifyContext::new(&execution_props);
                 let expr = ExprSimplifier::new(info).simplify(expr.clone())?;
 
-                if let Expr::Literal(ScalarValue::Int64(Some(limit))) = expr {
+                if let Expr::Literal(ScalarValue::Int64(Some(limit)), _) = expr {
                     Ok(limit as usize)
                 } else {
                     plan_err!("Limit must be an integer")

--- a/datafusion-examples/examples/simplify_udaf_expression.rs
+++ b/datafusion-examples/examples/simplify_udaf_expression.rs
@@ -91,7 +91,7 @@ impl AggregateUDFImpl for BetterAvgUdaf {
         // as an example for this functionality we replace UDF function
         // with build-in aggregate function to illustrate the use
         let simplify = |aggregate_function: AggregateFunction, _: &dyn SimplifyInfo| {
-            Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
+            Ok(Expr::aggregate_function(AggregateFunction::new_udf(
                 avg_udaf(),
                 // yes it is the same Avg, `BetterAvgUdaf` was just a
                 // marketing pitch :)

--- a/datafusion-examples/examples/simplify_udwf_expression.rs
+++ b/datafusion-examples/examples/simplify_udwf_expression.rs
@@ -71,7 +71,7 @@ impl WindowUDFImpl for SimplifySmoothItUdf {
     /// this function will simplify `SimplifySmoothItUdf` to `SmoothItUdf`.
     fn simplify(&self) -> Option<WindowFunctionSimplification> {
         let simplify = |window_function: WindowFunction, _: &dyn SimplifyInfo| {
-            Ok(Expr::WindowFunction(WindowFunction {
+            Ok(Expr::window_function(WindowFunction {
                 fun: datafusion_expr::WindowFunctionDefinition::AggregateUDF(avg_udaf()),
                 args: window_function.args,
                 partition_by: window_function.partition_by,

--- a/datafusion-examples/examples/sql_analysis.rs
+++ b/datafusion-examples/examples/sql_analysis.rs
@@ -39,7 +39,7 @@ fn total_join_count(plan: &LogicalPlan) -> usize {
     // We can use the TreeNode API to walk over a LogicalPlan.
     plan.apply(|node| {
         // if we encounter a join we update the running count
-        if matches!(node, LogicalPlan::Join(_)) {
+        if matches!(node, LogicalPlan::Join(_, _)) {
             total += 1;
         }
         Ok(TreeNodeRecursion::Continue)
@@ -89,7 +89,7 @@ fn count_trees(plan: &LogicalPlan) -> (usize, Vec<usize>) {
     while let Some(node) = to_visit.pop() {
         // if we encounter a join, we know were at the root of the tree
         // count this tree and recurse on it's inputs
-        if matches!(node, LogicalPlan::Join(_)) {
+        if matches!(node, LogicalPlan::Join(_, _)) {
             let (group_count, inputs) = count_tree(node);
             total += group_count;
             groups.push(group_count);
@@ -146,12 +146,12 @@ fn count_tree(join: &LogicalPlan) -> (usize, Vec<&LogicalPlan>) {
         //     /  \
         //    B    C
         // we can continue the recursion in this case
-        if let LogicalPlan::Projection(_) = node {
+        if let LogicalPlan::Projection(_, _) = node {
             return Ok(TreeNodeRecursion::Continue);
         }
 
         // any join we count
-        if matches!(node, LogicalPlan::Join(_)) {
+        if matches!(node, LogicalPlan::Join(_, _)) {
             total += 1;
             Ok(TreeNodeRecursion::Continue)
         } else {

--- a/datafusion/catalog/src/table.rs
+++ b/datafusion/catalog/src/table.rs
@@ -213,7 +213,7 @@ pub trait TableProvider: Debug + Sync + Send {
     ///         let support: Vec<_> = filters.iter().map(|expr| {
     ///           match expr {
     ///             // This example only supports a between expr with a single column named "c1".
-    ///             Expr::Between(between_expr) => {
+    ///             Expr::Between(between_expr, _) => {
     ///                 between_expr.expr
     ///                 .try_as_col()
     ///                 .map(|column| {

--- a/datafusion/common/src/tree_node.rs
+++ b/datafusion/common/src/tree_node.rs
@@ -686,6 +686,11 @@ impl<T> Transformed<T> {
         Self::new(data, false, TreeNodeRecursion::Continue)
     }
 
+    /// Wrapper for unchanged data with [`TreeNodeRecursion::Jump`] statement.
+    pub fn jump(data: T) -> Self {
+        Self::new(data, false, TreeNodeRecursion::Jump)
+    }
+
     /// Applies an infallible `f` to the data of this [`Transformed`] object,
     /// without modifying the `transformed` flag.
     pub fn update_data<U, F: FnOnce(T) -> U>(self, f: F) -> Transformed<U> {

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -110,6 +110,7 @@ datafusion-physical-expr-common = { workspace = true }
 datafusion-physical-optimizer = { workspace = true }
 datafusion-physical-plan = { workspace = true }
 datafusion-sql = { workspace = true }
+enumset = { workspace = true }
 flate2 = { version = "1.0.24", optional = true }
 futures = { workspace = true }
 glob = "0.3.0"

--- a/datafusion/core/benches/map_query_sql.rs
+++ b/datafusion/core/benches/map_query_sql.rs
@@ -71,8 +71,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut value_buffer = Vec::new();
 
     for i in 0..1000 {
-        key_buffer.push(Expr::Literal(ScalarValue::Utf8(Some(keys[i].clone()))));
-        value_buffer.push(Expr::Literal(ScalarValue::Int32(Some(values[i]))));
+        key_buffer.push(Expr::literal(ScalarValue::Utf8(Some(keys[i].clone()))));
+        value_buffer.push(Expr::literal(ScalarValue::Int32(Some(values[i]))));
     }
     c.bench_function("map_1000_1", |b| {
         b.iter(|| {

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1954,10 +1954,10 @@ mod tests {
             false,
         )]));
 
-        let filter_predicate = Expr::BinaryExpr(BinaryExpr::new(
-            Box::new(Expr::Column("column1".into())),
+        let filter_predicate = Expr::binary_expr(BinaryExpr::new(
+            Box::new(Expr::column("column1".into())),
             Operator::GtEq,
-            Box::new(Expr::Literal(ScalarValue::Int32(Some(0)))),
+            Box::new(Expr::literal(ScalarValue::Int32(Some(0)))),
         ));
 
         // Create a new batch of data to insert into the table

--- a/datafusion/core/src/datasource/mod.rs
+++ b/datafusion/core/src/datasource/mod.rs
@@ -65,7 +65,7 @@ fn create_ordering(
         let mut sort_exprs = LexOrdering::default();
         for sort in exprs {
             match &sort.expr {
-                Expr::Column(col) => match expressions::col(&col.name, schema) {
+                Expr::Column(col, _) => match expressions::col(&col.name, schema) {
                     Ok(expr) => {
                         sort_exprs.push(PhysicalSortExpr {
                             expr,

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_filter.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_filter.rs
@@ -432,7 +432,7 @@ pub fn can_expr_be_pushed_down_with_schemas(
 ) -> bool {
     let mut can_be_pushed = true;
     expr.apply(|expr| match expr {
-        datafusion_expr::Expr::Column(column) => {
+        datafusion_expr::Expr::Column(column, _) => {
             can_be_pushed &=
                 !would_column_prevent_pushdown(column.name(), file_schema, table_schema);
             Ok(if can_be_pushed {
@@ -699,7 +699,7 @@ mod test {
             .expect("expected error free record batch");
 
         // Test all should fail
-        let expr = col("timestamp_col").lt(Expr::Literal(
+        let expr = col("timestamp_col").lt(Expr::literal(
             ScalarValue::TimestampNanosecond(Some(1), Some(Arc::from("UTC"))),
         ));
         let expr = logical2physical(&expr, &table_schema);
@@ -723,7 +723,7 @@ mod test {
         assert!(matches!(filtered, Ok(a) if a == BooleanArray::from(vec![false; 8])));
 
         // Test all should pass
-        let expr = col("timestamp_col").gt(Expr::Literal(
+        let expr = col("timestamp_col").gt(Expr::literal(
             ScalarValue::TimestampNanosecond(Some(0), Some(Arc::from("UTC"))),
         ));
         let expr = logical2physical(&expr, &table_schema);
@@ -826,7 +826,7 @@ mod test {
 
         let expr = col("str_col")
             .is_not_null()
-            .or(col("int_col").gt(Expr::Literal(ScalarValue::UInt64(Some(5)))));
+            .or(col("int_col").gt(Expr::literal(ScalarValue::UInt64(Some(5)))));
 
         assert!(can_expr_be_pushed_down_with_schemas(
             &expr,

--- a/datafusion/core/src/datasource/physical_plan/parquet/row_group_filter.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/row_group_filter.rs
@@ -1231,10 +1231,10 @@ mod tests {
             .run(
                 lit("1").eq(lit("1")).and(
                     col(r#""String""#)
-                        .eq(Expr::Literal(ScalarValue::Utf8View(Some(String::from(
+                        .eq(Expr::literal(ScalarValue::Utf8View(Some(String::from(
                             "Hello_Not_Exists",
                         )))))
-                        .or(col(r#""String""#).eq(Expr::Literal(ScalarValue::Utf8View(
+                        .or(col(r#""String""#).eq(Expr::literal(ScalarValue::Utf8View(
                             Some(String::from("Hello_Not_Exists2")),
                         )))),
                 ),
@@ -1316,13 +1316,13 @@ mod tests {
             // generate pruning predicate `(String = "Hello") OR (String = "the quick") OR (String = "are you")`
             .run(
                 col(r#""String""#)
-                    .eq(Expr::Literal(ScalarValue::Utf8View(Some(String::from(
+                    .eq(Expr::literal(ScalarValue::Utf8View(Some(String::from(
                         "Hello",
                     )))))
-                    .or(col(r#""String""#).eq(Expr::Literal(ScalarValue::Utf8View(
+                    .or(col(r#""String""#).eq(Expr::literal(ScalarValue::Utf8View(
                         Some(String::from("the quick")),
                     ))))
-                    .or(col(r#""String""#).eq(Expr::Literal(ScalarValue::Utf8View(
+                    .or(col(r#""String""#).eq(Expr::literal(ScalarValue::Utf8View(
                         Some(String::from("are you")),
                     )))),
             )

--- a/datafusion/core/src/datasource/view.rs
+++ b/datafusion/core/src/datasource/view.rs
@@ -139,7 +139,7 @@ impl TableProvider for ViewTable {
                 let fields: Vec<Expr> = projection
                     .iter()
                     .map(|i| {
-                        Expr::Column(Column::from(
+                        Expr::column(Column::from(
                             self.logical_plan.schema().qualified_field(*i),
                         ))
                     })

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -632,7 +632,7 @@ impl SessionState {
 
     /// Optimizes the logical plan by applying optimizer rules.
     pub fn optimize(&self, plan: &LogicalPlan) -> datafusion_common::Result<LogicalPlan> {
-        if let LogicalPlan::Explain(e) = plan {
+        if let LogicalPlan::Explain(e, _) = plan {
             let mut stringified_plans = e.stringified_plans.clone();
 
             // analyze & capture output of each rule
@@ -652,7 +652,7 @@ impl SessionState {
                     stringified_plans
                         .push(StringifiedPlan::new(plan_type, err.to_string()));
 
-                    return Ok(LogicalPlan::Explain(Explain {
+                    return Ok(LogicalPlan::explain(Explain {
                         verbose: e.verbose,
                         plan: Arc::clone(&e.plan),
                         stringified_plans,
@@ -688,7 +688,7 @@ impl SessionState {
                 Err(e) => return Err(e),
             };
 
-            Ok(LogicalPlan::Explain(Explain {
+            Ok(LogicalPlan::explain(Explain {
                 verbose: e.verbose,
                 plan,
                 stringified_plans,

--- a/datafusion/core/tests/custom_sources_cases/mod.rs
+++ b/datafusion/core/tests/custom_sources_cases/mod.rs
@@ -236,11 +236,14 @@ async fn custom_source_dataframe() -> Result<()> {
 
     let optimized_plan = state.optimize(&logical_plan)?;
     match &optimized_plan {
-        LogicalPlan::TableScan(TableScan {
-            source,
-            projected_schema,
-            ..
-        }) => {
+        LogicalPlan::TableScan(
+            TableScan {
+                source,
+                projected_schema,
+                ..
+            },
+            _,
+        ) => {
             assert_eq!(source.schema().fields().len(), 2);
             assert_eq!(projected_schema.fields().len(), 1);
         }

--- a/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
@@ -172,14 +172,14 @@ impl TableProvider for CustomProvider {
         let empty = Vec::new();
         let projection = projection.unwrap_or(&empty);
         match &filters[0] {
-            Expr::BinaryExpr(BinaryExpr { right, .. }) => {
+            Expr::BinaryExpr(BinaryExpr { right, .. }, _) => {
                 let int_value = match &**right {
-                    Expr::Literal(ScalarValue::Int8(Some(i))) => *i as i64,
-                    Expr::Literal(ScalarValue::Int16(Some(i))) => *i as i64,
-                    Expr::Literal(ScalarValue::Int32(Some(i))) => *i as i64,
-                    Expr::Literal(ScalarValue::Int64(Some(i))) => *i,
-                    Expr::Cast(Cast { expr, data_type: _ }) => match expr.deref() {
-                        Expr::Literal(lit_value) => match lit_value {
+                    Expr::Literal(ScalarValue::Int8(Some(i)), _) => *i as i64,
+                    Expr::Literal(ScalarValue::Int16(Some(i)), _) => *i as i64,
+                    Expr::Literal(ScalarValue::Int32(Some(i)), _) => *i as i64,
+                    Expr::Literal(ScalarValue::Int64(Some(i)), _) => *i,
+                    Expr::Cast(Cast { expr, data_type: _ }, _) => match expr.deref() {
+                        Expr::Literal(lit_value, _) => match lit_value {
                             ScalarValue::Int8(Some(v)) => *v as i64,
                             ScalarValue::Int16(Some(v)) => *v as i64,
                             ScalarValue::Int32(Some(v)) => *v as i64,

--- a/datafusion/core/tests/dataframe/dataframe_functions.rs
+++ b/datafusion/core/tests/dataframe/dataframe_functions.rs
@@ -31,7 +31,6 @@ use datafusion::prelude::*;
 
 use datafusion::assert_batches_eq;
 use datafusion_common::{DFSchema, ScalarValue};
-use datafusion_expr::expr::Alias;
 use datafusion_expr::ExprSchemable;
 use datafusion_functions_aggregate::expr_fn::{approx_median, approx_percentile_cont};
 use datafusion_functions_nested::map::map;
@@ -376,11 +375,7 @@ async fn test_fn_approx_percentile_cont() -> Result<()> {
     assert_batches_eq!(expected, &batches);
 
     // the arg2 parameter is a complex expr, but it can be evaluated to the literal value
-    let alias_expr = Expr::Alias(Alias::new(
-        cast(lit(0.5), DataType::Float32),
-        None::<&str>,
-        "arg_2".to_string(),
-    ));
+    let alias_expr = cast(lit(0.5), DataType::Float32).alias("arg_2".to_string());
     let expr = approx_percentile_cont(col("b"), alias_expr, None);
     let df = create_test_table().await?;
     let expected = [

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -180,7 +180,7 @@ async fn test_count_wildcard_on_window() -> Result<()> {
     let df_results = ctx
         .table("t1")
         .await?
-        .select(vec![Expr::WindowFunction(expr::WindowFunction::new(
+        .select(vec![Expr::window_function(expr::WindowFunction::new(
             WindowFunctionDefinition::AggregateUDF(count_udaf()),
             vec![wildcard()],
         ))
@@ -589,7 +589,7 @@ async fn select_with_alias_overwrite() -> Result<()> {
 
 #[tokio::test]
 async fn test_grouping_sets() -> Result<()> {
-    let grouping_set_expr = Expr::GroupingSet(GroupingSet::GroupingSets(vec![
+    let grouping_set_expr = Expr::grouping_set(GroupingSet::GroupingSets(vec![
         vec![col("a")],
         vec![col("b")],
         vec![col("a"), col("b")],
@@ -631,7 +631,7 @@ async fn test_grouping_sets() -> Result<()> {
 async fn test_grouping_sets_count() -> Result<()> {
     let ctx = SessionContext::new();
 
-    let grouping_set_expr = Expr::GroupingSet(GroupingSet::GroupingSets(vec![
+    let grouping_set_expr = Expr::grouping_set(GroupingSet::GroupingSets(vec![
         vec![col("c1")],
         vec![col("c2")],
     ]));
@@ -671,7 +671,7 @@ async fn test_grouping_sets_count() -> Result<()> {
 async fn test_grouping_set_array_agg_with_overflow() -> Result<()> {
     let ctx = SessionContext::new();
 
-    let grouping_set_expr = Expr::GroupingSet(GroupingSet::GroupingSets(vec![
+    let grouping_set_expr = Expr::grouping_set(GroupingSet::GroupingSets(vec![
         vec![col("c1")],
         vec![col("c2")],
         vec![col("c1"), col("c2")],
@@ -1629,7 +1629,7 @@ async fn consecutive_projection_same_schema() -> Result<()> {
 
     // Add `t` column full of nulls
     let df = df
-        .with_column("t", cast(Expr::Literal(ScalarValue::Null), DataType::Int32))
+        .with_column("t", cast(Expr::literal(ScalarValue::Null), DataType::Int32))
         .unwrap();
     df.clone().show().await.unwrap();
 

--- a/datafusion/core/tests/execution/logical_plan.rs
+++ b/datafusion/core/tests/execution/logical_plan.rs
@@ -40,24 +40,24 @@ async fn count_only_nulls() -> Result<()> {
         vec![Field::new("col", DataType::Null, true)].into(),
         HashMap::new(),
     )?);
-    let input = Arc::new(LogicalPlan::Values(Values {
+    let input = Arc::new(LogicalPlan::values(Values {
         schema: input_schema,
         values: vec![
-            vec![Expr::Literal(ScalarValue::Null)],
-            vec![Expr::Literal(ScalarValue::Null)],
-            vec![Expr::Literal(ScalarValue::Null)],
+            vec![Expr::literal(ScalarValue::Null)],
+            vec![Expr::literal(ScalarValue::Null)],
+            vec![Expr::literal(ScalarValue::Null)],
         ],
     }));
-    let input_col_ref = Expr::Column(Column {
+    let input_col_ref = Expr::column(Column {
         relation: None,
         name: "col".to_string(),
     });
 
     // Aggregation: count(col) AS count
-    let aggregate = LogicalPlan::Aggregate(Aggregate::try_new(
+    let aggregate = LogicalPlan::aggregate(Aggregate::try_new(
         input,
         vec![],
-        vec![Expr::AggregateFunction(AggregateFunction {
+        vec![Expr::aggregate_function(AggregateFunction {
             func: Arc::new(AggregateUDF::new_from_impl(Count::new())),
             args: vec![input_col_ref],
             distinct: false,

--- a/datafusion/core/tests/optimizer/mod.rs
+++ b/datafusion/core/tests/optimizer/mod.rs
@@ -301,7 +301,7 @@ fn test_inequalities_non_null_bounded() {
         (col("x").not_between(lit(0), lit(5)), false),
         (col("x").not_between(lit(5), lit(10)), true),
         (
-            Expr::BinaryExpr(BinaryExpr {
+            Expr::binary_expr(BinaryExpr {
                 left: Box::new(col("x")),
                 op: Operator::IsDistinctFrom,
                 right: Box::new(lit(ScalarValue::Null)),
@@ -309,7 +309,7 @@ fn test_inequalities_non_null_bounded() {
             true,
         ),
         (
-            Expr::BinaryExpr(BinaryExpr {
+            Expr::binary_expr(BinaryExpr {
                 left: Box::new(col("x")),
                 op: Operator::IsDistinctFrom,
                 right: Box::new(lit(5)),

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -327,11 +327,14 @@ async fn nyc() -> Result<()> {
     let optimized_plan = dataframe.into_optimized_plan().unwrap();
 
     match &optimized_plan {
-        LogicalPlan::Aggregate(Aggregate { input, .. }) => match input.as_ref() {
-            LogicalPlan::TableScan(TableScan {
-                ref projected_schema,
-                ..
-            }) => {
+        LogicalPlan::Aggregate(Aggregate { input, .. }, _) => match input.as_ref() {
+            LogicalPlan::TableScan(
+                TableScan {
+                    ref projected_schema,
+                    ..
+                },
+                _,
+            ) => {
                 assert_eq!(2, projected_schema.fields().len());
                 assert_eq!(projected_schema.field(0).name(), "passenger_count");
                 assert_eq!(projected_schema.field(1).name(), "fare_amount");

--- a/datafusion/core/tests/user_defined/expr_planner.rs
+++ b/datafusion/core/tests/user_defined/expr_planner.rs
@@ -25,7 +25,6 @@ use datafusion::logical_expr::Operator;
 use datafusion::prelude::*;
 use datafusion::sql::sqlparser::ast::BinaryOperator;
 use datafusion_common::ScalarValue;
-use datafusion_expr::expr::Alias;
 use datafusion_expr::planner::{ExprPlanner, PlannerResult, RawBinaryExpr};
 use datafusion_expr::BinaryExpr;
 
@@ -40,26 +39,23 @@ impl ExprPlanner for MyCustomPlanner {
     ) -> Result<PlannerResult<RawBinaryExpr>> {
         match &expr.op {
             BinaryOperator::Arrow => {
-                Ok(PlannerResult::Planned(Expr::BinaryExpr(BinaryExpr {
+                Ok(PlannerResult::Planned(Expr::binary_expr(BinaryExpr {
                     left: Box::new(expr.left.clone()),
                     right: Box::new(expr.right.clone()),
                     op: Operator::StringConcat,
                 })))
             }
             BinaryOperator::LongArrow => {
-                Ok(PlannerResult::Planned(Expr::BinaryExpr(BinaryExpr {
+                Ok(PlannerResult::Planned(Expr::binary_expr(BinaryExpr {
                     left: Box::new(expr.left.clone()),
                     right: Box::new(expr.right.clone()),
                     op: Operator::Plus,
                 })))
             }
-            BinaryOperator::Question => {
-                Ok(PlannerResult::Planned(Expr::Alias(Alias::new(
-                    Expr::Literal(ScalarValue::Boolean(Some(true))),
-                    None::<&str>,
-                    format!("{} ? {}", expr.left, expr.right),
-                ))))
-            }
+            BinaryOperator::Question => Ok(PlannerResult::Planned(
+                Expr::literal(ScalarValue::Boolean(Some(true)))
+                    .alias(format!("{} ? {}", expr.left, expr.right)),
+            )),
             _ => Ok(PlannerResult::Original(expr)),
         }
     }

--- a/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
@@ -707,7 +707,7 @@ impl ScalarUDFImpl for CastToI64UDF {
             arg
         } else {
             // need to use an actual cast to get the correct type
-            Expr::Cast(datafusion_expr::Cast {
+            Expr::cast(datafusion_expr::Cast {
                 expr: Box::new(arg),
                 data_type: DataType::Int64,
             })
@@ -829,7 +829,7 @@ impl ScalarUDFImpl for TakeUDF {
             return plan_err!("Expected 3 arguments, got {}.", arg_exprs.len());
         }
 
-        let take_idx = if let Some(Expr::Literal(ScalarValue::Int64(Some(idx)))) =
+        let take_idx = if let Some(Expr::Literal(ScalarValue::Int64(Some(idx)), _)) =
             arg_exprs.get(2)
         {
             if *idx == 0 || *idx == 1 {
@@ -988,7 +988,7 @@ impl ScalarFunctionWrapper {
     fn replacement(expr: &Expr, args: &[Expr]) -> Result<Expr> {
         let result = expr.clone().transform(|e| {
             let r = match e {
-                Expr::Placeholder(placeholder) => {
+                Expr::Placeholder(placeholder, _) => {
                     let placeholder_position =
                         Self::parse_placeholder_identifier(&placeholder.id)?;
                     if placeholder_position < args.len() {

--- a/datafusion/core/tests/user_defined/user_defined_table_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_table_functions.rs
@@ -165,7 +165,7 @@ impl SimpleCsvTable {
     async fn interpreter_expr(&self, state: &dyn Session) -> Result<i64> {
         use datafusion::logical_expr::expr_rewriter::normalize_col;
         use datafusion::logical_expr::utils::columnize_expr;
-        let plan = LogicalPlan::EmptyRelation(EmptyRelation {
+        let plan = LogicalPlan::empty_relation(EmptyRelation {
             produce_one_row: true,
             schema: Arc::new(DFSchema::empty()),
         });
@@ -176,7 +176,7 @@ impl SimpleCsvTable {
             )?],
             Arc::new(plan),
         )
-        .map(LogicalPlan::Projection)?;
+        .map(LogicalPlan::projection)?;
         let rbs = collect(
             state.create_physical_plan(&logical_plan).await?,
             Arc::new(TaskContext::from(state)),
@@ -201,7 +201,7 @@ impl TableFunctionImpl for SimpleCsvTableFunc {
         let mut filepath = String::new();
         for expr in exprs {
             match expr {
-                Expr::Literal(ScalarValue::Utf8(Some(ref path))) => {
+                Expr::Literal(ScalarValue::Utf8(Some(ref path)), _) => {
                     filepath.clone_from(path);
                 }
                 expr => new_exprs.push(expr.clone()),

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -49,6 +49,7 @@ datafusion-expr-common = { workspace = true }
 datafusion-functions-aggregate-common = { workspace = true }
 datafusion-functions-window-common = { workspace = true }
 datafusion-physical-expr-common = { workspace = true }
+enumset = { workspace = true }
 indexmap = { workspace = true }
 paste = "^1.0"
 recursive = { workspace = true }

--- a/datafusion/expr/src/conditional_expressions.rs
+++ b/datafusion/expr/src/conditional_expressions.rs
@@ -72,7 +72,7 @@ impl CaseBuilder {
         let then_types: Vec<DataType> = then_expr
             .iter()
             .map(|e| match e {
-                Expr::Literal(_) => e.get_type(&DFSchema::empty()),
+                Expr::Literal(_, _) => e.get_type(&DFSchema::empty()),
                 _ => Ok(DataType::Null),
             })
             .collect::<Result<Vec<_>>>()?;
@@ -88,7 +88,7 @@ impl CaseBuilder {
             }
         }
 
-        Ok(Expr::Case(Case::new(
+        Ok(Expr::case(Case::new(
             self.expr.clone(),
             self.when_expr
                 .iter()

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -19,7 +19,7 @@
 
 use crate::expr::{
     AggregateFunction, BinaryExpr, Cast, Exists, GroupingSet, InList, InSubquery,
-    Placeholder, TryCast, Unnest, WildcardOptions, WindowFunction,
+    Placeholder, TryCast, Unnest, Wildcard, WildcardOptions, WindowFunction,
 };
 use crate::function::{
     AccumulatorArgs, AccumulatorFactoryFunction, PartitionEvaluatorFactory,
@@ -121,18 +121,18 @@ pub fn placeholder(id: impl Into<String>) -> Expr {
 /// assert_eq!(p.to_string(), "*")
 /// ```
 pub fn wildcard() -> Expr {
-    Expr::Wildcard {
+    Expr::Wildcard(Wildcard {
         qualifier: None,
         options: WildcardOptions::default(),
-    }
+    })
 }
 
 /// Create an '*' [`Expr::Wildcard`] expression with the wildcard options
 pub fn wildcard_with_options(options: WildcardOptions) -> Expr {
-    Expr::Wildcard {
+    Expr::Wildcard(Wildcard {
         qualifier: None,
         options,
-    }
+    })
 }
 
 /// Create an 't.*' [`Expr::Wildcard`] expression that matches all columns from a specific table
@@ -146,10 +146,10 @@ pub fn wildcard_with_options(options: WildcardOptions) -> Expr {
 /// assert_eq!(p.to_string(), "t.*")
 /// ```
 pub fn qualified_wildcard(qualifier: impl Into<TableReference>) -> Expr {
-    Expr::Wildcard {
+    Expr::Wildcard(Wildcard {
         qualifier: Some(qualifier.into()),
         options: WildcardOptions::default(),
-    }
+    })
 }
 
 /// Create an 't.*' [`Expr::Wildcard`] expression with the wildcard options
@@ -157,10 +157,10 @@ pub fn qualified_wildcard_with_options(
     qualifier: impl Into<TableReference>,
     options: WildcardOptions,
 ) -> Expr {
-    Expr::Wildcard {
+    Expr::Wildcard(Wildcard {
         qualifier: Some(qualifier.into()),
         options,
-    }
+    })
 }
 
 /// Return a new expression `left <op> right`

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -62,13 +62,13 @@ use std::sync::Arc;
 /// assert_ne!(c1, c3);
 /// ```
 pub fn col(ident: impl Into<Column>) -> Expr {
-    Expr::Column(ident.into())
+    Expr::column(ident.into())
 }
 
 /// Create an out reference column which hold a reference that has been resolved to a field
 /// outside of the current plan.
 pub fn out_ref_col(dt: DataType, ident: impl Into<Column>) -> Expr {
-    Expr::OuterReferenceColumn(dt, ident.into())
+    Expr::outer_reference_column(dt, ident.into())
 }
 
 /// Create an unqualified column expression from the provided name, without normalizing
@@ -90,7 +90,7 @@ pub fn out_ref_col(dt: DataType, ident: impl Into<Column>) -> Expr {
 /// assert_ne!(c4, c5);
 /// ```
 pub fn ident(name: impl Into<String>) -> Expr {
-    Expr::Column(Column::from_name(name))
+    Expr::column(Column::from_name(name))
 }
 
 /// Create placeholder value that will be filled in (such as `$1`)
@@ -105,7 +105,7 @@ pub fn ident(name: impl Into<String>) -> Expr {
 /// assert_eq!(p.to_string(), "$0")
 /// ```
 pub fn placeholder(id: impl Into<String>) -> Expr {
-    Expr::Placeholder(Placeholder {
+    Expr::placeholder(Placeholder {
         id: id.into(),
         data_type: None,
     })
@@ -121,7 +121,7 @@ pub fn placeholder(id: impl Into<String>) -> Expr {
 /// assert_eq!(p.to_string(), "*")
 /// ```
 pub fn wildcard() -> Expr {
-    Expr::Wildcard(Wildcard {
+    Expr::wildcard(Wildcard {
         qualifier: None,
         options: WildcardOptions::default(),
     })
@@ -129,7 +129,7 @@ pub fn wildcard() -> Expr {
 
 /// Create an '*' [`Expr::Wildcard`] expression with the wildcard options
 pub fn wildcard_with_options(options: WildcardOptions) -> Expr {
-    Expr::Wildcard(Wildcard {
+    Expr::wildcard(Wildcard {
         qualifier: None,
         options,
     })
@@ -146,7 +146,7 @@ pub fn wildcard_with_options(options: WildcardOptions) -> Expr {
 /// assert_eq!(p.to_string(), "t.*")
 /// ```
 pub fn qualified_wildcard(qualifier: impl Into<TableReference>) -> Expr {
-    Expr::Wildcard(Wildcard {
+    Expr::wildcard(Wildcard {
         qualifier: Some(qualifier.into()),
         options: WildcardOptions::default(),
     })
@@ -157,7 +157,7 @@ pub fn qualified_wildcard_with_options(
     qualifier: impl Into<TableReference>,
     options: WildcardOptions,
 ) -> Expr {
-    Expr::Wildcard(Wildcard {
+    Expr::wildcard(Wildcard {
         qualifier: Some(qualifier.into()),
         options,
     })
@@ -165,12 +165,12 @@ pub fn qualified_wildcard_with_options(
 
 /// Return a new expression `left <op> right`
 pub fn binary_expr(left: Expr, op: Operator, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(Box::new(left), op, Box::new(right)))
+    Expr::binary_expr(BinaryExpr::new(Box::new(left), op, Box::new(right)))
 }
 
 /// Return a new expression with a logical AND
 pub fn and(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::binary_expr(BinaryExpr::new(
         Box::new(left),
         Operator::And,
         Box::new(right),
@@ -179,7 +179,7 @@ pub fn and(left: Expr, right: Expr) -> Expr {
 
 /// Return a new expression with a logical OR
 pub fn or(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::binary_expr(BinaryExpr::new(
         Box::new(left),
         Operator::Or,
         Box::new(right),
@@ -193,7 +193,7 @@ pub fn not(expr: Expr) -> Expr {
 
 /// Return a new expression with bitwise AND
 pub fn bitwise_and(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::binary_expr(BinaryExpr::new(
         Box::new(left),
         Operator::BitwiseAnd,
         Box::new(right),
@@ -202,7 +202,7 @@ pub fn bitwise_and(left: Expr, right: Expr) -> Expr {
 
 /// Return a new expression with bitwise OR
 pub fn bitwise_or(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::binary_expr(BinaryExpr::new(
         Box::new(left),
         Operator::BitwiseOr,
         Box::new(right),
@@ -211,7 +211,7 @@ pub fn bitwise_or(left: Expr, right: Expr) -> Expr {
 
 /// Return a new expression with bitwise XOR
 pub fn bitwise_xor(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::binary_expr(BinaryExpr::new(
         Box::new(left),
         Operator::BitwiseXor,
         Box::new(right),
@@ -220,7 +220,7 @@ pub fn bitwise_xor(left: Expr, right: Expr) -> Expr {
 
 /// Return a new expression with bitwise SHIFT RIGHT
 pub fn bitwise_shift_right(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::binary_expr(BinaryExpr::new(
         Box::new(left),
         Operator::BitwiseShiftRight,
         Box::new(right),
@@ -229,7 +229,7 @@ pub fn bitwise_shift_right(left: Expr, right: Expr) -> Expr {
 
 /// Return a new expression with bitwise SHIFT LEFT
 pub fn bitwise_shift_left(left: Expr, right: Expr) -> Expr {
-    Expr::BinaryExpr(BinaryExpr::new(
+    Expr::binary_expr(BinaryExpr::new(
         Box::new(left),
         Operator::BitwiseShiftLeft,
         Box::new(right),
@@ -238,13 +238,13 @@ pub fn bitwise_shift_left(left: Expr, right: Expr) -> Expr {
 
 /// Create an in_list expression
 pub fn in_list(expr: Expr, list: Vec<Expr>, negated: bool) -> Expr {
-    Expr::InList(InList::new(Box::new(expr), list, negated))
+    Expr::_in_list(InList::new(Box::new(expr), list, negated))
 }
 
 /// Create an EXISTS subquery expression
 pub fn exists(subquery: Arc<LogicalPlan>) -> Expr {
     let outer_ref_columns = subquery.all_out_ref_exprs();
-    Expr::Exists(Exists {
+    Expr::exists(Exists {
         subquery: Subquery {
             subquery,
             outer_ref_columns,
@@ -256,7 +256,7 @@ pub fn exists(subquery: Arc<LogicalPlan>) -> Expr {
 /// Create a NOT EXISTS subquery expression
 pub fn not_exists(subquery: Arc<LogicalPlan>) -> Expr {
     let outer_ref_columns = subquery.all_out_ref_exprs();
-    Expr::Exists(Exists {
+    Expr::exists(Exists {
         subquery: Subquery {
             subquery,
             outer_ref_columns,
@@ -268,7 +268,7 @@ pub fn not_exists(subquery: Arc<LogicalPlan>) -> Expr {
 /// Create an IN subquery expression
 pub fn in_subquery(expr: Expr, subquery: Arc<LogicalPlan>) -> Expr {
     let outer_ref_columns = subquery.all_out_ref_exprs();
-    Expr::InSubquery(InSubquery::new(
+    Expr::in_subquery(InSubquery::new(
         Box::new(expr),
         Subquery {
             subquery,
@@ -281,7 +281,7 @@ pub fn in_subquery(expr: Expr, subquery: Arc<LogicalPlan>) -> Expr {
 /// Create a NOT IN subquery expression
 pub fn not_in_subquery(expr: Expr, subquery: Arc<LogicalPlan>) -> Expr {
     let outer_ref_columns = subquery.all_out_ref_exprs();
-    Expr::InSubquery(InSubquery::new(
+    Expr::in_subquery(InSubquery::new(
         Box::new(expr),
         Subquery {
             subquery,
@@ -294,7 +294,7 @@ pub fn not_in_subquery(expr: Expr, subquery: Arc<LogicalPlan>) -> Expr {
 /// Create a scalar subquery expression
 pub fn scalar_subquery(subquery: Arc<LogicalPlan>) -> Expr {
     let outer_ref_columns = subquery.all_out_ref_exprs();
-    Expr::ScalarSubquery(Subquery {
+    Expr::scalar_subquery(Subquery {
         subquery,
         outer_ref_columns,
     })
@@ -302,62 +302,62 @@ pub fn scalar_subquery(subquery: Arc<LogicalPlan>) -> Expr {
 
 /// Create a grouping set
 pub fn grouping_set(exprs: Vec<Vec<Expr>>) -> Expr {
-    Expr::GroupingSet(GroupingSet::GroupingSets(exprs))
+    Expr::grouping_set(GroupingSet::GroupingSets(exprs))
 }
 
 /// Create a grouping set for all combination of `exprs`
 pub fn cube(exprs: Vec<Expr>) -> Expr {
-    Expr::GroupingSet(GroupingSet::Cube(exprs))
+    Expr::grouping_set(GroupingSet::Cube(exprs))
 }
 
 /// Create a grouping set for rollup
 pub fn rollup(exprs: Vec<Expr>) -> Expr {
-    Expr::GroupingSet(GroupingSet::Rollup(exprs))
+    Expr::grouping_set(GroupingSet::Rollup(exprs))
 }
 
 /// Create a cast expression
 pub fn cast(expr: Expr, data_type: DataType) -> Expr {
-    Expr::Cast(Cast::new(Box::new(expr), data_type))
+    Expr::cast(Cast::new(Box::new(expr), data_type))
 }
 
 /// Create a try cast expression
 pub fn try_cast(expr: Expr, data_type: DataType) -> Expr {
-    Expr::TryCast(TryCast::new(Box::new(expr), data_type))
+    Expr::try_cast(TryCast::new(Box::new(expr), data_type))
 }
 
 /// Create is null expression
 pub fn is_null(expr: Expr) -> Expr {
-    Expr::IsNull(Box::new(expr))
+    Expr::_is_null(Box::new(expr))
 }
 
 /// Create is true expression
 pub fn is_true(expr: Expr) -> Expr {
-    Expr::IsTrue(Box::new(expr))
+    Expr::_is_true(Box::new(expr))
 }
 
 /// Create is not true expression
 pub fn is_not_true(expr: Expr) -> Expr {
-    Expr::IsNotTrue(Box::new(expr))
+    Expr::_is_not_true(Box::new(expr))
 }
 
 /// Create is false expression
 pub fn is_false(expr: Expr) -> Expr {
-    Expr::IsFalse(Box::new(expr))
+    Expr::_is_false(Box::new(expr))
 }
 
 /// Create is not false expression
 pub fn is_not_false(expr: Expr) -> Expr {
-    Expr::IsNotFalse(Box::new(expr))
+    Expr::_is_not_false(Box::new(expr))
 }
 
 /// Create is unknown expression
 pub fn is_unknown(expr: Expr) -> Expr {
-    Expr::IsUnknown(Box::new(expr))
+    Expr::_is_unknown(Box::new(expr))
 }
 
 /// Create is not unknown expression
 pub fn is_not_unknown(expr: Expr) -> Expr {
-    Expr::IsNotUnknown(Box::new(expr))
+    Expr::_is_not_unknown(Box::new(expr))
 }
 
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
@@ -372,7 +372,7 @@ pub fn when(when: Expr, then: Expr) -> CaseBuilder {
 
 /// Create a Unnest expression
 pub fn unnest(expr: Expr) -> Expr {
-    Expr::Unnest(Unnest {
+    Expr::unnest(Unnest {
         expr: Box::new(expr),
     })
 }
@@ -697,17 +697,17 @@ impl WindowUDFImpl for SimpleWindowUDF {
 
 pub fn interval_year_month_lit(value: &str) -> Expr {
     let interval = parse_interval_year_month(value).ok();
-    Expr::Literal(ScalarValue::IntervalYearMonth(interval))
+    Expr::literal(ScalarValue::IntervalYearMonth(interval))
 }
 
 pub fn interval_datetime_lit(value: &str) -> Expr {
     let interval = parse_interval_day_time(value).ok();
-    Expr::Literal(ScalarValue::IntervalDayTime(interval))
+    Expr::literal(ScalarValue::IntervalDayTime(interval))
 }
 
 pub fn interval_month_day_nano_lit(value: &str) -> Expr {
     let interval = parse_interval_month_day_nano(value).ok();
-    Expr::Literal(ScalarValue::IntervalMonthDayNano(interval))
+    Expr::literal(ScalarValue::IntervalMonthDayNano(interval))
 }
 
 /// Extensions for configuring [`Expr::AggregateFunction`] or [`Expr::WindowFunction`]
@@ -832,7 +832,7 @@ impl ExprFuncBuilder {
                 udaf.filter = filter.map(Box::new);
                 udaf.distinct = distinct;
                 udaf.null_treatment = null_treatment;
-                Expr::AggregateFunction(udaf)
+                Expr::aggregate_function(udaf)
             }
             ExprFuncKind::Window(mut udwf) => {
                 let has_order_by = order_by.as_ref().map(|o| !o.is_empty());
@@ -841,7 +841,7 @@ impl ExprFuncBuilder {
                 udwf.window_frame =
                     window_frame.unwrap_or(WindowFrame::new(has_order_by));
                 udwf.null_treatment = null_treatment;
-                Expr::WindowFunction(udwf)
+                Expr::window_function(udwf)
             }
         };
 
@@ -891,10 +891,10 @@ impl ExprFunctionExt for ExprFuncBuilder {
 impl ExprFunctionExt for Expr {
     fn order_by(self, order_by: Vec<Sort>) -> ExprFuncBuilder {
         let mut builder = match self {
-            Expr::AggregateFunction(udaf) => {
+            Expr::AggregateFunction(udaf, _) => {
                 ExprFuncBuilder::new(Some(ExprFuncKind::Aggregate(udaf)))
             }
-            Expr::WindowFunction(udwf) => {
+            Expr::WindowFunction(udwf, _) => {
                 ExprFuncBuilder::new(Some(ExprFuncKind::Window(udwf)))
             }
             _ => ExprFuncBuilder::new(None),
@@ -906,7 +906,7 @@ impl ExprFunctionExt for Expr {
     }
     fn filter(self, filter: Expr) -> ExprFuncBuilder {
         match self {
-            Expr::AggregateFunction(udaf) => {
+            Expr::AggregateFunction(udaf, _) => {
                 let mut builder =
                     ExprFuncBuilder::new(Some(ExprFuncKind::Aggregate(udaf)));
                 builder.filter = Some(filter);
@@ -917,7 +917,7 @@ impl ExprFunctionExt for Expr {
     }
     fn distinct(self) -> ExprFuncBuilder {
         match self {
-            Expr::AggregateFunction(udaf) => {
+            Expr::AggregateFunction(udaf, _) => {
                 let mut builder =
                     ExprFuncBuilder::new(Some(ExprFuncKind::Aggregate(udaf)));
                 builder.distinct = true;
@@ -931,10 +931,10 @@ impl ExprFunctionExt for Expr {
         null_treatment: impl Into<Option<NullTreatment>>,
     ) -> ExprFuncBuilder {
         let mut builder = match self {
-            Expr::AggregateFunction(udaf) => {
+            Expr::AggregateFunction(udaf, _) => {
                 ExprFuncBuilder::new(Some(ExprFuncKind::Aggregate(udaf)))
             }
-            Expr::WindowFunction(udwf) => {
+            Expr::WindowFunction(udwf, _) => {
                 ExprFuncBuilder::new(Some(ExprFuncKind::Window(udwf)))
             }
             _ => ExprFuncBuilder::new(None),
@@ -947,7 +947,7 @@ impl ExprFunctionExt for Expr {
 
     fn partition_by(self, partition_by: Vec<Expr>) -> ExprFuncBuilder {
         match self {
-            Expr::WindowFunction(udwf) => {
+            Expr::WindowFunction(udwf, _) => {
                 let mut builder = ExprFuncBuilder::new(Some(ExprFuncKind::Window(udwf)));
                 builder.partition_by = Some(partition_by);
                 builder
@@ -958,7 +958,7 @@ impl ExprFunctionExt for Expr {
 
     fn window_frame(self, window_frame: WindowFrame) -> ExprFuncBuilder {
         match self {
-            Expr::WindowFunction(udwf) => {
+            Expr::WindowFunction(udwf, _) => {
                 let mut builder = ExprFuncBuilder::new(Some(ExprFuncKind::Window(udwf)));
                 builder.window_frame = Some(window_frame);
                 builder

--- a/datafusion/expr/src/literal.rs
+++ b/datafusion/expr/src/literal.rs
@@ -43,37 +43,37 @@ pub trait TimestampLiteral {
 
 impl Literal for &str {
     fn lit(&self) -> Expr {
-        Expr::Literal(ScalarValue::from(*self))
+        Expr::literal(ScalarValue::from(*self))
     }
 }
 
 impl Literal for String {
     fn lit(&self) -> Expr {
-        Expr::Literal(ScalarValue::from(self.as_ref()))
+        Expr::literal(ScalarValue::from(self.as_ref()))
     }
 }
 
 impl Literal for &String {
     fn lit(&self) -> Expr {
-        Expr::Literal(ScalarValue::from(self.as_ref()))
+        Expr::literal(ScalarValue::from(self.as_ref()))
     }
 }
 
 impl Literal for Vec<u8> {
     fn lit(&self) -> Expr {
-        Expr::Literal(ScalarValue::Binary(Some((*self).to_owned())))
+        Expr::literal(ScalarValue::Binary(Some((*self).to_owned())))
     }
 }
 
 impl Literal for &[u8] {
     fn lit(&self) -> Expr {
-        Expr::Literal(ScalarValue::Binary(Some((*self).to_owned())))
+        Expr::literal(ScalarValue::Binary(Some((*self).to_owned())))
     }
 }
 
 impl Literal for ScalarValue {
     fn lit(&self) -> Expr {
-        Expr::Literal(self.clone())
+        Expr::literal(self.clone())
     }
 }
 
@@ -82,7 +82,7 @@ macro_rules! make_literal {
         #[doc = $DOC]
         impl Literal for $TYPE {
             fn lit(&self) -> Expr {
-                Expr::Literal(ScalarValue::$SCALAR(Some(self.clone())))
+                Expr::literal(ScalarValue::$SCALAR(Some(self.clone())))
             }
         }
     };
@@ -93,7 +93,7 @@ macro_rules! make_nonzero_literal {
         #[doc = $DOC]
         impl Literal for $TYPE {
             fn lit(&self) -> Expr {
-                Expr::Literal(ScalarValue::$SCALAR(Some(self.get())))
+                Expr::literal(ScalarValue::$SCALAR(Some(self.get())))
             }
         }
     };
@@ -104,7 +104,7 @@ macro_rules! make_timestamp_literal {
         #[doc = $DOC]
         impl TimestampLiteral for $TYPE {
             fn lit_timestamp_nano(&self) -> Expr {
-                Expr::Literal(ScalarValue::TimestampNanosecond(
+                Expr::literal(ScalarValue::TimestampNanosecond(
                     Some((self.clone()).into()),
                     None,
                 ))

--- a/datafusion/expr/src/logical_plan/display.rs
+++ b/datafusion/expr/src/logical_plan/display.rs
@@ -312,18 +312,18 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
     /// Converts a logical plan node to a json object.
     fn to_json_value(node: &LogicalPlan) -> serde_json::Value {
         match node {
-            LogicalPlan::EmptyRelation(_) => {
+            LogicalPlan::EmptyRelation(_, _) => {
                 json!({
                     "Node Type": "EmptyRelation",
                 })
             }
-            LogicalPlan::RecursiveQuery(RecursiveQuery { is_distinct, .. }) => {
+            LogicalPlan::RecursiveQuery(RecursiveQuery { is_distinct, .. }, _) => {
                 json!({
                     "Node Type": "RecursiveQuery",
                     "Is Distinct": is_distinct,
                 })
             }
-            LogicalPlan::Values(Values { ref values, .. }) => {
+            LogicalPlan::Values(Values { ref values, .. }, _) => {
                 let str_values = values
                     .iter()
                     // limit to only 5 values to avoid horrible display
@@ -347,13 +347,16 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
                     "Values": values_str
                 })
             }
-            LogicalPlan::TableScan(TableScan {
-                ref source,
-                ref table_name,
-                ref filters,
-                ref fetch,
-                ..
-            }) => {
+            LogicalPlan::TableScan(
+                TableScan {
+                    ref source,
+                    ref table_name,
+                    ref filters,
+                    ref fetch,
+                    ..
+                },
+                _,
+            ) => {
                 let mut object = json!({
                     "Node Type": "TableScan",
                     "Relation Name": table_name.table(),
@@ -407,26 +410,29 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
 
                 object
             }
-            LogicalPlan::Projection(Projection { ref expr, .. }) => {
+            LogicalPlan::Projection(Projection { ref expr, .. }, _) => {
                 json!({
                     "Node Type": "Projection",
                     "Expressions": expr.iter().map(|e| e.to_string()).collect::<Vec<_>>()
                 })
             }
-            LogicalPlan::Dml(DmlStatement { table_name, op, .. }) => {
+            LogicalPlan::Dml(DmlStatement { table_name, op, .. }, _) => {
                 json!({
                     "Node Type": "Projection",
                     "Operation": op.name(),
                     "Table Name": table_name.table()
                 })
             }
-            LogicalPlan::Copy(CopyTo {
-                input: _,
-                output_url,
-                file_type,
-                partition_by: _,
-                options,
-            }) => {
+            LogicalPlan::Copy(
+                CopyTo {
+                    input: _,
+                    output_url,
+                    file_type,
+                    partition_by: _,
+                    options,
+                },
+                _,
+            ) => {
                 let op_str = options
                     .iter()
                     .map(|(k, v)| format!("{}={}", k, v))
@@ -439,41 +445,50 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
                     "Options": op_str
                 })
             }
-            LogicalPlan::Ddl(ddl) => {
+            LogicalPlan::Ddl(ddl, _) => {
                 json!({
                     "Node Type": "Ddl",
                     "Operation": format!("{}", ddl.display())
                 })
             }
-            LogicalPlan::Filter(Filter {
-                predicate: ref expr,
-                ..
-            }) => {
+            LogicalPlan::Filter(
+                Filter {
+                    predicate: ref expr,
+                    ..
+                },
+                _,
+            ) => {
                 json!({
                     "Node Type": "Filter",
                     "Condition": format!("{}", expr)
                 })
             }
-            LogicalPlan::Window(Window {
-                ref window_expr, ..
-            }) => {
+            LogicalPlan::Window(
+                Window {
+                    ref window_expr, ..
+                },
+                _,
+            ) => {
                 json!({
                     "Node Type": "WindowAggr",
                     "Expressions": expr_vec_fmt!(window_expr)
                 })
             }
-            LogicalPlan::Aggregate(Aggregate {
-                ref group_expr,
-                ref aggr_expr,
-                ..
-            }) => {
+            LogicalPlan::Aggregate(
+                Aggregate {
+                    ref group_expr,
+                    ref aggr_expr,
+                    ..
+                },
+                _,
+            ) => {
                 json!({
                     "Node Type": "Aggregate",
                     "Group By": expr_vec_fmt!(group_expr),
                     "Aggregates": expr_vec_fmt!(aggr_expr)
                 })
             }
-            LogicalPlan::Sort(Sort { expr, fetch, .. }) => {
+            LogicalPlan::Sort(Sort { expr, fetch, .. }, _) => {
                 let mut object = json!({
                     "Node Type": "Sort",
                     "Sort Key": expr_vec_fmt!(expr),
@@ -485,13 +500,16 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
 
                 object
             }
-            LogicalPlan::Join(Join {
-                on: ref keys,
-                filter,
-                join_constraint,
-                join_type,
-                ..
-            }) => {
+            LogicalPlan::Join(
+                Join {
+                    on: ref keys,
+                    filter,
+                    join_constraint,
+                    join_type,
+                    ..
+                },
+                _,
+            ) => {
                 let join_expr: Vec<String> =
                     keys.iter().map(|(l, r)| format!("{l} = {r}")).collect();
                 let filter_expr = filter
@@ -505,10 +523,13 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
                     "Filter": format!("{}", filter_expr)
                 })
             }
-            LogicalPlan::Repartition(Repartition {
-                partitioning_scheme,
-                ..
-            }) => match partitioning_scheme {
+            LogicalPlan::Repartition(
+                Repartition {
+                    partitioning_scheme,
+                    ..
+                },
+                _,
+            ) => match partitioning_scheme {
                 Partitioning::RoundRobinBatch(n) => {
                     json!({
                         "Node Type": "Repartition",
@@ -537,11 +558,14 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
                     })
                 }
             },
-            LogicalPlan::Limit(Limit {
-                ref skip,
-                ref fetch,
-                ..
-            }) => {
+            LogicalPlan::Limit(
+                Limit {
+                    ref skip,
+                    ref fetch,
+                    ..
+                },
+                _,
+            ) => {
                 let mut object = serde_json::json!(
                     {
                         "Node Type": "Limit",
@@ -555,24 +579,24 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
                 };
                 object
             }
-            LogicalPlan::Subquery(Subquery { .. }) => {
+            LogicalPlan::Subquery(Subquery { .. }, _) => {
                 json!({
                     "Node Type": "Subquery"
                 })
             }
-            LogicalPlan::SubqueryAlias(SubqueryAlias { ref alias, .. }) => {
+            LogicalPlan::SubqueryAlias(SubqueryAlias { ref alias, .. }, _) => {
                 json!({
                     "Node Type": "Subquery",
                     "Alias": alias.table(),
                 })
             }
-            LogicalPlan::Statement(statement) => {
+            LogicalPlan::Statement(statement, _) => {
                 json!({
                     "Node Type": "Statement",
                     "Statement": format!("{}", statement.display())
                 })
             }
-            LogicalPlan::Distinct(distinct) => match distinct {
+            LogicalPlan::Distinct(distinct, _) => match distinct {
                 Distinct::All(_) => {
                     json!({
                         "Node Type": "DistinctAll"
@@ -607,28 +631,31 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
                     "Node Type": "Analyze"
                 })
             }
-            LogicalPlan::Union(_) => {
+            LogicalPlan::Union(_, _) => {
                 json!({
                     "Node Type": "Union"
                 })
             }
-            LogicalPlan::Extension(e) => {
+            LogicalPlan::Extension(e, _) => {
                 json!({
                     "Node Type": e.node.name(),
                     "Detail": format!("{:?}", e.node)
                 })
             }
-            LogicalPlan::DescribeTable(DescribeTable { .. }) => {
+            LogicalPlan::DescribeTable(DescribeTable { .. }, _) => {
                 json!({
                     "Node Type": "DescribeTable"
                 })
             }
-            LogicalPlan::Unnest(Unnest {
-                input: plan,
-                list_type_columns: list_col_indices,
-                struct_type_columns: struct_col_indices,
-                ..
-            }) => {
+            LogicalPlan::Unnest(
+                Unnest {
+                    input: plan,
+                    list_type_columns: list_col_indices,
+                    struct_type_columns: struct_col_indices,
+                    ..
+                },
+                _,
+            ) => {
                 let input_columns = plan.schema().columns();
                 let list_type_columns = list_col_indices
                     .iter()

--- a/datafusion/expr/src/logical_plan/dml.rs
+++ b/datafusion/expr/src/logical_plan/dml.rs
@@ -21,11 +21,11 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+use crate::logical_plan::tree_node::LogicalPlanStats;
+use crate::LogicalPlan;
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion_common::file_options::file_type::FileType;
 use datafusion_common::{DFSchemaRef, TableReference};
-
-use crate::LogicalPlan;
 
 /// Operator that copies the contents of a database to file(s)
 #[derive(Clone)]
@@ -89,6 +89,12 @@ impl Hash for CopyTo {
     }
 }
 
+impl CopyTo {
+    pub(crate) fn stats(&self) -> LogicalPlanStats {
+        self.input.stats()
+    }
+}
+
 /// The operator that modifies the content of a database (adapted from
 /// substrait WriteRel)
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -127,6 +133,10 @@ impl DmlStatement {
     /// Return a descriptive name of this [`DmlStatement`]
     pub fn name(&self) -> &str {
         self.op.name()
+    }
+
+    pub(crate) fn stats(&self) -> LogicalPlanStats {
+        self.input.stats()
     }
 }
 

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -26,7 +26,7 @@ use std::sync::{Arc, OnceLock};
 use super::dml::CopyTo;
 use super::DdlStatement;
 use crate::builder::{change_redundant_column, unnest_with_options};
-use crate::expr::{Placeholder, Sort as SortExpr, WindowFunction};
+use crate::expr::{Placeholder, Sort as SortExpr, Wildcard, WindowFunction};
 use crate::expr_rewriter::{
     create_col_from_scalar_expr, normalize_cols, normalize_sorts, NamePreserver,
 };
@@ -3187,12 +3187,12 @@ fn calc_func_dependencies_for_project(
     let proj_indices = exprs
         .iter()
         .map(|expr| match expr {
-            Expr::Wildcard { qualifier, options } => {
+            Expr::Wildcard(Wildcard { qualifier, options }) => {
                 let wildcard_fields = exprlist_to_fields(
-                    vec![&Expr::Wildcard {
+                    vec![&Expr::Wildcard(Wildcard {
                         qualifier: qualifier.clone(),
                         options: options.clone(),
-                    }],
+                    })],
                     input,
                 )?;
                 Ok::<_, DataFusionError>(

--- a/datafusion/expr/src/operation.rs
+++ b/datafusion/expr/src/operation.rs
@@ -117,7 +117,7 @@ impl ops::Neg for Expr {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        Expr::Negative(Box::new(self))
+        Expr::negative(Box::new(self))
     }
 }
 
@@ -127,33 +127,33 @@ impl Not for Expr {
 
     fn not(self) -> Self::Output {
         match self {
-            Expr::Like(Like {
-                negated,
-                expr,
-                pattern,
-                escape_char,
-                case_insensitive,
-            }) => Expr::Like(Like::new(
-                !negated,
-                expr,
-                pattern,
-                escape_char,
-                case_insensitive,
-            )),
-            Expr::SimilarTo(Like {
-                negated,
-                expr,
-                pattern,
-                escape_char,
-                case_insensitive,
-            }) => Expr::SimilarTo(Like::new(
-                !negated,
-                expr,
-                pattern,
-                escape_char,
-                case_insensitive,
-            )),
-            _ => Expr::Not(Box::new(self)),
+            Expr::Like(
+                Like {
+                    negated,
+                    expr,
+                    pattern,
+                    escape_char,
+                    case_insensitive,
+                },
+                stats,
+            ) => Expr::Like(
+                Like::new(!negated, expr, pattern, escape_char, case_insensitive),
+                stats,
+            ),
+            Expr::SimilarTo(
+                Like {
+                    negated,
+                    expr,
+                    pattern,
+                    escape_char,
+                    case_insensitive,
+                },
+                stats,
+            ) => Expr::SimilarTo(
+                Like::new(!negated, expr, pattern, escape_char, case_insensitive),
+                stats,
+            ),
+            _ => Expr::_not(Box::new(self)),
         }
     }
 }

--- a/datafusion/expr/src/test/function_stub.rs
+++ b/datafusion/expr/src/test/function_stub.rs
@@ -60,7 +60,7 @@ macro_rules! create_func {
 create_func!(Sum, sum_udaf);
 
 pub fn sum(expr: Expr) -> Expr {
-    Expr::AggregateFunction(AggregateFunction::new_udf(
+    Expr::aggregate_function(AggregateFunction::new_udf(
         sum_udaf(),
         vec![expr],
         false,
@@ -73,7 +73,7 @@ pub fn sum(expr: Expr) -> Expr {
 create_func!(Count, count_udaf);
 
 pub fn count(expr: Expr) -> Expr {
-    Expr::AggregateFunction(AggregateFunction::new_udf(
+    Expr::aggregate_function(AggregateFunction::new_udf(
         count_udaf(),
         vec![expr],
         false,
@@ -86,7 +86,7 @@ pub fn count(expr: Expr) -> Expr {
 create_func!(Avg, avg_udaf);
 
 pub fn avg(expr: Expr) -> Expr {
-    Expr::AggregateFunction(AggregateFunction::new_udf(
+    Expr::aggregate_function(AggregateFunction::new_udf(
         avg_udaf(),
         vec![expr],
         false,
@@ -284,7 +284,7 @@ impl AggregateUDFImpl for Count {
 create_func!(Min, min_udaf);
 
 pub fn min(expr: Expr) -> Expr {
-    Expr::AggregateFunction(AggregateFunction::new_udf(
+    Expr::aggregate_function(AggregateFunction::new_udf(
         min_udaf(),
         vec![expr],
         false,
@@ -369,7 +369,7 @@ impl AggregateUDFImpl for Min {
 create_func!(Max, max_udaf);
 
 pub fn max(expr: Expr) -> Expr {
-    Expr::AggregateFunction(AggregateFunction::new_udf(
+    Expr::aggregate_function(AggregateFunction::new_udf(
         max_udaf(),
         vec![expr],
         false,

--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -145,7 +145,7 @@ impl AggregateUDF {
     /// This utility allows using the UDAF without requiring access to
     /// the registry, such as with the DataFrame API.
     pub fn call(&self, args: Vec<Expr>) -> Expr {
-        Expr::AggregateFunction(AggregateFunction::new_udf(
+        Expr::aggregate_function(AggregateFunction::new_udf(
             Arc::new(self.clone()),
             args,
             false,

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -123,7 +123,7 @@ impl ScalarUDF {
     /// let expr = my_func.call(vec![col("a"), lit(12.3)]);
     /// ```
     pub fn call(&self, args: Vec<Expr>) -> Expr {
-        Expr::ScalarFunction(crate::expr::ScalarFunction::new_udf(
+        Expr::scalar_function(crate::expr::ScalarFunction::new_udf(
             Arc::new(self.clone()),
             args,
         ))

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -130,7 +130,7 @@ impl WindowUDF {
     pub fn call(&self, args: Vec<Expr>) -> Expr {
         let fun = crate::WindowFunctionDefinition::WindowUDF(Arc::new(self.clone()));
 
-        Expr::WindowFunction(WindowFunction::new(fun, args))
+        Expr::window_function(WindowFunction::new(fun, args))
     }
 
     /// Returns this function's name

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use crate::expr::{Alias, Sort, WildcardOptions, WindowFunction};
+use crate::expr::{Alias, Sort, Wildcard, WildcardOptions, WindowFunction};
 use crate::expr_rewriter::strip_outer_reference;
 use crate::{
     and, BinaryExpr, Expr, ExprSchemable, Filter, GroupingSet, LogicalPlan, Operator,
@@ -703,7 +703,7 @@ pub fn exprlist_to_fields<'a>(
     let result = exprs
         .into_iter()
         .map(|e| match e {
-            Expr::Wildcard { qualifier, options } => match qualifier {
+            Expr::Wildcard(Wildcard { qualifier, options }) => match qualifier {
                 None => {
                     let excluded: Vec<String> = get_excluded_columns(
                         options.exclude.as_ref(),
@@ -802,10 +802,10 @@ pub fn exprlist_len(
     exprs
         .iter()
         .map(|e| match e {
-            Expr::Wildcard {
+            Expr::Wildcard(Wildcard {
                 qualifier: None,
                 options,
-            } => {
+            }) => {
                 let excluded = get_excluded_columns(
                     options.exclude.as_ref(),
                     options.except.as_ref(),
@@ -819,10 +819,10 @@ pub fn exprlist_len(
                         .len(),
                 )
             }
-            Expr::Wildcard {
+            Expr::Wildcard(Wildcard {
                 qualifier: Some(qualifier),
                 options,
-            } => {
+            }) => {
                 let related_wildcard_schema = wildcard_schema.as_ref().map_or_else(
                     || Ok(Arc::clone(schema)),
                     |schema| {

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -69,7 +69,7 @@ make_udaf_expr_and_func!(
 );
 
 pub fn count_distinct(expr: Expr) -> Expr {
-    Expr::AggregateFunction(datafusion_expr::expr::AggregateFunction::new_udf(
+    Expr::aggregate_function(datafusion_expr::expr::AggregateFunction::new_udf(
         count_udaf(),
         vec![expr],
         true,

--- a/datafusion/functions-aggregate/src/macros.rs
+++ b/datafusion/functions-aggregate/src/macros.rs
@@ -22,7 +22,7 @@ macro_rules! make_udaf_expr {
         pub fn $EXPR_FN(
             $($arg: datafusion_expr::Expr,)*
         ) -> datafusion_expr::Expr {
-            datafusion_expr::Expr::AggregateFunction(datafusion_expr::expr::AggregateFunction::new_udf(
+            datafusion_expr::Expr::aggregate_function(datafusion_expr::expr::AggregateFunction::new_udf(
                 $AGGREGATE_UDF_FN(),
                 vec![$($arg),*],
                 false,
@@ -45,7 +45,7 @@ macro_rules! make_udaf_expr_and_func {
         pub fn $EXPR_FN(
             args: Vec<datafusion_expr::Expr>,
         ) -> datafusion_expr::Expr {
-            datafusion_expr::Expr::AggregateFunction(datafusion_expr::expr::AggregateFunction::new_udf(
+            datafusion_expr::Expr::aggregate_function(datafusion_expr::expr::AggregateFunction::new_udf(
                 $AGGREGATE_UDF_FN(),
                 args,
                 false,

--- a/datafusion/functions-nested/benches/map.rs
+++ b/datafusion/functions-nested/benches/map.rs
@@ -58,8 +58,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         let values = values(&mut rng);
         let mut buffer = Vec::new();
         for i in 0..1000 {
-            buffer.push(Expr::Literal(ScalarValue::Utf8(Some(keys[i].clone()))));
-            buffer.push(Expr::Literal(ScalarValue::Int32(Some(values[i]))));
+            buffer.push(Expr::literal(ScalarValue::Utf8(Some(keys[i].clone()))));
+            buffer.push(Expr::literal(ScalarValue::Int32(Some(values[i]))));
         }
 
         let planner = NestedFunctionPlanner {};

--- a/datafusion/functions-nested/src/macros.rs
+++ b/datafusion/functions-nested/src/macros.rs
@@ -49,7 +49,7 @@ macro_rules! make_udf_expr_and_func {
             // "fluent expr_fn" style function
             #[doc = $DOC]
             pub fn $EXPR_FN($($arg: datafusion_expr::Expr),*) -> datafusion_expr::Expr {
-                datafusion_expr::Expr::ScalarFunction(datafusion_expr::expr::ScalarFunction::new_udf(
+                datafusion_expr::Expr::scalar_function(datafusion_expr::expr::ScalarFunction::new_udf(
                     $SCALAR_UDF_FN(),
                     vec![$($arg),*],
                 ))
@@ -62,7 +62,7 @@ macro_rules! make_udf_expr_and_func {
             // "fluent expr_fn" style function
             #[doc = $DOC]
             pub fn $EXPR_FN(arg: Vec<datafusion_expr::Expr>) -> datafusion_expr::Expr {
-                datafusion_expr::Expr::ScalarFunction(datafusion_expr::expr::ScalarFunction::new_udf(
+                datafusion_expr::Expr::scalar_function(datafusion_expr::expr::ScalarFunction::new_udf(
                     $SCALAR_UDF_FN(),
                     arg,
                 ))

--- a/datafusion/functions-nested/src/map.rs
+++ b/datafusion/functions-nested/src/map.rs
@@ -38,7 +38,7 @@ use crate::make_array::make_array;
 pub fn map(keys: Vec<Expr>, values: Vec<Expr>) -> Expr {
     let keys = make_array(keys);
     let values = make_array(values);
-    Expr::ScalarFunction(ScalarFunction::new_udf(map_udf(), vec![keys, values]))
+    Expr::scalar_function(ScalarFunction::new_udf(map_udf(), vec![keys, values]))
 }
 
 create_func!(MapFunc, map_udf);

--- a/datafusion/functions/src/core/arrow_cast.rs
+++ b/datafusion/functions/src/core/arrow_cast.rs
@@ -129,7 +129,7 @@ impl ScalarUDFImpl for ArrowCastFunc {
             arg
         } else {
             // Use an actual cast to get the correct type
-            Expr::Cast(datafusion_expr::Cast {
+            Expr::cast(datafusion_expr::Cast {
                 expr: Box::new(arg),
                 data_type: target_type,
             })
@@ -176,7 +176,7 @@ fn data_type_from_args(args: &[Expr]) -> Result<DataType> {
     if args.len() != 2 {
         return plan_err!("arrow_cast needs 2 arguments, {} provided", args.len());
     }
-    let Expr::Literal(ScalarValue::Utf8(Some(val))) = &args[1] else {
+    let Expr::Literal(ScalarValue::Utf8(Some(val)), _) = &args[1] else {
         return plan_err!(
             "arrow_cast requires its second argument to be a constant string, got {:?}",
             &args[1]

--- a/datafusion/functions/src/core/getfield.rs
+++ b/datafusion/functions/src/core/getfield.rs
@@ -67,7 +67,7 @@ impl ScalarUDFImpl for GetFieldFunc {
         }
 
         let name = match &args[1] {
-            Expr::Literal(name) => name,
+            Expr::Literal(name, _) => name,
             _ => {
                 return exec_err!(
                     "get_field function requires the argument field_name to be a string"
@@ -87,7 +87,7 @@ impl ScalarUDFImpl for GetFieldFunc {
         }
 
         let name = match &args[1] {
-            Expr::Literal(name) => name,
+            Expr::Literal(name, _) => name,
             _ => {
                 return exec_err!(
                     "get_field function requires the argument field_name to be a string"
@@ -120,7 +120,7 @@ impl ScalarUDFImpl for GetFieldFunc {
         }
 
         let name = match &args[1] {
-            Expr::Literal(name) => name,
+            Expr::Literal(name, _) => name,
             _ => {
                 return exec_err!(
                     "get_field function requires the argument field_name to be a string"

--- a/datafusion/functions/src/core/named_struct.rs
+++ b/datafusion/functions/src/core/named_struct.rs
@@ -148,7 +148,7 @@ impl ScalarUDFImpl for NamedStructFunc {
                 let name = &chunk[0];
                 let value = &chunk[1];
 
-                if let Expr::Literal(ScalarValue::Utf8(Some(name))) = name {
+                if let Expr::Literal(ScalarValue::Utf8(Some(name)), _) = name {
                     Ok(Field::new(name, value.get_type(schema)?, true))
                 } else {
                     exec_err!("named_struct even arguments must be string literals, got {name} instead at position {}", i * 2)

--- a/datafusion/functions/src/core/planner.rs
+++ b/datafusion/functions/src/core/planner.rs
@@ -46,7 +46,7 @@ impl ExprPlanner for CoreFunctionPlanner {
         args: Vec<Expr>,
         is_named_struct: bool,
     ) -> Result<PlannerResult<Vec<Expr>>> {
-        Ok(PlannerResult::Planned(Expr::ScalarFunction(
+        Ok(PlannerResult::Planned(Expr::scalar_function(
             ScalarFunction::new_udf(
                 if is_named_struct {
                     named_struct()
@@ -59,7 +59,7 @@ impl ExprPlanner for CoreFunctionPlanner {
     }
 
     fn plan_overlay(&self, args: Vec<Expr>) -> Result<PlannerResult<Vec<Expr>>> {
-        Ok(PlannerResult::Planned(Expr::ScalarFunction(
+        Ok(PlannerResult::Planned(Expr::scalar_function(
             ScalarFunction::new_udf(crate::string::overlay(), args),
         )))
     }
@@ -70,7 +70,7 @@ impl ExprPlanner for CoreFunctionPlanner {
         qualifier: Option<&TableReference>,
         nested_names: &[String],
     ) -> Result<PlannerResult<Vec<Expr>>> {
-        let col = Expr::Column(Column::from((qualifier, field)));
+        let col = Expr::column(Column::from((qualifier, field)));
 
         // Start with the base column expression
         let mut expr = col;
@@ -78,7 +78,7 @@ impl ExprPlanner for CoreFunctionPlanner {
         // Iterate over nested_names and create nested get_field expressions
         for nested_name in nested_names {
             let get_field_args = vec![expr, lit(ScalarValue::from(nested_name.clone()))];
-            expr = Expr::ScalarFunction(ScalarFunction::new_udf(
+            expr = Expr::scalar_function(ScalarFunction::new_udf(
                 crate::core::get_field(),
                 get_field_args,
             ));

--- a/datafusion/functions/src/datetime/current_date.rs
+++ b/datafusion/functions/src/datetime/current_date.rs
@@ -99,7 +99,7 @@ impl ScalarUDFImpl for CurrentDateFunc {
                     .unwrap()
                     .num_days_from_ce(),
         );
-        Ok(ExprSimplifyResult::Simplified(Expr::Literal(
+        Ok(ExprSimplifyResult::Simplified(Expr::literal(
             ScalarValue::Date32(days),
         )))
     }

--- a/datafusion/functions/src/datetime/current_time.rs
+++ b/datafusion/functions/src/datetime/current_time.rs
@@ -87,7 +87,7 @@ impl ScalarUDFImpl for CurrentTimeFunc {
     ) -> Result<ExprSimplifyResult> {
         let now_ts = info.execution_props().query_execution_start_time;
         let nano = now_ts.timestamp_nanos_opt().map(|ts| ts % 86400000000000);
-        Ok(ExprSimplifyResult::Simplified(Expr::Literal(
+        Ok(ExprSimplifyResult::Simplified(Expr::literal(
             ScalarValue::Time64Nanosecond(nano),
         )))
     }

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -158,7 +158,7 @@ impl ScalarUDFImpl for DatePartFunc {
         _arg_types: &[DataType],
     ) -> Result<DataType> {
         match &args[0] {
-            Expr::Literal(ScalarValue::Utf8(Some(part))) if is_epoch(part) => {
+            Expr::Literal(ScalarValue::Utf8(Some(part)), _) if is_epoch(part) => {
                 Ok(DataType::Float64)
             }
             _ => Ok(DataType::Int32),

--- a/datafusion/functions/src/datetime/from_unixtime.rs
+++ b/datafusion/functions/src/datetime/from_unixtime.rs
@@ -72,7 +72,7 @@ impl ScalarUDFImpl for FromUnixtimeFunc {
         match arg_types.len() {
             1 => Ok(Timestamp(Second, None)),
             2 => match &args[1] {
-                    Expr::Literal(ScalarValue::Utf8(Some(tz))) => Ok(Timestamp(Second, Some(Arc::from(tz.to_string())))),
+                    Expr::Literal(ScalarValue::Utf8(Some(tz)), _) => Ok(Timestamp(Second, Some(Arc::from(tz.to_string())))),
                     _ => exec_err!(
                         "Second argument for `from_unixtime` must be non-null utf8, received {:?}",
                         arg_types[1]),

--- a/datafusion/functions/src/datetime/now.rs
+++ b/datafusion/functions/src/datetime/now.rs
@@ -89,7 +89,7 @@ impl ScalarUDFImpl for NowFunc {
             .execution_props()
             .query_execution_start_time
             .timestamp_nanos_opt();
-        Ok(ExprSimplifyResult::Simplified(Expr::Literal(
+        Ok(ExprSimplifyResult::Simplified(Expr::literal(
             ScalarValue::TimestampNanosecond(now_ts, Some("+00:00".into())),
         )))
     }

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -220,12 +220,14 @@ impl ScalarUDFImpl for LogFunc {
         };
 
         match number {
-            Expr::Literal(value) if value == ScalarValue::new_one(&number_datatype)? => {
+            Expr::Literal(value, _)
+                if value == ScalarValue::new_one(&number_datatype)? =>
+            {
                 Ok(ExprSimplifyResult::Simplified(lit(ScalarValue::new_zero(
                     &info.get_data_type(&base)?,
                 )?)))
             }
-            Expr::ScalarFunction(ScalarFunction { func, mut args })
+            Expr::ScalarFunction(ScalarFunction { func, mut args }, _)
                 if is_pow(&func) && args.len() == 2 && base == args[0] =>
             {
                 let b = args.pop().unwrap(); // length checked above

--- a/datafusion/functions/src/math/power.rs
+++ b/datafusion/functions/src/math/power.rs
@@ -151,15 +151,17 @@ impl ScalarUDFImpl for PowerFunc {
 
         let exponent_type = info.get_data_type(&exponent)?;
         match exponent {
-            Expr::Literal(value) if value == ScalarValue::new_zero(&exponent_type)? => {
-                Ok(ExprSimplifyResult::Simplified(Expr::Literal(
+            Expr::Literal(value, _)
+                if value == ScalarValue::new_zero(&exponent_type)? =>
+            {
+                Ok(ExprSimplifyResult::Simplified(Expr::literal(
                     ScalarValue::new_one(&info.get_data_type(&base)?)?,
                 )))
             }
-            Expr::Literal(value) if value == ScalarValue::new_one(&exponent_type)? => {
+            Expr::Literal(value, _) if value == ScalarValue::new_one(&exponent_type)? => {
                 Ok(ExprSimplifyResult::Simplified(base))
             }
-            Expr::ScalarFunction(ScalarFunction { func, mut args })
+            Expr::ScalarFunction(ScalarFunction { func, mut args }, _)
                 if is_log(&func) && args.len() == 2 && base == args[0] =>
             {
                 let b = args.pop().unwrap(); // length checked above

--- a/datafusion/functions/src/planner.rs
+++ b/datafusion/functions/src/planner.rs
@@ -30,21 +30,21 @@ pub struct UserDefinedFunctionPlanner;
 impl ExprPlanner for UserDefinedFunctionPlanner {
     #[cfg(feature = "datetime_expressions")]
     fn plan_extract(&self, args: Vec<Expr>) -> Result<PlannerResult<Vec<Expr>>> {
-        Ok(PlannerResult::Planned(Expr::ScalarFunction(
+        Ok(PlannerResult::Planned(Expr::scalar_function(
             ScalarFunction::new_udf(crate::datetime::date_part(), args),
         )))
     }
 
     #[cfg(feature = "unicode_expressions")]
     fn plan_position(&self, args: Vec<Expr>) -> Result<PlannerResult<Vec<Expr>>> {
-        Ok(PlannerResult::Planned(Expr::ScalarFunction(
+        Ok(PlannerResult::Planned(Expr::scalar_function(
             ScalarFunction::new_udf(crate::unicode::strpos(), args),
         )))
     }
 
     #[cfg(feature = "unicode_expressions")]
     fn plan_substring(&self, args: Vec<Expr>) -> Result<PlannerResult<Vec<Expr>>> {
-        Ok(PlannerResult::Planned(Expr::ScalarFunction(
+        Ok(PlannerResult::Planned(Expr::scalar_function(
             ScalarFunction::new_udf(crate::unicode::substr(), args),
         )))
     }

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -301,7 +301,7 @@ pub fn simplify_concat(args: Vec<Expr>) -> Result<ExprSimplifyResult> {
         let data_types: Vec<_> = args
             .iter()
             .filter_map(|expr| match expr {
-                Expr::Literal(l) => Some(l.data_type()),
+                Expr::Literal(l, _) => Some(l.data_type()),
                 _ => None,
             })
             .collect();
@@ -310,25 +310,25 @@ pub fn simplify_concat(args: Vec<Expr>) -> Result<ExprSimplifyResult> {
 
     for arg in args.clone() {
         match arg {
-            Expr::Literal(ScalarValue::Utf8(None)) => {}
-            Expr::Literal(ScalarValue::LargeUtf8(None)) => {
+            Expr::Literal(ScalarValue::Utf8(None), _) => {}
+            Expr::Literal(ScalarValue::LargeUtf8(None), _) => {
             }
-            Expr::Literal(ScalarValue::Utf8View(None)) => { }
+            Expr::Literal(ScalarValue::Utf8View(None), _) => { }
 
             // filter out `null` args
             // All literals have been converted to Utf8 or LargeUtf8 in type_coercion.
             // Concatenate it with the `contiguous_scalar`.
-            Expr::Literal(ScalarValue::Utf8(Some(v))) => {
+            Expr::Literal(ScalarValue::Utf8(Some(v)), _) => {
                 contiguous_scalar += &v;
             }
-            Expr::Literal(ScalarValue::LargeUtf8(Some(v))) => {
+            Expr::Literal(ScalarValue::LargeUtf8(Some(v)), _) => {
                 contiguous_scalar += &v;
             }
-            Expr::Literal(ScalarValue::Utf8View(Some(v))) => {
+            Expr::Literal(ScalarValue::Utf8View(Some(v)), _) => {
                 contiguous_scalar += &v;
             }
 
-            Expr::Literal(x) => {
+            Expr::Literal(x, _) => {
                 return internal_err!(
                     "The scalar {x} should be casted to string type during the type coercion."
                 )
@@ -365,7 +365,7 @@ pub fn simplify_concat(args: Vec<Expr>) -> Result<ExprSimplifyResult> {
     }
 
     if !args.eq(&new_args) {
-        Ok(ExprSimplifyResult::Simplified(Expr::ScalarFunction(
+        Ok(ExprSimplifyResult::Simplified(Expr::scalar_function(
             ScalarFunction {
                 func: concat(),
                 args: new_args,

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -42,6 +42,7 @@ chrono = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
 datafusion-physical-expr = { workspace = true }
+enumset = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }

--- a/datafusion/optimizer/src/analyzer/expand_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/expand_wildcard_rule.rs
@@ -22,7 +22,7 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult};
 use datafusion_common::{Column, Result};
 use datafusion_expr::builder::validate_unique_names;
-use datafusion_expr::expr::PlannedReplaceSelectItem;
+use datafusion_expr::expr::{PlannedReplaceSelectItem, Wildcard};
 use datafusion_expr::utils::{
     expand_qualified_wildcard, expand_wildcard, find_base_plan,
 };
@@ -89,7 +89,7 @@ fn expand_exprlist(input: &LogicalPlan, expr: Vec<Expr>) -> Result<Vec<Expr>> {
     let input = find_base_plan(input);
     for e in expr {
         match e {
-            Expr::Wildcard { qualifier, options } => {
+            Expr::Wildcard(Wildcard { qualifier, options }) => {
                 if let Some(qualifier) = qualifier {
                     let expanded = expand_qualified_wildcard(
                         &qualifier,

--- a/datafusion/optimizer/src/analyzer/function_rewrite.rs
+++ b/datafusion/optimizer/src/analyzer/function_rewrite.rs
@@ -50,7 +50,7 @@ impl ApplyFunctionRewrites {
         // resolution only, so order does not matter here
         let mut schema = merge_schema(&plan.inputs());
 
-        if let LogicalPlan::TableScan(ts) = &plan {
+        if let LogicalPlan::TableScan(ts, _) = &plan {
             let source_schema = DFSchema::try_from_qualified_schema(
                 ts.table_name.clone(),
                 &ts.source.schema(),

--- a/datafusion/optimizer/src/analyzer/inline_table_scan.rs
+++ b/datafusion/optimizer/src/analyzer/inline_table_scan.rs
@@ -23,7 +23,7 @@ use crate::analyzer::AnalyzerRule;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::{Column, Result};
-use datafusion_expr::expr::WildcardOptions;
+use datafusion_expr::expr::{Wildcard, WildcardOptions};
 use datafusion_expr::{logical_plan::LogicalPlan, Expr, LogicalPlanBuilder};
 
 /// Analyzed rule that inlines TableScan that provide a [`LogicalPlan`]
@@ -93,10 +93,10 @@ fn generate_projection_expr(
             )));
         }
     } else {
-        exprs.push(Expr::Wildcard {
+        exprs.push(Expr::Wildcard(Wildcard {
             qualifier: None,
             options: WildcardOptions::default(),
-        });
+        }));
     }
     Ok(exprs)
 }

--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -181,9 +181,9 @@ fn check_plan(plan: &LogicalPlan) -> Result<()> {
             // recursively look for subqueries
             expr.apply(|expr| {
                 match expr {
-                    Expr::Exists(Exists { subquery, .. })
-                    | Expr::InSubquery(InSubquery { subquery, .. })
-                    | Expr::ScalarSubquery(subquery) => {
+                    Expr::Exists(Exists { subquery, .. }, _)
+                    | Expr::InSubquery(InSubquery { subquery, .. }, _)
+                    | Expr::ScalarSubquery(subquery, _) => {
                         check_subquery_expr(plan, &subquery.subquery, expr)?;
                     }
                     _ => {}

--- a/datafusion/optimizer/src/eliminate_duplicated_expr.rs
+++ b/datafusion/optimizer/src/eliminate_duplicated_expr.rs
@@ -63,7 +63,7 @@ impl OptimizerRule for EliminateDuplicatedExpr {
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
         match plan {
-            LogicalPlan::Sort(sort) => {
+            LogicalPlan::Sort(sort, _) => {
                 let len = sort.expr.len();
                 let unique_exprs: Vec<_> = sort
                     .expr
@@ -80,13 +80,13 @@ impl OptimizerRule for EliminateDuplicatedExpr {
                     Transformed::no
                 };
 
-                Ok(transformed(LogicalPlan::Sort(Sort {
+                Ok(transformed(LogicalPlan::sort(Sort {
                     expr: unique_exprs,
                     input: sort.input,
                     fetch: sort.fetch,
                 })))
             }
-            LogicalPlan::Aggregate(agg) => {
+            LogicalPlan::Aggregate(agg, _) => {
                 let len = agg.group_expr.len();
 
                 let unique_exprs: Vec<Expr> = agg
@@ -103,7 +103,7 @@ impl OptimizerRule for EliminateDuplicatedExpr {
                 };
 
                 Aggregate::try_new(agg.input, unique_exprs, agg.aggr_expr)
-                    .map(|f| transformed(LogicalPlan::Aggregate(f)))
+                    .map(|f| transformed(LogicalPlan::aggregate(f)))
             }
             _ => Ok(Transformed::no(plan)),
         }

--- a/datafusion/optimizer/src/eliminate_filter.rs
+++ b/datafusion/optimizer/src/eliminate_filter.rs
@@ -59,13 +59,16 @@ impl OptimizerRule for EliminateFilter {
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
         match plan {
-            LogicalPlan::Filter(Filter {
-                predicate: Expr::Literal(ScalarValue::Boolean(v)),
-                input,
-                ..
-            }) => match v {
+            LogicalPlan::Filter(
+                Filter {
+                    predicate: Expr::Literal(ScalarValue::Boolean(v), _),
+                    input,
+                    ..
+                },
+                _,
+            ) => match v {
                 Some(true) => Ok(Transformed::yes(Arc::unwrap_or_clone(input))),
-                Some(false) | None => Ok(Transformed::yes(LogicalPlan::EmptyRelation(
+                Some(false) | None => Ok(Transformed::yes(LogicalPlan::empty_relation(
                     EmptyRelation {
                         produce_one_row: false,
                         schema: Arc::clone(input.schema()),
@@ -111,7 +114,7 @@ mod tests {
 
     #[test]
     fn filter_null() -> Result<()> {
-        let filter_expr = Expr::Literal(ScalarValue::Boolean(None));
+        let filter_expr = Expr::literal(ScalarValue::Boolean(None));
 
         let table_scan = test_table_scan().unwrap();
         let plan = LogicalPlanBuilder::from(table_scan)

--- a/datafusion/optimizer/src/eliminate_join.rs
+++ b/datafusion/optimizer/src/eliminate_join.rs
@@ -52,15 +52,17 @@ impl OptimizerRule for EliminateJoin {
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
         match plan {
-            LogicalPlan::Join(join) if join.join_type == Inner && join.on.is_empty() => {
+            LogicalPlan::Join(join, _)
+                if join.join_type == Inner && join.on.is_empty() =>
+            {
                 match join.filter {
-                    Some(Expr::Literal(ScalarValue::Boolean(Some(false)))) => Ok(
-                        Transformed::yes(LogicalPlan::EmptyRelation(EmptyRelation {
+                    Some(Expr::Literal(ScalarValue::Boolean(Some(false)), _)) => Ok(
+                        Transformed::yes(LogicalPlan::empty_relation(EmptyRelation {
                             produce_one_row: false,
                             schema: join.schema,
                         })),
                     ),
-                    _ => Ok(Transformed::no(LogicalPlan::Join(join))),
+                    _ => Ok(Transformed::no(LogicalPlan::join(join))),
                 }
             }
             _ => Ok(Transformed::no(plan)),

--- a/datafusion/optimizer/src/eliminate_one_union.rs
+++ b/datafusion/optimizer/src/eliminate_one_union.rs
@@ -50,7 +50,7 @@ impl OptimizerRule for EliminateOneUnion {
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
         match plan {
-            LogicalPlan::Union(Union { mut inputs, .. }) if inputs.len() == 1 => Ok(
+            LogicalPlan::Union(Union { mut inputs, .. }, _) if inputs.len() == 1 => Ok(
                 Transformed::yes(Arc::unwrap_or_clone(inputs.pop().unwrap())),
             ),
             _ => Ok(Transformed::no(plan)),
@@ -110,7 +110,7 @@ mod tests {
             &schema().to_dfschema()?,
         )?;
         let schema = Arc::clone(table_plan.schema());
-        let single_union_plan = LogicalPlan::Union(Union {
+        let single_union_plan = LogicalPlan::union(Union {
             inputs: vec![Arc::new(table_plan)],
             schema,
         });

--- a/datafusion/optimizer/src/extract_equijoin_predicate.rs
+++ b/datafusion/optimizer/src/extract_equijoin_predicate.rs
@@ -67,16 +67,19 @@ impl OptimizerRule for ExtractEquijoinPredicate {
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
         match plan {
-            LogicalPlan::Join(Join {
-                left,
-                right,
-                mut on,
-                filter: Some(expr),
-                join_type,
-                join_constraint,
-                schema,
-                null_equals_null,
-            }) => {
+            LogicalPlan::Join(
+                Join {
+                    left,
+                    right,
+                    mut on,
+                    filter: Some(expr),
+                    join_type,
+                    join_constraint,
+                    schema,
+                    null_equals_null,
+                },
+                _,
+            ) => {
                 let left_schema = left.schema();
                 let right_schema = right.schema();
                 let (equijoin_predicates, non_equijoin_expr) =
@@ -84,7 +87,7 @@ impl OptimizerRule for ExtractEquijoinPredicate {
 
                 if !equijoin_predicates.is_empty() {
                     on.extend(equijoin_predicates);
-                    Ok(Transformed::yes(LogicalPlan::Join(Join {
+                    Ok(Transformed::yes(LogicalPlan::join(Join {
                         left,
                         right,
                         on,
@@ -95,7 +98,7 @@ impl OptimizerRule for ExtractEquijoinPredicate {
                         null_equals_null,
                     })))
                 } else {
-                    Ok(Transformed::no(LogicalPlan::Join(Join {
+                    Ok(Transformed::no(LogicalPlan::join(Join {
                         left,
                         right,
                         on,
@@ -123,11 +126,14 @@ fn split_eq_and_noneq_join_predicate(
     let mut accum_filters: Vec<Expr> = vec![];
     for expr in exprs {
         match expr {
-            Expr::BinaryExpr(BinaryExpr {
-                ref left,
-                op: Operator::Eq,
-                ref right,
-            }) => {
+            Expr::BinaryExpr(
+                BinaryExpr {
+                    ref left,
+                    op: Operator::Eq,
+                    ref right,
+                },
+                _,
+            ) => {
                 let join_key_pair =
                     find_valid_equijoin_key_pair(left, right, left_schema, right_schema)?;
 

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -495,7 +495,7 @@ mod tests {
     fn skip_failing_rule() {
         let opt = Optimizer::with_rules(vec![Arc::new(BadRule {})]);
         let config = OptimizerContext::new().with_skip_failing_rules(true);
-        let plan = LogicalPlan::EmptyRelation(EmptyRelation {
+        let plan = LogicalPlan::empty_relation(EmptyRelation {
             produce_one_row: false,
             schema: Arc::new(DFSchema::empty()),
         });
@@ -506,7 +506,7 @@ mod tests {
     fn no_skip_failing_rule() {
         let opt = Optimizer::with_rules(vec![Arc::new(BadRule {})]);
         let config = OptimizerContext::new().with_skip_failing_rules(false);
-        let plan = LogicalPlan::EmptyRelation(EmptyRelation {
+        let plan = LogicalPlan::empty_relation(EmptyRelation {
             produce_one_row: false,
             schema: Arc::new(DFSchema::empty()),
         });
@@ -522,7 +522,7 @@ mod tests {
     fn generate_different_schema() {
         let opt = Optimizer::with_rules(vec![Arc::new(GetTableScanRule {})]);
         let config = OptimizerContext::new().with_skip_failing_rules(false);
-        let plan = LogicalPlan::EmptyRelation(EmptyRelation {
+        let plan = LogicalPlan::empty_relation(EmptyRelation {
             produce_one_row: false,
             schema: Arc::new(DFSchema::empty()),
         });
@@ -555,7 +555,7 @@ mod tests {
     fn skip_generate_different_schema() {
         let opt = Optimizer::with_rules(vec![Arc::new(GetTableScanRule {})]);
         let config = OptimizerContext::new().with_skip_failing_rules(true);
-        let plan = LogicalPlan::EmptyRelation(EmptyRelation {
+        let plan = LogicalPlan::empty_relation(EmptyRelation {
             produce_one_row: false,
             schema: Arc::new(DFSchema::empty()),
         });
@@ -572,7 +572,7 @@ mod tests {
         let input = Arc::new(test_table_scan()?);
         let input_schema = Arc::clone(input.schema());
 
-        let plan = LogicalPlan::Projection(Projection::try_new_with_schema(
+        let plan = LogicalPlan::projection(Projection::try_new_with_schema(
             vec![col("a"), col("b"), col("c")],
             input,
             add_metadata_to_fields(input_schema.as_ref()),
@@ -739,7 +739,7 @@ mod tests {
             _config: &dyn OptimizerConfig,
         ) -> Result<Transformed<LogicalPlan>> {
             let projection = match plan {
-                LogicalPlan::Projection(p) if p.expr.len() >= 2 => p,
+                LogicalPlan::Projection(p, _) if p.expr.len() >= 2 => p,
                 _ => return Ok(Transformed::no(plan)),
             };
 
@@ -753,7 +753,7 @@ mod tests {
                 exprs.rotate_left(1);
             }
 
-            Ok(Transformed::yes(LogicalPlan::Projection(
+            Ok(Transformed::yes(LogicalPlan::projection(
                 Projection::try_new(exprs, Arc::clone(&projection.input))?,
             )))
         }

--- a/datafusion/optimizer/src/plan_signature.rs
+++ b/datafusion/optimizer/src/plan_signature.rs
@@ -97,21 +97,22 @@ mod tests {
     fn node_number_for_some_plan() -> Result<()> {
         let schema = Arc::new(DFSchema::empty());
 
-        let one_node_plan =
-            Arc::new(LogicalPlan::EmptyRelation(datafusion_expr::EmptyRelation {
+        let one_node_plan = Arc::new(LogicalPlan::empty_relation(
+            datafusion_expr::EmptyRelation {
                 produce_one_row: false,
                 schema: Arc::clone(&schema),
-            }));
+            },
+        ));
 
         assert_eq!(1, get_node_number(&one_node_plan).get());
 
-        let two_node_plan = Arc::new(LogicalPlan::Projection(
+        let two_node_plan = Arc::new(LogicalPlan::projection(
             datafusion_expr::Projection::try_new(vec![lit(1), lit(2)], one_node_plan)?,
         ));
 
         assert_eq!(2, get_node_number(&two_node_plan).get());
 
-        let five_node_plan = Arc::new(LogicalPlan::Union(datafusion_expr::Union {
+        let five_node_plan = Arc::new(LogicalPlan::union(datafusion_expr::Union {
             inputs: vec![Arc::clone(&two_node_plan), two_node_plan],
             schema,
         }));

--- a/datafusion/optimizer/src/simplify_expressions/inlist_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/inlist_simplifier.rs
@@ -38,11 +38,14 @@ impl TreeNodeRewriter for ShortenInListSimplifier {
     fn f_up(&mut self, expr: Expr) -> Result<Transformed<Expr>> {
         // if expr is a single column reference:
         // expr IN (A, B, ...) --> (expr = A) OR (expr = B) OR (expr = C)
-        if let Expr::InList(InList {
-            expr,
-            list,
-            negated,
-        }) = expr.clone()
+        if let Expr::InList(
+            InList {
+                expr,
+                list,
+                negated,
+            },
+            _,
+        ) = expr.clone()
         {
             if !list.is_empty()
                 && (

--- a/datafusion/optimizer/src/simplify_expressions/regex.rs
+++ b/datafusion/optimizer/src/simplify_expressions/regex.rs
@@ -42,7 +42,7 @@ pub fn simplify_regex_expr(
 ) -> Result<Expr> {
     let mode = OperatorMode::new(&op);
 
-    if let Expr::Literal(ScalarValue::Utf8(Some(pattern))) = right.as_ref() {
+    if let Expr::Literal(ScalarValue::Utf8(Some(pattern)), _) = right.as_ref() {
         match regex_syntax::Parser::new().parse(pattern) {
             Ok(hir) => {
                 let kind = hir.kind();
@@ -67,7 +67,7 @@ pub fn simplify_regex_expr(
     }
 
     // Leave untouched if optimization didn't work
-    Ok(Expr::BinaryExpr(BinaryExpr { left, op, right }))
+    Ok(Expr::binary_expr(BinaryExpr { left, op, right }))
 }
 
 #[derive(Debug)]
@@ -100,12 +100,12 @@ impl OperatorMode {
         let like = Like {
             negated: self.not,
             expr,
-            pattern: Box::new(Expr::Literal(ScalarValue::from(pattern))),
+            pattern: Box::new(Expr::literal(ScalarValue::from(pattern))),
             escape_char: None,
             case_insensitive: self.i,
         };
 
-        Expr::Like(like)
+        Expr::_like(like)
     }
 
     /// Creates an [`Expr::BinaryExpr`] of "`left` = `right`" or "`left` != `right`".
@@ -115,7 +115,7 @@ impl OperatorMode {
         } else {
             Operator::Eq
         };
-        Expr::BinaryExpr(BinaryExpr { left, op, right })
+        Expr::binary_expr(BinaryExpr { left, op, right })
     }
 }
 

--- a/datafusion/optimizer/src/test/user_defined.rs
+++ b/datafusion/optimizer/src/test/user_defined.rs
@@ -30,7 +30,7 @@ use std::{
 /// Create a new user defined plan node, for testing
 pub fn new(input: LogicalPlan) -> LogicalPlan {
     let node = Arc::new(TestUserDefinedPlanNode { input });
-    LogicalPlan::Extension(Extension { node })
+    LogicalPlan::extension(Extension { node })
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Hash)]

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -132,7 +132,7 @@ pub fn is_restrict_null_predicate<'a>(
     predicate: Expr,
     join_cols_of_predicate: impl IntoIterator<Item = &'a Column>,
 ) -> Result<bool> {
-    if matches!(predicate, Expr::Column(_)) {
+    if matches!(predicate, Expr::Column(_, _)) {
         return Ok(true);
     }
 
@@ -195,10 +195,10 @@ mod tests {
             // a IS NULL
             (is_null(col("a")), false),
             // a IS NOT NULL
-            (Expr::IsNotNull(Box::new(col("a"))), true),
+            (Expr::_is_not_null(Box::new(col("a"))), true),
             // a = NULL
             (
-                binary_expr(col("a"), Operator::Eq, Expr::Literal(ScalarValue::Null)),
+                binary_expr(col("a"), Operator::Eq, Expr::literal(ScalarValue::Null)),
                 true,
             ),
             // a > 8
@@ -261,12 +261,12 @@ mod tests {
             ),
             // a IN (NULL)
             (
-                in_list(col("a"), vec![Expr::Literal(ScalarValue::Null)], false),
+                in_list(col("a"), vec![Expr::literal(ScalarValue::Null)], false),
                 true,
             ),
             // a NOT IN (NULL)
             (
-                in_list(col("a"), vec![Expr::Literal(ScalarValue::Null)], true),
+                in_list(col("a"), vec![Expr::literal(ScalarValue::Null)], true),
                 true,
             ),
         ];

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -97,7 +97,7 @@ impl PhysicalExpr for Literal {
 /// Create a literal expression
 pub fn lit<T: datafusion_expr::Literal>(value: T) -> Arc<dyn PhysicalExpr> {
     match value.lit() {
-        Expr::Literal(v) => Arc::new(Literal::new(v)),
+        Expr::Literal(v, _) => Arc::new(Literal::new(v)),
         _ => unreachable!(),
     }
 }

--- a/datafusion/physical-optimizer/src/pruning.rs
+++ b/datafusion/physical-optimizer/src/pruning.rs
@@ -2549,7 +2549,7 @@ mod tests {
             Field::new("c2", DataType::Int32, false),
         ]);
         // test c1 in(1, 2, 3)
-        let expr = Expr::InList(InList::new(
+        let expr = Expr::_in_list(InList::new(
             Box::new(col("c1")),
             vec![lit(1), lit(2), lit(3)],
             false,
@@ -2580,7 +2580,7 @@ mod tests {
             Field::new("c2", DataType::Int32, false),
         ]);
         // test c1 in()
-        let expr = Expr::InList(InList::new(Box::new(col("c1")), vec![], false));
+        let expr = Expr::_in_list(InList::new(Box::new(col("c1")), vec![], false));
         let expected_expr = "true";
         let predicate_expr =
             test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
@@ -2596,7 +2596,7 @@ mod tests {
             Field::new("c2", DataType::Int32, false),
         ]);
         // test c1 not in(1, 2, 3)
-        let expr = Expr::InList(InList::new(
+        let expr = Expr::_in_list(InList::new(
             Box::new(col("c1")),
             vec![lit(1), lit(2), lit(3)],
             true,
@@ -2747,7 +2747,7 @@ mod tests {
     fn row_group_predicate_cast_list() -> Result<()> {
         let schema = Schema::new(vec![Field::new("c1", DataType::Int32, false)]);
         // test cast(c1 as int64) in int64(1, 2, 3)
-        let expr = Expr::InList(InList::new(
+        let expr = Expr::_in_list(InList::new(
             Box::new(cast(col("c1"), DataType::Int64)),
             vec![
                 lit(ScalarValue::Int64(Some(1))),
@@ -2772,7 +2772,7 @@ mod tests {
             test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
         assert_eq!(predicate_expr.to_string(), expected_expr);
 
-        let expr = Expr::InList(InList::new(
+        let expr = Expr::_in_list(InList::new(
             Box::new(cast(col("c1"), DataType::Int64)),
             vec![
                 lit(ScalarValue::Int64(Some(1))),
@@ -3107,7 +3107,7 @@ mod tests {
 
         // -i < 0
         prune_with_expr(
-            Expr::Negative(Box::new(col("i"))).lt(lit(0)),
+            Expr::negative(Box::new(col("i"))).lt(lit(0)),
             &schema,
             &statistics,
             expected_ret,
@@ -3136,7 +3136,7 @@ mod tests {
 
         prune_with_expr(
             // -i >= 0
-            Expr::Negative(Box::new(col("i"))).gt_eq(lit(0)),
+            Expr::negative(Box::new(col("i"))).gt_eq(lit(0)),
             &schema,
             &statistics,
             expected_ret,
@@ -3173,7 +3173,7 @@ mod tests {
 
         prune_with_expr(
             // cast(-i as utf8) >= 0
-            cast(Expr::Negative(Box::new(col("i"))), DataType::Utf8).gt_eq(lit("0")),
+            cast(Expr::negative(Box::new(col("i"))), DataType::Utf8).gt_eq(lit("0")),
             &schema,
             &statistics,
             expected_ret,
@@ -3181,7 +3181,7 @@ mod tests {
 
         prune_with_expr(
             // try_cast(-i as utf8) >= 0
-            try_cast(Expr::Negative(Box::new(col("i"))), DataType::Utf8).gt_eq(lit("0")),
+            try_cast(Expr::negative(Box::new(col("i"))), DataType::Utf8).gt_eq(lit("0")),
             &schema,
             &statistics,
             expected_ret,
@@ -3281,7 +3281,7 @@ mod tests {
 
         prune_with_expr(
             // -i < 1
-            Expr::Negative(Box::new(col("i"))).lt(lit(1)),
+            Expr::negative(Box::new(col("i"))).lt(lit(1)),
             &schema,
             &statistics,
             expected_ret,
@@ -3431,7 +3431,7 @@ mod tests {
 
         prune_with_expr(
             // `-cast(i as int64) < 0` convert to `cast(i as int64) > -0`
-            Expr::Negative(Box::new(cast(col("i"), DataType::Int64)))
+            Expr::negative(Box::new(cast(col("i"), DataType::Int64)))
                 .lt(lit(ScalarValue::Int64(Some(0)))),
             &schema,
             &statistics,

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -22,7 +22,7 @@ use datafusion_common::{
     exec_datafusion_err, internal_err, plan_datafusion_err, RecursionUnnestOption,
     Result, ScalarValue, TableReference, UnnestOptions,
 };
-use datafusion_expr::expr::{Alias, Placeholder, Sort};
+use datafusion_expr::expr::{Alias, Placeholder, Sort, Wildcard};
 use datafusion_expr::expr::{Unnest, WildcardOptions};
 use datafusion_expr::ExprFunctionExt;
 use datafusion_expr::{
@@ -511,10 +511,10 @@ pub fn parse_expr(
         ))),
         ExprType::Wildcard(protobuf::Wildcard { qualifier }) => {
             let qualifier = qualifier.to_owned().map(|x| x.try_into()).transpose()?;
-            Ok(Expr::Wildcard {
+            Ok(Expr::Wildcard(Wildcard {
                 qualifier,
                 options: WildcardOptions::default(),
-            })
+            }))
         }
         ExprType::ScalarUdfExpr(protobuf::ScalarUdfExprNode {
             fun_name,

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -22,7 +22,7 @@
 use datafusion_common::{TableReference, UnnestOptions};
 use datafusion_expr::expr::{
     self, Alias, Between, BinaryExpr, Cast, GroupingSet, InList, Like, Placeholder,
-    ScalarFunction, Unnest,
+    ScalarFunction, Unnest, Wildcard,
 };
 use datafusion_expr::{
     logical_plan::PlanType, logical_plan::StringifiedPlan, Expr, JoinConstraint,
@@ -552,7 +552,7 @@ pub fn serialize_expr(
                 expr_type: Some(ExprType::InList(expr)),
             }
         }
-        Expr::Wildcard { qualifier, .. } => protobuf::LogicalExprNode {
+        Expr::Wildcard(Wildcard { qualifier, .. }) => protobuf::LogicalExprNode {
             expr_type: Some(ExprType::Wildcard(protobuf::Wildcard {
                 qualifier: qualifier.to_owned().map(|x| x.into()),
             })),

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -65,7 +65,7 @@ use datafusion_common::{
 use datafusion_expr::dml::CopyTo;
 use datafusion_expr::expr::{
     self, Between, BinaryExpr, Case, Cast, GroupingSet, InList, Like, ScalarFunction,
-    Unnest, WildcardOptions,
+    Unnest, Wildcard, WildcardOptions,
 };
 use datafusion_expr::logical_plan::{Extension, UserDefinedLogicalNodeCore};
 use datafusion_expr::{
@@ -2059,10 +2059,10 @@ fn roundtrip_unnest() {
 
 #[test]
 fn roundtrip_wildcard() {
-    let test_expr = Expr::Wildcard {
+    let test_expr = Expr::Wildcard(Wildcard {
         qualifier: None,
         options: WildcardOptions::default(),
-    };
+    });
 
     let ctx = SessionContext::new();
     roundtrip_expr_test(test_expr, ctx);
@@ -2070,10 +2070,10 @@ fn roundtrip_wildcard() {
 
 #[test]
 fn roundtrip_qualified_wildcard() {
-    let test_expr = Expr::Wildcard {
+    let test_expr = Expr::Wildcard(Wildcard {
         qualifier: Some("foo".into()),
         options: WildcardOptions::default(),
-    };
+    });
 
     let ctx = SessionContext::new();
     roundtrip_expr_test(test_expr, ctx);

--- a/datafusion/proto/tests/cases/serialize.rs
+++ b/datafusion/proto/tests/cases/serialize.rs
@@ -44,7 +44,7 @@ fn plan_to_json() {
     use datafusion_expr::{logical_plan::EmptyRelation, LogicalPlan};
     use datafusion_proto::bytes::logical_plan_to_json;
 
-    let plan = LogicalPlan::EmptyRelation(EmptyRelation {
+    let plan = LogicalPlan::empty_relation(EmptyRelation {
         produce_one_row: false,
         schema: Arc::new(DFSchema::empty()),
     });
@@ -62,7 +62,7 @@ fn json_to_plan() {
     let input = r#"{"emptyRelation":{}}"#.to_string();
     let ctx = SessionContext::new();
     let actual = logical_plan_from_json(&input, &ctx).unwrap();
-    let result = matches!(actual, LogicalPlan::EmptyRelation(_));
+    let result = matches!(actual, LogicalPlan::EmptyRelation(_, _));
     assert!(result, "Should parse empty relation");
 }
 
@@ -256,12 +256,12 @@ fn test_expression_serialization_roundtrip() {
     use datafusion_proto::logical_plan::from_proto::parse_expr;
 
     let ctx = SessionContext::new();
-    let lit = Expr::Literal(ScalarValue::Utf8(None));
+    let lit = Expr::literal(ScalarValue::Utf8(None));
     for function in string::functions() {
         // default to 4 args (though some exprs like substr have error checking)
         let num_args = 4;
         let args: Vec<_> = std::iter::repeat(&lit).take(num_args).cloned().collect();
-        let expr = Expr::ScalarFunction(ScalarFunction::new_udf(function, args));
+        let expr = Expr::scalar_function(ScalarFunction::new_udf(function, args));
 
         let extension_codec = DefaultLogicalExtensionCodec {};
         let proto = serialize_expr(&expr, &extension_codec).unwrap();

--- a/datafusion/sql/src/cte.rs
+++ b/datafusion/sql/src/cte.rs
@@ -193,7 +193,7 @@ fn has_work_table_reference(
 ) -> bool {
     let mut has_reference = false;
     plan.apply(|node| {
-        if let LogicalPlan::TableScan(scan) = node {
+        if let LogicalPlan::TableScan(scan, _) = node {
             if Arc::ptr_eq(&scan.source, work_table_source) {
                 has_reference = true;
                 return Ok(TreeNodeRecursion::Stop);

--- a/datafusion/sql/src/expr/grouping_set.rs
+++ b/datafusion/sql/src/expr/grouping_set.rs
@@ -36,7 +36,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     .collect()
             })
             .collect();
-        Ok(Expr::GroupingSet(GroupingSet::GroupingSets(args?)))
+        Ok(Expr::grouping_set(GroupingSet::GroupingSets(args?)))
     }
 
     pub(super) fn sql_rollup_to_expr(
@@ -57,7 +57,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
             })
             .collect();
-        Ok(Expr::GroupingSet(GroupingSet::Rollup(args?)))
+        Ok(Expr::grouping_set(GroupingSet::Rollup(args?)))
     }
 
     pub(super) fn sql_cube_to_expr(
@@ -76,6 +76,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
             })
             .collect();
-        Ok(Expr::GroupingSet(GroupingSet::Cube(args?)))
+        Ok(Expr::grouping_set(GroupingSet::Cube(args?)))
     }
 }

--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -44,7 +44,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 .ok_or_else(|| {
                     plan_datafusion_err!("variable {var_names:?} has no type information")
                 })?;
-            Ok(Expr::ScalarVariable(ty, var_names))
+            Ok(Expr::scalar_variable(ty, var_names))
         } else {
             // Don't use `col()` here because it will try to
             // interpret names with '.' as if they were
@@ -56,7 +56,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             if let Ok((qualifier, _)) =
                 schema.qualified_field_with_unqualified_name(normalize_ident.as_str())
             {
-                return Ok(Expr::Column(Column {
+                return Ok(Expr::column(Column {
                     relation: qualifier.filter(|q| q.table() != UNNAMED_TABLE).cloned(),
                     name: normalize_ident,
                 }));
@@ -68,7 +68,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     outer.qualified_field_with_unqualified_name(normalize_ident.as_str())
                 {
                     // Found an exact match on a qualified name in the outer plan schema, so this is an outer reference column
-                    return Ok(Expr::OuterReferenceColumn(
+                    return Ok(Expr::outer_reference_column(
                         field.data_type().clone(),
                         Column::from((qualifier, field)),
                     ));
@@ -76,7 +76,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             }
 
             // Default case
-            Ok(Expr::Column(Column {
+            Ok(Expr::column(Column {
                 relation: None,
                 name: normalize_ident,
             }))
@@ -106,7 +106,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         "variable {var_names:?} has no type information"
                     ))
                 })?;
-            Ok(Expr::ScalarVariable(ty, var_names))
+            Ok(Expr::scalar_variable(ty, var_names))
         } else {
             let ids = ids
                 .into_iter()
@@ -136,7 +136,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
                 // Found matching field with no spare identifier(s)
                 Some((field, qualifier, _nested_names)) => {
-                    Ok(Expr::Column(Column::from((qualifier, field))))
+                    Ok(Expr::column(Column::from((qualifier, field))))
                 }
                 None => {
                     // Return default where use all identifiers to not have a nested field
@@ -161,7 +161,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 // Found matching field with no spare identifier(s)
                                 Some((field, qualifier, _nested_names)) => {
                                     // Found an exact match on a qualified name in the outer plan schema, so this is an outer reference column
-                                    Ok(Expr::OuterReferenceColumn(
+                                    Ok(Expr::outer_reference_column(
                                         field.data_type().clone(),
                                         Column::from((qualifier, field)),
                                     ))
@@ -172,14 +172,14 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                     // safe unwrap as s can never be empty or exceed the bounds
                                     let (relation, column_name) =
                                         form_identifier(s).unwrap();
-                                    Ok(Expr::Column(Column::new(relation, column_name)))
+                                    Ok(Expr::column(Column::new(relation, column_name)))
                                 }
                             }
                         } else {
                             let s = &ids[0..ids.len()];
                             // Safe unwrap as s can never be empty or exceed the bounds
                             let (relation, column_name) = form_identifier(s).unwrap();
-                            Ok(Expr::Column(Column::new(relation, column_name)))
+                            Ok(Expr::column(Column::new(relation, column_name)))
                         }
                     }
                 }
@@ -223,7 +223,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             None
         };
 
-        Ok(Expr::Case(Case::new(
+        Ok(Expr::case(Case::new(
             expr,
             when_expr
                 .iter()

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -30,8 +30,8 @@ use datafusion_common::{
     internal_datafusion_err, internal_err, not_impl_err, plan_err, DFSchema, Result,
     ScalarValue,
 };
-use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::expr::{InList, WildcardOptions};
+use datafusion_expr::expr::{ScalarFunction, Wildcard};
 use datafusion_expr::{
     lit, Between, BinaryExpr, Cast, Expr, ExprSchemable, GetFieldAccess, Like, Literal,
     Operator, TryCast,
@@ -565,14 +565,14 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
                 not_impl_err!("AnyOp not supported by ExprPlanner: {binary_expr:?}")
             }
-            SQLExpr::Wildcard => Ok(Expr::Wildcard {
+            SQLExpr::Wildcard => Ok(Expr::Wildcard(Wildcard {
                 qualifier: None,
                 options: WildcardOptions::default(),
-            }),
-            SQLExpr::QualifiedWildcard(object_name) => Ok(Expr::Wildcard {
+            })),
+            SQLExpr::QualifiedWildcard(object_name) => Ok(Expr::Wildcard(Wildcard {
                 qualifier: Some(self.object_name_to_table_reference(object_name)?),
                 options: WildcardOptions::default(),
-            }),
+            })),
             SQLExpr::Tuple(values) => self.parse_tuple(schema, planner_context, values),
             _ => not_impl_err!("Unsupported ast node in sqltorel: {sql:?}"),
         }

--- a/datafusion/sql/src/expr/order_by.rs
+++ b/datafusion/sql/src/expr/order_by.rs
@@ -90,7 +90,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         );
                     }
 
-                    Expr::Column(Column::from(
+                    Expr::column(Column::from(
                         input_schema.qualified_field(field_index - 1),
                     ))
                 }

--- a/datafusion/sql/src/expr/subquery.rs
+++ b/datafusion/sql/src/expr/subquery.rs
@@ -37,7 +37,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         let sub_plan = self.query_to_plan(subquery, planner_context)?;
         let outer_ref_columns = sub_plan.all_out_ref_exprs();
         planner_context.set_outer_query_schema(old_outer_query_schema);
-        Ok(Expr::Exists(Exists {
+        Ok(Expr::exists(Exists {
             subquery: Subquery {
                 subquery: Arc::new(sub_plan),
                 outer_ref_columns,
@@ -60,7 +60,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         let outer_ref_columns = sub_plan.all_out_ref_exprs();
         planner_context.set_outer_query_schema(old_outer_query_schema);
         let expr = Box::new(self.sql_to_expr(expr, input_schema, planner_context)?);
-        Ok(Expr::InSubquery(InSubquery::new(
+        Ok(Expr::in_subquery(InSubquery::new(
             expr,
             Subquery {
                 subquery: Arc::new(sub_plan),
@@ -81,7 +81,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         let sub_plan = self.query_to_plan(subquery, planner_context)?;
         let outer_ref_columns = sub_plan.all_out_ref_exprs();
         planner_context.set_outer_query_schema(old_outer_query_schema);
-        Ok(Expr::ScalarSubquery(Subquery {
+        Ok(Expr::scalar_subquery(Subquery {
             subquery: Arc::new(sub_plan),
             outer_ref_columns,
         }))

--- a/datafusion/sql/src/expr/substring.rs
+++ b/datafusion/sql/src/expr/substring.rs
@@ -51,7 +51,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             (None, Some(for_expr)) => {
                 let arg =
                     self.sql_expr_to_logical_expr(*expr, schema, planner_context)?;
-                let from_logic = Expr::Literal(ScalarValue::Int64(Some(1)));
+                let from_logic = Expr::literal(ScalarValue::Int64(Some(1)));
                 let for_logic =
                     self.sql_expr_to_logical_expr(*for_expr, schema, planner_context)?;
                 vec![arg, from_logic, for_logic]

--- a/datafusion/sql/src/expr/unary_op.rs
+++ b/datafusion/sql/src/expr/unary_op.rs
@@ -32,7 +32,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         planner_context: &mut PlannerContext,
     ) -> Result<Expr> {
         match op {
-            UnaryOperator::Not => Ok(Expr::Not(Box::new(
+            UnaryOperator::Not => Ok(Expr::_not(Box::new(
                 self.sql_expr_to_logical_expr(expr, schema, planner_context)?,
             ))),
             UnaryOperator::Plus => {
@@ -59,7 +59,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         self.sql_interval_to_expr(true, interval)
                     }
                     // Not a literal, apply negative operator on expression
-                    _ => Ok(Expr::Negative(Box::new(self.sql_expr_to_logical_expr(
+                    _ => Ok(Expr::negative(Box::new(self.sql_expr_to_logical_expr(
                         expr,
                         schema,
                         planner_context,

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -41,7 +41,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         match value {
             Value::Number(n, _) => self.parse_sql_number(&n, false),
             Value::SingleQuotedString(s) | Value::DoubleQuotedString(s) => Ok(lit(s)),
-            Value::Null => Ok(Expr::Literal(ScalarValue::Null)),
+            Value::Null => Ok(Expr::literal(ScalarValue::Null)),
             Value::Boolean(n) => Ok(lit(n)),
             Value::Placeholder(param) => {
                 Self::create_placeholder_expr(param, param_data_types)
@@ -112,7 +112,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             Ok(index) => index - 1,
             Err(_) => {
                 return if param_data_types.is_empty() {
-                    Ok(Expr::Placeholder(Placeholder::new(param, None)))
+                    Ok(Expr::placeholder(Placeholder::new(param, None)))
                 } else {
                     // when PREPARE Statement, param_data_types length is always 0
                     plan_err!("Invalid placeholder, not a number: {param}")
@@ -127,7 +127,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             param, param_type
         );
 
-        Ok(Expr::Placeholder(Placeholder::new(
+        Ok(Expr::placeholder(Placeholder::new(
             param,
             param_type.cloned(),
         )))
@@ -223,7 +223,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     fractional_seconds_precision: None,
                 },
             )?;
-            return Ok(Expr::BinaryExpr(BinaryExpr::new(
+            return Ok(Expr::binary_expr(BinaryExpr::new(
                 Box::new(left_expr),
                 df_op,
                 Box::new(right_expr),
@@ -349,7 +349,7 @@ fn parse_decimal_128(unsigned_number: &str, negative: bool) -> Result<Expr> {
         ))));
     }
 
-    Ok(Expr::Literal(ScalarValue::Decimal128(
+    Ok(Expr::literal(ScalarValue::Decimal128(
         Some(if negative { -number } else { number }),
         precision as u8,
         scale as i8,

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -380,7 +380,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         find_column_exprs(exprs)
             .iter()
             .try_for_each(|col| match col {
-                Expr::Column(col) => match &col.relation {
+                Expr::Column(col, _) => match &col.relation {
                     Some(r) => {
                         schema.field_with_qualified_name(r, &col.name)?;
                         Ok(())

--- a/datafusion/sql/src/query.rs
+++ b/datafusion/sql/src/query.rs
@@ -116,11 +116,11 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             return Ok(plan);
         }
 
-        if let LogicalPlan::Distinct(Distinct::On(ref distinct_on)) = plan {
+        if let LogicalPlan::Distinct(Distinct::On(ref distinct_on), _) = plan {
             // In case of `DISTINCT ON` we must capture the sort expressions since during the plan
             // optimization we're effectively doing a `first_value` aggregation according to them.
             let distinct_on = distinct_on.clone().with_sort_expr(order_by)?;
-            Ok(LogicalPlan::Distinct(Distinct::On(distinct_on)))
+            Ok(LogicalPlan::distinct(Distinct::On(distinct_on)))
         } else {
             LogicalPlanBuilder::from(plan).sort(order_by)?.build()
         }
@@ -133,7 +133,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         select_into: Option<SelectInto>,
     ) -> Result<LogicalPlan> {
         match select_into {
-            Some(into) => Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
+            Some(into) => Ok(LogicalPlan::ddl(DdlStatement::CreateMemoryTable(
                 CreateMemoryTable {
                     name: self.object_name_to_table_reference(into.name)?,
                     constraints: Constraints::empty(),

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -206,10 +206,14 @@ fn test_parse_options_value_normalization() {
             assert_eq!(expected_plan, format!("{plan}"));
 
             match plan {
-                LogicalPlan::Ddl(DdlStatement::CreateExternalTable(
-                    CreateExternalTable { options, .. },
-                ))
-                | LogicalPlan::Copy(CopyTo { options, .. }) => {
+                LogicalPlan::Ddl(
+                    DdlStatement::CreateExternalTable(CreateExternalTable {
+                        options,
+                        ..
+                    }),
+                    _,
+                )
+                | LogicalPlan::Copy(CopyTo { options, .. }, _) => {
                     expected_options.iter().for_each(|(k, v)| {
                         assert_eq!(Some(&v.to_string()), options.get(*k));
                     });
@@ -2715,7 +2719,7 @@ fn prepare_stmt_quick_test(
     assert_eq!(format!("{assert_plan}"), expected_plan);
 
     // verify data types
-    if let LogicalPlan::Statement(Statement::Prepare(Prepare { data_types, .. })) =
+    if let LogicalPlan::Statement(Statement::Prepare(Prepare { data_types, .. }), _) =
         assert_plan
     {
         let dt = format!("{data_types:?}");
@@ -4440,15 +4444,18 @@ fn plan_create_index() {
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_name ON test USING btree (name, age DESC)";
     let plan = logical_plan_with_options(sql, ParserOptions::default()).unwrap();
     match plan {
-        LogicalPlan::Ddl(DdlStatement::CreateIndex(CreateIndex {
-            name,
-            table,
-            using,
-            columns,
-            unique,
-            if_not_exists,
-            ..
-        })) => {
+        LogicalPlan::Ddl(
+            DdlStatement::CreateIndex(CreateIndex {
+                name,
+                table,
+                using,
+                columns,
+                unique,
+                if_not_exists,
+                ..
+            }),
+            _,
+        ) => {
             assert_eq!(name, Some("idx_name".to_string()));
             assert_eq!(format!("{table}"), "test");
             assert_eq!(using, Some("btree".to_string()));

--- a/datafusion/sqllogictest/test_files/arrow_typeof.slt
+++ b/datafusion/sqllogictest/test_files/arrow_typeof.slt
@@ -95,7 +95,7 @@ SELECT arrow_cast('1', 'Int16')
 query error
 SELECT arrow_cast('1')
 
-query error DataFusion error: Error during planning: arrow_cast requires its second argument to be a constant string, got Literal\(Int64\(43\)\)
+query error DataFusion error: Error during planning: arrow_cast requires its second argument to be a constant string, got Literal\(Int64\(43\), LogicalPlanStats\)
 SELECT arrow_cast('1', 43)
 
 query error Error unrecognized word: unknown

--- a/datafusion/sqllogictest/test_files/arrow_typeof.slt
+++ b/datafusion/sqllogictest/test_files/arrow_typeof.slt
@@ -95,7 +95,7 @@ SELECT arrow_cast('1', 'Int16')
 query error
 SELECT arrow_cast('1')
 
-query error DataFusion error: Error during planning: arrow_cast requires its second argument to be a constant string, got Literal\(Int64\(43\), LogicalPlanStats\)
+query error DataFusion error: Error during planning: arrow_cast requires its second argument to be a constant string, got Literal\(Int64\(43\), LogicalPlanStats \{ patterns: EnumSet\(ExprLiteral\) \}\)
 SELECT arrow_cast('1', 43)
 
 query error Error unrecognized word: unknown

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -429,7 +429,7 @@ logical_plan
 04)------Aggregate: groupBy=[[]], aggr=[[count(Int64(1)) AS count(*)]]
 05)--------TableScan: t2
 06)--TableScan: t1 projection=[a]
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression Exists(Exists { subquery: <subquery>, negated: false })
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression Exists(Exists { subquery: <subquery>, negated: false }, LogicalPlanStats)
 
 statement ok
 drop table t1;

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -429,7 +429,7 @@ logical_plan
 04)------Aggregate: groupBy=[[]], aggr=[[count(Int64(1)) AS count(*)]]
 05)--------TableScan: t2
 06)--TableScan: t1 projection=[a]
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression Exists(Exists { subquery: <subquery>, negated: false }, LogicalPlanStats)
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression Exists(Exists { subquery: <subquery>, negated: false }, LogicalPlanStats { patterns: EnumSet(ExprColumn | ExprLiteral | ExprAggregateFunction | ExprExists | LogicalPlanProjection | LogicalPlanAggregate) })
 
 statement ok
 drop table t1;

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -4062,12 +4062,12 @@ logical_plan
 07)--------Unnest: lists[unnest_placeholder(generate_series(Int64(1),outer_ref(t1.t1_int)))|depth=1] structs[]
 08)----------Projection: generate_series(Int64(1), CAST(outer_ref(t1.t1_int) AS Int64)) AS unnest_placeholder(generate_series(Int64(1),outer_ref(t1.t1_int)))
 09)------------EmptyRelation
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(UInt32, Column { relation: Some(Bare { table: "t1" }), name: "t1_int" }, LogicalPlanStats)
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(UInt32, Column { relation: Some(Bare { table: "t1" }), name: "t1_int" }, LogicalPlanStats { patterns: EnumSet() })
 
 
 # Test CROSS JOIN LATERAL syntax (execution)
 # TODO: https://github.com/apache/datafusion/issues/10048
-query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t1" \}\), name: "t1_int" \}, LogicalPlanStats\)
+query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t1" \}\), name: "t1_int" \}, LogicalPlanStats \{ patterns: EnumSet\(\) \}\)
 select t1_id, t1_name, i from join_t1 t1 cross join lateral (select * from unnest(generate_series(1, t1_int))) as series(i);
 
 
@@ -4085,12 +4085,12 @@ logical_plan
 07)--------Unnest: lists[unnest_placeholder(generate_series(Int64(1),outer_ref(t2.t1_int)))|depth=1] structs[]
 08)----------Projection: generate_series(Int64(1), CAST(outer_ref(t2.t1_int) AS Int64)) AS unnest_placeholder(generate_series(Int64(1),outer_ref(t2.t1_int)))
 09)------------EmptyRelation
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(UInt32, Column { relation: Some(Bare { table: "t2" }), name: "t1_int" }, LogicalPlanStats)
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(UInt32, Column { relation: Some(Bare { table: "t2" }), name: "t1_int" }, LogicalPlanStats { patterns: EnumSet() })
 
 
 # Test INNER JOIN LATERAL syntax (execution)
 # TODO: https://github.com/apache/datafusion/issues/10048
-query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t2" \}\), name: "t1_int" \}, LogicalPlanStats\)
+query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t2" \}\), name: "t1_int" \}, LogicalPlanStats \{ patterns: EnumSet\(\) \}\)
 select t1_id, t1_name, i from join_t1 t2 inner join lateral (select * from unnest(generate_series(1, t1_int))) as series(i) on(t1_id > i);
 
 # Test RIGHT JOIN LATERAL syntax (unsupported)

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -4062,12 +4062,12 @@ logical_plan
 07)--------Unnest: lists[unnest_placeholder(generate_series(Int64(1),outer_ref(t1.t1_int)))|depth=1] structs[]
 08)----------Projection: generate_series(Int64(1), CAST(outer_ref(t1.t1_int) AS Int64)) AS unnest_placeholder(generate_series(Int64(1),outer_ref(t1.t1_int)))
 09)------------EmptyRelation
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(UInt32, Column { relation: Some(Bare { table: "t1" }), name: "t1_int" })
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(UInt32, Column { relation: Some(Bare { table: "t1" }), name: "t1_int" }, LogicalPlanStats)
 
 
 # Test CROSS JOIN LATERAL syntax (execution)
 # TODO: https://github.com/apache/datafusion/issues/10048
-query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t1" \}\), name: "t1_int" \}\)
+query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t1" \}\), name: "t1_int" \}, LogicalPlanStats\)
 select t1_id, t1_name, i from join_t1 t1 cross join lateral (select * from unnest(generate_series(1, t1_int))) as series(i);
 
 
@@ -4085,12 +4085,12 @@ logical_plan
 07)--------Unnest: lists[unnest_placeholder(generate_series(Int64(1),outer_ref(t2.t1_int)))|depth=1] structs[]
 08)----------Projection: generate_series(Int64(1), CAST(outer_ref(t2.t1_int) AS Int64)) AS unnest_placeholder(generate_series(Int64(1),outer_ref(t2.t1_int)))
 09)------------EmptyRelation
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(UInt32, Column { relation: Some(Bare { table: "t2" }), name: "t1_int" })
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(UInt32, Column { relation: Some(Bare { table: "t2" }), name: "t1_int" }, LogicalPlanStats)
 
 
 # Test INNER JOIN LATERAL syntax (execution)
 # TODO: https://github.com/apache/datafusion/issues/10048
-query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t2" \}\), name: "t1_int" \}\)
+query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(UInt32, Column \{ relation: Some\(Bare \{ table: "t2" \}\), name: "t1_int" \}, LogicalPlanStats\)
 select t1_id, t1_name, i from join_t1 t2 inner join lateral (select * from unnest(generate_series(1, t1_int))) as series(i) on(t1_id > i);
 
 # Test RIGHT JOIN LATERAL syntax (unsupported)

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -60,7 +60,7 @@ logical_plan
 06)----------Filter: outer_ref(t1.a) = t2.a
 07)------------TableScan: t2
 08)----TableScan: t1
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression ScalarSubquery(<subquery>)
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression ScalarSubquery(<subquery>, LogicalPlanStats)
 
 # set from other table
 query TT

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -60,7 +60,7 @@ logical_plan
 06)----------Filter: outer_ref(t1.a) = t2.a
 07)------------TableScan: t2
 08)----TableScan: t1
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression ScalarSubquery(<subquery>, LogicalPlanStats)
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression ScalarSubquery(<subquery>, LogicalPlanStats { patterns: EnumSet(ExprColumn | ExprBinaryExpr | ExprAggregateFunction | ExprScalarSubquery | LogicalPlanProjection | LogicalPlanFilter | LogicalPlanAggregate) })
 
 # set from other table
 query TT

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -908,7 +908,7 @@ async fn roundtrip_values() -> Result<()> {
 async fn roundtrip_values_no_columns() -> Result<()> {
     let ctx = create_context().await?;
     // "VALUES ()" is not yet supported by the SQL parser, so we construct the plan manually
-    let plan = LogicalPlan::Values(Values {
+    let plan = LogicalPlan::values(Values {
         values: vec![vec![], vec![]], // two rows, no columns
         schema: DFSchemaRef::new(DFSchema::empty()),
     });
@@ -981,7 +981,7 @@ async fn new_test_grammar() -> Result<()> {
 async fn extension_logical_plan() -> Result<()> {
     let ctx = create_context().await?;
     let validation_bytes = "MockUserDefinedLogicalPlan".as_bytes().to_vec();
-    let ext_plan = LogicalPlan::Extension(Extension {
+    let ext_plan = LogicalPlan::extension(Extension {
         node: Arc::new(MockUserDefinedLogicalPlan {
             validation_bytes,
             inputs: vec![],
@@ -1086,7 +1086,7 @@ async fn roundtrip_window_udf() -> Result<()> {
 async fn roundtrip_repartition_roundrobin() -> Result<()> {
     let ctx = create_context().await?;
     let scan_plan = ctx.sql("SELECT * FROM data").await?.into_optimized_plan()?;
-    let plan = LogicalPlan::Repartition(Repartition {
+    let plan = LogicalPlan::repartition(Repartition {
         input: Arc::new(scan_plan),
         partitioning_scheme: Partitioning::RoundRobinBatch(8),
     });
@@ -1103,7 +1103,7 @@ async fn roundtrip_repartition_roundrobin() -> Result<()> {
 async fn roundtrip_repartition_hash() -> Result<()> {
     let ctx = create_context().await?;
     let scan_plan = ctx.sql("SELECT * FROM data").await?.into_optimized_plan()?;
-    let plan = LogicalPlan::Repartition(Repartition {
+    let plan = LogicalPlan::repartition(Repartition {
         input: Arc::new(scan_plan),
         partitioning_scheme: Partitioning::Hash(vec![col("data.a")], 8),
     });

--- a/docs/source/library-user-guide/building-logical-plans.md
+++ b/docs/source/library-user-guide/building-logical-plans.md
@@ -55,7 +55,7 @@ fn main() -> Result<(), DataFusionError> {
     let projection = None; // optional projection
     let filters = vec![]; // optional filters to push down
     let fetch = None; // optional LIMIT
-    let table_scan = LogicalPlan::TableScan(TableScan::try_new(
+    let table_scan = LogicalPlan::table_scan(TableScan::try_new(
         "person",
         Arc::new(table_source),
         projection,
@@ -66,7 +66,7 @@ fn main() -> Result<(), DataFusionError> {
 
     // create a Filter plan that evaluates `id > 500` that wraps the TableScan
     let filter_expr = col("id").gt(lit(500));
-    let plan = LogicalPlan::Filter(Filter::try_new(filter_expr, Arc::new(table_scan)) ? );
+    let plan = LogicalPlan::filter(Filter::try_new(filter_expr, Arc::new(table_scan)) ? );
 
     // print the plan
     println!("{}", plan.display_indent_schema());


### PR DESCRIPTION
## Which issue does this PR close?

This a proof of concept PR to improve performance of `TreeNode` traversals. The main purpose of this PR is to demonstrate a promising but API breaking optimization.

## Rationale for this change
`TreeNode` traversal APIs are crucial parts of query plan analysis and optimzation. This PR explores the idea of storing some pre-calculated statistics/properties of nodes (or subtrees) inside the nodes during creation and automatically update the values during transfomations.

This PR focuses on logical plan building blocks (`LogicalPlan`, `Expr`) and only one particular optimization that stores a bitset pattern in each node to describe the subtree content, but additional attributes/properties can be added in follow-up PRs like:
- The type of expressions to speed up `Expr::get_type()` (https://github.com/apache/datafusion/issues/9375#issuecomment-2477605188, https://github.com/apache/datafusion/issues/12604)
- Hash / semantic hash of expressions to improve CSE (https://github.com/apache/datafusion/pull/13315#discussion_r1843848953)

and the idea can be extended to physical trees as well.

## What changes are included in this PR?

To store the pre-calculated statistics/properties `LogicalPlanStats` struct fields are added to each `LogicalPlan` and `Expr` nodes:
```rust
pub enum LogicalPlan {
    Projection(Projection, LogicalPlanStats),
    Filter(Filter, LogicalPlanStats),
    ...
}

pub enum Expr {
    BinaryExpr(BinaryExpr, LogicalPlanStats),
    Like(Like, LogicalPlanStats),
    ...
}
```
This might look redundant but most likely this is the least intrusive way to the existing code. Pattern matching against `LogicalPlan` and `Expr` just need to add a new param, while new enum constructor methods can be defined as lowercase version of the enum items (if there is no conflict with existing methods). The constructor methods calculate the `LogicalPlanStats` fields based on main content of the node.

Please note that even this approach requites quite a lot of API breaking changes in the codebase, but all are mechanical. The following table summarizes the before/after code to construct the enum items. (I just used the `_` prefix to avoid conflicts, but we can come up with better names.)
| Before | After |
| --- |  --- |
| `Expr::Alias` | `Expr::alias_qualified` |
| `Expr::Column` | `Expr::column` |
| `Expr::ScalarVariable` | `Expr::scalar_variable` |
| `Expr::Literal` | `Expr::literal` |
| `Expr::BinaryExpr` | `Expr::binary_expr` |
| `Expr::Like` | `Expr::_like` |
| `Expr::SimilarTo` | `Expr::similar_to` |
| `Expr::Not` | `Expr::_not` |
| `Expr::IsNotNull` | `Expr::_is_not_null` |
| `Expr::IsNull` | `Expr::_is_null` |
| `Expr::IsTrue` | `Expr::_is_true` |
| `Expr::IsFalse` | `Expr::_is_false` |
| `Expr::IsUnknown` | `Expr::_is_unknown` |
| `Expr::IsNotTrue` | `Expr::_is_not_true` |
| `Expr::IsNotFalse` | `Expr::_is_not_false` |
| `Expr::IsNotUnknown` | `Expr::_is_not_unknown` |
| `Expr::Negative` | `Expr::negative` |
| `Expr::Between` | `Expr::_between` |
| `Expr::Case` | `Expr::case` |
| `Expr::Cast` | `Expr::cast` |
| `Expr::TryCast` | `Expr:: try_cast|
| `Expr::ScalarFunction` | `Expr::scalar_function` |
| `Expr::AggregateFunction` | `Expr::aggregate_function` |
| `Expr::WindowFunction` | `Expr::window_function` |
| `Expr::InList` | `Expr::_in_list` |
| `Expr::Exists` | `Expr::exists` |
| `Expr::InSubquery` | `Expr::in_subquery` |
| `Expr::ScalarSubquery` | `Expr::scalar_subquery` |
| `Expr::Wildcard` | `Expr::wildcard` |
| `Expr::GroupingSet` | `Expr::grouping_set` |
| `Expr::Placeholder` | `Expr::placeholder` |
| `Expr::OuterReferenceColumn` | `Expr::outer_reference_column` |
| `Expr::Unnest` | `Expr::unnest` |
| `LogicalPlan::Projection` | `LogicalPlan::projection` |
| `LogicalPlan::Filter` | `LogicalPlan::filter` |
| `LogicalPlan::Window` | `LogicalPlan::window` |
| `LogicalPlan::Aggregate` | `LogicalPlan::aggregate` |
| `LogicalPlan::Sort` | `LogicalPlan::sort` |
| `LogicalPlan::Join` | `LogicalPlan::join` |
| `LogicalPlan::Repartition` | `LogicalPlan::repartition` |
| `LogicalPlan::Union` | `LogicalPlan::union` |
| `LogicalPlan::TableScan` | `LogicalPlan::table_ccan` |
| `LogicalPlan::EmptyRelation` | `LogicalPlan::empty_relation` |
| `LogicalPlan::Subquery` | `LogicalPlan::subquery` |
| `LogicalPlan::SubqueryAlias` | `LogicalPlan::subquery_alias` |
| `LogicalPlan::Limit` | `LogicalPlan::limit` |
| `LogicalPlan::Statement` | `LogicalPlan::statement` |
| `LogicalPlan::Values` | `LogicalPlan::values` |
| `LogicalPlan::Explain` | `LogicalPlan::explain` |
| `LogicalPlan::Analyze` | `LogicalPlan::analyze` |
| `LogicalPlan::Extension` | `LogicalPlan::extension` |
| `LogicalPlan::Distinct` | `LogicalPlan::distinct` |
| `LogicalPlan::Dml` | `LogicalPlan::dml` |
| `LogicalPlan::Ddl` | `LogicalPlan::ddl` |
| `LogicalPlan::Copy` | `LogicalPlan::copy` |
| `LogicalPlan::DescribeTable` | `LogicalPlan::describe_table` |
| `LogicalPlan::Unnest` | `LogicalPlan::unnest` |
| `LogicalPlan::RecursiveQuery` | `LogicalPlan::recursive_query` |

For the above mentioned pattern based optimization the PR defines a `LogicalPlanPattern` enum that contains all possible node kinds of a logical plan:
```rust
pub enum LogicalPlanPattern {
    // [`Expr`] nodes
    ExprBinaryExpr,
    ExprLike,
    ...

    // [`LogicalPlan`] nodes
    LogicalPlanProjection,
    LogicalPlanFilter,
    ...
}
```
A bitset of `LogicalPlanPattern` enum is added to the `LogicalPlanStats` struct to reflect the content of the node's subtree. The implementation could use any kind of bitset, but https://docs.rs/enumset/latest/enumset/ looks like a good candidate.
```rust
pub struct LogicalPlanStats {
    patterns: EnumSet<LogicalPlanPattern>,
}
```
For example here are a few `Expr` item constructors:
```rust
impl Enum {
    pub fn binary_expr(binary_expr: BinaryExpr) -> Self {
        // A `BinaryExpr` node contains the `ExprBinaryExpr` pattern and the patterns of its children
        let stats = LogicalPlanStats::new(enum_set!(LogicalPlanPattern::ExprBinaryExpr)).merge(binary_expr.stats());
        Expr::BinaryExpr(binary_expr, stats)
    }

    pub fn _like(like: Like) -> Self {
        // A `Like` node contains the `ExprLike` pattern and the patterns of its children
        let stats = LogicalPlanStats::new(enum_set!(LogicalPlanPattern::ExprLike)).merge(like.stats());
        Expr::Like(like, stats)
    }

    ...
}
```
While maintaining the bitset during tree transformations comes with some costs, with the bitset we can speed up `LogicalPlan` and `Expr` traversals significantly. For example if we have a traversal that does something with `Expr::BinaryExpr` nodes only:
```rust
expr.apply(|e| {
    match e {
        Expr::BinaryExpr(..) => // do something
        _ => // do nothing
    }

})
```
then we can check the presence of `Expr::BinaryExpr` in a subtree and simply skip traversing subtrees without the `LogicalPlanPattern::ExprBinaryExpr` pattern:
```rust
expr.apply(|e| {
    if !e.stats().contains_pattern(enum_set!(LogicalPlanPattern::ExprBinaryExpr)) {
        return Ok(TreeNodeRecursion::Jump);
    }

    match e {
        Expr::BinaryExpr(..) => // do something
        _ => // do nothing
    }
})
```
I modified some of the traversal functions in this PR to demonstrate that the optimization brings significant performance improvement to `sql_planner`:
```
% critcmp main stats
group                                         main                                    stats
-----                                         ----                                    -----
logical_aggregate_with_join                   1.15  649.7±183.81µs        ? ?/sec     1.00    564.2±6.04µs        ? ?/sec
logical_select_all_from_1000                  1.00      2.8±0.02ms        ? ?/sec     1.00      2.8±0.03ms        ? ?/sec
logical_select_one_from_700                   1.00   408.8±43.00µs        ? ?/sec     1.00   408.9±45.43µs        ? ?/sec
logical_trivial_join_high_numbered_columns    1.00    396.2±6.83µs        ? ?/sec     1.00    396.0±5.13µs        ? ?/sec
logical_trivial_join_low_numbered_columns     1.00   381.7±19.18µs        ? ?/sec     1.00   383.5±30.79µs        ? ?/sec
physical_intersection                         1.53  1034.7±13.33µs        ? ?/sec     1.00   677.8±53.69µs        ? ?/sec
physical_join_consider_sort                   1.49  1459.6±13.75µs        ? ?/sec     1.00   979.1±75.49µs        ? ?/sec
physical_join_distinct                        1.07   378.0±26.75µs        ? ?/sec     1.00   353.8±12.57µs        ? ?/sec
physical_many_self_joins                      1.38     10.4±0.61ms        ? ?/sec     1.00      7.5±0.48ms        ? ?/sec
physical_plan_clickbench_all                  1.15     89.8±0.71ms        ? ?/sec     1.00     78.0±0.69ms        ? ?/sec
physical_plan_clickbench_q1                   1.15  1301.7±210.59µs        ? ?/sec    1.00  1136.1±14.32µs        ? ?/sec
physical_plan_clickbench_q10                  1.15  1680.5±20.50µs        ? ?/sec     1.00  1464.7±121.45µs        ? ?/sec
physical_plan_clickbench_q11                  1.22  1785.3±195.51µs        ? ?/sec    1.00  1458.5±19.58µs        ? ?/sec
physical_plan_clickbench_q12                  1.12  1823.1±151.47µs        ? ?/sec    1.00  1634.2±226.69µs        ? ?/sec
physical_plan_clickbench_q13                  1.16  1655.8±203.04µs        ? ?/sec    1.00  1423.1±159.93µs        ? ?/sec
physical_plan_clickbench_q14                  1.12  1722.6±99.00µs        ? ?/sec     1.00  1532.4±253.66µs        ? ?/sec
physical_plan_clickbench_q15                  1.15  1673.2±16.20µs        ? ?/sec     1.00  1455.6±120.38µs        ? ?/sec
physical_plan_clickbench_q16                  1.13  1442.7±11.38µs        ? ?/sec     1.00  1280.9±31.93µs        ? ?/sec
physical_plan_clickbench_q17                  1.17  1515.6±123.83µs        ? ?/sec    1.00  1296.1±24.30µs        ? ?/sec
physical_plan_clickbench_q18                  1.12  1381.2±148.46µs        ? ?/sec    1.00  1233.7±18.41µs        ? ?/sec
physical_plan_clickbench_q19                  1.10  1689.3±51.93µs        ? ?/sec     1.00  1532.3±140.70µs        ? ?/sec
physical_plan_clickbench_q2                   1.12  1368.6±100.33µs        ? ?/sec    1.00  1222.7±24.16µs        ? ?/sec
physical_plan_clickbench_q20                  1.05  1237.2±14.74µs        ? ?/sec     1.00  1182.7±219.27µs        ? ?/sec
physical_plan_clickbench_q21                  1.12  1353.3±106.07µs        ? ?/sec    1.00  1209.1±13.96µs        ? ?/sec
physical_plan_clickbench_q22                  1.13  1817.7±299.10µs        ? ?/sec    1.00  1610.8±27.71µs        ? ?/sec
physical_plan_clickbench_q23                  1.12      2.0±0.21ms        ? ?/sec     1.00  1797.8±176.74µs        ? ?/sec
physical_plan_clickbench_q24                  1.28      2.5±0.37ms        ? ?/sec     1.00  1960.8±138.84µs        ? ?/sec
physical_plan_clickbench_q25                  1.12  1485.4±24.37µs        ? ?/sec     1.00  1324.8±124.35µs        ? ?/sec
physical_plan_clickbench_q26                  1.14  1373.9±21.27µs        ? ?/sec     1.00  1203.5±14.13µs        ? ?/sec
physical_plan_clickbench_q27                  1.19  1556.4±179.85µs        ? ?/sec    1.00  1312.8±16.84µs        ? ?/sec
physical_plan_clickbench_q28                  1.11  1787.1±108.99µs        ? ?/sec    1.00  1602.9±148.44µs        ? ?/sec
physical_plan_clickbench_q29                  1.13      2.3±0.02ms        ? ?/sec     1.00  1989.6±135.85µs        ? ?/sec
physical_plan_clickbench_q3                   1.08  1346.0±69.08µs        ? ?/sec     1.00  1246.4±140.79µs        ? ?/sec
physical_plan_clickbench_q30                  1.31      8.6±0.08ms        ? ?/sec     1.00      6.5±0.08ms        ? ?/sec
physical_plan_clickbench_q31                  1.12  1868.6±251.29µs        ? ?/sec    1.00  1662.7±137.91µs        ? ?/sec
physical_plan_clickbench_q32                  1.07  1846.9±118.97µs        ? ?/sec    1.00  1725.8±222.02µs        ? ?/sec
physical_plan_clickbench_q33                  1.09  1630.4±72.61µs        ? ?/sec     1.00  1490.4±147.75µs        ? ?/sec
physical_plan_clickbench_q34                  1.06  1434.8±17.97µs        ? ?/sec     1.00  1348.2±111.82µs        ? ?/sec
physical_plan_clickbench_q35                  1.09  1536.3±169.30µs        ? ?/sec    1.00  1412.6±227.81µs        ? ?/sec
physical_plan_clickbench_q36                  1.21      2.2±0.26ms        ? ?/sec     1.00  1814.2±50.46µs        ? ?/sec
physical_plan_clickbench_q37                  1.19      2.2±0.02ms        ? ?/sec     1.00  1813.6±17.51µs        ? ?/sec
physical_plan_clickbench_q38                  1.20      2.2±0.02ms        ? ?/sec     1.00  1806.1±19.72µs        ? ?/sec
physical_plan_clickbench_q39                  1.00  1920.2±123.71µs        ? ?/sec    1.02  1952.7±496.68µs        ? ?/sec
physical_plan_clickbench_q4                   1.06  1249.8±13.81µs        ? ?/sec     1.00  1174.0±129.47µs        ? ?/sec
physical_plan_clickbench_q40                  1.07      2.1±0.02ms        ? ?/sec     1.00  1964.5±179.40µs        ? ?/sec
physical_plan_clickbench_q41                  1.08      2.0±0.03ms        ? ?/sec     1.00  1897.2±360.88µs        ? ?/sec
physical_plan_clickbench_q42                  1.12  1983.9±163.89µs        ? ?/sec    1.00  1765.5±124.55µs        ? ?/sec
physical_plan_clickbench_q43                  1.13      2.0±0.25ms        ? ?/sec     1.00  1789.7±137.35µs        ? ?/sec
physical_plan_clickbench_q44                  1.09  1320.8±117.18µs        ? ?/sec    1.00  1206.4±12.62µs        ? ?/sec
physical_plan_clickbench_q45                  1.09  1312.0±97.44µs        ? ?/sec     1.00  1201.4±32.21µs        ? ?/sec
physical_plan_clickbench_q46                  1.04  1536.8±16.35µs        ? ?/sec     1.00  1471.9±319.91µs        ? ?/sec
physical_plan_clickbench_q47                  1.11  1785.4±14.40µs        ? ?/sec     1.00  1612.5±269.34µs        ? ?/sec
physical_plan_clickbench_q48                  1.17      2.1±0.16ms        ? ?/sec     1.00  1763.0±114.77µs        ? ?/sec
physical_plan_clickbench_q49                  1.16      2.1±0.10ms        ? ?/sec     1.00  1841.9±53.85µs        ? ?/sec
physical_plan_clickbench_q5                   1.10  1325.1±13.65µs        ? ?/sec     1.00  1199.8±13.83µs        ? ?/sec
physical_plan_clickbench_q6                   1.14  1371.1±87.24µs        ? ?/sec     1.00  1201.4±12.84µs        ? ?/sec
physical_plan_clickbench_q7                   1.11  1668.0±202.24µs        ? ?/sec    1.00  1505.9±215.37µs        ? ?/sec
physical_plan_clickbench_q8                   1.07  1458.5±106.34µs        ? ?/sec    1.00  1360.3±268.51µs        ? ?/sec
physical_plan_clickbench_q9                   1.11  1566.6±11.70µs        ? ?/sec     1.00  1412.1±108.23µs        ? ?/sec
physical_plan_tpcds_all                       1.35    655.1±2.04ms        ? ?/sec     1.00   484.8±11.59ms        ? ?/sec
physical_plan_tpch_all                        1.34     38.6±0.30ms        ? ?/sec     1.00     28.7±0.36ms        ? ?/sec
physical_plan_tpch_q1                         1.36  1217.8±49.60µs        ? ?/sec     1.00    897.0±5.98µs        ? ?/sec
physical_plan_tpch_q10                        1.28  1695.3±11.60µs        ? ?/sec     1.00  1324.0±12.04µs        ? ?/sec
physical_plan_tpch_q11                        1.21  1520.2±13.43µs        ? ?/sec     1.00  1255.0±277.75µs        ? ?/sec
physical_plan_tpch_q12                        1.48  1343.2±245.97µs        ? ?/sec    1.00   910.5±59.66µs        ? ?/sec
physical_plan_tpch_q13                        1.24   836.6±44.52µs        ? ?/sec     1.00   674.1±47.79µs        ? ?/sec
physical_plan_tpch_q14                        1.36  1025.8±11.05µs        ? ?/sec     1.00   754.6±12.43µs        ? ?/sec
physical_plan_tpch_q16                        1.35  1520.9±13.61µs        ? ?/sec     1.00  1129.8±24.25µs        ? ?/sec
physical_plan_tpch_q17                        1.37  1490.4±169.95µs        ? ?/sec    1.00  1090.4±101.67µs        ? ?/sec
physical_plan_tpch_q18                        1.34  1604.3±109.68µs        ? ?/sec    1.00  1198.2±47.00µs        ? ?/sec
physical_plan_tpch_q19                        1.65      3.0±0.03ms        ? ?/sec     1.00  1826.9±11.52µs        ? ?/sec
physical_plan_tpch_q2                         1.38      3.2±0.04ms        ? ?/sec     1.00      2.4±0.02ms        ? ?/sec
physical_plan_tpch_q20                        1.29  1970.1±19.51µs        ? ?/sec     1.00  1523.3±164.47µs        ? ?/sec
physical_plan_tpch_q21                        1.45      2.7±0.24ms        ? ?/sec     1.00  1869.4±112.54µs        ? ?/sec
physical_plan_tpch_q22                        1.31  1384.3±28.58µs        ? ?/sec     1.00  1056.8±20.60µs        ? ?/sec
physical_plan_tpch_q3                         1.35  1277.6±198.82µs        ? ?/sec    1.00   945.0±66.16µs        ? ?/sec
physical_plan_tpch_q4                         1.24   946.5±49.43µs        ? ?/sec     1.00  765.5±153.06µs        ? ?/sec
physical_plan_tpch_q5                         1.37  1805.6±138.24µs        ? ?/sec    1.00  1321.7±11.72µs        ? ?/sec
physical_plan_tpch_q6                         1.36    655.3±8.70µs        ? ?/sec     1.00    482.4±6.81µs        ? ?/sec
physical_plan_tpch_q7                         1.36      2.4±0.04ms        ? ?/sec     1.00  1778.4±126.30µs        ? ?/sec
physical_plan_tpch_q8                         1.41      2.9±0.10ms        ? ?/sec     1.00      2.1±0.02ms        ? ?/sec
physical_plan_tpch_q9                         1.33      2.2±0.17ms        ? ?/sec     1.00  1654.2±444.38µs        ? ?/sec
physical_select_aggregates_from_200           1.17     15.2±0.59ms        ? ?/sec     1.00     13.0±0.68ms        ? ?/sec
physical_select_all_from_1000                 1.09     30.1±0.47ms        ? ?/sec     1.00     27.7±0.38ms        ? ?/sec
physical_select_one_from_700                  1.61  1597.4±109.43µs        ? ?/sec    1.00   991.4±63.84µs        ? ?/sec
physical_theta_join_consider_sort             1.60  1776.6±333.62µs        ? ?/sec    1.00  1111.7±10.90µs        ? ?/sec
physical_unnest_to_join                       1.59  1503.9±34.19µs        ? ?/sec     1.00   946.3±66.67µs        ? ?/sec
with_param_values_many_columns                20.70    84.5±0.64µs        ? ?/sec     1.00      4.1±0.05µs        ? ?/sec
```
Most likely further improvements could be achievable by using the new patterns in more traversals, but let's leave it to follow-up PRs.

To sum up this PR contains 3 initial commits:
- The 1st commit is not closely related to the main puspose of the PR. It just refactors `Expr::Wildcard` to incorporate its fields to a named `Wildcard` struct. This makes `Expr::Wildcard` similar to other `Expr` items.
- The 2nd commit adds `LogicalPlanStats` container to all `LogicalPlan` and `Expr` enum items. `LogicalPlanStats` is just an empty struct in this commit and all the changes are mechanical.
- The 3rd commit implements plan pattern optimization in `LogicalPlanStats` and adjusts some of the logical plan traversals to utilize it.

## Are these changes tested?

Yes, with existing tests.

## Are there any user-facing changes?

No.
