### PR TITLE
typo: remove extraneous "`" in doc comment, fix header

### DIFF
--- a/datafusion/execution/src/runtime_env.rs
+++ b/datafusion/execution/src/runtime_env.rs
@@ -118,7 +118,7 @@ impl RuntimeEnv {
     /// runtime_env.register_object_store(&url, Arc::new(object_store));
     /// ```
     ///
-    /// # Example: Register local file system object store
+    /// # Example: Register remote URL object store like [Github](https://github.com)
     ///
     /// To register reading from urls such as <https://github.com>
     ///

--- a/datafusion/execution/src/runtime_env.rs
+++ b/datafusion/execution/src/runtime_env.rs
@@ -120,7 +120,6 @@ impl RuntimeEnv {
     ///
     /// # Example: Register remote URL object store like [Github](https://github.com)
     ///
-    /// To register reading from urls such as <https://github.com>
     ///
     /// ```
     /// # use std::sync::Arc;

--- a/datafusion/execution/src/runtime_env.rs
+++ b/datafusion/execution/src/runtime_env.rs
@@ -120,7 +120,7 @@ impl RuntimeEnv {
     ///
     /// # Example: Register local file system object store
     ///
-    /// To register reading from urls such as <https://github.com>`
+    /// To register reading from urls such as <https://github.com>
     ///
     /// ```
     /// # use std::sync::Arc;


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Improve documentation.

## What changes are included in this PR?

typo: remove extraneous "`" in doc comment

## Are these changes tested?

N/A

## Are there any user-facing changes?

No