### PR TITLE
Unlock lexical-write-integer version.

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -132,10 +132,6 @@ xz2 = { version = "0.1", optional = true, features = ["static"] }
 zstd = { version = "0.13", optional = true, default-features = false }
 
 [dev-dependencies]
-# Temporary fix for https://github.com/apache/datafusion/issues/13686
-# TODO: Remove it once the upstream has a fix
-lexical-write-integer = { version = "=1.0.2" }
-
 arrow-buffer = { workspace = true }
 async-trait = { workspace = true }
 criterion = { version = "0.5", features = ["async_tokio"] }


### PR DESCRIPTION
Issue was patched as of lexical release 1.0.5.

Reverts #13689
Closes #13686