### PR TITLE
fix: incorrect error message of function_length_check

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -939,6 +939,7 @@ mod tests {
 
     use super::*;
     use arrow::datatypes::Field;
+    use datafusion_common::assert_contains;
 
     #[test]
     fn test_string_conversion() {
@@ -1023,6 +1024,29 @@ mod tests {
         let valid_types = get_valid_types(&signature, &args)?;
         assert_eq!(valid_types.len(), 1);
         assert_eq!(valid_types[0], args);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_valid_types_length_check() -> Result<()> {
+        let signature = TypeSignature::Numeric(1);
+
+        let err = get_valid_types(&signature, &[]).unwrap_err();
+        assert_contains!(
+            err.to_string(),
+            "The signature expected at least one argument but received 0"
+        );
+
+        let err = get_valid_types(
+            &signature,
+            &[DataType::Int32, DataType::Int32, DataType::Int32],
+        )
+        .unwrap_err();
+        assert_contains!(
+            err.to_string(),
+            "The signature expected 1 arguments but received 3"
+        );
 
         Ok(())
     }

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -440,13 +440,13 @@ fn get_valid_types(
     fn function_length_check(length: usize, expected_length: usize) -> Result<()> {
         if length < 1 {
             return plan_err!(
-                "The signature expected at least one argument but received {expected_length}"
+                "The signature expected at least one argument but received {length}"
             );
         }
 
         if length != expected_length {
             return plan_err!(
-                "The signature expected {length} arguments but received {expected_length}"
+                "The signature expected {expected_length} arguments but received {length}"
             );
         }
 

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -438,18 +438,11 @@ fn get_valid_types(
     }
 
     fn function_length_check(length: usize, expected_length: usize) -> Result<()> {
-        if length < 1 {
-            return plan_err!(
-                "The signature expected at least one argument but received {length}"
-            );
-        }
-
         if length != expected_length {
             return plan_err!(
                 "The signature expected {expected_length} arguments but received {length}"
             );
         }
-
         Ok(())
     }
 
@@ -1035,7 +1028,7 @@ mod tests {
         let err = get_valid_types(&signature, &[]).unwrap_err();
         assert_contains!(
             err.to_string(),
-            "The signature expected at least one argument but received 0"
+            "The signature expected 1 arguments but received 0"
         );
 
         let err = get_valid_types(


### PR DESCRIPTION
## Which issue does this PR close?

No

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The error message of the `function_length_check` is incorrect.

## What changes are included in this PR?

Place the `expected_length` and `length` at where they should be.

## Are these changes tested?

Yes, added a simple unit test.

## Are there any user-facing changes?

Yes, users will see correct error message when given unexpected number of args.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
