### PR TITLE
Improve error messages for incorrect zero argument signatures

### DIFF
--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -351,6 +351,15 @@ impl TypeSignature {
         }
     }
 
+    /// Returns true if the signature currently supports or used to supported 0
+    /// input arguments in a previous version of DataFusion.
+    pub fn used_to_support_zero_arguments(&self) -> bool {
+        match &self {
+            TypeSignature::Any(num) => *num == 0,
+            _ => self.supports_zero_argument(),
+        }
+    }
+
     /// get all possible types for the given `TypeSignature`
     pub fn get_possible_types(&self) -> Vec<Vec<DataType>> {
         match self {

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -50,17 +50,23 @@ pub fn data_types_with_scalar_udf(
     func: &ScalarUDF,
 ) -> Result<Vec<DataType>> {
     let signature = func.signature();
+    let type_signature = &signature.type_signature;
 
     if current_types.is_empty() {
-        if signature.type_signature.supports_zero_argument() {
+        if type_signature.supports_zero_argument() {
             return Ok(vec![]);
         } else {
-            return plan_err!("{} does not support zero arguments.", func.name());
+            if type_signature.used_to_support_zero_arguments() {
+                // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
+                return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.", func.name());
+            } else {
+                return plan_err!("{} does not support zero arguments.", func.name());
+            }
         }
     }
 
     let valid_types =
-        get_valid_types_with_scalar_udf(&signature.type_signature, current_types, func)?;
+        get_valid_types_with_scalar_udf(&type_signature, current_types, func)?;
 
     if valid_types
         .iter()
@@ -69,12 +75,7 @@ pub fn data_types_with_scalar_udf(
         return Ok(current_types.to_vec());
     }
 
-    try_coerce_types(
-        func.name(),
-        valid_types,
-        current_types,
-        &signature.type_signature,
-    )
+    try_coerce_types(func.name(), valid_types, current_types, type_signature)
 }
 
 /// Performs type coercion for aggregate function arguments.
@@ -89,20 +90,23 @@ pub fn data_types_with_aggregate_udf(
     func: &AggregateUDF,
 ) -> Result<Vec<DataType>> {
     let signature = func.signature();
+    let type_signature = &signature.type_signature;
 
     if current_types.is_empty() {
-        if signature.type_signature.supports_zero_argument() {
+        if type_signature.supports_zero_argument() {
             return Ok(vec![]);
         } else {
-            return plan_err!("{} does not support zero arguments.", func.name());
+            if type_signature.used_to_support_zero_arguments() {
+                // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
+                return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.", func.name());
+            } else {
+                return plan_err!("{} does not support zero arguments.", func.name());
+            }
         }
     }
 
-    let valid_types = get_valid_types_with_aggregate_udf(
-        &signature.type_signature,
-        current_types,
-        func,
-    )?;
+    let valid_types =
+        get_valid_types_with_aggregate_udf(type_signature, current_types, func)?;
     if valid_types
         .iter()
         .any(|data_type| data_type == current_types)
@@ -110,12 +114,7 @@ pub fn data_types_with_aggregate_udf(
         return Ok(current_types.to_vec());
     }
 
-    try_coerce_types(
-        func.name(),
-        valid_types,
-        current_types,
-        &signature.type_signature,
-    )
+    try_coerce_types(func.name(), valid_types, current_types, type_signature)
 }
 
 /// Performs type coercion for window function arguments.
@@ -130,17 +129,23 @@ pub fn data_types_with_window_udf(
     func: &WindowUDF,
 ) -> Result<Vec<DataType>> {
     let signature = func.signature();
+    let type_signature = &signature.type_signature;
 
     if current_types.is_empty() {
-        if signature.type_signature.supports_zero_argument() {
+        if type_signature.supports_zero_argument() {
             return Ok(vec![]);
         } else {
-            return plan_err!("{} does not support zero arguments.", func.name());
+            if type_signature.used_to_support_zero_arguments() {
+                // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
+                return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.", func.name());
+            } else {
+                return plan_err!("{} does not support zero arguments.", func.name());
+            }
         }
     }
 
     let valid_types =
-        get_valid_types_with_window_udf(&signature.type_signature, current_types, func)?;
+        get_valid_types_with_window_udf(type_signature, current_types, func)?;
     if valid_types
         .iter()
         .any(|data_type| data_type == current_types)
@@ -148,12 +153,7 @@ pub fn data_types_with_window_udf(
         return Ok(current_types.to_vec());
     }
 
-    try_coerce_types(
-        func.name(),
-        valid_types,
-        current_types,
-        &signature.type_signature,
-    )
+    try_coerce_types(func.name(), valid_types, current_types, type_signature)
 }
 
 /// Performs type coercion for function arguments.
@@ -168,18 +168,28 @@ pub fn data_types(
     current_types: &[DataType],
     signature: &Signature,
 ) -> Result<Vec<DataType>> {
+    let type_signature = &signature.type_signature;
+
     if current_types.is_empty() {
-        if signature.type_signature.supports_zero_argument() {
+        if type_signature.supports_zero_argument() {
             return Ok(vec![]);
         } else {
-            return plan_err!(
-                "signature {:?} does not support zero arguments.",
-                &signature.type_signature
+            if type_signature.used_to_support_zero_arguments() {
+                // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
+                return plan_err!(
+                "signature {:?} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.",
+                type_signature
             );
+            } else {
+                return plan_err!(
+                    "signature {:?} does not support zero arguments.",
+                    type_signature
+                );
+            }
         }
     }
 
-    let valid_types = get_valid_types(&signature.type_signature, current_types)?;
+    let valid_types = get_valid_types(type_signature, current_types)?;
     if valid_types
         .iter()
         .any(|data_type| data_type == current_types)
@@ -187,12 +197,7 @@ pub fn data_types(
         return Ok(current_types.to_vec());
     }
 
-    try_coerce_types(
-        function_name,
-        valid_types,
-        current_types,
-        &signature.type_signature,
-    )
+    try_coerce_types(function_name, valid_types, current_types, type_signature)
 }
 
 fn is_well_supported_signature(type_signature: &TypeSignature) -> bool {

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1181,8 +1181,13 @@ from arrays_values_without_nulls;
 ## array_element (aliases: array_extract, list_extract, list_element)
 
 # Testing with empty arguments should result in an error
-query error DataFusion error: Error during planning: Error during planning: array_element does not support zero arguments
+query error
 select array_element();
+----
+DataFusion error: Error during planning: Error during planning: array_element does not support zero arguments. No function matches the given name and argument types 'array_element()'. You might need to add explicit type casts.
+	Candidate functions:
+	array_element(array, index)
+
 
 # array_element error
 query error
@@ -2023,8 +2028,13 @@ select array_slice(a, -1, 2, 1), array_slice(a, -1, 2),
 [6.0] [6.0] [] []
 
 # Testing with empty arguments should result in an error
-query error DataFusion error: Error during planning: Error during planning: array_slice does not support zero arguments
+query error
 select array_slice();
+----
+DataFusion error: Error during planning: Error during planning: array_slice does not support zero arguments. No function matches the given name and argument types 'array_slice()'. You might need to add explicit type casts.
+	Candidate functions:
+	array_slice(Any, .., Any)
+
 
 ## array_any_value (aliases: list_any_value)
 

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -842,8 +842,13 @@ SELECT greatest(-1, 1, 2.3, 123456789, 3 + 5, -(-4), abs(-9.0))
 123456789
 
 
-query error greatest does not support zero arguments
+query error
 SELECT greatest()
+----
+DataFusion error: Error during planning: Error during planning: greatest does not support zero arguments. No function matches the given name and argument types 'greatest()'. You might need to add explicit type casts.
+	Candidate functions:
+	greatest(UserDefined)
+
 
 query I
 SELECT greatest(4, 5, 7, 1, 2)
@@ -1040,8 +1045,13 @@ SELECT least(-1, 1, 2.3, 123456789, 3 + 5, -(-4), abs(-9.0))
 -1
 
 
-query error least does not support zero arguments
+query error
 SELECT least()
+----
+DataFusion error: Error during planning: Error during planning: least does not support zero arguments. No function matches the given name and argument types 'least()'. You might need to add explicit type casts.
+	Candidate functions:
+	least(UserDefined)
+
 
 query I
 SELECT least(4, 5, 7, 1, 2)


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/13763


## Rationale for this change

As described on https://github.com/apache/datafusion/issues/13763

In version s 43.0.0 and earlier of DataFusion, a `TypeSignature::Any(0)` means your udf could be called with zero arguments:
```sql
SELECT my_udf();
```

However in version 44.0.0 you get a very confusing error that says zero arguments are not supported but then gives you a candidate function is the one it just said was not supported:

```sql
SELECT my_udf();

Error during planning: example_union does not support zero arguments. 
No function matches the given name and argument types 'my_udf()'. 
You might need to add explicit type casts.

Candidate functions:
example_union()
```


## What changes are included in this PR?

Improve error message to direct people to nullary

## Are these changes tested?
Yes by CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
