### PR TITLE
refactor: switch BooleanBufferBuilder to NullBufferBuilder in sort function

### DIFF
--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -20,7 +20,7 @@
 use crate::utils::make_scalar_function;
 use arrow::compute;
 use arrow_array::{Array, ArrayRef, ListArray};
-use arrow_buffer::{BooleanBufferBuilder, NullBuffer, OffsetBuffer};
+use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 use arrow_schema::DataType::{FixedSizeList, LargeList, List};
 use arrow_schema::{DataType, Field, SortOptions};
 use datafusion_common::cast::{as_list_array, as_string_array};
@@ -172,11 +172,11 @@ pub fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 
     let mut array_lengths = vec![];
     let mut arrays = vec![];
-    let mut valid = BooleanBufferBuilder::new(row_count);
+    let mut valid = NullBufferBuilder::new(row_count);
     for i in 0..row_count {
         if list_array.is_null(i) {
             array_lengths.push(0);
-            valid.append(false);
+            valid.append_null();
         } else {
             let arr_ref = list_array.value(i);
             let arr_ref = arr_ref.as_ref();
@@ -184,7 +184,7 @@ pub fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
             let sorted_array = compute::sort(arr_ref, sort_option)?;
             array_lengths.push(sorted_array.len());
             arrays.push(sorted_array);
-            valid.append(true);
+            valid.append_non_null();
         }
     }
 
@@ -201,7 +201,7 @@ pub fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         Arc::new(Field::new_list_field(data_type, true)),
         OffsetBuffer::from_lengths(array_lengths),
         Arc::new(compute::concat(elements.as_slice())?),
-        Some(NullBuffer::new(buffer)),
+        buffer,
     );
     Ok(Arc::new(list_arr))
 }


### PR DESCRIPTION
…nction

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #14115 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
As mentioned in #14115 , several examples in DataFusion codebase still using `BooleanBufferBuilder` rather than `NullBufferBuilder`, they should be replaced with `NullBufferBuilder` for optimization.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
