### PR TITLE
WIP: Update to arrow-rs / parquet `54.1.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,3 +188,17 @@ large_futures = "warn"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
 unused_qualifications = "deny"
+
+[patch.crates-io]
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,15 +190,15 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
 unused_qualifications = "deny"
 
 [patch.crates-io]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -176,8 +176,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ccdcc8fb14508ca20aaec7076032e5c0b0751b906036d4496786e2f227a37a"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -197,8 +196,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aad8e27f32e411a0fc0bf5a625a35f0bf9b9f871cf4542abe31f7cef4beea2"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -211,8 +209,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6ed90c28c6f73a706c55799b8cc3a094e89257238e5b1d65ca7c70bd3ae23f"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -228,8 +225,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4a40bdc1552ea10fbdeae4e5a945d8572c32f66bce457b96c13d9c46b80447"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "bytes",
  "half",
@@ -239,8 +235,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430c0a21aa7f81bcf0f97c57216d7127795ea755f494d27bae2bd233be43c2cc"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -260,8 +255,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4444c8f8c57ac00e6a679ede67d1ae8872c170797dc45b46f75702437a77888"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -276,8 +270,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09af476cfbe9879937e50b1334c73189de6039186e025b1b1ac84b283b87b20e"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -288,8 +281,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136296e8824333a8a4c4a6e508e4aa65d5678b801246d0408825ae7b2523c628"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -302,8 +294,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e222ad0e419ab8276818c5605a5bb1e35ed86fa8c5e550726433cc63b09c3c78"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -322,8 +313,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddf14c5f03b679ec8ceac4dfac43f63cdc4ed54dab3cc120a4ef46af38481eb"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -335,8 +325,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9acdc58da19f383f4ba381fa0e3583534ae2ceb31269aaf4a03f08ff13e8443"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -348,14 +337,12 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1822a1a952955637e85e8f9d6b0e04dd75d65492b87ec548dd593d3a1f772b"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 
 [[package]]
 name = "arrow-select"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4172e9a12dfe15303d3926269f9ead471ea93bdd067d113abc65cb6c48e246"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -368,8 +355,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73683040445f4932342781926189901c9521bb1a787c35dbe628a3ce51372d3c"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2899,8 +2885,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3334c50239d9f4951653d84fa6f636da86f53742e5e5849a30fbe852f3ff4383"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2924,6 +2909,7 @@ dependencies = [
  "object_store",
  "paste",
  "seq-macro",
+ "simdutf8",
  "snap",
  "thrift",
  "tokio",
@@ -3712,6 +3698,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -4711,3 +4703,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "arrow-flight"
+version = "54.0.0"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233#b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233"

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -84,3 +84,17 @@ debug = false
 debug-assertions = false
 strip = "debuginfo"
 incremental = false
+
+[patch.crates-io]
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -86,15 +86,15 @@ strip = "debuginfo"
 incremental = false
 
 [patch.crates-io]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
-parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "6aaff7e38a573f797b31f89f869c3706cbe26e37" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "b1bfa0f5852536ef2edb43ac8ddb66c39e8a7233" }

--- a/datafusion/core/src/datasource/physical_plan/arrow_file.rs
+++ b/datafusion/core/src/datasource/physical_plan/arrow_file.rs
@@ -309,10 +309,8 @@ impl FileOpener for ArrowOpener {
                     for (dict_block, dict_result) in
                         footer.dictionaries().iter().flatten().zip(dict_results)
                     {
-                        decoder.read_dictionary(
-                            dict_block,
-                            &Buffer::from_bytes(dict_result.into()),
-                        )?;
+                        decoder
+                            .read_dictionary(dict_block, &Buffer::from(dict_result))?;
                     }
 
                     // filter recordbatches according to range
@@ -348,10 +346,7 @@ impl FileOpener for ArrowOpener {
                             .zip(recordbatch_results)
                             .filter_map(move |(block, data)| {
                                 decoder
-                                    .read_record_batch(
-                                        &block,
-                                        &Buffer::from_bytes(data.into()),
-                                    )
+                                    .read_record_batch(&block, &Buffer::from(data))
                                     .transpose()
                             }),
                     )

--- a/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
+++ b/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
@@ -26,7 +26,8 @@ use crate::{OptimizerConfig, OptimizerRule};
 
 use crate::utils::NamePreserver;
 use arrow::datatypes::{
-    DataType, TimeUnit, MAX_DECIMAL_FOR_EACH_PRECISION, MIN_DECIMAL_FOR_EACH_PRECISION,
+    DataType, TimeUnit, MAX_DECIMAL128_FOR_EACH_PRECISION,
+    MIN_DECIMAL128_FOR_EACH_PRECISION,
 };
 use arrow::temporal_conversions::{MICROSECONDS, MILLISECONDS, NANOSECONDS};
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
@@ -369,8 +370,8 @@ fn try_cast_numeric_literal(
             // Different precision for decimal128 can store different range of value.
             // For example, the precision is 3, the max of value is `999` and the min
             // value is `-999`
-            MIN_DECIMAL_FOR_EACH_PRECISION[*precision as usize - 1],
-            MAX_DECIMAL_FOR_EACH_PRECISION[*precision as usize - 1],
+            MIN_DECIMAL128_FOR_EACH_PRECISION[*precision as usize],
+            MAX_DECIMAL128_FOR_EACH_PRECISION[*precision as usize],
         ),
         _ => return None,
     };


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/arrow-rs/issues/6929

## Rationale for this change

Keep up with dependencies

## What changes are included in this PR?
1. Update version of arrow-rs used in DataFusion (currently pinned until release)
2. Update for API changes

## Are these changes tested?

By existing CI

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
