### PR TITLE
fix: add `null_buffer` length check to `StringArrayBuilder`/`LargeStringArrayBuilder`

### DIFF
--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -335,7 +335,27 @@ impl LargeStringArrayBuilder {
         unsafe { self.offsets_buffer.push_unchecked(next_offset) };
     }
 
+    /// Finalise the builder into a concrete [`LargeStringArray`].
+    ///
+    /// # Panics
+    ///
+    /// This method can panic when:
+    ///
+    /// - the provided `null_buffer` is not the same length as the `offsets_buffer`.
+    /// - the provided `null_buffer` is not the same length as the `value_buffer`.
     pub fn finish(self, null_buffer: Option<NullBuffer>) -> LargeStringArray {
+        if let Some(ref null_buffer) = null_buffer {
+            assert_eq!(
+                null_buffer.len(),
+                self.offsets_buffer.len() / size_of::<i64>() - 1,
+                "Null buffer and offsets buffer must be the same length"
+            );
+            assert_eq!(
+                null_buffer.len(),
+                self.value_buffer.len(),
+                "Null buffer and value buffer must be the same length"
+            );
+        }
         let array_builder = ArrayDataBuilder::new(DataType::LargeUtf8)
             .len(self.offsets_buffer.len() / size_of::<i64>() - 1)
             .add_buffer(self.offsets_buffer.into())

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -193,15 +193,16 @@ impl StringArrayBuilder {
     ///
     /// - the provided `null_buffer` is not the same length as the `offsets_buffer`.
     pub fn finish(self, null_buffer: Option<NullBuffer>) -> StringArray {
+        let row_count = self.offsets_buffer.len() / size_of::<i32>() - 1;
         if let Some(ref null_buffer) = null_buffer {
             assert_eq!(
                 null_buffer.len(),
-                self.offsets_buffer.len() / size_of::<i32>() - 1,
+                row_count,
                 "Null buffer and offsets buffer must be the same length"
             );
         }
         let array_builder = ArrayDataBuilder::new(DataType::Utf8)
-            .len(self.offsets_buffer.len() / size_of::<i32>() - 1)
+            .len(row_count)
             .add_buffer(self.offsets_buffer.into())
             .add_buffer(self.value_buffer.into())
             .nulls(null_buffer);
@@ -357,15 +358,16 @@ impl LargeStringArrayBuilder {
     ///
     /// - the provided `null_buffer` is not the same length as the `offsets_buffer`.
     pub fn finish(self, null_buffer: Option<NullBuffer>) -> LargeStringArray {
+        let row_count = self.offsets_buffer.len() / size_of::<i64>() - 1;
         if let Some(ref null_buffer) = null_buffer {
             assert_eq!(
                 null_buffer.len(),
-                self.offsets_buffer.len() / size_of::<i64>() - 1,
+                row_count,
                 "Null buffer and offsets buffer must be the same length"
             );
         }
         let array_builder = ArrayDataBuilder::new(DataType::LargeUtf8)
-            .len(self.offsets_buffer.len() / size_of::<i64>() - 1)
+            .len(row_count)
             .add_buffer(self.offsets_buffer.into())
             .add_buffer(self.value_buffer.into())
             .nulls(null_buffer);

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -185,7 +185,21 @@ impl StringArrayBuilder {
         unsafe { self.offsets_buffer.push_unchecked(next_offset) };
     }
 
+    /// Finalise the builder into a concrete [`StringArray`].
+    ///
+    /// # Panics
+    ///
+    /// This method can panic when:
+    ///
+    /// - the provided `null_buffer` is not the same length as the `offsets_buffer`.
     pub fn finish(self, null_buffer: Option<NullBuffer>) -> StringArray {
+        if let Some(ref null_buffer) = null_buffer {
+            assert_eq!(
+                null_buffer.len(),
+                self.offsets_buffer.len() / size_of::<i32>() - 1,
+                "Null buffer and offsets buffer must be the same length"
+            );
+        }
         let array_builder = ArrayDataBuilder::new(DataType::Utf8)
             .len(self.offsets_buffer.len() / size_of::<i32>() - 1)
             .add_buffer(self.offsets_buffer.into())

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -342,18 +342,12 @@ impl LargeStringArrayBuilder {
     /// This method can panic when:
     ///
     /// - the provided `null_buffer` is not the same length as the `offsets_buffer`.
-    /// - the provided `null_buffer` is not the same length as the `value_buffer`.
     pub fn finish(self, null_buffer: Option<NullBuffer>) -> LargeStringArray {
         if let Some(ref null_buffer) = null_buffer {
             assert_eq!(
                 null_buffer.len(),
                 self.offsets_buffer.len() / size_of::<i64>() - 1,
                 "Null buffer and offsets buffer must be the same length"
-            );
-            assert_eq!(
-                null_buffer.len(),
-                self.value_buffer.len(),
-                "Null buffer and value buffer must be the same length"
             );
         }
         let array_builder = ArrayDataBuilder::new(DataType::LargeUtf8)


### PR DESCRIPTION
Add a safety check to ensure that the null buffer and offsets buffers are the same length. This introduces a panic if they are not aligned through a
runtime assertion.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

~I couldn't find an issue for this, it was raised internally for InfluxData's use of `datafusion`. I can create one if necessary :smile:~
Fixes https://github.com/apache/datafusion/issues/13759

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

See description.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I believe the existing test suite should cover this, although I'm happy to add a forced `#[should_panic]`, I'm not quite sure how much value this provides though.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Users of the `LargeStringArrayBuilder` must be aware that method can now panic when the invariants are not upheld.
