### PR TITLE
Add casting of `count` to `Int64` in `array_repeat` function to ensure consistent integer type handling

### DIFF
--- a/datafusion/functions-nested/src/repeat.rs
+++ b/datafusion/functions-nested/src/repeat.rs
@@ -161,11 +161,11 @@ pub fn array_repeat_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 
     let count_array = match count_array.data_type() {
         DataType::Int64 => &cast(count_array, &DataType::UInt64)?,
-        DataType::UInt64 => &count_array,
+        DataType::UInt64 => count_array,
         _ => return exec_err!("count must be an integer type"),
     };
 
-    let count_array = as_uint64_array(&count_array)?;
+    let count_array = as_uint64_array(count_array)?;
 
     match element.data_type() {
         List(_) => {

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2750,6 +2750,15 @@ select
 ----
 [[1], [1], [1], [1], [1]] [[1.1, 2.2, 3.3], [1.1, 2.2, 3.3], [1.1, 2.2, 3.3]] [[NULL, NULL], [NULL, NULL], [NULL, NULL]] [[[1, 2], [3, 4]], [[1, 2], [3, 4]]]
 
+# array_repeat scalar function with count of different integer types
+query ???
+Select
+  array_repeat(1, arrow_cast(2,'Int8')),
+  array_repeat(2, arrow_cast(2,'Int16')),
+  array_repeat(3, arrow_cast(2,'Int32'));
+----
+[1, 1] [2, 2] [3, 3]
+
 # array_repeat with columns #1
 
 statement ok

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2751,13 +2751,28 @@ select
 [[1], [1], [1], [1], [1]] [[1.1, 2.2, 3.3], [1.1, 2.2, 3.3], [1.1, 2.2, 3.3]] [[NULL, NULL], [NULL, NULL], [NULL, NULL]] [[[1, 2], [3, 4]], [[1, 2], [3, 4]]]
 
 # array_repeat scalar function with count of different integer types
-query ???
+query ????????
 Select
   array_repeat(1, arrow_cast(2,'Int8')),
   array_repeat(2, arrow_cast(2,'Int16')),
-  array_repeat(3, arrow_cast(2,'Int32'));
+  array_repeat(3, arrow_cast(2,'Int32')),
+  array_repeat(4, arrow_cast(2,'Int64')),
+  array_repeat(1, arrow_cast(2,'UInt8')),
+  array_repeat(2, arrow_cast(2,'UInt16')),
+  array_repeat(3, arrow_cast(2,'UInt32')),
+  array_repeat(4, arrow_cast(2,'UInt64'));
 ----
-[1, 1] [2, 2] [3, 3]
+[1, 1] [2, 2] [3, 3] [4, 4] [1, 1] [2, 2] [3, 3] [4, 4]
+
+# array_repeat scalar function with count of negative integer types
+query ????
+Select
+  array_repeat(1, arrow_cast(-2,'Int8')),
+  array_repeat(2, arrow_cast(-2,'Int16')),
+  array_repeat(3, arrow_cast(-2,'Int32')),
+  array_repeat(4, arrow_cast(-2,'Int64'));
+----
+[] [] [] []
 
 # array_repeat with columns #1
 


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/14228.

## Rationale for this change

The count in `array_repeat` function only works with `Int64` data type. Now, we have upcasted the count variable if the dataype is `Int8`, `Int16` and `Int32`. 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Updated the implementation of `array_repeat` to upcast  datatype of `count` argument.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, Added test in `array.slt` file.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
