### PR TITLE
Support `Dictionary` and `List` types in  `scalar_to_sql`

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1260,7 +1260,7 @@ impl Unparser<'_> {
             ScalarValue::Struct(_) => not_impl_err!("Unsupported scalar: {v:?}"),
             ScalarValue::Map(_) => not_impl_err!("Unsupported scalar: {v:?}"),
             ScalarValue::Union(..) => not_impl_err!("Unsupported scalar: {v:?}"),
-            ScalarValue::Dictionary(_k, v) => self.scalar_to_sql(&v),
+            ScalarValue::Dictionary(_k, v) => self.scalar_to_sql(v),
         }
     }
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -33,7 +33,7 @@ use arrow_array::types::{
     Time64NanosecondType, TimestampMicrosecondType, TimestampMillisecondType,
     TimestampNanosecondType, TimestampSecondType,
 };
-use arrow_array::{Date32Array, Date64Array, PrimitiveArray};
+use arrow_array::{ArrayRef, Date32Array, Date64Array, PrimitiveArray};
 use arrow_schema::DataType;
 use datafusion_common::{
     internal_datafusion_err, internal_err, not_impl_err, plan_err, Column, Result,
@@ -526,6 +526,16 @@ impl Unparser<'_> {
             elem: args,
             named: false,
         }))
+    }
+
+    fn scalar_value_list_to_sql(&self, array: &ArrayRef) -> Result<ast::Expr> {
+        let mut elem = Vec::new();
+        for i in 0..array.len() {
+            let value = ScalarValue::try_from_array(&array, i)?;
+            elem.push(self.scalar_to_sql(&value)?);
+        }
+
+        Ok(ast::Expr::Array(Array { elem, named: false }))
     }
 
     fn array_element_to_sql(&self, args: &[Expr]) -> Result<ast::Expr> {
@@ -1120,39 +1130,9 @@ impl Unparser<'_> {
                 not_impl_err!("Unsupported scalar: {v:?}")
             }
             ScalarValue::LargeBinary(None) => Ok(ast::Expr::Value(ast::Value::Null)),
-            ScalarValue::FixedSizeList(a) => {
-                let array = a.values();
-
-                let mut elem = Vec::new();
-                for i in 0..array.len() {
-                    let value = ScalarValue::try_from_array(&array, i)?;
-                    elem.push(self.scalar_to_sql(&value)?);
-                }
-
-                Ok(ast::Expr::Array(Array { elem, named: true }))
-            }
-            ScalarValue::List(a) => {
-                let array = a.values();
-
-                let mut elem = Vec::new();
-                for i in 0..array.len() {
-                    let value = ScalarValue::try_from_array(&array, i)?;
-                    elem.push(self.scalar_to_sql(&value)?);
-                }
-
-                Ok(ast::Expr::Array(Array { elem, named: true }))
-            }
-            ScalarValue::LargeList(a) => {
-                let array = a.values();
-
-                let mut elem = Vec::new();
-                for i in 0..array.len() {
-                    let value = ScalarValue::try_from_array(&array, i)?;
-                    elem.push(self.scalar_to_sql(&value)?);
-                }
-
-                Ok(ast::Expr::Array(Array { elem, named: true }))
-            }
+            ScalarValue::FixedSizeList(a) => self.scalar_value_list_to_sql(a.values()),
+            ScalarValue::List(a) => self.scalar_value_list_to_sql(a.values()),
+            ScalarValue::LargeList(a) => self.scalar_value_list_to_sql(a.values()),
             ScalarValue::Date32(Some(_)) => {
                 let date = v
                     .to_array()?
@@ -1655,8 +1635,9 @@ mod tests {
     use std::ops::{Add, Sub};
     use std::{any::Any, sync::Arc, vec};
 
-    use arrow::datatypes::TimeUnit;
     use arrow::datatypes::{Field, Schema};
+    use arrow::datatypes::{Int32Type, TimeUnit};
+    use arrow_array::ListArray;
     use arrow_schema::DataType::Int8;
     use ast::ObjectName;
     use datafusion_common::{Spans, TableReference};
@@ -2092,6 +2073,23 @@ mod tests {
             (
                 map(vec![lit("a"), lit("b")], vec![lit(1), lit(2)]),
                 "MAP {'a': 1, 'b': 2}",
+            ),
+            (
+                Expr::Literal(ScalarValue::Dictionary(
+                    Box::new(DataType::Int32),
+                    Box::new(ScalarValue::Utf8(Some("foo".into()))),
+                )),
+                "'foo'",
+            ),
+            (
+                Expr::Literal(ScalarValue::List(Arc::new(
+                    ListArray::from_iter_primitive::<Int32Type, _, _>(vec![Some(vec![
+                        Some(1),
+                        Some(2),
+                        Some(3),
+                    ])]),
+                ))),
+                "[1, 2, 3]",
             ),
         ];
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1637,7 +1637,7 @@ mod tests {
 
     use arrow::datatypes::{Field, Schema};
     use arrow::datatypes::{Int32Type, TimeUnit};
-    use arrow_array::ListArray;
+    use arrow_array::{LargeListArray, ListArray};
     use arrow_schema::DataType::Int8;
     use ast::ObjectName;
     use datafusion_common::{Spans, TableReference};
@@ -2088,6 +2088,14 @@ mod tests {
                         Some(2),
                         Some(3),
                     ])]),
+                ))),
+                "[1, 2, 3]",
+            ),
+            (
+                Expr::Literal(ScalarValue::LargeList(Arc::new(
+                    LargeListArray::from_iter_primitive::<Int32Type, _, _>(vec![Some(
+                        vec![Some(1), Some(2), Some(3)],
+                    )]),
                 ))),
                 "[1, 2, 3]",
             ),


### PR DESCRIPTION
## Rationale for this change

Adds more support for `ScalarValue` variants in `scalar_to_sql`

## What changes are included in this PR?

Includes support for lists and dictionary type scalars.

## Are these changes tested?

Tests have been added for the `ScalarValue::Dictionary` and `ScalarValue::List` variants

## Are there any user-facing changes?

There are no breaking/user-facing changes