### PR TITLE
Optimize performance of `initcap` function (~2x faster)

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -207,3 +207,8 @@ required-features = ["unicode_expressions"]
 harness = false
 name = "trunc"
 required-features = ["math_expressions"]
+
+[[bench]]
+harness = false
+name = "initcap"
+required-features = ["string_expressions"]

--- a/datafusion/functions/benches/initcap.rs
+++ b/datafusion/functions/benches/initcap.rs
@@ -49,26 +49,32 @@ fn criterion_benchmark(c: &mut Criterion) {
     let initcap = string::initcap();
     for size in [1024, 4096] {
         let args = create_args::<i32>(size, 8, true);
-        c.bench_function(format!("initcap string view shorter than 12 [size={}]", size).as_str(), |b| {
-            b.iter(|| {
-                black_box(initcap.invoke_with_args(ScalarFunctionArgs {
-                    args: args.clone(),
-                    number_rows: size,
-                    return_type: &DataType::Utf8View,
-                }))
-            })
-        });
+        c.bench_function(
+            format!("initcap string view shorter than 12 [size={}]", size).as_str(),
+            |b| {
+                b.iter(|| {
+                    black_box(initcap.invoke_with_args(ScalarFunctionArgs {
+                        args: args.clone(),
+                        number_rows: size,
+                        return_type: &DataType::Utf8View,
+                    }))
+                })
+            },
+        );
 
         let args = create_args::<i32>(size, 16, true);
-        c.bench_function(format!("initcap string view longer than 12 [size={}]", size).as_str(), |b| {
-            b.iter(|| {
-                black_box(initcap.invoke_with_args(ScalarFunctionArgs {
-                    args: args.clone(),
-                    number_rows: size,
-                    return_type: &DataType::Utf8View,
-                }))
-            })
-        });
+        c.bench_function(
+            format!("initcap string view longer than 12 [size={}]", size).as_str(),
+            |b| {
+                b.iter(|| {
+                    black_box(initcap.invoke_with_args(ScalarFunctionArgs {
+                        args: args.clone(),
+                        number_rows: size,
+                        return_type: &DataType::Utf8View,
+                    }))
+                })
+            },
+        );
 
         let args = create_args::<i32>(size, 16, false);
         c.bench_function(format!("initcap string [size={}]", size).as_str(), |b| {

--- a/datafusion/functions/benches/initcap.rs
+++ b/datafusion/functions/benches/initcap.rs
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate criterion;
+
+use arrow::array::OffsetSizeTrait;
+use arrow::datatypes::DataType;
+use arrow::util::bench_util::{
+    create_string_array_with_len, create_string_view_array_with_len,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs};
+use datafusion_functions::string;
+use std::sync::Arc;
+
+fn create_args<O: OffsetSizeTrait>(
+    size: usize,
+    str_len: usize,
+    force_view_types: bool,
+) -> Vec<ColumnarValue> {
+    if force_view_types {
+        let string_array =
+            Arc::new(create_string_view_array_with_len(size, 0.2, str_len, false));
+
+        vec![ColumnarValue::Array(string_array)]
+    } else {
+        let string_array =
+            Arc::new(create_string_array_with_len::<O>(size, 0.2, str_len));
+
+        vec![ColumnarValue::Array(string_array)]
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let initcap = string::initcap();
+    for size in [1024, 4096] {
+        let args = create_args::<i32>(size, 8, true);
+        c.bench_function(format!("initcap string view shorter than 12 [size={}]", size).as_str(), |b| {
+            b.iter(|| {
+                black_box(initcap.invoke_with_args(ScalarFunctionArgs {
+                    args: args.clone(),
+                    number_rows: size,
+                    return_type: &DataType::Utf8View,
+                }))
+            })
+        });
+
+        let args = create_args::<i32>(size, 16, true);
+        c.bench_function(format!("initcap string view longer than 12 [size={}]", size).as_str(), |b| {
+            b.iter(|| {
+                black_box(initcap.invoke_with_args(ScalarFunctionArgs {
+                    args: args.clone(),
+                    number_rows: size,
+                    return_type: &DataType::Utf8View,
+                }))
+            })
+        });
+
+        let args = create_args::<i32>(size, 16, false);
+        c.bench_function(format!("initcap string [size={}]", size).as_str(), |b| {
+            b.iter(|| {
+                black_box(initcap.invoke_with_args(ScalarFunctionArgs {
+                    args: args.clone(),
+                    number_rows: size,
+                    return_type: &DataType::Utf8,
+                }))
+            })
+        });
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/functions/src/string/initcap.rs
+++ b/datafusion/functions/src/string/initcap.rs
@@ -132,21 +132,22 @@ fn initcap_utf8view(args: &[ArrayRef]) -> Result<ArrayRef> {
     Ok(Arc::new(result) as ArrayRef)
 }
 
-fn initcap_string(string: Option<&str>) -> Option<String> {
-    let mut char_vector = Vec::<char>::new();
-    string.map(|string: &str| {
-        char_vector.clear();
-        let mut previous_character_letter_or_number = false;
-        for c in string.chars() {
-            if previous_character_letter_or_number {
-                char_vector.push(c.to_ascii_lowercase());
+fn initcap_string(input: Option<&str>) -> Option<String> {
+    input.map(|s| {
+        let mut result = String::with_capacity(s.len());
+        let mut prev_is_alphanumeric = false;
+
+        for c in s.chars() {
+            let transformed = if prev_is_alphanumeric {
+                c.to_ascii_lowercase()
             } else {
-                char_vector.push(c.to_ascii_uppercase());
-            }
-            previous_character_letter_or_number =
-                c.is_ascii_uppercase() || c.is_ascii_lowercase() || c.is_ascii_digit();
+                c.to_ascii_uppercase()
+            };
+            result.push(transformed);
+            prev_is_alphanumeric = c.is_ascii_alphanumeric();
         }
-        char_vector.iter().collect::<String>()
+
+        result
     })
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
Eliminate the intermediate `Vec<char>` and directly push into a `String`.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Update the `initcap` function, benchmark included.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, existing unit tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
*BENCHMARK RESULT
```rust
Compiling datafusion-functions v43.0.0 (/home/tailm/repos/github/datafusion/datafusion/functions)
    Finished `bench` profile [optimized] target(s) in 1m 02s
     Running benches/initcap.rs (target/release/deps/initcap-408d405a24fbbea1)
Gnuplot not found, using plotters backend
initcap string view shorter than 12 [size=1024]
                        time:   [34.326 µs 34.353 µs 34.383 µs]
                        change: [-48.954% -48.796% -48.631%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 26 outliers among 100 measurements (26.00%)
  4 (4.00%) low severe
  9 (9.00%) low mild
  5 (5.00%) high mild
  8 (8.00%) high severe

initcap string view longer than 12 [size=1024]
                        time:   [52.105 µs 52.151 µs 52.201 µs]
                        change: [-54.232% -54.111% -53.998%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

initcap string [size=1024]
                        time:   [53.143 µs 53.324 µs 53.587 µs]
                        change: [-53.164% -52.956% -52.775%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

initcap string view shorter than 12 [size=4096]
                        time:   [135.91 µs 136.08 µs 136.27 µs]
                        change: [-51.523% -51.418% -51.301%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

initcap string view longer than 12 [size=4096]
                        time:   [202.91 µs 203.35 µs 204.06 µs]
                        change: [-53.743% -53.636% -53.540%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

initcap string [size=4096]
                        time:   [205.59 µs 205.78 µs 206.00 µs]
                        change: [-53.462% -53.306% -53.164%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
```