### PR TITLE
Revert "fix(expr-common): Coerce to Decimal(20, 0) when combining UInt64 with signed integers (#14223)"

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -777,19 +777,29 @@ pub fn binary_numeric_coercion(
         (_, Float32) | (Float32, _) => Some(Float32),
         // The following match arms encode the following logic: Given the two
         // integral types, we choose the narrowest possible integral type that
-        // accommodates all values of both types. Note that to avoid information
-        // loss when combining UInt64 with signed integers we use Decimal128(20, 0).
-        (UInt64, Int64 | Int32 | Int16 | Int8)
-        | (Int64 | Int32 | Int16 | Int8, UInt64) => Some(Decimal128(20, 0)),
-        (UInt64, _) | (_, UInt64) => Some(UInt64),
+        // accommodates all values of both types. Note that some information
+        // loss is inevitable when we have a signed type and a `UInt64`, in
+        // which case we use `Int64`;i.e. the widest signed integral type.
+
+        // TODO: For i64 and u64, we can use decimal or float64
+        // Postgres has no unsigned type :(
+        // DuckDB v.0.10.0 has double (double precision floating-point number (8 bytes))
+        // for largest signed (signed sixteen-byte integer) and unsigned integer (unsigned sixteen-byte integer)
         (Int64, _)
         | (_, Int64)
+        | (UInt64, Int8)
+        | (Int8, UInt64)
+        | (UInt64, Int16)
+        | (Int16, UInt64)
+        | (UInt64, Int32)
+        | (Int32, UInt64)
         | (UInt32, Int8)
         | (Int8, UInt32)
         | (UInt32, Int16)
         | (Int16, UInt32)
         | (UInt32, Int32)
         | (Int32, UInt32) => Some(Int64),
+        (UInt64, _) | (_, UInt64) => Some(UInt64),
         (Int32, _)
         | (_, Int32)
         | (UInt16, Int16)
@@ -918,16 +928,16 @@ pub fn get_wider_type(lhs: &DataType, rhs: &DataType) -> Result<DataType> {
 }
 
 /// Convert the numeric data type to the decimal data type.
-/// We support signed and unsigned integer types and floating-point type.
+/// Now, we just support the signed integer type and floating-point type.
 fn coerce_numeric_type_to_decimal(numeric_type: &DataType) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
     // This conversion rule is from spark
     // https://github.com/apache/spark/blob/1c81ad20296d34f137238dadd67cc6ae405944eb/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala#L127
     match numeric_type {
-        Int8 | UInt8 => Some(Decimal128(3, 0)),
-        Int16 | UInt16 => Some(Decimal128(5, 0)),
-        Int32 | UInt32 => Some(Decimal128(10, 0)),
-        Int64 | UInt64 => Some(Decimal128(20, 0)),
+        Int8 => Some(Decimal128(3, 0)),
+        Int16 => Some(Decimal128(5, 0)),
+        Int32 => Some(Decimal128(10, 0)),
+        Int64 => Some(Decimal128(20, 0)),
         // TODO if we convert the floating-point data to the decimal type, it maybe overflow.
         Float32 => Some(Decimal128(14, 7)),
         Float64 => Some(Decimal128(30, 15)),
@@ -936,16 +946,16 @@ fn coerce_numeric_type_to_decimal(numeric_type: &DataType) -> Option<DataType> {
 }
 
 /// Convert the numeric data type to the decimal data type.
-/// We support signed and unsigned integer types and floating-point type.
+/// Now, we just support the signed integer type and floating-point type.
 fn coerce_numeric_type_to_decimal256(numeric_type: &DataType) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
     // This conversion rule is from spark
     // https://github.com/apache/spark/blob/1c81ad20296d34f137238dadd67cc6ae405944eb/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala#L127
     match numeric_type {
-        Int8 | UInt8 => Some(Decimal256(3, 0)),
-        Int16 | UInt16 => Some(Decimal256(5, 0)),
-        Int32 | UInt32 => Some(Decimal256(10, 0)),
-        Int64 | UInt64 => Some(Decimal256(20, 0)),
+        Int8 => Some(Decimal256(3, 0)),
+        Int16 => Some(Decimal256(5, 0)),
+        Int32 => Some(Decimal256(10, 0)),
+        Int64 => Some(Decimal256(20, 0)),
         // TODO if we convert the floating-point data to the decimal type, it maybe overflow.
         Float32 => Some(Decimal256(14, 7)),
         Float64 => Some(Decimal256(30, 15)),
@@ -1984,18 +1994,6 @@ mod tests {
             Operator::Gt,
             DataType::UInt32
         );
-        test_coercion_binary_rule!(
-            DataType::UInt64,
-            DataType::UInt8,
-            Operator::Eq,
-            DataType::UInt64
-        );
-        test_coercion_binary_rule!(
-            DataType::UInt64,
-            DataType::Int64,
-            Operator::Eq,
-            DataType::Decimal128(20, 0)
-        );
         // numeric/decimal
         test_coercion_binary_rule!(
             DataType::Int64,
@@ -2026,12 +2024,6 @@ mod tests {
             DataType::Decimal128(10, 3),
             Operator::GtEq,
             DataType::Decimal128(15, 3)
-        );
-        test_coercion_binary_rule!(
-            DataType::UInt64,
-            DataType::Decimal128(20, 0),
-            Operator::Eq,
-            DataType::Decimal128(20, 0)
         );
 
         // Binary

--- a/datafusion/sqllogictest/test_files/coalesce.slt
+++ b/datafusion/sqllogictest/test_files/coalesce.slt
@@ -105,13 +105,13 @@ select
 ----
 2 Int64
 
-# i64 and u64, cast to decimal128(20, 0)
-query RT
+# TODO: Got types (i64, u64), casting to decimal or double or even i128 if supported
+query IT
 select
   coalesce(2, arrow_cast(3, 'UInt64')),
   arrow_typeof(coalesce(2, arrow_cast(3, 'UInt64')));
 ----
-2 Decimal128(20, 0)
+2 Int64
 
 statement ok
 create table t1 (a bigint, b int, c int) as values (null, null, 1), (null, 2, null);

--- a/datafusion/sqllogictest/test_files/insert.slt
+++ b/datafusion/sqllogictest/test_files/insert.slt
@@ -433,30 +433,3 @@ drop table test_column_defaults
 
 statement error DataFusion error: Error during planning: Column reference is not allowed in the DEFAULT expression : Schema error: No field named a.
 create table test_column_defaults(a int, b int default a+1)
-
-
-# test inserting UInt64 and signed integers into a bigint unsigned column
-statement ok
-create table unsigned_bigint_test (v bigint unsigned)
-
-query I
-insert into unsigned_bigint_test values (10000000000000000000), (18446744073709551615)
-----
-2
-
-query I
-insert into unsigned_bigint_test values (10000000000000000001), (1), (10000000000000000002)
-----
-3
-
-query I rowsort
-select * from unsigned_bigint_test
-----
-1
-10000000000000000000
-10000000000000000001
-10000000000000000002
-18446744073709551615
-
-statement ok
-drop table unsigned_bigint_test

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -1828,7 +1828,7 @@ AS VALUES
 ('BB', 6, 1),
 ('BB', 6, 1);
 
-query TIR
+query TII
 select col1, col2, coalesce(sum_col3, 0) as sum_col3
 from (select distinct col2 from tbl) AS q1
 cross join (select distinct col1 from tbl) AS q2

--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -413,23 +413,23 @@ explain SELECT c1, c9 FROM aggregate_test_100 UNION ALL SELECT c1, c3 FROM aggre
 logical_plan
 01)Sort: aggregate_test_100.c9 DESC NULLS FIRST, fetch=5
 02)--Union
-03)----Projection: aggregate_test_100.c1, CAST(aggregate_test_100.c9 AS Decimal128(20, 0)) AS c9
+03)----Projection: aggregate_test_100.c1, CAST(aggregate_test_100.c9 AS Int64) AS c9
 04)------TableScan: aggregate_test_100 projection=[c1, c9]
