### PR TITLE
fix: fetch is missed during EnforceDistribution

### DIFF
--- a/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
@@ -3229,6 +3229,8 @@ async fn apply_enforce_distribution_multiple_times() -> Result<()> {
         .create_physical_plan(&optimized_logical_plan, &session_state)
         .await?;
 
+    // println!("{}", displayable(optimized_physical_plan.as_ref()).indent(true));
+
     let mut results = optimized_physical_plan
         .execute(0, ctx.task_ctx().clone())
         .unwrap();

--- a/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
@@ -3212,6 +3212,7 @@ async fn apply_enforce_distribution_multiple_times() -> Result<()> {
         Arc::new(ProjectionPushdown::new()),
         Arc::new(CoalesceBatches::new()),
         Arc::new(EnforceDistribution::new()), // -- Add enforce distribution rule again
+        // The second `EnforceDistribution` should be run before removing `OutputRequirements` to reproduce the bug.
         Arc::new(OutputRequirements::new_remove_mode()),
         Arc::new(ProjectionPushdown::new()),
         Arc::new(LimitPushdown::new()),

--- a/datafusion/core/tests/sql/mod.rs
+++ b/datafusion/core/tests/sql/mod.rs
@@ -243,7 +243,7 @@ pub struct ExplainNormalizer {
 }
 
 impl ExplainNormalizer {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let mut replacements = vec![];
 
         let mut push_path = |path: PathBuf, key: &str| {
@@ -266,7 +266,7 @@ impl ExplainNormalizer {
         Self { replacements }
     }
 
-    fn normalize(&self, s: impl Into<String>) -> String {
+    pub(crate) fn normalize(&self, s: impl Into<String>) -> String {
         let mut s = s.into();
         for (from, to) in &self.replacements {
             s = s.replace(from, to);

--- a/datafusion/physical-optimizer/src/enforce_distribution.rs
+++ b/datafusion/physical-optimizer/src/enforce_distribution.rs
@@ -932,6 +932,7 @@ fn add_hash_on_top(
 /// # Arguments
 ///
 /// * `input`: Current node.
+/// * `fetch`: Possible fetch value
 ///
 /// # Returns
 ///

--- a/datafusion/physical-optimizer/src/enforce_distribution.rs
+++ b/datafusion/physical-optimizer/src/enforce_distribution.rs
@@ -1390,12 +1390,14 @@ pub fn ensure_distribution(
     } else {
         plan.with_new_children(children_plans)?
     };
+    let mut optimized_distribution_ctx =
+        DistributionContext::new(Arc::clone(&plan), data.clone(), children);
 
     // If `fetch` was not consumed, it means that there was `SortPreservingMergeExec` with fetch before
     // It was removed by `remove_dist_changing_operators`
     // and we need to add it back.
     if fetch.is_some() {
-        plan = Arc::new(
+        let plan = Arc::new(
             SortPreservingMergeExec::new(
                 plan.output_ordering()
                     .unwrap_or(&LexOrdering::default())
@@ -1403,12 +1405,12 @@ pub fn ensure_distribution(
                 plan,
             )
             .with_fetch(fetch.take()),
-        )
+        );
+        optimized_distribution_ctx =
+            DistributionContext::new(plan, data, vec![optimized_distribution_ctx]);
     }
 
-    Ok(Transformed::yes(DistributionContext::new(
-        plan, data, children,
-    )))
+    Ok(Transformed::yes(optimized_distribution_ctx))
 }
 
 /// Distribution context that tracks distribution changing operators and fetch limits


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/14150

## Rationale for this change

The root of the bug is that if there is a **SortPreservingMergeExec** operator and it has the fetch, the method(`remove_dist_changing_operators `) will remove it directly, and **miss the fetch**. So it's definitely a bug.

IIUC, **SortPreservingMergeExec** only will be added after `EnforceSorting`, so if we want to reproduce the bug, `EnforceDistribution` needs to run after `EnforceSorting`, the default physical optimizer has the order of rules: `EnforceDistribution` -> `EnforceSorting`, so it won't trigger the bug(fetch is missed), but if we run `EnforceDistribution` again after `EnforceSorting`, the bug will surface.

What the PR is doing is that it will remain the fetch of `SortPreservingMergeExec` and add it back if necessary, as the comments of the method said: `If they are necessary, they will be added in subsequent stages.`

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Avoid missing fetch during `EnforceDistribution`.

## Are these changes tested?

YES

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

NO

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
