### PR TITLE
WIP: Reduce time spent normalizing

### DIFF
--- a/datafusion/physical-expr/src/equivalence/ordering.rs
+++ b/datafusion/physical-expr/src/equivalence/ordering.rs
@@ -101,6 +101,8 @@ impl OrderingEquivalenceClass {
     }
 
     /// Extend this ordering equivalence class with the `other` class.
+    #[deprecated(since = "45.0.0", note = "Use add_new_orderings instead")]
+
     pub fn extend(&mut self, other: Self) {
         self.orderings.extend(other.orderings);
         // Make sure that there are no redundant orderings:

--- a/datafusion/physical-expr/src/equivalence/ordering.rs
+++ b/datafusion/physical-expr/src/equivalence/ordering.rs
@@ -102,7 +102,6 @@ impl OrderingEquivalenceClass {
 
     /// Extend this ordering equivalence class with the `other` class.
     #[deprecated(since = "45.0.0", note = "Use add_new_orderings instead")]
-
     pub fn extend(&mut self, other: Self) {
         self.orderings.extend(other.orderings);
         // Make sure that there are no redundant orderings:


### PR DESCRIPTION
Still a Work In Progress 🚨 

## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/13748

## Rationale for this change

The continued re-normalization of equivalence classes, especially when the number of expressions and number of constants in the sort order is substantial, is very expensive as described on https://github.com/apache/datafusion/issues/13748#issuecomment-2542462344

A substantial amount of the planning time for these queries is continually recomputing a normalized version of OrderingEquivalenceClass.


## What changes are included in this PR?
Always keep `OrderingEquivalenceClass` normalized (deprecate OrderingEquivalenceClass::normalized_oeq_class)


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
By CI. 

Manually testing performance, on datafusion 44:
```
Running with 10 columns...completed in 36.26575ms
Running with 20 columns...completed in 106.079083ms
Running with 30 columns...completed in 432.379833ms
Running with 40 columns...completed in 1.415281375s
Running with 50 columns...completed in 3.870661417s
Running with 60 columns...completed in 9.034940917s
```


Currently (Jan 8): 
```
Running with 10 columns...completed in 21.796ms
Running with 20 columns...completed in 80.530584ms
Running with 30 columns...completed in 318.37525ms
Running with 40 columns...completed in 1.091937708s
Running with 50 columns...completed in 2.966728667s
Running with 60 columns...completed in 7.124604708s
```

So this is better but still not good enough

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
