### PR TITLE
Increase MSRV to 1.81.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ homepage = "https://datafusion.apache.org"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/datafusion"
-rust-version = "1.80.1"
+rust-version = "1.81.0"
 version = "44.0.0"
 
 [workspace.dependencies]

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -25,7 +25,7 @@ keywords = ["arrow", "datafusion", "query", "sql"]
 license = "Apache-2.0"
 homepage = "https://datafusion.apache.org"
 repository = "https://github.com/apache/datafusion"
-rust-version = "1.80.1"
+rust-version = "1.81.0"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
## Which issue does this PR close?


## Rationale for this change

Per the policy: https://github.com/apache/datafusion?tab=readme-ov-file#rust-version-compatibility-policy

> DataFusion's supports the last 4 stable Rust minor versions released and any such versions released within the last 4 months.

The most recent versions are `1.81`, `1.82`, `1.83`, `1.84`
https://github.com/rust-lang/rust/blob/master/RELEASES.md


- Related to https://github.com/apache/datafusion/pull/14257

Several of our dependencies now have a MSRV of 1.81




## What changes are included in this PR?
Update MSRV to 1.81
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
