### PR TITLE
Implement `SHOW FUNCTIONS`

### DIFF
--- a/datafusion/core/src/catalog_common/information_schema.rs
+++ b/datafusion/core/src/catalog_common/information_schema.rs
@@ -247,6 +247,7 @@ impl InformationSchemaConfig {
                     return_type,
                     "SCALAR",
                     udf.documentation().map(|d| d.description.to_string()),
+                    udf.documentation().map(|d| d.syntax_example.to_string()),
                 )
             }
         }
@@ -266,6 +267,7 @@ impl InformationSchemaConfig {
                     return_type,
                     "AGGREGATE",
                     udaf.documentation().map(|d| d.description.to_string()),
+                    udaf.documentation().map(|d| d.syntax_example.to_string()),
                 )
             }
         }
@@ -285,6 +287,7 @@ impl InformationSchemaConfig {
                     return_type,
                     "WINDOW",
                     udwf.documentation().map(|d| d.description.to_string()),
+                    udwf.documentation().map(|d| d.syntax_example.to_string()),
                 )
             }
         }
@@ -374,7 +377,6 @@ impl InformationSchemaConfig {
                 );
                 rid += 1;
             }
-
         }
 
         for (func_name, udwf) in udwfs {
@@ -1108,6 +1110,7 @@ impl InformationSchemaRoutines {
             Field::new("data_type", DataType::Utf8, true),
             Field::new("function_type", DataType::Utf8, true),
             Field::new("description", DataType::Utf8, true),
+            Field::new("syntax_example", DataType::Utf8, true),
         ]));
 
         Self { schema, config }
@@ -1127,6 +1130,7 @@ impl InformationSchemaRoutines {
             data_type: StringBuilder::new(),
             function_type: StringBuilder::new(),
             description: StringBuilder::new(),
+            syntax_example: StringBuilder::new(),
         }
     }
 }
@@ -1144,6 +1148,7 @@ struct InformationSchemaRoutinesBuilder {
     data_type: StringBuilder,
     function_type: StringBuilder,
     description: StringBuilder,
+    syntax_example: StringBuilder,
 }
 
 impl InformationSchemaRoutinesBuilder {
@@ -1158,6 +1163,7 @@ impl InformationSchemaRoutinesBuilder {
         data_type: Option<impl AsRef<str>>,
         function_type: impl AsRef<str>,
         description: Option<impl AsRef<str>>,
+        syntax_example: Option<impl AsRef<str>>,
     ) {
         self.specific_catalog.append_value(catalog_name.as_ref());
         self.specific_schema.append_value(schema_name.as_ref());
@@ -1170,6 +1176,7 @@ impl InformationSchemaRoutinesBuilder {
         self.data_type.append_option(data_type.as_ref());
         self.function_type.append_value(function_type.as_ref());
         self.description.append_option(description);
+        self.syntax_example.append_option(syntax_example);
     }
 
     fn finish(&mut self) -> RecordBatch {
@@ -1187,6 +1194,7 @@ impl InformationSchemaRoutinesBuilder {
                 Arc::new(self.data_type.finish()),
                 Arc::new(self.function_type.finish()),
                 Arc::new(self.description.finish()),
+                Arc::new(self.syntax_example.finish()),
             ],
         )
         .unwrap()

--- a/datafusion/core/src/catalog_common/information_schema.rs
+++ b/datafusion/core/src/catalog_common/information_schema.rs
@@ -1237,6 +1237,11 @@ impl InformationSchemaParameters {
             Field::new("data_type", DataType::Utf8, false),
             Field::new("parameter_default", DataType::Utf8, true),
             Field::new("is_variadic", DataType::Boolean, false),
+            // `rid` (short for `routine id`) is used to differentiate parameters from different signatures
+            // (It serves as the group-by key when generating the `SHOW FUNCTIONS` query).
+            // For example, the following signatures have different `rid` values:
+            //     - `datetrunc(Utf8, Timestamp(Microsecond, Some("+TZ"))) -> Timestamp(Microsecond, Some("+TZ"))`
+            //     - `datetrunc(Utf8View, Timestamp(Nanosecond, None)) -> Timestamp(Nanosecond, None)`
             Field::new("rid", DataType::UInt8, false),
         ]));
 

