### PR TITLE
feat(substrait): introduce consume_rel and consume_expression

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -233,6 +233,8 @@ pub trait SubstraitConsumer: Send + Sync + Sized {
     // These methods have default implementations calling the common handler code, to allow for users
     // to re-use common handling logic.
 
+    /// All [Rel]s to be converted pass through this method.
+    /// You can provide your own implementation if you wish to customize the conversion behaviour.
     async fn consume_rel(&self, rel: &Rel) -> Result<LogicalPlan> {
         from_substrait_rel(self, rel).await
     }
@@ -289,6 +291,8 @@ pub trait SubstraitConsumer: Send + Sync + Sized {
     // These methods have default implementations calling the common handler code, to allow for users
     // to re-use common handling logic.
 
+    /// All [Expression]s to be converted pass through this method.
+    /// You can provide your own implementation if you wish to customize the conversion behaviour.
     async fn consume_expression(
         &self,
         expr: &Expression,
@@ -751,11 +755,9 @@ pub async fn from_substrait_plan_with_consumer(
         1 => {
             match plan.relations[0].rel_type.as_ref() {
                 Some(rt) => match rt {
-                    plan_rel::RelType::Rel(rel) => {
-                        Ok(consumer.consume_rel( rel).await?)
-                    },
+                    plan_rel::RelType::Rel(rel) => Ok(consumer.consume_rel(rel).await?),
                     plan_rel::RelType::Root(root) => {
-                        let plan = consumer.consume_rel( root.input.as_ref().unwrap()).await?;
+                        let plan = consumer.consume_rel(root.input.as_ref().unwrap()).await?;
                         if root.names.is_empty() {
                             // Backwards compatibility for plans missing names
                             return Ok(plan);


### PR DESCRIPTION
## Which issue does this PR close?
Additional work for https://github.com/apache/datafusion/issues/13318

## Rationale for this change
Improve the ergonomics of the consumer and fixed a gap in null literal handling.

## What changes are included in this PR?

### Consumer Improvements
Adds two handlers to the SubstraitConsumer
* `consume_rel`
* `consume_expression`

and routes all calls to `from_substrait_rel` and `from_substrait_rex` through them to allow users to customize behaviour at the Rel and Expression level.

### Null Literal Improvements
The existing code in `from_substrait_null` would fail to handle nulls of user-defined types. The null handling code has been simplified to first convert the type of the null into a DataFusion DataType, which already allows for conversion of user-defined Substrait types using `consume_user_defined_type` and then converting that DataType into a ScalarValue.

As an added benefit, this also allows us to remove a big-match block in `from_substrait_null`.

## Are these changes tested?
Covered by existing conversion tests.

## Are there any user-facing changes?
There are user-facing changes that require not work from uses. There are now additional methods on the SubstraitConsumer trait, but they have default implementations.