### PR TITLE
Added job board as a separate header in the documentation

### DIFF
--- a/docs/source/contributor-guide/communication.md
+++ b/docs/source/contributor-guide/communication.md
@@ -72,7 +72,7 @@ Discord server.
 
 There are plenty of opportunities to work with DataFusion advertised on the
 #hiring channel on the [Arrow Rust Discord Server][discord-link].
-Please feel free to post links to DataFusion related jobs there. 
+Please feel free to post links to DataFusion related jobs there.
 
 ## Mailing Lists
 

--- a/docs/source/contributor-guide/communication.md
+++ b/docs/source/contributor-guide/communication.md
@@ -70,7 +70,7 @@ Discord server.
 
 ### Job Board
 
-There are plenty of opportunities to work on DataFusion advertised on the
+There are plenty of opportunities to work with DataFusion advertised on the
 #hiring channel on the [Arrow Rust Discord Server][discord-link].
 
 ## Mailing Lists

--- a/docs/source/contributor-guide/communication.md
+++ b/docs/source/contributor-guide/communication.md
@@ -72,6 +72,7 @@ Discord server.
 
 There are plenty of opportunities to work with DataFusion advertised on the
 #hiring channel on the [Arrow Rust Discord Server][discord-link].
+Please feel free to post links to DataFusion related jobs there. 
 
 ## Mailing Lists
 

--- a/docs/source/contributor-guide/communication.md
+++ b/docs/source/contributor-guide/communication.md
@@ -39,7 +39,7 @@ decisions are made fully in the open, on GitHub.
 
 Most of us use the [ASF Slack
 workspace](https://s.apache.org/slack-invite) and the [Arrow Rust Discord
-server](https://discord.gg/Qw5gKqHxUM) for discussions.
+server][discord-link] for discussions.
 
 There are specific channels for Arrow, DataFusion, and the DataFusion subprojects (Ballista, Comet, Python, etc).
 
@@ -68,6 +68,11 @@ Unfortunately, due to spammers, the ASF Slack workspace requires an invitation
 to join. We are happy to invite you -- please ask for an invitation in the
 Discord server.
 
+### Job Board
+
+There are plenty of opportunities to work on DataFusion advertised on the
+#hiring channel on the [Arrow Rust Discord Server][discord-link].
+
 ## Mailing Lists
 
 Like other Apache projects, we use [mailing lists] for certain purposes, most
@@ -88,3 +93,4 @@ the actual discussion occurs. The project mailing lists are:
   [archives](https://lists.apache.org/list.html?private@datafusion.apache.org)
 
 [mailing lists]: https://www.apache.org/foundation/mailinglists
+[discord-link]: https://discord.gg/Qw5gKqHxUM


### PR DESCRIPTION
Following up suggestion from @alamb in our Discord community