### PR TITLE
Replace `once_cell::Lazy` with `std::sync::LazyLock`

### DIFF
--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -68,7 +68,6 @@ tokio = { workspace = true }
 criterion = { version = "0.5", features = ["async_futures"] }
 datafusion-functions-aggregate = { workspace = true }
 datafusion-functions-window = { workspace = true }
-once_cell = "1.18.0"
 rand = { workspace = true }
 rstest = { workspace = true }
 rstest_reuse = "0.7.0"

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -1711,7 +1711,7 @@ pub enum SHJStreamState {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::sync::{LazyLock, Mutex};
 
     use super::*;
     use crate::joins::test_utils::{
@@ -1729,7 +1729,6 @@ mod tests {
     use datafusion_physical_expr::expressions::{binary, col, lit, Column};
     use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
 
-    use once_cell::sync::Lazy;
     use rstest::*;
 
     const TABLE_SIZE: i32 = 30;
@@ -1738,8 +1737,8 @@ mod tests {
     type TableValue = (Vec<RecordBatch>, Vec<RecordBatch>); // (left, right)
 
     // Cache for storing tables
-    static TABLE_CACHE: Lazy<Mutex<HashMap<TableKey, TableValue>>> =
-        Lazy::new(|| Mutex::new(HashMap::new()));
+    static TABLE_CACHE: LazyLock<Mutex<HashMap<TableKey, TableValue>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
 
     fn get_or_create_table(
         cardinality: (i32, i32),


### PR DESCRIPTION
## Which issue does this PR close?

None.

## Rationale for this change

With the MSRV > 1.80 we can use `std::sync::LazyLock` instead of `once_cell::Lazy`.

## What changes are included in this PR?

Remove `once_cell` dependency from `datafusion-physical-plan` and replace use of `once_cell::Lazy` with `std::sync::LazyLock`.

## Are these changes tested?

CI.

## Are there any user-facing changes?

Datafusion crates no longer depend directly on `once_cell`.