### PR TITLE
Changed the url for downloading IMDB dataset from benchmark - Fixed Issue #13896

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -456,11 +456,11 @@ run_clickbench_extended() {
 }
 
 # Downloads the csv.gz files IMDB datasets from Peter Boncz's homepage(one of the JOB paper authors)
-# http://homepages.cwi.nl/~boncz/job/imdb.tgz
+# https://event.cwi.nl/da/job/imdb.tgz
 data_imdb() {
     local imdb_dir="${DATA_DIR}/imdb"
     local imdb_temp_gz="${imdb_dir}/imdb.tgz"
-    local imdb_url="https://homepages.cwi.nl/~boncz/job/imdb.tgz"
+    local imdb_url="https://event.cwi.nl/da/job/imdb.tgz"
 
    # imdb has 21 files, we just separate them into 3 groups for better readability 
     local first_required_files=(


### PR DESCRIPTION
The URL to the external website was returning a 404. Presuming recent changes in the external website's structure, the required data has been moved to a different URL. The commit ensures the new URL is used.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13896 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The bug was occuring due to referencing a file hosted on an external website whose URL had been changed. The PR updates the code to point at the correct URL.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
The [bench.sh#463](https://github.com/apache/datafusion/blob/7b4e5598a5d3e95a6c0dfcb9375f50778a2b2f64/benchmarks/bench.sh#L463) has been changed to use the correct URL for the file.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes. After the change, the expected command worked correctly, initiating a download as intended:
![20241225_001005(1)](https://github.com/user-attachments/assets/8c0e31c9-0a6b-4081-8a52-7aec4ce54e98)

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No.