### PR TITLE
Update substrait requirement from 0.51 to 0.52

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -41,7 +41,7 @@ object_store = { workspace = true }
 pbjson-types = "0.7"
 # TODO use workspace version
 prost = "0.13"
-substrait = { version = "0.51", features = ["serde"] }
+substrait = { version = "0.52", features = ["serde"] }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/datafusion/substrait/tests/utils.rs
+++ b/datafusion/substrait/tests/utils.rs
@@ -174,6 +174,7 @@ pub mod test {
                         ReadType::LocalFiles(_) => todo!(),
                         ReadType::NamedTable(nt) => self.collect_named_table(r, nt)?,
                         ReadType::ExtensionTable(_) => todo!(),
+                        ReadType::IcebergTable(_) => todo!(),
                     }
                     if let Some(expr) = r.filter.as_ref() {
                         self.collect_schemas_from_expr(expr)?


### PR DESCRIPTION
## Which issue does this PR close?

Handle breaking change in substrait bump. Closes #14103.
