### PR TITLE
Minor: Use `resize` instead of `extend` for static values in SMJ logic

### DIFF
--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -1578,7 +1578,7 @@ impl SortMergeJoinStream {
                     .append_nulls(num_rows);
                 self.output_record_batches
                     .batch_ids
-                    .extend(vec![0; num_rows]);
+                    .resize(self.output_record_batches.batch_ids.len() + num_rows, 0);
 
                 self.output_record_batches.batches.push(record_batch);
             }
@@ -1622,7 +1622,7 @@ impl SortMergeJoinStream {
                 .append_nulls(num_rows);
             self.output_record_batches
                 .batch_ids
-                .extend(vec![0; num_rows]);
+                .resize(self.output_record_batches.batch_ids.len() + num_rows, 0);
             self.output_record_batches.batches.push(record_batch);
         }
         buffered_batch.join_filter_not_matched_map.clear();
@@ -1757,10 +1757,10 @@ impl SortMergeJoinStream {
                         self.output_record_batches.filter_mask.extend(pre_mask);
                     }
                     self.output_record_batches.row_indices.extend(&left_indices);
-                    self.output_record_batches.batch_ids.extend(vec![
-                        self.streamed_batch_counter.load(Relaxed);
-                        left_indices.len()
-                        ]);
+                    self.output_record_batches.batch_ids.resize(
+                        self.output_record_batches.batch_ids.len() + left_indices.len(),
+                        self.streamed_batch_counter.load(Relaxed),
+                    );
 
                     // For outer joins, we need to push the null joined rows to the output if
                     // all joined rows are failed on the join filter.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Minor improvement when dealing with internal arrays for SMJ potentially removing extra allocation for filtered SortMergeJoin

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
