### PR TITLE
docs: Add datafusion python 43.1.0 blog post to events page

### DIFF
--- a/docs/source/user-guide/concepts-readings-events.md
+++ b/docs/source/user-guide/concepts-readings-events.md
@@ -124,6 +124,8 @@ This is a list of DataFusion related blog posts, articles, and other resources. 
 
 ## 📅 Release Notes & Updates
 
+- **2024-09-14** [Apache DataFusion Python 43.1.0 Released](https://datafusion.apache.org/blog/2024/12/14/datafusion-python-43.1.0/)
+
 - **2024-08-24** [Apache DataFusion Python 40.1.0 Released, Significant usability updates](https://datafusion.apache.org/blog/2024/08/20/python-datafusion-40.0.0/)
 
 - **2024-07-24** [DataFusion 40.0.0 Release](https://datafusion.apache.org/blog/2024/07/24/datafusion-40.0.0/)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Adding blog post to doc.

## What changes are included in this PR?

Link to DF python 43.1.0 blog post added.

## Are these changes tested?

Yes.

## Are there any user-facing changes?
