### PR TITLE
doc-gen: migrate scalar functions (string) documentation 4/4

### DIFF
--- a/datafusion/functions/src/unicode/left.rs
+++ b/datafusion/functions/src/unicode/left.rs
@@ -17,7 +17,7 @@
 
 use std::any::Any;
 use std::cmp::Ordering;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use arrow::array::{
     Array, ArrayAccessor, ArrayIter, ArrayRef, GenericStringArray, Int64Array,
@@ -31,12 +31,28 @@ use datafusion_common::cast::{
 };
 use datafusion_common::exec_err;
 use datafusion_common::Result;
-use datafusion_expr::scalar_doc_sections::DOC_SECTION_STRING;
 use datafusion_expr::TypeSignature::Exact;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
+use datafusion_macros::user_doc;
 
+#[user_doc(
+    doc_section(label = "String Functions"),
+    description = "Returns a specified number of characters from the left side of a string.",
+    syntax_example = "left(str, n)",
+    sql_example = r#"```sql
+> select left('datafusion', 4);
++-----------------------------------+
+| left(Utf8("datafusion"),Int64(4)) |
++-----------------------------------+
+| data                              |
++-----------------------------------+
+```"#,
+    standard_argument(name = "str", prefix = "String"),
+    argument(name = "n", description = "Number of characters to return."),
+    related_udf(name = "right")
+)]
 #[derive(Debug)]
 pub struct LeftFunc {
     signature: Signature,
@@ -99,34 +115,8 @@ impl ScalarUDFImpl for LeftFunc {
     }
 
     fn documentation(&self) -> Option<&Documentation> {
-        Some(get_left_doc())
+        self.doc()
     }
-}
-
-static DOCUMENTATION: OnceLock<Documentation> = OnceLock::new();
-
-fn get_left_doc() -> &'static Documentation {
-    DOCUMENTATION.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_STRING,
-            "Returns a specified number of characters from the left side of a string.",
-            "left(str, n)",
-        )
-        .with_sql_example(
-            r#"```sql
-> select left('datafusion', 4);
-+-----------------------------------+
-| left(Utf8("datafusion"),Int64(4)) |
-+-----------------------------------+
-| data                              |
-+-----------------------------------+
-```"#,
-        )
-        .with_standard_argument("str", Some("String"))
-        .with_argument("n", "Number of characters to return.")
-        .with_related_udf("right")
-        .build()
-    })
 }
 
 /// Returns first n characters in the string, or when n is negative, returns all but last |n| characters.

--- a/datafusion/functions/src/unicode/lpad.rs
+++ b/datafusion/functions/src/unicode/lpad.rs
@@ -50,7 +50,7 @@ use datafusion_macros::user_doc;
 +---------------------------------------------+
 ```"#,
     standard_argument(name = "str", prefix = "String"),
-    argument(name = "n", description = "String length to pad to"),
+    argument(name = "n", description = "String length to pad to."),
     argument(
         name = "padding_str",
         description = "Optional string expression to pad with. Can be a constant, column, or function, and any combination of string operators. _Default is a space._"

--- a/datafusion/functions/src/unicode/right.rs
+++ b/datafusion/functions/src/unicode/right.rs
@@ -17,7 +17,7 @@
 
 use std::any::Any;
 use std::cmp::{max, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use arrow::array::{
     Array, ArrayAccessor, ArrayIter, ArrayRef, GenericStringArray, Int64Array,
@@ -31,12 +31,28 @@ use datafusion_common::cast::{
 };
 use datafusion_common::exec_err;
 use datafusion_common::Result;
-use datafusion_expr::scalar_doc_sections::DOC_SECTION_STRING;
 use datafusion_expr::TypeSignature::Exact;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
+use datafusion_macros::user_doc;
 
+#[user_doc(
+    doc_section(label = "String Functions"),
+    description = "Returns a specified number of characters from the right side of a string.",
+    syntax_example = "right(str, n)",
+    sql_example = r#"```sql
+> select right('datafusion', 6);
++------------------------------------+
+| right(Utf8("datafusion"),Int64(6)) |
++------------------------------------+
+| fusion                             |
++------------------------------------+
+```"#,
+    standard_argument(name = "str", prefix = "String"),
+    argument(name = "n", description = "Number of characters to return."),
+    related_udf(name = "left")
+)]
 #[derive(Debug)]
 pub struct RightFunc {
     signature: Signature,
@@ -99,34 +115,8 @@ impl ScalarUDFImpl for RightFunc {
     }
 
     fn documentation(&self) -> Option<&Documentation> {
-        Some(get_right_doc())
+        self.doc()
     }
-}
-
-static DOCUMENTATION: OnceLock<Documentation> = OnceLock::new();
-
-fn get_right_doc() -> &'static Documentation {
-    DOCUMENTATION.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_STRING,
-            "Returns a specified number of characters from the right side of a string.",
-            "right(str, n)",
-        )
-        .with_sql_example(
-            r#"```sql
-> select right('datafusion', 6);
-+------------------------------------+
-| right(Utf8("datafusion"),Int64(6)) |
-+------------------------------------+
-| fusion                             |
-+------------------------------------+
-```"#,
-        )
-        .with_standard_argument("str", Some("String"))
-        .with_argument("n", "Number of characters to return")
-        .with_related_udf("left")
-        .build()
-    })
 }
 
 /// Returns last n characters in the string, or when n is negative, returns all but first |n| characters.

--- a/datafusion/functions/src/unicode/rpad.rs
+++ b/datafusion/functions/src/unicode/rpad.rs
@@ -25,17 +25,37 @@ use arrow::datatypes::DataType;
 use datafusion_common::cast::as_int64_array;
 use datafusion_common::DataFusionError;
 use datafusion_common::{exec_err, Result};
-use datafusion_expr::scalar_doc_sections::DOC_SECTION_STRING;
 use datafusion_expr::TypeSignature::Exact;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
+use datafusion_macros::user_doc;
 use std::any::Any;
 use std::fmt::Write;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use unicode_segmentation::UnicodeSegmentation;
 use DataType::{LargeUtf8, Utf8, Utf8View};
 
+#[user_doc(
+    doc_section(label = "String Functions"),
+    description = "Pads the right side of a string with another string to a specified string length.",
+    syntax_example = "rpad(str, n[, padding_str])",
+    sql_example = r#"```sql
+>  select rpad('datafusion', 20, '_-');
++-----------------------------------------------+
+| rpad(Utf8("datafusion"),Int64(20),Utf8("_-")) |
++-----------------------------------------------+
+| datafusion_-_-_-_-_-                          |
++-----------------------------------------------+
+```"#,
+    standard_argument(name = "str", prefix = "String"),
+    argument(name = "n", description = "String length to pad to."),
+    argument(
+        name = "padding_str",
+        description = "String expression to pad with. Can be a constant, column, or function, and any combination of string operators. _Default is a space._"
+    ),
+    related_udf(name = "lpad")
+)]
 #[derive(Debug)]
 pub struct RPadFunc {
     signature: Signature,
@@ -122,36 +142,8 @@ impl ScalarUDFImpl for RPadFunc {
     }
 
     fn documentation(&self) -> Option<&Documentation> {
-        Some(get_rpad_doc())
+        self.doc()
     }
-}
-
-static DOCUMENTATION: OnceLock<Documentation> = OnceLock::new();
-
-fn get_rpad_doc() -> &'static Documentation {
-    DOCUMENTATION.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_STRING,
-            "Pads the right side of a string with another string to a specified string length.",
-            "rpad(str, n[, padding_str])")
-            .with_sql_example(r#"```sql
->  select rpad('datafusion', 20, '_-');
-+-----------------------------------------------+
-| rpad(Utf8("datafusion"),Int64(20),Utf8("_-")) |
-+-----------------------------------------------+
-| datafusion_-_-_-_-_-                          |
-+-----------------------------------------------+
-```"#)
-            .with_standard_argument(
-                "str",
-                Some("String"),
-            )
-            .with_argument("n", "String length to pad to.")
-            .with_argument("padding_str",
-                           "String expression to pad with. Can be a constant, column, or function, and any combination of string operators. _Default is a space._")
-            .with_related_udf("lpad")
-            .build()
-    })
 }
 
 pub fn rpad<StringArrayLen: OffsetSizeTrait, FillArrayLen: OffsetSizeTrait>(

--- a/datafusion/functions/src/unicode/strpos.rs
+++ b/datafusion/functions/src/unicode/strpos.rs
@@ -16,18 +16,34 @@
 // under the License.
 
 use std::any::Any;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use crate::strings::StringArrayType;
 use crate::utils::{make_scalar_function, utf8_to_int_type};
 use arrow::array::{ArrayRef, ArrowPrimitiveType, AsArray, PrimitiveArray};
 use arrow::datatypes::{ArrowNativeType, DataType, Int32Type, Int64Type};
 use datafusion_common::{exec_err, Result};
-use datafusion_expr::scalar_doc_sections::DOC_SECTION_STRING;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
+use datafusion_macros::user_doc;
 
+#[user_doc(
+    doc_section(label = "String Functions"),
+    description = "Returns the starting position of a specified substring in a string. Positions begin at 1. If the substring does not exist in the string, the function returns 0.",
+    syntax_example = "strpos(str, substr)",
+    alternative_syntax = "position(substr in origstr)",
+    sql_example = r#"```sql
+> select strpos('datafusion', 'fus');
++----------------------------------------+
+| strpos(Utf8("datafusion"),Utf8("fus")) |
++----------------------------------------+
+| 5                                      |
++----------------------------------------+ 
+```"#,
+    standard_argument(name = "str", prefix = "String"),
+    argument(name = "substr", description = "Substring expression to search for.")
+)]
 #[derive(Debug)]
 pub struct StrposFunc {
     signature: Signature,
@@ -79,31 +95,8 @@ impl ScalarUDFImpl for StrposFunc {
     }
 
     fn documentation(&self) -> Option<&Documentation> {
-        Some(get_strpos_doc())
+        self.doc()
     }
-}
-
-static DOCUMENTATION: OnceLock<Documentation> = OnceLock::new();
-
-fn get_strpos_doc() -> &'static Documentation {
-    DOCUMENTATION.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_STRING,
-            "Returns the starting position of a specified substring in a string. Positions begin at 1. If the substring does not exist in the string, the function returns 0.",
-            "strpos(str, substr)")
-            .with_sql_example(r#"```sql
-> select strpos('datafusion', 'fus');
-+----------------------------------------+
-| strpos(Utf8("datafusion"),Utf8("fus")) |
-+----------------------------------------+
-| 5                                      |
-+----------------------------------------+ 
-```"#)
-            .with_standard_argument("str", Some("String"))
-            .with_argument("substr", "Substring expression to search for.")
-            .with_alternative_syntax("position(substr in origstr)")
-            .build()
-    })
 }
 
 fn strpos(args: &[ArrayRef]) -> Result<ArrayRef> {

--- a/datafusion/functions/src/unicode/substr.rs
+++ b/datafusion/functions/src/unicode/substr.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::any::Any;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use crate::strings::{make_and_append_view, StringArrayType};
 use crate::utils::{make_scalar_function, utf8_to_str_type};
@@ -28,11 +28,34 @@ use arrow::datatypes::DataType;
 use arrow_buffer::{NullBufferBuilder, ScalarBuffer};
 use datafusion_common::cast::as_int64_array;
 use datafusion_common::{exec_err, plan_err, Result};
-use datafusion_expr::scalar_doc_sections::DOC_SECTION_STRING;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
+use datafusion_macros::user_doc;
 
+#[user_doc(
+    doc_section(label = "String Functions"),
+    description = "Extracts a substring of a specified number of characters from a specific starting position in a string.",
+    syntax_example = "substr(str, start_pos[, length])",
+    alternative_syntax = "substring(str from start_pos for length)",
+    sql_example = r#"```sql
+> select substr('datafusion', 5, 3);
++----------------------------------------------+
+| substr(Utf8("datafusion"),Int64(5),Int64(3)) |
++----------------------------------------------+
+| fus                                          |
++----------------------------------------------+ 
+```"#,
+    standard_argument(name = "str", prefix = "String"),
+    argument(
+        name = "start_pos",
+        description = "Character position to start the substring at. The first character in the string has a position of 1."
+    ),
+    argument(
+        name = "length",
+        description = "Number of characters to extract. If not specified, returns the rest of the string after the start position."
+    )
+)]
 #[derive(Debug)]
 pub struct SubstrFunc {
     signature: Signature,
@@ -154,32 +177,8 @@ impl ScalarUDFImpl for SubstrFunc {
     }
 
     fn documentation(&self) -> Option<&Documentation> {
-        Some(get_substr_doc())
+        self.doc()
     }
-}
-
-static DOCUMENTATION: OnceLock<Documentation> = OnceLock::new();
-
-fn get_substr_doc() -> &'static Documentation {
-    DOCUMENTATION.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_STRING,
-            "Extracts a substring of a specified number of characters from a specific starting position in a string.",
-            "substr(str, start_pos[, length])")
-            .with_sql_example(r#"```sql
-> select substr('datafusion', 5, 3);
-+----------------------------------------------+
-| substr(Utf8("datafusion"),Int64(5),Int64(3)) |
-+----------------------------------------------+
-| fus                                          |
-+----------------------------------------------+ 
-```"#)
-            .with_standard_argument("str", Some("String"))
-            .with_argument("start_pos", "Character position to start the substring at. The first character in the string has a position of 1.")
-            .with_argument("length", "Number of characters to extract. If not specified, returns the rest of the string after the start position.")
-            .with_alternative_syntax("substring(str from start_pos for length)")
-            .build()
-    })
 }
 
 /// Extracts the substring of string starting at the start'th character, and extending for count characters if that is specified. (Same as substring(string from start for count).)

--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::any::Any;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use arrow::array::{
     ArrayAccessor, ArrayIter, ArrayRef, ArrowPrimitiveType, AsArray, OffsetSizeTrait,
@@ -26,12 +26,42 @@ use arrow::datatypes::{DataType, Int32Type, Int64Type};
 
 use crate::utils::{make_scalar_function, utf8_to_str_type};
 use datafusion_common::{exec_err, Result};
-use datafusion_expr::scalar_doc_sections::DOC_SECTION_STRING;
 use datafusion_expr::TypeSignature::Exact;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
+use datafusion_macros::user_doc;
 
+#[user_doc(
+    doc_section(label = "String Functions"),
+    description = r#"Returns the substring from str before count occurrences of the delimiter delim.
+If count is positive, everything to the left of the final delimiter (counting from the left) is returned.
+If count is negative, everything to the right of the final delimiter (counting from the right) is returned."#,
+    syntax_example = "substr(str, start_pos[, length])",
+    sql_example = r#"```sql
+> select substr_index('www.apache.org', '.', 1);
++---------------------------------------------------------+
+| substr_index(Utf8("www.apache.org"),Utf8("."),Int64(1)) |
++---------------------------------------------------------+
+| www                                                     |
++---------------------------------------------------------+
+> select substr_index('www.apache.org', '.', -1);
++----------------------------------------------------------+
+| substr_index(Utf8("www.apache.org"),Utf8("."),Int64(-1)) |
++----------------------------------------------------------+
+| org                                                      |
++----------------------------------------------------------+
+```"#,
+    standard_argument(name = "str", prefix = "String"),
+    argument(
+        name = "delim",
+        description = "The string to find in str to split str."
+    ),
+    argument(
+        name = "count",
+        description = "The number of times to search for the delimiter. Can be either a positive or negative number."
+    )
+)]
 #[derive(Debug)]
 pub struct SubstrIndexFunc {
     signature: Signature,
@@ -91,39 +121,8 @@ impl ScalarUDFImpl for SubstrIndexFunc {
     }
 
     fn documentation(&self) -> Option<&Documentation> {
-        Some(get_substr_index_doc())
+        self.doc()
     }
-}
-
-static DOCUMENTATION: OnceLock<Documentation> = OnceLock::new();
-
-fn get_substr_index_doc() -> &'static Documentation {
-    DOCUMENTATION.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_STRING,
-            r#"Returns the substring from str before count occurrences of the delimiter delim.
-If count is positive, everything to the left of the final delimiter (counting from the left) is returned.
-If count is negative, everything to the right of the final delimiter (counting from the right) is returned."#,
-            "substr_index(str, delim, count)")
-            .with_sql_example(r#"```sql
-> select substr_index('www.apache.org', '.', 1);
-+---------------------------------------------------------+
-| substr_index(Utf8("www.apache.org"),Utf8("."),Int64(1)) |
-+---------------------------------------------------------+
-| www                                                     |
-+---------------------------------------------------------+
-> select substr_index('www.apache.org', '.', -1);
-+----------------------------------------------------------+
-| substr_index(Utf8("www.apache.org"),Utf8("."),Int64(-1)) |
-+----------------------------------------------------------+
-| org                                                      |
-+----------------------------------------------------------+
-```"#)
-            .with_standard_argument("str", Some("String"))
-            .with_argument("delim", "The string to find in str to split str.")
-            .with_argument("count", "The number of times to search for the delimiter. Can be either a positive or negative number.")
-            .build()
-    })
 }
 
 /// Returns the substring from str before count occurrences of the delimiter delim. If count is positive, everything to the left of the final delimiter (counting from the left) is returned. If count is negative, everything to the right of the final delimiter (counting from the right) is returned.

--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -37,7 +37,7 @@ use datafusion_macros::user_doc;
     description = r#"Returns the substring from str before count occurrences of the delimiter delim.
 If count is positive, everything to the left of the final delimiter (counting from the left) is returned.
 If count is negative, everything to the right of the final delimiter (counting from the right) is returned."#,
-    syntax_example = "substr(str, start_pos[, length])",
+    syntax_example = "substr_index(str, delim, count)",
     sql_example = r#"```sql
 > select substr_index('www.apache.org', '.', 1);
 +---------------------------------------------------------+

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -1369,7 +1369,7 @@ right(str, n)
 #### Arguments
 
 - **str**: String expression to operate on. Can be a constant, column, or function, and any combination of operators.
-- **n**: Number of characters to return
+- **n**: Number of characters to return.
 
 #### Example
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #13671 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
As discussed in #13671  , this PR will migrate the parts of builtin string functions documentation that currently support migration.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
