### PR TITLE
fix(datafusion-functions-nested): `arrow-distinct` now work with null rows

### DIFF
--- a/datafusion/functions-nested/src/set_ops.rs
+++ b/datafusion/functions-nested/src/set_ops.rs
@@ -518,13 +518,11 @@ fn general_array_distinct<OffsetSize: OffsetSizeTrait>(
     // distinct for each list in ListArray
     for arr in array.iter() {
         let last_offset: OffsetSize = offsets.last().copied().unwrap();
-        if arr.is_none() {
+        let Some(arr) = arr else {
             // Add same offset for null
             offsets.push(last_offset);
             continue;
         }
-
-        let arr = arr.unwrap();
         let values = converter.convert_columns(&[arr])?;
         // sort elements in list and remove duplicates
         let rows = values.iter().sorted().dedup().collect::<Vec<_>>();

--- a/datafusion/functions-nested/src/set_ops.rs
+++ b/datafusion/functions-nested/src/set_ops.rs
@@ -522,7 +522,7 @@ fn general_array_distinct<OffsetSize: OffsetSizeTrait>(
             // Add same offset for null
             offsets.push(last_offset);
             continue;
-        }
+        };
         let values = converter.convert_columns(&[arr])?;
         // sort elements in list and remove duplicates
         let rows = values.iter().sorted().dedup().collect::<Vec<_>>();

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5675,6 +5675,13 @@ statement ok
 drop table t1;
 
 query ?
+select array_distinct(a) from values ([1, 2, 3]), (null), ([1, 3, 1]) as X(a);
+----
+[1, 2, 3]
+NULL
+[1, 3]
+
+query ?
 select array_distinct([]);
 ----
 []


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13961

## What changes are included in this PR?

Just add the last offset in case of null, and migrated the input list nulls to the output

## Are these changes tested?
Yes, and of course created a failing test first, fixed and made sure the test now pass

## Are there any user-facing changes?

not requiring any docs update
