### PR TITLE
Minor: Add doc example to RecordBatchStreamAdapter

### DIFF
--- a/datafusion/physical-plan/src/stream.rs
+++ b/datafusion/physical-plan/src/stream.rs
@@ -351,7 +351,7 @@ pin_project! {
 impl<S> RecordBatchStreamAdapter<S> {
     /// Creates a new [`RecordBatchStreamAdapter`] from the provided schema and stream.
     ///
-    /// Note to create a [`SendableRecordBatchStream`] you pun the result
+    /// Note to create a [`SendableRecordBatchStream`] you pin the result
     ///
     /// # Example
     /// ```

--- a/datafusion/physical-plan/src/stream.rs
+++ b/datafusion/physical-plan/src/stream.rs
@@ -337,7 +337,9 @@ impl RecordBatchReceiverStream {
 
 pin_project! {
     /// Combines a [`Stream`] with a [`SchemaRef`] implementing
-    /// [`RecordBatchStream`] for the combination
+    /// [`SendableRecordBatchStream`] for the combination
+    ///
+    /// See [`Self::new`] for an example
     pub struct RecordBatchStreamAdapter<S> {
         schema: SchemaRef,
 
@@ -347,7 +349,28 @@ pin_project! {
 }
 
 impl<S> RecordBatchStreamAdapter<S> {
-    /// Creates a new [`RecordBatchStreamAdapter`] from the provided schema and stream
+    /// Creates a new [`RecordBatchStreamAdapter`] from the provided schema and stream.
+    ///
+    /// Note to create a [`SendableRecordBatchStream`] you pun the result
+    ///
+    /// # Example
+    /// ```
+    /// # use arrow::array::record_batch;
+    /// # use datafusion_execution::SendableRecordBatchStream;
+    /// # use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+    /// // Create stream of Result<RecordBatch>
+    /// let batch = record_batch!(
+    ///   ("a", Int32, [1, 2, 3]),
+    ///   ("b", Float64, [Some(4.0), None, Some(5.0)])
+    /// ).expect("created batch");
+    /// let schema = batch.schema();
+    /// let stream = futures::stream::iter(vec![Ok(batch)]);
+    /// // Convert the stream to a SendableRecordBatchStream
+    /// let adapter = RecordBatchStreamAdapter::new(schema, stream);
+    /// // Now you can use the adapter as a SendableRecordBatchStream
+    /// let batch_stream: SendableRecordBatchStream = Box::pin(adapter);
+    /// // ...
+    /// ```
     pub fn new(schema: SchemaRef, stream: S) -> Self {
         Self { schema, stream }
     }


### PR DESCRIPTION
## Which issue does this PR close?
Part of #7013 

## Rationale for this change

While working on https://github.com/apache/datafusion/issues/13714 I got hung up (again) on creating a `SendableRecordBatchStream` from some batches (I forgot to `Box::pin` the `RecordBatchStreamAdapter`  a while)

Let's put this in a documentation example on `RecordBatchStreamAdapter`


## What changes are included in this PR?
1. Add a doc example of using `RecordBatchStreamAdapter`


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

Only docs, no functional changes
