### PR TITLE
Minor: Rename extended test job name

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -50,7 +50,7 @@ jobs:
 
   # Run extended tests (with feature 'extended_tests')
   linux-test-extended:
-    name: cargo test (amd64)
+    name: cargo test 'extended_tests' (amd64)
     needs: linux-build-lib
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## Which issue does this PR close?

- Follow on to https://github.com/apache/datafusion/pull/14142 from @2010YOUY01 

## Rationale for this change

WHen checking if the job ran I went to github: https://github.com/apache/datafusion/actions/runs/12850882520/job/35830990299

It was not immediately clear the right job had run because the name is somewhat generic:
<img width="984" alt="Screenshot 2025-01-19 at 9 50 43 AM" src="https://github.com/user-attachments/assets/6facd80d-38bf-45f9-bfd9-d60334db5e3a" />


## What changes are included in this PR?

Update the name to mention it runs with `extended_tests`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
