### PR TITLE
 Revert "Update sqllogictest requirement from 0.24.0 to 0.25.0 (#13917)"

### DIFF
--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -51,7 +51,7 @@ object_store = { workspace = true }
 postgres-protocol = { version = "0.6.7", optional = true }
 postgres-types = { version = "0.2.8", features = ["derive", "with-chrono-0_4"], optional = true }
 rust_decimal = { version = "1.36.0", features = ["tokio-pg"] }
-sqllogictest = "0.25.0"
+sqllogictest = "0.24.0"
 sqlparser = { workspace = true }
 tempfile = { workspace = true }
 thiserror = "2.0.0"

--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -51,7 +51,9 @@ object_store = { workspace = true }
 postgres-protocol = { version = "0.6.7", optional = true }
 postgres-types = { version = "0.2.8", features = ["derive", "with-chrono-0_4"], optional = true }
 rust_decimal = { version = "1.36.0", features = ["tokio-pg"] }
-sqllogictest = "0.24.0"
+# Pin to 0.24 until labels are supported
+# See https://github.com/risinglightdb/sqllogictest-rs/issues/242
+sqllogictest = "=0.24.0"
 sqlparser = { workspace = true }
 tempfile = { workspace = true }
 thiserror = "2.0.0"

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -80,7 +80,7 @@ SELECT col1 * cor0.col1 * 56 AS col1 FROM tab2 AS cor0 GROUP BY cor0.col1
 208376
 94136
 
-query I rowsort
+query I rowsort label-4
 SELECT ALL + tab2.col1 / tab2.col1 FROM tab2 GROUP BY col1
 ----
 1
@@ -442,7 +442,7 @@ SELECT DISTINCT * FROM tab2 AS cor0 GROUP BY cor0.col0, col1, cor0.col2
 91 59 79
 92 41 58
 
-query I rowsort
+query I rowsort label-58
 SELECT 9 / + cor0.col0 AS col1 FROM tab0 AS cor0 GROUP BY cor0.col0, cor0.col2
 ----
 0
@@ -470,7 +470,7 @@ SELECT ( col0 ) FROM tab1 AS cor0 GROUP BY cor0.col0
 28
 82
 
-query I rowsort
+query I rowsort label-62
 SELECT ALL 59 / 26 FROM tab2 AS cor0 GROUP BY cor0.col0
 ----
 2
@@ -558,7 +558,7 @@ SELECT DISTINCT ( - 31 ) col1 FROM tab1 GROUP BY tab1.col0
 ----
 -31
 
-query I rowsort
+query I rowsort label-75
 SELECT + + cor0.col0 / - cor0.col0 FROM tab1, tab0 AS cor0 GROUP BY cor0.col0
 ----
 -1
@@ -767,7 +767,7 @@ SELECT cor0.col2 AS col2 FROM tab0 AS cor0 GROUP BY cor0.col2
 38
 79
 
-query I rowsort
+query I rowsort label-106
 SELECT - 53 / cor0.col0 col0 FROM tab1 cor0 GROUP BY cor0.col0
 ----
 -1
@@ -1326,7 +1326,7 @@ SELECT + ( col0 ) * col0 AS col2 FROM tab2 AS cor0 GROUP BY cor0.col0
 8281
 8464
 
-query I rowsort
+query I rowsort label-188
 SELECT - 21 - + 57 / cor0.col0 FROM tab0 AS cor0 GROUP BY cor0.col0
 ----
 -21
@@ -1429,7 +1429,7 @@ SELECT cor0.col2 FROM tab2 AS cor0 GROUP BY cor0.col2
 79
 87
 
-query I rowsort
+query I rowsort label-203
 SELECT - cor0.col2 + CAST ( 80 AS INTEGER ) FROM tab1 AS cor0 GROUP BY col2
 ----
 35
@@ -1482,7 +1482,7 @@ SELECT DISTINCT + 45 col0 FROM tab1 AS cor0 GROUP BY col0
 ----
 45
 
-query I rowsort
+query I rowsort label-211
 SELECT ALL CAST ( NULL AS INTEGER ) FROM tab2 AS cor0 GROUP BY col1
 ----
 NULL


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Reverts https://github.com/apache/datafusion/pull/13917

## Rationale for this change

- @Omega359 is adding the sqlite sqllogictests in https://github.com/apache/datafusion/pull/13936
- Those tests include labels in the sqlogictest files, but there is an issue with sqllogictest 0.25.0 https://github.com/risinglightdb/sqllogictest-rs/issues/242 that prevents them from working

## What changes are included in this PR?

pin to sqllogictest `0.24.0` and add a note about why

## Are these changes tested?
By CI

## Are there any user-facing changes?

No this is development tooling