### PR TITLE
Make Pushdown Filters Public

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -32,10 +32,7 @@ use std::sync::Arc;
 
 use crate::datasource::listing::PartitionedFile;
 use crate::datasource::physical_plan::file_stream::FileStream;
-use crate::datasource::physical_plan::{
-    parquet::page_filter::PagePruningAccessPlanFilter, DisplayAs, FileGroupPartitioner,
-    FileScanConfig,
-};
+use crate::datasource::physical_plan::{DisplayAs, FileGroupPartitioner, FileScanConfig};
 use crate::datasource::schema_adapter::{
     DefaultSchemaAdapterFactory, SchemaAdapterFactory,
 };
@@ -58,8 +55,10 @@ use datafusion_physical_optimizer::pruning::PruningPredicate;
 use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
 pub use metrics::ParquetFileMetrics;
 use opener::ParquetOpener;
+pub use page_filter::PagePruningAccessPlanFilter;
 pub use reader::{DefaultParquetFileReaderFactory, ParquetFileReaderFactory};
 pub use row_filter::can_expr_be_pushed_down_with_schemas;
+pub use row_group_filter::RowGroupAccessPlanFilter;
 pub use writer::plan_to_parquet;
 
 use itertools::Itertools;


### PR DESCRIPTION
## Which issue does this PR close?

There is no outstanding issue that this closes

## Rationale for this change

I'm trying to reuse the two components in my own code in order to serve up some parquet files in a memory cache.  Currently I've just copy/pasted both structs, but it would be nice instead if they were public.

## What changes are included in this PR?

Sets the visibility for `RowGroupAccessPlanFilter` and `PagePruningAccessPlanFilter` to be public.

## Are these changes tested?

N/A

## Are there any user-facing changes?

No, just some extra visibility
