### PR TITLE
fix: cargo msrv check failed

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -42,8 +42,8 @@ object_store = { workspace = true }
 pbjson-types = "0.7"
 # TODO use workspace version
 prost = "0.13"
-# The MSRV of substrait@0.49.5 is 1.80.1, which is greater than ours.
-# TODO: Remove this version constraint when DataFusion updates its MSRV.
+# The MSRV of substrait@0.49.5 is 1.80.1, which is higher than ours.
+# TODO: Update this version constraint when DataFusion updates its MSRV.
 substrait = { version = ">=0.49.0, <0.49.5", features = ["serde"] }
 url = { workspace = true }
 

--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -42,7 +42,9 @@ object_store = { workspace = true }
 pbjson-types = "0.7"
 # TODO use workspace version
 prost = "0.13"
-substrait = { version = "0.49", features = ["serde"] }
+# The MSRV of substrait@0.49.5 is 1.80.1, which is greater than ours.
+# TODO: Remove this version constraint when DataFusion updates its MSRV.
+substrait = { version = ">=0.49.0, <0.49.5", features = ["serde"] }
 url = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13653.

## Rationale for this change
substrait@0.49.5 uses a higher MSRV 1.80.1.

[Changelog
](https://github.com/substrait-io/substrait-rs/blob/main/CHANGELOG.md)
> 0.49.5 (2024-12-04)
replace once_cell with std::sync::LazyLock, bumping msrv to 1.80.1

This PR restricts substrait‘s version to 0.49.4 to ensure compatibility with the current DataFusion MSRV.
 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. By CI.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
