### PR TITLE
fix: `List` of `FixedSizeList` coercion issue in SQL

### DIFF
--- a/datafusion/functions-nested/src/make_array.rs
+++ b/datafusion/functions-nested/src/make_array.rs
@@ -136,10 +136,7 @@ impl ScalarUDFImpl for MakeArray {
         }
 
         if let Some(new_type) = type_union_resolution(arg_types) {
-            // TODO: Move FixedSizeList to List in type_union_resolution
-            if let DataType::FixedSizeList(field, _) = new_type {
-                Ok(vec![List(field); arg_types.len()])
-            } else if new_type.is_null() {
+            if new_type.is_null() {
                 Ok(vec![DataType::Int64; arg_types.len()])
             } else {
                 Ok(vec![new_type; arg_types.len()])

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -6862,9 +6862,8 @@ select make_array(f0) from fixed_size_list_array
 query T
 select arrow_typeof(make_array(f0)) from fixed_size_list_array
 ----
-List(Field { name: "item", data_type: List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
-List(Field { name: "item", data_type: List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
-
+List(Field { name: "item", data_type: FixedSizeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, 2), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
+List(Field { name: "item", data_type: FixedSizeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, 2), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
 
 query ?
 select array_concat(column1, [7]) from arrays_values_v2;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #13819.  

## Rationale for this change  

Currently, `FixedSizeList` values inside a `make_array` call are eagerly coerced into `List`, resulting in non-intuitive behavior.  

To improve consistency, this PR aligns the behavior with DuckDB: coercion should only occur when the `FixedSizeList` is modified. This approach makes coercion more predictable and avoids unnecessary type transformations.  

## What changes are included in this PR?  

This PR removes the coercion logic in `make_array` when the type union resolves to `FixedSizeList`, ensuring that `make_array` no longer performs eager coercion.  

### Creating `List(FixedSizeList)`  

Previously, `make_array` would automatically coerce `FixedSizeList` into `List`, even when no operations were performed. With this fix, the expected behavior is preserved:  

```sql
> SELECT arrow_typeof([arrow_cast([1, 2, 3], 'FixedSizeList(3, Int64)')]);
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| arrow_typeof(make_array(arrow_cast(make_array(Int64(1),Int64(2),Int64(3)),Utf8("FixedSizeList(3, Int64)"))))                                                                                                                            |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| List(Field { name: "item", data_type: FixedSizeList(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, 3), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row(s) fetched.
Elapsed 0.002 seconds.
```  

### Appending After Casting to `FixedSizeList`  

If an element is appended to a `FixedSizeList`, coercion to `List` will still occur, as expected:  

```sql
> SELECT arrow_typeof([array_append(arrow_cast([1, 2, 3], 'FixedSizeList(3, Int64)'), 4)]);
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| arrow_typeof(make_array(array_append(arrow_cast(make_array(Int64(1),Int64(2),Int64(3)),Utf8("FixedSizeList(3, Int64)")),Int64(4))))                                                                                         |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| List(Field { name: "item", data_type: List(Field { name: "item", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }) |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row(s) fetched.
Elapsed 0.002 seconds.
```  

## Are these changes tested?  

One of the test cases in `sqllogictest` has been modified to reflect the updated behavior.  

## Are there any user-facing changes?  

Yes, users who previously relied on `make_array` coercing `FixedSizeList` into `List` by default will see a change in behavior. Now, coercion only occurs when modifications (e.g., `array_append`) are applied.