### PR TITLE
Improve performance of `find_in_set` function

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -213,3 +213,8 @@ required-features = ["math_expressions"]
 harness = false
 name = "initcap"
 required-features = ["unicode_expressions"]
+
+[[bench]]
+harness = false
+name = "find_in_set"
+required-features = ["unicode_expressions"]

--- a/datafusion/functions/benches/find_in_set.rs
+++ b/datafusion/functions/benches/find_in_set.rs
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate criterion;
+
+use arrow::array::{StringArray, StringViewArray};
+use arrow::datatypes::DataType;
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs};
+use rand::distributions::Alphanumeric;
+use rand::prelude::StdRng;
+use rand::{Rng, SeedableRng};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// gen_arr(4096, 128, 0.1, 0.1, true) will generate a StringViewArray with
+/// 4096 rows, each row containing a string with 128 random characters.
+/// around 10% of the rows are null, around 10% of the rows are non-ASCII.
+fn gen_string_array(
+    n_rows: usize,
+    str_len_chars: usize,
+    null_density: f32,
+    utf8_density: f32,
+    is_string_view: bool, // false -> StringArray, true -> StringViewArray
+) -> Vec<ColumnarValue> {
+    let mut rng = StdRng::seed_from_u64(42);
+    let rng_ref = &mut rng;
+
+    let num_elements = 5; // 5 elements separated by comma
+    let utf8 = "DataFusionДатаФусион数据融合📊🔥"; // includes utf8 encoding with 1~4 bytes
+    let corpus_char_count = utf8.chars().count();
+
+    let mut output_set_vec: Vec<Option<String>> = Vec::with_capacity(n_rows);
+    let mut output_element_vec: Vec<Option<String>> = Vec::with_capacity(n_rows);
+    for _ in 0..n_rows {
+        let rand_num = rng_ref.gen::<f32>(); // [0.0, 1.0)
+        if rand_num < null_density {
+            output_element_vec.push(None);
+            output_set_vec.push(None);
+        } else if rand_num < null_density + utf8_density {
+            // Generate random UTF-8 string with comma separators
+            let mut generated_string = String::with_capacity(str_len_chars);
+            for i in 0..num_elements {
+                for _ in 0..str_len_chars {
+                    let idx = rng_ref.gen_range(0..corpus_char_count);
+                    let char = utf8.chars().nth(idx).unwrap();
+                    generated_string.push(char);
+                }
+                if i < num_elements - 1 {
+                    generated_string.push(',');
+                }
+            }
+            output_element_vec.push(Some(random_element_in_set(&generated_string)));
+            output_set_vec.push(Some(generated_string));
+        } else {
+            // Generate random ASCII-only string with comma separators
+            let mut generated_string = String::with_capacity(str_len_chars);
+            for i in 0..num_elements {
+                for _ in 0..str_len_chars {
+                    let c = rng_ref.sample(&Alphanumeric);
+                    generated_string.push(c as char);
+                }
+                if i < num_elements - 1 {
+                    generated_string.push(',');
+                }
+            }
+            output_element_vec.push(Some(random_element_in_set(&generated_string)));
+            output_set_vec.push(Some(generated_string));
+        }
+    }
+
+    if is_string_view {
+        let set_array: StringViewArray = output_set_vec.into_iter().collect();
+        let element_array: StringViewArray = output_element_vec.into_iter().collect();
+        vec![
+            ColumnarValue::Array(Arc::new(element_array)),
+            ColumnarValue::Array(Arc::new(set_array)),
+        ]
+    } else {
+        let set_array: StringArray = output_set_vec.clone().into_iter().collect();
+        let element_array: StringArray = output_element_vec.into_iter().collect();
+        vec![
+            ColumnarValue::Array(Arc::new(element_array)),
+            ColumnarValue::Array(Arc::new(set_array)),
+        ]
+    }
+}
+
+fn random_element_in_set(string: &String) -> String {
+    let elements: Vec<&str> = string.split(',').collect();
+
+    if elements.is_empty() || (elements.len() == 1 && elements[0].is_empty()) {
+        return String::new();
+    }
+
+    let mut rng = StdRng::seed_from_u64(44);
+    let random_index = rng.gen_range(0..elements.len());
+
+    elements[random_index].to_string()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // All benches are single batch run with 8192 rows
+    let find_in_set = datafusion_functions::unicode::find_in_set();
+
+    let n_rows = 8192;
+    for str_len in [8, 32, 1024] {
+        let mut group = c.benchmark_group("find_in_set");
+        group.sampling_mode(SamplingMode::Flat);
+        group.sample_size(50);
+        group.measurement_time(Duration::from_secs(10));
+
+        let args = gen_string_array(n_rows, str_len, 0.1, 0.5, false);
+        group.bench_function(&format!("string_len_{}", str_len), |b| {
+            b.iter(|| {
+                black_box(find_in_set.invoke_with_args(ScalarFunctionArgs {
+                    args: args.clone(),
+                    number_rows: n_rows,
+                    return_type: &DataType::Int32,
+                }))
+            })
+        });
+
+        let args = gen_string_array(n_rows, str_len, 0.1, 0.5, true);
+        group.bench_function(&format!("string_view_len_{}", str_len), |b| {
+            b.iter(|| {
+                black_box(find_in_set.invoke_with_args(ScalarFunctionArgs {
+                    args: args.clone(),
+                    number_rows: n_rows,
+                    return_type: &DataType::Int32,
+                }))
+            })
+        });
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/functions/benches/find_in_set.rs
+++ b/datafusion/functions/benches/find_in_set.rs
@@ -71,7 +71,7 @@ fn gen_string_array(
             let mut generated_string = String::with_capacity(str_len_chars);
             for i in 0..num_elements {
                 for _ in 0..str_len_chars {
-                    let c = rng_ref.sample(&Alphanumeric);
+                    let c = rng_ref.sample(Alphanumeric);
                     generated_string.push(c as char);
                 }
                 if i < num_elements - 1 {
@@ -100,7 +100,7 @@ fn gen_string_array(
     }
 }
 
-fn random_element_in_set(string: &String) -> String {
+fn random_element_in_set(string: &str) -> String {
     let elements: Vec<&str> = string.split(',').collect();
 
     if elements.is_empty() || (elements.len() == 1 && elements[0].is_empty()) {
@@ -125,7 +125,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.measurement_time(Duration::from_secs(10));
 
         let args = gen_string_array(n_rows, str_len, 0.1, 0.5, false);
-        group.bench_function(&format!("string_len_{}", str_len), |b| {
+        group.bench_function(format!("string_len_{}", str_len), |b| {
             b.iter(|| {
                 black_box(find_in_set.invoke_with_args(ScalarFunctionArgs {
                     args: args.clone(),
@@ -136,7 +136,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
 
         let args = gen_string_array(n_rows, str_len, 0.1, 0.5, true);
-        group.bench_function(&format!("string_view_len_{}", str_len), |b| {
+        group.bench_function(format!("string_view_len_{}", str_len), |b| {
             b.iter(|| {
                 black_box(find_in_set.invoke_with_args(ScalarFunctionArgs {
                     args: args.clone(),

--- a/datafusion/functions/src/unicode/find_in_set.rs
+++ b/datafusion/functions/src/unicode/find_in_set.rs
@@ -19,16 +19,17 @@ use std::any::Any;
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayAccessor, ArrayIter, ArrayRef, ArrowPrimitiveType, AsArray, OffsetSizeTrait,
-    PrimitiveArray,
+    new_null_array, ArrayAccessor, ArrayIter, ArrayRef, ArrowPrimitiveType, AsArray,
+    OffsetSizeTrait, PrimitiveArray,
 };
 use arrow::datatypes::{ArrowNativeType, DataType, Int32Type, Int64Type};
 
-use crate::utils::{make_scalar_function, utf8_to_int_type};
-use datafusion_common::{exec_err, Result};
+use crate::utils::utf8_to_int_type;
+use datafusion_common::{exec_err, internal_err, Result, ScalarValue};
 use datafusion_expr::TypeSignature::Exact;
 use datafusion_expr::{
-    ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
+    ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    Volatility,
 };
 use datafusion_macros::user_doc;
 
@@ -42,7 +43,7 @@ use datafusion_macros::user_doc;
 | find_in_set(Utf8("b"),Utf8("a,b,c,d")) |
 +----------------------------------------+
 | 2                                      |
-+----------------------------------------+ 
++----------------------------------------+
 ```"#,
     argument(name = "str", description = "String expression to find in strlist."),
     argument(
@@ -94,12 +95,141 @@ impl ScalarUDFImpl for FindInSetFunc {
         utf8_to_int_type(&arg_types[0], "find_in_set")
     }
 
-    fn invoke_batch(
-        &self,
-        args: &[ColumnarValue],
-        _number_rows: usize,
-    ) -> Result<ColumnarValue> {
-        make_scalar_function(find_in_set, vec![])(args)
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs { mut args, .. } = args;
+
+        if args.len() != 2 {
+            return exec_err!(
+                "find_in_set was called with {} arguments. It requires 2.",
+                args.len()
+            );
+        }
+
+        let str_list = args.pop().unwrap();
+        let string = args.pop().unwrap();
+
+        match (string, str_list) {
+            // both inputs are scalars
+            (
+                ColumnarValue::Scalar(
+                    ScalarValue::Utf8View(string)
+                    | ScalarValue::Utf8(string)
+                    | ScalarValue::LargeUtf8(string),
+                ),
+                ColumnarValue::Scalar(
+                    ScalarValue::Utf8View(str_list)
+                    | ScalarValue::Utf8(str_list)
+                    | ScalarValue::LargeUtf8(str_list),
+                ),
+            ) => {
+                let res = match (string, str_list) {
+                    (Some(string), Some(str_list)) => {
+                        let position = str_list
+                            .split(',')
+                            .position(|s| s == string)
+                            .map_or(0, |idx| idx + 1);
+
+                        Some(position as i32)
+                    }
+                    _ => None,
+                };
+                Ok(ColumnarValue::Scalar(ScalarValue::from(res)))
+            }
+
+            // `string` is an array, `str_list` is scalar
+            (
+                ColumnarValue::Array(str_array),
+                ColumnarValue::Scalar(
+                    ScalarValue::Utf8View(str_list_literal)
+                    | ScalarValue::Utf8(str_list_literal)
+                    | ScalarValue::LargeUtf8(str_list_literal),
+                ),
+            ) => {
+                let result_array = match str_list_literal {
+                    // find_in_set(column_a, null) = null
+                    None => new_null_array(str_array.data_type(), str_array.len()),
+                    Some(str_list_literal) => {
+                        let str_list = str_list_literal.split(',').collect::<Vec<&str>>();
+                        let result = match str_array.data_type() {
+                            DataType::Utf8 => {
+                                let string_array = str_array.as_string::<i32>();
+                                find_in_set_right_literal::<Int32Type, _>(
+                                    string_array,
+                                    str_list,
+                                )
+                            }
+                            DataType::LargeUtf8 => {
+                                let string_array = str_array.as_string::<i64>();
+                                find_in_set_right_literal::<Int64Type, _>(
+                                    string_array,
+                                    str_list,
+                                )
+                            }
+                            DataType::Utf8View => {
+                                let string_array = str_array.as_string_view();
+                                find_in_set_right_literal::<Int32Type, _>(
+                                    string_array,
+                                    str_list,
+                                )
+                            }
+                            other => {
+                                exec_err!("Unsupported data type {other:?} for function find_in_set")
+                            }
+                        };
+                        Arc::new(result?)
+                    }
+                };
+                Ok(ColumnarValue::Array(result_array))
+            }
+
+            // `string` is scalar, `str_list` is an array
+            (
+                ColumnarValue::Scalar(
+                    ScalarValue::Utf8View(string_literal)
+                    | ScalarValue::Utf8(string_literal)
+                    | ScalarValue::LargeUtf8(string_literal),
+                ),
+                ColumnarValue::Array(str_list_array),
+            ) => {
+                let res = match string_literal {
+                    // find_in_set(null, column_b) = null
+                    None => {
+                        new_null_array(str_list_array.data_type(), str_list_array.len())
+                    }
+                    Some(string) => {
+                        let result = match str_list_array.data_type() {
+                            DataType::Utf8 => {
+                                let str_list = str_list_array.as_string::<i32>();
+                                find_in_set_left_literal::<Int32Type, _>(string, str_list)
+                            }
+                            DataType::LargeUtf8 => {
+                                let str_list = str_list_array.as_string::<i64>();
+                                find_in_set_left_literal::<Int64Type, _>(string, str_list)
+                            }
+                            DataType::Utf8View => {
+                                let str_list = str_list_array.as_string_view();
+                                find_in_set_left_literal::<Int32Type, _>(string, str_list)
+                            }
+                            other => {
+                                exec_err!("Unsupported data type {other:?} for function find_in_set")
+                            }
+                        };
+                        Arc::new(result?)
+                    }
+                };
+                Ok(ColumnarValue::Array(res))
+            }
+
+            // both inputs are arrays
+            (ColumnarValue::Array(base_array), ColumnarValue::Array(exp_array)) => {
+                let res = find_in_set(base_array, exp_array)?;
+
+                Ok(ColumnarValue::Array(res))
+            }
+            _ => {
+                internal_err!("Invalid argument types for `find_in_set` function")
+            }
+        }
     }
 
     fn documentation(&self) -> Option<&Documentation> {
@@ -107,29 +237,24 @@ impl ScalarUDFImpl for FindInSetFunc {
     }
 }
 
-///Returns a value in the range of 1 to N if the string str is in the string list strlist consisting of N substrings
-///A string list is a string composed of substrings separated by , characters.
-fn find_in_set(args: &[ArrayRef]) -> Result<ArrayRef> {
-    if args.len() != 2 {
-        return exec_err!(
-            "find_in_set was called with {} arguments. It requires 2.",
-            args.len()
-        );
-    }
-    match args[0].data_type() {
+/// Returns a value in the range of 1 to N if the string `str` is in the string list `strlist`
+/// consisting of N substrings. A string list is a string composed of substrings separated by `,`
+/// characters.
+fn find_in_set(str: ArrayRef, str_list: ArrayRef) -> Result<ArrayRef> {
+    match str.data_type() {
         DataType::Utf8 => {
-            let string_array = args[0].as_string::<i32>();
-            let str_list_array = args[1].as_string::<i32>();
+            let string_array = str.as_string::<i32>();
+            let str_list_array = str_list.as_string::<i32>();
             find_in_set_general::<Int32Type, _>(string_array, str_list_array)
         }
         DataType::LargeUtf8 => {
-            let string_array = args[0].as_string::<i64>();
-            let str_list_array = args[1].as_string::<i64>();
+            let string_array = str.as_string::<i64>();
+            let str_list_array = str_list.as_string::<i64>();
             find_in_set_general::<Int64Type, _>(string_array, str_list_array)
         }
         DataType::Utf8View => {
-            let string_array = args[0].as_string_view();
-            let str_list_array = args[1].as_string_view();
+            let string_array = str.as_string_view();
+            let str_list_array = str_list.as_string_view();
             find_in_set_general::<Int32Type, _>(string_array, str_list_array)
         }
         other => {
@@ -170,14 +295,69 @@ where
     Ok(Arc::new(builder.finish()) as ArrayRef)
 }
 
+fn find_in_set_left_literal<'a, T, V>(
+    string: String,
+    str_list_array: V,
+) -> Result<ArrayRef>
+where
+    T: ArrowPrimitiveType,
+    T::Native: OffsetSizeTrait,
+    V: ArrayAccessor<Item = &'a str>,
+{
+    let mut builder = PrimitiveArray::<T>::builder(str_list_array.len());
+
+    let str_list_iter = ArrayIter::new(str_list_array);
+
+    str_list_iter.for_each(|str_list_opt| match str_list_opt {
+        Some(str_list) => {
+            let position = str_list
+                .split(',')
+                .position(|s| s == string)
+                .map_or(0, |idx| idx + 1);
+            builder.append_value(T::Native::from_usize(position).unwrap());
+        }
+        None => builder.append_null(),
+    });
+
+    Ok(Arc::new(builder.finish()) as ArrayRef)
+}
+
+fn find_in_set_right_literal<'a, T, V>(
+    string_array: V,
+    str_list: Vec<&str>,
+) -> Result<ArrayRef>
+where
+    T: ArrowPrimitiveType,
+    T::Native: OffsetSizeTrait,
+    V: ArrayAccessor<Item = &'a str>,
+{
+    let mut builder = PrimitiveArray::<T>::builder(string_array.len());
+
+    let string_iter = ArrayIter::new(string_array);
+
+    string_iter.for_each(|string_opt| match string_opt {
+        Some(string) => {
+            let position = str_list
+                .iter()
+                .position(|s| *s == string)
+                .map_or(0, |idx| idx + 1);
+            builder.append_value(T::Native::from_usize(position).unwrap());
+        }
+        None => builder.append_null(),
+    });
+
+    Ok(Arc::new(builder.finish()) as ArrayRef)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::unicode::find_in_set::FindInSetFunc;
     use crate::utils::test::test_function;
-    use arrow::array::{Array, Int32Array};
+    use arrow::array::{Array, Int32Array, StringArray};
     use arrow::datatypes::DataType::Int32;
     use datafusion_common::{Result, ScalarValue};
-    use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
+    use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl};
+    use std::sync::Arc;
 
     #[test]
     fn test_functions() -> Result<()> {
@@ -278,4 +458,84 @@ mod tests {
 
         Ok(())
     }
+
+    macro_rules! test_find_in_set {
+        ($test_name:ident, $args:expr, $expected:expr) => {
+            #[test]
+            fn $test_name() -> Result<()> {
+                let fis = crate::unicode::find_in_set();
+
+                let args = $args;
+                let expected = $expected;
+
+                let type_array = args.iter().map(|a| a.data_type()).collect::<Vec<_>>();
+                let cardinality = args
+                    .iter()
+                    .fold(Option::<usize>::None, |acc, arg| match arg {
+                        ColumnarValue::Scalar(_) => acc,
+                        ColumnarValue::Array(a) => Some(a.len()),
+                    })
+                    .unwrap_or(1);
+                let return_type = fis.return_type(&type_array)?;
+                let result = fis.invoke_with_args(ScalarFunctionArgs {
+                    args,
+                    number_rows: cardinality,
+                    return_type: &return_type,
+                });
+                assert!(result.is_ok());
+
+                let result = result?
+                    .to_array(cardinality)
+                    .expect("Failed to convert to array");
+                let result = result
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .expect("Failed to convert to type");
+                assert_eq!(*result, expected);
+
+                Ok(())
+            }
+        };
+    }
+
+    test_find_in_set!(
+        test_find_in_set_with_scalar_args,
+        vec![
+            ColumnarValue::Array(Arc::new(StringArray::from(vec![
+                "", "a", "b", "c", "d"
+            ]))),
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some("b,c,d".to_string()))),
+        ],
+        Int32Array::from(vec![0, 0, 1, 2, 3])
+    );
+    test_find_in_set!(
+        test_find_in_set_with_scalar_args_2,
+        vec![
+            ColumnarValue::Scalar(ScalarValue::Utf8View(Some(
+                "ApacheSoftware".to_string()
+            ))),
+            ColumnarValue::Array(Arc::new(StringArray::from(vec![
+                "a,b,c",
+                "ApacheSoftware,Github,DataFusion",
+                ""
+            ]))),
+        ],
+        Int32Array::from(vec![0, 1, 0])
+    );
+    test_find_in_set!(
+        test_find_in_set_with_scalar_args_3,
+        vec![
+            ColumnarValue::Array(Arc::new(StringArray::from(vec![None::<&str>; 3]))),
+            ColumnarValue::Scalar(ScalarValue::Utf8View(Some("a,b,c".to_string()))),
+        ],
+        Int32Array::from(vec![None::<i32>; 3])
+    );
+    test_find_in_set!(
+        test_find_in_set_with_scalar_args_4,
+        vec![
+            ColumnarValue::Scalar(ScalarValue::Utf8View(Some("a".to_string()))),
+            ColumnarValue::Array(Arc::new(StringArray::from(vec![None::<&str>; 3]))),
+        ],
+        Int32Array::from(vec![None::<i32>; 3])
+    );
 }

--- a/datafusion/functions/src/unicode/mod.rs
+++ b/datafusion/functions/src/unicode/mod.rs
@@ -102,7 +102,7 @@ pub mod expr_fn {
         string
     ),(
         find_in_set,
-        "Returns a value in the range of 1 to N if the string str is in the string list strlist consisting of N substrings",
+        "Returns a value in the range of 1 to N if the string `str` is in the string list `strlist` consisting of N substrings",
         string strlist
     ));
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
Improve performance of `find_in_set` function
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. Added unit tests and benchmarks.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
*BENCHMARK RESULT
```rust
Compiling datafusion-functions v44.0.0 (/home/tailm/repos/github/datafusion/datafusion/functions)
    Finished `bench` profile [optimized] target(s) in 1m 02s
     Running benches/find_in_set.rs (target/release/deps/find_in_set-c80fb04778cbe610)
Gnuplot not found, using plotters backend
find_in_set/string_len_8
                        time:   [414.89 µs 415.67 µs 416.41 µs]
                        change: [-64.610% -64.526% -64.440%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) low mild
find_in_set/string_view_len_8
                        time:   [440.65 µs 441.02 µs 441.50 µs]
                        change: [-63.746% -63.607% -63.494%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe

find_in_set/string_len_32
                        time:   [474.24 µs 474.97 µs 475.79 µs]
                        change: [-61.751% -61.586% -61.447%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high mild
find_in_set/string_view_len_32
                        time:   [493.30 µs 494.79 µs 496.58 µs]
                        change: [-61.565% -61.365% -61.171%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 50 measurements (8.00%)
  1 (2.00%) high mild
  3 (6.00%) high severe

find_in_set/string_len_1024
                        time:   [4.8152 ms 4.8243 ms 4.8367 ms]
                        change: [-12.694% -12.465% -12.233%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe
find_in_set/string_view_len_1024
                        time:   [4.8690 ms 4.8755 ms 4.8825 ms]
                        change: [-13.472% -13.274% -13.072%] (p = 0.00 < 0.05)
                        Performance has improved.
```