### PR TITLE
Minor: make nested functions  public and implement Default trait

### DIFF
--- a/datafusion/functions-nested/src/cardinality.rs
+++ b/datafusion/functions-nested/src/cardinality.rs
@@ -75,9 +75,15 @@ impl Cardinality {
     )
 )]
 #[derive(Debug)]
-pub(super) struct Cardinality {
+pub struct Cardinality {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for Cardinality {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 impl ScalarUDFImpl for Cardinality {
     fn as_any(&self) -> &dyn Any {

--- a/datafusion/functions-nested/src/dimension.rs
+++ b/datafusion/functions-nested/src/dimension.rs
@@ -61,9 +61,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayDims {
+pub struct ArrayDims {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayDims {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayDims {

--- a/datafusion/functions-nested/src/distance.rs
+++ b/datafusion/functions-nested/src/distance.rs
@@ -67,9 +67,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayDistance {
+pub struct ArrayDistance {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayDistance {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayDistance {

--- a/datafusion/functions-nested/src/empty.rs
+++ b/datafusion/functions-nested/src/empty.rs
@@ -56,9 +56,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayEmpty {
+pub struct ArrayEmpty {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayEmpty {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 impl ArrayEmpty {
     pub fn new() -> Self {

--- a/datafusion/functions-nested/src/except.rs
+++ b/datafusion/functions-nested/src/except.rs
@@ -67,9 +67,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayExcept {
+pub struct ArrayExcept {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayExcept {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayExcept {

--- a/datafusion/functions-nested/src/extract.rs
+++ b/datafusion/functions-nested/src/extract.rs
@@ -102,9 +102,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayElement {
+pub struct ArrayElement {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayElement {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayElement {

--- a/datafusion/functions-nested/src/map_extract.rs
+++ b/datafusion/functions-nested/src/map_extract.rs
@@ -72,9 +72,15 @@ SELECT map_extract(MAP {'x': 10, 'y': NULL, 'z': 30}, 'y');
     )
 )]
 #[derive(Debug)]
-pub(super) struct MapExtract {
+pub struct MapExtract {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for MapExtract {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MapExtract {

--- a/datafusion/functions-nested/src/map_keys.rs
+++ b/datafusion/functions-nested/src/map_keys.rs
@@ -56,8 +56,14 @@ SELECT map_keys(map([100, 5], [42, 43]));
     )
 )]
 #[derive(Debug)]
-pub(crate) struct MapKeysFunc {
+pub struct MapKeysFunc {
     signature: Signature,
+}
+
+impl Default for MapKeysFunc {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MapKeysFunc {

--- a/datafusion/functions-nested/src/map_values.rs
+++ b/datafusion/functions-nested/src/map_values.rs
@@ -60,6 +60,12 @@ pub(crate) struct MapValuesFunc {
     signature: Signature,
 }
 
+impl Default for MapValuesFunc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MapValuesFunc {
     pub fn new() -> Self {
         Self {

--- a/datafusion/functions-nested/src/position.rs
+++ b/datafusion/functions-nested/src/position.rs
@@ -76,9 +76,15 @@ make_udf_expr_and_func!(
     argument(name = "index", description = "Index at which to start searching.")
 )]
 #[derive(Debug)]
-pub(super) struct ArrayPosition {
+pub struct ArrayPosition {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayPosition {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 impl ArrayPosition {
     pub fn new() -> Self {

--- a/datafusion/functions-nested/src/range.rs
+++ b/datafusion/functions-nested/src/range.rs
@@ -89,9 +89,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct Range {
+pub struct Range {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for Range {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 impl Range {
     pub fn new() -> Self {

--- a/datafusion/functions-nested/src/remove.rs
+++ b/datafusion/functions-nested/src/remove.rs
@@ -64,9 +64,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayRemove {
+pub struct ArrayRemove {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayRemove {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayRemove {

--- a/datafusion/functions-nested/src/repeat.rs
+++ b/datafusion/functions-nested/src/repeat.rs
@@ -72,9 +72,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayRepeat {
+pub struct ArrayRepeat {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayRepeat {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayRepeat {

--- a/datafusion/functions-nested/src/replace.rs
+++ b/datafusion/functions-nested/src/replace.rs
@@ -78,9 +78,15 @@ make_udf_expr_and_func!(ArrayReplaceAll,
     argument(name = "to", description = "Final element.")
 )]
 #[derive(Debug)]
-pub(super) struct ArrayReplace {
+pub struct ArrayReplace {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayReplace {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayReplace {

--- a/datafusion/functions-nested/src/resize.rs
+++ b/datafusion/functions-nested/src/resize.rs
@@ -65,9 +65,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayResize {
+pub struct ArrayResize {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayResize {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayResize {

--- a/datafusion/functions-nested/src/reverse.rs
+++ b/datafusion/functions-nested/src/reverse.rs
@@ -58,9 +58,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayReverse {
+pub struct ArrayReverse {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayReverse {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayReverse {

--- a/datafusion/functions-nested/src/set_ops.rs
+++ b/datafusion/functions-nested/src/set_ops.rs
@@ -90,9 +90,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayUnion {
+pub struct ArrayUnion {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayUnion {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayUnion {

--- a/datafusion/functions-nested/src/string.rs
+++ b/datafusion/functions-nested/src/string.rs
@@ -145,9 +145,15 @@ make_udf_expr_and_func!(
     )
 )]
 #[derive(Debug)]
-pub(super) struct ArrayToString {
+pub struct ArrayToString {
     signature: Signature,
     aliases: Vec<String>,
+}
+
+impl Default for ArrayToString {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrayToString {


### PR DESCRIPTION
## Which issue does this PR close?
Changes the visibility of the ArraySort struct from super to public to allows broader access to the struct, enabling its use in other modules

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Once again While working on adding support for ArrayPosition, I discovered it was not publicly accessible. To prevent others from encountering this issue, I updated the visibility of all nested function structs.
Related to #14006

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
