### PR TITLE
Return err if wildcard is not expanded before type coercion

### DIFF
--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1030,8 +1030,6 @@ mod test {
     use datafusion_common::{DFSchema, DFSchemaRef, Result, ScalarValue};
     use datafusion_expr::expr::{self, InSubquery, Like, ScalarFunction};
     use datafusion_expr::logical_plan::{EmptyRelation, Projection, Sort};
-    use datafusion_expr::sqlparser::dialect::PostgreSqlDialect;
-    use datafusion_expr::sqlparser::parser::Parser;
     use datafusion_expr::test::function_stub::avg_udaf;
     use datafusion_expr::{
         cast, col, create_udaf, is_true, lit, AccumulatorFactoryFunction, AggregateUDF,
@@ -1040,7 +1038,6 @@ mod test {
         Volatility,
     };
     use datafusion_functions_aggregate::average::AvgAccumulator;
-    use datafusion_sql::planner::SqlToRel;
 
     fn empty() -> Arc<LogicalPlan> {
         Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -409,6 +409,8 @@ fn test_union_coercion_with_wildcard() -> Result<()> {
             err,
             "Error during planning: Wildcard should be expanded before type coercion"
         );
+    } else {
+        panic!("Expected Union plan");
     }
     Ok(())
 }

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{plan_err, Result};
+use datafusion_common::{assert_contains, plan_err, Result};
 use datafusion_expr::sqlparser::dialect::PostgreSqlDialect;
 use datafusion_expr::test::function_stub::sum_udaf;
 use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource, WindowUDF};
@@ -405,7 +405,10 @@ fn test_union_coercion_with_wildcard() -> Result<()> {
             .err()
             .unwrap()
             .to_string();
-        assert_eq!(err, "Error during planning: Wildcard should be expanded before going to the method");
+        assert_contains!(
+            err,
+            "Error during planning: Wildcard should be expanded before type coercion"
+        );
     }
     Ok(())
 }

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -23,10 +23,12 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{plan_err, Result};
+use datafusion_expr::sqlparser::dialect::PostgreSqlDialect;
 use datafusion_expr::test::function_stub::sum_udaf;
 use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource, WindowUDF};
 use datafusion_functions_aggregate::average::avg_udaf;
 use datafusion_functions_aggregate::count::count_udaf;
+use datafusion_optimizer::analyzer::type_coercion::TypeCoercionRewriter;
 use datafusion_optimizer::analyzer::Analyzer;
 use datafusion_optimizer::optimizer::Optimizer;
 use datafusion_optimizer::{OptimizerConfig, OptimizerContext, OptimizerRule};
@@ -385,6 +387,27 @@ fn select_correlated_predicate_subquery_with_uppercase_ident() {
     \n        Filter: test.col_int32 IS NOT NULL\
     \n          TableScan: test projection=[col_int32]";
     assert_eq!(expected, format!("{plan}"));
+}
+
+// The test should return an error
+// because the wildcard didn't be expanded before type coercion
+#[test]
+fn test_union_coercion_with_wildcard() -> Result<()> {
+    let dialect = PostgreSqlDialect {};
+    let context_provider = MyContextProvider::default();
+    let sql = "select * from (SELECT col_int32, col_uint32 FROM test) union all select * from(SELECT col_uint32, col_int32 FROM test)";
+    let statements = Parser::parse_sql(&dialect, sql)?;
+    let sql_to_rel = SqlToRel::new(&context_provider);
+    let logical_plan = sql_to_rel.sql_statement_to_plan(statements[0].clone())?;
+
+    if let LogicalPlan::Union(union) = logical_plan {
+        let err = TypeCoercionRewriter::coerce_union(union)
+            .err()
+            .unwrap()
+            .to_string();
+        assert_eq!(err, "Error during planning: Wildcard should be expanded before going to the method");
+    }
+    Ok(())
 }
 
 fn test_sql(sql: &str) -> Result<LogicalPlan> {


### PR DESCRIPTION
## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

If users use the whole analyzer, they won't encounter the issue. But if only use the [TypeCoercionRewriter](https://docs.rs/datafusion/latest/datafusion/optimizer/analyzer/type_coercion/struct.TypeCoercionRewriter.html)(Yes, it's me), such as 
```rust
  if let LogicalPlan::Union(union) = logical_plan  {
      logical_plan = TypeCoercionRewriter::coerce_union(union)?;
  }
``` 
and if there is the wildcard in the union, such as the test in the PR, I'll get the error `https://github.com/apache/datafusion/blob/main/datafusion/expr/src/logical_plan/plan.rs#L2138`.


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Make the error report early and clear, the current change will directly tell the user what they are missing.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No