### PR TITLE
Remove  temp `lexical-write-integer` pin

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -132,10 +132,6 @@ xz2 = { version = "0.1", optional = true, features = ["static"] }
 zstd = { version = "0.13", optional = true, default-features = false }
 
 [dev-dependencies]
-# Temporary fix for https://github.com/apache/datafusion/issues/13686
-# TODO: Remove it once the upstream has a fix
-lexical-write-integer = { version = "=1.0.2" }
-
 arrow-buffer = { workspace = true }
 async-trait = { workspace = true }
 criterion = { version = "0.5", features = ["async_tokio"] }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/13686

## Rationale for this change

@jonahgao pinned the dependency temporarily in https://github.com/apache/datafusion/pull/13689 as there was a bug that was introduced upstream. 

The upstream issue has been fixed: 
- https://github.com/Alexhuszagh/rust-lexical/issues/191

## What changes are included in this PR?

Remove `lexical-write-integer` pin
## Are these changes tested?
by CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
