### PR TITLE
refactor: switch `BooleanBufferBuilder` to `NullBufferBuilder` in single_group_by

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -169,7 +169,7 @@ where
                 buffer.append_n_non_nulls(null_idx);
                 buffer.append_null();
                 buffer.append_n_non_nulls(values.len() - null_idx - 1);
-                // SAFETY: The inner builder must be constructed
+                // NOTE: The inner builder must be constructed as there is at least one null
                 buffer.finish().unwrap()
             });
             PrimitiveArray::<T>::new(values.into(), nulls)

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -17,12 +17,11 @@
 
 use crate::aggregates::group_values::GroupValues;
 use ahash::RandomState;
-use arrow::array::BooleanBufferBuilder;
-use arrow::buffer::NullBuffer;
 use arrow::datatypes::i256;
 use arrow::record_batch::RecordBatch;
 use arrow_array::cast::AsArray;
 use arrow_array::{ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, PrimitiveArray};
+use arrow_buffer::NullBufferBuilder;
 use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
 use arrow_schema::DataType;
 use datafusion_common::Result;
@@ -166,10 +165,12 @@ where
             null_idx: Option<usize>,
         ) -> PrimitiveArray<T> {
             let nulls = null_idx.map(|null_idx| {
-                let mut buffer = BooleanBufferBuilder::new(values.len());
-                buffer.append_n(values.len(), true);
-                buffer.set_bit(null_idx, false);
-                unsafe { NullBuffer::new_unchecked(buffer.finish(), 1) }
+                let mut buffer = NullBufferBuilder::new(values.len());
+                buffer.append_n_non_nulls(null_idx);
+                buffer.append_null();
+                buffer.append_n_non_nulls(values.len() - null_idx - 1);
+                // SAFETY: The inner builder must be constructed
+                buffer.finish().unwrap()
             });
             PrimitiveArray::<T>::new(values.into(), nulls)
         }


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #14115 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
As mentioned in #14115  , several examples in DataFusion codebase still using BooleanBufferBuilder rather than NullBufferBuilder, they should be replaced with NullBufferBuilder for optimization.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
