### PR TITLE
refactor: replace `OnceLock` with `LazyLock` (round 2)

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::process::ExitCode;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock};
 
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::SessionConfig;
@@ -279,9 +279,8 @@ impl ByteUnit {
 }
 
 fn extract_memory_pool_size(size: &str) -> Result<usize, String> {
-    fn byte_suffixes() -> &'static HashMap<&'static str, ByteUnit> {
-        static BYTE_SUFFIXES: OnceLock<HashMap<&'static str, ByteUnit>> = OnceLock::new();
-        BYTE_SUFFIXES.get_or_init(|| {
+    static BYTE_SUFFIXES: LazyLock<HashMap<&'static str, ByteUnit>> =
+        LazyLock::new(|| {
             let mut m = HashMap::new();
             m.insert("b", ByteUnit::Byte);
             m.insert("k", ByteUnit::KiB);
@@ -293,23 +292,20 @@ fn extract_memory_pool_size(size: &str) -> Result<usize, String> {
             m.insert("t", ByteUnit::TiB);
             m.insert("tb", ByteUnit::TiB);
             m
-        })
-    }
+        });
 
-    fn suffix_re() -> &'static regex::Regex {
-        static SUFFIX_REGEX: OnceLock<regex::Regex> = OnceLock::new();
-        SUFFIX_REGEX.get_or_init(|| regex::Regex::new(r"^(-?[0-9]+)([a-z]+)?$").unwrap())
-    }
+    static SUFFIX_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"^(-?[0-9]+)([a-z]+)?$").unwrap());
 
     let lower = size.to_lowercase();
