### PR TITLE
14044/enhancement/add xxhash algorithms in expression api

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -35,6 +35,7 @@ workspace = true
 # enable core functions
 core_expressions = []
 crypto_expressions = ["md-5", "sha2", "blake2", "blake3"]
+hash_expressions = ["twox-hash"]
 # enable datetime functions
 datetime_expressions = []
 # Enable encoding by default so the doctests work. In general don't automatically enable all packages.
@@ -46,6 +47,7 @@ default = [
     "regex_expressions",
     "string_expressions",
     "unicode_expressions",
+    "hash_expressions",
 ]
 # enable encode/decode functions
 encoding_expressions = ["base64", "hex"]
@@ -85,6 +87,7 @@ md-5 = { version = "^0.10.0", optional = true }
 rand = { workspace = true }
 regex = { workspace = true, optional = true }
 sha2 = { version = "^0.10.1", optional = true }
+twox-hash = { version = "1.6.3", optional = true }
 unicode-segmentation = { version = "^1.7.1", optional = true }
 uuid = { version = "1.7", features = ["v4"], optional = true }
 

--- a/datafusion/functions/src/hash/mod.rs
+++ b/datafusion/functions/src/hash/mod.rs
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! "xxhash" DataFusion functions
+
+use datafusion_expr::ScalarUDF;
+use std::sync::Arc;
+
+pub mod xxhash;
+make_udf_function!(xxhash::XxHash32Func, xxhash32);
+make_udf_function!(xxhash::XxHash64Func, xxhash64);
+
+pub mod expr_fn {
+    export_functions!((
+        xxhash32,
+        "Computes the XXHash32 hash of a binary string.",
+        input
+    ),(
+        xxhash64,
+        "Computes the XXHash64 hash of a binary string.",
+        input
+    ));
+}
+
+/// Returns all DataFusion functions defined in this package
+pub fn functions() -> Vec<Arc<ScalarUDF>> {
+    vec![xxhash32(), xxhash64()]
+}

--- a/datafusion/functions/src/hash/xxhash.rs
+++ b/datafusion/functions/src/hash/xxhash.rs
@@ -1,17 +1,17 @@
 // Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements. See the NOTICE file
+// or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership. The ASF licenses this file
+// regarding copyright ownership.  The ASF licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
-// with the License. You may obtain a copy of the License at
+// with the License.  You may obtain a copy of the License at
 //
 //   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied. See the License for the
+// KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
 

