### PR TITLE
Make it easier to make optimizers: Move join input swapping and related methods into PhysicalOperators

### DIFF
--- a/datafusion/common/src/join_type.rs
+++ b/datafusion/common/src/join_type.rs
@@ -73,6 +73,40 @@ impl JoinType {
     pub fn is_outer(self) -> bool {
         self == JoinType::Left || self == JoinType::Right || self == JoinType::Full
     }
+
+    /// Returns the `JoinType` if the (2) inputs were swapped
+    ///
+    /// Panics if [`Self::supports_swap`] returns false
+    pub fn swap(&self) -> JoinType {
+        match self {
+            JoinType::Inner => JoinType::Inner,
+            JoinType::Full => JoinType::Full,
+            JoinType::Left => JoinType::Right,
+            JoinType::Right => JoinType::Left,
+            JoinType::LeftSemi => JoinType::RightSemi,
+            JoinType::RightSemi => JoinType::LeftSemi,
+            JoinType::LeftAnti => JoinType::RightAnti,
+            JoinType::RightAnti => JoinType::LeftAnti,
+            JoinType::LeftMark => {
+                unreachable!("LeftMark join type does not support swapping")
+            }
+        }
+    }
+
+    /// Does the join type support swapping  inputs?
+    pub fn supports_swap(&self) -> bool {
+        matches!(
+            self,
+            JoinType::Inner
+                | JoinType::Left
+                | JoinType::Right
+                | JoinType::Full
+                | JoinType::LeftSemi
+                | JoinType::RightSemi
+                | JoinType::LeftAnti
+                | JoinType::RightAnti
+        )
+    }
 }
 
 impl Display for JoinType {

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::task::Poll;
 use std::{any::Any, vec};
 
-use super::utils::asymmetric_join_output_partitioning;
+use super::utils::{asymmetric_join_output_partitioning, reorder_output_after_swap};
 use super::{
     utils::{OnceAsync, OnceFut},
     PartitionMode,
@@ -566,8 +566,87 @@ impl HashJoinExec {
             boundedness_from_children([left, right]),
         ))
     }
+
+    /// Returns a new `ExecutionPlan` that computes the same join as this one,
+    /// with the left and right inputs swapped using the  specified
+    /// `partition_mode`.
+    ///
+    /// # Notes:
+    ///
+    /// This function is public so other downstream projects can use it to
+    /// construct `HashJoinExec` with right side as the build side.
+    pub fn swap_inputs(
+        &self,
+        partition_mode: PartitionMode,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let left = self.left();
+        let right = self.right();
+        let new_join = HashJoinExec::try_new(
+            Arc::clone(right),
+            Arc::clone(left),
+            self.on()
+                .iter()
+                .map(|(l, r)| (Arc::clone(r), Arc::clone(l)))
+                .collect(),
+            self.filter().map(JoinFilter::swap),
+            &self.join_type().swap(),
+            swap_join_projection(
+                left.schema().fields().len(),
+                right.schema().fields().len(),
+                self.projection.as_ref(),
+                self.join_type(),
+            ),
+            partition_mode,
+            self.null_equals_null(),
+        )?;
+        // In case of anti / semi joins or if there is embedded projection in HashJoinExec, output column order is preserved, no need to add projection again
+        if matches!(
+            self.join_type(),
+            JoinType::LeftSemi
+                | JoinType::RightSemi
+                | JoinType::LeftAnti
+                | JoinType::RightAnti
+        ) || self.projection.is_some()
+        {
+            Ok(Arc::new(new_join))
+        } else {
+            reorder_output_after_swap(Arc::new(new_join), &left.schema(), &right.schema())
+        }
+    }
 }
 