-    if let Some(caps) = suffix_re().captures(&lower) {
+    if let Some(caps) = SUFFIX_REGEX.captures(&lower) {
         let num_str = caps.get(1).unwrap().as_str();
         let num = num_str.parse::<usize>().map_err(|_| {
             format!("Invalid numeric value in memory pool size '{}'", size)
         })?;
 
         let suffix = caps.get(2).map(|m| m.as_str()).unwrap_or("b");
-        let unit = byte_suffixes()
+        let unit = &BYTE_SUFFIXES
             .get(suffix)
             .ok_or_else(|| format!("Invalid memory pool size '{}'", size))?;
         let memory_pool_size = usize::try_from(unit.multiplier())

--- a/datafusion/core/tests/expr_api/mod.rs
+++ b/datafusion/core/tests/expr_api/mod.rs
@@ -28,7 +28,7 @@ use datafusion_functions_aggregate::sum::sum_udaf;
 use datafusion_functions_nested::expr_ext::{IndexAccessor, SliceAccessor};
 use sqlparser::ast::NullTreatment;
 /// Tests of using and evaluating `Expr`s outside the context of a LogicalPlan
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock};
 
 mod parse_sql_expr;
 mod simplification;
@@ -305,13 +305,11 @@ async fn test_aggregate_ext_null_treatment() {
 /// Evaluates the specified expr as an aggregate and compares the result to the
 /// expected result.
 async fn evaluate_agg_test(expr: Expr, expected_lines: Vec<&str>) {
-    let batch = test_batch();
-
     let ctx = SessionContext::new();
     let group_expr = vec![];
     let agg_expr = vec![expr];
     let result = ctx
-        .read_batch(batch)
+        .read_batch(TEST_BATCH.clone())
         .unwrap()
         .aggregate(group_expr, agg_expr)
         .unwrap()
@@ -332,13 +330,13 @@ async fn evaluate_agg_test(expr: Expr, expected_lines: Vec<&str>) {
 /// Converts the `Expr` to a `PhysicalExpr`, evaluates it against the provided
 /// `RecordBatch` and compares the result to the expected result.
 fn evaluate_expr_test(expr: Expr, expected_lines: Vec<&str>) {
-    let batch = test_batch();
+    let batch = &TEST_BATCH;
     let df_schema = DFSchema::try_from(batch.schema()).unwrap();
     let physical_expr = SessionContext::new()
         .create_physical_expr(expr, &df_schema)
         .unwrap();
 
-    let result = physical_expr.evaluate(&batch).unwrap();
+    let result = physical_expr.evaluate(batch).unwrap();
     let array = result.into_array(1).unwrap();
     let result = pretty_format_columns("expr", &[array]).unwrap().to_string();
     let actual_lines = result.lines().collect::<Vec<_>>();
@@ -350,39 +348,33 @@ fn evaluate_expr_test(expr: Expr, expected_lines: Vec<&str>) {
     );
 }
 
-static TEST_BATCH: OnceLock<RecordBatch> = OnceLock::new();
+static TEST_BATCH: LazyLock<RecordBatch> = LazyLock::new(|| {
+    let string_array: ArrayRef = Arc::new(StringArray::from(vec!["1", "2", "3"]));
+    let int_array: ArrayRef =
+        Arc::new(Int64Array::from_iter(vec![Some(10), None, Some(5)]));
 
-fn test_batch() -> RecordBatch {
-    TEST_BATCH
-        .get_or_init(|| {
-            let string_array: ArrayRef = Arc::new(StringArray::from(vec!["1", "2", "3"]));
-            let int_array: ArrayRef =
-                Arc::new(Int64Array::from_iter(vec![Some(10), None, Some(5)]));
+    // { a: "2021-02-01" } { a: "2021-02-02" } { a: "2021-02-03" }
+    let struct_array: ArrayRef = Arc::from(StructArray::from(vec![(
+        Arc::new(Field::new("a", DataType::Utf8, false)),
+        Arc::new(StringArray::from(vec![
+            "2021-02-01",
+            "2021-02-02",
+            "2021-02-03",
+        ])) as _,
+    )]));
 
-            // { a: "2021-02-01" } { a: "2021-02-02" } { a: "2021-02-03" }
-            let struct_array: ArrayRef = Arc::from(StructArray::from(vec![(
-                Arc::new(Field::new("a", DataType::Utf8, false)),
-                Arc::new(StringArray::from(vec![
-                    "2021-02-01",
-                    "2021-02-02",
-                    "2021-02-03",
-                ])) as _,
-            )]));
+    // ["one"] ["two", "three", "four"] ["five"]
+    let mut builder = ListBuilder::new(StringBuilder::new());
+    builder.append_value([Some("one")]);
+    builder.append_value([Some("two"), Some("three"), Some("four")]);
+    builder.append_value([Some("five")]);
+    let list_array: ArrayRef = Arc::new(builder.finish());
 
-            // ["one"] ["two", "three", "four"] ["five"]
-            let mut builder = ListBuilder::new(StringBuilder::new());
-            builder.append_value([Some("one")]);
-            builder.append_value([Some("two"), Some("three"), Some("four")]);
-            builder.append_value([Some("five")]);
-            let list_array: ArrayRef = Arc::new(builder.finish());
-
-            RecordBatch::try_from_iter(vec![
-                ("id", string_array),
-                ("i", int_array),
-                ("props", struct_array),
-                ("list", list_array),
-            ])
-            .unwrap()
-        })
-        .clone()
-}
+    RecordBatch::try_from_iter(vec![
+        ("id", string_array),
+        ("i", int_array),
+        ("props", struct_array),
+        ("list", list_array),
+    ])
+    .unwrap()
+});

--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -35,7 +35,7 @@ use datafusion_physical_plan::spill::get_record_batch_memory_size;
 use futures::StreamExt;
 use std::any::Any;
 use std::num::NonZeroUsize;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock};
 use tokio::fs::File;
 
 use datafusion::datasource::streaming::StreamingTable;
@@ -730,15 +730,14 @@ fn maybe_split_batches(
         .collect()
 }
 
-static DICT_BATCHES: OnceLock<Vec<RecordBatch>> = OnceLock::new();
-
 /// Returns 5 sorted string dictionary batches each with 50 rows with
 /// this schema.
 ///
 /// a: Dictionary<Utf8, Int32>,
 /// b: Dictionary<Utf8, Int32>,
 fn dict_batches() -> Vec<RecordBatch> {
-    DICT_BATCHES.get_or_init(make_dict_batches).clone()
+    static DICT_BATCHES: LazyLock<Vec<RecordBatch>> = LazyLock::new(make_dict_batches);
+    DICT_BATCHES.clone()
 }
 
 fn make_dict_batches() -> Vec<RecordBatch> {

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -21,7 +21,7 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock};
 
 use super::dml::CopyTo;
 use super::DdlStatement;
@@ -3067,12 +3067,12 @@ impl Aggregate {
 
     /// Get the output expressions.
     fn output_expressions(&self) -> Result<Vec<&Expr>> {
-        static INTERNAL_ID_EXPR: OnceLock<Expr> = OnceLock::new();
+        static INTERNAL_ID_EXPR: LazyLock<Expr> = LazyLock::new(|| {
+            Expr::Column(Column::from_name(Aggregate::INTERNAL_GROUPING_ID))
+        });
         let mut exprs = grouping_set_to_exprlist(self.group_expr.as_slice())?;
         if self.is_grouping_set() {
-            exprs.push(INTERNAL_ID_EXPR.get_or_init(|| {
-                Expr::Column(Column::from_name(Self::INTERNAL_GROUPING_ID))
-            }));
+            exprs.push(&INTERNAL_ID_EXPR);
         }
         exprs.extend(self.aggr_expr.iter());
         debug_assert!(exprs.len() == self.schema.fields().len());

--- a/datafusion/expr/src/test/function_stub.rs
+++ b/datafusion/expr/src/test/function_stub.rs
@@ -41,7 +41,7 @@ macro_rules! create_func {
         paste::paste! {
             #[doc = concat!("AggregateFunction that returns a [AggregateUDF](crate::AggregateUDF) for [`", stringify!($UDAF), "`]")]
             pub fn $AGGREGATE_UDF_FN() -> std::sync::Arc<crate::AggregateUDF> {
-                /// Singleton instance of [$UDAF], ensures the UDAF is only created once
+                // Singleton instance of [$UDAF], ensures the UDAF is only created once
                 static INSTANCE: std::sync::LazyLock<std::sync::Arc<crate::AggregateUDF>> =
                     std::sync::LazyLock::new(|| {
                         std::sync::Arc::new(crate::AggregateUDF::from(<$UDAF>::default()))

--- a/datafusion/expr/src/test/function_stub.rs
+++ b/datafusion/expr/src/test/function_stub.rs
@@ -39,19 +39,14 @@ use crate::{
 macro_rules! create_func {
     ($UDAF:ty, $AGGREGATE_UDF_FN:ident) => {
         paste::paste! {
-            /// Singleton instance of [$UDAF], ensures the UDAF is only created once
-            /// named STATIC_$(UDAF). For example `STATIC_FirstValue`
-            #[allow(non_upper_case_globals)]
-            static [< STATIC_ $UDAF >]: std::sync::OnceLock<std::sync::Arc<crate::AggregateUDF>> =
-                std::sync::OnceLock::new();
-
             #[doc = concat!("AggregateFunction that returns a [AggregateUDF](crate::AggregateUDF) for [`", stringify!($UDAF), "`]")]
             pub fn $AGGREGATE_UDF_FN() -> std::sync::Arc<crate::AggregateUDF> {
-                [< STATIC_ $UDAF >]
-                    .get_or_init(|| {
+                /// Singleton instance of [$UDAF], ensures the UDAF is only created once
+                static INSTANCE: std::sync::LazyLock<std::sync::Arc<crate::AggregateUDF>> =
+                    std::sync::LazyLock::new(|| {
                         std::sync::Arc::new(crate::AggregateUDF::from(<$UDAF>::default()))
-                    })
-                    .clone()
+                    });
+                std::sync::Arc::clone(&INSTANCE)
             }
         }
     }

--- a/datafusion/functions-aggregate/src/macros.rs
+++ b/datafusion/functions-aggregate/src/macros.rs
@@ -65,19 +65,14 @@ macro_rules! create_func {
     };
     ($UDAF:ty, $AGGREGATE_UDF_FN:ident, $CREATE:expr) => {
         paste::paste! {
-            /// Singleton instance of [$UDAF], ensures the UDAF is only created once
-            /// named STATIC_$(UDAF). For example `STATIC_FirstValue`
-            #[allow(non_upper_case_globals)]
-            static [< STATIC_ $UDAF >]: std::sync::OnceLock<std::sync::Arc<datafusion_expr::AggregateUDF>> =
-                std::sync::OnceLock::new();
-
             #[doc = concat!("AggregateFunction that returns a [`AggregateUDF`](datafusion_expr::AggregateUDF) for [`", stringify!($UDAF), "`]")]
             pub fn $AGGREGATE_UDF_FN() -> std::sync::Arc<datafusion_expr::AggregateUDF> {
-                [< STATIC_ $UDAF >]
-                    .get_or_init(|| {
+                /// Singleton instance of [$UDAF], ensures the UDAF is only created once
+                static INSTANCE: std::sync::LazyLock<std::sync::Arc<datafusion_expr::AggregateUDF>> =
+                    std::sync::LazyLock::new(|| {
                         std::sync::Arc::new(datafusion_expr::AggregateUDF::from($CREATE))
-                    })
-                    .clone()
+                    });
+                std::sync::Arc::clone(&INSTANCE)
             }
         }
     }

--- a/datafusion/functions-aggregate/src/macros.rs
+++ b/datafusion/functions-aggregate/src/macros.rs
@@ -67,7 +67,7 @@ macro_rules! create_func {
         paste::paste! {
             #[doc = concat!("AggregateFunction that returns a [`AggregateUDF`](datafusion_expr::AggregateUDF) for [`", stringify!($UDAF), "`]")]
             pub fn $AGGREGATE_UDF_FN() -> std::sync::Arc<datafusion_expr::AggregateUDF> {
-                /// Singleton instance of [$UDAF], ensures the UDAF is only created once
+                // Singleton instance of [$UDAF], ensures the UDAF is only created once
                 static INSTANCE: std::sync::LazyLock<std::sync::Arc<datafusion_expr::AggregateUDF>> =
                     std::sync::LazyLock::new(|| {
                         std::sync::Arc::new(datafusion_expr::AggregateUDF::from($CREATE))

--- a/datafusion/functions-nested/src/macros.rs
+++ b/datafusion/functions-nested/src/macros.rs
@@ -85,22 +85,17 @@ macro_rules! make_udf_expr_and_func {
 macro_rules! create_func {
     ($UDF:ty, $SCALAR_UDF_FN:ident) => {
         paste::paste! {
-            /// Singleton instance of [`$UDF`], ensures the UDF is only created once
-            /// named STATIC_$(UDF). For example `STATIC_ArrayToString`
-            #[allow(non_upper_case_globals)]
-            static [< STATIC_ $UDF >]: std::sync::OnceLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
-                std::sync::OnceLock::new();
-
             #[doc = concat!("ScalarFunction that returns a [`ScalarUDF`](datafusion_expr::ScalarUDF) for ")]
             #[doc = stringify!($UDF)]
             pub fn $SCALAR_UDF_FN() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
-                [< STATIC_ $UDF >]
-                    .get_or_init(|| {
+                /// Singleton instance of [`$UDF`], ensures the UDF is only created once
+                static INSTANCE: std::sync::LazyLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
+                    std::sync::LazyLock::new(|| {
                         std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
                             <$UDF>::new(),
                         ))
-                    })
-                    .clone()
+                    });
+                std::sync::Arc::clone(&INSTANCE)
             }
         }
     };

--- a/datafusion/functions-nested/src/macros.rs
+++ b/datafusion/functions-nested/src/macros.rs
@@ -88,7 +88,7 @@ macro_rules! create_func {
             #[doc = concat!("ScalarFunction that returns a [`ScalarUDF`](datafusion_expr::ScalarUDF) for ")]
             #[doc = stringify!($UDF)]
             pub fn $SCALAR_UDF_FN() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
-                /// Singleton instance of [`$UDF`], ensures the UDF is only created once
+                // Singleton instance of [`$UDF`], ensures the UDF is only created once
                 static INSTANCE: std::sync::LazyLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
                     std::sync::LazyLock::new(|| {
                         std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(

--- a/datafusion/functions-table/src/lib.rs
+++ b/datafusion/functions-table/src/lib.rs
@@ -34,15 +34,15 @@ pub fn all_default_table_functions() -> Vec<Arc<TableFunction>> {
 macro_rules! create_udtf_function {
     ($module:path, $name:expr) => {
         paste::paste! {
-            static INSTANCE: std::sync::OnceLock<Arc<TableFunction>> = std::sync::OnceLock::new();
-
             pub fn [<$name:lower>]() -> Arc<TableFunction> {
-                INSTANCE.get_or_init(|| {
-                    Arc::new(TableFunction::new(
-                        $name.to_string(),
-                        Arc::new($module {}),
-                    ))
-                }).clone()
+                static INSTANCE: std::sync::LazyLock<Arc<TableFunction>> =
+                    std::sync::LazyLock::new(|| {
+                        std::sync::Arc::new(TableFunction::new(
+                            $name.to_string(),
+                            Arc::new($module {}),
+                        ))
+                    });
+                std::sync::Arc::clone(&INSTANCE)
             }
         }
     };

--- a/datafusion/functions-window/src/macros.rs
+++ b/datafusion/functions-window/src/macros.rs
@@ -102,18 +102,16 @@ macro_rules! get_or_init_udwf {
             #[doc = concat!(" Singleton instance of [`", stringify!($OUT_FN_NAME), "`], ensures the user-defined")]
             #[doc = concat!(" window function is only created once.")]
             #[allow(non_upper_case_globals)]
-            static [<STATIC_ $UDWF>]: std::sync::OnceLock<std::sync::Arc<datafusion_expr::WindowUDF>> =
-                std::sync::OnceLock::new();
+            static [<STATIC_ $UDWF>]: std::sync::LazyLock<std::sync::Arc<datafusion_expr::WindowUDF>> =
+                std::sync::LazyLock::new(|| {
+                    std::sync::Arc::new(datafusion_expr::WindowUDF::from($CTOR()))
+                });
 
             #[doc = concat!(" Returns a [`WindowUDF`](datafusion_expr::WindowUDF) for [`", stringify!($OUT_FN_NAME), "`].")]
             #[doc = ""]
             #[doc = concat!(" ", $DOC)]
             pub fn [<$OUT_FN_NAME _udwf>]() -> std::sync::Arc<datafusion_expr::WindowUDF> {
-                [<STATIC_ $UDWF>]
-                    .get_or_init(|| {
-                        std::sync::Arc::new(datafusion_expr::WindowUDF::from($CTOR()))
-                    })
-                    .clone()
+                std::sync::Arc::clone(&[<STATIC_ $UDWF>])
             }
         }
     };

--- a/datafusion/functions-window/src/macros.rs
+++ b/datafusion/functions-window/src/macros.rs
@@ -99,19 +99,16 @@ macro_rules! get_or_init_udwf {
 
     ($UDWF:ident, $OUT_FN_NAME:ident, $DOC:expr, $CTOR:path) => {
         paste::paste! {
-            #[doc = concat!(" Singleton instance of [`", stringify!($OUT_FN_NAME), "`], ensures the user-defined")]
-            #[doc = concat!(" window function is only created once.")]
-            #[allow(non_upper_case_globals)]
-            static [<STATIC_ $UDWF>]: std::sync::LazyLock<std::sync::Arc<datafusion_expr::WindowUDF>> =
-                std::sync::LazyLock::new(|| {
-                    std::sync::Arc::new(datafusion_expr::WindowUDF::from($CTOR()))
-                });
-
             #[doc = concat!(" Returns a [`WindowUDF`](datafusion_expr::WindowUDF) for [`", stringify!($OUT_FN_NAME), "`].")]
             #[doc = ""]
             #[doc = concat!(" ", $DOC)]
             pub fn [<$OUT_FN_NAME _udwf>]() -> std::sync::Arc<datafusion_expr::WindowUDF> {
-                std::sync::Arc::clone(&[<STATIC_ $UDWF>])
+                // Singleton instance of UDWF, ensures it is only created once.
+                static INSTANCE: std::sync::LazyLock<std::sync::Arc<datafusion_expr::WindowUDF>> =
+                    std::sync::LazyLock::new(|| {
+                        std::sync::Arc::new(datafusion_expr::WindowUDF::from($CTOR()))
+                    });
+                std::sync::Arc::clone(&INSTANCE)
             }
         }
     };

--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -71,20 +71,18 @@ macro_rules! export_functions {
 /// This is used to ensure creating the list of `ScalarUDF` only happens once.
 macro_rules! make_udf_function {
     ($UDF:ty, $GNAME:ident, $NAME:ident) => {
-        /// Singleton instance of the function
-        static $GNAME: std::sync::OnceLock<std::sync::Arc<datafusion_expr::ScalarUDF>> =
-            std::sync::OnceLock::new();
-
         #[doc = "Return a [`ScalarUDF`](datafusion_expr::ScalarUDF) implementation "]
         #[doc = stringify!($UDF)]
         pub fn $NAME() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
-            $GNAME
-                .get_or_init(|| {
-                    std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
-                        <$UDF>::new(),
-                    ))
-                })
-                .clone()
+            /// Singleton instance of the function
+            static $GNAME: std::sync::LazyLock<
+                std::sync::Arc<datafusion_expr::ScalarUDF>,
+            > = std::sync::LazyLock::new(|| {
+                std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
+                    <$UDF>::new(),
+                ))
+            });
+            std::sync::Arc::clone(&$GNAME)
         }
     };
 }

--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -74,7 +74,7 @@ macro_rules! make_udf_function {
         #[doc = "Return a [`ScalarUDF`](datafusion_expr::ScalarUDF) implementation "]
         #[doc = stringify!($UDF)]
         pub fn $NAME() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
-            /// Singleton instance of the function
+            // Singleton instance of the function
             static $GNAME: std::sync::LazyLock<
                 std::sync::Arc<datafusion_expr::ScalarUDF>,
             > = std::sync::LazyLock::new(|| {

--- a/datafusion/physical-expr-common/src/sort_expr.rs
+++ b/datafusion/physical-expr-common/src/sort_expr.rs
@@ -22,7 +22,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock};
 use std::vec::IntoIter;
 
 use arrow::compute::kernels::sort::{SortColumn, SortOptions};
@@ -336,8 +336,6 @@ impl AsRef<LexOrdering> for LexOrdering {
     }
 }
 
-static EMPTY_ORDER: OnceLock<LexOrdering> = OnceLock::new();
-
 impl LexOrdering {
     // Creates a new [`LexOrdering`] from a vector
     pub fn new(inner: Vec<PhysicalSortExpr>) -> Self {
@@ -346,7 +344,8 @@ impl LexOrdering {
 
     /// Return an empty LexOrdering (no expressions)
     pub fn empty() -> &'static LexOrdering {
-        EMPTY_ORDER.get_or_init(LexOrdering::default)
+        static EMPTY_ORDER: LazyLock<LexOrdering> = LazyLock::new(LexOrdering::default);
+        &EMPTY_ORDER
     }
 
     pub fn capacity(&self) -> usize {

--- a/datafusion/physical-expr/src/expressions/not.rs
+++ b/datafusion/physical-expr/src/expressions/not.rs
@@ -127,7 +127,7 @@ mod tests {
     use super::*;
     use crate::expressions::col;
     use arrow::{array::BooleanArray, datatypes::*};
-    use std::sync::OnceLock;
+    use std::sync::LazyLock;
 
     #[test]
     fn neg_op() -> Result<()> {
@@ -190,10 +190,9 @@ mod tests {
     }
 
     fn schema() -> SchemaRef {
-        Arc::clone(SCHEMA.get_or_init(|| {
+        static SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
             Arc::new(Schema::new(vec![Field::new("a", DataType::Boolean, true)]))
-        }))
+        });
+        Arc::clone(&SCHEMA)
     }
-
-    static SCHEMA: OnceLock<SchemaRef> = OnceLock::new();
 }

--- a/datafusion/physical-expr/src/utils/guarantee.rs
+++ b/datafusion/physical-expr/src/utils/guarantee.rs
@@ -412,7 +412,7 @@ impl<'a> ColOpLit<'a> {
 
 #[cfg(test)]
 mod test {
-    use std::sync::OnceLock;
+    use std::sync::LazyLock;
 
     use super::*;
     use crate::planner::logical2physical;
@@ -863,13 +863,12 @@ mod test {
 
     // Schema for testing
     fn schema() -> SchemaRef {
-        Arc::clone(SCHEMA.get_or_init(|| {
+        static SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
             Arc::new(Schema::new(vec![
                 Field::new("a", DataType::Utf8, false),
                 Field::new("b", DataType::Int32, false),
             ]))
-        }))
+        });
+        Arc::clone(&SCHEMA)
     }
-
-    static SCHEMA: OnceLock<SchemaRef> = OnceLock::new();
 }

--- a/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
@@ -23,7 +23,7 @@ use arrow::{array, array::ArrayRef, datatypes::DataType, record_batch::RecordBat
 use datafusion_common::format::DEFAULT_FORMAT_OPTIONS;
 use datafusion_common::DataFusionError;
 use std::path::PathBuf;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 use super::super::conversion::*;
 use super::error::{DFSqlLogicTestError, Result};
@@ -130,7 +130,7 @@ fn expand_row(mut row: Vec<String>) -> impl Iterator<Item = Vec<String>> {
 /// ```
 fn normalize_paths(mut row: Vec<String>) -> Vec<String> {
     row.iter_mut().for_each(|s| {
-        let workspace_root: &str = workspace_root().as_ref();
+        let workspace_root: &str = WORKSPACE_ROOT.as_ref();
         if s.contains(workspace_root) {
             *s = s.replace(workspace_root, "WORKSPACE_ROOT");
         }
@@ -138,34 +138,30 @@ fn normalize_paths(mut row: Vec<String>) -> Vec<String> {
     row
 }
 
-/// return the location of the datafusion checkout
-fn workspace_root() -> &'static object_store::path::Path {
-    static WORKSPACE_ROOT_LOCK: OnceLock<object_store::path::Path> = OnceLock::new();
-    WORKSPACE_ROOT_LOCK.get_or_init(|| {
-        // e.g. /Software/datafusion/datafusion/core
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+/// The location of the datafusion checkout
+static WORKSPACE_ROOT: LazyLock<object_store::path::Path> = LazyLock::new(|| {
+    // e.g. /Software/datafusion/datafusion/core
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-        // e.g. /Software/datafusion/datafusion
-        let workspace_root = dir
-            .parent()
-            .expect("Can not find parent of datafusion/core")
-            // e.g. /Software/datafusion
-            .parent()
-            .expect("parent of datafusion")
-            .to_string_lossy();
+    // e.g. /Software/datafusion/datafusion
+    let workspace_root = dir
+        .parent()
+        .expect("Can not find parent of datafusion/core")
+        // e.g. /Software/datafusion
+        .parent()
+        .expect("parent of datafusion")
+        .to_string_lossy();
 
-        let sanitized_workplace_root = if cfg!(windows) {
-            // Object store paths are delimited with `/`, e.g. `/datafusion/datafusion/testing/data/csv/aggregate_test_100.csv`.
-            // The default windows delimiter is `\`, so the workplace path is `datafusion\datafusion`.
-            workspace_root
-                .replace(std::path::MAIN_SEPARATOR, object_store::path::DELIMITER)
-        } else {
-            workspace_root.to_string()
-        };
+    let sanitized_workplace_root = if cfg!(windows) {
+        // Object store paths are delimited with `/`, e.g. `/datafusion/datafusion/testing/data/csv/aggregate_test_100.csv`.
+        // The default windows delimiter is `\`, so the workplace path is `datafusion\datafusion`.
+        workspace_root.replace(std::path::MAIN_SEPARATOR, object_store::path::DELIMITER)
+    } else {
+        workspace_root.to_string()
+    };
 
-        object_store::path::Path::parse(sanitized_workplace_root).unwrap()
-    })
-}
+    object_store::path::Path::parse(sanitized_workplace_root).unwrap()
+});
 
 /// Convert a single batch to a `Vec<Vec<String>>` for comparison
 fn convert_batch(batch: RecordBatch) -> Result<Vec<Vec<String>>> {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Part of #11687

Replaced the remaining `OnceLock`s except for function [Documentation](https://github.com/apache/datafusion/blob/2464703c84c400a09cc59277018813f0e797bb4e/datafusion/functions/src/math/pi.rs#L89) instances.

## Rationale for this change
LazyLock provides a simpler way to define static variables.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
