### PR TITLE
fix: Make `Display` implementation for `InList` deterministic

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1843,11 +1843,12 @@ fn rewrite_placeholder(expr: &mut Expr, other: &Expr, schema: &DFSchema) -> Resu
 #[macro_export]
 macro_rules! expr_vec_fmt {
     ( $ARRAY:expr ) => {{
-        $ARRAY
+        let mut expr_str = $ARRAY
             .iter()
             .map(|e| format!("{e}"))
-            .collect::<Vec<String>>()
-            .join(", ")
+            .collect::<Vec<String>>();
+        expr_str.sort();
+        expr_str.join(", ")
     }};
 }
 

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1843,6 +1843,17 @@ fn rewrite_placeholder(expr: &mut Expr, other: &Expr, schema: &DFSchema) -> Resu
 #[macro_export]
 macro_rules! expr_vec_fmt {
     ( $ARRAY:expr ) => {{
+        $ARRAY
+            .iter()
+            .map(|e| format!("{e}"))
+            .collect::<Vec<String>>()
+            .join(", ")
+    }};
+}
+
+#[macro_export]
+macro_rules! expr_vec_sorted_fmt {
+    ( $ARRAY:expr ) => {{
         let mut expr_str = $ARRAY
             .iter()
             .map(|e| format!("{e}"))
@@ -2317,9 +2328,9 @@ impl Display for Expr {
                 negated,
             }) => {
                 if *negated {
-                    write!(f, "{expr} NOT IN ([{}])", expr_vec_fmt!(list))
+                    write!(f, "{expr} NOT IN ([{}])", expr_vec_sorted_fmt!(list))
                 } else {
-                    write!(f, "{expr} IN ([{}])", expr_vec_fmt!(list))
+                    write!(f, "{expr} IN ([{}])", expr_vec_sorted_fmt!(list))
                 }
             }
             Expr::Wildcard { qualifier, options } => match qualifier {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In DataFusion Ray we have tests that check for an expected logical plan but the plans are not deterministic due to the order of items changing for `IN` expressions such as `IN (1, 2, 3)` could sometimes be `IN (2, 1, 3)`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Sort the expressions during formatting.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
