### PR TITLE
Fix build "missing field `sum_value` in initializer of `ColumnStatistics`"

### DIFF
--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -463,6 +463,7 @@ fn collect_new_statistics(
                         null_count: Precision::Exact(0),
                         max_value: Precision::Exact(ScalarValue::Null),
                         min_value: Precision::Exact(ScalarValue::Null),
+                        sum_value: Precision::Exact(ScalarValue::Null),
                         distinct_count: Precision::Exact(0),
                     };
                 };
@@ -1090,12 +1091,14 @@ mod tests {
                 ColumnStatistics {
                     min_value: Precision::Exact(ScalarValue::Null),
                     max_value: Precision::Exact(ScalarValue::Null),
+                    sum_value: Precision::Exact(ScalarValue::Null),
                     distinct_count: Precision::Exact(0),
                     null_count: Precision::Exact(0),
                 },
                 ColumnStatistics {
                     min_value: Precision::Exact(ScalarValue::Null),
                     max_value: Precision::Exact(ScalarValue::Null),
+                    sum_value: Precision::Exact(ScalarValue::Null),
                     distinct_count: Precision::Exact(0),
                     null_count: Precision::Exact(0),
                 },


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #14347

## Rationale for this change

CI is failing after I merged
- https://github.com/apache/datafusion/pull/14074

https://github.com/apache/datafusion/actions/runs/13018845357/job/36314586166

```
error[E0063]: missing field `sum_value` in initializer of `ColumnStatistics`
   --> datafusion/physical-plan/src/filter.rs:462:28
    |
462 |                     return ColumnStatistics {
    |                            ^^^^^^^^^^^^^^^^ missing `sum_value`

```


## What changes are included in this PR?

Fix compilation

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
