### PR TITLE
Support n-ary monotonic functions in ordering equivalence

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -1549,7 +1549,6 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
- "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",

--- a/datafusion/expr-common/src/sort_properties.rs
+++ b/datafusion/expr-common/src/sort_properties.rs
@@ -129,19 +129,21 @@ impl Neg for SortProperties {
     }
 }
 
-/// Represents the properties of a `PhysicalExpr`, including its sorting and range attributes.
+/// Represents the properties of a `PhysicalExpr`, including its sorting, range, and whether it preserves lexicographical ordering.
 #[derive(Debug, Clone)]
 pub struct ExprProperties {
     pub sort_properties: SortProperties,
     pub range: Interval,
+    pub preserves_lex_ordering: bool,
 }
 
 impl ExprProperties {
-    /// Creates a new `ExprProperties` instance with unknown sort properties and unknown range.
+    /// Creates a new `ExprProperties` instance with unknown sort properties, unknown range, and unknown lexicographical ordering preservation.
     pub fn new_unknown() -> Self {
         Self {
             sort_properties: SortProperties::default(),
             range: Interval::make_unbounded(&DataType::Null).unwrap(),
+            preserves_lex_ordering: false,
         }
     }
 
@@ -154,6 +156,12 @@ impl ExprProperties {
     /// Sets the range of the expression and returns the modified instance.
     pub fn with_range(mut self, range: Interval) -> Self {
         self.range = range;
+        self
+    }
+
+    /// Sets whether the expression maintains lexicographical ordering and returns the modified instance.
+    pub fn with_preserves_lex_ordering(mut self, preserves_lex_ordering: bool) -> Self {
+        self.preserves_lex_ordering = preserves_lex_ordering;
         self
     }
 }

--- a/datafusion/expr-common/src/sort_properties.rs
+++ b/datafusion/expr-common/src/sort_properties.rs
@@ -129,16 +129,25 @@ impl Neg for SortProperties {
     }
 }
 
