### PR TITLE
Perform hashing in CollectLeft HashJoin in parallel

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -684,7 +684,7 @@ impl ExecutionPlan for HashJoinExec {
     fn required_input_distribution(&self) -> Vec<Distribution> {
         match self.mode {
             PartitionMode::CollectLeft => vec![
-                Distribution::SinglePartition,
+                Distribution::UnspecifiedDistribution,
                 Distribution::UnspecifiedDistribution,
             ],
             PartitionMode::Partitioned => {

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -952,7 +952,7 @@ async fn collect_left_input(
         offset += batch.batch.num_rows();
     }
     // Merge all batches into a single batch, so we can directly index into the arrays
-    let record_batches = batches.iter().map(|b| &b.batch);
+    let record_batches = batches.iter().rev().map(|b| &b.batch);
     let single_batch = concat_batches(&schema, record_batches)?;
 
     // Reserve additional memory for visited indices bitmap and create shared builder

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -33,7 +33,6 @@ use super::{
     utils::{OnceAsync, OnceFut},
     PartitionMode, SharedBitmapBuilder,
 };
-use crate::coalesce_partitions::CoalescePartitionsExec;
 use crate::execution_plan::{boundedness_from_children, EmissionType};
 use crate::ExecutionPlanProperties;
 use crate::{

--- a/datafusion/physical-plan/src/joins/mod.rs
+++ b/datafusion/physical-plan/src/joins/mod.rs
@@ -31,6 +31,7 @@ mod nested_loop_join;
 mod sort_merge_join;
 mod stream_join_utils;
 mod symmetric_hash_join;
+mod with_hash_stream;
 pub mod utils;
 
 mod join_filter;

--- a/datafusion/physical-plan/src/joins/with_hash_stream.rs
+++ b/datafusion/physical-plan/src/joins/with_hash_stream.rs
@@ -24,7 +24,7 @@ pub struct HashExprStream {
 pub struct WithHashedExpr {
     pub(crate) batch: RecordBatch,
     pub(crate) hashes: Vec<u64>,
-    pub(crate) exprs: Vec<ArrayRef>,
+    pub(crate) _exprs: Vec<ArrayRef>,
 }
 
 impl HashExprStream {
@@ -67,7 +67,7 @@ impl Stream for HashExprStream {
                 Poll::Ready(Some(Ok(WithHashedExpr {
                     batch,
                     hashes,
-                    exprs,
+                    _exprs: exprs,
                 })))
             }
             Some(Err(e)) => Poll::Ready(Some(Err(e))),

--- a/datafusion/physical-plan/src/joins/with_hash_stream.rs
+++ b/datafusion/physical-plan/src/joins/with_hash_stream.rs
@@ -1,0 +1,114 @@
+use std::{pin::Pin, task::Poll};
+
+use ahash::RandomState;
+use arrow_array::{ArrayRef, RecordBatch};
+use datafusion_common::{error::Result, hash_utils::create_hashes};
+use datafusion_execution::SendableRecordBatchStream;
+use datafusion_physical_expr::PhysicalExprRef;
+use futures::{ready, stream::BoxStream, Stream, StreamExt};
+
+use crate::stream::ReceiverStreamBuilder;
+
+
+//
+// HashExprStream evaluates `expr` on incoming batches and attaches
+// the result + its hash to the output.
+//
+
+pub struct HashExprStream {
+    exprs: Vec<PhysicalExprRef>,
+    random_state: RandomState,
+    inner: SendableRecordBatchStream,
+}
+
+pub struct WithHashedExpr {
+    pub(crate) batch: RecordBatch,
+    pub(crate) hashes: Vec<u64>,
+    pub(crate) exprs: Vec<ArrayRef>,
+}
+
+impl HashExprStream {
+    pub fn new(
+        exprs: Vec<PhysicalExprRef>,
+        random_state: RandomState,
+        inner: SendableRecordBatchStream,
+    ) -> HashExprStream {
+        HashExprStream {
+            exprs,
+            random_state,
+            inner,
+        }
+    }
+
+    fn eval(&self, batch: &RecordBatch) -> Result<Vec<ArrayRef>> {
+        self.exprs
+            .iter()
+            .map(|e| {
+                e.evaluate(batch)
+                    .and_then(|column| column.into_array(batch.num_rows()))
+            })
+            .collect()
+    }
+}
+
+impl Stream for HashExprStream {
+    type Item = Result<WithHashedExpr>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match ready!(self.inner.poll_next_unpin(cx)) {
+            Some(Ok(batch)) => {
+                let expr = self.eval(&batch)?;
+                let mut hashes = vec![0; batch.num_rows()];
+                create_hashes(expr.as_slice(), &self.random_state, &mut hashes)?;
+                let exprs = self.eval(&batch)?;
+                Poll::Ready(Some(Ok(WithHashedExpr {
+                    batch,
+                    hashes,
+                    exprs,
+                })))
+            }
+            Some(Err(e)) => Poll::Ready(Some(Err(e))),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+// Could be more generic?
+pub(crate) struct HashCoalescerBuilder {
+    inner: ReceiverStreamBuilder<WithHashedExpr>,
+}
+
+impl HashCoalescerBuilder {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            inner: ReceiverStreamBuilder::new(capacity),
+        }
+    }
+
+    pub(crate) fn run_input(&mut self, mut stream: BoxStream<'static, Result<WithHashedExpr>>) {
+        let output = self.inner.tx();
+
+        self.inner.spawn(async move {
+            while let Some(item) = stream.next().await {
+                let is_err = item.is_err();
+
+                if output.send(item).await.is_err() {
+                    return Ok(());
+                }
+
+                if is_err {
+                    return Ok(());
+                }
+            }
+
+            Ok(())
+        });
+    }
+
+    pub fn build(self) -> BoxStream<'static, Result<WithHashedExpr>> {
+        self.inner.build()
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This PR is an experiment to perform the hashing part of CollectLeft joins in parallel. Instead of directly coalescing the partitions on the build side of the hash join, I tried to perform the hashing for each partition separately, and coalesce the RecordBatches+Hashes afterwards.
While this approach does perform the hashing of the build side in parallel, it also requires those hashes to be stored and accumulated in the HashJoinStream.

**Benchmarking on TPCH showed no significant performance advantage.**

## What changes are included in this PR?

1. Introduce a Stream that attaches hashes to a given stream of RecordBatches + A variation of CoalescePartitions for this RecordBatch+Hash Stream data type. 
2. Relax the distribution constraint for the build side of CollectLeft to UnspecifiedDistribution
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Covered by the existing hash join test suite
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
