### PR TITLE
Fix: regularize order bys when consuming from substrait

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -3353,7 +3353,7 @@ mod test {
         let mut consumer = test_consumer();
 
         // Just registering a single function (index 0) so that the plan
-        // does not through a function not found error.
+        // does not throw a "function not found" error.
         let mut extensions = Extensions::default();
         extensions.register_function("count".to_string());
         consumer.extensions = &extensions;


### PR DESCRIPTION
## Which issue does this PR close?

No issue added, let me know if one is needed

## Rationale for this change

Fixing an issue with the current substrait consumer

## What changes are included in this PR?

Using built-in method for regularizing order by statements based on window frames in the substrait consumer

## Are these changes tested?

Yes

## Are there any user-facing changes?

Anyone that is passing substrait plans directly to DataFusion should be able to pass window function nodes with no order bys and with a "RANGE" window frame unit.
