### PR TITLE
Add comments to physical optimizer tests

### DIFF
--- a/datafusion/core/tests/physical_optimizer/combine_partial_final_agg.rs
+++ b/datafusion/core/tests/physical_optimizer/combine_partial_final_agg.rs
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Tests for [`CombinePartialFinalAggregate`] physical optimizer rule
+//!
+//! Note these tests are not in the same module as the optimizer pass because
+//! they rely on `ParquetExec` which is in the core crate.
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};

--- a/datafusion/core/tests/physical_optimizer/limited_distinct_aggregation.rs
+++ b/datafusion/core/tests/physical_optimizer/limited_distinct_aggregation.rs
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Tests for the limited distinct aggregation optimizer rule
-
+//! Tests for [`LimitedDistinctAggregation`] physical optimizer rule
+//!
+//! Note these tests are not in the same module as the optimizer pass because
+//! they rely on `ParquetExec` which is in the core crate.
 use super::test_util::{parquet_exec_with_sort, schema, trim_plan_display};
 
 use std::sync::Arc;


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/11502

## Rationale for this change

I tried to move some of these tests to be with the code they are testing, but found out the reason is the dependency on ParquetExec

## What changes are included in this PR?

Add comments explaining this rationale so it is clearer to the next reader

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
