### PR TITLE
Make scalar and array handling for array_has consistent

### DIFF
--- a/datafusion/functions-nested/src/array_has.rs
+++ b/datafusion/functions-nested/src/array_has.rs
@@ -214,12 +214,7 @@ fn array_has_dispatch_for_array<O: OffsetSizeTrait>(
         let is_nested = arr.data_type().is_nested();
         let needle_row = Scalar::new(needle.slice(i, 1));
         let eq_array = compare_with_eq(&arr, &needle_row, is_nested)?;
-        let is_contained = eq_array.true_count() > 0;
-        if is_contained || eq_array.null_count() == 0 {
-            boolean_builder.append_value(is_contained);
-        } else {
-            boolean_builder.append_null();
-        }
+        boolean_builder.append_value(eq_array.true_count() > 0);
     }
 
     Ok(Arc::new(boolean_builder.finish()))
@@ -252,11 +247,7 @@ fn array_has_dispatch_for_scalar<O: OffsetSizeTrait>(
             continue;
         }
         let sliced_array = eq_array.slice(start, length);
-        // For nested list, check number of nulls
-        let is_contained = sliced_array.true_count() > 0;
-        if is_contained || sliced_array.null_count() == 0 {
-            final_contained[i] = Some(is_contained);
-        }
+        final_contained[i] = Some(sliced_array.true_count() > 0);
     }
 
     Ok(Arc::new(BooleanArray::from(final_contained)))

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5270,7 +5270,7 @@ select array_has([], null),
 ----
 NULL NULL NULL
 
-# If lhs is has any Nulls, we return Null instead of false
+# Always return false if not contained even if list has null elements
 query BB
 select array_has([1, null, 2], 3),
        array_has([null, null, null], 3);

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -353,6 +353,16 @@ AS VALUES
 ;
 
 statement ok
+CREATE TABLE array_has_table_null
+AS VALUES
+  (make_array(1, 2), 1),
+  (make_array(1, NULL), 1),
+  (make_array(3, 4, 5), 2),
+  (make_array(3, NULL, 5), 2),
+  (make_array(NULL, NULL, NULL), 2)
+;
+
+statement ok
 CREATE TABLE array_distinct_table_1D
 AS VALUES
   (make_array(1, 1, 2, 2, 3)),
@@ -5260,6 +5270,13 @@ select array_has([], null),
 ----
 NULL NULL NULL
 
+# If lhs is has any Nulls, we return Null instead of false
+query BB
+select array_has([1, null, 2], 3),
+       array_has([null, null, null], 3);
+----
+NULL NULL
+
 #TODO: array_has_all and array_has_any cannot handle NULL
 #query BBBB
 #select array_has_any([], null),
@@ -5337,6 +5354,16 @@ from array_has_table_1D;
 ----
 true true true
 false false false
+
+query B
+select array_has(column1, column2)
+from array_has_table_null;
+----
+true
+true
+false
+NULL
+NULL
 
 query B
 select array_has(column1, column2)
@@ -5541,9 +5568,9 @@ select array_has(column1, make_array(5, 6)),
 from arrays;
 ----
 false false false true
-true false true false
+true false true NULL
 true false false true
-false true false false
+false true NULL false
 NULL NULL false false
 false false NULL false
 false false false NULL
@@ -5556,9 +5583,9 @@ select array_has(arrow_cast(column1, 'LargeList(List(Int64))'), make_array(5, 6)
 from arrays;
 ----
 false false false true
-true false true false
+true false true NULL
 true false false true
-false true false false
+false true NULL false
 NULL NULL false false
 false false NULL false
 false false false NULL
@@ -5571,9 +5598,9 @@ select array_has(column1, make_array(5, 6)),
 from fixed_size_arrays;
 ----
 false false false true
-true false true false
+true false true NULL
 true false false true
-false true false false
+false true NULL false
 NULL NULL false false
 false false NULL false
 false false false NULL

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5275,7 +5275,7 @@ query BB
 select array_has([1, null, 2], 3),
        array_has([null, null, null], 3);
 ----
-NULL NULL
+false false
 
 #TODO: array_has_all and array_has_any cannot handle NULL
 #query BBBB
@@ -5362,8 +5362,8 @@ from array_has_table_null;
 true
 true
 false
-NULL
-NULL
+false
+false
 
 query B
 select array_has(column1, column2)
@@ -5568,9 +5568,9 @@ select array_has(column1, make_array(5, 6)),
 from arrays;
 ----
 false false false true
-true false true NULL
+true false true false
 true false false true
-false true NULL false
+false true false false
 NULL NULL false false
 false false NULL false
 false false false NULL
@@ -5583,9 +5583,9 @@ select array_has(arrow_cast(column1, 'LargeList(List(Int64))'), make_array(5, 6)
 from arrays;
 ----
 false false false true
-true false true NULL
+true false true false
 true false false true
-false true NULL false
+false true false false
 NULL NULL false false
 false false NULL false
 false false false NULL
@@ -5598,12 +5598,12 @@ select array_has(column1, make_array(5, 6)),
 from fixed_size_arrays;
 ----
 false false false true
-true false true NULL
+true false true false
 true false false true
-false true NULL false
-NULL NULL false false
-false false NULL false
-false false false NULL
+false true false false
+false false false false
+false false false false
+false false false false
 
 query BBBBBBBBBBBBB
 select array_has_all(make_array(1,2,3), make_array(1,3)),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13682 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Makes null handling for `array_has` consistent across scalars and arrays, following the DuckDB behavior of returning false instead of null if a list contains null values.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Updates both scalar and array handling for `array_has` to return false regardless of if the left hand side has any null values in it. This matches DuckDB, but differs from systems like Postgres, Spark, and Trino.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Tests are added and updated to accommodate the changes.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Fix handling of array_has for scalars to match the array behavior.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->