### PR TITLE
fix: enable DF's nested_expressions feature by in datafusion-substrait tests to make them pass

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -46,6 +46,7 @@ substrait = { version = "0.50", features = ["serde"] }
 url = { workspace = true }
 
 [dev-dependencies]
+datafusion = { workspace = true, features = ["nested_expressions"] }
 datafusion-functions-aggregate = { workspace = true }
 serde_json = "1.0"
 tokio = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13854

## Rationale for this change

https://github.com/apache/datafusion/pull/13594/files#diff-d195b6dfaaed44b9828e145dc50c075c77b7faf8f44783ca5e6eda2c617af928L39 removed DF default features from the substrait crate. That broke some tests that depended on stuff coming from nested_expressions feature. 

Interestingly, the tests still passed in CI but failed when run locally - maybe due to CI running a whole bunch of tests at once and thus compiling DF with different set of features, or something?

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No - but in the original PR that caused the issue, that _might_ be a breaking change to some consumer if someone has disabled default_features for DF but things have been working still because datafusion-substrait has been pulling those features in anyways. Not sure if that can happen - I checked our internal stuff and that seems to work fine against a recent commit on main.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
