### PR TITLE
Do not rename struct fields when coercing types in `CASE`

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -961,21 +961,29 @@ fn struct_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType>
                 return None;
             }
 
-            let types = std::iter::zip(lhs_fields.iter(), rhs_fields.iter())
+            let coerced_types = std::iter::zip(lhs_fields.iter(), rhs_fields.iter())
                 .map(|(lhs, rhs)| comparison_coercion(lhs.data_type(), rhs.data_type()))
                 .collect::<Option<Vec<DataType>>>()?;
 
-            let fields = types
+            // preserve the field name and nullability
+            let orig_fields = std::iter::zip(lhs_fields.iter(), rhs_fields.iter());
+
+            let fields: Vec<FieldRef> = coerced_types
                 .into_iter()
-                .enumerate()
-                .map(|(i, datatype)| {
-                    Arc::new(Field::new(format!("c{i}"), datatype, true))
-                })
-                .collect::<Vec<FieldRef>>();
+                .zip(orig_fields)
+                .map(|(datatype, (lhs, rhs))| coerce_fields(datatype, lhs, rhs))
+                .collect();
             Some(Struct(fields.into()))
         }
         _ => None,
     }
+}
+
+/// returns the result of coercing two fields to a common type
+fn coerce_fields(common_type: DataType, lhs: &FieldRef, rhs: &FieldRef) -> FieldRef {
+    let is_nullable = lhs.is_nullable() || rhs.is_nullable();
+    let name = lhs.name(); // pick the name from the left field
+    Arc::new(Field::new(name, common_type, is_nullable))
 }
 
 /// Returns the output type of applying mathematics operations such as

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -339,7 +339,7 @@ SELECT
   end
 FROM t;
 ----
-{c0: bar}
+{xxx: bar}
 
 query ?
 SELECT
@@ -350,7 +350,7 @@ SELECT
   end
 FROM t;
 ----
-{c0: baz}
+{foo: baz}
 
 query ?
 SELECT
@@ -361,4 +361,5 @@ SELECT
   end
 FROM t;
 ----
-{c0: blarg}
+{foo: blarg}
+

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -308,3 +308,57 @@ NULL NULL false
 
 statement ok
 drop table foo
