### PR TITLE
fix: yield when the next file is ready to open to prevent CPU starvation

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -478,7 +478,12 @@ impl<F: FileOpener> FileStream<F> {
                                                     reader,
                                                 )),
                                                 partition_values,
-                                            }
+                                            };
+                                            // Return control to the runtime when we're ready to open the next file
+                                            // to prevent uncancellable queries in scenarios with many large files.
+                                            // This functions similarly to a `tokio::task::yield_now()`.
+                                            cx.waker().wake_by_ref();
+                                            return Poll::Pending;
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #14036

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Return `Pending` when a new File is opened in the `FileStream` to yield control back to Tokio. This should help prevent queries from running after cancellation.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
