### PR TITLE
fix: Avoid re-wrapping planning errors  Err(DataFusionError::Plan) for use in plan_datafusion_err

### DIFF
--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -28,8 +28,8 @@ use crate::{utils, LogicalPlan, Projection, Subquery, WindowFunctionDefinition};
 use arrow::compute::can_cast_types;
 use arrow::datatypes::{DataType, Field};
 use datafusion_common::{
-    not_impl_err, plan_datafusion_err, plan_err, Column, ExprSchema, Result,
-    TableReference,
+    not_impl_err, plan_datafusion_err, plan_err, Column, DataFusionError, ExprSchema,
+    Result, TableReference,
 };
 use datafusion_functions_window_common::field::WindowUDFFieldArgs;
 use std::collections::HashMap;
@@ -156,7 +156,10 @@ impl ExprSchemable for Expr {
                     .map_err(|err| {
                         plan_datafusion_err!(
                             "{} {}",
-                            err,
+                            match err {
+                                DataFusionError::Plan(msg) => msg,
+                                err => err.to_string(),
+                            },
                             utils::generate_signature_error_msg(
                                 func.name(),
                                 func.signature().clone(),
@@ -181,7 +184,10 @@ impl ExprSchemable for Expr {
                     .map_err(|err| {
                         plan_datafusion_err!(
                             "{} {}",
-                            err,
+                            match err {
+                                DataFusionError::Plan(msg) => msg,
+                                err => err.to_string(),
+                            },
                             utils::generate_signature_error_msg(
                                 func.name(),
                                 func.signature().clone(),
@@ -485,7 +491,10 @@ impl Expr {
                     .map_err(|err| {
                         plan_datafusion_err!(
                             "{} {}",
-                            err,
+                            match err {
+                                DataFusionError::Plan(msg) => msg,
+                                err => err.to_string(),
+                            },
                             utils::generate_signature_error_msg(
                                 fun.name(),
                                 fun.signature(),
@@ -504,7 +513,10 @@ impl Expr {
                     data_types_with_window_udf(&data_types, udwf).map_err(|err| {
                         plan_datafusion_err!(
                             "{} {}",
-                            err,
+                            match err {
+                                DataFusionError::Plan(msg) => msg,
+                                err => err.to_string(),
+                            },
                             utils::generate_signature_error_msg(
                                 fun.name(),
                                 fun.signature(),

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1357,7 +1357,7 @@ mod test {
 
         let err = Projection::try_new(vec![udaf], empty).err().unwrap();
         assert!(
-            err.strip_backtrace().starts_with("Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to MY_AVG function: coercion from [Utf8] to the signature Uniform(1, [Float64]) failed")
+            err.strip_backtrace().starts_with("Error during planning: Failed to coerce arguments to satisfy a call to MY_AVG function: coercion from [Utf8] to the signature Uniform(1, [Float64]) failed")
         );
         Ok(())
     }
@@ -1407,7 +1407,7 @@ mod test {
             .err()
             .unwrap()
             .strip_backtrace();
-        assert!(err.starts_with("Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to avg function: coercion from [Utf8] to the signature Uniform(1, [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64]) failed."));
+        assert!(err.starts_with("Error during planning: Failed to coerce arguments to satisfy a call to avg function: coercion from [Utf8] to the signature Uniform(1, [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64]) failed."));
         Ok(())
     }
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -76,26 +76,26 @@ statement error DataFusion error: Schema error: Schema contains duplicate unqual
 SELECT approx_distinct(c9) count_c9, approx_distinct(cast(c9 as varchar)) count_c9_str FROM aggregate_test_100
 
 # csv_query_approx_percentile_cont_with_weight
-statement error DataFusion error: Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont_with_weight function: coercion from \[Utf8, Int8, Float64\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont_with_weight function: coercion from \[Utf8, Int8, Float64\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont_with_weight(c1, c2, 0.95) FROM aggregate_test_100
 
-statement error DataFusion error: Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont_with_weight function: coercion from \[Int16, Utf8, Float64\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont_with_weight function: coercion from \[Int16, Utf8, Float64\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont_with_weight(c3, c1, 0.95) FROM aggregate_test_100
 
-statement error DataFusion error: Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont_with_weight function: coercion from \[Int16, Int8, Utf8\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont_with_weight function: coercion from \[Int16, Int8, Utf8\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont_with_weight(c3, c2, c1) FROM aggregate_test_100
 
 # csv_query_approx_percentile_cont_with_histogram_bins
 statement error DataFusion error: External error: This feature is not implemented: Tdigest max_size value for 'APPROX_PERCENTILE_CONT' must be UInt > 0 literal \(got data type Int64\)\.
 SELECT c1, approx_percentile_cont(c3, 0.95, -1000) AS c3_p95 FROM aggregate_test_100 GROUP BY 1 ORDER BY 1
 
-statement error DataFusion error: Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont function: coercion from \[Int16, Float64, Utf8\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont function: coercion from \[Int16, Float64, Utf8\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont(c3, 0.95, c1) FROM aggregate_test_100
 
-statement error DataFusion error: Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont function: coercion from \[Int16, Float64, Float64\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont function: coercion from \[Int16, Float64, Float64\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont(c3, 0.95, 111.1) FROM aggregate_test_100
 
-statement error DataFusion error: Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont function: coercion from \[Float64, Float64, Float64\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont function: coercion from \[Float64, Float64, Float64\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont(c12, 0.95, 111.1) FROM aggregate_test_100
 
 statement error DataFusion error: This feature is not implemented: Percentile value for 'APPROX_PERCENTILE_CONT' must be a literal

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1181,7 +1181,7 @@ from arrays_values_without_nulls;
 ## array_element (aliases: array_extract, list_extract, list_element)
 
 # Testing with empty arguments should result in an error
-query error DataFusion error: Error during planning: Error during planning: array_element does not support zero arguments
+query error DataFusion error: Error during planning: array_element does not support zero arguments
 select array_element();
 
 # array_element error
@@ -2023,7 +2023,7 @@ select array_slice(a, -1, 2, 1), array_slice(a, -1, 2),
 [6.0] [6.0] [] []
 
 # Testing with empty arguments should result in an error
-query error DataFusion error: Error during planning: Error during planning: array_slice does not support zero arguments
+query error DataFusion error: Error during planning: array_slice does not support zero arguments
 select array_slice();
 
 ## array_any_value (aliases: list_any_value)

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -108,11 +108,11 @@ query error
 select avg(c1, c12) from aggregate_test_100;
 
 # AggregateFunction with wrong argument type
-statement error DataFusion error: Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to regr_slope function: coercion from
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to regr_slope function: coercion from
 select regr_slope(1, '2');
 
 # WindowFunction using AggregateFunction wrong signature
-statement error DataFusion error: Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to regr_slope function: coercion from
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to regr_slope function: coercion from
 select
 c9,
 regr_slope(c11, '2') over () as min1
@@ -120,7 +120,7 @@ from aggregate_test_100
 order by c9
 
 # WindowFunction wrong signature
-statement error DataFusion error: Error during planning: Error during planning: Failed to coerce arguments to satisfy a call to nth_value function: coercion from \[Int32, Int64, Int64\] to the signature OneOf\(\[Any\(0\), Any\(1\), Any\(2\)\]\) failed
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to nth_value function: coercion from \[Int32, Int64, Int64\] to the signature OneOf\(\[Any\(0\), Any\(1\), Any\(2\)\]\) failed
 select
 c9,
 nth_value(c5, 2, 3) over (order by c9) as nv1

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1940,7 +1940,7 @@ select position('' in '')
 ----
 1
 
-query error DataFusion error: Error during planning: Error during planning: The signature expected NativeType::String but received NativeType::Int64
+query error DataFusion error: Error during planning: The signature expected NativeType::String but received NativeType::Int64
 select position(1 in 1)
 
 query I


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #13979.

<!-- ## Rationale for this change -->

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

<!-- ## What changes are included in this PR? -->

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I added several new unit tests in `sql_integrations`, despite the fact that some cases are already covered in sqllogictest. It was also manually tested (removed the duplicated 'Error during planning'; no changes made to 'Error during planning: Execution error:' in the third case):

<table>
<tr>
<td><b>Before</b></td><td><b>After</b></td>
</tr>
<tr>
<td>

```sql
> select version(1);
Error during planning: Error during planning:
Failed to coerce arguments to satisfy a call
to version function: coercion from [Int64] to
the signature Exact([]) failed. No function
matches the given name and argument
types 'version(Int64)'. You might need to
add explicit type casts.
```

</td>
<td>

```sql
> select version(1);
Error during planning: Failed to coerce
arguments to satisfy a call to version
function: coercion from [Int64] to the
signature Exact([]) failed. No function
matches the given name and argument
types 'version(Int64)'. You might need
to add explicit type casts.
```

</td>
</tr>

<tr>
<td>

```sql
> select rank(1) over();
Error during planning: Error during planning:
The function expected zero argument but
received 1 No function matches the given
name and argument types 'rank(Int64)'. You
might need to add explicit type casts.

```

</td>
<td>

```sql
> select rank(1) over();
Error during planning: The function expected
zero argument but received 1 No function
matches the given name and argument types
'rank(Int64)'. You might need to add explicit
type casts.

```

</td>
</tr>

<tr>
<td>

```sql
> select max(1,2);
Error during planning: Execution error:
User-defined coercion failed with
Execution("min/max was called with 2
arguments. It requires only 1.") No
function matches the given name and
argument types 'max(Int64, Int64)'. You
might need to add explicit type casts.
```

</td>
<td>

```sql
> select max(1,2);
Error during planning: Execution error:
User-defined coercion failed with
Execution("min/max was called with 2
arguments. It requires only 1.") No
function matches the given name and
argument types 'max(Int64, Int64)'. You
might need to add explicit type casts.
```

</td>
</tr>

</table>

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Although the output of some errors will change (improve), changes in the documentation are probably not necessary.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
