### PR TITLE
DFParser should skip unsupported COPY INTO

### DIFF
--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -354,6 +354,14 @@ impl<'a> DFParser<'a> {
                         self.parse_create()
                     }
                     Keyword::COPY => {
+                        if let Token::Word(w) = self.parser.peek_nth_token(1).token {
+                            // use native parser for COPY INTO
+                            if w.keyword == Keyword::INTO {
+                                return Ok(Statement::Statement(Box::from(
+                                    self.parser.parse_statement()?,
+                                )));
+                            }
+                        }
                         self.parser.next_token(); // COPY
                         self.parse_copy()
                     }

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -885,7 +885,7 @@ mod tests {
     use super::*;
     use sqlparser::ast::Expr::Identifier;
     use sqlparser::ast::{BinaryOperator, DataType, Expr, Ident};
-    use sqlparser::dialect::{dialect_from_str, SnowflakeDialect};
+    use sqlparser::dialect::SnowflakeDialect;
     use sqlparser::tokenizer::Span;
 
     fn expect_parse_ok(sql: &str, expected: Statement) -> Result<(), ParserError> {
@@ -1418,7 +1418,7 @@ mod tests {
         let dialect = Box::new(SnowflakeDialect);
         let statements = DFParser::parse_sql_with_dialect(sql, dialect.as_ref())?;
        
-        assert_eq!( statements.len(), 1, "Expected to parse exactly one statement");
+        assert_eq!(statements.len(), 1, "Expected to parse exactly one statement");
         if let Statement::CopyTo(_) = &statements[0] {
             panic!(
                 "Expected non COPY TO statement, but was successful: {statements:?}"

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -1411,18 +1411,20 @@ mod tests {
         assert_eq!(verified_stmt(sql), expected);
         Ok(())
     }
-    
+
     #[test]
     fn skip_copy_into_snowflake() -> Result<(), ParserError> {
         let sql = "COPY INTO foo FROM @~/staged FILE_FORMAT = (FORMAT_NAME = 'mycsv');";
         let dialect = Box::new(SnowflakeDialect);
         let statements = DFParser::parse_sql_with_dialect(sql, dialect.as_ref())?;
-       
-        assert_eq!(statements.len(), 1, "Expected to parse exactly one statement");
+
+        assert_eq!(
+            statements.len(),
+            1,
+            "Expected to parse exactly one statement"
+        );
         if let Statement::CopyTo(_) = &statements[0] {
-            panic!(
-                "Expected non COPY TO statement, but was successful: {statements:?}"
-            );
+            panic!("Expected non COPY TO statement, but was successful: {statements:?}");
         }
         Ok(())
     }

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -1411,8 +1411,7 @@ mod tests {
         assert_eq!(verified_stmt(sql), expected);
         Ok(())
     }
-
-
+    
     #[test]
     fn skip_copy_into_snowflake() -> Result<(), ParserError> {
         let sql = "COPY INTO foo FROM @~/staged FILE_FORMAT = (FORMAT_NAME = 'mycsv');";
@@ -1427,7 +1426,6 @@ mod tests {
         }
         Ok(())
     }
-
 
     #[test]
     fn explain_copy_to_table_to_table() -> Result<(), ParserError> {


### PR DESCRIPTION
## Which issue does this PR close?

Closes apache/datafusion#14372

## What changes are included in this PR?

This PR allows to skip **[COPY INTO](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table)** statement which is not supported by DFParser.
**COPY INTO** already supported by native parser as a **Statement::CopyIntoSnowflake**

## Are these changes tested?

Added some tests with snowflake dialect

## Are there any user-facing changes?
No
