### PR TITLE
refactor: remove uses of `arrow_buffer` & `arrow_array` and use reexport in arrow instead

### DIFF
--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -25,8 +25,7 @@ use arrow::array::*;
 use arrow::datatypes::*;
 #[cfg(not(feature = "force_hash_collisions"))]
 use arrow::{downcast_dictionary_array, downcast_primitive_array};
-use arrow_buffer::IntervalDayTime;
-use arrow_buffer::IntervalMonthDayNano;
+use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
 
 #[cfg(not(feature = "force_hash_collisions"))]
 use crate::cast::{
@@ -700,7 +699,7 @@ mod tests {
     // Tests actual values of hashes, which are different if forcing collisions
     #[cfg(not(feature = "force_hash_collisions"))]
     fn create_hashes_for_struct_arrays() {
-        use arrow_buffer::Buffer;
+        use arrow::buffer::Buffer;
 
         let boolarr = Arc::new(BooleanArray::from(vec![
             false, false, true, true, true, true,

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -3958,12 +3958,11 @@ mod tests {
     };
 
     use crate::assert_batches_eq;
-    use arrow::buffer::OffsetBuffer;
+    use arrow::array::{types::Float64Type, NullBufferBuilder};
+    use arrow::buffer::{Buffer, OffsetBuffer};
     use arrow::compute::{is_null, kernels};
     use arrow::error::ArrowError;
     use arrow::util::pretty::pretty_format_columns;
-    use arrow_array::types::Float64Type;
-    use arrow_buffer::{Buffer, NullBufferBuilder};
     use arrow_schema::Fields;
     use chrono::NaiveDate;
     use rand::Rng;

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -19,6 +19,7 @@
 mod dataframe_functions;
 mod describe;
 
+use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::{DataType, Field, Float32Type, Int32Type, Schema, UInt64Type};
 use arrow::util::pretty::pretty_format_batches;
 use arrow::{
@@ -33,7 +34,6 @@ use arrow_array::{
     record_batch, Array, BooleanArray, DictionaryArray, Float32Array, Float64Array,
     Int8Array, UnionArray,
 };
-use arrow_buffer::ScalarBuffer;
 use arrow_schema::{ArrowError, SchemaRef, UnionFields, UnionMode};
 use datafusion_functions_aggregate::count::count_udaf;
 use datafusion_functions_aggregate::expr_fn::{

--- a/datafusion/functions-aggregate/benches/array_agg.rs
+++ b/datafusion/functions-aggregate/benches/array_agg.rs
@@ -17,7 +17,9 @@
 
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, ArrowPrimitiveType, AsArray, ListArray};
+use arrow::array::{
+    Array, ArrayRef, ArrowPrimitiveType, AsArray, ListArray, NullBufferBuilder,
+};
 use arrow::datatypes::Int64Type;
 use arrow::util::bench_util::create_primitive_array;
 use arrow_schema::Field;
@@ -25,8 +27,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use datafusion_expr::Accumulator;
 use datafusion_functions_aggregate::array_agg::ArrayAggAccumulator;
 
+use arrow::buffer::OffsetBuffer;
 use arrow::util::test_util::seedable_rng;
-use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -23,7 +23,8 @@ use std::mem::size_of_val;
 use std::sync::Arc;
 
 use arrow::array::{
-    downcast_array, Array, AsArray, BooleanArray, Float64Array, UInt64Array,
+    downcast_array, Array, AsArray, BooleanArray, Float64Array, NullBufferBuilder,
+    UInt64Array,
 };
 use arrow::compute::{and, filter, is_not_null, kernels::cast};
 use arrow::datatypes::{Float64Type, UInt64Type};
@@ -31,7 +32,6 @@ use arrow::{
     array::ArrayRef,
     datatypes::{DataType, Field},
 };
-use arrow_buffer::NullBufferBuilder;
 use datafusion_expr::{EmitTo, GroupsAccumulator};
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::accumulate::accumulate_multiple;
 use log::debug;

--- a/datafusion/functions-nested/benches/map.rs
+++ b/datafusion/functions-nested/benches/map.rs
@@ -17,8 +17,8 @@
 
 extern crate criterion;
 
+use arrow::buffer::{OffsetBuffer, ScalarBuffer};
 use arrow_array::{Int32Array, ListArray, StringArray};
-use arrow_buffer::{OffsetBuffer, ScalarBuffer};
 use arrow_schema::{DataType, Field};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::prelude::ThreadRng;

--- a/datafusion/functions-nested/src/array_has.rs
+++ b/datafusion/functions-nested/src/array_has.rs
@@ -18,10 +18,10 @@
 //! [`ScalarUDFImpl`] definitions for array_has, array_has_all and array_has_any functions.
 
 use arrow::array::{Array, ArrayRef, BooleanArray, OffsetSizeTrait};
+use arrow::buffer::BooleanBuffer;
 use arrow::datatypes::DataType;
 use arrow::row::{RowConverter, Rows, SortField};
 use arrow_array::{Datum, GenericListArray, Scalar};
-use arrow_buffer::BooleanBuffer;
 use datafusion_common::cast::as_generic_list_array;
 use datafusion_common::utils::string_utils::string_array_to_vec;
 use datafusion_common::{exec_err, Result, ScalarValue};

--- a/datafusion/functions-nested/src/concat.rs
+++ b/datafusion/functions-nested/src/concat.rs
@@ -20,9 +20,11 @@
 use std::sync::Arc;
 use std::{any::Any, cmp::Ordering};
 
-use arrow::array::{Capacities, MutableArrayData};
-use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
-use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
+use arrow::array::{
+    Array, ArrayRef, Capacities, GenericListArray, MutableArrayData, NullBufferBuilder,
+    OffsetSizeTrait,
+};
+use arrow::buffer::OffsetBuffer;
 use arrow_schema::{DataType, Field};
 use datafusion_common::Result;
 use datafusion_common::{

--- a/datafusion/functions-nested/src/except.rs
+++ b/datafusion/functions-nested/src/except.rs
@@ -18,10 +18,10 @@
 //! [`ScalarUDFImpl`] definitions for array_except function.
 
 use crate::utils::{check_datatypes, make_scalar_function};
+use arrow::buffer::OffsetBuffer;
 use arrow::row::{RowConverter, SortField};
 use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
-use arrow_buffer::OffsetBuffer;
 use arrow_schema::{DataType, FieldRef};
 use datafusion_common::{exec_err, internal_err, HashSet, Result};
 use datafusion_expr::{

--- a/datafusion/functions-nested/src/extract.rs
+++ b/datafusion/functions-nested/src/extract.rs
@@ -17,17 +17,12 @@
 
 //! [`ScalarUDFImpl`] definitions for array_element, array_slice, array_pop_front, array_pop_back, and array_any_value functions.
 
-use arrow::array::Array;
-use arrow::array::ArrayRef;
-use arrow::array::ArrowNativeTypeOp;
-use arrow::array::Capacities;
-use arrow::array::GenericListArray;
-use arrow::array::Int64Array;
-use arrow::array::MutableArrayData;
-use arrow::array::OffsetSizeTrait;
+use arrow::array::{
+    Array, ArrayRef, ArrowNativeTypeOp, Capacities, GenericListArray, Int64Array,
+    MutableArrayData, NullBufferBuilder, OffsetSizeTrait,
+};
 use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::DataType;
-use arrow_buffer::NullBufferBuilder;
 use arrow_schema::DataType::{FixedSizeList, LargeList, List};
 use arrow_schema::Field;
 use datafusion_common::cast::as_int64_array;

--- a/datafusion/functions-nested/src/flatten.rs
+++ b/datafusion/functions-nested/src/flatten.rs
@@ -18,8 +18,8 @@
 //! [`ScalarUDFImpl`] definitions for flatten function.
 
 use crate::utils::make_scalar_function;
+use arrow::buffer::OffsetBuffer;
 use arrow_array::{ArrayRef, GenericListArray, OffsetSizeTrait};
-use arrow_buffer::OffsetBuffer;
 use arrow_schema::DataType;
 use arrow_schema::DataType::{FixedSizeList, LargeList, List, Null};
 use datafusion_common::cast::{

--- a/datafusion/functions-nested/src/make_array.rs
+++ b/datafusion/functions-nested/src/make_array.rs
@@ -23,10 +23,10 @@ use std::vec;
 
 use crate::utils::make_scalar_function;
 use arrow::array::{ArrayData, Capacities, MutableArrayData};
+use arrow::buffer::OffsetBuffer;
 use arrow_array::{
     new_null_array, Array, ArrayRef, GenericListArray, NullArray, OffsetSizeTrait,
 };
-use arrow_buffer::OffsetBuffer;
 use arrow_schema::DataType::{List, Null};
 use arrow_schema::{DataType, Field};
 use datafusion_common::utils::SingleRowListArrayBuilder;

--- a/datafusion/functions-nested/src/map_extract.rs
+++ b/datafusion/functions-nested/src/map_extract.rs
@@ -20,9 +20,9 @@
 use arrow::array::{ArrayRef, Capacities, MutableArrayData};
 use arrow_array::{make_array, ListArray};
 
+use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::DataType;
 use arrow_array::{Array, MapArray};
-use arrow_buffer::OffsetBuffer;
 use arrow_schema::Field;
 
 use datafusion_common::{cast::as_map_array, exec_err, Result};

--- a/datafusion/functions-nested/src/range.rs
+++ b/datafusion/functions-nested/src/range.rs
@@ -18,16 +18,16 @@
 //! [`ScalarUDFImpl`] definitions for range and gen_series functions.
 
 use crate::utils::make_scalar_function;
-use arrow::array::{Array, ArrayRef, Int64Array, ListArray, ListBuilder};
-use arrow::datatypes::{DataType, Field};
-use arrow_array::builder::{Date32Builder, TimestampNanosecondBuilder};
-use arrow_array::temporal_conversions::as_datetime_with_timezone;
-use arrow_array::timezone::Tz;
-use arrow_array::types::{
-    Date32Type, IntervalMonthDayNanoType, TimestampNanosecondType as TSNT,
+use arrow::array::{
+    builder::{Date32Builder, TimestampNanosecondBuilder},
+    temporal_conversions::as_datetime_with_timezone,
+    timezone::Tz,
+    types::{Date32Type, IntervalMonthDayNanoType, TimestampNanosecondType as TSNT},
+    Array, ArrayRef, Int64Array, ListArray, ListBuilder, NullArray, NullBufferBuilder,
+    TimestampNanosecondArray,
 };
-use arrow_array::{NullArray, TimestampNanosecondArray};
-use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::{DataType, Field};
 use arrow_schema::DataType::*;
 use arrow_schema::IntervalUnit::MonthDayNano;
 use arrow_schema::TimeUnit::Nanosecond;

--- a/datafusion/functions-nested/src/remove.rs
+++ b/datafusion/functions-nested/src/remove.rs
@@ -19,11 +19,11 @@
 
 use crate::utils;
 use crate::utils::make_scalar_function;
+use arrow::buffer::OffsetBuffer;
 use arrow_array::cast::AsArray;
 use arrow_array::{
     new_empty_array, Array, ArrayRef, BooleanArray, GenericListArray, OffsetSizeTrait,
 };
-use arrow_buffer::OffsetBuffer;
 use arrow_schema::{DataType, Field};
 use datafusion_common::cast::as_int64_array;
 use datafusion_common::{exec_err, Result};

--- a/datafusion/functions-nested/src/repeat.rs
+++ b/datafusion/functions-nested/src/repeat.rs
@@ -19,13 +19,13 @@
 
 use crate::utils::make_scalar_function;
 use arrow::array::{Capacities, MutableArrayData};
+use arrow::buffer::OffsetBuffer;
 use arrow::compute;
 use arrow::compute::cast;
 use arrow_array::{
     new_null_array, Array, ArrayRef, GenericListArray, ListArray, OffsetSizeTrait,
     UInt64Array,
 };
-use arrow_buffer::OffsetBuffer;
 use arrow_schema::DataType::{LargeList, List};
 use arrow_schema::{DataType, Field};
 use datafusion_common::cast::{as_large_list_array, as_list_array, as_uint64_array};

--- a/datafusion/functions-nested/src/replace.rs
+++ b/datafusion/functions-nested/src/replace.rs
@@ -18,12 +18,12 @@
 //! [`ScalarUDFImpl`] definitions for array_replace, array_replace_n and array_replace_all functions.
 
 use arrow::array::{
-    Array, ArrayRef, AsArray, Capacities, MutableArrayData, OffsetSizeTrait,
+    Array, ArrayRef, AsArray, Capacities, GenericListArray, MutableArrayData,
+    NullBufferBuilder, OffsetSizeTrait,
 };
 use arrow::datatypes::DataType;
 
-use arrow_array::GenericListArray;
-use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
+use arrow::buffer::OffsetBuffer;
 use arrow_schema::Field;
 use datafusion_common::cast::as_int64_array;
 use datafusion_common::{exec_err, Result};

--- a/datafusion/functions-nested/src/resize.rs
+++ b/datafusion/functions-nested/src/resize.rs
@@ -18,11 +18,12 @@
 //! [`ScalarUDFImpl`] definitions for array_resize function.
 
 use crate::utils::make_scalar_function;
-use arrow::array::{Capacities, MutableArrayData};
-use arrow_array::{
-    new_null_array, Array, ArrayRef, GenericListArray, Int64Array, OffsetSizeTrait,
+use arrow::array::{
+    new_null_array, Array, ArrayRef, Capacities, GenericListArray, Int64Array,
+    MutableArrayData, NullBufferBuilder, OffsetSizeTrait,
 };
-use arrow_buffer::{ArrowNativeType, NullBufferBuilder, OffsetBuffer};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::ArrowNativeType;
 use arrow_schema::DataType::{FixedSizeList, LargeList, List};
 use arrow_schema::{DataType, FieldRef};
 use datafusion_common::cast::{as_int64_array, as_large_list_array, as_list_array};

--- a/datafusion/functions-nested/src/reverse.rs
+++ b/datafusion/functions-nested/src/reverse.rs
@@ -19,8 +19,8 @@
 
 use crate::utils::make_scalar_function;
 use arrow::array::{Capacities, MutableArrayData};
+use arrow::buffer::OffsetBuffer;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
-use arrow_buffer::OffsetBuffer;
 use arrow_schema::DataType::{LargeList, List, Null};
 use arrow_schema::{DataType, FieldRef};
 use datafusion_common::cast::{as_large_list_array, as_list_array};

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -18,9 +18,9 @@
 //! [`ScalarUDFImpl`] definitions for array_sort function.
 
 use crate::utils::make_scalar_function;
+use arrow::array::{Array, ArrayRef, ListArray, NullBufferBuilder};
+use arrow::buffer::OffsetBuffer;
 use arrow::compute;
-use arrow_array::{Array, ArrayRef, ListArray};
-use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 use arrow_schema::DataType::{FixedSizeList, LargeList, List};
 use arrow_schema::{DataType, Field, SortOptions};
 use datafusion_common::cast::{as_list_array, as_string_array};

--- a/datafusion/functions-nested/src/utils.rs
+++ b/datafusion/functions-nested/src/utils.rs
@@ -21,11 +21,11 @@ use std::sync::Arc;
 
 use arrow::{array::ArrayRef, datatypes::DataType};
 
+use arrow::buffer::OffsetBuffer;
 use arrow_array::{
     Array, BooleanArray, GenericListArray, ListArray, OffsetSizeTrait, Scalar,
     UInt32Array,
 };
-use arrow_buffer::OffsetBuffer;
 use arrow_schema::{Field, Fields};
 use datafusion_common::cast::{as_large_list_array, as_list_array};
 use datafusion_common::{

--- a/datafusion/functions/src/core/greatest.rs
+++ b/datafusion/functions/src/core/greatest.rs
@@ -17,10 +17,10 @@
 
 use crate::core::greatest_least_utils::GreatestLeastOperator;
 use arrow::array::{make_comparator, Array, BooleanArray};
+use arrow::buffer::BooleanBuffer;
 use arrow::compute::kernels::cmp;
 use arrow::compute::SortOptions;
 use arrow::datatypes::DataType;
-use arrow_buffer::BooleanBuffer;
 use datafusion_common::{internal_err, Result, ScalarValue};
 use datafusion_doc::Documentation;
 use datafusion_expr::ColumnarValue;

--- a/datafusion/functions/src/core/least.rs
+++ b/datafusion/functions/src/core/least.rs
@@ -17,10 +17,10 @@
 
 use crate::core::greatest_least_utils::GreatestLeastOperator;
 use arrow::array::{make_comparator, Array, BooleanArray};
+use arrow::buffer::BooleanBuffer;
 use arrow::compute::kernels::cmp;
 use arrow::compute::SortOptions;
 use arrow::datatypes::DataType;
-use arrow_buffer::BooleanBuffer;
 use datafusion_common::{internal_err, Result, ScalarValue};
 use datafusion_doc::Documentation;
 use datafusion_expr::ColumnarValue;

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -23,11 +23,10 @@ use std::sync::Arc;
 use crate::strings::make_and_append_view;
 use arrow::array::{
     new_null_array, Array, ArrayRef, GenericStringArray, GenericStringBuilder,
-    OffsetSizeTrait, StringBuilder, StringViewArray,
+    NullBufferBuilder, OffsetSizeTrait, StringBuilder, StringViewArray,
 };
-use arrow::buffer::Buffer;
+use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::DataType;
-use arrow_buffer::{NullBufferBuilder, ScalarBuffer};
 use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
 use datafusion_common::Result;
 use datafusion_common::{exec_err, ScalarValue};

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -19,11 +19,11 @@ use std::mem::size_of;
 
 use arrow::array::{
     make_view, Array, ArrayAccessor, ArrayDataBuilder, ArrayIter, ByteView,
-    GenericStringArray, LargeStringArray, OffsetSizeTrait, StringArray, StringViewArray,
-    StringViewBuilder,
+    GenericStringArray, LargeStringArray, NullBufferBuilder, OffsetSizeTrait,
+    StringArray, StringViewArray, StringViewBuilder,
 };
+use arrow::buffer::{MutableBuffer, NullBuffer};
 use arrow::datatypes::DataType;
-use arrow_buffer::{MutableBuffer, NullBuffer, NullBufferBuilder};
 
 /// Abstracts iteration over different types of string arrays.
 #[deprecated(since = "45.0.0", note = "Use arrow::array::StringArrayType instead")]

--- a/datafusion/functions/src/unicode/substr.rs
+++ b/datafusion/functions/src/unicode/substr.rs
@@ -22,10 +22,10 @@ use crate::strings::make_and_append_view;
 use crate::utils::{make_scalar_function, utf8_to_str_type};
 use arrow::array::{
     Array, ArrayIter, ArrayRef, AsArray, GenericStringBuilder, Int64Array,
-    OffsetSizeTrait, StringArrayType, StringViewArray,
+    NullBufferBuilder, OffsetSizeTrait, StringArrayType, StringViewArray,
 };
+use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::DataType;
-use arrow_buffer::{NullBufferBuilder, ScalarBuffer};
 use datafusion_common::cast::as_int64_array;
 use datafusion_common::{exec_err, plan_err, Result};
 use datafusion_expr::{

--- a/datafusion/physical-expr-common/src/binary_map.rs
+++ b/datafusion/physical-expr-common/src/binary_map.rs
@@ -19,14 +19,14 @@
 //! StringArray / LargeStringArray / BinaryArray / LargeBinaryArray.
 
 use ahash::RandomState;
-use arrow::array::cast::AsArray;
-use arrow::array::types::{ByteArrayType, GenericBinaryType, GenericStringType};
 use arrow::array::{
+    cast::AsArray,
+    types::{ByteArrayType, GenericBinaryType, GenericStringType},
     Array, ArrayRef, BufferBuilder, GenericBinaryArray, GenericStringArray,
-    OffsetSizeTrait,
+    NullBufferBuilder, OffsetSizeTrait,
 };
+use arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::DataType;
-use arrow_buffer::{NullBuffer, NullBufferBuilder, OffsetBuffer, ScalarBuffer};
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::utils::proxy::{HashTableAllocExt, VecAllocExt};
 use std::any::type_name;

--- a/datafusion/physical-expr/src/expressions/is_not_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_not_null.rs
@@ -115,12 +115,12 @@ pub fn is_not_null(arg: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> 
 mod tests {
     use super::*;
     use crate::expressions::col;
+    use arrow::buffer::ScalarBuffer;
     use arrow::{
         array::{BooleanArray, StringArray},
         datatypes::*,
     };
     use arrow_array::{Array, Float64Array, Int32Array, UnionArray};
-    use arrow_buffer::ScalarBuffer;
     use datafusion_common::cast::as_boolean_array;
 
     #[test]

--- a/datafusion/physical-expr/src/expressions/is_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_null.rs
@@ -114,12 +114,12 @@ pub fn is_null(arg: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> {
 mod tests {
     use super::*;
     use crate::expressions::col;
+    use arrow::buffer::ScalarBuffer;
     use arrow::{
         array::{BooleanArray, StringArray},
         datatypes::*,
     };
     use arrow_array::{Array, Float64Array, Int32Array, UnionArray};
-    use arrow_buffer::ScalarBuffer;
     use datafusion_common::cast::as_boolean_array;
 
     #[test]

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
@@ -17,11 +17,12 @@
 
 use crate::aggregates::group_values::multi_group_by::{nulls_equal_to, GroupColumn};
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{AsArray, BufferBuilder, GenericBinaryArray, GenericStringArray};
+use arrow::array::{
+    types::GenericStringType, Array, ArrayRef, AsArray, BufferBuilder,
+    GenericBinaryArray, GenericByteArray, GenericStringArray, OffsetSizeTrait,
+};
 use arrow::buffer::{OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{ByteArrayType, DataType, GenericBinaryType};
-use arrow_array::types::GenericStringType;
-use arrow_array::{Array, ArrayRef, GenericByteArray, OffsetSizeTrait};
 use datafusion_common::utils::proxy::VecAllocExt;
 use datafusion_physical_expr_common::binary_map::{OutputType, INITIAL_BUFFER_CAPACITY};
 use itertools::izip;
@@ -404,8 +405,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::aggregates::group_values::multi_group_by::bytes::ByteGroupValueBuilder;
-    use arrow_array::{ArrayRef, StringArray};
-    use arrow_buffer::NullBufferBuilder;
+    use arrow::array::{ArrayRef, NullBufferBuilder, StringArray};
     use datafusion_physical_expr::binary_map::OutputType;
 
     use super::GroupColumn;

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -18,10 +18,9 @@
 use crate::aggregates::group_values::multi_group_by::{nulls_equal_to, GroupColumn};
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
 use arrow::array::{make_view, AsArray, ByteView};
-use arrow::buffer::ScalarBuffer;
+use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::ByteViewType;
 use arrow_array::{Array, ArrayRef, GenericByteViewArray};
-use arrow_buffer::Buffer;
 use itertools::izip;
 use std::marker::PhantomData;
 use std::mem::{replace, size_of};
@@ -545,10 +544,8 @@ mod tests {
     use std::sync::Arc;
 
     use crate::aggregates::group_values::multi_group_by::bytes_view::ByteViewGroupValueBuilder;
-    use arrow::array::AsArray;
+    use arrow::array::{ArrayRef, AsArray, NullBufferBuilder, StringViewArray};
     use arrow::datatypes::StringViewType;
-    use arrow_array::{ArrayRef, StringViewArray};
-    use arrow_buffer::NullBufferBuilder;
 
     use super::GroupColumn;
 

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
@@ -17,9 +17,8 @@
 
 use crate::aggregates::group_values::multi_group_by::{nulls_equal_to, GroupColumn};
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
+use arrow::array::{cast::AsArray, Array, ArrayRef, ArrowPrimitiveType, PrimitiveArray};
 use arrow::buffer::ScalarBuffer;
-use arrow_array::cast::AsArray;
-use arrow_array::{Array, ArrayRef, ArrowPrimitiveType, PrimitiveArray};
 use arrow_schema::DataType;
 use datafusion_execution::memory_pool::proxy::VecAllocExt;
 use itertools::izip;
@@ -212,9 +211,8 @@ mod tests {
     use std::sync::Arc;
 
     use crate::aggregates::group_values::multi_group_by::primitive::PrimitiveGroupValueBuilder;
+    use arrow::array::{ArrayRef, Int64Array, NullBufferBuilder};
     use arrow::datatypes::Int64Type;
-    use arrow_array::{ArrayRef, Int64Array};
-    use arrow_buffer::NullBufferBuilder;
     use arrow_schema::DataType;
 
     use super::GroupColumn;

--- a/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_buffer::{BooleanBufferBuilder, NullBuffer};
+use arrow::array::BooleanBufferBuilder;
+use arrow::buffer::NullBuffer;
 
 /// Builder for an (optional) null mask
 ///

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -17,11 +17,12 @@
 
 use crate::aggregates::group_values::GroupValues;
 use ahash::RandomState;
+use arrow::array::{
+    cast::AsArray, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, NullBufferBuilder,
+    PrimitiveArray,
+};
 use arrow::datatypes::i256;
 use arrow::record_batch::RecordBatch;
-use arrow_array::cast::AsArray;
-use arrow_array::{ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, PrimitiveArray};
-use arrow_buffer::NullBufferBuilder;
 use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
 use arrow_schema::DataType;
 use datafusion_common::Result;

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -1644,9 +1644,9 @@ mod tests {
     };
 
     use arrow::array::{Date32Array, Int32Array};
+    use arrow::buffer::NullBuffer;
     use arrow::datatypes::{DataType, Field};
     use arrow_array::StructArray;
-    use arrow_buffer::NullBuffer;
     use datafusion_common::{
         assert_batches_eq, assert_batches_sorted_eq, assert_contains, exec_err,
         ScalarValue,

--- a/datafusion/physical-plan/src/joins/mod.rs
+++ b/datafusion/physical-plan/src/joins/mod.rs
@@ -17,7 +17,7 @@
 
 //! DataFusion Join implementations
 
-use arrow_buffer::BooleanBufferBuilder;
+use arrow::array::BooleanBufferBuilder;
 pub use cross_join::CrossJoinExec;
 pub use hash_join::HashJoinExec;
 pub use nested_loop_join::NestedLoopJoinExec;

--- a/datafusion/physical-plan/src/joins/stream_join_utils.rs
+++ b/datafusion/physical-plan/src/joins/stream_join_utils.rs
@@ -26,9 +26,11 @@ use crate::joins::utils::{JoinFilter, JoinHashMapType};
 use crate::metrics::{ExecutionPlanMetricsSet, MetricBuilder};
 use crate::{metrics, ExecutionPlan};
 
+use arrow::array::{
+    ArrowPrimitiveType, BooleanBufferBuilder, NativeAdapter, PrimitiveArray, RecordBatch,
+};
 use arrow::compute::concat_batches;
-use arrow_array::{ArrowPrimitiveType, NativeAdapter, PrimitiveArray, RecordBatch};
-use arrow_buffer::{ArrowNativeType, BooleanBufferBuilder};
+use arrow_buffer::ArrowNativeType;
 use arrow_schema::{Schema, SchemaRef};
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::{

--- a/datafusion/physical-plan/src/sorts/cursor.rs
+++ b/datafusion/physical-plan/src/sorts/cursor.rs
@@ -18,6 +18,7 @@
 use std::cmp::Ordering;
 
 use arrow::buffer::ScalarBuffer;
+use arrow::buffer::{Buffer, OffsetBuffer};
 use arrow::compute::SortOptions;
 use arrow::datatypes::ArrowNativeTypeOp;
 use arrow::row::Rows;
@@ -25,7 +26,6 @@ use arrow_array::types::ByteArrayType;
 use arrow_array::{
     Array, ArrowPrimitiveType, GenericByteArray, OffsetSizeTrait, PrimitiveArray,
 };
-use arrow_buffer::{Buffer, OffsetBuffer};
 use datafusion_execution::memory_pool::MemoryReservation;
 
 /// A comparable collection of values for use with [`Cursor`]

--- a/datafusion/physical-plan/src/unnest.rs
+++ b/datafusion/physical-plan/src/unnest.rs
@@ -951,9 +951,11 @@ fn repeat_arrs_from_indices(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::{
+        GenericListArray, NullBufferBuilder, OffsetSizeTrait, StringArray,
+    };
+    use arrow::buffer::{NullBuffer, OffsetBuffer};
     use arrow::datatypes::{Field, Int32Type};
-    use arrow_array::{GenericListArray, OffsetSizeTrait, StringArray};
-    use arrow_buffer::{NullBuffer, NullBufferBuilder, OffsetBuffer};
     use datafusion_common::assert_batches_eq;
 
     // Create a GenericListArray with the following list values:


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #14115.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
As https://github.com/apache/datafusion/issues/14115#issuecomment-2634836571 says, we should use reexport in arrow as much as possible.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

1. `use arrow_buffer:: xxx` -> `use arrow::buffer::xxx`
2. `use arrow_array:: xxx` -> `use arrow::array::xxx`

I leave some imports as it is when those modules weren't reexported in arrow

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
