### PR TITLE
Bump `wasm-bindgen-*` crates

### DIFF
--- a/datafusion/wasmtest/Cargo.toml
+++ b/datafusion/wasmtest/Cargo.toml
@@ -62,9 +62,9 @@ datafusion-sql = { workspace = true }
 getrandom = { version = "0.2.8", features = ["js"] }
 
 parquet = { workspace = true }
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "0.4.40"
+wasm-bindgen = "0.2.99"
+wasm-bindgen-futures = "0.4.49"
 
 [dev-dependencies]
 tokio = { workspace = true }
-wasm-bindgen-test = "0.3.44"
+wasm-bindgen-test = "0.3.49"


### PR DESCRIPTION
## Which issue does this PR close?

Prevent https://github.com/apache/datafusion/pull/14065#issuecomment-2582412339.

## Rationale for this change

Bumps `wasm-bindgen-*` patch versions to make sure cargo selects the latest version for users building with rust `1.84` to prevent the issue linked above.

## What changes are included in this PR?

Version bumps.

## Are these changes tested?

In CI.

## Are there any user-facing changes?

Cargo selects the latest patch version for `wasm-bindgen-*` crates.