### PR TITLE
Expose more components from sqllogictest

### DIFF
--- a/datafusion/sqllogictest/src/engines/datafusion_engine/mod.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/mod.rs
@@ -21,4 +21,5 @@ mod normalize;
 mod runner;
 
 pub use error::*;
+pub use normalize::*;
 pub use runner::*;

--- a/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
@@ -29,7 +29,7 @@ use super::super::conversion::*;
 use super::error::{DFSqlLogicTestError, Result};
 
 /// Converts `batches` to a result as expected by sqllogictest.
-pub(crate) fn convert_batches(batches: Vec<RecordBatch>) -> Result<Vec<Vec<String>>> {
+pub fn convert_batches(batches: Vec<RecordBatch>) -> Result<Vec<Vec<String>>> {
     if batches.is_empty() {
         Ok(vec![])
     } else {

--- a/datafusion/sqllogictest/src/engines/mod.rs
+++ b/datafusion/sqllogictest/src/engines/mod.rs
@@ -20,7 +20,10 @@ mod conversion;
 mod datafusion_engine;
 mod output;
 
+pub use datafusion_engine::convert_batches;
 pub use datafusion_engine::DataFusion;
+pub use output::DFColumnType;
+pub use output::DFOutput;
 
 #[cfg(feature = "postgres")]
 mod postgres_engine;

--- a/datafusion/sqllogictest/src/engines/output.rs
+++ b/datafusion/sqllogictest/src/engines/output.rs
@@ -54,4 +54,4 @@ impl ColumnType for DFColumnType {
     }
 }
 
-pub(crate) type DFOutput = DBOutput<DFColumnType>;
+pub type DFOutput = DBOutput<DFColumnType>;

--- a/datafusion/sqllogictest/src/lib.rs
+++ b/datafusion/sqllogictest/src/lib.rs
@@ -19,6 +19,9 @@
 
 mod engines;
 
+pub use engines::convert_batches;
+pub use engines::DFColumnType;
+pub use engines::DFOutput;
 pub use engines::DataFusion;
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow up https://github.com/apache/datafusion/pull/14233

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
For datafusion users, if they want to build their own sqllogictest frameworks, `normalize` and `output` components will be useful.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
