### PR TITLE
fix union serialisation order in proto

### DIFF
--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -25,6 +25,8 @@ use arrow::datatypes::{
 };
 use arrow::util::pretty::pretty_format_batches;
 use datafusion::datasource::file_format::json::JsonFormatFactory;
+use datafusion::optimizer::eliminate_nested_union::EliminateNestedUnion;
+use datafusion::optimizer::{Optimizer, OptimizerRule};
 use datafusion_common::parsers::CompressionTypeVariant;
 use prost::Message;
 use std::any::Any;
@@ -2554,4 +2556,48 @@ async fn roundtrip_recursive_query() {
         format!("{}", pretty_format_batches(&output).unwrap()),
         format!("{}", pretty_format_batches(&output_round_trip).unwrap())
     );
+}
+
+#[tokio::test]
+async fn roundtrip_union_query() -> Result<()> {
+    let query = "SELECT a FROM t1
+        UNION (SELECT a from t1 UNION SELECT a from t2)";
+
+    let ctx = SessionContext::new();
+    ctx.register_csv("t1", "tests/testdata/test.csv", CsvReadOptions::default())
+        .await?;
+    ctx.register_csv("t2", "tests/testdata/test.csv", CsvReadOptions::default())
+        .await?;
+    let dataframe = ctx.sql(query).await?;
+    let plan = dataframe.into_optimized_plan()?;
+    // plan.display_indent_schema()
+    // Aggregate: groupBy=[[t1.a]], aggr=[[]] [a:Int64;N]
+    //   Union [a:Int64;N]
+    //     TableScan: t1 projection=[a] [a:Int64;N]
+    //     TableScan: t1 projection=[a] [a:Int64;N]
+    //     TableScan: t2 projection=[a] [a:Int64;N]
+
+    let bytes = logical_plan_to_bytes(&plan)?;
+
+    let ctx = SessionContext::new();
+    ctx.register_csv("t1", "tests/testdata/test.csv", CsvReadOptions::default())
+        .await?;
+    ctx.register_csv("t2", "tests/testdata/test.csv", CsvReadOptions::default())
+        .await?;
+    let logical_round_trip = logical_plan_from_bytes(&bytes, &ctx)?;
+    // proto deserialisation only supports 2-way union, hence this plan has nested unions
+    // logical_round_trip.display_indent_schema()
+    // Aggregate: groupBy=[[t1.a]], aggr=[[]] [a:Int64;N]
+    //   Union [a:Int64;N]
+    //     Union [a:Int64;N]
+    //       TableScan: t1 projection=[a] [a:Int64;N]
+    //       TableScan: t1 projection=[a] [a:Int64;N]
+    //     TableScan: t2 projection=[a] [a:Int64;N]
+    let optimizer = Optimizer::with_rules(vec![Arc::new(EliminateNestedUnion::new())]);
+    let unnested = optimizer.optimize(logical_round_trip, &(ctx.state()), |_x, _y| {})?;
+    assert_eq!(
+        format!("{}", plan.display_indent_schema()),
+        format!("{}", unnested.display_indent_schema()),
+    );
+    Ok(())
 }

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -26,7 +26,7 @@ use arrow::datatypes::{
 use arrow::util::pretty::pretty_format_batches;
 use datafusion::datasource::file_format::json::JsonFormatFactory;
 use datafusion::optimizer::eliminate_nested_union::EliminateNestedUnion;
-use datafusion::optimizer::{Optimizer, OptimizerRule};
+use datafusion::optimizer::Optimizer;
 use datafusion_common::parsers::CompressionTypeVariant;
 use prost::Message;
 use std::any::Any;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Unions with multiple tables result in an optimised plan with an Aggregate Node on top, example:
```sql
SELECT a FROM t1 UNION (SELECT a from t1 UNION SELECT a from t2)
```
```
    Aggregate: groupBy=[[t1.a]], aggr=[[]] [a:Int64;N]
      Union [a:Int64;N]
        TableScan: t1 projection=[a] [a:Int64;N]
        TableScan: t1 projection=[a] [a:Int64;N]
        TableScan: t2 projection=[a] [a:Int64;N]

```
This Aggregate node uses the first tables name as references in its `groupBy`. Currently on `main` deserialisation from proto gets the last child of the Union node.
I added a test in this PR that previously failed to deserialise the optimised plan above with:
```
SchemaError(FieldNotFound { field: Column { relation: Some(Bare { table: "t1" }), name: "a" }, valid_fields: [Column { relation: Some(Bare { table: "t2" }), name: "a" }] }
```
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Changes try_into_logical_plan for union nodes to create a nested union starting from the first child of the union node in the serialised plan, not the last. 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Added a test that fails on `main`
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
