### PR TITLE
Distinguish None and empty projection in unparser

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -41,7 +41,7 @@ use crate::utils::UNNEST_PLACEHOLDER;
 use datafusion_common::{
     internal_err, not_impl_err,
     tree_node::{TransformedResult, TreeNode},
-    Column, DataFusionError, Result, TableReference,
+    Column, DataFusionError, Result, ScalarValue, TableReference,
 };
 use datafusion_expr::expr::OUTER_REFERENCE_COLUMN_PREFIX;
 use datafusion_expr::{
@@ -919,23 +919,29 @@ impl Unparser<'_> {
                 // information included in the TableScan node.
                 if !already_projected {
                     if let Some(project_vec) = &table_scan.projection {
-                        let project_columns = project_vec
-                            .iter()
-                            .cloned()
-                            .map(|i| {
-                                let schema = table_scan.source.schema();
-                                let field = schema.field(i);
-                                if alias.is_some() {
-                                    Column::new(alias.clone(), field.name().clone())
-                                } else {
-                                    Column::new(
-                                        Some(table_scan.table_name.clone()),
-                                        field.name().clone(),
-                                    )
-                                }
-                            })
-                            .collect::<Vec<_>>();
-                        builder = builder.project(project_columns)?;
+                        if project_vec.is_empty() {
+                            builder = builder.project(vec![Expr::Literal(
+                                ScalarValue::Int64(Some(1)),
+                            )])?;
+                        } else {
+                            let project_columns = project_vec
+                                .iter()
+                                .cloned()
+                                .map(|i| {
+                                    let schema = table_scan.source.schema();
+                                    let field = schema.field(i);
+                                    if alias.is_some() {
+                                        Column::new(alias.clone(), field.name().clone())
+                                    } else {
+                                        Column::new(
+                                            Some(table_scan.table_name.clone()),
+                                            field.name().clone(),
+                                        )
+                                    }
+                                })
+                                .collect::<Vec<_>>();
+                            builder = builder.project(project_columns)?;
+                        };
                     }
                 }
 

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -792,7 +792,7 @@ fn test_table_references_in_plan_to_sql() {
 }
 
 #[test]
-fn test_table_scan_with_no_projection_in_plan_to_sql() {
+fn test_table_scan_with_none_projection_in_plan_to_sql() {
     fn test(table_name: &str, expected_sql: &str) {
         let schema = Schema::new(vec![
             Field::new("id", DataType::Utf8, false),
@@ -813,6 +813,30 @@ fn test_table_scan_with_no_projection_in_plan_to_sql() {
     );
     test("schema.table", r#"SELECT * FROM "schema"."table""#);
     test("table", r#"SELECT * FROM "table""#);
+}
+
+#[test]
+fn test_table_scan_with_empty_projection_in_plan_to_sql() {
+    fn test(table_name: &str, expected_sql: &str) {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, false),
+        ]);
+
+        let plan = table_scan(Some(table_name), &schema, Some(vec![]))
+            .unwrap()
+            .build()
+            .unwrap();
+        let sql = plan_to_sql(&plan).unwrap();
+        assert_eq!(sql.to_string(), expected_sql)
+    }
+
+    test(
+        "catalog.schema.table",
+        r#"SELECT 1 FROM "catalog"."schema"."table""#,
+    );
+    test("schema.table", r#"SELECT 1 FROM "schema"."table""#);
+    test("table", r#"SELECT 1 FROM "table""#);
 }
 
 #[test]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/datafusion/issues/11743, cc @LatrecheYasser 

## Rationale for this change

This is a small improvement to the sql unparser. 

Basically, the projection of a table can be `None` or `Some(vec![])`. 
`None` means we want to select everything, or the table doesn't support projection pushdown. 
`Some(vec![])` means the table has empty projection, potentially because all the computation is been pushed down.

For example, with filter push down, this query has empty projection (i.e., `Some(vec![])`): `SELECT COUNT(*) FROM hits WHERE "URL" <> '';`, in that case the unpraser should return `SELECT 1 FROM ...` rather than `SELECT * FROM ...`

Please let me know if this makes sense!

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
