### PR TITLE
Support spaceship operator (`<=>`) support (alias for `IS NOT DISTINCT FROM`

### DIFF
--- a/datafusion/sql/src/expr/binary_op.rs
+++ b/datafusion/sql/src/expr/binary_op.rs
@@ -53,6 +53,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             BinaryOperator::StringConcat => Ok(Operator::StringConcat),
             BinaryOperator::ArrowAt => Ok(Operator::ArrowAt),
             BinaryOperator::AtArrow => Ok(Operator::AtArrow),
+            BinaryOperator::Spaceship => Ok(Operator::IsNotDistinctFrom),
             _ => not_impl_err!("Unsupported SQL binary operator {op:?}"),
         }
     }

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -1602,6 +1602,25 @@ true
 false 
 true
 
+# Sanity test - comparing <=> with equivalent expression
+query B
+SELECT 
+  (column1 <=> column2) = 
+  (IFNULL(column1, false) = IFNULL(column2, false)) AS comparison_result
+FROM (VALUES 
+  (1, 1),      -- equal values
+  (1, 2),      -- different values
+  (NULL, NULL), -- both NULL
+  (1, NULL),    -- first not NULL, second NULL
+  (NULL, 1)     -- first NULL, second not NULL
+) AS t(column1, column2);
+----
+true
+true
+true
+true
+true
+
 #### binary_mathematical_operator_with_null_lt
 
 # 1. Integer and NULL

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -1565,6 +1565,43 @@ select NULL < column1 from (VALUES (true), (false)) as t;
 NULL
 NULL
 
+#### comparisons_with_spaceship_operator
+
+# Basic comparisons
+query B
+select 1 <=> 1;
+----
+true
+
+query B
+select 1 <=> 2;
+----
+false
+
+# NULL handling
+query B
+select NULL <=> NULL;
+----
+true
+
+query B
+select 1 <=> NULL;
+----
+false
+
+query B
+select NULL <=> 1;
+----
+false
+
+# Table comparisons
+query B
+select column1 <=> column2 from (VALUES (1, 1), (2, 3), (NULL, NULL)) as t;
+----
+true
+false 
+true
+
 #### binary_mathematical_operator_with_null_lt
 
 # 1. Integer and NULL


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #14098.

## Rationale for this change
This change adds support for the Spaceship operator (<=>) by mapping it to the IsNotDistinctFrom operator and adds tests for the operator as well.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
1. Mapping of Spaceship operator (<=>) with IsNotDistinctFrom
2. Adds tests for the Spaceship operator
3. Sanity test for the Spaceship operator
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. Tests have been added in the sqllogictest/test_files/expr.slt as well.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
The users can now use the Spaceship operator (<=>) in their queries.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