-/// Represents the properties of a `PhysicalExpr`, including its sorting, range, and whether it preserves lexicographical ordering.
+/// Represents the properties of a `PhysicalExpr`, including its sorting,
+/// range, and whether it preserves lexicographical ordering.
 #[derive(Debug, Clone)]
 pub struct ExprProperties {
+    /// Properties that describe the sorting behavior of the expression,
+    /// such as whether it is ordered, unordered, or a singleton value.
     pub sort_properties: SortProperties,
+    /// A closed interval representing the range of possible values for
+    /// the expression. Used to compute reliable bounds.
     pub range: Interval,
+    /// Indicates whether the expression preserves lexicographical ordering
+    /// of its inputs. For example, string concatenation preserves ordering,
+    /// while addition does not.
     pub preserves_lex_ordering: bool,
 }
 
 impl ExprProperties {
-    /// Creates a new `ExprProperties` instance with unknown sort properties, unknown range, and unknown lexicographical ordering preservation.
+    /// Creates a new `ExprProperties` instance with unknown sort properties,
+    /// unknown range, and unknown lexicographical ordering preservation.
     pub fn new_unknown() -> Self {
         Self {
             sort_properties: SortProperties::default(),

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -668,7 +668,11 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
             return Ok(SortProperties::Unordered);
         };
 
-        if inputs.iter().skip(1).all(|input| &input.sort_properties == first_order) {
+        if inputs
+            .iter()
+            .skip(1)
+            .all(|input| &input.sort_properties == first_order)
+        {
             Ok(first_order.clone())
         } else {
             Ok(SortProperties::Unordered)
@@ -681,7 +685,10 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
             .first()
             .map(|first| &first.sort_properties)
             .filter(|&first_ordering| {
-                inputs.iter().skip(1).all(|input| &input.sort_properties == first_ordering)
+                inputs
+                    .iter()
+                    .skip(1)
+                    .all(|input| &input.sort_properties == first_ordering)
             })
             .is_some())
     }

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -673,7 +673,7 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
             .skip(1)
             .all(|input| &input.sort_properties == first_order)
         {
-            Ok(first_order.clone())
+            Ok(*first_order)
         } else {
             Ok(SortProperties::Unordered)
         }

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -303,11 +303,8 @@ impl ScalarUDF {
         self.inner.output_ordering(inputs)
     }
 
-    pub fn output_preserves_lex_ordering(
-        &self,
-        inputs: &[ExprProperties],
-    ) -> Result<bool> {
-        self.inner.output_preserves_lex_ordering(inputs)
+    pub fn preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
+        self.inner.preserves_lex_ordering(inputs)
     }
 
     /// See [`ScalarUDFImpl::coerce_types`] for more details.
@@ -660,7 +657,7 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     /// Calculates the [`SortProperties`] of this function based on its
     /// children's properties.
     fn output_ordering(&self, inputs: &[ExprProperties]) -> Result<SortProperties> {
-        if !self.output_preserves_lex_ordering(inputs)? {
+        if !self.preserves_lex_ordering(inputs)? {
             return Ok(SortProperties::Unordered);
         }
 
@@ -680,7 +677,7 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     }
 
     /// Whether the function preserves lexicographical ordering based on the input ordering
-    fn output_preserves_lex_ordering(&self, _inputs: &[ExprProperties]) -> Result<bool> {
+    fn preserves_lex_ordering(&self, _inputs: &[ExprProperties]) -> Result<bool> {
         Ok(false)
     }
 
@@ -837,8 +834,8 @@ impl ScalarUDFImpl for AliasedScalarUDFImpl {
         self.inner.output_ordering(inputs)
     }
 
-    fn output_preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
-        self.inner.output_preserves_lex_ordering(inputs)
+    fn preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
+        self.inner.preserves_lex_ordering(inputs)
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -303,6 +303,13 @@ impl ScalarUDF {
         self.inner.output_ordering(inputs)
     }
 
+    pub fn output_preserves_lex_ordering(
+        &self,
+        inputs: &[ExprProperties],
+    ) -> Result<bool> {
+        self.inner.output_preserves_lex_ordering(inputs)
+    }
+
     /// See [`ScalarUDFImpl::coerce_types`] for more details.
     pub fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         self.inner.coerce_types(arg_types)
@@ -656,6 +663,11 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
         Ok(SortProperties::Unordered)
     }
 
+    /// Whether the function preserves lexicographical ordering based on the input ordering
+    fn output_preserves_lex_ordering(&self, _inputs: &[ExprProperties]) -> Result<bool> {
+        Ok(false)
+    }
+
     /// Coerce arguments of a function call to types that the function can evaluate.
     ///
     /// This function is only called if [`ScalarUDFImpl::signature`] returns [`crate::TypeSignature::UserDefined`]. Most
@@ -807,6 +819,10 @@ impl ScalarUDFImpl for AliasedScalarUDFImpl {
 
     fn output_ordering(&self, inputs: &[ExprProperties]) -> Result<SortProperties> {
         self.inner.output_ordering(inputs)
+    }
+
+    fn output_preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
+        self.inner.output_preserves_lex_ordering(inputs)
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -682,10 +682,12 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     /// Whether the function preserves lexicographical ordering based on the input ordering
     fn output_preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
         // Check for non-empty input and verify all elements have same sort properties as first
-        Ok(inputs.first().is_some_and(|first| inputs
-            .iter()
-            .skip(1)
-            .all(|input| input.sort_properties == first.sort_properties)))
+        Ok(inputs.first().is_some_and(|first| {
+            inputs
+                .iter()
+                .skip(1)
+                .all(|input| input.sort_properties == first.sort_properties)
+        }))
     }
 
     /// Coerce arguments of a function call to types that the function can evaluate.

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -681,16 +681,11 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
 
     /// Whether the function preserves lexicographical ordering based on the input ordering
     fn output_preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
-        Ok(inputs
-            .first()
-            .map(|first| &first.sort_properties)
-            .filter(|&first_ordering| {
-                inputs
-                    .iter()
-                    .skip(1)
-                    .all(|input| &input.sort_properties == first_ordering)
-            })
-            .is_some())
+        // Check for non-empty input and verify all elements have same sort properties as first
+        Ok(inputs.first().is_some_and(|first| inputs
+            .iter()
+            .skip(1)
+            .all(|input| input.sort_properties == first.sort_properties)))
     }
 
     /// Coerce arguments of a function call to types that the function can evaluate.

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -654,15 +654,14 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
         Ok(Some(vec![]))
     }
 
-    /// Calculates the [`SortProperties`] of this function based on its
-    /// children's properties.
+    /// Calculates the [`SortProperties`] of this function based on its children's properties.
     fn output_ordering(&self, inputs: &[ExprProperties]) -> Result<SortProperties> {
         if !self.preserves_lex_ordering(inputs)? {
             return Ok(SortProperties::Unordered);
         }
 
         let Some(first_order) = inputs.first().map(|p| &p.sort_properties) else {
-            return Ok(SortProperties::Unordered);
+            return Ok(SortProperties::Singleton);
         };
 
         if inputs

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -680,14 +680,8 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     }
 
     /// Whether the function preserves lexicographical ordering based on the input ordering
-    fn output_preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
-        // Check for non-empty input and verify all elements have same sort properties as first
-        Ok(inputs.first().is_some_and(|first| {
-            inputs
-                .iter()
-                .skip(1)
-                .all(|input| input.sort_properties == first.sort_properties)
-        }))
+    fn output_preserves_lex_ordering(&self, _inputs: &[ExprProperties]) -> Result<bool> {
+        Ok(false)
     }
 
     /// Coerce arguments of a function call to types that the function can evaluate.

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -267,21 +267,8 @@ impl ScalarUDFImpl for ConcatFunc {
         Some(get_concat_doc())
     }
 
-    fn output_ordering(&self, inputs: &[ExprProperties]) -> Result<SortProperties> {
-        Ok(inputs
-            .first()
-            .map(|first| first.sort_properties.clone())
-            .filter(|first_ordering| {
-                inputs
-                    .iter()
-                    .skip(1)
-                    .all(|input| input.sort_properties == *first_ordering)
-            })
-            .unwrap_or(SortProperties::Unordered))
-    }
-
-    fn output_preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
-        Ok(inputs.iter().all(|input| input.preserves_lex_ordering))
+    fn output_preserves_lex_ordering(&self, _inputs: &[ExprProperties]) -> Result<bool> {
+        Ok(true)
     }
 }
 

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -17,6 +17,7 @@
 
 use arrow::array::{as_largestring_array, Array};
 use arrow::datatypes::DataType;
