### PR TITLE
Revert `is_sorted` removal, deprecate instead

### DIFF
--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -770,6 +770,7 @@ pub fn set_difference<T: Borrow<usize>, S: Borrow<usize>>(
 }
 
 /// Checks whether the given index sequence is monotonically non-decreasing.
+#[deprecated(since = "45.0.0", note = "Use std::iterator::is_sorted instead")]
 pub fn is_sorted<T: Borrow<usize>>(sequence: impl IntoIterator<Item = T>) -> bool {
     // TODO: Remove this function when `is_sorted` graduates from Rust nightly.
     let mut previous = 0;
@@ -1172,6 +1173,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(deprecated)]
     fn test_is_sorted() {
         assert!(is_sorted::<usize>([]));
         assert!(is_sorted([0]));

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -769,6 +769,20 @@ pub fn set_difference<T: Borrow<usize>, S: Borrow<usize>>(
         .collect()
 }
 
+/// Checks whether the given index sequence is monotonically non-decreasing.
+pub fn is_sorted<T: Borrow<usize>>(sequence: impl IntoIterator<Item = T>) -> bool {
+    // TODO: Remove this function when `is_sorted` graduates from Rust nightly.
+    let mut previous = 0;
+    for item in sequence.into_iter() {
+        let current = *item.borrow();
+        if current < previous {
+            return false;
+        }
+        previous = current;
+    }
+    true
+}
+
 /// Find indices of each element in `targets` inside `items`. If one of the
 /// elements is absent in `items`, returns an error.
 pub fn find_indices<T: PartialEq, S: Borrow<T>>(
@@ -1155,6 +1169,18 @@ mod tests {
         assert_eq!(set_difference([3, 4, 0], [1, 2, 4]), vec![3, 0]);
         assert_eq!(set_difference([0, 3, 4], [4, 1, 2]), vec![0, 3]);
         assert_eq!(set_difference([3, 4, 0], [4, 1, 2]), vec![3, 0]);
+    }
+
+    #[test]
+    fn test_is_sorted() {
+        assert!(is_sorted::<usize>([]));
+        assert!(is_sorted([0]));
+        assert!(is_sorted([0, 3, 4]));
+        assert!(is_sorted([0, 1, 2]));
+        assert!(is_sorted([0, 1, 4]));
+        assert!(is_sorted([0usize; 0]));
+        assert!(is_sorted([1, 2]));
+        assert!(!is_sorted([3, 2]));
     }
 
     #[test]

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -770,7 +770,7 @@ pub fn set_difference<T: Borrow<usize>, S: Borrow<usize>>(
 }
 
 /// Checks whether the given index sequence is monotonically non-decreasing.
-#[deprecated(since = "45.0.0", note = "Use std::iterator::is_sorted instead")]
+#[deprecated(since = "45.0.0", note = "Use std::Iterator::is_sorted instead")]
 pub fn is_sorted<T: Borrow<usize>>(sequence: impl IntoIterator<Item = T>) -> bool {
     // TODO: Remove this function when `is_sorted` graduates from Rust nightly.
     let mut previous = 0;


### PR DESCRIPTION
## Which issue does this PR close?

- related to https://github.com/apache/datafusion/pull/14370
- Part of #14008 

## Rationale for this change

As @andygrove  mentioned https://github.com/apache/datafusion/pull/14370/files#r1937564039 we should deprecate public APIs rather than remove them immediately


## What changes are included in this PR?

- Revert the changes in https://github.com/apache/datafusion/pull/14370
- Deprecate `is_sorted` instead

## Are these changes tested?

By the compiler

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
