### PR TITLE
docs(ci): use up-to-date protoc with docs.rs

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -54,3 +54,10 @@ tokio = { workspace = true }
 default = ["physical"]
 physical = ["datafusion/parquet"]
 protoc = ["substrait/protoc"]
+
+[package.metadata.docs.rs]
+# Use default features ("physical") for docs, plus "protoc". "protoc" is needed
+# to get a consistent version of the protobuf compiler in the docs build;
+# without that, an outdated protobuf compiler may fail to compile the protobuf
+# files as it did in versions 42.0.0 through 44.0.0.
+all-features = true


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13853.

## Rationale for this change

This uses the same basic solution as in `substrait-rs`:

https://github.com/substrait-io/substrait-rs/blob/bbcc9f6d0b084a13706f39a43bbba9d37bf2a959/Cargo.toml#L62-L63

- `substrait-rs` has an optional `protoc` [feature](https://github.com/substrait-io/substrait-rs/blob/d0945cd0123e2cb39667e196b410a610242bcd54/Cargo.toml#L31)
0 The `protoc` feature [adds a dependency](https://github.com/substrait-io/substrait-rs/blob/d0945cd0123e2cb39667e196b410a610242bcd54/Cargo.toml#L54) on [`protobuf-src`](
https://docs.rs/protobuf-src/2.1.0/protobuf_src/), which ensures a fixed version of the protobuf compiler by compiling/vendoring it
- In the `build.rs` file, the [vendored protoc](https://github.com/substrait-io/substrait-rs/blob/d0945cd0123e2cb39667e196b410a610242bcd54/build.rs#L284-L285) is used when the `protoc` feature is enabled
- The feature is [enabled for `docs.rs`](https://github.com/substrait-io/substrait-rs/blob/d0945cd0123e2cb39667e196b410a610242bcd54/Cargo.toml#L62C1-L63)


## What changes are included in this PR?

Given that `datafusion-substrait` only uses the `protoc` compiler with the `substrait-rs` crate and already has a `protoc` feature, we should be able to solve this problem by enabling the `protoc` feature for `docs.rs`, as done here.

## Are these changes tested?

This is difficult to test, as it depends on the `docs.rs` environment, which is hard to replicate.

I have verified locally that adding the same version of `protoc` to my path as in `docs.rs` leads to the problem, and is solved with enabling all features:

```sh
datafusion/datafusion/substrait ❯ PATH="$HOME/protobuf/bin:$PATH" cargo doc
…
Error: Custom { kind: Other, error: "protoc failed: substrait/algebra.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.\n" }
datafusion/datafusion/substrait ❯ PATH="$HOME/protobuf/bin:$PATH" cargo doc --all-features
…
Documenting datafusion-substrait v44.0.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 14s
   Generated /Users/wendell.smith/go/src/github.com/DataDog/datafusion/target/doc/datafusion_substrait/index.html
```

I have attempted to replicate this in a `docs.rs` environment following the instructions [here](https://github.com/rust-lang/docs.rs/blob/master/README.md#build-subcommand) and [here](https://forge.rust-lang.org/docs-rs/add-dependencies.html#testing-the-image), but running it on any local crate gives an error like `invalid type: null, expected a string at line 1 column 2617950` and fails, so I haven't been able to do so.

## Are there any user-facing changes?

No, other than that `docs.rs` should work again.