### PR TITLE
Fix build `use of undeclared type ShowStatementFilter`

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -62,8 +62,8 @@ use sqlparser::ast::{
     Assignment, AssignmentTarget, ColumnDef, CreateIndex, CreateTable,
     CreateTableOptions, Delete, DescribeAlias, Expr as SQLExpr, FromTable, Ident, Insert,
     ObjectName, ObjectType, OneOrManyWithParens, Query, SchemaName, SetExpr,
-    ShowCreateObject, Statement, TableConstraint, TableFactor, TableWithJoins,
-    TransactionMode, UnaryOperator, Value,
+    ShowCreateObject, ShowStatementFilter, Statement, TableConstraint, TableFactor,
+    TableWithJoins, TransactionMode, UnaryOperator, Value,
 };
 use sqlparser::parser::ParserError::ParserError;
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Build on main is broken due to a logical conflict between

- https://github.com/apache/datafusion/pull/13799
- https://github.com/apache/datafusion/pull/13767

Example failure:

https://github.com/apache/datafusion/actions/runs/12441590178/job/34738687199
```
error[E0433]: failed to resolve: use of undeclared type `ShowStatementFilter`
    --> datafusion/sql/src/statement.rs:2003:17
     |
2003 |                 ShowStatementFilter::Like(like) => {
     |                 ^^^^^^^^^^^^^^^^^^^ use of undeclared type `ShowStatementFilter`
     |
help: a struct with a similar name exists
     |
2003 |                 ShowStatementIn::Like(like) => {
     |                 ~~~~~~~~~~~~~~~
help: consider importing one of these enums
     |
18   + use crate::statement::ast::ShowStatementFilter;
     |
18   + use sqlparser::ast::ShowStatementFilter;
     |

    Checking datafusion-functions v43.0.0 (/__w/datafusion/datafusion/datafusion/functions)
    Checking datafusion-physical-plan v43.0.0 (/__w/datafusion/datafusion/datafusion/physical-plan)
    Checking datafusion-functions-aggregate v43.0.0 (/__w/datafusion/datafusion/datafusion/functions-aggregate)
Some errors have detailed explanations: E0[412](https://github.com/apache/datafusion/actions/runs/12441590178/job/34738687199#step:6:413), E0433.
```

## What changes are included in this PR?

Fix logical conflict

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
