### PR TITLE
fix: make get_valid_types handle TypeSignature::Numeric correctly

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -551,6 +551,10 @@ fn get_valid_types(
             // and their default type is double precision
             if logical_data_type == NativeType::Null {
                 valid_type = DataType::Float64;
+            } else if !logical_data_type.is_numeric() {
+                return plan_err!(
+                    "The signature expected NativeType::Numeric but received {logical_data_type}"
+                );
             }
 
             vec![vec![valid_type; *number]]
@@ -939,6 +943,7 @@ mod tests {
 
     use super::*;
     use arrow::datatypes::Field;
+    use datafusion_common::assert_contains;
 
     #[test]
     fn test_string_conversion() {
@@ -1001,6 +1006,67 @@ mod tests {
         for case in cases {
             assert_eq!(maybe_data_types(&case.0, &case.1), case.2)
         }
+    }
+
+    #[test]
+    fn test_get_valid_types_numeric() -> Result<()> {
+        let get_valid_types_flatten =
+            |signature: &TypeSignature, current_types: &[DataType]| {
+                get_valid_types(signature, current_types)
+                    .unwrap()
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+            };
+
+        // Trivial case.
+        let got = get_valid_types_flatten(&TypeSignature::Numeric(1), &[DataType::Int32]);
+        assert_eq!(got, [DataType::Int32]);
+
+        // Args are coerced into a common numeric type.
+        let got = get_valid_types_flatten(
+            &TypeSignature::Numeric(2),
+            &[DataType::Int32, DataType::Int64],
+        );
+        assert_eq!(got, [DataType::Int64, DataType::Int64]);
+
+        // Args are coerced into a common numeric type, specifically, int would be coerced to float.
+        let got = get_valid_types_flatten(
+            &TypeSignature::Numeric(3),
+            &[DataType::Int32, DataType::Int64, DataType::Float64],
+        );
+        assert_eq!(
+            got,
+            [DataType::Float64, DataType::Float64, DataType::Float64]
+        );
+
+        // Cannot coerce args to a common numeric type.
+        let got = get_valid_types(
+            &TypeSignature::Numeric(2),
+            &[DataType::Int32, DataType::Utf8],
+        )
+        .unwrap_err();
+        assert_contains!(
+            got.to_string(),
+            "The signature expected NativeType::Numeric but received NativeType::String"
+        );
+
+        // Fallbacks to float64 if the arg is of type null.
+        let got = get_valid_types_flatten(&TypeSignature::Numeric(1), &[DataType::Null]);
+        assert_eq!(got, [DataType::Float64]);
+
+        // Rejects non-numeric arg.
+        let got = get_valid_types(
+            &TypeSignature::Numeric(1),
+            &[DataType::Timestamp(TimeUnit::Second, None)],
+        )
+        .unwrap_err();
+        assert_contains!(
+            got.to_string(),
+            "The signature expected NativeType::Numeric but received NativeType::Timestamp(Second, None)"
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -126,15 +126,15 @@ statement error
 SELECT abs(1, 2);
 
 # abs: unsupported argument type
-query error This feature is not implemented: Unsupported data type Utf8 for function abs
+query error DataFusion error: Error during planning: The signature expected NativeType::Numeric but received NativeType::String
 SELECT abs('foo');
 
 # abs: numeric string
 # TODO: In Postgres, '-1.2' is unknown type and interpreted to float8 so they don't fail on this query
-query error DataFusion error: This feature is not implemented: Unsupported data type Utf8 for function abs
+query error DataFusion error: Error during planning: The signature expected NativeType::Numeric but received NativeType::String
 select abs('-1.2');
 
-query error DataFusion error: This feature is not implemented: Unsupported data type Utf8 for function abs
+query error DataFusion error: Error during planning: The signature expected NativeType::Numeric but received NativeType::String
 select abs(arrow_cast('-1.2', 'Utf8'));
 
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?


Closes #14059.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Make `get_valid_types` handle TypeSignature::Numeric(n) correctly, for various n.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, added a unit test.

## Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
