### PR TITLE
[bugfix] ScalarFunctionExpr does not preserve the nullable flag on roundtrip

### DIFF
--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -838,6 +838,7 @@ message PhysicalScalarUdfNode {
   repeated PhysicalExprNode args = 2;
   optional bytes fun_definition = 3;
   datafusion_common.ArrowType return_type = 4;
+  bool nullable = 5;
 }
 
 message PhysicalAggregateExprNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -15720,6 +15720,9 @@ impl serde::Serialize for PhysicalScalarUdfNode {
         if self.return_type.is_some() {
             len += 1;
         }
+        if self.nullable {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion.PhysicalScalarUdfNode", len)?;
         if !self.name.is_empty() {
             struct_ser.serialize_field("name", &self.name)?;
@@ -15734,6 +15737,9 @@ impl serde::Serialize for PhysicalScalarUdfNode {
         }
         if let Some(v) = self.return_type.as_ref() {
             struct_ser.serialize_field("returnType", v)?;
+        }
+        if self.nullable {
+            struct_ser.serialize_field("nullable", &self.nullable)?;
         }
         struct_ser.end()
     }
@@ -15751,6 +15757,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalScalarUdfNode {
             "funDefinition",
             "return_type",
             "returnType",
+            "nullable",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -15759,6 +15766,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalScalarUdfNode {
             Args,
             FunDefinition,
             ReturnType,
+            Nullable,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -15784,6 +15792,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalScalarUdfNode {
                             "args" => Ok(GeneratedField::Args),
                             "funDefinition" | "fun_definition" => Ok(GeneratedField::FunDefinition),
                             "returnType" | "return_type" => Ok(GeneratedField::ReturnType),
+                            "nullable" => Ok(GeneratedField::Nullable),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -15807,6 +15816,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalScalarUdfNode {
                 let mut args__ = None;
                 let mut fun_definition__ = None;
                 let mut return_type__ = None;
+                let mut nullable__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Name => {
@@ -15835,6 +15845,12 @@ impl<'de> serde::Deserialize<'de> for PhysicalScalarUdfNode {
                             }
                             return_type__ = map_.next_value()?;
                         }
+                        GeneratedField::Nullable => {
+                            if nullable__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("nullable"));
+                            }
+                            nullable__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(PhysicalScalarUdfNode {
@@ -15842,6 +15858,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalScalarUdfNode {
                     args: args__.unwrap_or_default(),
                     fun_definition: fun_definition__,
                     return_type: return_type__,
+                    nullable: nullable__.unwrap_or_default(),
                 })
             }
         }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1228,6 +1228,8 @@ pub struct PhysicalScalarUdfNode {
     pub fun_definition: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     #[prost(message, optional, tag = "4")]
     pub return_type: ::core::option::Option<super::datafusion_common::ArrowType>,
+    #[prost(bool, tag = "5")]
+    pub nullable: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PhysicalAggregateExprNode {

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -358,12 +358,15 @@ pub fn parse_physical_expr(
 
             let args = parse_physical_exprs(&e.args, registry, input_schema, codec)?;
 
-            Arc::new(ScalarFunctionExpr::new(
-                e.name.as_str(),
-                scalar_fun_def,
-                args,
-                convert_required!(e.return_type)?,
-            ))
+            Arc::new(
+                ScalarFunctionExpr::new(
+                    e.name.as_str(),
+                    scalar_fun_def,
+                    args,
+                    convert_required!(e.return_type)?,
+                )
+                .with_nullable(e.nullable),
+            )
         }
         ExprType::LikeExpr(like_expr) => Arc::new(LikeExpr::new(
             like_expr.negated,

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -347,6 +347,7 @@ pub fn serialize_physical_expr(
                     args: serialize_physical_exprs(expr.args(), codec)?,
                     fun_definition: (!buf.is_empty()).then_some(buf),
                     return_type: Some(expr.return_type().try_into()?),
+                    nullable: expr.nullable(),
                 },
             )),
         })


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13829.

## Rationale for this change

Preserve the nullable flag for scalar functions after a ser/deser roundtrip.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- a test to showcase the bug
- the fix, consisting in adding the `nullable` field in the proto file and using it to propagate the flag on serialization.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
The first commit is a test that fails and the subsequent commits make it pass.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
