### PR TITLE
Correct return type for initcap scalar function with utf8view

### DIFF
--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -192,7 +192,7 @@ mod tests {
     use crate::unicode::initcap::InitcapFunc;
     use crate::utils::test::test_function;
     use arrow::array::{Array, StringArray, StringViewArray};
-    use arrow::datatypes::DataType::Utf8;
+    use arrow::datatypes::DataType::{Utf8, Utf8View};
     use datafusion_common::{Result, ScalarValue};
     use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
 
@@ -251,7 +251,7 @@ mod tests {
             )))],
             Ok(Some("Hi Thomas")),
             &str,
-            Utf8,
+            Utf8View,
             StringViewArray
         );
         test_function!(
@@ -261,7 +261,7 @@ mod tests {
             )))],
             Ok(Some("Hi Thomas With M0re Than 12 Chars")),
             &str,
-            Utf8,
+            Utf8View,
             StringViewArray
         );
         test_function!(
@@ -274,7 +274,7 @@ mod tests {
                 "Đẹp Đẽ Êm Ả Ñandú Árbol Олег Иванович Íslensku Þjóðarinnar Ελληνική"
             )),
             &str,
-            Utf8,
+            Utf8View,
             StringViewArray
         );
         test_function!(
@@ -284,7 +284,7 @@ mod tests {
             )))],
             Ok(Some("")),
             &str,
-            Utf8,
+            Utf8View,
             StringViewArray
         );
         test_function!(
@@ -292,7 +292,7 @@ mod tests {
             vec![ColumnarValue::Scalar(ScalarValue::Utf8View(None))],
             Ok(None),
             &str,
-            Utf8,
+            Utf8View,
             StringViewArray
         );
 

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -63,7 +63,11 @@ impl ScalarUDFImpl for InitcapFunc {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        utf8_to_str_type(&arg_types[0], "initcap")
+        if let DataType::Utf8View = arg_types[0] {
+            Ok(DataType::Utf8View)
+        } else {
+            utf8_to_str_type(&arg_types[0], "initcap")
+        }
     }
 
     fn invoke_batch(

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -154,6 +154,7 @@ pub mod test {
 
                     let result = result.unwrap().to_array(cardinality).expect("Failed to convert to array");
                     let result = result.as_any().downcast_ref::<$ARRAY_TYPE>().expect("Failed to convert to type");
+                    assert_eq!(result.data_type(), &$EXPECTED_DATA_TYPE);
 
                     // value is correct
                     match expected {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13907

## Rationale for this change

Described in the issue, when the input type is utf8view for initcap, so should the return type. The actual return type *is* utf8view, so we just need to set it in the `return_type` function to match.

## What changes are included in this PR?

One change to return_type function

## Are these changes tested?

Tested in datafusion-python unit tests. I also updated the unit test macro to validate that data types returned from scalar functions matches those that are expected, which is why this problem was not identified previously.

## Are there any user-facing changes?

None