### PR TITLE
Bump `ctor` to `0.2.9`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ async-trait = "0.1.73"
 bigdecimal = "0.4.7"
 bytes = "1.4"
 chrono = { version = "0.4.38", default-features = false }
-ctor = "0.2.0"
+ctor = "0.2.9"
 dashmap = "6.0.1"
 datafusion = { path = "datafusion/core", version = "44.0.0", default-features = false }
 datafusion-catalog = { path = "datafusion/catalog", version = "44.0.0" }


### PR DESCRIPTION
Fixes https://github.com/apache/datafusion/pull/14065#issuecomment-2582438534.

Maybe we should just add a `Cargo.lock` file to have checks in CI to prevent this in the future, following suggestions from https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control and https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-latest-dependencies.