### PR TITLE
PoC Adaptive round robin repartitioning

### DIFF
--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -836,7 +836,8 @@ fn add_roundrobin_on_top(
     n_target: usize,
 ) -> Result<DistributionContext> {
     // Adding repartition is helpful:
-    if input.plan.output_partitioning().partition_count() < n_target {
+    // TODO: should we only do for certain sources?
+    if input.plan.output_partitioning().partition_count() < n_target || input.plan.children().is_empty() {
         // When there is an existing ordering, we preserve ordering
         // during repartition. This will be un-done in the future
         // If any of the following conditions is true

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -808,8 +808,8 @@ impl RepartitionExec {
                 let size = batch.get_array_memory_size();
 
                 if is_round_robin {
-                    // try out the default (round robin) partition, then other partitions
-                    for p in std::iter::once(partition).chain(0..num_partitions) {
+                    // try out the default (round robin) partition, then all other partitions once starting with partition + 1
+                    for p in std::iter::once(partition).chain(partition+1..num_partitions).chain(0..partition) {
                         let timer = metrics.send_time[partition].timer();
 
                         if let Some((tx, reservation)) = output_channels.get_mut(&p) {

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -39,7 +39,6 @@ use crate::sorts::streaming_merge::StreamingMergeBuilder;
 use crate::stream::RecordBatchStreamAdapter;
 use crate::{DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, Statistics};
 
-use arrow::compute::kernels::zip::zip;
 use arrow::compute::take_arrays;
 use arrow::datatypes::{SchemaRef, UInt32Type};
 use arrow::record_batch::RecordBatch;
@@ -804,7 +803,7 @@ impl RepartitionExec {
                 None => break,
             };
 
-            for res in partitioner.partition_iter(batch)? {
+            'next_batch: for res in partitioner.partition_iter(batch)? {
                 let (partition, batch) = res?;
                 let size = batch.get_array_memory_size();
 
@@ -826,7 +825,7 @@ impl RepartitionExec {
                                 }
                                 Some(_) => {
                                     timer.done();
-                                    continue;
+                                    continue 'next_batch;
                                 }
                                 None => {
                                     timer.done();


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

TODO

- [ ] Verify results, check if the perf. change comes from adaptive repartitioning or from other changes
- [ ] Run more benchmarks
- [ ] Try to be more fair (e.g. don't start at 0)
- [ ] Introduce more round robin repartitioning for sources (even when already splitted)
- [ ] Put it behind config (on by default?)
- [ ] Fix / improve test

```
--------------------
Benchmark tpch_mem_sf1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃     main ┃ repartition_exec_poc ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  83.38ms │              76.98ms │ +1.08x faster │
│ QQuery 2     │  15.09ms │              13.93ms │ +1.08x faster │
│ QQuery 3     │  25.32ms │              23.96ms │ +1.06x faster │
│ QQuery 4     │  13.39ms │              13.49ms │     no change │
│ QQuery 5     │  40.86ms │              38.85ms │     no change │
│ QQuery 6     │   6.18ms │               5.23ms │ +1.18x faster │
│ QQuery 7     │  81.24ms │              76.82ms │ +1.06x faster │
│ QQuery 8     │  19.83ms │              19.37ms │     no change │
│ QQuery 9     │  49.55ms │              44.83ms │ +1.11x faster │
│ QQuery 10    │  41.14ms │              37.67ms │ +1.09x faster │
│ QQuery 11    │   7.19ms │               6.23ms │ +1.15x faster │
│ QQuery 12    │  29.19ms │              26.92ms │ +1.08x faster │
│ QQuery 13    │  21.48ms │              18.15ms │ +1.18x faster │
│ QQuery 14    │   6.01ms │               5.88ms │     no change │
│ QQuery 15    │  13.09ms │              15.43ms │  1.18x slower │
│ QQuery 16    │  14.31ms │              14.30ms │     no change │
│ QQuery 17    │  55.49ms │              62.14ms │  1.12x slower │
│ QQuery 18    │ 151.61ms │             150.71ms │     no change │
│ QQuery 19    │  28.32ms │              24.11ms │ +1.17x faster │
│ QQuery 20    │  24.71ms │              21.99ms │ +1.12x faster │
│ QQuery 21    │ 111.26ms │             103.85ms │ +1.07x faster │
│ QQuery 22    │  14.59ms │              13.03ms │ +1.12x faster │
└──────────────┴──────────┴──────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ Benchmark Summary                   ┃          ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ Total Time (main)                   │ 853.23ms │
│ Total Time (repartition_exec_poc)   │ 813.85ms │
│ Average Time (main)                 │  38.78ms │
│ Average Time (repartition_exec_poc) │  36.99ms │
│ Queries Faster                      │       14 │
│ Queries Slower                      │        2 │
│ Queries with No Change              │        6 │
└─────────────────────────────────────┴──────────┘
Note: Skipping /Users/danielheres/Code/arrow-datafusion-personal/benchmarks/results/main/tpch_mem_sf10.json as /Users/danielheres/Code/arrow-datafusion-personal/benchmarks/results/repartition_exec_poc/tpch_mem_sf10.json does not exist
--------------------
Benchmark tpch_sf1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃     main ┃ repartition_exec_poc ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │ 125.52ms │             104.10ms │ +1.21x faster │
│ QQuery 2     │  57.14ms │              36.75ms │ +1.56x faster │
│ QQuery 3     │  56.00ms │              55.02ms │     no change │
│ QQuery 4     │  41.75ms │              40.46ms │     no change │
│ QQuery 5     │  78.27ms │              73.82ms │ +1.06x faster │
│ QQuery 6     │  21.36ms │              21.31ms │     no change │
│ QQuery 7     │  93.01ms │              95.74ms │     no change │
│ QQuery 8     │  79.40ms │              75.75ms │     no change │
│ QQuery 9     │ 115.29ms │             100.02ms │ +1.15x faster │
│ QQuery 10    │ 101.89ms │             100.49ms │     no change │
│ QQuery 11    │  40.69ms │              26.26ms │ +1.55x faster │
│ QQuery 12    │  54.58ms │              50.62ms │ +1.08x faster │
│ QQuery 13    │ 122.04ms │              80.41ms │ +1.52x faster │
│ QQuery 14    │  39.81ms │              40.11ms │     no change │
│ QQuery 15    │  49.66ms │              51.29ms │     no change │
│ QQuery 16    │  36.18ms │              25.92ms │ +1.40x faster │
│ QQuery 17    │ 105.28ms │              94.82ms │ +1.11x faster │
│ QQuery 18    │ 164.32ms │             143.05ms │ +1.15x faster │
│ QQuery 19    │  65.62ms │              58.38ms │ +1.12x faster │
│ QQuery 20    │  60.52ms │              63.31ms │     no change │
│ QQuery 21    │ 130.67ms │             120.20ms │ +1.09x faster │
│ QQuery 22    │  35.66ms │              28.42ms │ +1.25x faster │
└──────────────┴──────────┴──────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Summary                   ┃           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Total Time (main)                   │ 1674.66ms │
│ Total Time (repartition_exec_poc)   │ 1486.23ms │
│ Average Time (main)                 │   76.12ms │
│ Average Time (repartition_exec_poc) │   67.56ms │
│ Queries Faster                      │        13 │
│ Queries Slower                      │         0 │
│ Queries with No Change              │         9 │
└─────────────────────────────────────┴───────────┘

```
Closes #.

## Rationale for this change

In 
https://github.com/apache/datafusion/issues/7001

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