--- a/datafusion/core/src/catalog_common/information_schema.rs
+++ b/datafusion/core/src/catalog_common/information_schema.rs
@@ -348,51 +348,45 @@ impl InformationSchemaConfig {
         for (func_name, udf) in udfs {
             let args = udf.documentation().and_then(|d| d.arguments.clone());
             let combinations = get_udf_args_and_return_types(udf)?;
-            let mut rid = 0u8;
-            for (arg_types, return_type) in combinations {
+            for (rid, (arg_types, return_type)) in combinations.into_iter().enumerate() {
                 add_parameters(
                     func_name,
                     args.as_ref(),
                     arg_types,
                     return_type,
                     Self::is_variadic(udf.signature()),
-                    rid,
+                    rid as u8,
                 );
-                rid += 1;
             }
         }
 
         for (func_name, udaf) in udafs {
             let args = udaf.documentation().and_then(|d| d.arguments.clone());
             let combinations = get_udaf_args_and_return_types(udaf)?;
-            let mut rid = 0u8;
-            for (arg_types, return_type) in combinations {
+            for (rid, (arg_types, return_type)) in combinations.into_iter().enumerate() {
                 add_parameters(
                     func_name,
                     args.as_ref(),
                     arg_types,
                     return_type,
                     Self::is_variadic(udaf.signature()),
-                    rid,
+                    rid as u8,
                 );
-                rid += 1;
             }
         }
 
         for (func_name, udwf) in udwfs {
             let args = udwf.documentation().and_then(|d| d.arguments.clone());
             let combinations = get_udwf_args_and_return_types(udwf)?;
-            let mut rid = 0u8;
-            for (arg_types, return_type) in combinations {
+            for (rid, (arg_types, return_type)) in combinations.into_iter().enumerate() {
                 add_parameters(
                     func_name,
                     args.as_ref(),
                     arg_types,
                     return_type,
                     Self::is_variadic(udwf.signature()),
-                    rid,
+                    rid as u8,
                 );
-                rid += 1;
             }
         }
 

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1902,7 +1902,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             r#"
 SELECT DISTINCT
     p.*,
-    r.routine_type function_type,
+    r.function_type function_type,
     r.description description,
     r.syntax_example syntax_example
 FROM

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1883,6 +1883,16 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         self.statement_to_plan(rewrite.pop_front().unwrap()) // length of rewrite is 1
     }
 
+    /// Rewrite `SHOW FUNCTIONS` to another SQL query
+    /// The query is based on the `information_schema.routines` and `information_schema.parameters` tables
+    ///
+    /// The output columns:
+    /// - function_name: The name of function
+    /// - return_type: The return type of the function
+    /// - parameters: The name of parameters (ordered by the ordinal position)
+    /// - parameter_types: The type of parameters (ordered by the ordinal position)
+    /// - description: The description of the function (the description defined in the document)
+    /// - syntax_example: The syntax_example of the function (the syntax_example defined in the document)
     fn show_functions_to_plan(
         &self,
         filter: Option<ShowStatementFilter>,

--- a/datafusion/sqllogictest/test_files/information_schema.slt
+++ b/datafusion/sqllogictest/test_files/information_schema.slt
@@ -734,22 +734,22 @@ repeat Utf8View 1 IN 2
 query TT??TTT rowsort
 show functions like 'date_trunc';
 ----
-date_trunc Timestamp(Microsecond, None) [precision, expression] [Utf8, Timestamp(Microsecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Microsecond, None) [precision, expression] [Utf8View, Timestamp(Microsecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Microsecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Microsecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Microsecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Microsecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Millisecond, None) [precision, expression] [Utf8, Timestamp(Millisecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Millisecond, None) [precision, expression] [Utf8View, Timestamp(Millisecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Millisecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Millisecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Millisecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Millisecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Nanosecond, None) [precision, expression] [Utf8, Timestamp(Nanosecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Nanosecond, None) [precision, expression] [Utf8View, Timestamp(Nanosecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Nanosecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Nanosecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Nanosecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Nanosecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Second, None) [precision, expression] [Utf8, Timestamp(Second, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Second, None) [precision, expression] [Utf8View, Timestamp(Second, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Second, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Second, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Second, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Second, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Microsecond, None) [precision, expression] [Utf8, Timestamp(Microsecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Microsecond, None) [precision, expression] [Utf8View, Timestamp(Microsecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Microsecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Microsecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Microsecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Microsecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, None) [precision, expression] [Utf8, Timestamp(Millisecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, None) [precision, expression] [Utf8View, Timestamp(Millisecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Millisecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Millisecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, None) [precision, expression] [Utf8, Timestamp(Nanosecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, None) [precision, expression] [Utf8View, Timestamp(Nanosecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Nanosecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Nanosecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, None) [precision, expression] [Utf8, Timestamp(Second, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, None) [precision, expression] [Utf8View, Timestamp(Second, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Second, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Second, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
 
 statement ok
 show functions

--- a/datafusion/sqllogictest/test_files/information_schema.slt
+++ b/datafusion/sqllogictest/test_files/information_schema.slt
@@ -625,19 +625,19 @@ select routine_name, data_type, function_type from information_schema.routines w
 string_agg LargeUtf8 AGGREGATE
 
 # test every function type are included in the result
-query TTTTTTTBTTT rowsort
-select * from information_schema.routines where routine_name = 'date_trunc' OR routine_name = 'string_agg' OR routine_name = 'rank';
+query TTTTTTTBTTTT rowsort
+select * from information_schema.routines where routine_name = 'date_trunc' OR routine_name = 'string_agg' OR routine_name = 'rank' ORDER BY routine_name
 ----
-datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Microsecond, None) SCALAR Truncates a timestamp value to a specified precision.
-datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Microsecond, Some("+TZ")) SCALAR Truncates a timestamp value to a specified precision.
-datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Millisecond, None) SCALAR Truncates a timestamp value to a specified precision.
-datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Millisecond, Some("+TZ")) SCALAR Truncates a timestamp value to a specified precision.
-datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Nanosecond, None) SCALAR Truncates a timestamp value to a specified precision.
-datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Nanosecond, Some("+TZ")) SCALAR Truncates a timestamp value to a specified precision.
-datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Second, None) SCALAR Truncates a timestamp value to a specified precision.
-datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Second, Some("+TZ")) SCALAR Truncates a timestamp value to a specified precision.
-datafusion public rank datafusion public rank FUNCTION true NULL WINDOW Returns the rank of the current row within its partition, allowing gaps between ranks. This function provides a ranking similar to `row_number`, but skips ranks for identical values.
-datafusion public string_agg datafusion public string_agg FUNCTION true LargeUtf8 AGGREGATE Concatenates the values of string expressions and places separator values between them.
+datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Microsecond, None) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Microsecond, Some("+TZ")) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Millisecond, None) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Millisecond, Some("+TZ")) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Nanosecond, None) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Nanosecond, Some("+TZ")) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Second, None) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Second, Some("+TZ")) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+datafusion public rank datafusion public rank FUNCTION true NULL WINDOW Returns the rank of the current row within its partition, allowing gaps between ranks. This function provides a ranking similar to `row_number`, but skips ranks for identical values. rank()
+datafusion public string_agg datafusion public string_agg FUNCTION true LargeUtf8 AGGREGATE Concatenates the values of string expressions and places separator values between them. string_agg(expression, delimiter)
 
 query B
 select is_deterministic from information_schema.routines where routine_name = 'now';
@@ -731,18 +731,25 @@ repeat Utf8 1 OUT 0
 repeat Utf8 1 OUT 2
 repeat Utf8View 1 IN 2
 
-query TTTTT??T rowsort
-show functions like 'regexp_count';
+query TT??TTT rowsort
+show functions like 'date_trunc';
 ----
-datafusion public regexp_count SCALAR Int64 [str, regexp, start, flags] [LargeUtf8, LargeUtf8, Int64, LargeUtf8] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
-datafusion public regexp_count SCALAR Int64 [str, regexp, start, flags] [Utf8, Utf8, Int64, Utf8] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
-datafusion public regexp_count SCALAR Int64 [str, regexp, start, flags] [Utf8View, Utf8View, Int64, Utf8View] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
-datafusion public regexp_count SCALAR Int64 [str, regexp, start] [LargeUtf8, LargeUtf8, Int64] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
-datafusion public regexp_count SCALAR Int64 [str, regexp, start] [Utf8, Utf8, Int64] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
-datafusion public regexp_count SCALAR Int64 [str, regexp, start] [Utf8View, Utf8View, Int64] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
-datafusion public regexp_count SCALAR Int64 [str, regexp] [LargeUtf8, LargeUtf8] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
-datafusion public regexp_count SCALAR Int64 [str, regexp] [Utf8, Utf8] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
-datafusion public regexp_count SCALAR Int64 [str, regexp] [Utf8View, Utf8View] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+date_trunc Timestamp(Microsecond, None) [precision, expression] [Utf8, Timestamp(Microsecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Microsecond, None) [precision, expression] [Utf8View, Timestamp(Microsecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Microsecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Microsecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Microsecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Microsecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, None) [precision, expression] [Utf8, Timestamp(Millisecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, None) [precision, expression] [Utf8View, Timestamp(Millisecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Millisecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Millisecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, None) [precision, expression] [Utf8, Timestamp(Nanosecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, None) [precision, expression] [Utf8View, Timestamp(Nanosecond, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Nanosecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Nanosecond, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, None) [precision, expression] [Utf8, Timestamp(Second, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, None) [precision, expression] [Utf8View, Timestamp(Second, None)] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Second, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Second, Some("+TZ"))] FUNCTION Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
 
 statement ok
-show functions;
+show functions

--- a/datafusion/sqllogictest/test_files/information_schema.slt
+++ b/datafusion/sqllogictest/test_files/information_schema.slt
@@ -645,51 +645,88 @@ select is_deterministic from information_schema.routines where routine_name = 'n
 false
 
 # test every function type are included in the result
-query TTTITTTTB rowsort
-select * from information_schema.parameters where specific_name = 'date_trunc' OR specific_name = 'string_agg' OR specific_name = 'rank';
+query TTTITTTTBI
+select * from information_schema.parameters where specific_name = 'date_trunc' OR specific_name = 'string_agg' OR specific_name = 'rank' ORDER BY specific_name, rid;
 ----
-datafusion public date_trunc 1 IN precision Utf8 NULL false
-datafusion public date_trunc 1 IN precision Utf8View NULL false
-datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, None) NULL false
-datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, Some("+TZ")) NULL false
-datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, None) NULL false
-datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, Some("+TZ")) NULL false
-datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, None) NULL false
-datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, Some("+TZ")) NULL false
-datafusion public date_trunc 1 OUT NULL Timestamp(Second, None) NULL false
-datafusion public date_trunc 1 OUT NULL Timestamp(Second, Some("+TZ")) NULL false
-datafusion public date_trunc 2 IN expression Timestamp(Microsecond, None) NULL false
-datafusion public date_trunc 2 IN expression Timestamp(Microsecond, Some("+TZ")) NULL false
-datafusion public date_trunc 2 IN expression Timestamp(Millisecond, None) NULL false
-datafusion public date_trunc 2 IN expression Timestamp(Millisecond, Some("+TZ")) NULL false
-datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, None) NULL false
-datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, Some("+TZ")) NULL false
-datafusion public date_trunc 2 IN expression Timestamp(Second, None) NULL false
-datafusion public date_trunc 2 IN expression Timestamp(Second, Some("+TZ")) NULL false
-datafusion public string_agg 1 IN expression LargeUtf8 NULL false
-datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false
-datafusion public string_agg 2 IN delimiter LargeUtf8 NULL false
-datafusion public string_agg 2 IN delimiter Null NULL false
-datafusion public string_agg 2 IN delimiter Utf8 NULL false
+datafusion public date_trunc 1 IN precision Utf8 NULL false 0
+datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, None) NULL false 0
+datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, None) NULL false 0
+datafusion public date_trunc 1 IN precision Utf8View NULL false 1
+datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, None) NULL false 1
+datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, None) NULL false 1
+datafusion public date_trunc 1 IN precision Utf8 NULL false 2
+datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, Some("+TZ")) NULL false 2
+datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, Some("+TZ")) NULL false 2
+datafusion public date_trunc 1 IN precision Utf8View NULL false 3
+datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, Some("+TZ")) NULL false 3
+datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, Some("+TZ")) NULL false 3
+datafusion public date_trunc 1 IN precision Utf8 NULL false 4
+datafusion public date_trunc 2 IN expression Timestamp(Microsecond, None) NULL false 4
+datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, None) NULL false 4
+datafusion public date_trunc 1 IN precision Utf8View NULL false 5
+datafusion public date_trunc 2 IN expression Timestamp(Microsecond, None) NULL false 5
+datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, None) NULL false 5
+datafusion public date_trunc 1 IN precision Utf8 NULL false 6
+datafusion public date_trunc 2 IN expression Timestamp(Microsecond, Some("+TZ")) NULL false 6
+datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, Some("+TZ")) NULL false 6
+datafusion public date_trunc 1 IN precision Utf8View NULL false 7
+datafusion public date_trunc 2 IN expression Timestamp(Microsecond, Some("+TZ")) NULL false 7
+datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, Some("+TZ")) NULL false 7
+datafusion public date_trunc 1 IN precision Utf8 NULL false 8
+datafusion public date_trunc 2 IN expression Timestamp(Millisecond, None) NULL false 8
+datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, None) NULL false 8
+datafusion public date_trunc 1 IN precision Utf8View NULL false 9
+datafusion public date_trunc 2 IN expression Timestamp(Millisecond, None) NULL false 9
+datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, None) NULL false 9
+datafusion public date_trunc 1 IN precision Utf8 NULL false 10
+datafusion public date_trunc 2 IN expression Timestamp(Millisecond, Some("+TZ")) NULL false 10
+datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, Some("+TZ")) NULL false 10
+datafusion public date_trunc 1 IN precision Utf8View NULL false 11
+datafusion public date_trunc 2 IN expression Timestamp(Millisecond, Some("+TZ")) NULL false 11
+datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, Some("+TZ")) NULL false 11
+datafusion public date_trunc 1 IN precision Utf8 NULL false 12
+datafusion public date_trunc 2 IN expression Timestamp(Second, None) NULL false 12
+datafusion public date_trunc 1 OUT NULL Timestamp(Second, None) NULL false 12
+datafusion public date_trunc 1 IN precision Utf8View NULL false 13
+datafusion public date_trunc 2 IN expression Timestamp(Second, None) NULL false 13
+datafusion public date_trunc 1 OUT NULL Timestamp(Second, None) NULL false 13
+datafusion public date_trunc 1 IN precision Utf8 NULL false 14
+datafusion public date_trunc 2 IN expression Timestamp(Second, Some("+TZ")) NULL false 14
+datafusion public date_trunc 1 OUT NULL Timestamp(Second, Some("+TZ")) NULL false 14
+datafusion public date_trunc 1 IN precision Utf8View NULL false 15
+datafusion public date_trunc 2 IN expression Timestamp(Second, Some("+TZ")) NULL false 15
+datafusion public date_trunc 1 OUT NULL Timestamp(Second, Some("+TZ")) NULL false 15
+datafusion public string_agg 1 IN expression LargeUtf8 NULL false 0
+datafusion public string_agg 2 IN delimiter Utf8 NULL false 0
+datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 0
+datafusion public string_agg 1 IN expression LargeUtf8 NULL false 1
+datafusion public string_agg 2 IN delimiter LargeUtf8 NULL false 1
+datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 1
+datafusion public string_agg 1 IN expression LargeUtf8 NULL false 2
+datafusion public string_agg 2 IN delimiter Null NULL false 2
+datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 2
 
 # test variable length arguments
