### PR TITLE
minor: improve PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
 -->
 
-Closes #.
+- Closes #.
 
 ## Rationale for this change
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

When reading a PR it is often helpful to see the title of the related ticket. I would like to be able to do so without having to click a link

However, the default issue template renders as a number
![Screenshot 2025-02-05 at 6 49 23 AM](https://github.com/user-attachments/assets/cdede4e9-8bca-45da-9cbc-66c3f5e1436a)


In github markdown if you put a `-` in front, it renders as a name

![Screenshot 2025-02-05 at 6 49 14 AM](https://github.com/user-attachments/assets/4a5169ec-7e85-47cf-bc35-d87aa076c236)


## What changes are included in this PR?
Add a `- ` to the front of the issue template


## Are these changes tested?
Not really (I don't know how to test them)

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
