### PR TITLE
Custom scalar to sql overrides support for DuckDB Unparser dialect

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -153,6 +153,18 @@ pub trait Dialect: Send + Sync {
         Ok(None)
     }
 
+    /// Extends the dialect's default rules for unparsing scalar functions.
+    /// This is useful for supporting application-specific UDFs or custom engine extensions.
+    fn with_custom_scalar_overrides(
+        self,
+        _handlers: Vec<(&str, ScalarFnToSqlHandler)>,
+    ) -> Self
+    where
+        Self: Sized,
+    {
+        unimplemented!("Custom scalar overrides are not supported by this dialect yet");
+    }
+
     /// Allow to unparse a qualified column with a full qualified name
     /// (e.g. catalog_name.schema_name.table_name.column_name)
     /// Otherwise, the column will be unparsed with only the table name and column name
@@ -320,17 +332,6 @@ impl DuckDBDialect {
             custom_scalar_fn_overrides: HashMap::new(),
         }
     }
-
-    pub fn with_custom_scalar_overrides(
-        mut self,
-        handlers: Vec<(&str, ScalarFnToSqlHandler)>,
-    ) -> Self {
-        for (func_name, handler) in handlers {
-            self.custom_scalar_fn_overrides
-                .insert(func_name.to_string(), handler);
-        }
-        self
-    }
 }
 
 impl Dialect for DuckDBDialect {
@@ -344,6 +345,17 @@ impl Dialect for DuckDBDialect {
 
     fn division_operator(&self) -> BinaryOperator {
         BinaryOperator::DuckIntegerDivide
+    }
+
+    fn with_custom_scalar_overrides(
+        mut self,
+        handlers: Vec<(&str, ScalarFnToSqlHandler)>,
+    ) -> Self {
+        for (func_name, handler) in handlers {
+            self.custom_scalar_fn_overrides
+                .insert(func_name.to_string(), handler);
+        }
+        self
     }
 
     fn scalar_function_to_sql_overrides(


### PR DESCRIPTION
## Which issue does this PR close?

Unparser does not currently support extending dialect with custom handlers for internal UDFs or new engine extensions. Possible workarounds here are creating a custom dialect wrapper around original dialect with overrided `scalar_function_to_sql_overrides` or using `CustomDialect`. This is not very convenient and robust as requires tracking changes to the main dialect and reflecting the same improvements in the custom dialect.

## Rationale for this change

Propose introducing  a pattern and approach for extending `scalar_function_to_sql_overrides` for dialects with additional handlers, example usage.

```rust
/// Create a new instance of the `DuckDB` dialect with support of custom internal UDFs
let dialect = DuckDBDialect::new().with_custom_scalar_overrides(vec![(
    "cosine_distance",
    Box::new(duckdb::cosine_distance_to_sql) as ScalarFnToSqlHandler,
)]);
``` 

## What changes are included in this PR?

PR introduces new pattern for extending dialects with custom `scalar_function_to_sql_overrides` handlers  starting from  DuckDB that could be extended to other dialects next 

```rust
pub type ScalarFnToSqlHandler = Box<dyn Fn(&Unparser, &[Expr]) -> Result<Option<ast::Expr>> + Send + Sync>;

pub fn with_custom_scalar_overrides(
        mut self,
        handlers: Vec<(&str, ScalarFnToSqlHandler)>,
    ) -> Self {
        ...
        self
    }
```

## Are these changes tested?

Added unit test `test_custom_scalar_overrides_duckdb`

## Are there any user-facing changes?

Breaking change: as we are adding additional field to DuckDB dialect, existing approach to construct `DuckDBDialect {}` can't be used and needs to be updated to `DuckDBDialect::new()`
