### PR TITLE
Deprecate the use of `datafusion_sql::ResolvedTableReference and TableReference`

### DIFF
--- a/datafusion-examples/examples/sql_frontend.rs
+++ b/datafusion-examples/examples/sql_frontend.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion::common::plan_err;
+use datafusion::common::{plan_err, TableReference};
 use datafusion::config::ConfigOptions;
 use datafusion::error::Result;
 use datafusion::logical_expr::{
@@ -29,7 +29,6 @@ use datafusion::optimizer::{
 use datafusion::sql::planner::{ContextProvider, SqlToRel};
 use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::sqlparser::parser::Parser;
-use datafusion::sql::TableReference;
 use std::any::Any;
 use std::sync::Arc;
 

--- a/datafusion/core/src/catalog_common/mod.rs
+++ b/datafusion/core/src/catalog_common/mod.rs
@@ -25,8 +25,7 @@ pub mod information_schema;
 pub mod listing_schema;
 pub use crate::catalog::{CatalogProvider, CatalogProviderList, SchemaProvider};
 
-pub use datafusion_sql::{ResolvedTableReference, TableReference};
-
+use datafusion_common::TableReference;
 use std::collections::BTreeSet;
 use std::ops::ControlFlow;
 

--- a/datafusion/core/tests/optimizer/mod.rs
+++ b/datafusion/core/tests/optimizer/mod.rs
@@ -26,7 +26,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use arrow_schema::{Fields, SchemaBuilder};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{TransformedResult, TreeNode};
-use datafusion_common::{plan_err, DFSchema, Result, ScalarValue};
+use datafusion_common::{plan_err, DFSchema, Result, ScalarValue, TableReference};
 use datafusion_expr::interval_arithmetic::{Interval, NullableInterval};
 use datafusion_expr::{
     col, lit, AggregateUDF, BinaryExpr, Expr, ExprSchemable, LogicalPlan, Operator,
@@ -41,7 +41,6 @@ use datafusion_sql::planner::{ContextProvider, SqlToRel};
 use datafusion_sql::sqlparser::ast::Statement;
 use datafusion_sql::sqlparser::dialect::GenericDialect;
 use datafusion_sql::sqlparser::parser::Parser;
-use datafusion_sql::TableReference;
 
 use chrono::DateTime;
 use datafusion_functions::datetime;

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{assert_contains, plan_err, Result};
+use datafusion_common::{assert_contains, plan_err, Result, TableReference};
 use datafusion_expr::sqlparser::dialect::PostgreSqlDialect;
 use datafusion_expr::test::function_stub::sum_udaf;
 use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource, WindowUDF};
@@ -36,7 +36,6 @@ use datafusion_sql::planner::{ContextProvider, SqlToRel};
 use datafusion_sql::sqlparser::ast::Statement;
 use datafusion_sql::sqlparser::dialect::GenericDialect;
 use datafusion_sql::sqlparser::parser::Parser;
-use datafusion_sql::TableReference;
 
 #[cfg(test)]
 #[ctor::ctor]

--- a/datafusion/sql/examples/sql.rs
+++ b/datafusion/sql/examples/sql.rs
@@ -20,7 +20,7 @@ use std::{collections::HashMap, sync::Arc};
 use arrow_schema::{DataType, Field, Schema};
 
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{plan_err, Result};
+use datafusion_common::{plan_err, Result, TableReference};
 use datafusion_expr::planner::ExprPlanner;
 use datafusion_expr::WindowUDF;
 use datafusion_expr::{
@@ -32,7 +32,6 @@ use datafusion_functions_aggregate::sum::sum_udaf;
 use datafusion_sql::{
     planner::{ContextProvider, SqlToRel},
     sqlparser::{dialect::GenericDialect, parser::Parser},
-    TableReference,
 };
 
 fn main() {

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -1075,10 +1075,9 @@ mod tests {
     use sqlparser::parser::Parser;
 
     use datafusion_common::config::ConfigOptions;
+    use datafusion_common::TableReference;
     use datafusion_expr::logical_plan::builder::LogicalTableSource;
     use datafusion_expr::{AggregateUDF, ScalarUDF, TableSource, WindowUDF};
-
-    use crate::TableReference;
 
     use super::*;
 

--- a/datafusion/sql/src/lib.rs
+++ b/datafusion/sql/src/lib.rs
@@ -50,6 +50,9 @@ pub mod unparser;
 pub mod utils;
 mod values;
 
-#[deprecated(since = "45.0.0", note = "use datafusion_common::{ResolvedTableReference, TableReference}")]
+#[deprecated(
+    since = "45.0.0",
+    note = "use datafusion_common::{ResolvedTableReference, TableReference}"
+)]
 pub use datafusion_common::{ResolvedTableReference, TableReference};
 pub use sqlparser;

--- a/datafusion/sql/src/lib.rs
+++ b/datafusion/sql/src/lib.rs
@@ -50,5 +50,6 @@ pub mod unparser;
 pub mod utils;
 mod values;
 
+#[deprecated(since = "45.0.0", note = "use datafusion_common::{ResolvedTableReference, TableReference}")]
 pub use datafusion_common::{ResolvedTableReference, TableReference};
 pub use sqlparser;

--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -23,7 +23,7 @@ use datafusion::arrow::datatypes::{
 };
 use datafusion::common::{
     not_impl_datafusion_err, not_impl_err, plan_datafusion_err, plan_err,
-    substrait_datafusion_err, substrait_err, DFSchema, DFSchemaRef,
+    substrait_datafusion_err, substrait_err, DFSchema, DFSchemaRef, TableReference,
 };
 use datafusion::datasource::provider_as_source;
 use datafusion::logical_expr::expr::{Exists, InSubquery, Sort};
@@ -66,7 +66,6 @@ use datafusion::logical_expr::{
     WindowFrameBound, WindowFrameUnits, WindowFunctionDefinition,
 };
 use datafusion::prelude::{lit, JoinType};
-use datafusion::sql::TableReference;
 use datafusion::{
     error::Result, logical_expr::utils::split_conjunction, prelude::Column,
     scalar::ScalarValue,

--- a/datafusion/substrait/tests/cases/substrait_validations.rs
+++ b/datafusion/substrait/tests/cases/substrait_validations.rs
@@ -22,8 +22,7 @@ mod tests {
     mod schema_compatibility {
         use crate::utils::test::read_json;
         use datafusion::arrow::datatypes::{DataType, Field};
-        use datafusion::catalog_common::TableReference;
-        use datafusion::common::{DFSchema, Result};
+        use datafusion::common::{DFSchema, Result, TableReference};
         use datafusion::datasource::empty::EmptyTable;
         use datafusion::prelude::SessionContext;
         use datafusion_substrait::logical_plan::consumer::from_substrait_plan;

--- a/datafusion/substrait/tests/utils.rs
+++ b/datafusion/substrait/tests/utils.rs
@@ -17,8 +17,7 @@
 
 #[cfg(test)]
 pub mod test {
-    use datafusion::catalog_common::TableReference;
-    use datafusion::common::{substrait_datafusion_err, substrait_err};
+    use datafusion::common::{substrait_datafusion_err, substrait_err, TableReference};
     use datafusion::datasource::empty::EmptyTable;
     use datafusion::datasource::TableProvider;
     use datafusion::error::Result;


### PR DESCRIPTION
## Which issue does this PR close?



## Rationale for this change

Noticed while working on https://github.com/apache/datafusion/pull/14364 with @logan-keede

`datafusion-sql` publically re-exports stuff from datafusion_common:
```rust
pub use datafusion_common::{ResolvedTableReference, TableReference};
```

Which can then lead to unecessary explicit dependencies in Cargo.toml


## What changes are included in this PR?

1. Deprecate the re-export `pub use`
2. Update references to avoid using `datafusion-sql`

## Are these changes tested?
By CI/ compiler
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
