### PR TITLE
MINOR: typo -- remove extra "`" interfering with doc formatting

### DIFF
--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -517,7 +517,7 @@ impl EquivalenceProperties {
         }
     }
 
-    /// Checks whether the `given`` sort requirements are equal or more specific
+    /// Checks whether the `given` sort requirements are equal or more specific
     /// than the `reference` sort requirements.
     pub fn requirements_compatible(
         &self,


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Minor fix: typo -- remove extra "`" interfering with doc formatting.

## Are these changes tested?

N/A

## Are there any user-facing changes?

No