-query TTTB rowsort
-select specific_name, data_type, parameter_mode, is_variadic from information_schema.parameters where specific_name = 'concat';
+query TTTBI rowsort
+select specific_name, data_type, parameter_mode, is_variadic, rid from information_schema.parameters where specific_name = 'concat';
 ----
-concat LargeUtf8 IN true
-concat LargeUtf8 OUT false
-concat Utf8 IN true
-concat Utf8 OUT false
-concat Utf8View IN true
-concat Utf8View OUT false
+concat LargeUtf8 IN true 2
+concat LargeUtf8 OUT false 2
+concat Utf8 IN true 1
+concat Utf8 OUT false 1
+concat Utf8View IN true 0
+concat Utf8View OUT false 0
 
 # test ceorcion signature
-query TTIT rowsort
-select specific_name, data_type, ordinal_position, parameter_mode from information_schema.parameters where specific_name = 'repeat';
+query TTITI rowsort
+select specific_name, data_type, ordinal_position, parameter_mode, rid from information_schema.parameters where specific_name = 'repeat';
 ----
-repeat Int64 2 IN
-repeat LargeUtf8 1 IN
-repeat LargeUtf8 1 OUT
-repeat Utf8 1 IN
-repeat Utf8 1 OUT
-repeat Utf8View 1 IN
+repeat Int64 2 IN 0
+repeat Int64 2 IN 1
+repeat Int64 2 IN 2
+repeat LargeUtf8 1 IN 1
+repeat LargeUtf8 1 OUT 1
+repeat Utf8 1 IN 0
+repeat Utf8 1 OUT 0
+repeat Utf8 1 OUT 2
+repeat Utf8View 1 IN 2

