### PR TITLE
Fix join type coercion when joining 2 relations with the same name via `DataFrame` API

### DIFF
--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -30,8 +30,8 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use arrow_array::{
-    Array, BooleanArray, DictionaryArray, Float32Array, Float64Array, Int8Array,
-    UnionArray,
+    record_batch, Array, BooleanArray, DictionaryArray, Float32Array, Float64Array,
+    Int8Array, UnionArray,
 };
 use arrow_buffer::ScalarBuffer;
 use arrow_schema::{ArrowError, SchemaRef, UnionFields, UnionMode};
@@ -1118,6 +1118,39 @@ async fn join() -> Result<()> {
     assert_eq!(100, left_rows.iter().map(|x| x.num_rows()).sum::<usize>());
     assert_eq!(100, right_rows.iter().map(|x| x.num_rows()).sum::<usize>());
     assert_eq!(2008, join_rows.iter().map(|x| x.num_rows()).sum::<usize>());
+    Ok(())
+}
+
+#[tokio::test]
+async fn join_coercion_unnnamed() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    // Test that join will coerce column types when necessary
+    // even when the relations don't have unique names
+    let left = ctx.read_batch(record_batch!(
+        ("id", Int32, [1, 2, 3]),
+        ("name", Utf8, ["a", "b", "c"])
+    )?)?;
+    let right = ctx.read_batch(record_batch!(
+        ("id", Int32, [10, 3]),
+        ("name", Utf8View, ["d", "c"]) // Utf8View is a different type
+    )?)?;
+    let cols = vec!["name", "id"];
+
+    let filter = None;
+    let join = right.join(left, JoinType::LeftAnti, &cols, &cols, filter)?;
+    let results = join.collect().await?;
+
+    assert_batches_sorted_eq!(
+        [
+            "+----+------+",
+            "| id | name |",
+            "+----+------+",
+            "| 10 | d    |",
+            "+----+------+",
+        ],
+        &results
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/13510

## Rationale for this change

Fix a bug
## What changes are included in this PR?

Resolve join predicates using the correct schema

## Are these changes tested?
Yes, a new unit test is added

## Are there any user-facing changes?
Bug fix