### PR TITLE
make AnalysisContext aware of empty sets to represent certainly false bounds

### DIFF
--- a/datafusion-examples/examples/expr_api.rs
+++ b/datafusion-examples/examples/expr_api.rs
@@ -270,7 +270,7 @@ fn range_analysis_demo() -> Result<()> {
     // In this case, we can see that, as expected, `analyze` has figured out
     // that in this case,  `date` must be in the range `['2020-09-01', '2020-10-01']`
     let expected_range = Interval::try_new(september_1, october_1)?;
-    assert_eq!(analysis_result.boundaries[0].interval, expected_range);
+    assert_eq!(analysis_result.boundaries[0].interval, Some(expected_range));
 
     Ok(())
 }

--- a/datafusion/physical-expr/src/analysis.rs
+++ b/datafusion/physical-expr/src/analysis.rs
@@ -81,7 +81,8 @@ impl AnalysisContext {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprBoundaries {
     pub column: Column,
-    /// Minimum and maximum values this expression can have.
+    /// Minimum and maximum values this expression can have. A `None` value
+    /// represents an infeasible expression.
     pub interval: Option<Interval>,
     /// Maximum number of distinct values this expression can produce, if known.
     pub distinct_count: Precision<usize>,
@@ -356,7 +357,7 @@ mod tests {
             )
             .unwrap();
             let Some(actual) = &analysis_result.boundaries[0].interval else {
-                panic!("Interval should be initialized for all columns");
+                panic!("The analysis result should contain non-empty intervals for all columns");
             };
             let expected = Interval::make(lower, upper).unwrap();
             assert_eq!(

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -423,12 +423,14 @@ fn collect_new_statistics(
             )| {
                 let (lower, upper) = match interval {
                     Some(interval) => interval.into_bounds(),
-                    // If the interval is None, we can say that there are no rows 
-                    None => return ColumnStatistics {
-                        null_count: Precision::Exact(0),
-                        max_value: Precision::Exact(ScalarValue::Int32(Some(0))),
-                        min_value: Precision::Exact(ScalarValue::Int32(Some(0))),
-                        distinct_count: Precision::Exact(0),
+                    // If the interval is None, we can say that there are no rows
+                    None => {
+                        return ColumnStatistics {
+                            null_count: Precision::Exact(0),
+                            max_value: Precision::Exact(ScalarValue::Int32(Some(0))),
+                            min_value: Precision::Exact(ScalarValue::Int32(Some(0))),
+                            distinct_count: Precision::Exact(0),
+                        }
                     }
                 };
                 let (min_value, max_value) = if lower.eq(&upper) {

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -425,8 +425,8 @@ fn collect_new_statistics(
                     // If the interval is `None`, we can say that there are no rows:
                     return ColumnStatistics {
                         null_count: Precision::Exact(0),
-                        max_value: Precision::Exact(ScalarValue::Int32(Some(0))),
-                        min_value: Precision::Exact(ScalarValue::Int32(Some(0))),
+                        max_value: Precision::Exact(ScalarValue::Null),
+                        min_value: Precision::Exact(ScalarValue::Null),
                         distinct_count: Precision::Exact(0),
                     };
                 };
@@ -1051,14 +1051,16 @@ mod tests {
             statistics.column_statistics,
             vec![
                 ColumnStatistics {
-                    min_value: Precision::Inexact(ScalarValue::Int32(Some(1))),
-                    max_value: Precision::Inexact(ScalarValue::Int32(Some(100))),
-                    ..Default::default()
+                    min_value: Precision::Exact(ScalarValue::Null),
+                    max_value: Precision::Exact(ScalarValue::Null),
+                    distinct_count: Precision::Exact(0),
+                    null_count: Precision::Exact(0),
                 },
                 ColumnStatistics {
-                    min_value: Precision::Inexact(ScalarValue::Int32(Some(1))),
-                    max_value: Precision::Inexact(ScalarValue::Int32(Some(3))),
-                    ..Default::default()
+                    min_value: Precision::Exact(ScalarValue::Null),
+                    max_value: Precision::Exact(ScalarValue::Null),
+                    distinct_count: Precision::Exact(0),
+                    null_count: Precision::Exact(0),
                 },
             ]
         );

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -421,18 +421,16 @@ fn collect_new_statistics(
                     ..
                 },
             )| {
-                let (lower, upper) = match interval {
-                    Some(interval) => interval.into_bounds(),
-                    // If the interval is None, we can say that there are no rows
-                    None => {
-                        return ColumnStatistics {
-                            null_count: Precision::Exact(0),
-                            max_value: Precision::Exact(ScalarValue::Int32(Some(0))),
-                            min_value: Precision::Exact(ScalarValue::Int32(Some(0))),
-                            distinct_count: Precision::Exact(0),
-                        }
-                    }
+                let Some(interval) = interval else {
+                    // If the interval is `None`, we can say that there are no rows:
+                    return ColumnStatistics {
+                        null_count: Precision::Exact(0),
+                        max_value: Precision::Exact(ScalarValue::Int32(Some(0))),
+                        min_value: Precision::Exact(ScalarValue::Int32(Some(0))),
+                        distinct_count: Precision::Exact(0),
+                    };
                 };
+                let (lower, upper) = interval.into_bounds();
                 let (min_value, max_value) = if lower.eq(&upper) {
                     (Precision::Exact(lower), Precision::Exact(upper))
                 } else {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #14226

## Rationale for this change
Details from #14226:

The [`AnalysisContext`](https://github.com/apache/datafusion/blob/2aff98e002ce6d48008b8bbe2b38ee644a6d5c20/datafusion/physical-expr/src/analysis.rs#L38) which is the result of the [`analyze`](https://github.com/apache/datafusion/blob/2aff98e002ce6d48008b8bbe2b38ee644a6d5c20/datafusion/physical-expr/src/analysis.rs#L159) method for refining column boundaries from a physical expression represents an empty set the same as an unbounded set.

For example, in the case where the bounds can not be shrunk, e.g., a < 0 OR a >= 0, this results an interval of [None, None], but means [-∞, ∞], i.e., [CERTAINLY_TRUE](https://github.com/apache/datafusion/blob/2aff98e002ce6d48008b8bbe2b38ee644a6d5c20/datafusion/expr-common/src/interval_arithmetic.rs#L419-L422). In the case where the bounds represent an empty set, e.g., a < 0 AND a > 0, this also results in an interval of [None, None], but should mean [CERTAINLY_FALSE](https://github.com/apache/datafusion/blob/2aff98e002ce6d48008b8bbe2b38ee644a6d5c20/datafusion/expr-common/src/interval_arithmetic.rs#L409).

## What changes are included in this PR?
- Change AnalysisContext boundaries to be Option to represent empty set


## Are these changes tested?
Added unit tests. Also existing tests is to be passed before merging this one

## Are there any user-facing changes?
I think this breaks public API but I could not find any other way to do this without it. 