--- a/datafusion/sqllogictest/test_files/information_schema.slt
+++ b/datafusion/sqllogictest/test_files/information_schema.slt
@@ -730,3 +730,19 @@ repeat Utf8 1 IN 0
 repeat Utf8 1 OUT 0
 repeat Utf8 1 OUT 2
 repeat Utf8View 1 IN 2
+
+query TTTTT??T rowsort
+show functions like 'regexp_count';
+----
+datafusion public regexp_count SCALAR Int64 [str, regexp, start, flags] [LargeUtf8, LargeUtf8, Int64, LargeUtf8] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+datafusion public regexp_count SCALAR Int64 [str, regexp, start, flags] [Utf8, Utf8, Int64, Utf8] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+datafusion public regexp_count SCALAR Int64 [str, regexp, start, flags] [Utf8View, Utf8View, Int64, Utf8View] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+datafusion public regexp_count SCALAR Int64 [str, regexp, start] [LargeUtf8, LargeUtf8, Int64] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+datafusion public regexp_count SCALAR Int64 [str, regexp, start] [Utf8, Utf8, Int64] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+datafusion public regexp_count SCALAR Int64 [str, regexp, start] [Utf8View, Utf8View, Int64] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+datafusion public regexp_count SCALAR Int64 [str, regexp] [LargeUtf8, LargeUtf8] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+datafusion public regexp_count SCALAR Int64 [str, regexp] [Utf8, Utf8] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+datafusion public regexp_count SCALAR Int64 [str, regexp] [Utf8View, Utf8View] Returns the number of matches that a [regular expression](https://docs.rs/regex/latest/regex/#syntax) has in a string.
+
+statement ok
+show functions;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12144.

## Rationale for this change
This PR implements `SHOW FUNCTIONS` to list the available functions during runtime. Instead of listing the function name only ([like Apache Spark](https://spark.apache.org/docs/3.5.3/sql-ref-syntax-aux-show-functions.html)), I think it's better to provide more information like [what Snowflake did](https://docs.snowflake.com/en/sql-reference/sql/show-functions#output). 

To provide the required information, I also added some columns to `information_schema.routines` and `information_schema.parameters`.

### Syntax
```
SHOW FUNCTIONS [ LIKE <pattern> ];
```

### Sample Output
```
> show functions like '%datetrunc';
+---------------+-------------------------------------+-------------------------+-------------------------------------------------+---------------+-------------------------------------------------------+-----------------------------------+
| function_name | return_type                         | parameters              | parameter_types                                 | function_type | description                                           | syntax_example                    |
+---------------+-------------------------------------+-------------------------+-------------------------------------------------+---------------+-------------------------------------------------------+-----------------------------------+
| datetrunc     | Timestamp(Microsecond, Some("+TZ")) | [precision, expression] | [Utf8, Timestamp(Microsecond, Some("+TZ"))]     | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Nanosecond, None)         | [precision, expression] | [Utf8View, Timestamp(Nanosecond, None)]         | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Second, Some("+TZ"))      | [precision, expression] | [Utf8View, Timestamp(Second, Some("+TZ"))]      | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Microsecond, None)        | [precision, expression] | [Utf8View, Timestamp(Microsecond, None)]        | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Second, None)             | [precision, expression] | [Utf8View, Timestamp(Second, None)]             | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Microsecond, None)        | [precision, expression] | [Utf8, Timestamp(Microsecond, None)]            | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Second, None)             | [precision, expression] | [Utf8, Timestamp(Second, None)]                 | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Microsecond, Some("+TZ")) | [precision, expression] | [Utf8View, Timestamp(Microsecond, Some("+TZ"))] | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Nanosecond, Some("+TZ"))  | [precision, expression] | [Utf8, Timestamp(Nanosecond, Some("+TZ"))]      | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Millisecond, None)        | [precision, expression] | [Utf8, Timestamp(Millisecond, None)]            | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Millisecond, Some("+TZ")) | [precision, expression] | [Utf8, Timestamp(Millisecond, Some("+TZ"))]     | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Second, Some("+TZ"))      | [precision, expression] | [Utf8, Timestamp(Second, Some("+TZ"))]          | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Nanosecond, None)         | [precision, expression] | [Utf8, Timestamp(Nanosecond, None)]             | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Millisecond, None)        | [precision, expression] | [Utf8View, Timestamp(Millisecond, None)]        | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Millisecond, Some("+TZ")) | [precision, expression] | [Utf8View, Timestamp(Millisecond, Some("+TZ"))] | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
| datetrunc     | Timestamp(Nanosecond, Some("+TZ"))  | [precision, expression] | [Utf8View, Timestamp(Nanosecond, Some("+TZ"))]  | SCALAR        | Truncates a timestamp value to a specified precision. | date_trunc(precision, expression) |
+---------------+-------------------------------------+-------------------------+-------------------------------------------------+---------------+-------------------------------------------------------+-----------------------------------+
16 row(s) fetched. 
```
### The Output Schema
- `function_name`
- `return_type`
- `parameters`: The name of parameters (ordered by the ordinal position)
- `parameter_types`: The type of parameters (ordered by the ordinal position)
- `description`: The description of the function (the description defined in the document)
- `syntax_example`: The syntax_example of the function (the syntax_example defined in the document) 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Implement `SHOW FUNCTIONS`.
- Add the `syntax_example` field to `information_schema.routines`.
- Add the `rid` field to `information_schema.parameters`.
  - `rid` (short for `routine id`) is used to differentiate parameters from different signatures (it serves as the group-by key when generating the `SHOW FUNCTIONS` query). For example, the following signatures have different `rid` values:
    - `datetrunc(Utf8, Timestamp(Microsecond, Some("+TZ"))) -> Timestamp(Microsecond, Some("+TZ"))`
    - `datetrunc(Utf8View, Timestamp(Nanosecond, None)) -> Timestamp(Nanosecond, None)`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes, tested by sqllogictests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
New SQL syntax.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
