### PR TITLE
Improve deprecation message for MemoryExec

### DIFF
--- a/datafusion/physical-plan/src/values.rs
+++ b/datafusion/physical-plan/src/values.rs
@@ -27,7 +27,6 @@ use crate::{
     PhysicalExpr,
 };
 
-use crate::memory::MemoryExec;
 use arrow::datatypes::{Schema, SchemaRef};
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion_common::{internal_err, plan_err, Result, ScalarValue};
@@ -41,6 +40,9 @@ use datafusion_physical_expr::EquivalenceProperties;
 /// * [`MemoryExec::try_new`]
 /// * [`MemoryExec::try_new_from_batches`]
 ///
+/// [`MemoryExec`]: crate::memory::MemoryExec
+/// [`MemoryExec::try_new`]: crate::memory::MemoryExec::try_new
+/// [`MemoryExec::try_new_from_batches`]: crate::memory::MemoryExec::try_new_from_batches
 #[deprecated(since = "45.0.0", note = "Use `MemoryExec` instead")]
 #[derive(Debug, Clone)]
 pub struct ValuesExec {

--- a/datafusion/physical-plan/src/values.rs
+++ b/datafusion/physical-plan/src/values.rs
@@ -27,6 +27,7 @@ use crate::{
     PhysicalExpr,
 };
 
+use crate::memory::MemoryExec;
 use arrow::datatypes::{Schema, SchemaRef};
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion_common::{internal_err, plan_err, Result, ScalarValue};
@@ -34,7 +35,13 @@ use datafusion_execution::TaskContext;
 use datafusion_physical_expr::EquivalenceProperties;
 
 /// Execution plan for values list based relation (produces constant rows)
-#[deprecated(since = "45.0.0", note = "Use `MemoryExec::try_new_as_values` instead")]
+///
+/// Note this structure is the same as [`MemoryExec`] and is deprecated.
+/// Please see the following for alternatives
+/// * [`MemoryExec::try_new`]
+/// * [`MemoryExec::try_new_from_batches`]
+///
+#[deprecated(since = "45.0.0", note = "Use `MemoryExec` instead")]
 #[derive(Debug, Clone)]
 pub struct ValuesExec {
     /// The schema
@@ -48,6 +55,7 @@ pub struct ValuesExec {
 #[allow(deprecated)]
 impl ValuesExec {
     /// Create a new values exec from data as expr
+    #[deprecated(since = "45.0.0", note = "Use `MemoryExec::try_new` instead")]
     pub fn try_new(
         schema: SchemaRef,
         data: Vec<Vec<Arc<dyn PhysicalExpr>>>,
@@ -101,6 +109,10 @@ impl ValuesExec {
     ///
     /// Errors if any of the batches don't match the provided schema, or if no
     /// batches are provided.
+    #[deprecated(
+        since = "45.0.0",
+        note = "Use `MemoryExec::try_new_from_batches` instead"
+    )]
     pub fn try_new_from_batches(
         schema: SchemaRef,
         batches: Vec<RecordBatch>,


### PR DESCRIPTION
## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/14008
- Follow on to #14032

## Rationale for this change

@shehabgamin notes on https://github.com/apache/datafusion/issues/14008#issuecomment-2609034408:

 > **DataFusion**
> `ValuesExec` is now deprecated. The deprecation message is a bit confusing though. It currently states: "Use `MemoryExec::try_new_as_values` instead", but I think should say: "Use `MemoryExec::try_new_as_values` or `MemoryExec::try_new_from_batches` instead". Or, just simply: "Use `MemoryExec` instead".



## What changes are included in this PR?

Improve documentation about deprecation and the suitable alternatives

## Are these changes tested?

By CI

## Are there any user-facing changes?

Only documentation, no functional change
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
