### PR TITLE
Restore `DocBuilder::new()` to avoid breaking API change

### DIFF
--- a/datafusion/doc/src/lib.rs
+++ b/datafusion/doc/src/lib.rs
@@ -17,9 +17,11 @@
 
 #[allow(rustdoc::broken_intra_doc_links)]
 /// Documentation for use by [`ScalarUDFImpl`](ScalarUDFImpl),
-/// [`AggregateUDFImpl`](AggregateUDFImpl) and [`WindowUDFImpl`](WindowUDFImpl) functions
-/// that will be used to generate public documentation.
+/// [`AggregateUDFImpl`](AggregateUDFImpl) and [`WindowUDFImpl`](WindowUDFImpl) functions.
 ///
+/// See the [`DocumentationBuilder`] to create a new [`Documentation`] struct.
+///
+/// The DataFusion [SQL function documentation] is automatically  generated from these structs.
 /// The name of the udf will be pulled from the [`ScalarUDFImpl::name`](ScalarUDFImpl::name),
 /// [`AggregateUDFImpl::name`](AggregateUDFImpl::name) or [`WindowUDFImpl::name`](WindowUDFImpl::name)
 /// function as appropriate.
@@ -29,6 +31,8 @@
 ///
 /// Currently, documentation only supports a single language
 /// thus all text should be in English.
+///
+/// [SQL function documentation]: https://datafusion.apache.org/user-guide/sql/index.html
 #[derive(Debug, Clone)]
 pub struct Documentation {
     /// The section in the documentation where the UDF will be documented
@@ -61,7 +65,7 @@ impl Documentation {
         description: impl Into<String>,
         syntax_example: impl Into<String>,
     ) -> DocumentationBuilder {
-        DocumentationBuilder::new(doc_section, description, syntax_example)
+        DocumentationBuilder::new_with_details(doc_section, description, syntax_example)
     }
 
     /// Output the `Documentation` struct in form of custom Rust documentation attributes
@@ -160,7 +164,21 @@ pub struct DocSection {
     pub description: Option<&'static str>,
 }
 
-/// A builder to be used for building [`Documentation`]'s.
+impl Default for DocSection {
+    /// Returns a "default" Doc section.
+    ///
+    /// This is suitable for user defined functions that do not appear in the
+    /// DataFusion documentation.
+    fn default() -> Self {
+        Self {
+            include: true,
+            label: "Default",
+            description: None,
+        }
+    }
+}
+
+/// A builder for [`Documentation`]'s.
 ///
 /// Example:
 ///
@@ -189,7 +207,13 @@ pub struct DocumentationBuilder {
 }
 
 impl DocumentationBuilder {
-    pub fn new(
+    #[deprecated(since = "44.0.0", note = "please use `DocumentationBuilder::new_with_details` instead")]
+    pub fn new() -> Self {
+        Self::new_with_details(DocSection::default(), "<no description>", "<no example>")
+    }
+
+    /// Creates a new [`DocumentationBuilder`] with all required fields
+    pub fn new_with_details(
         doc_section: DocSection,
         description: impl Into<String>,
         syntax_example: impl Into<String>,

--- a/datafusion/doc/src/lib.rs
+++ b/datafusion/doc/src/lib.rs
@@ -207,7 +207,10 @@ pub struct DocumentationBuilder {
 }
 
 impl DocumentationBuilder {
-    #[deprecated(since = "44.0.0", note = "please use `DocumentationBuilder::new_with_details` instead")]
+    #[deprecated(
+        since = "44.0.0",
+        note = "please use `DocumentationBuilder::new_with_details` instead"
+    )]
     pub fn new() -> Self {
         Self::new_with_details(DocSection::default(), "<no description>", "<no example>")
     }

--- a/datafusion/doc/src/lib.rs
+++ b/datafusion/doc/src/lib.rs
@@ -207,6 +207,7 @@ pub struct DocumentationBuilder {
 }
 
 impl DocumentationBuilder {
+    #[allow(clippy::new_without_default)]
     #[deprecated(
         since = "44.0.0",
         note = "please use `DocumentationBuilder::new_with_details` instead"

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -62,8 +62,8 @@ use sqlparser::ast::{
     Assignment, AssignmentTarget, ColumnDef, CreateIndex, CreateTable,
     CreateTableOptions, Delete, DescribeAlias, Expr as SQLExpr, FromTable, Ident, Insert,
     ObjectName, ObjectType, OneOrManyWithParens, Query, SchemaName, SetExpr,
-    ShowCreateObject, Statement, TableConstraint, TableFactor, TableWithJoins,
-    TransactionMode, UnaryOperator, Value,
+    ShowCreateObject, ShowStatementFilter, Statement, TableConstraint, TableFactor,
+    TableWithJoins, TransactionMode, UnaryOperator, Value,
 };
 use sqlparser::parser::ParserError::ParserError;
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/13764

## Rationale for this change

I would like to help people upgrade DataFusion versions with as much help as possible. This means following the [deprecation guidelines](https://github.com/apache/datafusion/blob/main/README.md) 

Changes to `DocBuilder` introduced a breaking API change that could be confusing to some during upgrade
- https://github.com/apache/datafusion/pull/13575

## What changes are included in this PR?
1. Restore `DocumentationBuilder::new`, and mark it  `#[deprecated]``, following the [deprecation guidelines](https://github.com/apache/datafusion/blob/main/README.md) 
2. Make `DocumentationBuilder::new_with_defaults`  new to help users find the new API
3. Add `Default` for `DocSection` to make it easier for users to bash out their own docs
4. Improve some other docs

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