+
+
+# Test coercion of inner struct names
+# Reproducer for https://github.com/apache/datafusion/issues/14383
+statement ok
+create table t as values
+(
+ 100,                                       -- column1 int (so the case isn't constant folded)
+ { 'foo': 'bar' },                          -- column2 has List of Struct w/ Utf8
+ { 'foo': arrow_cast('baz', 'Utf8View') },  -- column3 has List of Struct w/ Utf8View
+ { 'xxx': arrow_cast('blarg', 'Utf8View') } -- column4 has List of Struct w/ Utf8View and a different field name
+);
+
+
+# Note field names
+query ???
+SELECT column2, column3, column4  FROM t;
+----
+{foo: bar} {foo: baz} {xxx: blarg}
+
+# Coerce fields, expect the field name to be the name of the first arg to case
+# the field should not be named 'c0'
+query ?
+SELECT
+  case
+    when column1 > 0 then column2
+    when column1 < 0 then column3
+    else column4
+  end
+FROM t;
+----
+{c0: bar}
+
+query ?
+SELECT
+  case
+    when column1 > 0 then column3 -- different arg order affects field name
+    when column1 < 0 then column4
+    else column2
+  end
+FROM t;
+----
+{c0: baz}
+
+query ?
+SELECT
+  case
+    when column1 > 0 then column4 -- different arg order affects field name
+    when column1 < 0 then column2
+    else column3
+  end
+FROM t;
+----
+{c0: blarg}

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -318,15 +318,15 @@ create table t as values
  100,                                       -- column1 int (so the case isn't constant folded)
  { 'foo': 'bar' },                          -- column2 has List of Struct w/ Utf8
  { 'foo': arrow_cast('baz', 'Utf8View') },  -- column3 has List of Struct w/ Utf8View
- { 'xxx': arrow_cast('blarg', 'Utf8View') } -- column4 has List of Struct w/ Utf8View and a different field name
+ { 'foo': arrow_cast('blarg', 'Utf8View') } -- column4 has List of Struct w/ Utf8View
 );
 
 
-# Note field names are foo/foo/xxx
+# Note field name is foo
 query ???
 SELECT column2, column3, column4  FROM t;
 ----
-{foo: bar} {foo: baz} {xxx: blarg}
+{foo: bar} {foo: baz} {foo: blarg}
 
 # Coerce fields, expect the field name to be the name of the first arg to case
 # the field should not be named 'c0'
@@ -339,12 +339,12 @@ SELECT
   end
 FROM t;
 ----
-{xxx: bar}
+{foo: bar}
 
 query ?
 SELECT
   case
-    when column1 > 0 then column3 -- different arg order affects field name
+    when column1 > 0 then column3 -- different arg order shouldn't affect name
     when column1 < 0 then column4
     else column2
   end
@@ -355,7 +355,7 @@ FROM t;
 query ?
 SELECT
   case
-    when column1 > 0 then column4 -- different arg order affects field name
+    when column1 > 0 then column4 -- different arg order shouldn't affect name
     when column1 < 0 then column2
     else column3
   end

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -310,7 +310,7 @@ statement ok
 drop table foo
 
 
-# Test coercion of inner struct names
+# Test coercion of inner struct field names
 # Reproducer for https://github.com/apache/datafusion/issues/14383
 statement ok
 create table t as values
@@ -322,7 +322,7 @@ create table t as values
 );
 
 
-# Note field names
+# Note field names are foo/foo/xxx
 query ???
 SELECT column2, column3, column4  FROM t;
 ----
@@ -363,3 +363,58 @@ FROM t;
 ----
 {foo: blarg}
 
+statement ok
+drop table t
+
+
+# Test coercion of inner struct field names with different orders / missing fields
+statement ok
+create table t as values
+(
+ 100,                        -- column1 int (so the case isn't constant folded)
+ { 'foo': 'a', 'xxx': 'b' }, -- column2: Struct with fields foo, xxx
+ { 'xxx': 'c', 'foo': 'd' }, -- column3: Struct with fields xxx, foo
+ { 'xxx': 'e'             }  -- column4: Struct with field xxx (no second field)
+);
+
+# Note field names are in different orders
+query ???
+SELECT column2, column3, column4  FROM t;
+----
+{foo: a, xxx: b} {xxx: c, foo: d} {xxx: e}
+
+# coerce structs with different field orders,
+# (note the *value*s are from column2 but the field name is 'xxx', as the coerced
+# type takes the field name from the last argument (column3)
+query ?
+SELECT
+  case
+    when column1 > 0 then column2 -- always true
+    else column3
+  end
+FROM t;
+----
+{xxx: a, foo: b}
+
+# coerce structs with different field orders
+query ?
+SELECT
+  case
+    when column1 < 0 then column2 -- always false
+    else column3
+  end
+FROM t;
+----
+{xxx: c, foo: d}
+
+# coerce structs with subset of fields
+query error Failed to coerce then
+SELECT
+  case
+    when column1 > 0 then column3
+    else column4
+  end
+FROM t;
+
+statement ok
+drop table t


### PR DESCRIPTION
## Which issue does this PR close?

- Fixes https://github.com/apache/datafusion/issues/14383

## Rationale for this change

When coercing fields for a struct, we shouldn't rename the fields to `c0`, `c1`, etc. See https://github.com/apache/datafusion/issues/14383

## What changes are included in this PR?

Preserve the Struct field names

## Are these changes tested?
Yes, sqllogictests are added

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
coerced struct field names do not revever to `c0`, `c1, etc
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
