### PR TITLE
Minor: Document the rationale for the lack of Cargo.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ CI tests always run against the latest compatible versions of all dependencies
 and we rely on Dependabot for other upgrades. This strategy has two problems
 that occasionally arise:
 
-2. CI failures when downstream libraries upgrade in some non compatible way
-3. Local development builds that fail when DataFusion inadvertently relies on
+1. CI failures when downstream libraries upgrade in some non compatible way
+2. Local development builds that fail when DataFusion inadvertently relies on
    a feature in a newer version of a dependency than declared in `Cargo.toml`
    (e.g. a new method is added to a trait that we use).
 

--- a/README.md
+++ b/README.md
@@ -146,3 +146,27 @@ stable API, we also improve the API over time. As a result, we typically
 deprecate methods before removing them, according to the [deprecation guidelines].
 
 [deprecation guidelines]: https://datafusion.apache.org/library-user-guide/api-health.html
+
+## Dependencies and a `Cargo.lock`
+
+`datafusion` is intended for use as a library and thus purposely does not have a
+`Cargo.lock` file checked in. You can read more about the distinction in the
+[Cargo book].
+
+CI tests always run against the latest compatible versions of all dependencies
+(the equivalent of doing `cargo update`), as suggested in the [Cargo CI guide]
+and we rely on Dependabot for other upgrades. This strategy has two problems
+that occasionally arise:
+
+2. CI failures when downstream libraries upgrade in some non compatible way
+3. Local development builds that fail when DataFusion inadvertently relies on
+   a feature in a newer version of a dependency than declared in `Cargo.toml`
+   (e.g. a new method is added to a trait that we use).
+
+However, we think the current strategy is the best tradeoff between maintenance
+overhead and user experience and ensures DataFusion always works with the latest
+compatible versions of all dependencies. If you encounter either of these
+problems, please open an issue or PR.
+
+[cargo book]: https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
+[cargo ci guide]: https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-latest-dependencies

--- a/datafusion-cli/README.md
+++ b/datafusion-cli/README.md
@@ -41,6 +41,8 @@ The reason `datafusion-cli` is not part of the main workspace in
 checked in `Cargo.lock` file to ensure reproducible builds.
 
 However, the `datafusion` and sub crates are intended for use as libraries and
-thus do not have a `Cargo.lock` file checked in.
+thus do not have a `Cargo.lock` file checked in, as described in the [main
+README] file.
 
 [`datafusion cargo.toml`]: https://github.com/apache/datafusion/blob/main/Cargo.toml
+[main readme]: ../README.md


### PR DESCRIPTION
## Which issue does this PR close?
The question of why `Cargo.lock` is not checked in comes up from time to time, most recently in
- https://github.com/apache/datafusion/pull/14069#pullrequestreview-2542239568
from @mbrobbel 


## Rationale for this change

I think documenting the rationale as I understand it will help:
1. To answer questions about why it is this way
2. Help us decide if we want to change the process

## What changes are included in this PR?

Document my recollection of why Cargo.lock is not checked in

## Are these changes tested?

By CI
## Are there any user-facing changes?
Update the readme

