### PR TITLE
Add `ScalarValue::try_as_str` to get str value from logical strings

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -2849,6 +2849,50 @@ impl ScalarValue {
         ScalarValue::from(value).cast_to(target_type)
     }
 
+    /// Returns the Some(`&str`) representation of `ScalarValue` of logical string type
+    ///
+    /// Returns `None` if this `ScalarValue` is not a logical string type or the
+    /// `ScalarValue` represents the `NULL` value.
+    ///
+    /// Note you can use [`Option::flatten`] to check for non null logical
+    /// strings.
+    ///
+    /// For example, [`ScalarValue::Utf8`], [`ScalarValue::LargeUtf8`], and
+    /// [`ScalarValue::Dictionary`] with a logical string value and store
+    /// strings and can be accessed as `&str` using this method.
+    ///
+    /// # Example: logical strings
+    /// ```
+    /// # use datafusion_common::ScalarValue;
+    /// /// non strings return None
+    /// let scalar = ScalarValue::from(42);
+    /// assert_eq!(scalar.try_as_str(), None);
+    /// // Non null logical string returns Some(Some(&str))
+    /// let scalar = ScalarValue::from("hello");
+    /// assert_eq!(scalar.try_as_str(), Some(Some("hello")));
+    /// // Null logical string returns Some(None)
+    /// let scalar = ScalarValue::Utf8(None);
+    /// assert_eq!(scalar.try_as_str(), Some(None));
+    /// ```
+    ///
+    /// # Example: use [`Option::flatten`] to check for non-null logical strings
+    /// ```
+    /// # use datafusion_common::ScalarValue;
+    /// // Non null logical string returns Some(Some(&str))
+    /// let scalar = ScalarValue::from("hello");
+    /// assert_eq!(scalar.try_as_str().flatten(), Some("hello"));
+    /// ```
+    pub fn try_as_str(&self) -> Option<Option<&str>> {
+        let v = match self {
+            ScalarValue::Utf8(v) => v,
+            ScalarValue::LargeUtf8(v) => v,
+            ScalarValue::Utf8View(v) => v,
+            ScalarValue::Dictionary(_, v) => return v.try_as_str(),
+            _ => return None,
+        };
+        Some(v.as_ref().map(|v| v.as_str()))
+    }
+
     /// Try to cast this value to a ScalarValue of type `data_type`
     pub fn cast_to(&self, target_type: &DataType) -> Result<Self> {
         self.cast_to_with_options(target_type, &DEFAULT_CAST_OPTIONS)

--- a/datafusion/core/tests/sql/path_partition.rs
+++ b/datafusion/core/tests/sql/path_partition.rs
@@ -218,10 +218,11 @@ async fn parquet_distinct_partition_col() -> Result<()> {
     assert_eq!(min_limit, resulting_limit);
 
     let s = ScalarValue::try_from_array(results[0].column(1), 0)?;
-    let month = match extract_as_utf(&s) {
-        Some(month) => month,
-        s => panic!("Expected month as Dict(_, Utf8) found {s:?}"),
-    };
+    assert!(
+        matches!(s.data_type(), DataType::Dictionary(_, v) if v.as_ref() == &DataType::Utf8),
+        "Expected month as Dict(_, Utf8) found {s:?}"
+    );
+    let month = s.try_as_str().flatten().unwrap();
 
     let sql_on_partition_boundary = format!(
         "SELECT month from t where month = '{}' LIMIT {}",
@@ -239,15 +240,6 @@ async fn parquet_distinct_partition_col() -> Result<()> {
     let partition_row_count = max_limit - 1;
     assert_eq!(partition_row_count, resulting_limit);
     Ok(())
-}
-
-fn extract_as_utf(v: &ScalarValue) -> Option<String> {
-    if let ScalarValue::Dictionary(_, v) = v {
-        if let ScalarValue::Utf8(v) = v.as_ref() {
-            return v.clone();
-        }
-    }
-    None
 }
 
 #[tokio::test]

--- a/datafusion/functions/src/crypto/basic.rs
+++ b/datafusion/functions/src/crypto/basic.rs
@@ -121,11 +121,9 @@ pub fn digest(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         );
     }
     let digest_algorithm = match &args[1] {
-        ColumnarValue::Scalar(scalar) => match scalar {
-            ScalarValue::Utf8View(Some(method))
-            | ScalarValue::Utf8(Some(method))
-            | ScalarValue::LargeUtf8(Some(method)) => method.parse::<DigestAlgorithm>(),
-            other => exec_err!("Unsupported data type {other:?} for function digest"),
+        ColumnarValue::Scalar(scalar) => match scalar.try_as_str() {
+            Some(Some(method)) => method.parse::<DigestAlgorithm>(),
+            _ => exec_err!("Unsupported data type {scalar:?} for function digest"),
         },
         ColumnarValue::Array(_) => {
             internal_err!("Digest using dynamically decided method is not yet supported")

--- a/datafusion/functions/src/encoding/inner.rs
+++ b/datafusion/functions/src/encoding/inner.rs
@@ -546,12 +546,10 @@ fn encode(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         );
     }
     let encoding = match &args[1] {
-        ColumnarValue::Scalar(scalar) => match scalar {
-            ScalarValue::Utf8(Some(method)) | ScalarValue::Utf8View(Some(method)) | ScalarValue::LargeUtf8(Some(method)) => {
-                method.parse::<Encoding>()
-            }
+        ColumnarValue::Scalar(scalar) => match scalar.try_as_str() {
+            Some(Some(method)) => method.parse::<Encoding>(),
             _ => not_impl_err!(
-                "Second argument to encode must be a constant: Encode using dynamically decided method is not yet supported"
+                "Second argument to encode must be non null constant string: Encode using dynamically decided method is not yet supported. Got {scalar:?}"
             ),
         },
         ColumnarValue::Array(_) => not_impl_err!(
@@ -572,12 +570,10 @@ fn decode(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         );
     }
     let encoding = match &args[1] {
-        ColumnarValue::Scalar(scalar) => match scalar {
-            ScalarValue::Utf8(Some(method)) | ScalarValue::Utf8View(Some(method)) | ScalarValue::LargeUtf8(Some(method)) => {
-                method.parse::<Encoding>()
-            }
+        ColumnarValue::Scalar(scalar) => match scalar.try_as_str() {
+            Some(Some(method))=> method.parse::<Encoding>(),
             _ => not_impl_err!(
-                "Second argument to decode must be a utf8 constant: Decode using dynamically decided method is not yet supported"
+                "Second argument to decode must be a non null constant string: Decode using dynamically decided method is not yet supported. Got {scalar:?}"
             ),
         },
         ColumnarValue::Array(_) => not_impl_err!(

--- a/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
+++ b/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
@@ -475,12 +475,7 @@ fn try_cast_string_literal(
     lit_value: &ScalarValue,
     target_type: &DataType,
 ) -> Option<ScalarValue> {
-    let string_value = match lit_value {
-        ScalarValue::Utf8(s) | ScalarValue::LargeUtf8(s) | ScalarValue::Utf8View(s) => {
-            s.clone()
-        }
-        _ => return None,
-    };
+    let string_value = lit_value.try_as_str()?.map(|s| s.to_string());
     let scalar_value = match target_type {
         DataType::Utf8 => ScalarValue::Utf8(string_value),
         DataType::LargeUtf8 => ScalarValue::LargeUtf8(string_value),

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -251,22 +251,13 @@ macro_rules! compute_utf8_flag_op_scalar {
             .downcast_ref::<$ARRAYTYPE>()
             .expect("compute_utf8_flag_op_scalar failed to downcast array");
 
-        let string_value = match $RIGHT {
-            ScalarValue::Utf8(Some(string_value)) | ScalarValue::LargeUtf8(Some(string_value)) => string_value,
-            ScalarValue::Dictionary(_, value) => {
-                match *value {
-                    ScalarValue::Utf8(Some(string_value)) | ScalarValue::LargeUtf8(Some(string_value)) => string_value,
-                    other => return internal_err!(
-                            "compute_utf8_flag_op_scalar failed to cast dictionary value {} for operation '{}'",
-                            other, stringify!($OP)
-                        )
-                }
-            },
+        let string_value = match $RIGHT.try_as_str() {
+            Some(Some(string_value)) => string_value,
+            // null literal or non string
             _ => return internal_err!(
-                "compute_utf8_flag_op_scalar failed to cast literal value {} for operation '{}'",
-                $RIGHT, stringify!($OP)
-            )
-
+                        "compute_utf8_flag_op_scalar failed to cast literal value {} for operation '{}'",
+                        $RIGHT, stringify!($OP)
+                    )
         };
 
         let flag = $FLAG.then_some("i");


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/14166

## Rationale for this change
See https://github.com/apache/datafusion/issues/14166

TLDR is I don't want to have to remember to check all the variants of ScalarValue that can contain a string

## What changes are included in this PR?

1. Add `ScalarValue::try_as_str` to get str value from logical strings
2. Add docs/examples
3. Update some of the code in DataFusion to use this new API

## Are these changes tested?

yes, by doc tests and examples

## Are there any user-facing changes?
there is a new API but all existing APIs still work