### PR TITLE
Optimize performance of `character_length` function

### DIFF
--- a/datafusion/functions/src/unicode/character_length.rs
+++ b/datafusion/functions/src/unicode/character_length.rs
@@ -161,24 +161,22 @@ where
                 builder.append_value(T::Native::usize_as(value.chars().count()));
             }
         }
-    } else {
-        if is_array_ascii_only {
-            for i in 0..array.len() {
-                if array.is_null(i) {
-                    builder.append_null();
-                } else {
-                    let value = array.value(i);
-                    builder.append_value(T::Native::usize_as(value.len()));
-                }
+    } else if is_array_ascii_only {
+        for i in 0..array.len() {
+            if array.is_null(i) {
+                builder.append_null();
+            } else {
+                let value = array.value(i);
+                builder.append_value(T::Native::usize_as(value.len()));
             }
-        } else {
-            for i in 0..array.len() {
-                if array.is_null(i) {
-                    builder.append_null();
-                } else {
-                    let value = array.value(i);
-                    builder.append_value(T::Native::usize_as(value.chars().count()));
-                }
+        }
+    } else {
+        for i in 0..array.len() {
+            if array.is_null(i) {
+                builder.append_null();
+            } else {
+                let value = array.value(i);
+                builder.append_value(T::Native::usize_as(value.chars().count()));
             }
         }
     }

--- a/datafusion/functions/src/unicode/character_length.rs
+++ b/datafusion/functions/src/unicode/character_length.rs
@@ -18,7 +18,7 @@
 use crate::strings::StringArrayType;
 use crate::utils::{make_scalar_function, utf8_to_int_type};
 use arrow::array::{
-    Array, ArrayRef, ArrowPrimitiveType, AsArray, OffsetSizeTrait, PrimitiveArray,
+    Array, ArrayRef, ArrowPrimitiveType, AsArray, OffsetSizeTrait, PrimitiveBuilder,
 };
 use arrow::datatypes::{ArrowNativeType, DataType, Int32Type, Int64Type};
 use datafusion_common::Result;
@@ -136,31 +136,40 @@ fn character_length(args: &[ArrayRef]) -> Result<ArrayRef> {
     }
 }
 
-fn character_length_general<'a, T: ArrowPrimitiveType, V: StringArrayType<'a>>(
-    array: V,
-) -> Result<ArrayRef>
+fn character_length_general<'a, T, V>(array: V) -> Result<ArrayRef>
 where
+    T: ArrowPrimitiveType,
     T::Native: OffsetSizeTrait,
+    V: StringArrayType<'a>,
 {
+    let mut builder = PrimitiveBuilder::<T>::with_capacity(array.len());
+
     // String characters are variable length encoded in UTF-8, counting the
     // number of chars requires expensive decoding, however checking if the
     // string is ASCII only is relatively cheap.
     // If strings are ASCII only, count bytes instead.
     let is_array_ascii_only = array.is_ascii();
-    let iter = array.iter();
-    let result = iter
-        .map(|string| {
-            string.map(|string: &str| {
-                if is_array_ascii_only {
-                    T::Native::usize_as(string.len())
-                } else {
-                    T::Native::usize_as(string.chars().count())
-                }
-            })
-        })
-        .collect::<PrimitiveArray<T>>();
+    if is_array_ascii_only {
+        for i in 0..array.len() {
+            if array.is_null(i) {
+                builder.append_null();
+            } else {
+                let value = array.value(i);
+                builder.append_value(T::Native::usize_as(value.len()));
+            }
+        }
+    } else {
+        for i in 0..array.len() {
+            if array.is_null(i) {
+                builder.append_null();
+            } else {
+                let value = array.value(i);
+                builder.append_value(T::Native::usize_as(value.chars().count()));
+            }
+        }
+    }
 
-    Ok(Arc::new(result) as ArrayRef)
+    Ok(Arc::new(builder.finish()) as ArrayRef)
 }
 
 #[cfg(test)]

--- a/datafusion/functions/src/unicode/character_length.rs
+++ b/datafusion/functions/src/unicode/character_length.rs
@@ -149,22 +149,36 @@ where
     // string is ASCII only is relatively cheap.
     // If strings are ASCII only, count bytes instead.
     let is_array_ascii_only = array.is_ascii();
-    if is_array_ascii_only {
-        for i in 0..array.len() {
-            if array.is_null(i) {
-                builder.append_null();
-            } else {
+    if array.null_count() == 0 {
+        if is_array_ascii_only {
+            for i in 0..array.len() {
                 let value = array.value(i);
                 builder.append_value(T::Native::usize_as(value.len()));
             }
-        }
-    } else {
-        for i in 0..array.len() {
-            if array.is_null(i) {
-                builder.append_null();
-            } else {
+        } else {
+            for i in 0..array.len() {
                 let value = array.value(i);
                 builder.append_value(T::Native::usize_as(value.chars().count()));
+            }
+        }
+    } else {
+        if is_array_ascii_only {
+            for i in 0..array.len() {
+                if array.is_null(i) {
+                    builder.append_null();
+                } else {
+                    let value = array.value(i);
+                    builder.append_value(T::Native::usize_as(value.len()));
+                }
+            }
+        } else {
+            for i in 0..array.len() {
+                if array.is_null(i) {
+                    builder.append_null();
+                } else {
+                    let value = array.value(i);
+                    builder.append_value(T::Native::usize_as(value.chars().count()));
+                }
             }
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
Optimize performance of `character_length` function.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
1. Using `PrimitiveBuilder` to build the `PrimitiveArray` instead of collecting via `iter().map(...).collect::<PrimitiveArray<T>>()`.
2. Pre-check one-time `is_array_ascii_only` instead of calling array.is_ascii() for every element while loop.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, existing unit tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
*BENCHMARK RESULT
```rust
Compiling datafusion-functions v43.0.0 (/home/tailm/repos/github/datafusion/datafusion/functions)
    Finished `bench` profile [optimized] target(s) in 1m 02s
     Running benches/character_length.rs (target/release/deps/character_length-a803a7794d6fcb71)
Gnuplot not found, using plotters backend
character_length_StringArray_ascii_str_len_8
                        time:   [35.772 µs 35.949 µs 36.158 µs]
                        change: [-28.386% -28.101% -27.755%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  9 (9.00%) low mild
  4 (4.00%) high mild
  8 (8.00%) high severe

character_length_StringArray_utf8_str_len_8
                        time:   [98.774 µs 98.989 µs 99.231 µs]
                        change: [-16.325% -14.812% -13.621%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

character_length_StringViewArray_ascii_str_len_8
                        time:   [48.213 µs 48.381 µs 48.563 µs]
                        change: [-17.896% -17.562% -17.238%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

character_length_StringViewArray_utf8_str_len_8
                        time:   [86.783 µs 87.039 µs 87.362 µs]
                        change: [-19.788% -19.302% -18.828%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

character_length_StringArray_ascii_str_len_32
                        time:   [40.784 µs 40.843 µs 40.909 µs]
                        change: [-32.203% -31.952% -31.724%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

character_length_StringArray_utf8_str_len_32
                        time:   [129.06 µs 129.42 µs 129.97 µs]
                        change: [-13.418% -12.974% -12.454%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

character_length_StringViewArray_ascii_str_len_32
                        time:   [55.699 µs 55.797 µs 55.918 µs]
                        change: [-19.913% -19.479% -19.033%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

character_length_StringViewArray_utf8_str_len_32
                        time:   [139.87 µs 140.07 µs 140.28 µs]
                        change: [-14.665% -14.296% -13.965%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

character_length_StringArray_ascii_str_len_128
                        time:   [62.961 µs 63.088 µs 63.227 µs]
                        change: [-39.222% -39.021% -38.854%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

character_length_StringArray_utf8_str_len_128
                        time:   [180.41 µs 180.78 µs 181.17 µs]
                        change: [-7.6931% -7.3970% -7.1001%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

character_length_StringViewArray_ascii_str_len_128
                        time:   [85.145 µs 85.324 µs 85.498 µs]
                        change: [-14.455% -14.157% -13.884%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

character_length_StringViewArray_utf8_str_len_128
                        time:   [188.84 µs 189.14 µs 189.47 µs]
                        change: [-9.9002% -9.5874% -9.2220%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe

Benchmarking character_length_StringArray_ascii_str_len_4096: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.7s, enable flat sampling, or reduce sample count to 50.
character_length_StringArray_ascii_str_len_4096
                        time:   [1.4920 ms 1.4955 ms 1.4995 ms]
                        change: [-33.271% -32.981% -32.525%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

character_length_StringArray_utf8_str_len_4096
                        time:   [3.1494 ms 3.1581 ms 3.1675 ms]
                        change: [-1.8213% -1.4980% -1.1815%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe

Benchmarking character_length_StringViewArray_ascii_str_len_4096: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.7s, enable flat sampling, or reduce sample count to 50.
character_length_StringViewArray_ascii_str_len_4096
                        time:   [1.4964 ms 1.5000 ms 1.5041 ms]
                        change: [-8.3333% -7.7158% -7.0690%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe

character_length_StringViewArray_utf8_str_len_4096
                        time:   [3.2453 ms 3.2524 ms 3.2601 ms]
                        change: [-0.8036% -0.4848% -0.1442%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```