### PR TITLE
Deprecate ScalarUDFImpl::return_type

### DIFF
--- a/datafusion/core/src/catalog_common/information_schema.rs
+++ b/datafusion/core/src/catalog_common/information_schema.rs
@@ -406,6 +406,7 @@ fn get_udf_args_and_return_types(
             .into_iter()
             .map(|arg_types| {
                 // only handle the function which implemented [`ScalarUDFImpl::return_type`] method
+                #[allow(deprecated)]
                 let return_type = udf.return_type(&arg_types).ok().map(|t| t.to_string());
                 let arg_types = arg_types
                     .into_iter()

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -173,6 +173,7 @@ impl ScalarUDF {
     /// its [`ScalarUDFImpl::return_type`] should raise an error.
     ///
     /// See [`ScalarUDFImpl::return_type`] for more details.
+    #[deprecated(since = "44.0.0", note = "Use return_type_from_exprs() instead")]
     pub fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         #[allow(deprecated)]
         self.inner.return_type(arg_types)

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -174,6 +174,7 @@ impl ScalarUDF {
     ///
     /// See [`ScalarUDFImpl::return_type`] for more details.
     pub fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        #[allow(deprecated)]
         self.inner.return_type(arg_types)
     }
 
@@ -450,6 +451,7 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     /// is recommended to return [`DataFusionError::Internal`].
     ///
     /// [`DataFusionError::Internal`]: datafusion_common::DataFusionError::Internal
+    #[deprecated(since = "44.0.0", note = "Use `return_type_from_exprs` instead")]
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType>;
 
     /// What [`DataType`] will be returned by this function, given the
@@ -483,6 +485,7 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
         _schema: &dyn ExprSchema,
         arg_types: &[DataType],
     ) -> Result<DataType> {
+        #[allow(deprecated)]
         self.return_type(arg_types)
     }
 
@@ -756,6 +759,7 @@ impl ScalarUDFImpl for AliasedScalarUDFImpl {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        #[allow(deprecated)]
         self.inner.return_type(arg_types)
     }
 

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -148,9 +148,7 @@ impl ScalarUDFImpl for DatePartFunc {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        // return type could be Float32 or Int32 depending on the input arguments
-        // return_type_from_exprs should be called instead
-        Ok(DataType::Float64)
+        internal_err!("return_type_from_exprs shoud be called instead")
     }
 
     fn return_type_from_exprs(

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -148,7 +148,9 @@ impl ScalarUDFImpl for DatePartFunc {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        internal_err!("return_type_from_exprs shoud be called instead")
+        // return type could be Float32 or Int32 depending on the input arguments
+        // return_type_from_exprs should be called instead
+        Ok(DataType::Float64)
     }
 
     fn return_type_from_exprs(

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -305,6 +305,7 @@ pub fn simplify_concat(args: Vec<Expr>) -> Result<ExprSimplifyResult> {
                 _ => None,
             })
             .collect();
+        #[allow(deprecated)]
         ConcatFunc::new().return_type(&data_types)
     }?;
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/13716

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

While upgrading the DataFusion version used by Comet, I saw test failures due to a breaking API change where `ScalarUDFImpl.return_type` returns an internal error for `DatePartFunc`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Return Float64 instead of throwing an error to preserve previous (incorrect) behavior. Deprecate `return_type` and recommend `return_type_from_exprs` instead.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
