### PR TITLE
minor: add unit tests for monotonicity.rs

### DIFF
--- a/datafusion/functions/src/math/monotonicity.rs
+++ b/datafusion/functions/src/math/monotonicity.rs
@@ -944,8 +944,8 @@ mod tests {
                 ),
                 (Err(e1), Err(e2)) => {
                     assert_eq!(
-                        e1.to_string(),
-                        e2.to_string(),
+                        e1.strip_backtrace().to_string(),
+                        e2.strip_backtrace().to_string(),
                         "Test '{}' failed: got {:?}, expected {:?}",
                         tcase.name,
                         e1,

--- a/datafusion/functions/src/math/monotonicity.rs
+++ b/datafusion/functions/src/math/monotonicity.rs
@@ -558,3 +558,418 @@ pub fn get_tanh_doc() -> &'static Documentation {
         .build()
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use arrow::compute::SortOptions;
+    use datafusion_common::Result;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct MonotonicityTestCase {
+        name: &'static str,
+        func: fn(&[ExprProperties]) -> Result<SortProperties>,
+        lower: f64,
+        upper: f64,
+        input_sort: SortProperties,
+        expected: Result<SortProperties>,
+    }
+
+    #[test]
+    fn test_monotonicity_table() {
+        fn create_ep(lower: f64, upper: f64, sp: SortProperties) -> ExprProperties {
+            ExprProperties {
+                range: Interval::try_new(
+                    ScalarValue::from(lower),
+                    ScalarValue::from(upper),
+                )
+                .unwrap(),
+                sort_properties: sp,
+                preserves_lex_ordering: false,
+            }
+        }
+
+        let test_cases = vec![
+            MonotonicityTestCase {
+                name: "acos_order within domain",
+                func: acos_order,
+                lower: -0.5,
+                upper: 0.5,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "acos_order out of domain",
+                func: acos_order,
+                lower: -2.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                // Should Err: "Input range of ACOS contains out-of-domain values"
+                expected: Err(datafusion_common::DataFusionError::Execution(
+                    "Input range of ACOS contains out-of-domain values".to_string(),
+                )),
+            },
+            MonotonicityTestCase {
+                name: "acosh_order within domain",
+                func: acosh_order,
+                lower: 2.0,
+                upper: 100.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: true,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: true,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "acosh_order out of domain",
+                func: acosh_order,
+                lower: 0.5,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                }),
+                expected: Err(datafusion_common::DataFusionError::Execution(
+                    "Input range of ACOSH contains out-of-domain values".to_string(),
+                )),
+            },
+            MonotonicityTestCase {
+                name: "asin_order within domain",
+                func: asin_order,
+                lower: -0.5,
+                upper: 0.5,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "asin_order out of domain",
+                func: asin_order,
+                lower: -2.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                // Should Err: "Input range of ASIN contains out-of-domain values"
+                expected: Err(datafusion_common::DataFusionError::Execution(
+                    "Input range of ASIN contains out-of-domain values".to_string(),
+                )),
+            },
+            MonotonicityTestCase {
+                name: "asinh_order within domain",
+                func: asinh_order,
+                lower: -1.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "asinh_order out of domain",
+                func: asinh_order,
+                lower: -2.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "atan_order within domain",
+                func: atan_order,
+                lower: -1.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "atan_order out of domain",
+                func: atan_order,
+                lower: -2.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "atanh_order within domain",
+                func: atanh_order,
+                lower: -0.6,
+                upper: 0.6,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "atanh_order out of domain",
+                func: atanh_order,
+                lower: -2.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Err(datafusion_common::DataFusionError::Execution(
+                    "Input range of ATANH contains out-of-domain values".to_string(),
+                )),
+            },
+            MonotonicityTestCase {
+                name: "cbrt_order within domain",
+                func: cbrt_order,
+                lower: -1.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "cbrt_order out of domain",
+                func: cbrt_order,
+                lower: -2.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "ceil_order within domain",
+                func: ceil_order,
+                lower: -1.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "ceil_order out of domain",
+                func: ceil_order,
+                lower: -2.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "cos_order within domain",
+                func: cos_order,
+                lower: 0.0,
+                upper: 2.0 * std::f64::consts::PI,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Unordered),
+            },
+            MonotonicityTestCase {
+                name: "cos_order out of domain",
+                func: cos_order,
+                lower: -2.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Unordered),
+            },
+            MonotonicityTestCase {
+                name: "cosh_order within domain positive",
+                func: cosh_order,
+                lower: 5.0,
+                upper: 100.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "cosh_order within domain negative",
+                func: cosh_order,
+                lower: -100.0,
+                upper: -5.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "cosh_order out of domain so unordered",
+                func: cosh_order,
+                lower: -1.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Unordered),
+            },
+            MonotonicityTestCase {
+                name: "degrees_order",
+                func: degrees_order,
+                lower: -1.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: true,
+                    nulls_first: true,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: true,
+                    nulls_first: true,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "exp_order",
+                func: exp_order,
+                lower: -1000.0,
+                upper: 1000.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "floor_order",
+                func: floor_order,
+                lower: -1.0,
+                upper: 1.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: true,
+                    nulls_first: true,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: true,
+                    nulls_first: true,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "ln_order within domain",
+                func: ln_order,
+                lower: 1.0,
+                upper: 2.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                expected: Ok(SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                })),
+            },
+            MonotonicityTestCase {
+                name: "ln_order out of domain",
+                func: ln_order,
+                lower: -5.0,
+                upper: -4.0,
+                input_sort: SortProperties::Ordered(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+                // Should Err: "Input range of LN contains out-of-domain values"
+                expected: Err(datafusion_common::DataFusionError::Execution(
+                    "Input range of LN contains out-of-domain values".to_string(),
+                )),
+            },
+        ];
+
+        for tcase in test_cases {
+            let input = vec![create_ep(tcase.lower, tcase.upper, tcase.input_sort)];
+            let actual = (tcase.func)(&input);
+            match (&actual, &tcase.expected) {
+                (Ok(a), Ok(e)) => assert_eq!(
+                    a, e,
+                    "Test '{}' failed: got {:?}, expected {:?}",
+                    tcase.name, a, e
+                ),
+                (Err(e1), Err(e2)) => {
+                    assert_eq!(
+                        e1.to_string(),
+                        e2.to_string(),
+                        "Test '{}' failed: got {:?}, expected {:?}",
+                        tcase.name,
+                        e1,
+                        e2
+                    )
+                } // Both are errors, so it's fine
+                _ => panic!(
+                    "Test '{}' failed: got {:?}, expected {:?}",
+                    tcase.name, actual, tcase.expected
+                ),
+            }
+        }
+    }
+}