+/// This function swaps the given join's projection.
+fn swap_join_projection(
+    left_schema_len: usize,
+    right_schema_len: usize,
+    projection: Option<&Vec<usize>>,
+    join_type: &JoinType,
+) -> Option<Vec<usize>> {
+    match join_type {
+        // For Anti/Semi join types, projection should remain unmodified,
+        // since these joins output schema remains the same after swap
+        JoinType::LeftAnti
+        | JoinType::LeftSemi
+        | JoinType::RightAnti
+        | JoinType::RightSemi => projection.cloned(),
+
+        _ => projection.map(|p| {
+            p.iter()
+                .map(|i| {
+                    // If the index is less than the left schema length, it is from
+                    // the left schema, so we add the right schema length to it.
+                    // Otherwise, it is from the right schema, so we subtract the left
+                    // schema length from it.
+                    if *i < left_schema_len {
+                        *i + right_schema_len
+                    } else {
+                        *i - left_schema_len
+                    }
+                })
+                .collect()
+        }),
+    }
+}
 impl DisplayAs for HashJoinExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
         match t {

--- a/datafusion/physical-plan/src/joins/join_filter.rs
+++ b/datafusion/physical-plan/src/joins/join_filter.rs
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::joins::utils::ColumnIndex;
+use arrow_schema::Schema;
+use datafusion_common::JoinSide;
+use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
+use std::sync::Arc;
+
+/// Filter applied before join output. Fields are crate-public to allow
+/// downstream implementations to experiment with custom joins.
+#[derive(Debug, Clone)]
+pub struct JoinFilter {
+    /// Filter expression
+    pub(crate) expression: Arc<dyn PhysicalExpr>,
+    /// Column indices required to construct intermediate batch for filtering
+    pub(crate) column_indices: Vec<ColumnIndex>,
+    /// Physical schema of intermediate batch
+    pub(crate) schema: Schema,
+}
+
+impl JoinFilter {
+    /// Creates new JoinFilter
+    pub fn new(
+        expression: Arc<dyn PhysicalExpr>,
+        column_indices: Vec<ColumnIndex>,
+        schema: Schema,
+    ) -> JoinFilter {
+        JoinFilter {
+            expression,
+            column_indices,
+            schema,
+        }
+    }
+
+    /// Helper for building ColumnIndex vector from left and right indices
+    pub fn build_column_indices(
+        left_indices: Vec<usize>,
+        right_indices: Vec<usize>,
+    ) -> Vec<ColumnIndex> {
+        left_indices
+            .into_iter()
+            .map(|i| ColumnIndex {
+                index: i,
+                side: JoinSide::Left,
+            })
+            .chain(right_indices.into_iter().map(|i| ColumnIndex {
+                index: i,
+                side: JoinSide::Right,
+            }))
+            .collect()
+    }
+
+    /// Filter expression
+    pub fn expression(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.expression
+    }
+
+    /// Column indices for intermediate batch creation
+    pub fn column_indices(&self) -> &[ColumnIndex] {
+        &self.column_indices
+    }
+
+    /// Intermediate batch schema
+    pub fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    /// Rewrites the join filter if the inputs to the join are rewritten
+    pub fn swap(&self) -> JoinFilter {
+        let column_indices = self
+            .column_indices()
+            .iter()
+            .map(|idx| ColumnIndex {
+                index: idx.index,
+                side: idx.side.negate(),
+            })
+            .collect();
+
+        JoinFilter::new(
+            Arc::clone(self.expression()),
+            column_indices,
+            self.schema().clone(),
+        )
+    }
+}

--- a/datafusion/physical-plan/src/joins/mod.rs
+++ b/datafusion/physical-plan/src/joins/mod.rs
@@ -31,18 +31,20 @@ mod stream_join_utils;
 mod symmetric_hash_join;
 pub mod utils;
 
+mod join_filter;
 #[cfg(test)]
 pub mod test_utils;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-/// Partitioning mode to use for hash join
+/// Hash join Partitioning mode
 pub enum PartitionMode {
     /// Left/right children are partitioned using the left and right keys
     Partitioned,
     /// Left side will collected into one partition
     CollectLeft,
-    /// When set to Auto, DataFusion optimizer will decide which PartitionMode mode(Partitioned/CollectLeft) is optimal based on statistics.
-    /// It will also consider swapping the left and right inputs for the Join
+    /// DataFusion optimizer decides which PartitionMode
+    /// mode(Partitioned/CollectLeft) is optimal based on statistics. It will
+    /// also consider swapping the left and right inputs for the Join
     Auto,
 }
 

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -29,6 +29,8 @@ use crate::metrics::{self, ExecutionPlanMetricsSet, MetricBuilder};
 use crate::{
     ColumnStatistics, ExecutionPlan, ExecutionPlanProperties, Partitioning, Statistics,
 };
+// compatibility
+pub use super::join_filter::JoinFilter;
 
 use arrow::array::{
     downcast_array, new_null_array, Array, BooleanBufferBuilder, UInt32Array,
@@ -54,6 +56,7 @@ use datafusion_physical_expr::{
     LexOrdering, PhysicalExpr, PhysicalExprRef, PhysicalSortExpr,
 };
 
+use crate::projection::ProjectionExec;
 use futures::future::{BoxFuture, Shared};
 use futures::{ready, FutureExt};
 use hashbrown::raw::RawTable;
@@ -547,66 +550,6 @@ pub struct ColumnIndex {
     pub index: usize,
     /// Whether the column is at the left or right side
     pub side: JoinSide,
-}
-
-/// Filter applied before join output. Fields are crate-public to allow
-/// downstream implementations to experiment with custom joins.
-#[derive(Debug, Clone)]
-pub struct JoinFilter {
-    /// Filter expression
-    pub(crate) expression: Arc<dyn PhysicalExpr>,
-    /// Column indices required to construct intermediate batch for filtering
-    pub(crate) column_indices: Vec<ColumnIndex>,
-    /// Physical schema of intermediate batch
-    pub(crate) schema: Schema,
-}
-
-impl JoinFilter {
-    /// Creates new JoinFilter
-    pub fn new(
-        expression: Arc<dyn PhysicalExpr>,
-        column_indices: Vec<ColumnIndex>,
-        schema: Schema,
-    ) -> JoinFilter {
-        JoinFilter {
-            expression,
-            column_indices,
-            schema,
-        }
-    }
-
-    /// Helper for building ColumnIndex vector from left and right indices
-    pub fn build_column_indices(
-        left_indices: Vec<usize>,
-        right_indices: Vec<usize>,
-    ) -> Vec<ColumnIndex> {
-        left_indices
-            .into_iter()
-            .map(|i| ColumnIndex {
-                index: i,
-                side: JoinSide::Left,
-            })
-            .chain(right_indices.into_iter().map(|i| ColumnIndex {
-                index: i,
-                side: JoinSide::Right,
-            }))
-            .collect()
-    }
-
-    /// Filter expression
-    pub fn expression(&self) -> &Arc<dyn PhysicalExpr> {
-        &self.expression
-    }
-
-    /// Column indices for intermediate batch creation
-    pub fn column_indices(&self) -> &[ColumnIndex] {
-        &self.column_indices
-    }
-
-    /// Intermediate batch schema
-    pub fn schema(&self) -> &Schema {
-        &self.schema
-    }
 }
 
 /// Returns the output field given the input field. Outer joins may
@@ -1788,6 +1731,50 @@ impl BatchTransformer for BatchSplitter {
     }
 }
 
+/// When the order of the join inputs are changed, the output order of columns
+/// must remain the same.
+///
+/// Joins output columns from their left input followed by their right input.
+/// Thus if the inputs are reordered, the output columns must be reordered to
+/// match the original order.
+pub(crate) fn reorder_output_after_swap(
+    plan: Arc<dyn ExecutionPlan>,
+    left_schema: &Schema,
+    right_schema: &Schema,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let proj = ProjectionExec::try_new(
+        swap_reverting_projection(left_schema, right_schema),
+        plan,
+    )?;
+    Ok(Arc::new(proj))
+}
+
+/// When the order of the join is changed, the output order of columns must
+/// remain the same.
+///
+/// Returns the expressions that will allow to swap back the values from the
+/// original left as the first columns and those on the right next.
+fn swap_reverting_projection(
+    left_schema: &Schema,
+    right_schema: &Schema,
+) -> Vec<(Arc<dyn PhysicalExpr>, String)> {
+    let right_cols = right_schema.fields().iter().enumerate().map(|(i, f)| {
+        (
+            Arc::new(Column::new(f.name(), i)) as Arc<dyn PhysicalExpr>,
+            f.name().to_owned(),
+        )
+    });
+    let right_len = right_cols.len();
+    let left_cols = left_schema.fields().iter().enumerate().map(|(i, f)| {
+        (
+            Arc::new(Column::new(f.name(), right_len + i)) as Arc<dyn PhysicalExpr>,
+            f.name().to_owned(),
+        )
+    });
+
+    left_cols.chain(right_cols).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::pin::Pin;
@@ -2753,5 +2740,40 @@ mod tests {
 
         assert!(splitter.next().is_none());
         assert_split_batches(batches, batch_size, num_rows);
+    }
+
+    #[tokio::test]
+    async fn test_swap_reverting_projection() {
+        let left_schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]);
+
+        let right_schema = Schema::new(vec![Field::new("c", DataType::Int32, false)]);
+
+        let proj = swap_reverting_projection(&left_schema, &right_schema);
+
+        assert_eq!(proj.len(), 3);
+
+        let (col, name) = &proj[0];
+        assert_eq!(name, "a");
+        assert_col_expr(col, "a", 1);
+
+        let (col, name) = &proj[1];
+        assert_eq!(name, "b");
+        assert_col_expr(col, "b", 2);
+
+        let (col, name) = &proj[2];
+        assert_eq!(name, "c");
+        assert_col_expr(col, "c", 0);
+    }
+
+    fn assert_col_expr(expr: &Arc<dyn PhysicalExpr>, name: &str, index: usize) {
+        let col = expr
+            .as_any()
+            .downcast_ref::<Column>()
+            .expect("Projection items should be Column expression");
+        assert_eq!(col.name(), name);
+        assert_eq!(col.index(), index);
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

I want to make it as easy as possible for people to implement (join order) optimizers on top of DataFusion (for example, https://github.com/cmu-db/optd, though I fully admit I have failed so far to get them to engage with us)

However, some of the key building blocks of such optimizations like swapping join inputs, are crate internal APIs of the very basic join ordering optimizer included with DataFusion. Thus it will be hard for others to find and use this cdoe

Some additional evidence there is demand for these functions is 
- this PR (that makes them more visible for use in forks) https://github.com/apache/datafusion/pull/13893 from @berkaysynnada 
- `swap_hash_join` is used in comet: https://github.com/apache/datafusion/pull/13899

Making the functions public and on the `Exec`s they are used for will make it even easier to find and use

This also makes the datafusion core crate a tiny bit smaller which should help compile times



## What changes are included in this PR?

There are no functional changes, this PR just moves code around

1. Create HashJoinExec::swap_inputs, `NestedLoopsJoinExec::swap_inputs`, and `CrossJoinExec::swap_inputs`
2. Refactor JoinSelection to use those functions
2. Extract JoinFilter into its own module, and move `swap` and `can_swap` there
4. Deprecate existing functions 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
