### PR TITLE
Remove partition_mode parameter from HashJoinExec::swap_inputs

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -576,10 +576,7 @@ impl HashJoinExec {
     ///
     /// This function is public so other downstream projects can use it to
     /// construct `HashJoinExec` with right side as the build side.
-    pub fn swap_inputs(
-        &self,
-        partition_mode: PartitionMode,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
+    pub fn swap_inputs(&self) -> Result<Arc<dyn ExecutionPlan>> {
         let left = self.left();
         let right = self.right();
         let new_join = HashJoinExec::try_new(
@@ -597,7 +594,7 @@ impl HashJoinExec {
                 self.projection.as_ref(),
                 self.join_type(),
             ),
-            partition_mode,
+            *self.partition_mode(),
             self.null_equals_null(),
         )?;
         // In case of anti / semi joins or if there is embedded projection in HashJoinExec, output column order is preserved, no need to add projection again


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Test out the question of "why bother to pass this parameter" from @berkaysynnada  on https://github.com/apache/datafusion/pull/13910#discussion_r1898451972

## What changes are included in this PR?

1, Remove partition_mode parameter from HashJoinExec::swap_inputs

## Are these changes tested?

By CI

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
