### PR TITLE
Add publishing datafusion-sqllogictest to release README.md

### DIFF
--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -17,6 +17,7 @@
 
 [package]
 authors = { workspace = true }
+description = "DataFusion sqllogictest driver"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -296,6 +296,7 @@ Verify that the Cargo.toml in the tarball contains the correct version
 (cd datafusion/substrait && cargo publish)
 (cd datafusion/ffi && cargo publish)
 (cd datafusion-cli && cargo publish)
+(cd datafusion/sqllogictest && cargo publish)
 ```
 
 ### Publish datafusion-cli on Homebrew


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/discussions/14229

## Rationale for this change

Other projects such as rust-iceberg would like to use the datafusion sqllogictest driver to write tests

The code is structured to be published as a crate, and is part of the official release tarballs. We just haven't previously published it to crates. io. 

## What changes are included in this PR?
1. Add instructions to release for publishing the datafusion-sqllogictest crates as part of releasing


## Are these changes tested?
I tested it manually to publish previously approved releases
- https://dist.apache.org/repos/dist/release/datafusion/datafusion-42.2.0/
- https://dist.apache.org/repos/dist/release/datafusion/datafusion-43.0.0/
- https://dist.apache.org/repos/dist/release/datafusion/datafusion-44.0.0/

(I had to add the new description field to Cargo.toml)

They are now available on crates.io as well:
- https://crates.io/crates/datafusion-sqllogictest/42.0.0
- https://crates.io/crates/datafusion-sqllogictest/43.0.0
- https://crates.io/crates/datafusion-sqllogictest/44.0.0

I also sent crate ownership invitations to match the existing datafusion crates

## Are there any user-facing changes?
New crate on crates.io
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
