### PR TITLE
Improve `case` expr constant handling for when `<scalar>`

### DIFF
--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -235,3 +235,66 @@ SELECT CASE WHEN a < 5 THEN a + b ELSE b - NVL(a, 0) END FROM foo
 NULL
 NULL
 7
+
+# Reproducer for
+# https://github.com/apache/datafusion/issues/14099
+query I
+SELECT - 79 * + 91 * - COUNT ( * ) * + - 2 * + - NULLIF ( - 49, - COALESCE ( - + 69, - COALESCE ( + COALESCE ( - 20, ( - 18 ) * + COUNT ( * ) + - 93, - CASE 51 WHEN + COUNT ( * ) + 28 THEN 0 ELSE + 29 * + CASE ( 50 ) WHEN - ( - ( CASE WHEN NOT + 37 IS NULL THEN + COUNT ( * ) END ) ) THEN NULL WHEN - 46 + 87 * - 28 THEN 85 WHEN - COUNT ( * ) THEN NULL END END ), COUNT ( * ) - 39 ) * + 22 ) / - COUNT ( * ) )
+----
+-704522
+
+
+query B
+select case when true then false end from foo;
+----
+false
+false
+false
+false
+false
+false
+
+query I
+select case when true then a end from foo;
+----
+1
+3
+5
+NULL
+6
+NULL
+
+query I
+select case when false then a end from foo;
+----
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+
+query I
+select case when null then a end from foo;
+----
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+
+
+query B
+select case when a=1 then false end from foo;
+----
+false
+false
+false
+false
+false
+false
+
+
+statement ok
+drop table foo


### PR DESCRIPTION
~Draft as it builds on https://github.com/apache/datafusion/pull/14156~


## Which issue does this PR close?

- Follow on to https://github.com/apache/datafusion/pull/14156


## Rationale for this change

While reviewing https://github.com/apache/datafusion/pull/14156 I noticed that the code unecessairly expanded a constant to an array, and that I could update it avoid having any internal errors

## What changes are included in this PR?

1. New .slt tests
2. Update case handling code to make it clear the errors are unreachable
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

yes, with new slt tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
