### PR TITLE
'array_repeat' if the  repeat count value is 0, return NULL instead of empty array

### DIFF
--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2729,7 +2729,7 @@ select
   list_repeat('rust', 4),
   list_repeat(null, 0);
 ----
-[1, 1, 1, 1, 1] [3.14, 3.14, 3.14] [l, l, l, l] [, ] [-1, -1, -1, -1, -1] [] [rust, rust, rust, rust] []
+[1, 1, 1, 1, 1] [3.14, 3.14, 3.14] [l, l, l, l] [, ] [-1, -1, -1, -1, -1] NULL [rust, rust, rust, rust] NULL
 
 # array_repeat scalar function #2 (element as list)
 query ????
@@ -2783,7 +2783,7 @@ from array_repeat_table;
 [1] [1.1] [a] [[4, 5, 6]] [1, 1, 1] [[1]]
 [, ] [, ] [, ] [, ] [, , ] [[1], [1]]
 [2, 2, 2] [2.2, 2.2, 2.2] [rust, rust, rust] [[7], [7], [7]] [2, 2, 2] [[1], [1], [1]]
-[] [] [] [] [3, 3, 3] []
+NULL NULL NULL NULL [3, 3, 3] NULL
 
 query ??????
 select
@@ -2798,7 +2798,7 @@ from large_array_repeat_table;
 [1] [1.1] [a] [[4, 5, 6]] [1, 1, 1] [[1]]
 [, ] [, ] [, ] [, ] [, , ] [[1], [1]]
 [2, 2, 2] [2.2, 2.2, 2.2] [rust, rust, rust] [[7], [7], [7]] [2, 2, 2] [[1], [1], [1]]
-[] [] [] [] [3, 3, 3] []
+NULL NULL NULL NULL [3, 3, 3] NULL
 
 statement ok
 drop table array_repeat_table;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/13872.

## Rationale for this change



<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We noticed that, 
Array of null: []
Empty array: []
```
> select array_repeat(null, 0);
+-----------------------------+
| array_repeat(NULL,Int64(0)) |
+-----------------------------+
| []                          |
+-----------------------------+
1 row(s) fetched. 
Elapsed 0.006 seconds.

> select array_repeat(null, 1);
+-----------------------------+
| array_repeat(NULL,Int64(1)) |
+-----------------------------+
| []                          |
+-----------------------------+
```

Appears same

To distinguish both,
Updated the `empty array` to return `null` instead
Array of null: []
Empty array will return:  null
Now,
```
> select array_repeat(null, 0);
+-----------------------------+
| array_repeat(NULL,Int64(0)) |
+-----------------------------+
|                             |
+-----------------------------+
1 row(s) fetched. 
Elapsed 0.025 seconds.

> select array_repeat(null, 1);
+-----------------------------+
| array_repeat(NULL,Int64(1)) |
+-----------------------------+
| []                          |
+-----------------------------+
```



## What changes are included in this PR?


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes,

Updated the `array.slt` file 

## Are there any user-facing changes?
Yes

It has breaking change. Please add the label `api change`

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
