### PR TITLE
Add Round trip tests for Array <--> ScalarValue

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -5683,7 +5683,6 @@ mod tests {
                 // [ ] (empty list)
                 builder.append(true);
                 // Null
-                builder.values().append_value("?"); // irrelevant
                 builder.append(false);
                 Arc::new(builder.finish())
             },

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -5577,8 +5577,7 @@ mod tests {
             Arc::new(StringArray::from(vec![Some("foo"), None, Some("bar")])),
             Arc::new(LargeStringArray::from(vec![Some("foo"), None, Some("bar")])),
             Arc::new(StringViewArray::from(vec![Some("foo"), None, Some("bar")])),
-            // string dictionary fails due to XXX
-            /*
+            // string dictionary
             {
                 let mut builder = StringDictionaryBuilder::<Int32Type>::new();
                 builder.append("foo").unwrap();
@@ -5586,7 +5585,6 @@ mod tests {
                 builder.append("bar").unwrap();
                 Arc::new(builder.finish())
             },
-            */
             // binary array
             Arc::new(BinaryArray::from_iter(vec![
                 Some(b"foo"),

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -5691,7 +5691,7 @@ mod tests {
                 let values_builder = Int32Builder::new();
                 let mut builder = FixedSizeListBuilder::new(values_builder, 3);
 
-                //  [[0, 1, 2], null, [3, null, 5], [6, 7, null]]
+                //  [[0, 1, 2], null, [3, null, 5]
                 builder.values().append_value(0);
                 builder.values().append_value(1);
                 builder.values().append_value(2);
@@ -5730,7 +5730,10 @@ mod tests {
         }
     }
 
-    /// for each index in array, convert to to a scalar and back to an array and compare for equality
+    /// for each row in `arr`:
+    /// 1. convert to a `ScalarValue`
+    /// 2. Convert `ScalarValue` back to an `ArrayRef`
+    /// 3. Compare the original array (sliced) and new array for equality
     fn round_trip_through_scalar(arr: ArrayRef) {
         for i in 0..arr.len() {
             // convert Scalar --> Array


### PR DESCRIPTION
## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/13762

## Rationale for this change

When trying to write a unit test for https://github.com/apache/datafusion/issues/13762 I found there was no good place to test the round tripping of Array --> ScalarValue --> Array (which is what is done for constant values)

So I wrote some

## What changes are included in this PR?

Add tests for this path, with ones that fail due to bugs commented out

## Are these changes tested?
Yes, by CI

## Are there any user-facing changes?
No - this are just tests