### PR TITLE
refactor: switch `BooleanBufferBuilder` to `NullBufferBuilder` in an unit test of common_scalar

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -3963,7 +3963,7 @@ mod tests {
     use arrow::error::ArrowError;
     use arrow::util::pretty::pretty_format_columns;
     use arrow_array::types::Float64Type;
-    use arrow_buffer::{Buffer, NullBuffer};
+    use arrow_buffer::{Buffer, NullBufferBuilder};
     use arrow_schema::Fields;
     use chrono::NaiveDate;
     use rand::Rng;
@@ -6912,12 +6912,11 @@ mod tests {
         let array_b = Arc::new(Int32Array::from_iter_values([2]));
         let arrays: Vec<ArrayRef> = vec![array_a, array_b];
 
-        let mut not_nulls = BooleanBufferBuilder::new(1);
-        not_nulls.append(true);
-        let not_nulls = not_nulls.finish();
-        let not_nulls = Some(NullBuffer::new(not_nulls));
+        let mut not_nulls = NullBufferBuilder::new(1);
 
-        let ar = StructArray::new(fields, arrays, not_nulls);
+        not_nulls.append_non_null();
+
+        let ar = StructArray::new(fields, arrays, not_nulls.finish());
         let s = ScalarValue::Struct(Arc::new(ar));
 
         assert_eq!(s.to_string(), "{a:1,b:2}");


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #14115 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
As mentioned in #14115  , several examples in DataFusion codebase still using BooleanBufferBuilder rather than NullBufferBuilder, they should be replaced with NullBufferBuilder for optimization.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
