### PR TITLE
Minor: Add documentation explaining that initcap oly works for ASCII

### DIFF
--- a/datafusion/functions/src/string/initcap.rs
+++ b/datafusion/functions/src/string/initcap.rs
@@ -90,25 +90,36 @@ fn get_initcap_doc() -> &'static Documentation {
     DOCUMENTATION.get_or_init(|| {
         Documentation::builder(
             DOC_SECTION_STRING,
-            "Capitalizes the first character in each word in the input string. Words are delimited by non-alphanumeric characters.",
-            "initcap(str)")
-            .with_sql_example(r#"```sql
+            "Capitalizes the first character in each word in the ASCII input string. \
+            Words are delimited by non-alphanumeric characters.\n\n\
+            Note this function does not support UTF-8 characters.",
+            "initcap(str)",
+        )
+        .with_sql_example(
+            r#"```sql
 > select initcap('apache datafusion');
 +------------------------------------+
 | initcap(Utf8("apache datafusion")) |
 +------------------------------------+
 | Apache Datafusion                  |
 +------------------------------------+
-```"#)
-            .with_standard_argument("str", Some("String"))
-            .with_related_udf("lower")
-            .with_related_udf("upper")
-            .build()
+```"#,
+        )
+        .with_standard_argument("str", Some("String"))
+        .with_related_udf("lower")
+        .with_related_udf("upper")
+        .build()
     })
 }
 
-/// Converts the first letter of each word to upper case and the rest to lower case. Words are sequences of alphanumeric characters separated by non-alphanumeric characters.
+/// Converts the first letter of each word to upper case and the rest to lower
+/// case. Words are sequences of alphanumeric characters separated by
+/// non-alphanumeric characters.
+///
+/// Example:
+/// ```sql
 /// initcap('hi THOMAS') = 'Hi Thomas'
+/// ```
 fn initcap<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     let string_array = as_generic_string_array::<T>(&args[0])?;
 

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1046,7 +1046,9 @@ find_in_set(str, strlist)
 
 ### `initcap`
 
-Capitalizes the first character in each word in the input string. Words are delimited by non-alphanumeric characters.
+Capitalizes the first character in each word in the ASCII input string. Words are delimited by non-alphanumeric characters.
+
+Note this function does not support UTF-8 characters.
 
 ```
 initcap(str)


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/pull/13691
- Related to https://github.com/apache/datafusion/issues/13711

## Rationale for this change

@tlm365  says: https://github.com/apache/datafusion/pull/13691#discussion_r1877208207

> @Dandandan you're right. I tested it with some unit tests for special characters (unicode), this PR's implementation doesn't work and the old implementation doesn't work either. But I think it makes sense at the moment since the initcap function is in datafusion::function::string not datafusion::function::unicode.
> 
> Perhaps, it would be better if we update the documentation that initcap is not supported for unicode characters yet and try to handle it if necessary in another PR.


## What changes are included in this PR?
Update docs to reflect the caveat that init cap only works on ASCII strings

## Are these changes tested?

by CI
## Are there any user-facing changes?
Just docs, no functional change
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