--- a/datafusion/functions/src/hash/xxhash.rs
+++ b/datafusion/functions/src/hash/xxhash.rs
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{Array, StringArray, UInt32Array, UInt64Array};
+use arrow::datatypes::DataType;
+use datafusion_common::Result;
+use datafusion_expr::{
+    ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
+};
+use twox_hash::{XxHash64, XxHash32};
+use datafusion_macros::user_doc;
+use std::any::Any;
+use std::hash::Hasher;
+use datafusion_common::DataFusionError;
+use std::sync::Arc;
+
+#[user_doc(
+    doc_section(label = "Hashing Functions"),
+    description = "Computes the XXHash64 hash of a binary string.",
+    syntax_example = "xxhash64(expression)",
+    sql_example = r#"```sql
+> select xxhash64('foo');
++-------------------------------------------+
+| xxhash64(Utf8("foo"))                     |
++-------------------------------------------+
+| <xxhash64_result>                         |
++-------------------------------------------+
+```"#,
+    standard_argument(name = "expression", prefix = "String")
+)]
+
+#[derive(Debug)]
+pub struct XxHash64Func {
+    signature: Signature,
+}
+impl Default for XxHash64Func {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl XxHash64Func {
+    pub fn new() -> Self {
+        use DataType::*;
+        Self {
+            signature: Signature::uniform(
+                1,
+                vec![Utf8View, Utf8, LargeUtf8, Binary, LargeBinary],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+impl ScalarUDFImpl for XxHash64Func {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "xxhash64"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+        fn invoke_batch(
+            &self,
+            args: &[ColumnarValue],
+            _number_rows: usize,
+        ) -> Result<ColumnarValue> {
+            // Assuming that the argument is either a StringArray or BinaryArray
+            let input_data = &args[0];
+    
+            // Collect the output hash results
+            let result = match input_data {
+                ColumnarValue::Array(array) => {
+                    // Check if the array is a StringArray (or another type you expect)
+                    if let Some(string_array) = array.as_any().downcast_ref::<StringArray>() {
+                        let mut hash_results: Vec<String> = Vec::with_capacity(string_array.len());
+                        for i in 0..string_array.len() {
+                            if !string_array.is_null(i) {
+                                let value = string_array.value(i); // returns &str
+                                let mut hasher = XxHash64::default();
+                                hasher.write(value.as_bytes()); // as_bytes() on &str returns &[u8]
+                                let hash = hasher.finish();
+                                let hash_hex = hex::encode(hash.to_be_bytes());
+                                hash_results.push(hash_hex);
+                            } else {
+                                hash_results.push(String::from("00000000")); // or handle null values differently
+                            }
+                        }
+    
+                        // Create an UInt64Array from the hash results
+                        let hash_array = StringArray::from(hash_results);
+                        Arc::new(hash_array) as Arc<dyn Array>
+                    } else {
+                        return Err(DataFusionError::Internal("Unsupported array type".to_string()));
+                    }
+                },
+                _ => return Err(DataFusionError::Internal("Unsupported input type".to_string())),
+            };
+    
+            Ok(ColumnarValue::Array(result))
+        }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+#[user_doc(
+    doc_section(label = "Hashing Functions"),
+    description = "Computes the XXHash32 hash of a binary string.",
+    syntax_example = "xxhash32(expression)",
+    sql_example = r#"```sql
+> select xxhash32('foo');
++-------------------------------------------+
+| xxhash32(Utf8("foo"))                     |
++-------------------------------------------+
+| <xxhash32_result>                         |
++-------------------------------------------+
+```"#,
+    standard_argument(name = "expression", prefix = "String")
+)]
+
+#[derive(Debug)]
+pub struct XxHash32Func {
+    signature: Signature,
+}
+impl Default for XxHash32Func {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl XxHash32Func {
+    pub fn new() -> Self {
+        use DataType::*;
+        Self {
+            signature: Signature::uniform(
+                1,
+                vec![Utf8View, Utf8, LargeUtf8, Binary, LargeBinary],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+impl ScalarUDFImpl for XxHash32Func {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "xxhash32"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+        fn invoke_batch(
+            &self,
+            args: &[ColumnarValue],
+            _number_rows: usize,
+        ) -> Result<ColumnarValue> {
+            // Assuming that the argument is either a StringArray or BinaryArray
+            let input_data = &args[0];
+
+            // Collect the output hash results
+            let result = match input_data {
+                ColumnarValue::Array(array) => {
+                    // Check if the array is a StringArray (or another type you expect)
+                    if let Some(string_array) = array.as_any().downcast_ref::<StringArray>() {
+                        let mut hash_results: Vec<String> = Vec::with_capacity(string_array.len());
+                        for i in 0..string_array.len() {
+                            if !string_array.is_null(i) {
+                                let value = string_array.value(i); // returns &str
+                                let mut hasher = XxHash32::default();
+                                hasher.write(value.as_bytes()); // as_bytes() on &str returns &[u8]
+                                let hash: u32 = hasher.finish() as u32;
+                                let hash_hex = hex::encode(hash.to_be_bytes());
+                                hash_results.push(hash_hex);
+                            } else {
+                                hash_results.push(String::from("00000000")); // or handle null values differently
+                            }
+                        }
+
+                        // Create a StringArray from the hash results
+                        let hash_array = StringArray::from(hash_results);
+                        Arc::new(hash_array) as Arc<dyn Array>
+                    } else {
+                        return Err(DataFusionError::Internal("Unsupported array type".to_string()));
+                    }
+                },
+                _ => return Err(DataFusionError::Internal("Unsupported input type".to_string())),
+            };
+    
+            Ok(ColumnarValue::Array(result))
+        }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}

--- a/datafusion/functions/src/lib.rs
+++ b/datafusion/functions/src/lib.rs
@@ -133,6 +133,10 @@ make_stub_package!(crypto, "crypto_expressions");
 pub mod unicode;
 make_stub_package!(unicode, "unicode_expressions");
 
+#[cfg(feature = "hash_expressions")]
+pub mod hash;
+make_stub_package!(hash, "hash_expressions");
+
 #[cfg(any(feature = "datetime_expressions", feature = "unicode_expressions"))]
 pub mod planner;
 
@@ -158,6 +162,8 @@ pub mod expr_fn {
     pub use super::string::expr_fn::*;
     #[cfg(feature = "unicode_expressions")]
     pub use super::unicode::expr_fn::*;
+    #[cfg(feature = "hash_expressions")]
+    pub use super::hash::expr_fn::*;
 }
 
 /// Return all default functions
@@ -171,6 +177,7 @@ pub fn all_default_functions() -> Vec<Arc<ScalarUDF>> {
         .chain(crypto::functions())
         .chain(unicode::functions())
         .chain(string::functions())
+        .chain(hash::functions())
         .collect::<Vec<_>>()
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #14044.

## Rationale for this change
Lack of xxhash (a quick, non-cryptographic hashing technique) functions.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
The users shall now be able to use xxhash32 and xxhash64 functions.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