--- a/datafusion/functions/src/math/monotonicity.rs
+++ b/datafusion/functions/src/math/monotonicity.rs
@@ -614,10 +614,7 @@ mod tests {
                     descending: false,
                     nulls_first: false,
                 }),
-                // Should Err: "Input range of ACOS contains out-of-domain values"
-                expected: Err(datafusion_common::DataFusionError::Execution(
-                    "Input range of ACOS contains out-of-domain values".to_string(),
-                )),
+                expected: exec_err!("Input range of ACOS contains out-of-domain values"),
             },
             MonotonicityTestCase {
                 name: "acosh_order within domain",
@@ -642,9 +639,7 @@ mod tests {
                     descending: true,
                     nulls_first: false,
                 }),
-                expected: Err(datafusion_common::DataFusionError::Execution(
-                    "Input range of ACOSH contains out-of-domain values".to_string(),
-                )),
+                expected: exec_err!("Input range of ACOSH contains out-of-domain values"),
             },
             MonotonicityTestCase {
                 name: "asin_order within domain",
@@ -669,10 +664,7 @@ mod tests {
                     descending: false,
                     nulls_first: false,
                 }),
-                // Should Err: "Input range of ASIN contains out-of-domain values"
-                expected: Err(datafusion_common::DataFusionError::Execution(
-                    "Input range of ASIN contains out-of-domain values".to_string(),
-                )),
+                expected: exec_err!("Input range of ASIN contains out-of-domain values"),
             },
             MonotonicityTestCase {
                 name: "asinh_order within domain",
@@ -753,9 +745,7 @@ mod tests {
                     descending: false,
                     nulls_first: false,
                 }),
-                expected: Err(datafusion_common::DataFusionError::Execution(
-                    "Input range of ATANH contains out-of-domain values".to_string(),
-                )),
+                expected: exec_err!("Input range of ATANH contains out-of-domain values"),
             },
             MonotonicityTestCase {
                 name: "cbrt_order within domain",
@@ -939,10 +929,7 @@ mod tests {
                     descending: false,
                     nulls_first: false,
                 }),
-                // Should Err: "Input range of LN contains out-of-domain values"
-                expected: Err(datafusion_common::DataFusionError::Execution(
-                    "Input range of LN contains out-of-domain values".to_string(),
-                )),
+                expected: exec_err!("Input range of LN contains out-of-domain values"),
             },
         ];
 


### PR DESCRIPTION
## Which issue does this PR close?
Closes #10595

## Rationale for this change
These methods are pretty straight forward but they did not have any unit tests. Thus, this PR adds required tests.


## What changes are included in this PR?
- unit tests


## Are these changes tested?
- only change is addition of tests


 
## Are there any user-facing changes?
No