### PR TITLE
POC: Use IndexSet rather than `Vec` for OrderingEquivalenceClass

### DIFF
--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1313,15 +1313,15 @@ mod tests {
             // ok with one column
             (
                 vec![vec![col("string_col").sort(true, false)]],
-                Ok(vec![LexOrdering {
-                        inner: vec![PhysicalSortExpr {
+                Ok(vec![LexOrdering::new(
+                        vec![PhysicalSortExpr {
                             expr: physical_col("string_col", &schema).unwrap(),
                             options: SortOptions {
                                 descending: false,
                                 nulls_first: false,
                             },
                         }],
-                    }
+                )
                 ])
             ),
             // ok with two columns, different options
@@ -1330,8 +1330,8 @@ mod tests {
                     col("string_col").sort(true, false),
                     col("int_col").sort(false, true),
                 ]],
-                Ok(vec![LexOrdering {
-                        inner: vec![
+                Ok(vec![LexOrdering::new(
+                        vec![
                             PhysicalSortExpr::new_default(physical_col("string_col", &schema).unwrap())
                                         .asc()
                                         .nulls_last(),
@@ -1339,7 +1339,7 @@ mod tests {
                                         .desc()
                                         .nulls_first()
                         ],
-                    }
+                )
                 ])
             ),
         ];

--- a/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
@@ -1112,9 +1112,8 @@ mod tests {
                     ))))
                     .collect::<Vec<_>>(),
             ));
-            let sort_order = LexOrdering {
-                inner: case
-                    .sort
+            let sort_order = LexOrdering::from(
+                case.sort
                     .into_iter()
                     .map(|expr| {
                         crate::physical_planner::create_physical_sort_expr(
@@ -1124,7 +1123,7 @@ mod tests {
                         )
                     })
                     .collect::<Result<Vec<_>>>()?,
-            };
+            );
 
             let partitioned_files =
                 case.files.into_iter().map(From::from).collect::<Vec<_>>();

--- a/datafusion/core/src/datasource/physical_plan/statistics.rs
+++ b/datafusion/core/src/datasource/physical_plan/statistics.rs
@@ -119,8 +119,8 @@ impl MinMaxStatistics {
             projected_schema
                 .project(&(sort_columns.iter().map(|c| c.index()).collect::<Vec<_>>()))?,
         );
-        let min_max_sort_order = LexOrdering {
-            inner: sort_columns
+        let min_max_sort_order = LexOrdering::from(
+            sort_columns
                 .iter()
                 .zip(projected_sort_order.iter())
                 .enumerate()
@@ -129,7 +129,7 @@ impl MinMaxStatistics {
                     options: sort.options,
                 })
                 .collect::<Vec<_>>(),
-        };
+        );
 
         let (min_values, max_values): (Vec<_>, Vec<_>) = sort_columns
             .iter()

--- a/datafusion/core/src/physical_optimizer/replace_with_order_preserving_variants.rs
+++ b/datafusion/core/src/physical_optimizer/replace_with_order_preserving_variants.rs
@@ -133,10 +133,7 @@ fn plan_with_order_preserving_variants(
         if let Some(ordering) = child.output_ordering() {
             // When the input of a `CoalescePartitionsExec` has an ordering,
             // replace it with a `SortPreservingMergeExec` if appropriate:
-            let spm = SortPreservingMergeExec::new(
-                LexOrdering::new(ordering.inner.clone()),
-                Arc::clone(child),
-            );
+            let spm = SortPreservingMergeExec::new(ordering.clone(), Arc::clone(child));
             sort_input.plan = Arc::new(spm) as _;
             sort_input.children[0].data = true;
             return Ok(sort_input);

--- a/datafusion/core/src/physical_optimizer/utils.rs
+++ b/datafusion/core/src/physical_optimizer/utils.rs
@@ -40,7 +40,7 @@ pub fn add_sort_above<T: Clone + Default>(
     fetch: Option<usize>,
 ) -> PlanContext<T> {
     let mut sort_expr = LexOrdering::from(sort_requirements);
-    sort_expr.inner.retain(|sort_expr| {
+    sort_expr.retain(|sort_expr| {
         !node
             .plan
             .equivalence_properties()

--- a/datafusion/core/tests/fuzz_cases/equivalence/utils.rs
+++ b/datafusion/core/tests/fuzz_cases/equivalence/utils.rs
@@ -444,7 +444,7 @@ pub fn generate_table_for_orderings(
 
     assert!(!orderings.is_empty());
     // Sort the inner vectors by their lengths (longest first)
-    orderings.sort_by_key(|v| std::cmp::Reverse(v.inner.len()));
+    orderings.sort_by_key(|v| std::cmp::Reverse(v.len()));
 
     let arrays = schema
         .fields

--- a/datafusion/core/tests/fuzz_cases/window_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/window_fuzz.rs
@@ -617,7 +617,7 @@ async fn run_window_test(
             options: SortOptions::default(),
         })
     }
-    for order_by_expr in &orderby_exprs.inner {
+    for order_by_expr in &orderby_exprs {
         if !sort_keys.contains(order_by_expr) {
             sort_keys.push(order_by_expr.clone())
         }

--- a/datafusion/physical-expr/src/equivalence/class.rs
+++ b/datafusion/physical-expr/src/equivalence/class.rs
@@ -310,7 +310,6 @@ impl EquivalenceClass {
         let new_exprs = self
             .exprs
             .iter()
-            .cloned()
             .map(|e| add_offset_to_expr(e, offset))
             .collect();
         Self::new(new_exprs)

--- a/datafusion/physical-expr/src/equivalence/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/mod.rs
@@ -48,7 +48,7 @@ pub fn collapse_lex_req(input: LexRequirement) -> LexRequirement {
 
 /// Adds the `offset` value to `Column` indices inside `expr`. This function is
 /// generally used during the update of the right table schema in join operations.
-fn add_offset_to_expr(
+pub fn add_offset_to_expr(
     expr: &Arc<dyn PhysicalExpr>,
     offset: usize,
 ) -> Arc<dyn PhysicalExpr> {

--- a/datafusion/physical-expr/src/equivalence/ordering.rs
+++ b/datafusion/physical-expr/src/equivalence/ordering.rs
@@ -207,7 +207,7 @@ impl OrderingEquivalenceClass {
             for idx in 0..n_ordering {
                 // Calculate cross product index
                 let idx = outer_idx * n_ordering + idx;
-                self.orderings[idx].inner.extend(ordering.iter().cloned());
+                self.orderings[idx].extend(ordering.iter().cloned());
             }
         }
         self
@@ -217,9 +217,9 @@ impl OrderingEquivalenceClass {
     /// ordering equivalence class.
     pub fn add_offset(&mut self, offset: usize) {
         for ordering in self.orderings.iter_mut() {
-            for sort_expr in ordering.inner.iter_mut() {
+            ordering.transform(|sort_expr| {
                 sort_expr.expr = add_offset_to_expr(Arc::clone(&sort_expr.expr), offset);
-            }
+            })
         }
     }
 

--- a/datafusion/physical-expr/src/equivalence/ordering.rs
+++ b/datafusion/physical-expr/src/equivalence/ordering.rs
@@ -138,8 +138,8 @@ impl OrderingEquivalenceClass {
     /// then there is no need to keep ordering `[a ASC, b ASC]` in the state.
     fn remove_redundant_entries(&mut self) {
         // todo rework this algorthtm to avoid Vec
-        let mut orderings:Vec<_> = std::mem::take(&mut self.orderings).into_iter()
-            .collect();
+        let mut orderings: Vec<_> =
+            std::mem::take(&mut self.orderings).into_iter().collect();
         let mut work = true;
         while work {
             work = false;
@@ -148,7 +148,8 @@ impl OrderingEquivalenceClass {
                 let mut ordering_idx = idx + 1;
                 let mut removal = orderings[idx].is_empty();
                 while ordering_idx < orderings.len() {
-                    if let Some(new_len) = resolve_overlap(&orderings, idx, ordering_idx) {
+                    if let Some(new_len) = resolve_overlap(&orderings, idx, ordering_idx)
+                    {
                         work = true;
                         orderings[idx].truncate(new_len);
                     }
@@ -156,12 +157,13 @@ impl OrderingEquivalenceClass {
                         removal = true;
                         break;
                     }
-                    if let Some(new_len) = resolve_overlap(&orderings, ordering_idx, idx) {
+                    if let Some(new_len) = resolve_overlap(&orderings, ordering_idx, idx)
+                    {
                         work = true;
                         orderings[ordering_idx].truncate(new_len);
                     }
                     if orderings[ordering_idx].is_empty() {
-                       orderings.swap_remove(ordering_idx);
+                        orderings.swap_remove(ordering_idx);
                     } else {
                         ordering_idx += 1;
                     }
@@ -173,13 +175,12 @@ impl OrderingEquivalenceClass {
                 }
             }
         }
-        orderings.iter().for_each(|ordering| {
-            assert!(ordering.len()>0)
-        });
+        orderings
+            .iter()
+            .for_each(|ordering| assert!(ordering.len() > 0));
         // recreate the indexset
         self.orderings = orderings.into_iter().collect();
     }
-
 
     /// Returns the concatenation of all the orderings. This enables merge
     /// operations to preserve all equivalent orderings simultaneously.
@@ -253,13 +254,15 @@ impl OrderingEquivalenceClass {
 /// For example, if `orderings[idx]` is `[a ASC, b ASC, c DESC]` and
 /// `orderings[pre_idx]` is `[b ASC, c DESC]`, then the function will return a
 /// new size of `1`, corresponding to updating `orderings[idx]` to `[a ASC]`.
-fn resolve_overlap(orderings: &[LexOrdering], idx: usize, pre_idx: usize) -> Option<usize> {
+fn resolve_overlap(
+    orderings: &[LexOrdering],
+    idx: usize,
+    pre_idx: usize,
+) -> Option<usize> {
     let length = orderings[idx].len();
     let other_length = orderings[pre_idx].len();
     for overlap in 1..=length.min(other_length) {
-        if orderings[idx][length - overlap..]
-            == orderings[pre_idx][..overlap]
-        {
+        if orderings[idx][length - overlap..] == orderings[pre_idx][..overlap] {
             return Some(length - overlap);
         }
     }

--- a/datafusion/physical-expr/src/equivalence/ordering.rs
+++ b/datafusion/physical-expr/src/equivalence/ordering.rs
@@ -67,7 +67,9 @@ impl OrderingEquivalenceClass {
     /// Any redundant entries are removed
     pub fn new(orderings: impl IntoIterator<Item = LexOrdering>) -> Self {
         let orderings = orderings.into_iter().collect();
-        Self { orderings }
+        let mut result = Self { orderings };
+        result.remove_redundant_entries();
+        result
     }
 
     /// Converts this OrderingEquivalenceClass to a vector of orderings.

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -187,7 +187,6 @@ impl EquivalenceProperties {
         let mut output_ordering = self.oeq_class().output_ordering().unwrap_or_default();
         // Prune out constant expressions
         output_ordering
-            .inner
             .retain(|sort_expr| !const_exprs_contains(constants, &sort_expr.expr));
         (!output_ordering.is_empty()).then_some(output_ordering)
     }
@@ -697,7 +696,6 @@ impl EquivalenceProperties {
         // Generate all valid orderings, given substituted expressions.
         let res = new_orderings
             .into_iter()
-            .map(|ordering| ordering.inner)
             .multi_cartesian_product()
             .map(LexOrdering::new)
             .collect::<Vec<_>>();
@@ -1221,7 +1219,6 @@ impl EquivalenceProperties {
         let mut new_orderings = vec![];
         for ordering in self.oeq_class {
             let new_ordering = ordering
-                .inner
                 .into_iter()
                 .map(|mut sort_expr| {
                     sort_expr.expr = with_new_schema(sort_expr.expr, &schema)?;
@@ -1507,7 +1504,7 @@ fn generate_dependency_orderings(
                 .map(|prefixes| {
                     prefixes
                         .into_iter()
-                        .flat_map(|ordering| ordering.inner.clone())
+                        .flat_map(|ordering| ordering.clone())
                         .collect()
                 })
                 .collect::<Vec<_>>()
@@ -2177,8 +2174,8 @@ impl UnionEquivalentOrderingBuilder {
         existing_constants: &[ConstExpr],
     ) -> Option<LexOrdering> {
         let mut augmented_ordering = LexOrdering::default();
-        let mut sort_expr_iter = ordering.inner.iter().peekable();
-        let mut existing_sort_expr_iter = existing_ordering.inner.iter().peekable();
+        let mut sort_expr_iter = ordering.iter().peekable();
+        let mut existing_sort_expr_iter = existing_ordering.iter().peekable();
 
         // walk in parallel down the two orderings, trying to match them up
         while sort_expr_iter.peek().is_some() || existing_sort_expr_iter.peek().is_some()
@@ -2758,7 +2755,7 @@ mod tests {
             let leading_orderings = eq_properties
                 .oeq_class()
                 .iter()
-                .flat_map(|ordering| ordering.inner.first().cloned())
+                .flat_map(|ordering| ordering.first().cloned())
                 .collect::<Vec<_>>();
             let expr_props = eq_properties.get_expr_properties(Arc::clone(&expr));
             let err_msg = format!(

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -456,7 +456,7 @@ fn replace_on_columns_of_right_ordering(
     right_ordering: &mut LexOrdering,
 ) -> Result<()> {
     for (left_col, right_col) in on_columns {
-        for item in right_ordering.inner.iter_mut() {
+        right_ordering.transform(|item| {
             let new_expr = Arc::clone(&item.expr)
                 .transform(|e| {
                     if e.eq(right_col) {
@@ -465,9 +465,10 @@ fn replace_on_columns_of_right_ordering(
                         Ok(Transformed::no(e))
                     }
                 })
-                .data()?;
+                .data()
+                .expect("closure is infallible");
             item.expr = new_expr;
-        }
+        });
     }
     Ok(())
 }

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -441,7 +441,7 @@ pub fn adjust_right_output_partitioning(
         Partitioning::Hash(exprs, size) => {
             let new_exprs = exprs
                 .iter()
-                .map(|expr| add_offset_to_expr(Arc::clone(expr), left_columns_len))
+                .map(|expr| add_offset_to_expr(expr, left_columns_len))
                 .collect();
             Partitioning::Hash(new_exprs, *size)
         }
@@ -484,7 +484,7 @@ fn offset_ordering(
         JoinType::Inner | JoinType::Left | JoinType::Full | JoinType::Right => ordering
             .iter()
             .map(|sort_expr| PhysicalSortExpr {
-                expr: add_offset_to_expr(Arc::clone(&sort_expr.expr), offset),
+                expr: add_offset_to_expr(&sort_expr.expr, offset),
                 options: sort_expr.options,
             })
             .collect(),

--- a/datafusion/physical-plan/src/memory.rs
+++ b/datafusion/physical-plan/src/memory.rs
@@ -320,7 +320,7 @@ impl MemoryExec {
         let fields = self.schema.fields();
         let ambiguous_column = sort_information
             .iter()
-            .flat_map(|ordering| ordering.inner.clone())
+            .flat_map(|ordering| ordering.clone())
             .flat_map(|expr| collect_columns(&expr.expr))
             .find(|col| {
                 fields
@@ -660,8 +660,8 @@ mod memory_exec_tests {
             .try_with_sort_information(sort_information)?;
 
         assert_eq!(
-            mem_exec.properties().output_ordering().unwrap().to_vec(),
-            expected_output_order.inner
+            mem_exec.properties().output_ordering().unwrap(),
+            &expected_output_order
         );
         let eq_properties = mem_exec.properties().equivalence_properties();
         assert!(eq_properties.oeq_class().contains(&sort1));

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -282,7 +282,7 @@ impl ExternalSorter {
             in_mem_batches: vec![],
             in_mem_batches_sorted: true,
             spills: vec![],
-            expr: expr.inner.into(),
+            expr: expr.into(),
             metrics,
             fetch,
             reservation,

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -108,7 +108,7 @@ impl TopK {
         let reservation = MemoryConsumer::new(format!("TopK[{partition_id}]"))
             .register(&runtime.memory_pool);
 
-        let expr: Arc<[PhysicalSortExpr]> = expr.inner.into();
+        let expr: Arc<[PhysicalSortExpr]> = expr.into();
 
         let sort_fields: Vec<_> = expr
             .iter()

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -331,15 +331,13 @@ fn roundtrip_window() -> Result<()> {
     let udwf_expr = Arc::new(StandardWindowExpr::new(
         nth_value_window,
         &[col("b", &schema)?],
-        &LexOrdering {
-            inner: vec![PhysicalSortExpr {
-                expr: col("a", &schema)?,
-                options: SortOptions {
-                    descending: false,
-                    nulls_first: false,
-                },
-            }],
-        },
+        &LexOrdering::new(vec![PhysicalSortExpr {
+            expr: col("a", &schema)?,
+            options: SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+        }]),
         Arc::new(window_frame),
     ));
 
@@ -1130,15 +1128,13 @@ fn roundtrip_udwf_extension_codec() -> Result<()> {
     let udwf_expr = Arc::new(StandardWindowExpr::new(
         udwf,
         &[col("b", &schema)?],
-        &LexOrdering {
-            inner: vec![PhysicalSortExpr {
-                expr: col("a", &schema)?,
-                options: SortOptions {
-                    descending: false,
-                    nulls_first: false,
-                },
-            }],
-        },
+        &LexOrdering::new(vec![PhysicalSortExpr {
+            expr: col("a", &schema)?,
+            options: SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+        }]),
         Arc::new(window_frame),
     ));
 


### PR DESCRIPTION
WIP as I am still in the process of
- [ ]  I need to fix `resolve_overlap`
- [ ] Test timing

## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/13748


## Rationale for this change

I am trying to make many of the overlap algorthms constant time rather than polynomial in the number of expressions

## What changes are included in this PR?

Use IndexSet rather than `Vec` for OrderingEquivalenceClass

## Are these changes tested?
by existing CI

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
