### PR TITLE
Add swap_inputs to SMJ

### DIFF
--- a/datafusion/core/src/physical_optimizer/join_selection.rs
+++ b/datafusion/core/src/physical_optimizer/join_selection.rs
@@ -552,7 +552,9 @@ fn hash_join_swap_subrule(
 /// [`JoinType::Full`], [`JoinType::Right`], [`JoinType::RightAnti`] and
 /// [`JoinType::RightSemi`] can not run with an unbounded left side, even if
 /// we swap join sides. Therefore, we do not consider them here.
-fn swap_join_according_to_unboundedness(
+/// This function is crate public as it is useful for downstream projects
+/// to implement, or experiment with, their own join selection rules.
+pub(crate) fn swap_join_according_to_unboundedness(
     hash_join: &HashJoinExec,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let partition_mode = hash_join.partition_mode();


### PR DESCRIPTION
## Which issue does this PR close?

None.

## Rationale for this change

The function `swap_inputs` was missing for the SMJ operator. This is a continuation of #13910 that fills this gap.

## What changes are included in this PR?

This PR implements the `swap_inputs` method for the SMJ operator, which basically is the same with its sisters for other operators (e.g. Hash Join). It also makes the `swap_join_according_to_unboundedness` utility function in `join_selection.rs` crate public to enable implementation of (and experimentation with) custom join rules by downstream projects.

## Are these changes tested?

There are no explicit unit tests, but the sisters methods don't have such tests either. These methods are tested indirectly via optimization rules. We can consider whether to add such tests for all such methods in a future PR.

## Are there any user-facing changes?

None.