-05)----Projection: aggregate_test_100.c1, CAST(aggregate_test_100.c3 AS Decimal128(20, 0)) AS c9
+05)----Projection: aggregate_test_100.c1, CAST(aggregate_test_100.c3 AS Int64) AS c9
 06)------TableScan: aggregate_test_100 projection=[c1, c3]
 physical_plan
 01)SortPreservingMergeExec: [c9@1 DESC], fetch=5
 02)--UnionExec
 03)----SortExec: TopK(fetch=5), expr=[c9@1 DESC], preserve_partitioning=[true]
-04)------ProjectionExec: expr=[c1@0 as c1, CAST(c9@1 AS Decimal128(20, 0)) as c9]
+04)------ProjectionExec: expr=[c1@0 as c1, CAST(c9@1 AS Int64) as c9]
 05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
 06)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c9], has_header=true
 07)----SortExec: TopK(fetch=5), expr=[c9@1 DESC], preserve_partitioning=[true]
-08)------ProjectionExec: expr=[c1@0 as c1, CAST(c3@1 AS Decimal128(20, 0)) as c9]
+08)------ProjectionExec: expr=[c1@0 as c1, CAST(c3@1 AS Int64) as c9]
 09)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
 10)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c3], has_header=true
 
-query TR
+query TI
 SELECT c1, c9 FROM aggregate_test_100 UNION ALL SELECT c1, c3 FROM aggregate_test_100 ORDER BY c9 DESC LIMIT 5
 ----
 c 4268716378


