### PR TITLE
Improve substr() performance by avoiding using owned string

### DIFF
--- a/datafusion/functions/src/unicode/substr.rs
+++ b/datafusion/functions/src/unicode/substr.rs
@@ -21,8 +21,8 @@ use std::sync::{Arc, OnceLock};
 use crate::strings::{make_and_append_view, StringArrayType};
 use crate::utils::{make_scalar_function, utf8_to_str_type};
 use arrow::array::{
-    Array, ArrayIter, ArrayRef, AsArray, GenericStringArray, Int64Array, OffsetSizeTrait,
-    StringViewArray,
+    Array, ArrayIter, ArrayRef, AsArray, GenericStringBuilder, Int64Array,
+    OffsetSizeTrait, StringViewArray,
 };
 use arrow::datatypes::DataType;
 use arrow_buffer::{NullBufferBuilder, ScalarBuffer};
@@ -448,10 +448,9 @@ where
     match args.len() {
         1 => {
             let iter = ArrayIter::new(string_array);
-
-            let result = iter
-                .zip(start_array.iter())
-                .map(|(string, start)| match (string, start) {
+            let mut result_builder = GenericStringBuilder::<T>::new();
+            for (string, start) in iter.zip(start_array.iter()) {
+                match (string, start) {
                     (Some(string), Some(start)) => {
                         let (start, end) = get_true_start_end(
                             string,
@@ -460,47 +459,51 @@ where
                             enable_ascii_fast_path,
                         ); // start, end is byte-based
                         let substr = &string[start..end];
-                        Some(substr.to_string())
+                        result_builder.append_value(substr);
                     }
-                    _ => None,
-                })
-                .collect::<GenericStringArray<T>>();
-            Ok(Arc::new(result) as ArrayRef)
+                    _ => {
+                        result_builder.append_null();
+                    }
+                }
+            }
+            Ok(Arc::new(result_builder.finish()) as ArrayRef)
         }
         2 => {
             let iter = ArrayIter::new(string_array);
             let count_array = count_array_opt.unwrap();
+            let mut result_builder = GenericStringBuilder::<T>::new();
 
-            let result = iter
-                .zip(start_array.iter())
-                .zip(count_array.iter())
-                .map(|((string, start), count)| {
-                    match (string, start, count) {
-                        (Some(string), Some(start), Some(count)) => {
-                            if count < 0 {
-                                exec_err!(
+            for ((string, start), count) in
+                iter.zip(start_array.iter()).zip(count_array.iter())
+            {
+                match (string, start, count) {
+                    (Some(string), Some(start), Some(count)) => {
+                        if count < 0 {
+                            return exec_err!(
                                 "negative substring length not allowed: substr(<str>, {start}, {count})"
-                            )
-                            } else {
-                                if start == i64::MIN {
-                                    return exec_err!("negative overflow when calculating skip value");
-                                }
-                                let (start, end) = get_true_start_end(
-                                    string,
-                                    start,
-                                    Some(count as u64),
-                                    enable_ascii_fast_path,
-                                ); // start, end is byte-based
-                                let substr = &string[start..end];
-                                Ok(Some(substr.to_string()))
+                            );
+                        } else {
+                            if start == i64::MIN {
+                                return exec_err!(
+                                    "negative overflow when calculating skip value"
+                                );
                             }
+                            let (start, end) = get_true_start_end(
+                                string,
+                                start,
+                                Some(count as u64),
+                                enable_ascii_fast_path,
+                            ); // start, end is byte-based
+                            let substr = &string[start..end];
+                            result_builder.append_value(substr);
                         }
-                        _ => Ok(None),
                     }
-                })
-                .collect::<Result<GenericStringArray<T>>>()?;
-
-            Ok(Arc::new(result) as ArrayRef)
+                    _ => {
+                        result_builder.append_null();
+                    }
+                }
+            }
+            Ok(Arc::new(result_builder.finish()) as ArrayRef)
         }
         other => {
             exec_err!("substr was called with {other} arguments. It requires 2 or 3.")


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13687 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

tested with: cargo bench --bench substr
the result shows that `substr_string` and `substr_large_string` are running much faster in all cases.

```rust
   Compiling datafusion-functions v43.0.0 (/Volumes/Workspace/blaze-init/arrow-datafusion/datafusion/functions)
    Finished `bench` profile [optimized] target(s) in 2m 15s
     Running benches/substr.rs (target/release/deps/substr-a86cfe081ca878bf)
Gnuplot not found, using plotters backend
SHORTER THAN 12/substr_string_view [size=1024, strlen=12]
                        time:   [17.906 µs 18.033 µs 18.166 µs]
                        change: [-5.6189% -4.0418% -2.4317%] (p = 0.00 < 0.05)
                        Performance has improved.
SHORTER THAN 12/substr_string [size=1024, strlen=12]
                        time:   [16.450 µs 16.554 µs 16.670 µs]
                        change: [-71.933% -71.626% -71.291%] (p = 0.00 < 0.05)
                        Performance has improved.
SHORTER THAN 12/substr_large_string [size=1024, strlen=12]
                        time:   [18.539 µs 18.803 µs 19.144 µs]
                        change: [-70.591% -69.829% -69.005%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

LONGER THAN 12/substr_string_view [size=1024, count=64, strlen=128]
                        time:   [28.407 µs 28.605 µs 28.818 µs]
                        change: [-2.8033% -0.9698% +0.5511%] (p = 0.33 > 0.05)
                        No change in performance detected.
LONGER THAN 12/substr_string [size=1024, count=64, strlen=128]
                        time:   [29.680 µs 29.874 µs 30.084 µs]
                        change: [-64.029% -63.622% -63.202%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 10 measurements (30.00%)
  2 (20.00%) low mild
  1 (10.00%) high mild
LONGER THAN 12/substr_large_string [size=1024, count=64, strlen=128]
                        time:   [29.907 µs 30.260 µs 30.683 µs]
                        change: [-62.955% -61.999% -61.035%] (p = 0.00 < 0.05)
                        Performance has improved.

SRC_LEN > 12, SUB_LEN < 12/substr_string_view [size=1024, count=6, strlen=128]
                        time:   [26.295 µs 26.483 µs 26.682 µs]
                        change: [-5.6813% -4.7257% -3.7561%] (p = 0.00 < 0.05)
                        Performance has improved.
SRC_LEN > 12, SUB_LEN < 12/substr_string [size=1024, count=6, strlen=128]
                        time:   [29.560 µs 29.838 µs 30.140 µs]
                        change: [-59.939% -59.336% -58.767%] (p = 0.00 < 0.05)
                        Performance has improved.
SRC_LEN > 12, SUB_LEN < 12/substr_large_string [size=1024, count=6, strlen=128]
                        time:   [30.994 µs 31.199 µs 31.413 µs]
                        change: [-57.768% -57.255% -56.796%] (p = 0.00 < 0.05)
                        Performance has improved.

SHORTER THAN 12/substr_string_view [size=4096, strlen=12]
                        time:   [71.298 µs 71.768 µs 72.296 µs]
                        change: [-3.9430% -2.9409% -1.9043%] (p = 0.00 < 0.05)
                        Performance has improved.
SHORTER THAN 12/substr_string [size=4096, strlen=12]
                        time:   [64.237 µs 64.725 µs 65.242 µs]
                        change: [-72.971% -71.944% -71.285%] (p = 0.00 < 0.05)
                        Performance has improved.
SHORTER THAN 12/substr_large_string [size=4096, strlen=12]
                        time:   [71.706 µs 72.637 µs 74.080 µs]
                        change: [-70.310% -69.729% -69.034%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

LONGER THAN 12/substr_string_view [size=4096, count=64, strlen=128]
                        time:   [111.94 µs 113.43 µs 115.24 µs]
                        change: [-2.1479% -0.4786% +1.4386%] (p = 0.64 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
LONGER THAN 12/substr_string [size=4096, count=64, strlen=128]
                        time:   [114.55 µs 116.05 µs 118.04 µs]
                        change: [-64.142% -63.506% -62.753%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
LONGER THAN 12/substr_large_string [size=4096, count=64, strlen=128]
                        time:   [116.93 µs 117.71 µs 118.67 µs]
                        change: [-62.124% -61.458% -60.871%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

SRC_LEN > 12, SUB_LEN < 12/substr_string_view [size=4096, count=6, strlen=128]
                        time:   [104.15 µs 105.34 µs 106.74 µs]
                        change: [-5.7933% -4.3114% -2.7804%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
SRC_LEN > 12, SUB_LEN < 12/substr_string [size=4096, count=6, strlen=128]
                        time:   [114.42 µs 115.86 µs 117.83 µs]
                        change: [-60.701% -59.738% -58.852%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
SRC_LEN > 12, SUB_LEN < 12/substr_large_string [size=4096, count=6, strlen=128]
                        time:   [122.53 µs 123.66 µs 125.01 µs]
                        change: [-56.827% -56.179% -55.534%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
```


<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
