### PR TITLE
Merge SortMergeJoin filtered batches into larger batches

### DIFF
--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -1053,7 +1053,7 @@ impl Stream for SortMergeJoinStream {
                                     {
                                         self.freeze_all()?;
 
-                                        if !self.output_record_batches.batches.is_empty()
+                                        if !self.output_record_batches.batches.is_empty() && self.output_size >= self.batch_size
                                         {
                                             let out_filtered_batch =
                                                 self.filter_joined_batch()?;

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -1053,7 +1053,8 @@ impl Stream for SortMergeJoinStream {
                                     {
                                         self.freeze_all()?;
 
-                                        if !self.output_record_batches.batches.is_empty() && self.output_size >= self.batch_size
+                                        if !self.output_record_batches.batches.is_empty()
+                                            && self.output_size >= self.batch_size
                                         {
                                             let out_filtered_batch =
                                                 self.filter_joined_batch()?;

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -1056,19 +1056,24 @@ impl Stream for SortMergeJoinStream {
                                     {
                                         self.freeze_all()?;
 
+                                        // If join is filtered and there is joined tuples waiting
+                                        // to be filtered
                                         if !self
                                             .staging_output_record_batches
                                             .batches
                                             .is_empty()
                                         {
+                                            // Apply filter on joined tuples and get filtered batch
                                             let out_filtered_batch =
                                                 self.filter_joined_batch()?;
 
+                                            // Append filtered batch to the output buffer
                                             self.output = concat_batches(
                                                 &self.schema(),
                                                 vec![&self.output, &out_filtered_batch],
                                             )?;
 
+                                            // Send to output if the output buffer surpassed the `batch_size`
                                             if self.output.num_rows() >= self.batch_size {
                                                 let record_batch = std::mem::replace(
                                                     &mut self.output,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #14050.

## Rationale for this change

Filtered SortMergeJoin outputs the data after left row shift which is not performant, merging batches into bigger chunks close to `batch_size`

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