### PR DESCRIPTION
Draft PR to test the performance implications of #14223.

## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/14291

## Rationale for this change
There is concern that #14223 will slow down performance

I would like to gather some real data to find out, so I am preparing a branch to test. ~I don't know yet if I will propose to merge this~

Update, my measurements suggest there is no change in benchmark performance

## What changes are included in this PR?

Reverts 
- commit e0f9f65fa6a23a9f3946f5195c058df78f729674.
- #14223

## Are these changes tested?
I ran benchmark results;

### Clickbench
```
--------------------
Benchmark clickbench_partitioned.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃  main_base ┃ alamb_revert_14291 ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 0     │     2.33ms │             2.30ms │     no change │
│ QQuery 1     │    40.38ms │            39.35ms │     no change │
│ QQuery 2     │    98.00ms │            99.64ms │     no change │
│ QQuery 3     │   108.62ms │           105.25ms │     no change │
│ QQuery 4     │   923.58ms │           934.56ms │     no change │
│ QQuery 5     │   966.92ms │           956.66ms │     no change │
│ QQuery 6     │    38.23ms │            38.43ms │     no change │
│ QQuery 7     │    44.28ms │            42.90ms │     no change │
│ QQuery 8     │  1053.30ms │          1022.30ms │     no change │
│ QQuery 9     │  1343.71ms │          1351.18ms │     no change │
│ QQuery 10    │   295.52ms │           281.84ms │     no change │
│ QQuery 11    │   340.04ms │           324.68ms │     no change │
│ QQuery 12    │  1007.39ms │           967.09ms │     no change │
│ QQuery 13    │  1296.34ms │          1292.14ms │     no change │
│ QQuery 14    │   902.32ms │           905.02ms │     no change │
│ QQuery 15    │  1086.61ms │          1087.18ms │     no change │
│ QQuery 16    │  2016.05ms │          1971.24ms │     no change │
│ QQuery 17    │  1852.81ms │          1847.69ms │     no change │
│ QQuery 18    │  3995.11ms │          3995.56ms │     no change │
│ QQuery 19    │    97.99ms │            96.54ms │     no change │
│ QQuery 20    │  1258.22ms │          1249.90ms │     no change │
│ QQuery 21    │  1495.27ms │          1502.42ms │     no change │
│ QQuery 22    │  2714.73ms │          2649.74ms │     no change │
│ QQuery 23    │  8924.91ms │          8700.99ms │     no change │
│ QQuery 24    │   528.87ms │           498.62ms │ +1.06x faster │
│ QQuery 25    │   434.64ms │           426.47ms │     no change │
│ QQuery 26    │   597.96ms │           578.93ms │     no change │
│ QQuery 27    │  1841.25ms │          1805.83ms │     no change │
│ QQuery 28    │ 13032.24ms │         12870.17ms │     no change │
│ QQuery 29    │   530.51ms │           538.89ms │     no change │
│ QQuery 30    │   915.49ms │           905.28ms │     no change │
│ QQuery 31    │   966.31ms │           951.39ms │     no change │
│ QQuery 32    │  3739.78ms │          3984.97ms │  1.07x slower │
│ QQuery 33    │  3999.29ms │          4091.47ms │     no change │
│ QQuery 34    │  4045.53ms │          4093.23ms │     no change │
│ QQuery 35    │  1369.10ms │          1365.20ms │     no change │
│ QQuery 36    │   238.67ms │           232.64ms │     no change │
│ QQuery 37    │    98.54ms │            97.98ms │     no change │
│ QQuery 38    │   137.36ms │           138.82ms │     no change │
│ QQuery 39    │   450.38ms │           435.35ms │     no change │
│ QQuery 40    │    56.76ms │            55.85ms │     no change │
│ QQuery 41    │    49.64ms │            48.00ms │     no change │
│ QQuery 42    │    64.35ms │            64.80ms │     no change │
└──────────────┴────────────┴────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Benchmark Summary                 ┃            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Total Time (main_base)            │ 64999.31ms │
│ Total Time (alamb_revert_14291)   │ 64648.51ms │
│ Average Time (main_base)          │  1511.61ms │
│ Average Time (alamb_revert_14291) │  1503.45ms │
│ Queries Faster                    │          1 │
│ Queries Slower                    │          1 │
│ Queries with No Change            │         41 │
└───────────────────────────────────┴────────────┘
```