+use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
 use std::any::Any;
 use std::sync::{Arc, OnceLock};
 
@@ -264,6 +265,23 @@ impl ScalarUDFImpl for ConcatFunc {
 
     fn documentation(&self) -> Option<&Documentation> {
         Some(get_concat_doc())
+    }
+
+    fn output_ordering(&self, inputs: &[ExprProperties]) -> Result<SortProperties> {
+        Ok(inputs
+            .first()
+            .map(|first| first.sort_properties.clone())
+            .filter(|first_ordering| {
+                inputs
+                    .iter()
+                    .skip(1)
+                    .all(|input| input.sort_properties == *first_ordering)
+            })
+            .unwrap_or(SortProperties::Unordered))
+    }
+
+    fn output_preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
+        Ok(inputs.iter().all(|input| input.preserves_lex_ordering))
     }
 }
 

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -267,7 +267,7 @@ impl ScalarUDFImpl for ConcatFunc {
         Some(get_concat_doc())
     }
 
-    fn output_preserves_lex_ordering(&self, _inputs: &[ExprProperties]) -> Result<bool> {
+    fn preserves_lex_ordering(&self, _inputs: &[ExprProperties]) -> Result<bool> {
         Ok(true)
     }
 }

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -17,7 +17,7 @@
 
 use arrow::array::{as_largestring_array, Array};
 use arrow::datatypes::DataType;
