### PR TITLE
Minor: Add tests for types of arithmetic operator output types

### DIFF
--- a/datafusion/sqllogictest/test_files/operator.slt
+++ b/datafusion/sqllogictest/test_files/operator.slt
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Validate arithmetic operator output type
+
+statement ok
+create table numeric_types as
+SELECT
+    arrow_cast(1, 'Int8') as int8,
+    arrow_cast(1, 'Int16') as int16,
+    arrow_cast(1, 'Int32') as int32,
+    arrow_cast(1, 'Int64') as int64,
+    arrow_cast(1, 'UInt8') as uint8,
+    arrow_cast(1, 'UInt16') as uint16,
+    arrow_cast(1, 'UInt32') as uint32,
+    arrow_cast(1, 'UInt64') as uint64,
+    arrow_cast(1.23, 'Float32') as float32,
+    arrow_cast(1.23, 'Float64') as float64,
+    arrow_cast(1.25, 'Decimal128(5, 2)') as decimal
+;
+
+# Plus with the same operand type, expect the same output type
+# except for decimal which is  promoted to the highest precision
+query TTTTTTTTTTT
+select
+    arrow_typeof(int8 + int8),
+    arrow_typeof(int16 + int16),
+    arrow_typeof(int32 + int32),
+    arrow_typeof(int64 + int64),
+    arrow_typeof(uint8 + uint8),
+    arrow_typeof(uint16 + uint16),
+    arrow_typeof(uint32 + uint32),
+    arrow_typeof(uint64 + uint64),
+    arrow_typeof(float32 + float32),
+    arrow_typeof(float64 + float64),
+    arrow_typeof(decimal + decimal)
+from numeric_types;
+----
+Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64 Float32 Float64 Decimal128(6, 2)
+
+
+# Minus with the same operand type, expect the same output type
+# except for decimal which is promoted to the highest precision
+query TTTTTTTTTTT
+select
+    arrow_typeof(int8 - int8),
+    arrow_typeof(int16 - int16),
+    arrow_typeof(int32 - int32),
+    arrow_typeof(int64 - int64),
+    arrow_typeof(uint8 - uint8),
+    arrow_typeof(uint16 - uint16),
+    arrow_typeof(uint32 - uint32),
+    arrow_typeof(uint64 - uint64),
+    arrow_typeof(float32 - float32),
+    arrow_typeof(float64 - float64),
+    arrow_typeof(decimal - decimal)
+from numeric_types;
+----
+Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64 Float32 Float64 Decimal128(6, 2)
+
+# Multiply with the same operand type, expect the same output type
+# except for decimal which is promoted to the highest precision
+query TTTTTTTTTTT
+select
+    arrow_typeof(int8 * int8),
+    arrow_typeof(int16 * int16),
+    arrow_typeof(int32 * int32),
+    arrow_typeof(int64 * int64),
+    arrow_typeof(uint8 * uint8),
+    arrow_typeof(uint16 * uint16),
+    arrow_typeof(uint32 * uint32),
+    arrow_typeof(uint64 * uint64),
+    arrow_typeof(float32 * float32),
+    arrow_typeof(float64 * float64),
+    arrow_typeof(decimal * decimal)
+from numeric_types;
+----
+Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64 Float32 Float64 Decimal128(11, 4)
+
+# Divide with the same operand type, expect the same output type
+# except for decimal which is promoted to the highest precision
+query TTTTTTTTTTT
+select
+    arrow_typeof(int8 / int8),
+    arrow_typeof(int16 / int16),
+    arrow_typeof(int32 / int32),
+    arrow_typeof(int64 / int64),
+    arrow_typeof(uint8 / uint8),
+    arrow_typeof(uint16 / uint16),
+    arrow_typeof(uint32 / uint32),
+    arrow_typeof(uint64 / uint64),
+    arrow_typeof(float32 / float32),
+    arrow_typeof(float64 / float64),
+    arrow_typeof(decimal / decimal)
+from numeric_types;
+----
+Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64 Float32 Float64 Decimal128(11, 6)
+
+statement ok
+drop table numeric_types


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/pull/14223



## Rationale for this change

While reviewing https://github.com/apache/datafusion/pull/14223 I misinterpreted the impact of a change.
@jonahgao straightened me out in https://github.com/apache/datafusion/pull/14223/files#r1926245243 and had a good suggestion of how to test the behavior (don't overly extend the output types)

So let's add some tests to automatically ensure the coercion is working correctly


## What changes are included in this PR?

Add tests that show the output type of arithmetic operations with different input types



## Are these changes tested?
It is only tests, no behavior change
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
