### PR TITLE
Minor: fix: Include FetchRel when producing LogicalPlan from Sort

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -361,13 +361,13 @@ pub fn to_substrait_rel(
                 }))),
             }))
         }
-        LogicalPlan::Sort(sort) => {
-            let input = to_substrait_rel(sort.input.as_ref(), state, extensions)?;
-            let sort_fields = sort
-                .expr
+        LogicalPlan::Sort(datafusion::logical_expr::Sort { expr, input, fetch }) => {
+            let sort_fields = expr
                 .iter()
-                .map(|e| substrait_sort_field(state, e, sort.input.schema(), extensions))
+                .map(|e| substrait_sort_field(state, e, input.schema(), extensions))
                 .collect::<Result<Vec<_>>>()?;
+
+            let input = to_substrait_rel(input.as_ref(), state, extensions)?;
 
             let sort_rel = Box::new(Rel {
                 rel_type: Some(RelType::Sort(Box::new(SortRel {
@@ -378,23 +378,16 @@ pub fn to_substrait_rel(
                 }))),
             });
 
-            match sort.fetch {
-                Some(_) => {
-                    let empty_schema = Arc::new(DFSchema::empty());
-                    let count_mode = sort
-                        .fetch
-                        .map(|amount| {
-                            to_substrait_rex(
-                                state,
-                                &Expr::Literal(ScalarValue::Int64(Some(amount as i64))),
-                                &empty_schema,
-                                0,
-                                extensions,
-                            )
-                        })
-                        .transpose()?
-                        .map(Box::new)
-                        .map(fetch_rel::CountMode::CountExpr);
+            match fetch {
+                Some(amount) => {
+                    let count_mode =
+                        Some(fetch_rel::CountMode::CountExpr(Box::new(Expression {
+                            rex_type: Some(RexType::Literal(Literal {
+                                nullable: false,
+                                type_variation_reference: DEFAULT_TYPE_VARIATION_REF,
+                                literal_type: Some(LiteralType::I64(*amount as i64)),
+                            })),
+                        })));
                     Ok(Box::new(Rel {
                         rel_type: Some(RelType::Fetch(Box::new(FetchRel {
                             common: None,

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -201,6 +201,11 @@ async fn select_with_filter() -> Result<()> {
 }
 
 #[tokio::test]
+async fn select_with_filter_sort_limit() -> Result<()> {
+    roundtrip("SELECT * FROM data WHERE a > 1 ORDER BY b ASC LIMIT 2").await
+}
+
+#[tokio::test]
 async fn select_with_reused_functions() -> Result<()> {
     let ctx = create_context().await?;
     let sql = "SELECT * FROM data WHERE a > 1 AND a < 10 AND b > 0";

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -206,6 +206,11 @@ async fn select_with_filter_sort_limit() -> Result<()> {
 }
 
 #[tokio::test]
+async fn select_with_filter_sort_limit_offset() -> Result<()> {
+    roundtrip("SELECT * FROM data WHERE a > 1 ORDER BY b ASC LIMIT 2 OFFSET 1").await
+}
+
+#[tokio::test]
 async fn select_with_reused_functions() -> Result<()> {
     let ctx = create_context().await?;
     let sql = "SELECT * FROM data WHERE a > 1 AND a < 10 AND b > 0";


### PR DESCRIPTION
## Which issue does this PR close?
Closes #13860

## Rationale for this change

Explained in #13860 

## What changes are included in this PR?



## Are these changes tested?

Included a test that fails before this change

## Are there any user-facing changes?

`to_substrait_plan` will include a `FetchRel` when serializing a `Sort` that contains a `fetch`.   It had previously missed this.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
