### PR TITLE
refactor: replace `OnceLock` with `LazyLock`

### DIFF
--- a/datafusion/common/src/types/builtin.rs
+++ b/datafusion/common/src/types/builtin.rs
@@ -16,17 +16,17 @@
 // under the License.
 
 use crate::types::{LogicalTypeRef, NativeType};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock};
 
 macro_rules! singleton {
     ($name:ident, $getter:ident, $ty:ident) => {
-        // TODO: Use LazyLock instead of getter function when MSRV gets bumped
-        static $name: OnceLock<LogicalTypeRef> = OnceLock::new();
+        static $name: LazyLock<LogicalTypeRef> =
+            LazyLock::new(|| Arc::new(NativeType::$ty));
 
         #[doc = "Getter for singleton instance of a logical type representing"]
         #[doc = concat!("[`NativeType::", stringify!($ty), "`].")]
         pub fn $getter() -> LogicalTypeRef {
-            Arc::clone($name.get_or_init(|| Arc::new(NativeType::$ty)))
+            Arc::clone(&$name)
         }
     };
 }

--- a/datafusion/expr/src/logical_plan/statement.rs
+++ b/datafusion/expr/src/logical_plan/statement.rs
@@ -18,13 +18,9 @@
 use arrow::datatypes::DataType;
 use datafusion_common::{DFSchema, DFSchemaRef};
 use std::fmt::{self, Display};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock};
 
 use crate::{expr_vec_fmt, Expr, LogicalPlan};
-
-/// Statements have a unchanging empty schema.
-/// TODO: Use `LazyLock` when MSRV is 1.80.0
-static STATEMENT_EMPTY_SCHEMA: OnceLock<DFSchemaRef> = OnceLock::new();
 
 /// Various types of Statements.
 ///
@@ -54,7 +50,11 @@ pub enum Statement {
 impl Statement {
     /// Get a reference to the logical plan's schema
     pub fn schema(&self) -> &DFSchemaRef {
-        STATEMENT_EMPTY_SCHEMA.get_or_init(|| Arc::new(DFSchema::empty()))
+        // Statements have a unchanging empty schema.
+        static STATEMENT_EMPTY_SCHEMA: LazyLock<DFSchemaRef> =
+            LazyLock::new(|| Arc::new(DFSchema::empty()));
+
+        &STATEMENT_EMPTY_SCHEMA
     }
 
     /// Return a descriptive string describing the type of this

--- a/datafusion/expr/src/logical_plan/statement.rs
+++ b/datafusion/expr/src/logical_plan/statement.rs
@@ -50,7 +50,7 @@ pub enum Statement {
 impl Statement {
     /// Get a reference to the logical plan's schema
     pub fn schema(&self) -> &DFSchemaRef {
-        // Statements have a unchanging empty schema.
+        // Statements have an unchanging empty schema.
         static STATEMENT_EMPTY_SCHEMA: LazyLock<DFSchemaRef> =
             LazyLock::new(|| Arc::new(DFSchema::empty()));
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/11687

Clear the TODOs after updating MSRV to 1.80.


## Rationale for this change
`LazyLock` has been [stable](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#lazycell-and-lazylock) since Rust version 1.80.0, and it provides a simpler and more suitable way to define static variables.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. By existing tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
