### PR TITLE
Last Accumulator `update_batch` doesn't take the last value if the order by value are equals

### DIFF
--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -795,8 +795,13 @@ mod tests {
             Arc::new(BooleanArray::from(vec![true; 5])) as ArrayRef,     // is set
         ];
         last_accumulator.merge_batch(&states)?;
+        let states = vec![
+            Arc::new(Int64Array::from(vec![7, 8, 9])) as ArrayRef, // a
+            Arc::new(Int64Array::from(vec![1, 1, 1])) as ArrayRef, // order by
+            Arc::new(BooleanArray::from(vec![true; 3])) as ArrayRef, // is set
+        ];
         last_accumulator.merge_batch(&states)?;
-        assert_eq!(last_accumulator.evaluate()?, ScalarValue::Int64(Some(5)));
+        assert_eq!(last_accumulator.evaluate()?, ScalarValue::Int64(Some(9)));
         Ok(())
     }
 

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -613,7 +613,7 @@ impl Accumulator for LastValueAccumulator {
                 orderings,
                 &get_sort_options(self.ordering_req.as_ref()),
             )?
-            .is_lt()
+            .is_le()
             {
                 self.update_with_new_row(&row);
             }
@@ -652,7 +652,7 @@ impl Accumulator for LastValueAccumulator {
             // version in the new data:
             if !self.is_set
                 || self.requirement_satisfied
-                || compare_rows(&self.orderings, last_ordering, &sort_options)?.is_lt()
+                || compare_rows(&self.orderings, last_ordering, &sort_options)?.is_le()
             {
                 // Update with last value in the state. Note that we should exclude the
                 // is_set flag from the state. Otherwise, we will end up with a state

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -2998,12 +2998,22 @@ physical_plan
 05)--------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
 06)----------MemoryExec: partitions=1, partition_sizes=[1]
 
+query RP
+select amount, ts from sales_global;
+----
+30 2022-01-01T06:00:00
+50 2022-01-01T08:00:00
+75 2022-01-01T11:30:00
+200 2022-01-02T12:00:00
+100 2022-01-03T10:00:00
+80 2022-01-03T10:00:00
+
 query RR
 SELECT FIRST_VALUE(amount ORDER BY ts ASC) AS fv1,
   LAST_VALUE(amount ORDER BY ts ASC) AS fv2
   FROM sales_global
 ----
-30 100
+30 80
 
 # Conversion in between FIRST_VALUE and LAST_VALUE to resolve
 # contradictory requirements should work in multi partitions.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

To get the Last Value, we prefer the latter one instead.

Consider `last(a order by b)`, and we have (a=3, b=1) and (a=4, b=1). We would like (a=4, b=1) instead

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
