### PR TITLE
Support arrays_overlap function (alias of `array_has_any`)

### DIFF
--- a/datafusion/functions-nested/src/array_has.rs
+++ b/datafusion/functions-nested/src/array_has.rs
@@ -389,7 +389,7 @@ impl ArrayHasAny {
     pub fn new() -> Self {
         Self {
             signature: Signature::any(2, Volatility::Immutable),
-            aliases: vec![String::from("list_has_any")],
+            aliases: vec![String::from("list_has_any"), String::from("arrays_overlap")],
         }
     }
 }

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5978,6 +5978,15 @@ select list_has_all(make_array(1,2,3), make_array(4,5,6)),
 ----
 false true false true
 
+query BBBB
+select arrays_overlap(make_array(1,2,3), make_array(4,5,6)),
+        arrays_overlap(make_array(1,2,3), make_array(1,2,4)),
+        arrays_overlap(make_array(['aa']), make_array(['aa'],['bb'])),
+        arrays_overlap(make_array('aa',NULL), make_array('bb',NULL))
+;
+----
+false true true true
+
 query ???
 select range(column2),
        range(column1, column2),

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -2545,6 +2545,7 @@ _Alias of [current_date](#current_date)._
 - [array_sort](#array_sort)
 - [array_to_string](#array_to_string)
 - [array_union](#array_union)
+- [arrays_overlap](#arrays_overlap)
 - [cardinality](#cardinality)
 - [empty](#empty)
 - [flatten](#flatten)
@@ -2929,6 +2930,7 @@ array_has_any(array, sub-array)
 #### Aliases
 
 - list_has_any
+- arrays_overlap
 
 ### `array_indexof`
 
@@ -3572,6 +3574,10 @@ array_union(array1, array2)
 #### Aliases
 
 - list_union
+
+### `arrays_overlap`
+
+_Alias of [array_has_any](#array_has_any)._
 
 ### `cardinality`
 


### PR DESCRIPTION
## Which issue does this PR close?
Closes #14216.

## What changes are included in this PR?
`arrays_overlap` function is supported by following query engines:
`arrays_overlap`: `select arrays_overlap(array('hello', world'), array('hello'))` => `true`
References:
Spark: https://docs.databricks.com/en/sql/language-manual/functions/arrays_overlap.html
Snowflake: https://docs.snowflake.com/en/sql-reference/functions/arrays_overlap
Presto: https://prestodb.io/docs/current/functions/array.html#arrays_overlap-x-y-boolean

DataFusion' s `array_has_any` function aims to have same behavior with `arrays_overlap` function and it can also be exposed as alias of legacy `array_has_any` function.

Also, related DataFusion Comet PR: https://github.com/apache/datafusion-comet/pull/1312

## Are these changes tested?
Added new UT to verify `arrays_overlap` function in terms of different source arrays.

## Are there any user-facing changes?
Yes, new function is supported and documentation has also be updated.
