### PR TITLE
feat: Add `array_max` function support

### DIFF
--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -573,7 +573,7 @@ fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
 }
 
 /// dynamically-typed max(array) -> ScalarValue
-fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
+pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
     Ok(match values.data_type() {
         DataType::Utf8 => {
             typed_min_max_batch_string!(values, StringArray, Utf8, max_string)

--- a/datafusion/functions-nested/src/lib.rs
+++ b/datafusion/functions-nested/src/lib.rs
@@ -52,6 +52,7 @@ pub mod map;
 pub mod map_extract;
 pub mod map_keys;
 pub mod map_values;
+pub mod max;
 pub mod planner;
 pub mod position;
 pub mod range;
@@ -144,6 +145,7 @@ pub fn all_default_nested_functions() -> Vec<Arc<ScalarUDF>> {
         length::array_length_udf(),
         distance::array_distance_udf(),
         flatten::flatten_udf(),
+        max::array_max_udf(),
         sort::array_sort_udf(),
         repeat::array_repeat_udf(),
         resize::array_resize_udf(),

--- a/datafusion/functions-nested/src/max.rs
+++ b/datafusion/functions-nested/src/max.rs
@@ -16,18 +16,18 @@
 // under the License.
 
 //! [`ScalarUDFImpl`] definitions for array_max function.
-use crate::sort::array_sort_inner;
 use crate::utils::make_scalar_function;
-use arrow_array::{Array, ArrayRef, StringArray};
+use arrow::array::ArrayRef;
 use arrow_schema::DataType;
 use arrow_schema::DataType::{FixedSizeList, LargeList, List};
 use datafusion_common::cast::as_list_array;
 use datafusion_common::exec_err;
 use datafusion_doc::Documentation;
 use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
+use datafusion_functions::utils::take_function_args;
+use datafusion_functions_aggregate::min_max;
 use datafusion_macros::user_doc;
 use std::any::Any;
-use std::sync::Arc;
 
 make_udf_expr_and_func!(
     ArrayMax,
@@ -124,29 +124,14 @@ impl ScalarUDFImpl for ArrayMax {
 /// For example:
 /// > array_max(\[1, 3, 2]) -> 3
 pub fn array_max_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
-    if args.len() != 1 {
-        return exec_err!("array_max needs one argument");
-    }
+    let [arg1] = take_function_args("array_max", args)?;
 
-    match &args[0].data_type() {
+    match arg1.data_type() {
         List(_) | LargeList(_) | FixedSizeList(_, _) => {
-            let new_args = vec![
-                Arc::<dyn Array>::clone(&args[0]),
-                Arc::new(StringArray::from_iter(vec![Some("DESC")])),
-                Arc::new(StringArray::from_iter(vec![Some("NULLS LAST")])),
-            ];
-            array_max_internal(&new_args)
+            let input_array = as_list_array(&arg1)?.value(0);
+            let max_result = min_max::max_batch(&input_array);
+            max_result?.to_array()
         }
-        _ => exec_err!("array_max does not support type: {:?}", args[0].data_type()),
+        _ => exec_err!("array_max does not support type: {:?}", arg1.data_type()),
     }
-}
-
-fn array_max_internal(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
-    let sorted_array = array_sort_inner(args)?;
-    let result_array = as_list_array(&sorted_array)?.value(0);
-    if result_array.is_empty() {
-        return exec_err!("array_max needs one argument as non-empty array");
-    }
-    let max_result = result_array.slice(0, 1);
-    Ok(max_result)
 }

--- a/datafusion/functions-nested/src/max.rs
+++ b/datafusion/functions-nested/src/max.rs
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`ScalarUDFImpl`] definitions for array_max function.
+use crate::sort::array_sort_inner;
+use crate::utils::make_scalar_function;
+use arrow_array::{Array, ArrayRef, StringArray};
+use arrow_schema::DataType;
+use arrow_schema::DataType::{FixedSizeList, LargeList, List};
+use datafusion_common::cast::as_list_array;
+use datafusion_common::exec_err;
+use datafusion_doc::Documentation;
+use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
+use datafusion_macros::user_doc;
+use std::any::Any;
+use std::sync::Arc;
+
+make_udf_expr_and_func!(
+    ArrayMax,
+    array_max,
+    array,
+    "returns the maximum value in the array.",
+    array_max_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns the maximum value in the array.",
+    syntax_example = "array_max(array)",
+    sql_example = r#"```sql
+> select array_max([3,1,4,2]);
++-----------------------------------------+
+| array_max(List([3,1,4,2]))              |
++-----------------------------------------+
+| 4                                       |
++-----------------------------------------+
+```"#,
+    argument(
+        name = "array",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    )
+)]
+#[derive(Debug)]
+pub struct ArrayMax {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for ArrayMax {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArrayMax {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::array(Volatility::Immutable),
+            aliases: vec!["list_max".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for ArrayMax {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "array_max"
+    }
+
+    fn display_name(&self, args: &[Expr]) -> datafusion_common::Result<String> {
+        let args_name = args.iter().map(ToString::to_string).collect::<Vec<_>>();
+        if args_name.len() != 1 {
+            return exec_err!("expects 1 arg, got {}", args_name.len());
+        }
+
+        Ok(format!("{}", args_name[0]))
+    }
+
+    fn schema_name(&self, args: &[Expr]) -> datafusion_common::Result<String> {
+        let args_name = args
+            .iter()
+            .map(|e| e.schema_name().to_string())
+            .collect::<Vec<_>>();
+        if args_name.len() != 1 {
+            return exec_err!("expects 1 arg, got {}", args_name.len());
+        }
+
+        Ok(format!("{}", args_name[0]))
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+        match &arg_types[0] {
+            List(field) | LargeList(field) | FixedSizeList(field, _) => {
+                Ok(field.data_type().clone())
+            }
+            _ => exec_err!(
+                "Not reachable, data_type should be List, LargeList or FixedSizeList"
+            ),
+        }
+    }
+
+    fn invoke_batch(
+        &self,
+        args: &[ColumnarValue],
+        _number_rows: usize,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        make_scalar_function(array_max_inner)(args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+/// array_max SQL function
+///
+/// There is one argument for array_max as the array.
+/// `array_max(array)`
+///
+/// For example:
+/// > array_max(\[1, 3, 2]) -> 3
+pub fn array_max_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+    if args.len() != 1 {
+        return exec_err!("array_max needs one argument");
+    }
+
+    match &args[0].data_type() {
+        List(_) | LargeList(_) | FixedSizeList(_, _) => {
+            let new_args = vec![
+                args[0].clone(),
+                Arc::new(StringArray::from_iter(vec![Some("DESC")])),
+                Arc::new(StringArray::from_iter(vec![Some("NULLS LAST")])),
+            ];
+            array_max_internal(&new_args)
+        }
+        _ => exec_err!("array_max does not support type: {:?}", args[0].data_type()),
+    }
+}
+
+fn array_max_internal(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef> {
+    let sorted_array = array_sort_inner(args)?;
+    let result_array = as_list_array(&sorted_array)?.value(0);
+    if result_array.is_empty() {
+        return exec_err!("array_max needs one argument as non-empty array");
+    }
+    let max_result = result_array.slice(0, 1);
+    Ok(max_result)
+}

--- a/datafusion/functions-nested/src/max.rs
+++ b/datafusion/functions-nested/src/max.rs
@@ -24,7 +24,7 @@ use arrow_schema::DataType::{FixedSizeList, LargeList, List};
 use datafusion_common::cast::as_list_array;
 use datafusion_common::exec_err;
 use datafusion_doc::Documentation;
-use datafusion_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
+use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use datafusion_macros::user_doc;
 use std::any::Any;
 use std::sync::Arc;
@@ -84,27 +84,6 @@ impl ScalarUDFImpl for ArrayMax {
         "array_max"
     }
 
-    fn display_name(&self, args: &[Expr]) -> datafusion_common::Result<String> {
-        let args_name = args.iter().map(ToString::to_string).collect::<Vec<_>>();
-        if args_name.len() != 1 {
-            return exec_err!("expects 1 arg, got {}", args_name.len());
-        }
-
-        Ok(format!("{}", args_name[0]))
-    }
-
-    fn schema_name(&self, args: &[Expr]) -> datafusion_common::Result<String> {
-        let args_name = args
-            .iter()
-            .map(|e| e.schema_name().to_string())
-            .collect::<Vec<_>>();
-        if args_name.len() != 1 {
-            return exec_err!("expects 1 arg, got {}", args_name.len());
-        }
-
-        Ok(format!("{}", args_name[0]))
-    }
-
     fn signature(&self) -> &Signature {
         &self.signature
     }
@@ -152,7 +131,7 @@ pub fn array_max_inner(args: &[ArrayRef]) -> datafusion_common::Result<ArrayRef>
     match &args[0].data_type() {
         List(_) | LargeList(_) | FixedSizeList(_, _) => {
             let new_args = vec![
-                args[0].clone(),
+                Arc::<dyn Array>::clone(&args[0]),
                 Arc::new(StringArray::from_iter(vec![Some("DESC")])),
                 Arc::new(StringArray::from_iter(vec![Some("NULLS LAST")])),
             ];

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1496,6 +1496,20 @@ select array_max(make_array(5.1, -3.2, 6.3, 4.9));
 ----
 6.3
 
+query ?I
+select input, array_max(input) from (select make_array(d - 1, d, d + 1) input from (values (0), (10), (20), (30), (NULL)) t(d))
+----
+[-1, 0, 1] 1
+[9, 10, 11] 11
+[19, 20, 21] 21
+[29, 30, 31] 31
+[NULL, NULL, NULL] NULL
+
+query II
+select array_max(arrow_cast(make_array(1, 2, 3), 'FixedSizeList(3, Int64)')), array_max(arrow_cast(make_array(1), 'FixedSizeList(1, Int64)'));
+----
+3 1
+
 query I
 select array_max(make_array());
 ----

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1433,6 +1433,67 @@ NULL 23
 NULL 43
 5 NULL
 
+
+## array_max
+# array_max scalar function #1 (with positive index)
+query I
+select array_max(make_array(5, 3, 6, 4));
+----
+6
+
+query I
+select array_max(make_array(5, 3, 4, NULL, 6, NULL));
+----
+6
+
+query I
+select array_max(make_array(NULL, NULL));
+----
+NULL
+
+query T
+select array_max(make_array('h', 'e', 'o', 'l', 'l'));
+----
+o
+
+query T
+select array_max(make_array('h', 'e', 'l', NULL, 'l', 'o', NULL));
+----
+o
+
+query B
+select array_max(make_array(false, true, false, true));
+----
+true
+
+query B
+select array_max(make_array(false, true, NULL, false, true));
+----
+true
+
+query D
+select array_max(make_array(DATE '1992-09-01', DATE '1993-03-01', DATE '1999-05-01', DATE '1985-11-01'));
+----
+1999-05-01
+
+query D
+select array_max(make_array(DATE '1995-09-01', DATE '1999-05-01', DATE '1993-03-01', NULL));
+----
+1999-05-01
+
+query P
+select array_max(make_array(TIMESTAMP '1992-09-01', TIMESTAMP '1995-06-01', TIMESTAMP '1984-10-01'));
+----
+1995-06-01T00:00:00
+
+query P
+select array_max(make_array(NULL, TIMESTAMP '1996-10-01', TIMESTAMP '1995-06-01'));
+----
+1996-10-01T00:00:00
+
+query error Execution error: array_max needs one argument as non-empty array
+select array_max(make_array());
+
 ## array_pop_back (aliases: `list_pop_back`)
 
 # array_pop_back scalar function with null

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1491,8 +1491,20 @@ select array_max(make_array(NULL, TIMESTAMP '1996-10-01', TIMESTAMP '1995-06-01'
 ----
 1996-10-01T00:00:00
 
-query error Execution error: array_max needs one argument as non-empty array
+query R
+select array_max(make_array(5.1, -3.2, 6.3, 4.9));
+----
+6.3
+
+query I
 select array_max(make_array());
+----
+NULL
+
+# Testing with empty arguments should result in an error
+query error DataFusion error: Error during planning: 'array_max' does not support zero arguments
+select array_max();
+
 
 ## array_pop_back (aliases: `list_pop_back`)
 

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -3788,6 +3788,10 @@ _Alias of [array_to_string](#array_to_string)._
 
 _Alias of [array_length](#array_length)._
 
+### `list_max`
+
+_Alias of [array_max](#array_max)._
+
 ### `list_ndims`
 
 _Alias of [array_ndims](#array_ndims)._

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -2524,6 +2524,7 @@ _Alias of [current_date](#current_date)._
 - [array_intersect](#array_intersect)
 - [array_join](#array_join)
 - [array_length](#array_length)
+- [array_max](#array_max)
 - [array_ndims](#array_ndims)
 - [array_pop_back](#array_pop_back)
 - [array_pop_front](#array_pop_front)
@@ -2569,6 +2570,7 @@ _Alias of [current_date](#current_date)._
 - [list_intersect](#list_intersect)
 - [list_join](#list_join)
 - [list_length](#list_length)
+- [list_max](#list_max)
 - [list_ndims](#list_ndims)
 - [list_pop_back](#list_pop_back)
 - [list_pop_front](#list_pop_front)
@@ -3001,6 +3003,33 @@ array_length(array, dimension)
 #### Aliases
 
 - list_length
+
+### `array_max`
+
+Returns the maximum value in the array.
+
+```
+array_max(array)
+```
+
+#### Arguments
+
+- **array**: Array expression. Can be a constant, column, or function, and any combination of array operators.
+
+#### Example
+
+```sql
+> select array_max([3,1,4,2]);
++-----------------------------------------+
+| array_max(List([3,1,4,2]))              |
++-----------------------------------------+
+| 4                                       |
++-----------------------------------------+
+```
+
+#### Aliases
+
+- list_max
 
 ### `array_ndims`
 

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -3008,7 +3008,7 @@ array_length(array, dimension)
 
 Returns the maximum value in the array.
 
-```
+```sql
 array_max(array)
 ```
 


### PR DESCRIPTION
## Which issue does this PR close?
Closes #14469.

## What changes are included in this PR?
Currently, Spark, Snowflake and Presto support `array_max` function. This can also be useful for DataFusion.
```
array_max(make_array(3,1,4,2)) => 4
array_max(make_array('h','e','o','l','l',NULL)) => o
array_max(make_array(NULL,NULL)) => NULL
select input, array_max(input) from 
   (select make_array(d - 1, d, d + 1) input from (values (10), (NULL)) t(d)) =>
----
[9, 10, 11] 11
[NULL, NULL, NULL] NULL
```
Spark: https://docs.databricks.com/en/sql/language-manual/functions/array_max.html
Snowflake: https://docs.snowflake.com/en/sql-reference/functions/array_max
Presto: https://prestodb.io/docs/current/functions/array.html#array_max-x-x

All potential use-cases have been covered like different `data_types`, `empty array`, `NULL` etc.

## Are these changes tested?
Added new UT cases to verify `array_max` function in terms of different source arrays.

## Are there any user-facing changes?
Yes, new SQL function is supported and documentation has also be updated.