-use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
+use datafusion_expr::sort_properties::ExprProperties;
 use std::any::Any;
 use std::sync::{Arc, OnceLock};
 

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -44,6 +44,7 @@ arrow-schema = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
 datafusion-expr-common = { workspace = true }
+datafusion-functions = { workspace = true }
 datafusion-functions-aggregate-common = { workspace = true }
 datafusion-physical-expr-common = { workspace = true }
 half = { workspace = true }

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -44,7 +44,6 @@ arrow-schema = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
 datafusion-expr-common = { workspace = true }
-datafusion-functions = { workspace = true }
 datafusion-functions-aggregate-common = { workspace = true }
 datafusion-physical-expr-common = { workspace = true }
 half = { workspace = true }
@@ -58,6 +57,7 @@ petgraph = "0.6.2"
 [dev-dependencies]
 arrow = { workspace = true, features = ["test_utils"] }
 criterion = "0.5"
+datafusion-functions = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -348,21 +348,14 @@ impl EquivalenceProperties {
         let mut new_orderings: Vec<LexOrdering> = vec![];
 
         let normalized_oeq = self.normalized_oeq_class();
-        for (original_ordering, ordering) in self.oeq_class.iter().zip(normalized_oeq.iter()) {
+        for ordering in normalized_oeq.iter() {
             if !ordering[0].expr.eq(&normalized_expr) {
                 continue;
             }
 
             let leading_ordering_options = ordering[0].options;
-            let original_leading_ordering_expr = original_ordering[0].expr.clone();
 
             for equivalent_expr in &eq_class {
-                // Skip if original ordering starts with the equivalent expression
-                // This avoids unintended simplifications that may not be valid
-                if original_leading_ordering_expr.eq(&equivalent_expr) {
-                    continue;
-                }
-
                 let children = equivalent_expr.children();
 
                 if children.is_empty() {
@@ -394,7 +387,7 @@ impl EquivalenceProperties {
                 if all_children_match {
                     // Check if the expression is monotonic in all arguments
                     if let Ok(expr_properties) = equivalent_expr.get_properties(&child_properties) {
-                        if SortProperties::Ordered(leading_ordering_options) == expr_properties.sort_properties {
+                        if expr_properties.preserves_lex_ordering && SortProperties::Ordered(leading_ordering_options) == expr_properties.sort_properties {
                             // Assume existing ordering is [c ASC, a ASC, b ASC]
                             // When equality c = f(a,b) is given, if we know that given ordering `[a ASC, b ASC]`,
                             // ordering `[f(a,b) ASC]` is valid, then we can deduce that ordering `[a ASC, b ASC]` is also valid.

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -356,9 +356,9 @@ impl EquivalenceProperties {
             let leading_ordering_options = ordering[0].options;
             let original_leading_ordering_expr = original_ordering[0].expr.clone();
 
-            // Handle expressions with multiple children
             for equivalent_expr in &eq_class {
                 // Skip if original ordering starts with the equivalent expression
+                // This avoids unintended simplifications that may not be valid
                 if original_leading_ordering_expr.eq(&equivalent_expr) {
                     continue;
                 }
@@ -394,7 +394,11 @@ impl EquivalenceProperties {
                     // Check if the expression is monotonic in all arguments
                     if let Ok(expr_properties) = equivalent_expr.get_properties(&child_properties) {
                         if SortProperties::Ordered(leading_ordering_options) == expr_properties.sort_properties {
-                            // Add ordering with leading expression removed
+                            // Assume existing ordering is [c ASC, a ASC, b ASC]
+                            // When equality c = f(a,b) is given, if we know that given ordering `[a ASC, b ASC]`,
+                            // ordering `[f(a,b) ASC]` is valid, then we can deduce that ordering `[a ASC, b ASC]` is also valid.
+                            // Hence, ordering `[a ASC, b ASC]` can be added to the state as a valid ordering.
+                            // (e.g. existing ordering where leading ordering is removed)
                             new_orderings.push(LexOrdering::new(ordering[1..].to_vec()));
                             break;
                         }

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -346,9 +346,7 @@ impl EquivalenceProperties {
             .unwrap_or_else(|| vec![Arc::clone(&normalized_expr)]);
 
         let mut new_orderings: Vec<LexOrdering> = vec![];
-
-        let normalized_oeq = self.normalized_oeq_class();
-        for ordering in normalized_oeq.iter() {
+        for ordering in self.normalized_oeq_class().iter() {
             if !ordering[0].expr.eq(&normalized_expr) {
                 continue;
             }
@@ -357,7 +355,6 @@ impl EquivalenceProperties {
 
             for equivalent_expr in &eq_class {
                 let children = equivalent_expr.children();
-
                 if children.is_empty() {
                     continue;
                 }
@@ -3716,7 +3713,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ordering_equivalence_with_monotonic_concat() -> Result<()> {
+    fn test_ordering_equivalence_with_lex_monotonic_concat() -> Result<()> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Utf8, false),
             Field::new("b", DataType::Utf8, false),
@@ -3752,7 +3749,6 @@ mod tests {
             LexOrdering::from(vec![
                 PhysicalSortExpr::new_default(Arc::clone(&col_c)).asc()
             ]);
-
         let expected_ordering2 = LexOrdering::from(vec![
             PhysicalSortExpr::new_default(Arc::clone(&col_a)).asc(),
             PhysicalSortExpr::new_default(Arc::clone(&col_b)).asc(),
@@ -3767,7 +3763,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ordering_equivalence_with_non_monotonic_multiply() -> Result<()> {
+    fn test_ordering_equivalence_with_non_lex_monotonic_multiply() -> Result<()> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Int32, false),
@@ -3800,7 +3796,7 @@ mod tests {
 
         let orderings = eq_properties.oeq_class().orderings.clone();
 
-        // The ordering should remain unchanged since multiplication is not monotonic
+        // The ordering should remain unchanged since multiplication is not lex-monotonic
         assert_eq!(orderings.len(), 1);
         assert!(orderings.contains(&initial_ordering));
 

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -3694,4 +3694,92 @@ mod tests {
 
         sort_expr
     }
+
+    #[test]
+    fn test_discover_new_orderings_with_multiple_children() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let col_a = col("a", &schema)?;
+        let col_b = col("b", &schema)?;
+        let col_c = col("c", &schema)?;
+
+        let a_plus_b: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&col_a),
+            Operator::Plus,
+            Arc::clone(&col_b),
+        ));
+
+        let mut eq_properties = EquivalenceProperties::new(Arc::clone(&schema));
+        eq_properties.add_new_ordering(vec![
+            PhysicalSortExpr::new_default(Arc::clone(&a_plus_b)).asc(),
+            PhysicalSortExpr::new_default(Arc::clone(&col_a)).asc(),
+            PhysicalSortExpr::new_default(Arc::clone(&col_b)).asc(),
+        ]);
+
+        eq_properties.add_equal_conditions(&col_c, &a_plus_b)?;
+
+        let orderings = eq_properties.oeq_class().orderings.clone();
+
+        let expected_ordering1 = vec![PhysicalSortExpr::new_default(Arc::clone(&a_plus_b)).asc()];
+        let expected_ordering2 = vec![
+            PhysicalSortExpr::new_default(Arc::clone(&col_a)).asc(),
+            PhysicalSortExpr::new_default(Arc::clone(&col_b)).asc(),
+        ];
+
+        assert_eq!(orderings.len(), 2);
+        assert!(orderings.contains(&expected_ordering1));
+        assert!(orderings.contains(&expected_ordering2));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_discover_new_orderings_with_non_monotonic_children() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let col_a = col("a", &schema)?;
+        let col_b = col("b", &schema)?;
+        let col_c = col("c", &schema)?;
+
+        let a_minus_b: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&col_a),
+            Operator::Minus,
+            Arc::clone(&col_b),
+        ));
+
+        let mut eq_properties = EquivalenceProperties::new(Arc::clone(&schema));
+        let initial_ordering = vec![
+            PhysicalSortExpr::new_default(Arc::clone(&a_minus_b)).asc(),
+            PhysicalSortExpr::new_default(Arc::clone(&col_a)).asc(),
+            PhysicalSortExpr::new_default(Arc::clone(&col_b)).desc(),
+        ];
+        eq_properties.add_new_ordering(initial_ordering.clone());
+
+        let orderings_before = eq_properties.oeq_class().orderings.clone();
+        assert_eq!(orderings_before.len(), 1);
+        assert!(orderings_before.contains(&initial_ordering));
+
+        eq_properties.add_equal_conditions(&col_c, &a_minus_b)?;
+
+        let orderings = eq_properties.oeq_class().orderings.clone();
+        let expected_ordering1 = vec![PhysicalSortExpr::new_default(Arc::clone(&a_minus_b)).asc()];
+        let expected_ordering2 = vec![
+            PhysicalSortExpr::new_default(Arc::clone(&col_a)).asc(),
+            PhysicalSortExpr::new_default(Arc::clone(&col_b)).desc(),
+        ];
+
+        assert_eq!(orderings.len(), 2);
+        assert!(orderings.contains(&expected_ordering1));
+        assert!(orderings.contains(&expected_ordering2));
+
+        Ok(())
+    }
 }

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -3794,7 +3794,7 @@ mod tests {
 
         let mut eq_properties = EquivalenceProperties::new(Arc::clone(&schema));
         let initial_ordering = LexOrdering::from(vec![
-            PhysicalSortExpr::new_default(Arc::clone(&a_minus_b)).asc(),
+            PhysicalSortExpr::new_default(Arc::clone(&col_c)).asc(),
             PhysicalSortExpr::new_default(Arc::clone(&col_a)).asc(),
             PhysicalSortExpr::new_default(Arc::clone(&col_b)).desc(),
         ]);
@@ -3808,7 +3808,7 @@ mod tests {
         eq_properties.add_equal_conditions(&col_c, &a_minus_b)?;
 
         let orderings = eq_properties.oeq_class().orderings.clone();
-        let expected_ordering1 = LexOrdering::from(vec![PhysicalSortExpr::new_default(Arc::clone(&a_minus_b)).asc()]);
+        let expected_ordering1 = LexOrdering::from(vec![PhysicalSortExpr::new_default(Arc::clone(&col_c)).asc()]);
         let expected_ordering2 = LexOrdering::from(vec![
             PhysicalSortExpr::new_default(Arc::clone(&col_a)).asc(),
             PhysicalSortExpr::new_default(Arc::clone(&col_b)).desc(),

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -383,6 +383,7 @@ impl EquivalenceProperties {
                         child_properties.push(ExprProperties {
                             sort_properties: SortProperties::Ordered(next.options),
                             range: Interval::make_unbounded(&child.data_type(&self.schema)?)?,
+                            preserves_lex_ordering: true,
                         });
                     } else {
                         all_children_match = false;
@@ -1451,16 +1452,19 @@ fn get_expr_properties(
         Ok(ExprProperties {
             sort_properties: SortProperties::Ordered(column_order.options),
             range: Interval::make_unbounded(&expr.data_type(schema)?)?,
+            preserves_lex_ordering: false,
         })
     } else if expr.as_any().downcast_ref::<Column>().is_some() {
         Ok(ExprProperties {
             sort_properties: SortProperties::Unordered,
             range: Interval::make_unbounded(&expr.data_type(schema)?)?,
+            preserves_lex_ordering: false,
         })
     } else if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
         Ok(ExprProperties {
             sort_properties: SortProperties::Singleton,
             range: Interval::try_new(literal.value().clone(), literal.value().clone())?,
+            preserves_lex_ordering: true,
         })
     } else {
         // Find orderings of its children

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -503,34 +503,42 @@ impl PhysicalExpr for BinaryExpr {
             Operator::Plus => Ok(ExprProperties {
                 sort_properties: l_order.add(&r_order),
                 range: l_range.add(r_range)?,
+                preserves_lex_ordering: false,
             }),
             Operator::Minus => Ok(ExprProperties {
                 sort_properties: l_order.sub(&r_order),
                 range: l_range.sub(r_range)?,
+                preserves_lex_ordering: false,
             }),
             Operator::Gt => Ok(ExprProperties {
                 sort_properties: l_order.gt_or_gteq(&r_order),
                 range: l_range.gt(r_range)?,
+                preserves_lex_ordering: false,
             }),
             Operator::GtEq => Ok(ExprProperties {
                 sort_properties: l_order.gt_or_gteq(&r_order),
                 range: l_range.gt_eq(r_range)?,
+                preserves_lex_ordering: false,
             }),
             Operator::Lt => Ok(ExprProperties {
                 sort_properties: r_order.gt_or_gteq(&l_order),
                 range: l_range.lt(r_range)?,
+                preserves_lex_ordering: false,
             }),
             Operator::LtEq => Ok(ExprProperties {
                 sort_properties: r_order.gt_or_gteq(&l_order),
                 range: l_range.lt_eq(r_range)?,
+                preserves_lex_ordering: false,
             }),
             Operator::And => Ok(ExprProperties {
                 sort_properties: r_order.and_or(&l_order),
                 range: l_range.and(r_range)?,
+                preserves_lex_ordering: false,
             }),
             Operator::Or => Ok(ExprProperties {
                 sort_properties: r_order.and_or(&l_order),
                 range: l_range.or(r_range)?,
+                preserves_lex_ordering: false,
             }),
             _ => Ok(ExprProperties::new_unknown()),
         }

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -90,6 +90,7 @@ impl PhysicalExpr for Literal {
         Ok(ExprProperties {
             sort_properties: SortProperties::Singleton,
             range: Interval::try_new(self.value().clone(), self.value().clone())?,
+            preserves_lex_ordering: true,
         })
     }
 }

--- a/datafusion/physical-expr/src/expressions/negative.rs
+++ b/datafusion/physical-expr/src/expressions/negative.rs
@@ -145,6 +145,7 @@ impl PhysicalExpr for NegativeExpr {
         Ok(ExprProperties {
             sort_properties: -children[0].sort_properties,
             range: children[0].range.clone().arithmetic_negate()?,
+            preserves_lex_ordering: false,
         })
     }
 }

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -202,7 +202,7 @@ impl PhysicalExpr for ScalarFunctionExpr {
 
     fn get_properties(&self, children: &[ExprProperties]) -> Result<ExprProperties> {
         let sort_properties = self.fun.output_ordering(children)?;
-        let preserves_lex_ordering = self.fun.output_preserves_lex_ordering(children)?;
+        let preserves_lex_ordering = self.fun.preserves_lex_ordering(children)?;
         let children_range = children
             .iter()
             .map(|props| &props.range)

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -202,6 +202,7 @@ impl PhysicalExpr for ScalarFunctionExpr {
 
     fn get_properties(&self, children: &[ExprProperties]) -> Result<ExprProperties> {
         let sort_properties = self.fun.output_ordering(children)?;
+        let preserves_lex_ordering = self.fun.output_preserves_lex_ordering(children)?;
         let children_range = children
             .iter()
             .map(|props| &props.range)
@@ -211,6 +212,7 @@ impl PhysicalExpr for ScalarFunctionExpr {
         Ok(ExprProperties {
             sort_properties,
             range,
+            preserves_lex_ordering,
         })
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13839.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

DataFusion's ordering equivalence system currently only handles single-parameter monotonic functions. This PR extends support to N-ary functions that preserve lexicographical ordering, like concat(). This enables more optimization opportunities when working with ordered data.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Added `preserves_lex_ordering` field to `ExprProperties`
- Implemented `output_preserves_lex_ordering` for concat function
- Updated `discover_new_orderings()` to handle multiple parameters
- Added tests for concat and non-monotonic multiply cases

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, added three new test cases:
- test_ordering_equivalence_with_monotonic_concat
- test_ordering_equivalence_with_non_monotonic_multiply
- test_ordering_equivalence_with_concat_equality

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No user-facing changes. This is an internal optimization improvement.