### PR TITLE
Update release README for datafusion-cli publishing

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -292,12 +292,7 @@ Verify that the Cargo.toml in the tarball contains the correct version
 (cd datafusion/proto && cargo publish)
 (cd datafusion/substrait && cargo publish)
 (cd datafusion/ffi && cargo publish)
-```
-
-The CLI needs a `--no-verify` argument because `build.rs` generates source into the `src` directory.
-
-```shell
-(cd datafusion-cli && cargo publish --no-verify)
+(cd datafusion-cli && cargo publish)
 ```
 
 ### Publish datafusion-cli on Homebrew


### PR DESCRIPTION
## Which issue does this PR close?

- related to #13334 

## Rationale for this change

It turns out we no longer need to run `--no-verify` to publish `datafusion-cli` which I discovered while releasing DataFusion 44

https://github.com/apache/datafusion/issues/13334#issuecomment-2567705051

## What changes are included in this PR?

Update release instructions

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
