### PR TITLE
Fix error on `array_distinct` when input is empty #13810

### DIFF
--- a/datafusion/functions-nested/src/set_ops.rs
+++ b/datafusion/functions-nested/src/set_ops.rs
@@ -513,9 +513,6 @@ fn general_array_distinct<OffsetSize: OffsetSizeTrait>(
     array: &GenericListArray<OffsetSize>,
     field: &FieldRef,
 ) -> Result<ArrayRef> {
-    if array.len() == 0 {
-        return Ok(Arc::new(array.clone()) as ArrayRef);
-    }
     let dt = array.value_type();
     let mut offsets = Vec::with_capacity(array.len());
     offsets.push(OffsetSize::usize_as(0));
@@ -541,6 +538,9 @@ fn general_array_distinct<OffsetSize: OffsetSizeTrait>(
             }
         };
         new_arrays.push(array);
+    }
+    if new_arrays.is_empty() {
+        return Ok(Arc::new(array.clone()) as ArrayRef);
     }
     let offsets = OffsetBuffer::new(offsets.into());
     let new_arrays_ref = new_arrays.iter().map(|v| v.as_ref()).collect::<Vec<_>>();

--- a/datafusion/functions-nested/src/set_ops.rs
+++ b/datafusion/functions-nested/src/set_ops.rs
@@ -513,6 +513,9 @@ fn general_array_distinct<OffsetSize: OffsetSizeTrait>(
     array: &GenericListArray<OffsetSize>,
     field: &FieldRef,
 ) -> Result<ArrayRef> {
+    if array.is_empty() {
+        return Ok(Arc::new(array.clone()) as ArrayRef);
+    }
     let dt = array.value_type();
     let mut offsets = Vec::with_capacity(array.len());
     offsets.push(OffsetSize::usize_as(0));

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5682,70 +5682,10 @@ NULL
 [1, 3]
 
 query ?
-select array_distinct([]);
+select array_distinct(arrow_cast(null, 'LargeList(Int64)'));
 ----
-[]
+NULL
 
-query ?
-select array_distinct([[], []]);
-----
-[[]]
-
-query ?
-select array_distinct(column1)
-from array_distinct_table_1D;
-----
-[1, 2, 3]
-[1, 2, 3, 4, 5]
-[3, 5]
-
-query ?
-select array_distinct(column1)
-from array_distinct_table_1D_UTF8;
-----
-[a, bc, def]
-[a, bc, def, defg]
-[defg]
-
-query ?
-select array_distinct(column1)
-from array_distinct_table_2D;
-----
-[[1, 2], [3, 4], [5, 6]]
-[[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
-[, [5, 6]]
-
-query ?
-select array_distinct(column1)
-from array_distinct_table_1D_large;
-----
-[1, 2, 3]
-[1, 2, 3, 4, 5]
-[3, 5]
-
-query ?
-select array_distinct(column1)
-from array_distinct_table_1D_fixed;
-----
-[1, 2, 3]
-[1, 2, 3, 4, 5]
-[3, 5]
-
-query ?
-select array_distinct(column1)
-from array_distinct_table_1D_UTF8_fixed;
-----
-[a, bc, def]
-[a, bc, def, defg]
-[defg]
-
-query ?
-select array_distinct(column1)
-from array_distinct_table_2D_fixed;
-----
-[[1, 2], [3, 4], [5, 6]]
-[[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
-[, [5, 6]]
 
 query ???
 select array_intersect(column1, column2),

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5686,6 +5686,71 @@ select array_distinct(arrow_cast(null, 'LargeList(Int64)'));
 ----
 NULL
 
+query ?
+select array_distinct([]);
+----
+[]
+
+query ?
+select array_distinct([[], []]);
+----
+[[]]
+
+query ?
+select array_distinct(column1)
+from array_distinct_table_1D;
+----
+[1, 2, 3]
+[1, 2, 3, 4, 5]
+[3, 5]
+
+query ?
+select array_distinct(column1)
+from array_distinct_table_1D_UTF8;
+----
+[a, bc, def]
+[a, bc, def, defg]
+[defg]
+
+query ?
+select array_distinct(column1)
+from array_distinct_table_2D;
+----
+[[1, 2], [3, 4], [5, 6]]
+[[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
+[, [5, 6]]
+
+query ?
+select array_distinct(column1)
+from array_distinct_table_1D_large;
+----
+[1, 2, 3]
+[1, 2, 3, 4, 5]
+[3, 5]
+
+query ?
+select array_distinct(column1)
+from array_distinct_table_1D_fixed;
+----
+[1, 2, 3]
+[1, 2, 3, 4, 5]
+[3, 5]
+
+query ?
+select array_distinct(column1)
+from array_distinct_table_1D_UTF8_fixed;
+----
+[a, bc, def]
+[a, bc, def, defg]
+[defg]
+
+query ?
+select array_distinct(column1)
+from array_distinct_table_2D_fixed;
+----
+[[1, 2], [3, 4], [5, 6]]
+[[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
+[, [5, 6]]
 
 query ???
 select array_intersect(column1, column2),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes/FLUP #13809 

## Rationale for this change

FLUP for https://github.com/apache/datafusion/pull/13810, this fix will handle nulls as well

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
