### PR TITLE
Faster reverse() string function for ASCII-only case

### DIFF
--- a/datafusion/functions/benches/character_length.rs
+++ b/datafusion/functions/benches/character_length.rs
@@ -17,62 +17,10 @@
 
 extern crate criterion;
 
-use arrow::array::{StringArray, StringViewArray};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use datafusion_expr::ColumnarValue;
-use rand::distributions::Alphanumeric;
-use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::sync::Arc;
+use helper::gen_string_array;
 
-/// gen_arr(4096, 128, 0.1, 0.1, true) will generate a StringViewArray with
-/// 4096 rows, each row containing a string with 128 random characters.
-/// around 10% of the rows are null, around 10% of the rows are non-ASCII.
-fn gen_string_array(
-    n_rows: usize,
-    str_len_chars: usize,
-    null_density: f32,
-    utf8_density: f32,
-    is_string_view: bool, // false -> StringArray, true -> StringViewArray
-) -> Vec<ColumnarValue> {
-    let mut rng = StdRng::seed_from_u64(42);
-    let rng_ref = &mut rng;
-
-    let corpus = "DataFusionДатаФусион数据融合📊🔥"; // includes utf8 encoding with 1~4 bytes
-    let corpus_char_count = corpus.chars().count();
-
-    let mut output_string_vec: Vec<Option<String>> = Vec::with_capacity(n_rows);
-    for _ in 0..n_rows {
-        let rand_num = rng_ref.gen::<f32>(); // [0.0, 1.0)
-        if rand_num < null_density {
-            output_string_vec.push(None);
-        } else if rand_num < null_density + utf8_density {
-            // Generate random UTF8 string
-            let mut generated_string = String::with_capacity(str_len_chars);
-            for _ in 0..str_len_chars {
-                let idx = rng_ref.gen_range(0..corpus_char_count);
-                let char = corpus.chars().nth(idx).unwrap();
-                generated_string.push(char);
-            }
-            output_string_vec.push(Some(generated_string));
-        } else {
-            // Generate random ASCII-only string
-            let value = rng_ref
-                .sample_iter(&Alphanumeric)
-                .take(str_len_chars)
-                .collect();
-            let value = String::from_utf8(value).unwrap();
-            output_string_vec.push(Some(value));
-        }
-    }
-
-    if is_string_view {
-        let string_view_array: StringViewArray = output_string_vec.into_iter().collect();
-        vec![ColumnarValue::Array(Arc::new(string_view_array))]
-    } else {
-        let string_array: StringArray = output_string_vec.clone().into_iter().collect();
-        vec![ColumnarValue::Array(Arc::new(string_array))]
-    }
-}
+mod helper;
 
 fn criterion_benchmark(c: &mut Criterion) {
     // All benches are single batch run with 8192 rows

--- a/datafusion/functions/benches/helper.rs
+++ b/datafusion/functions/benches/helper.rs
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{StringArray, StringViewArray};
+use datafusion_expr::ColumnarValue;
+use rand::distributions::Alphanumeric;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::sync::Arc;
+
+/// gen_arr(4096, 128, 0.1, 0.1, true) will generate a StringViewArray with
+/// 4096 rows, each row containing a string with 128 random characters.
+/// around 10% of the rows are null, around 10% of the rows are non-ASCII.
+pub fn gen_string_array(
+    n_rows: usize,
+    str_len_chars: usize,
+    null_density: f32,
+    utf8_density: f32,
+    is_string_view: bool, // false -> StringArray, true -> StringViewArray
+) -> Vec<ColumnarValue> {
+    let mut rng = StdRng::seed_from_u64(42);
+    let rng_ref = &mut rng;
+
+    let corpus = "DataFusionДатаФусион数据融合📊🔥"; // includes utf8 encoding with 1~4 bytes
+    let corpus_char_count = corpus.chars().count();
+
+    let mut output_string_vec: Vec<Option<String>> = Vec::with_capacity(n_rows);
+    for _ in 0..n_rows {
+        let rand_num = rng_ref.gen::<f32>(); // [0.0, 1.0)
+        if rand_num < null_density {
+            output_string_vec.push(None);
+        } else if rand_num < null_density + utf8_density {
+            // Generate random UTF8 string
+            let mut generated_string = String::with_capacity(str_len_chars);
+            for _ in 0..str_len_chars {
+                let idx = rng_ref.gen_range(0..corpus_char_count);
+                let char = corpus.chars().nth(idx).unwrap();
+                generated_string.push(char);
+            }
+            output_string_vec.push(Some(generated_string));
+        } else {
+            // Generate random ASCII-only string
+            let value = rng_ref
+                .sample_iter(&Alphanumeric)
+                .take(str_len_chars)
+                .collect();
+            let value = String::from_utf8(value).unwrap();
+            output_string_vec.push(Some(value));
+        }
+    }
+
+    if is_string_view {
+        let string_view_array: StringViewArray = output_string_vec.into_iter().collect();
+        vec![ColumnarValue::Array(Arc::new(string_view_array))]
+    } else {
+        let string_array: StringArray = output_string_vec.clone().into_iter().collect();
+        vec![ColumnarValue::Array(Arc::new(string_array))]
+    }
+}

--- a/datafusion/functions/src/unicode/reverse.rs
+++ b/datafusion/functions/src/unicode/reverse.rs
@@ -120,15 +120,17 @@ fn reverse_impl<'a, T: OffsetSizeTrait, V: StringArrayType<'a>>(
     let mut builder = GenericStringBuilder::<T>::with_capacity(string_array.len(), 1024);
 
     let mut string_buf = String::new();
+    let mut byte_buf = Vec::<u8>::new();
     for string in string_array.iter() {
         if let Some(s) = string {
             if s.is_ascii() {
+                // reverse bytes directly since ASCII characters are single bytes
+                byte_buf.extend(s.as_bytes());
+                byte_buf.reverse();
                 // SAFETY: Since the original string was ASCII, reversing the bytes still results in valid UTF-8.
-                let reversed = unsafe {
-                    // reverse bytes directly since ASCII characters are single bytes
-                    String::from_utf8_unchecked(s.bytes().rev().collect::<Vec<u8>>())
-                };
-                builder.append_value(&reversed);
+                let reversed = unsafe { std::str::from_utf8_unchecked(&byte_buf) };
+                builder.append_value(reversed);
+                byte_buf.clear();
             } else {
                 string_buf.extend(s.chars().rev());
                 builder.append_value(&string_buf);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #12445.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
See the issue.


## What changes are included in this PR?
+ If all characters in this string are within the ASCII range, reverse bytes directly
+ Move `gen_string_array` in `benches/character_length.rs` to helper.rs
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. Using existing unit test
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
bench result
```
reverse_StringArray_ascii_str_len_8
                        time:   [93.762 µs 94.463 µs 95.301 µs]
                        change: [-38.347% -37.726% -37.143%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

reverse_StringArray_utf8_density_0.8_str_len_8
                        time:   [491.88 µs 496.57 µs 501.74 µs]
                        change: [-1.0373% +0.1648% +1.4032%] (p = 0.79 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

reverse_StringViewArray_ascii_str_len_8
                        time:   [87.226 µs 87.666 µs 88.147 µs]
                        change: [-34.737% -34.039% -33.350%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

reverse_StringViewArray_utf8_density_0.8_str_len_8
                        time:   [502.54 µs 505.02 µs 507.66 µs]
                        change: [-0.5734% +0.3619% +1.3269%] (p = 0.49 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

reverse_StringArray_ascii_str_len_32
                        time:   [98.021 µs 98.794 µs 99.785 µs]
                        change: [-70.309% -70.056% -69.817%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

reverse_StringArray_utf8_density_0.8_str_len_32
                        time:   [1.6026 ms 1.6100 ms 1.6181 ms]
                        change: [-0.0304% +1.0048% +2.0155%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

reverse_StringViewArray_ascii_str_len_32
                        time:   [102.37 µs 102.89 µs 103.44 µs]
                        change: [-68.935% -68.690% -68.454%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

reverse_StringViewArray_utf8_density_0.8_str_len_32
                        time:   [1.6199 ms 1.6269 ms 1.6345 ms]
                        change: [+0.1269% +1.4123% +3.0235%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

reverse_StringArray_ascii_str_len_128
                        time:   [166.01 µs 167.09 µs 168.33 µs]
                        change: [-84.421% -84.299% -84.176%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

reverse_StringArray_utf8_density_0.8_str_len_128
                        time:   [6.1278 ms 6.1569 ms 6.1883 ms]
                        change: [-1.0026% -0.2737% +0.5242%] (p = 0.48 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

reverse_StringViewArray_ascii_str_len_128
                        time:   [173.15 µs 174.16 µs 175.26 µs]
                        change: [-83.918% -83.731% -83.543%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

reverse_StringViewArray_utf8_density_0.8_str_len_128
                        time:   [6.1279 ms 6.1637 ms 6.2028 ms]
                        change: [-1.3879% -0.5410% +0.3269%] (p = 0.22 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

reverse_StringArray_ascii_str_len_4096
                        time:   [15.579 ms 15.687 ms 15.800 ms]
                        change: [-63.915% -63.620% -63.301%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

reverse_StringArray_utf8_density_0.8_str_len_4096
                        time:   [215.98 ms 217.47 ms 219.18 ms]
                        change: [-0.0524% +0.8008% +1.6803%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

reverse_StringViewArray_ascii_str_len_4096
                        time:   [8.6421 ms 8.8760 ms 9.1174 ms]
                        change: [-75.462% -74.835% -74.087%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

reverse_StringViewArray_utf8_density_0.8_str_len_4096
                        time:   [217.17 ms 218.29 ms 219.58 ms]
                        change: [+0.9451% +1.5937% +2.2792%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

```
## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
