### PR TITLE
Minor: include the number of files run in sqllogictest display

### DIFF
--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -186,7 +186,11 @@ async fn run_tests() -> Result<()> {
         .collect()
         .await;
 
-    m.println(format!("Completed {} tests in {}", num_tests, HumanDuration(start.elapsed())))?;
+    m.println(format!(
+        "Completed {} tests in {}",
+        num_tests,
+        HumanDuration(start.elapsed())
+    ))?;
 
     #[cfg(feature = "postgres")]
     terminate_postgres_container().await?;
@@ -493,9 +497,7 @@ impl TestFile {
     }
 }
 
-fn read_test_files(
-    options: &Options,
-) -> Result<Vec<TestFile>> {
+fn read_test_files(options: &Options) -> Result<Vec<TestFile>> {
     let mut paths = read_dir_recursive(TEST_DIRECTORY)?
         .into_iter()
         .map(TestFile::new)

--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -187,7 +187,7 @@ async fn run_tests() -> Result<()> {
         .await;
 
     m.println(format!(
-        "Completed {} tests in {}",
+        "Completed {} test files in {}",
         num_tests,
         HumanDuration(start.elapsed())
     ))?;


### PR DESCRIPTION
## Which issue does this PR close?
- Follow on to https://github.com/apache/datafusion/pull/14355
- Follow on to https://github.com/apache/datafusion/pull/13936

## Rationale for this change

While testing https://github.com/apache/datafusion/pull/14355 from @findepi  I found it hard to see how many files were run

## What changes are included in this PR?

Before this PR:
```shell
andrewlamb@Andrews-MacBook-Pro-2:~/Software/datafusion$ cargo test --test sqllogictests  -- union
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running bin/sqllogictests.rs (target/debug/deps/sqllogictests-3d953efd822e1e41)
Completed in 0 seconds
```

After this PR, it reports `Completed 2 tests`:

```shell
andrewlamb@Andrews-MacBook-Pro-2:~/Software/datafusion$ cargo test --test sqllogictests  -- union
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running bin/sqllogictests.rs (target/debug/deps/sqllogictests-3d953efd822e1e41)
Completed 2 tests in 0 seconds
```

## Are these changes tested?

I tested them manually
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
