### PR TITLE
Fix a clippy warning in `datafusion-sqllogictest`

### DIFF
--- a/datafusion/sqllogictest/src/engines/postgres_engine/mod.rs
+++ b/datafusion/sqllogictest/src/engines/postgres_engine/mod.rs
@@ -17,6 +17,7 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use datafusion_common_runtime::SpawnedTask;
 use futures::{SinkExt, StreamExt};
 use log::{debug, info};
 use sqllogictest::DBOutput;
@@ -24,7 +25,6 @@ use sqllogictest::DBOutput;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
-use tokio::task::JoinHandle;
 
 use super::conversion::*;
 use crate::engines::output::{DFColumnType, DFOutput};
@@ -54,7 +54,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct Postgres {
     client: tokio_postgres::Client,
-    join_handle: JoinHandle<()>,
+    _spawned_task: SpawnedTask<()>,
     /// Relative test file path
     relative_path: PathBuf,
     pb: ProgressBar,
@@ -90,7 +90,7 @@ impl Postgres {
 
         let (client, connection) = res?;
 
-        let join_handle = tokio::spawn(async move {
+        let _spawned_task = SpawnedTask::spawn(async move {
             if let Err(e) = connection.await {
                 log::error!("Postgres connection error: {:?}", e);
             }
@@ -114,7 +114,7 @@ impl Postgres {
 
         Ok(Self {
             client,
-            join_handle,
+            _spawned_task,
             relative_path,
             pb,
         })
@@ -220,12 +220,6 @@ fn schema_name(relative_path: &Path) -> String {
         .collect::<String>()
         .trim_start_matches("pg_")
         .to_string()
-}
-
-impl Drop for Postgres {
-    fn drop(&mut self) {
-        self.join_handle.abort()
-    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Which issue does this PR close?

```
❯ cargo clippy -p datafusion-sqllogictest --all-features -- -Dwarnings
    Checking datafusion-sqllogictest v45.0.0 (/Users/matthijsbrobbel/code/arrow-datafusion/datafusion/sqllogictest)
error: use of a disallowed method `tokio::task::spawn`
  --> datafusion/sqllogictest/src/engines/postgres_engine/mod.rs:93:27
   |
93 |         let join_handle = tokio::spawn(async move {
   |                           ^^^^^^^^^^^^
   |
   = note: To provide cancel-safety, use `SpawnedTask::spawn` instead (https://github.com/apache/datafusion/issues/6513)
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_methods
   = note: `-D clippy::disallowed-methods` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`

error: could not compile `datafusion-sqllogictest` (lib) due to 1 previous error
```

## Rationale for this change

https://github.com/apache/datafusion/pull/14483#discussion_r1942627197

## What changes are included in this PR?

Use `SpawnedTask::spawn` instead of `tokio::task::spawn`.

## Are these changes tested?

CI.

## Are there any user-facing changes?

No.