### TPCH
```
--------------------
Benchmark tpch_mem_sf1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃ main_base ┃ alamb_revert_14291 ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  129.31ms │           131.15ms │     no change │
│ QQuery 2     │   26.78ms │            27.34ms │     no change │
│ QQuery 3     │   40.49ms │            41.67ms │     no change │
│ QQuery 4     │   22.81ms │            22.92ms │     no change │
│ QQuery 5     │   64.09ms │            65.19ms │     no change │
│ QQuery 6     │    8.79ms │             8.59ms │     no change │
│ QQuery 7     │  129.23ms │           125.27ms │     no change │
│ QQuery 8     │   28.69ms │            29.49ms │     no change │
│ QQuery 9     │   75.24ms │            65.05ms │ +1.16x faster │
│ QQuery 10    │   60.30ms │            60.58ms │     no change │
│ QQuery 11    │   13.28ms │            13.39ms │     no change │
│ QQuery 12    │   39.85ms │            38.07ms │     no change │
│ QQuery 13    │   29.33ms │            29.23ms │     no change │
│ QQuery 14    │   10.49ms │            11.72ms │  1.12x slower │
│ QQuery 15    │   27.89ms │            28.80ms │     no change │
│ QQuery 16    │   23.40ms │            23.00ms │     no change │
│ QQuery 17    │  105.40ms │           100.46ms │     no change │
│ QQuery 18    │  247.95ms │           257.37ms │     no change │
│ QQuery 19    │   30.43ms │            30.58ms │     no change │
│ QQuery 20    │   42.96ms │            41.67ms │     no change │
│ QQuery 21    │  171.44ms │           180.23ms │  1.05x slower │
│ QQuery 22    │   18.16ms │            17.59ms │     no change │
└──────────────┴───────────┴────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Summary                 ┃           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Total Time (main_base)            │ 1346.32ms │
│ Total Time (alamb_revert_14291)   │ 1349.33ms │
│ Average Time (main_base)          │   61.20ms │
│ Average Time (alamb_revert_14291) │   61.33ms │
│ Queries Faster                    │         1 │
│ Queries Slower                    │         2 │
│ Queries with No Change            │        19 │
└───────────────────────────────────┴───────────┘
```

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
