### PR TITLE
`url` dependancy update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ serde_json = "1"
 sqlparser = { version = "0.53.0", features = ["visitor"] }
 tempfile = "3"
 tokio = { version = "1.36", features = ["macros", "rt", "sync"] }
-url = "2.2"
+url = "2.5.4"
 
 [profile.release]
 codegen-units = 1

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -63,7 +63,7 @@ parquet = { version = "53.0.0", default-features = false }
 regex = "1.8"
 rustyline = "14.0"
 tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot", "signal"] }
-url = "2.2"
+url = "2.5.4"
 
 [dev-dependencies]
 assert_cmd = "2.0"


### PR DESCRIPTION
## Which issue does this PR close?

Closes #14018

## Rationale for this change

DataFusion uses an old version of `url` crate which has known vulnerability https://rustsec.org/advisories/RUSTSEC-2024-0421 fixed in latest release.

## What changes are included in this PR?

`url` crate update

## Are these changes tested?

Tests not included as it is just a dependancy update which should be covered by existing tests.

## Are there any user-facing changes?

No user-facing changes.
