### PR TITLE
fix: specify roottype in substrait fieldreference

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -56,6 +56,7 @@ use datafusion::prelude::Expr;
 use pbjson_types::Any as ProtoAny;
 use substrait::proto::exchange_rel::{ExchangeKind, RoundRobin, ScatterFields};
 use substrait::proto::expression::cast::FailureBehavior;
+use substrait::proto::expression::field_reference::{RootReference, RootType};
 use substrait::proto::expression::literal::interval_day_to_second::PrecisionMode;
 use substrait::proto::expression::literal::map::KeyValue;
 use substrait::proto::expression::literal::{
@@ -70,7 +71,6 @@ use substrait::proto::rel_common::EmitKind::Emit;
 use substrait::proto::{
     rel_common, ExchangeRel, ExpressionReference, ExtendedExpression, RelCommon,
 };
-use substrait::proto::expression::field_reference::{RootReference, RootType};
 use substrait::{
     proto::{
         aggregate_function::AggregationInvocation,
@@ -2151,7 +2151,7 @@ fn try_to_substrait_field_reference(
                         }),
                     )),
                 })),
-                root_type: Some(RootType::RootReference(RootReference{}) ),
+                root_type: Some(RootType::RootReference(RootReference {})),
             })
         }
         _ => substrait_err!("Expect a `Column` expr, but found {expr:?}"),
@@ -2193,7 +2193,7 @@ fn substrait_field_ref(index: usize) -> Result<Expression> {
                     }),
                 )),
             })),
-            root_type: Some(RootType::RootReference(RootReference{}) ),
+            root_type: Some(RootType::RootReference(RootReference {})),
         }))),
     })
 }
@@ -2424,18 +2424,16 @@ mod test {
         Ok(())
     }
 
-
     #[test]
-    fn to_field_reference() -> Result<()>{
-        let expression = substrait_field_ref(2)? ;
+    fn to_field_reference() -> Result<()> {
+        let expression = substrait_field_ref(2)?;
 
         match &expression.rex_type {
             Some(RexType::Selection(field_ref)) => {
                 assert_ne!(field_ref.root_type, None);
-                
-            },
+            }
 
-            _ => assert!(false),
+            _ => panic!("Should not be anything other than field reference"),
         }
         Ok(())
     }

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -70,6 +70,7 @@ use substrait::proto::rel_common::EmitKind::Emit;
 use substrait::proto::{
     rel_common, ExchangeRel, ExpressionReference, ExtendedExpression, RelCommon,
 };
+use substrait::proto::expression::field_reference::{RootReference, RootType};
 use substrait::{
     proto::{
         aggregate_function::AggregationInvocation,
@@ -2150,7 +2151,7 @@ fn try_to_substrait_field_reference(
                         }),
                     )),
                 })),
-                root_type: None,
+                root_type: Some(RootType::RootReference(RootReference{}) ),
             })
         }
         _ => substrait_err!("Expect a `Column` expr, but found {expr:?}"),
@@ -2192,13 +2193,14 @@ fn substrait_field_ref(index: usize) -> Result<Expression> {
                     }),
                 )),
             })),
-            root_type: None,
+            root_type: Some(RootType::RootReference(RootReference{}) ),
         }))),
     })
 }
 
 #[cfg(test)]
 mod test {
+
     use super::*;
     use crate::logical_plan::consumer::{
         from_substrait_extended_expr, from_substrait_literal_without_names,
@@ -2419,6 +2421,22 @@ mod test {
         let roundtrip_dt =
             from_substrait_type_without_names(&substrait, &Extensions::default())?;
         assert_eq!(dt, roundtrip_dt);
+        Ok(())
+    }
+
+
+    #[test]
+    fn to_field_reference() -> Result<()>{
+        let expression = substrait_field_ref(2)? ;
+
+        match &expression.rex_type {
+            Some(RexType::Selection(field_ref)) => {
+                assert_ne!(field_ref.root_type, None);
+                
+            },
+
+            _ => assert!(false),
+        }
         Ok(())
     }
 

--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -2430,7 +2430,13 @@ mod test {
 
         match &expression.rex_type {
             Some(RexType::Selection(field_ref)) => {
-                assert_ne!(field_ref.root_type, None);
+                assert_eq!(
+                    field_ref
+                        .root_type
+                        .clone()
+                        .expect("root type should be set"),
+                    RootType::RootReference(RootReference {})
+                );
             }
 
             _ => panic!("Should not be anything other than field reference"),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13645 

## Rationale for this change

Should match the Substrait spec - None isn't valid for this protobuf

-->

## Are these changes tested?

Using the existing Substrait Tests; though I do note that some aren't passing any way

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
