### PR TITLE
perf: Improve `median` with no grouping by 2X 

### DIFF
--- a/datafusion/functions-aggregate/src/median.rs
+++ b/datafusion/functions-aggregate/src/median.rs
@@ -249,9 +249,11 @@ impl<T: ArrowNumericType> Accumulator for MedianAccumulator<T> {
             OffsetBuffer::new(ScalarBuffer::from(vec![0, self.all_values.len() as i32]));
 
         // Build inner array
-        let values_array =
-            PrimitiveArray::<T>::new(ScalarBuffer::from(self.all_values.clone()), None)
-                .with_data_type(self.data_type.clone());
+        let values_array = PrimitiveArray::<T>::new(
+            ScalarBuffer::from(std::mem::take(&mut self.all_values)),
+            None,
+        )
+        .with_data_type(self.data_type.clone());
 
         // Build the result list array
         let list_array = ListArray::new(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This is a small (one 20-lines change) follow-on to https://github.com/apache/datafusion/pull/13681

## Rationale for this change

@Rachelint (in https://github.com/apache/datafusion/pull/13681) makes `median()` aggregate function significantly faster by implementing `GroupsAccumulator`
However, regular `Accumulator` is still used in no-grouping aggregates and window expressions, this PR took some code from https://github.com/apache/datafusion/pull/13681 to also improve `median()`'s regular `Accumulator` implementation
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Benchmarks:
```
DataFusion CLI v44.0.0
> CREATE EXTERNAL TABLE IF NOT EXISTS lineitem (
        l_orderkey BIGINT,
        l_partkey BIGINT,
        l_suppkey BIGINT,
        l_linenumber INTEGER,
        l_quantity DECIMAL(15, 2),
        l_extendedprice DECIMAL(15, 2),
        l_discount DECIMAL(15, 2),
        l_tax DECIMAL(15, 2),
        l_returnflag VARCHAR,
        l_linestatus VARCHAR,
        l_shipdate DATE,
        l_commitdate DATE,
        l_receiptdate DATE,
        l_shipinstruct VARCHAR,
        l_shipmode VARCHAR,
        l_comment VARCHAR,
) STORED AS parquet
LOCATION '/Users/yongting/Code/datafusion/benchmarks/data/tpch_sf10/lineitem';
0 row(s) fetched.
Elapsed 0.011 seconds.

> select median(l_orderkey) from lineitem;
+-----------------------------+
| median(lineitem.l_orderkey) |
+-----------------------------+
| 29993285                    |
+-----------------------------+
1 row(s) fetched.
Elapsed 0.529 seconds.
```
PR: 0.5s
main: 1s

## What changes are included in this PR?
Changed `state()` implementation in `median`'s Accumulator
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
