### PR TITLE
Improve error messages to include the function name.

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -57,9 +57,9 @@ pub fn data_types_with_scalar_udf(
             return Ok(vec![]);
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
-            return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments", func.name());
+            return plan_err!("'{}' does not support zero arguments. Use TypeSignature::Nullary for zero arguments", func.name());
         } else {
-            return plan_err!("{} does not support zero arguments", func.name());
+            return plan_err!("'{}' does not support zero arguments", func.name());
         }
     }
 
@@ -95,9 +95,9 @@ pub fn data_types_with_aggregate_udf(
             return Ok(vec![]);
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
-            return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments", func.name());
+            return plan_err!("'{}' does not support zero arguments. Use TypeSignature::Nullary for zero arguments", func.name());
         } else {
-            return plan_err!("{} does not support zero arguments", func.name());
+            return plan_err!("'{}' does not support zero arguments", func.name());
         }
     }
 
@@ -132,9 +132,9 @@ pub fn data_types_with_window_udf(
             return Ok(vec![]);
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
-            return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments", func.name());
+            return plan_err!("'{}' does not support zero arguments. Use TypeSignature::Nullary for zero arguments", func.name());
         } else {
-            return plan_err!("{} does not support zero arguments", func.name());
+            return plan_err!("'{}' does not support zero arguments", func.name());
         }
     }
 
@@ -170,12 +170,12 @@ pub fn data_types(
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
             return plan_err!(
-                "function {} has signature {type_signature:?} which does not support zero arguments. Use TypeSignature::Nullary for zero arguments",
+                "function '{}' has signature {type_signature:?} which does not support zero arguments. Use TypeSignature::Nullary for zero arguments",
                 function_name.as_ref()
             );
         } else {
             return plan_err!(
-                "Function {} has signature {type_signature:?} which does not support zero arguments",
+                "Function '{}' has signature {type_signature:?} which does not support zero arguments",
                 function_name.as_ref()
             );
         }
@@ -248,7 +248,7 @@ fn try_coerce_types(
 
     // none possible -> Error
     plan_err!(
-        "Failed to coerce arguments to satisfy a call to {function_name} function: coercion from {current_types:?} to the signature {type_signature:?} failed"
+        "Failed to coerce arguments to satisfy a call to '{function_name}' function: coercion from {current_types:?} to the signature {type_signature:?} failed"
     )
 }
 
@@ -261,7 +261,7 @@ fn get_valid_types_with_scalar_udf(
         TypeSignature::UserDefined => match func.coerce_types(current_types) {
             Ok(coerced_types) => Ok(vec![coerced_types]),
             Err(e) => exec_err!(
-                "Function {} user-defined coercion failed with {e:?}",
+                "Function '{}' user-defined coercion failed with {e:?}",
                 func.name()
             ),
         },
@@ -282,7 +282,7 @@ fn get_valid_types_with_scalar_udf(
             // Every signature failed, return the joined error
             if res.is_empty() {
                 internal_err!(
-                    "Function {} failed to match any signature, errors: {}",
+                    "Function '{}' failed to match any signature, errors: {}",
                     func.name(),
                     errors.join(",")
                 )
@@ -304,7 +304,7 @@ fn get_valid_types_with_aggregate_udf(
             Ok(coerced_types) => vec![coerced_types],
             Err(e) => {
                 return exec_err!(
-                    "Function {} user-defined coercion failed with {e:?}",
+                    "Function '{}' user-defined coercion failed with {e:?}",
                     func.name()
                 )
             }
@@ -332,7 +332,7 @@ fn get_valid_types_with_window_udf(
             Ok(coerced_types) => vec![coerced_types],
             Err(e) => {
                 return exec_err!(
-                    "Function {} user-defined coercion failed with {e:?}",
+                    "Function '{}' user-defined coercion failed with {e:?}",
                     func.name()
                 )
             }
@@ -414,7 +414,7 @@ fn get_valid_types(
 
         let new_base_type = new_base_type.ok_or_else(|| {
             internal_datafusion_err!(
-                "Function {function_name} does not support coercion from {array_base_type:?} to {elem_base_type:?}"
+                "Function '{function_name}' does not support coercion from {array_base_type:?} to {elem_base_type:?}"
             )
         })?;
 
@@ -465,7 +465,7 @@ fn get_valid_types(
     ) -> Result<()> {
         if length != expected_length {
             return plan_err!(
-                "Function {function_name} expects {expected_length} arguments but received {length}"
+                "Function '{function_name}' expects {expected_length} arguments but received {length}"
             );
         }
         Ok(())
@@ -489,7 +489,7 @@ fn get_valid_types(
                     new_types.push(DataType::Utf8);
                 } else {
                     return plan_err!(
-                        "Function {function_name} expects NativeType::String but received {logical_data_type}"
+                        "Function '{function_name}' expects NativeType::String but received {logical_data_type}"
                     );
                 }
             }
@@ -513,7 +513,7 @@ fn get_valid_types(
                             Ok(coerced_type)
                         } else {
                             plan_err!(
-                                "Function {function_name}: could not coerce {lhs_type} and {rhs_type} to a common string type"
+                                "Function '{function_name}' could not coerce {lhs_type} and {rhs_type} to a common string type"
                             )
                         }
                     }
@@ -549,7 +549,7 @@ fn get_valid_types(
 
                 if !logical_data_type.is_numeric() {
                     return plan_err!(
-                        "Function {function_name} expects NativeType::Numeric but received {logical_data_type}"
+                        "Function '{function_name}' expects NativeType::Numeric but received {logical_data_type}"
                     );
                 }
 
@@ -557,7 +557,7 @@ fn get_valid_types(
                     valid_type = coerced_type;
                 } else {
                     return plan_err!(
-                        "For function {function_name} {valid_type} and {t} are not coercible to a common numeric type"
+                        "For function '{function_name}' {valid_type} and {t} are not coercible to a common numeric type"
                     );
                 }
             }
@@ -570,7 +570,7 @@ fn get_valid_types(
                 valid_type = DataType::Float64;
             } else if !logical_data_type.is_numeric() {
                 return plan_err!(
-                    "Function {function_name} expects NativeType::Numeric but received {logical_data_type}"
+                    "Function '{function_name}' expects NativeType::Numeric but received {logical_data_type}"
                 );
             }
 
@@ -583,7 +583,7 @@ fn get_valid_types(
                 if let Some(dt) = comparison_coercion_numeric(&target_type, data_type) {
                     target_type = dt;
                 } else {
-                    return plan_err!("For function {function_name} {target_type} and {data_type} is not comparable");
+                    return plan_err!("For function '{function_name}' {target_type} and {data_type} is not comparable");
                 }
             }
             // Convert null to String type.
@@ -626,7 +626,7 @@ fn get_valid_types(
                         }
 
                         internal_err!(
-                            "Function {function_name} expects {target_type_class} but received {current_type}"
+                            "Function '{function_name}' expects {target_type_class} but received {current_type}"
                         )
                     }
                     // Not consistent with Postgres and DuckDB but to avoid regression we implicit cast string to timestamp
@@ -651,7 +651,7 @@ fn get_valid_types(
                         Ok(current_type.to_owned())
                     }
                     _ => {
-                        not_impl_err!("Function {function_name} got logical_type: {logical_type} with target_type_class: {target_type_class}")
+                        not_impl_err!("Function '{function_name}' got logical_type: {logical_type} with target_type_class: {target_type_class}")
                     }
                 }
             }
@@ -668,7 +668,7 @@ fn get_valid_types(
         }
         TypeSignature::Uniform(number, valid_types) => {
             if *number == 0 {
-                return plan_err!("The function {function_name} expected at least one argument");
+                return plan_err!("The function '{function_name}' expected at least one argument");
             }
 
             valid_types
@@ -678,13 +678,13 @@ fn get_valid_types(
         }
         TypeSignature::UserDefined => {
             return internal_err!(
-                "Function {function_name} user-defined signature should be handled by function-specific coerce_types"
+                "Function '{function_name}' user-defined signature should be handled by function-specific coerce_types"
             )
         }
         TypeSignature::VariadicAny => {
             if current_types.is_empty() {
                 return plan_err!(
-                    "Function {function_name} expected at least one argument but received 0"
+                    "Function '{function_name}' expected at least one argument but received 0"
                 );
             }
             vec![current_types.to_vec()]
@@ -746,7 +746,7 @@ fn get_valid_types(
         TypeSignature::Nullary => {
             if !current_types.is_empty() {
                 return plan_err!(
-                    "The function {function_name} expected zero argument but received {}",
+                    "The function '{function_name}' expected zero argument but received {}",
                     current_types.len()
                 );
             }
@@ -755,13 +755,13 @@ fn get_valid_types(
         TypeSignature::Any(number) => {
             if current_types.is_empty() {
                 return plan_err!(
-                    "The function {function_name} expected at least one argument but received 0"
+                    "The function '{function_name}' expected at least one argument but received 0"
                 );
             }
 
             if current_types.len() != *number {
                 return plan_err!(
-                    "The function {function_name} expected {number} arguments but received {}",
+                    "The function '{function_name}' expected {number} arguments but received {}",
                     current_types.len()
                 );
             }
@@ -1083,7 +1083,7 @@ mod tests {
         .unwrap_err();
         assert_contains!(
             got.to_string(),
-            "Function test expects NativeType::Numeric but received NativeType::String"
+            "Function 'test' expects NativeType::Numeric but received NativeType::String"
         );
 
         // Fallbacks to float64 if the arg is of type null.
@@ -1103,7 +1103,7 @@ mod tests {
         .unwrap_err();
         assert_contains!(
             got.to_string(),
-            "Function test expects NativeType::Numeric but received NativeType::Timestamp(Second, None)"
+            "Function 'test' expects NativeType::Numeric but received NativeType::Timestamp(Second, None)"
         );
 
         Ok(())
@@ -1141,7 +1141,7 @@ mod tests {
         let err = get_valid_types("test", &signature, &[]).unwrap_err();
         assert_contains!(
             err.to_string(),
-            "Function test expects 1 arguments but received 0"
+            "Function 'test' expects 1 arguments but received 0"
         );
 
         let err = get_valid_types(
@@ -1152,7 +1152,7 @@ mod tests {
         .unwrap_err();
         assert_contains!(
             err.to_string(),
-            "Function test expects 1 arguments but received 3"
+            "Function 'test' expects 1 arguments but received 3"
         );
 
         Ok(())

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -170,18 +170,21 @@ pub fn data_types(
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
             return plan_err!(
-                "signature {:?} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.",
+                "For function {} signature {:?} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.",
+                function_name.as_ref(),
                 type_signature
             );
         } else {
             return plan_err!(
-                "signature {:?} does not support zero arguments.",
+                "For function {} signature {:?} does not support zero arguments.",
+                function_name.as_ref(),
                 type_signature
             );
         }
     }
 
-    let valid_types = get_valid_types(type_signature, current_types)?;
+    let valid_types =
+        get_valid_types(function_name.as_ref(), type_signature, current_types)?;
     if valid_types
         .iter()
         .any(|data_type| data_type == current_types)
@@ -189,7 +192,12 @@ pub fn data_types(
         return Ok(current_types.to_vec());
     }
 
-    try_coerce_types(function_name, valid_types, current_types, type_signature)
+    try_coerce_types(
+        function_name.as_ref(),
+        valid_types,
+        current_types,
+        type_signature,
+    )
 }
 
 fn is_well_supported_signature(type_signature: &TypeSignature) -> bool {
@@ -210,7 +218,7 @@ fn is_well_supported_signature(type_signature: &TypeSignature) -> bool {
 }
 
 fn try_coerce_types(
-    function_name: impl AsRef<str>,
+    function_name: &str,
     valid_types: Vec<Vec<DataType>>,
     current_types: &[DataType],
     type_signature: &TypeSignature,
@@ -243,7 +251,7 @@ fn try_coerce_types(
     // none possible -> Error
     plan_err!(
         "Failed to coerce arguments to satisfy a call to {} function: coercion from {:?} to the signature {:?} failed.",
-        function_name.as_ref(),
+        function_name,
         current_types,
         type_signature
     )
@@ -257,7 +265,11 @@ fn get_valid_types_with_scalar_udf(
     match signature {
         TypeSignature::UserDefined => match func.coerce_types(current_types) {
             Ok(coerced_types) => Ok(vec![coerced_types]),
-            Err(e) => exec_err!("User-defined coercion failed with {:?}", e),
+            Err(e) => exec_err!(
+                "For function {} user-defined coercion failed with {:?}",
+                func.name(),
+                e
+            ),
         },
         TypeSignature::OneOf(signatures) => {
             let mut res = vec![];
@@ -276,14 +288,15 @@ fn get_valid_types_with_scalar_udf(
             // Every signature failed, return the joined error
             if res.is_empty() {
                 internal_err!(
-                    "Failed to match any signature, errors: {}",
+                    "For function {} failed to match any signature, errors: {}",
+                    func.name(),
                     errors.join(",")
                 )
             } else {
                 Ok(res)
             }
         }
-        _ => get_valid_types(signature, current_types),
+        _ => get_valid_types(func.name(), signature, current_types),
     }
 }
 
@@ -295,7 +308,13 @@ fn get_valid_types_with_aggregate_udf(
     let valid_types = match signature {
         TypeSignature::UserDefined => match func.coerce_types(current_types) {
             Ok(coerced_types) => vec![coerced_types],
-            Err(e) => return exec_err!("User-defined coercion failed with {:?}", e),
+            Err(e) => {
+                return exec_err!(
+                    "For function {} user-defined coercion failed with {:?}",
+                    func.name(),
+                    e
+                )
+            }
         },
         TypeSignature::OneOf(signatures) => signatures
             .iter()
@@ -304,7 +323,7 @@ fn get_valid_types_with_aggregate_udf(
             })
             .flatten()
             .collect::<Vec<_>>(),
-        _ => get_valid_types(signature, current_types)?,
+        _ => get_valid_types(func.name(), signature, current_types)?,
     };
 
     Ok(valid_types)
@@ -318,14 +337,20 @@ fn get_valid_types_with_window_udf(
     let valid_types = match signature {
         TypeSignature::UserDefined => match func.coerce_types(current_types) {
             Ok(coerced_types) => vec![coerced_types],
-            Err(e) => return exec_err!("User-defined coercion failed with {:?}", e),
+            Err(e) => {
+                return exec_err!(
+                    "For function {} user-defined coercion failed with {:?}",
+                    func.name(),
+                    e
+                )
+            }
         },
         TypeSignature::OneOf(signatures) => signatures
             .iter()
             .filter_map(|t| get_valid_types_with_window_udf(t, current_types, func).ok())
             .flatten()
             .collect::<Vec<_>>(),
-        _ => get_valid_types(signature, current_types)?,
+        _ => get_valid_types(func.name(), signature, current_types)?,
     };
 
     Ok(valid_types)
@@ -333,10 +358,12 @@ fn get_valid_types_with_window_udf(
 
 /// Returns a Vec of all possible valid argument types for the given signature.
 fn get_valid_types(
+    function_name: &str,
     signature: &TypeSignature,
     current_types: &[DataType],
 ) -> Result<Vec<Vec<DataType>>> {
     fn array_element_and_optional_index(
+        function_name: &str,
         current_types: &[DataType],
     ) -> Result<Vec<Vec<DataType>>> {
         // make sure there's 2 or 3 arguments
@@ -345,7 +372,8 @@ fn get_valid_types(
         }
 
         let first_two_types = &current_types[0..2];
-        let mut valid_types = array_append_or_prepend_valid_types(first_two_types, true)?;
+        let mut valid_types =
+            array_append_or_prepend_valid_types(function_name, first_two_types, true)?;
 
         // Early return if there are only 2 arguments
         if current_types.len() == 2 {
@@ -367,6 +395,7 @@ fn get_valid_types(
     }
 
     fn array_append_or_prepend_valid_types(
+        function_name: &str,
         current_types: &[DataType],
         is_append: bool,
     ) -> Result<Vec<Vec<DataType>>> {
@@ -393,7 +422,7 @@ fn get_valid_types(
 
         let new_base_type = new_base_type.ok_or_else(|| {
             internal_datafusion_err!(
-                "Coercion from {array_base_type:?} to {elem_base_type:?} not supported."
+                "For function {function_name} coercion from {array_base_type:?} to {elem_base_type:?} not supported."
             )
         })?;
 
@@ -437,10 +466,14 @@ fn get_valid_types(
         }
     }
 
-    fn function_length_check(length: usize, expected_length: usize) -> Result<()> {
+    fn function_length_check(
+        function_name: &str,
+        length: usize,
+        expected_length: usize,
+    ) -> Result<()> {
         if length != expected_length {
             return plan_err!(
-                "The signature expected {expected_length} arguments but received {length}"
+                "For function {function_name} the signature expected {expected_length} arguments but received {length}"
             );
         }
         Ok(())
@@ -452,7 +485,7 @@ fn get_valid_types(
             .map(|valid_type| current_types.iter().map(|_| valid_type.clone()).collect())
             .collect(),
         TypeSignature::String(number) => {
-            function_length_check(current_types.len(), *number)?;
+            function_length_check(function_name, current_types.len(), *number)?;
 
             let mut new_types = Vec::with_capacity(current_types.len());
             for data_type in current_types.iter() {
@@ -464,30 +497,31 @@ fn get_valid_types(
                     new_types.push(DataType::Utf8);
                 } else {
                     return plan_err!(
-                        "The signature expected NativeType::String but received {logical_data_type}"
+                        "For function {function_name} the signature expected NativeType::String but received {logical_data_type}"
                     );
                 }
             }
 
             // Find the common string type for the given types
             fn find_common_type(
+                function_name: &str,
                 lhs_type: &DataType,
                 rhs_type: &DataType,
             ) -> Result<DataType> {
                 match (lhs_type, rhs_type) {
                     (DataType::Dictionary(_, lhs), DataType::Dictionary(_, rhs)) => {
-                        find_common_type(lhs, rhs)
+                        find_common_type(function_name, lhs, rhs)
                     }
                     (DataType::Dictionary(_, v), other)
-                    | (other, DataType::Dictionary(_, v)) => find_common_type(v, other),
+                    | (other, DataType::Dictionary(_, v)) => {
+                        find_common_type(function_name, v, other)
+                    }
                     _ => {
                         if let Some(coerced_type) = string_coercion(lhs_type, rhs_type) {
                             Ok(coerced_type)
                         } else {
                             plan_err!(
-                                "{} and {} are not coercible to a common string type",
-                                lhs_type,
-                                rhs_type
+                                "For function {function_name}: {lhs_type} and {rhs_type} are not coercible to a common string type"
                             )
                         }
                     }
@@ -497,7 +531,7 @@ fn get_valid_types(
             // Length checked above, safe to unwrap
             let mut coerced_type = new_types.first().unwrap().to_owned();
             for t in new_types.iter().skip(1) {
-                coerced_type = find_common_type(&coerced_type, t)?;
+                coerced_type = find_common_type(function_name, &coerced_type, t)?;
             }
 
             fn base_type_or_default_type(data_type: &DataType) -> DataType {
@@ -511,7 +545,7 @@ fn get_valid_types(
             vec![vec![base_type_or_default_type(&coerced_type); *number]]
         }
         TypeSignature::Numeric(number) => {
-            function_length_check(current_types.len(), *number)?;
+            function_length_check(function_name, current_types.len(), *number)?;
 
             // Find common numeric type among given types except string
             let mut valid_type = current_types.first().unwrap().to_owned();
@@ -523,7 +557,7 @@ fn get_valid_types(
 
                 if !logical_data_type.is_numeric() {
                     return plan_err!(
-                        "The signature expected NativeType::Numeric but received {logical_data_type}"
+                        "For function {function_name} the signature expected NativeType::Numeric but received {logical_data_type}"
                     );
                 }
 
@@ -531,9 +565,7 @@ fn get_valid_types(
                     valid_type = coerced_type;
                 } else {
                     return plan_err!(
-                        "{} and {} are not coercible to a common numeric type",
-                        valid_type,
-                        t
+                        "For function {function_name} {valid_type} and {t} are not coercible to a common numeric type"
                     );
                 }
             }
@@ -546,20 +578,20 @@ fn get_valid_types(
                 valid_type = DataType::Float64;
             } else if !logical_data_type.is_numeric() {
                 return plan_err!(
-                    "The signature expected NativeType::Numeric but received {logical_data_type}"
+                    "For function {function_name} the signature expected NativeType::Numeric but received {logical_data_type}"
                 );
             }
 
             vec![vec![valid_type; *number]]
         }
         TypeSignature::Comparable(num) => {
-            function_length_check(current_types.len(), *num)?;
+            function_length_check(function_name, current_types.len(), *num)?;
             let mut target_type = current_types[0].to_owned();
             for data_type in current_types.iter().skip(1) {
                 if let Some(dt) = comparison_coercion_numeric(&target_type, data_type) {
                     target_type = dt;
                 } else {
-                    return plan_err!("{target_type} and {data_type} is not comparable");
+                    return plan_err!("For function {function_name} {target_type} and {data_type} is not comparable");
                 }
             }
             // Convert null to String type.
@@ -570,12 +602,17 @@ fn get_valid_types(
             }
         }
         TypeSignature::Coercible(target_types) => {
-            function_length_check(current_types.len(), target_types.len())?;
+            function_length_check(
+                function_name,
+                current_types.len(),
+                target_types.len(),
+            )?;
 
             // Aim to keep this logic as SIMPLE as possible!
             // Make sure the corresponding test is covered
             // If this function becomes COMPLEX, create another new signature!
             fn can_coerce_to(
+                function_name: &str,
                 current_type: &DataType,
                 target_type_class: &TypeSignatureClass,
             ) -> Result<DataType> {
@@ -597,9 +634,7 @@ fn get_valid_types(
                         }
 
                         internal_err!(
-                            "Expect {} but received {}",
-                            target_type_class,
-                            current_type
+                            "For function {function_name} expect {target_type_class} but received {current_type}"
                         )
                     }
                     // Not consistent with Postgres and DuckDB but to avoid regression we implicit cast string to timestamp
@@ -624,7 +659,7 @@ fn get_valid_types(
                         Ok(current_type.to_owned())
                     }
                     _ => {
-                        not_impl_err!("Got logical_type: {logical_type} with target_type_class: {target_type_class}")
+                        not_impl_err!("For function {function_name} got logical_type: {logical_type} with target_type_class: {target_type_class}")
                     }
                 }
             }
@@ -633,7 +668,7 @@ fn get_valid_types(
             for (current_type, target_type_class) in
                 current_types.iter().zip(target_types.iter())
             {
-                let target_type = can_coerce_to(current_type, target_type_class)?;
+                let target_type = can_coerce_to(function_name, current_type, target_type_class)?;
                 new_types.push(target_type);
             }
 
@@ -641,7 +676,7 @@ fn get_valid_types(
         }
         TypeSignature::Uniform(number, valid_types) => {
             if *number == 0 {
-                return plan_err!("The function expected at least one argument");
+                return plan_err!("The function {function_name} expected at least one argument");
             }
 
             valid_types
@@ -651,13 +686,13 @@ fn get_valid_types(
         }
         TypeSignature::UserDefined => {
             return internal_err!(
-            "User-defined signature should be handled by function-specific coerce_types."
+            "For function {function_name} user-defined signature should be handled by function-specific coerce_types."
         )
         }
         TypeSignature::VariadicAny => {
             if current_types.is_empty() {
                 return plan_err!(
-                    "The function expected at least one argument but received 0"
+                    "The function {function_name} expected at least one argument but received 0"
                 );
             }
             vec![current_types.to_vec()]
@@ -666,10 +701,10 @@ fn get_valid_types(
         TypeSignature::ArraySignature(ref function_signature) => match function_signature
         {
             ArrayFunctionSignature::ArrayAndElement => {
-                array_append_or_prepend_valid_types(current_types, true)?
+                array_append_or_prepend_valid_types(function_name, current_types, true)?
             }
             ArrayFunctionSignature::ElementAndArray => {
-                array_append_or_prepend_valid_types(current_types, false)?
+                array_append_or_prepend_valid_types(function_name, current_types, false)?
             }
             ArrayFunctionSignature::ArrayAndIndexes(count) => {
                 if current_types.len() != count.get() + 1 {
@@ -688,7 +723,7 @@ fn get_valid_types(
                 )
             }
             ArrayFunctionSignature::ArrayAndElementAndOptionalIndex => {
-                array_element_and_optional_index(current_types)?
+                array_element_and_optional_index(function_name, current_types)?
             }
             ArrayFunctionSignature::Array => {
                 if current_types.len() != 1 {
@@ -719,7 +754,7 @@ fn get_valid_types(
         TypeSignature::Nullary => {
             if !current_types.is_empty() {
                 return plan_err!(
-                    "The function expected zero argument but received {}",
+                    "The function {function_name} expected zero argument but received {}",
                     current_types.len()
                 );
             }
@@ -728,13 +763,13 @@ fn get_valid_types(
         TypeSignature::Any(number) => {
             if current_types.is_empty() {
                 return plan_err!(
-                    "The function expected at least one argument but received 0"
+                    "The function {function_name} expected at least one argument but received 0"
                 );
             }
 
             if current_types.len() != *number {
                 return plan_err!(
-                    "The function expected {} arguments but received {}",
+                    "The function {function_name} expected {} arguments but received {}",
                     number,
                     current_types.len()
                 );
@@ -743,7 +778,7 @@ fn get_valid_types(
         }
         TypeSignature::OneOf(types) => types
             .iter()
-            .filter_map(|t| get_valid_types(t, current_types).ok())
+            .filter_map(|t| get_valid_types(function_name, t, current_types).ok())
             .flatten()
             .collect::<Vec<_>>(),
     };
@@ -1011,8 +1046,10 @@ mod tests {
     #[test]
     fn test_get_valid_types_numeric() -> Result<()> {
         let get_valid_types_flatten =
-            |signature: &TypeSignature, current_types: &[DataType]| {
-                get_valid_types(signature, current_types)
+            |function_name: &str,
+             signature: &TypeSignature,
+             current_types: &[DataType]| {
+                get_valid_types(function_name, signature, current_types)
                     .unwrap()
                     .into_iter()
                     .flatten()
@@ -1020,11 +1057,16 @@ mod tests {
             };
 
         // Trivial case.
-        let got = get_valid_types_flatten(&TypeSignature::Numeric(1), &[DataType::Int32]);
+        let got = get_valid_types_flatten(
+            "test",
+            &TypeSignature::Numeric(1),
+            &[DataType::Int32],
+        );
         assert_eq!(got, [DataType::Int32]);
 
         // Args are coerced into a common numeric type.
         let got = get_valid_types_flatten(
+            "test",
             &TypeSignature::Numeric(2),
             &[DataType::Int32, DataType::Int64],
         );
@@ -1032,6 +1074,7 @@ mod tests {
 
         // Args are coerced into a common numeric type, specifically, int would be coerced to float.
         let got = get_valid_types_flatten(
+            "test",
             &TypeSignature::Numeric(3),
             &[DataType::Int32, DataType::Int64, DataType::Float64],
         );
@@ -1042,28 +1085,34 @@ mod tests {
 
         // Cannot coerce args to a common numeric type.
         let got = get_valid_types(
+            "test",
             &TypeSignature::Numeric(2),
             &[DataType::Int32, DataType::Utf8],
         )
         .unwrap_err();
         assert_contains!(
             got.to_string(),
-            "The signature expected NativeType::Numeric but received NativeType::String"
+            "For function test the signature expected NativeType::Numeric but received NativeType::String"
         );
 
         // Fallbacks to float64 if the arg is of type null.
-        let got = get_valid_types_flatten(&TypeSignature::Numeric(1), &[DataType::Null]);
+        let got = get_valid_types_flatten(
+            "test",
+            &TypeSignature::Numeric(1),
+            &[DataType::Null],
+        );
         assert_eq!(got, [DataType::Float64]);
 
         // Rejects non-numeric arg.
         let got = get_valid_types(
+            "test",
             &TypeSignature::Numeric(1),
             &[DataType::Timestamp(TimeUnit::Second, None)],
         )
         .unwrap_err();
         assert_contains!(
             got.to_string(),
-            "The signature expected NativeType::Numeric but received NativeType::Timestamp(Second, None)"
+            "For function test the signature expected NativeType::Numeric but received NativeType::Timestamp(Second, None)"
         );
 
         Ok(())
@@ -1075,18 +1124,19 @@ mod tests {
             TypeSignature::OneOf(vec![TypeSignature::Any(1), TypeSignature::Any(2)]);
 
         let invalid_types = get_valid_types(
+            "test",
             &signature,
             &[DataType::Int32, DataType::Int32, DataType::Int32],
         )?;
         assert_eq!(invalid_types.len(), 0);
 
         let args = vec![DataType::Int32, DataType::Int32];
-        let valid_types = get_valid_types(&signature, &args)?;
+        let valid_types = get_valid_types("test", &signature, &args)?;
         assert_eq!(valid_types.len(), 1);
         assert_eq!(valid_types[0], args);
 
         let args = vec![DataType::Int32];
-        let valid_types = get_valid_types(&signature, &args)?;
+        let valid_types = get_valid_types("test", &signature, &args)?;
         assert_eq!(valid_types.len(), 1);
         assert_eq!(valid_types[0], args);
 
@@ -1097,20 +1147,21 @@ mod tests {
     fn test_get_valid_types_length_check() -> Result<()> {
         let signature = TypeSignature::Numeric(1);
 
-        let err = get_valid_types(&signature, &[]).unwrap_err();
+        let err = get_valid_types("test", &signature, &[]).unwrap_err();
         assert_contains!(
             err.to_string(),
-            "The signature expected 1 arguments but received 0"
+            "For function test the signature expected 1 arguments but received 0"
         );
 
         let err = get_valid_types(
+            "test",
             &signature,
             &[DataType::Int32, DataType::Int32, DataType::Int32],
         )
         .unwrap_err();
         assert_contains!(
             err.to_string(),
-            "The signature expected 1 arguments but received 3"
+            "For function test the signature expected 1 arguments but received 3"
         );
 
         Ok(())
@@ -1131,7 +1182,7 @@ mod tests {
             Volatility::Stable,
         );
 
-        let coerced_data_types = data_types("test", &current_types, &signature).unwrap();
+        let coerced_data_types = data_types("test", &current_types, &signature)?;
         assert_eq!(coerced_data_types, current_types);
 
         // make sure it can't coerce to a different size

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -57,9 +57,9 @@ pub fn data_types_with_scalar_udf(
             return Ok(vec![]);
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
-            return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.", func.name());
+            return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments", func.name());
         } else {
-            return plan_err!("{} does not support zero arguments.", func.name());
+            return plan_err!("{} does not support zero arguments", func.name());
         }
     }
 
@@ -95,9 +95,9 @@ pub fn data_types_with_aggregate_udf(
             return Ok(vec![]);
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
-            return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.", func.name());
+            return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments", func.name());
         } else {
-            return plan_err!("{} does not support zero arguments.", func.name());
+            return plan_err!("{} does not support zero arguments", func.name());
         }
     }
 
@@ -132,9 +132,9 @@ pub fn data_types_with_window_udf(
             return Ok(vec![]);
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
-            return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.", func.name());
+            return plan_err!("{} does not support zero arguments. Use TypeSignature::Nullary for zero arguments", func.name());
         } else {
-            return plan_err!("{} does not support zero arguments.", func.name());
+            return plan_err!("{} does not support zero arguments", func.name());
         }
     }
 
@@ -170,15 +170,13 @@ pub fn data_types(
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
             return plan_err!(
-                "function {} has signature {:?} which does not support zero arguments. Use TypeSignature::Nullary for zero arguments.",
-                function_name.as_ref(),
-                type_signature
+                "function {} has signature {type_signature:?} which does not support zero arguments. Use TypeSignature::Nullary for zero arguments",
+                function_name.as_ref()
             );
         } else {
             return plan_err!(
-                "Function {} has signature {:?} which does not support zero arguments.",
-                function_name.as_ref(),
-                type_signature
+                "Function {} has signature {type_signature:?} which does not support zero arguments",
+                function_name.as_ref()
             );
         }
     }
@@ -250,10 +248,7 @@ fn try_coerce_types(
 
     // none possible -> Error
     plan_err!(
-        "Failed to coerce arguments to satisfy a call to {} function: coercion from {:?} to the signature {:?} failed.",
-        function_name,
-        current_types,
-        type_signature
+        "Failed to coerce arguments to satisfy a call to {function_name} function: coercion from {current_types:?} to the signature {type_signature:?} failed"
     )
 }
 
@@ -266,9 +261,8 @@ fn get_valid_types_with_scalar_udf(
         TypeSignature::UserDefined => match func.coerce_types(current_types) {
             Ok(coerced_types) => Ok(vec![coerced_types]),
             Err(e) => exec_err!(
-                "Function {} user-defined coercion failed with {:?}",
-                func.name(),
-                e
+                "Function {} user-defined coercion failed with {e:?}",
+                func.name()
             ),
         },
         TypeSignature::OneOf(signatures) => {
@@ -310,9 +304,8 @@ fn get_valid_types_with_aggregate_udf(
             Ok(coerced_types) => vec![coerced_types],
             Err(e) => {
                 return exec_err!(
-                    "Function {} user-defined coercion failed with {:?}",
-                    func.name(),
-                    e
+                    "Function {} user-defined coercion failed with {e:?}",
+                    func.name()
                 )
             }
         },
@@ -339,9 +332,8 @@ fn get_valid_types_with_window_udf(
             Ok(coerced_types) => vec![coerced_types],
             Err(e) => {
                 return exec_err!(
-                    "Function {} user-defined coercion failed with {:?}",
-                    func.name(),
-                    e
+                    "Function {} user-defined coercion failed with {e:?}",
+                    func.name()
                 )
             }
         },
@@ -422,7 +414,7 @@ fn get_valid_types(
 
         let new_base_type = new_base_type.ok_or_else(|| {
             internal_datafusion_err!(
-                "Function {function_name} does not support coercion from {array_base_type:?} to {elem_base_type:?} ."
+                "Function {function_name} does not support coercion from {array_base_type:?} to {elem_base_type:?}"
             )
         })?;
 
@@ -634,7 +626,7 @@ fn get_valid_types(
                         }
 
                         internal_err!(
-                            "For function {function_name} expect {target_type_class} but received {current_type}"
+                            "Function {function_name} expects {target_type_class} but received {current_type}"
                         )
                     }
                     // Not consistent with Postgres and DuckDB but to avoid regression we implicit cast string to timestamp
@@ -686,8 +678,8 @@ fn get_valid_types(
         }
         TypeSignature::UserDefined => {
             return internal_err!(
-            "Function {function_name} user-defined signature should be handled by function-specific coerce_types."
-        )
+                "Function {function_name} user-defined signature should be handled by function-specific coerce_types"
+            )
         }
         TypeSignature::VariadicAny => {
             if current_types.is_empty() {
@@ -769,8 +761,7 @@ fn get_valid_types(
 
             if current_types.len() != *number {
                 return plan_err!(
-                    "The function {function_name} expected {} arguments but received {}",
-                    number,
+                    "The function {function_name} expected {number} arguments but received {}",
                     current_types.len()
                 );
             }
@@ -1092,7 +1083,7 @@ mod tests {
         .unwrap_err();
         assert_contains!(
             got.to_string(),
-            "Function test expected NativeType::Numeric but received NativeType::String"
+            "Function test expects NativeType::Numeric but received NativeType::String"
         );
 
         // Fallbacks to float64 if the arg is of type null.
@@ -1112,7 +1103,7 @@ mod tests {
         .unwrap_err();
         assert_contains!(
             got.to_string(),
-            "Function test expected NativeType::Numeric but received NativeType::Timestamp(Second, None)"
+            "Function test expects NativeType::Numeric but received NativeType::Timestamp(Second, None)"
         );
 
         Ok(())
@@ -1150,7 +1141,7 @@ mod tests {
         let err = get_valid_types("test", &signature, &[]).unwrap_err();
         assert_contains!(
             err.to_string(),
-            "For function test the signature expected 1 arguments but received 0"
+            "Function test expects 1 arguments but received 0"
         );
 
         let err = get_valid_types(
@@ -1161,7 +1152,7 @@ mod tests {
         .unwrap_err();
         assert_contains!(
             err.to_string(),
-            "For function test the signature expected 1 arguments but received 3"
+            "Function test expects 1 arguments but received 3"
         );
 
         Ok(())

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -170,13 +170,13 @@ pub fn data_types(
         } else if type_signature.used_to_support_zero_arguments() {
             // Special error to help during upgrade: https://github.com/apache/datafusion/issues/13763
             return plan_err!(
-                "For function {} signature {:?} does not support zero arguments. Use TypeSignature::Nullary for zero arguments.",
+                "function {} has signature {:?} which does not support zero arguments. Use TypeSignature::Nullary for zero arguments.",
                 function_name.as_ref(),
                 type_signature
             );
         } else {
             return plan_err!(
-                "For function {} signature {:?} does not support zero arguments.",
+                "Function {} has signature {:?} which does not support zero arguments.",
                 function_name.as_ref(),
                 type_signature
             );
@@ -266,7 +266,7 @@ fn get_valid_types_with_scalar_udf(
         TypeSignature::UserDefined => match func.coerce_types(current_types) {
             Ok(coerced_types) => Ok(vec![coerced_types]),
             Err(e) => exec_err!(
-                "For function {} user-defined coercion failed with {:?}",
+                "Function {} user-defined coercion failed with {:?}",
                 func.name(),
                 e
             ),
@@ -288,7 +288,7 @@ fn get_valid_types_with_scalar_udf(
             // Every signature failed, return the joined error
             if res.is_empty() {
                 internal_err!(
-                    "For function {} failed to match any signature, errors: {}",
+                    "Function {} failed to match any signature, errors: {}",
                     func.name(),
                     errors.join(",")
                 )
@@ -310,7 +310,7 @@ fn get_valid_types_with_aggregate_udf(
             Ok(coerced_types) => vec![coerced_types],
             Err(e) => {
                 return exec_err!(
-                    "For function {} user-defined coercion failed with {:?}",
+                    "Function {} user-defined coercion failed with {:?}",
                     func.name(),
                     e
                 )
@@ -339,7 +339,7 @@ fn get_valid_types_with_window_udf(
             Ok(coerced_types) => vec![coerced_types],
             Err(e) => {
                 return exec_err!(
-                    "For function {} user-defined coercion failed with {:?}",
+                    "Function {} user-defined coercion failed with {:?}",
                     func.name(),
                     e
                 )
@@ -422,7 +422,7 @@ fn get_valid_types(
 
         let new_base_type = new_base_type.ok_or_else(|| {
             internal_datafusion_err!(
-                "For function {function_name} coercion from {array_base_type:?} to {elem_base_type:?} not supported."
+                "Function {function_name} does not support coercion from {array_base_type:?} to {elem_base_type:?} ."
             )
         })?;
 
@@ -473,7 +473,7 @@ fn get_valid_types(
     ) -> Result<()> {
         if length != expected_length {
             return plan_err!(
-                "For function {function_name} the signature expected {expected_length} arguments but received {length}"
+                "Function {function_name} expects {expected_length} arguments but received {length}"
             );
         }
         Ok(())
@@ -497,7 +497,7 @@ fn get_valid_types(
                     new_types.push(DataType::Utf8);
                 } else {
                     return plan_err!(
-                        "For function {function_name} the signature expected NativeType::String but received {logical_data_type}"
+                        "Function {function_name} expects NativeType::String but received {logical_data_type}"
                     );
                 }
             }
@@ -521,7 +521,7 @@ fn get_valid_types(
                             Ok(coerced_type)
                         } else {
                             plan_err!(
-                                "For function {function_name}: {lhs_type} and {rhs_type} are not coercible to a common string type"
+                                "Function {function_name}: could not coerce {lhs_type} and {rhs_type} to a common string type"
                             )
                         }
                     }
@@ -557,7 +557,7 @@ fn get_valid_types(
 
                 if !logical_data_type.is_numeric() {
                     return plan_err!(
-                        "For function {function_name} the signature expected NativeType::Numeric but received {logical_data_type}"
+                        "Function {function_name} expects NativeType::Numeric but received {logical_data_type}"
                     );
                 }
 
@@ -578,7 +578,7 @@ fn get_valid_types(
                 valid_type = DataType::Float64;
             } else if !logical_data_type.is_numeric() {
                 return plan_err!(
-                    "For function {function_name} the signature expected NativeType::Numeric but received {logical_data_type}"
+                    "Function {function_name} expects NativeType::Numeric but received {logical_data_type}"
                 );
             }
 
@@ -659,7 +659,7 @@ fn get_valid_types(
                         Ok(current_type.to_owned())
                     }
                     _ => {
-                        not_impl_err!("For function {function_name} got logical_type: {logical_type} with target_type_class: {target_type_class}")
+                        not_impl_err!("Function {function_name} got logical_type: {logical_type} with target_type_class: {target_type_class}")
                     }
                 }
             }
@@ -686,13 +686,13 @@ fn get_valid_types(
         }
         TypeSignature::UserDefined => {
             return internal_err!(
-            "For function {function_name} user-defined signature should be handled by function-specific coerce_types."
+            "Function {function_name} user-defined signature should be handled by function-specific coerce_types."
         )
         }
         TypeSignature::VariadicAny => {
             if current_types.is_empty() {
                 return plan_err!(
-                    "The function {function_name} expected at least one argument but received 0"
+                    "Function {function_name} expected at least one argument but received 0"
                 );
             }
             vec![current_types.to_vec()]
@@ -1092,7 +1092,7 @@ mod tests {
         .unwrap_err();
         assert_contains!(
             got.to_string(),
-            "For function test the signature expected NativeType::Numeric but received NativeType::String"
+            "Function test expected NativeType::Numeric but received NativeType::String"
         );
 
         // Fallbacks to float64 if the arg is of type null.
@@ -1112,7 +1112,7 @@ mod tests {
         .unwrap_err();
         assert_contains!(
             got.to_string(),
-            "For function test the signature expected NativeType::Numeric but received NativeType::Timestamp(Second, None)"
+            "Function test expected NativeType::Numeric but received NativeType::Timestamp(Second, None)"
         );
 
         Ok(())

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1422,7 +1422,7 @@ mod test {
             .err()
             .unwrap()
             .strip_backtrace();
-        assert!(err.starts_with("Error during planning: Failed to coerce arguments to satisfy a call to avg function: coercion from [Utf8] to the signature Uniform(1, [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64]) failed."));
+        assert!(err.starts_with("Error during planning: Failed to coerce arguments to satisfy a call to avg function: coercion from [Utf8] to the signature Uniform(1, [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64]) failed"));
         Ok(())
     }
 

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1372,7 +1372,7 @@ mod test {
 
         let err = Projection::try_new(vec![udaf], empty).err().unwrap();
         assert!(
-            err.strip_backtrace().starts_with("Error during planning: Failed to coerce arguments to satisfy a call to MY_AVG function: coercion from [Utf8] to the signature Uniform(1, [Float64]) failed")
+            err.strip_backtrace().starts_with("Error during planning: Failed to coerce arguments to satisfy a call to 'MY_AVG' function: coercion from [Utf8] to the signature Uniform(1, [Float64]) failed")
         );
         Ok(())
     }
@@ -1422,7 +1422,7 @@ mod test {
             .err()
             .unwrap()
             .strip_backtrace();
-        assert!(err.starts_with("Error during planning: Failed to coerce arguments to satisfy a call to avg function: coercion from [Utf8] to the signature Uniform(1, [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64]) failed"));
+        assert!(err.starts_with("Error during planning: Failed to coerce arguments to satisfy a call to 'avg' function: coercion from [Utf8] to the signature Uniform(1, [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64]) failed"));
         Ok(())
     }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4536,7 +4536,7 @@ fn test_error_message_invalid_aggregate_function_signature() {
     // It might be incorrect, and we should consider keeping only one.
     error_message_test(
         "select max(9, 3)",
-        "Error during planning: Execution error: For function max user-defined coercion failed",
+        "Error during planning: Execution error: Function max user-defined coercion failed",
     );
 }
 
@@ -4544,7 +4544,7 @@ fn test_error_message_invalid_aggregate_function_signature() {
 fn test_error_message_invalid_window_function_signature() {
     error_message_test(
         "select rank(1) over()",
-        "Error during planning: The function rank expected zero argument but received 1",
+        "Error during planning: Function rank expected zero argument but received 1",
     );
 }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4544,7 +4544,7 @@ fn test_error_message_invalid_aggregate_function_signature() {
 fn test_error_message_invalid_window_function_signature() {
     error_message_test(
         "select rank(1) over()",
-        "Error during planning: Function rank expected zero argument but received 1",
+        "Error during planning: The function rank expected zero argument but received 1",
     );
 }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4536,7 +4536,7 @@ fn test_error_message_invalid_aggregate_function_signature() {
     // It might be incorrect, and we should consider keeping only one.
     error_message_test(
         "select max(9, 3)",
-        "Error during planning: Execution error: User-defined coercion failed",
+        "Error during planning: Execution error: For function max user-defined coercion failed",
     );
 }
 
@@ -4544,7 +4544,7 @@ fn test_error_message_invalid_aggregate_function_signature() {
 fn test_error_message_invalid_window_function_signature() {
     error_message_test(
         "select rank(1) over()",
-        "Error during planning: The function expected zero argument but received 1",
+        "Error during planning: The function rank expected zero argument but received 1",
     );
 }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4518,7 +4518,7 @@ fn error_message_test(sql: &str, err_msg_starts_with: &str) {
 fn test_error_message_invalid_scalar_function_signature() {
     error_message_test(
         "select sqrt()",
-        "Error during planning: sqrt does not support zero arguments",
+        "Error during planning: 'sqrt' does not support zero arguments",
     );
     error_message_test(
         "select sqrt(1, 2)",
@@ -4530,13 +4530,13 @@ fn test_error_message_invalid_scalar_function_signature() {
 fn test_error_message_invalid_aggregate_function_signature() {
     error_message_test(
         "select sum()",
-        "Error during planning: sum does not support zero arguments",
+        "Error during planning: 'sum' does not support zero arguments",
     );
     // We keep two different prefixes because they clarify each other.
     // It might be incorrect, and we should consider keeping only one.
     error_message_test(
         "select max(9, 3)",
-        "Error during planning: Execution error: Function max user-defined coercion failed",
+        "Error during planning: Execution error: Function 'max' user-defined coercion failed",
     );
 }
 
@@ -4544,7 +4544,7 @@ fn test_error_message_invalid_aggregate_function_signature() {
 fn test_error_message_invalid_window_function_signature() {
     error_message_test(
         "select rank(1) over()",
-        "Error during planning: The function rank expected zero argument but received 1",
+        "Error during planning: The function 'rank' expected zero argument but received 1",
     );
 }
 
@@ -4552,7 +4552,7 @@ fn test_error_message_invalid_window_function_signature() {
 fn test_error_message_invalid_window_aggregate_function_signature() {
     error_message_test(
         "select sum() over()",
-        "Error during planning: sum does not support zero arguments",
+        "Error during planning: 'sum' does not support zero arguments",
     );
 }
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -132,26 +132,26 @@ statement error DataFusion error: Schema error: Schema contains duplicate unqual
 SELECT approx_distinct(c9) count_c9, approx_distinct(cast(c9 as varchar)) count_c9_str FROM aggregate_test_100
 
 # csv_query_approx_percentile_cont_with_weight
-statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont_with_weight function: coercion from \[Utf8, Int8, Float64\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'approx_percentile_cont_with_weight' function: coercion from \[Utf8, Int8, Float64\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont_with_weight(c1, c2, 0.95) FROM aggregate_test_100
 
-statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont_with_weight function: coercion from \[Int16, Utf8, Float64\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'approx_percentile_cont_with_weight' function: coercion from \[Int16, Utf8, Float64\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont_with_weight(c3, c1, 0.95) FROM aggregate_test_100
 
-statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont_with_weight function: coercion from \[Int16, Int8, Utf8\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'approx_percentile_cont_with_weight' function: coercion from \[Int16, Int8, Utf8\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont_with_weight(c3, c2, c1) FROM aggregate_test_100
 
 # csv_query_approx_percentile_cont_with_histogram_bins
 statement error DataFusion error: External error: This feature is not implemented: Tdigest max_size value for 'APPROX_PERCENTILE_CONT' must be UInt > 0 literal \(got data type Int64\)\.
 SELECT c1, approx_percentile_cont(c3, 0.95, -1000) AS c3_p95 FROM aggregate_test_100 GROUP BY 1 ORDER BY 1
 
-statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont function: coercion from \[Int16, Float64, Utf8\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'approx_percentile_cont' function: coercion from \[Int16, Float64, Utf8\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont(c3, 0.95, c1) FROM aggregate_test_100
 
-statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont function: coercion from \[Int16, Float64, Float64\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'approx_percentile_cont' function: coercion from \[Int16, Float64, Float64\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont(c3, 0.95, 111.1) FROM aggregate_test_100
 
-statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to approx_percentile_cont function: coercion from \[Float64, Float64, Float64\] to the signature OneOf(.*) failed(.|\n)*
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'approx_percentile_cont' function: coercion from \[Float64, Float64, Float64\] to the signature OneOf(.*) failed(.|\n)*
 SELECT approx_percentile_cont(c12, 0.95, 111.1) FROM aggregate_test_100
 
 statement error DataFusion error: This feature is not implemented: Percentile value for 'APPROX_PERCENTILE_CONT' must be a literal

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1191,7 +1191,7 @@ from arrays_values_without_nulls;
 ## array_element (aliases: array_extract, list_extract, list_element)
 
 # Testing with empty arguments should result in an error
-query error DataFusion error: Error during planning: array_element does not support zero arguments
+query error DataFusion error: Error during planning: 'array_element' does not support zero arguments
 select array_element();
 
 # array_element error
@@ -2052,7 +2052,7 @@ select array_slice(a, -1, 2, 1), array_slice(a, -1, 2),
 [6.0] [6.0] [] []
 
 # Testing with empty arguments should result in an error
-query error DataFusion error: Error during planning: array_slice does not support zero arguments
+query error DataFusion error: Error during planning: 'array_slice' does not support zero arguments
 select array_slice();
 
 query error Failed to coerce arguments

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -108,11 +108,11 @@ query error
 select avg(c1, c12) from aggregate_test_100;
 
 # AggregateFunction with wrong argument type
-statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to regr_slope function: coercion from
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'regr_slope' function: coercion from
 select regr_slope(1, '2');
 
 # WindowFunction using AggregateFunction wrong signature
-statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to regr_slope function: coercion from
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'regr_slope' function: coercion from
 select
 c9,
 regr_slope(c11, '2') over () as min1
@@ -120,7 +120,7 @@ from aggregate_test_100
 order by c9
 
 # WindowFunction wrong signature
-statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to nth_value function: coercion from \[Int32, Int64, Int64\] to the signature OneOf\(\[Any\(0\), Any\(1\), Any\(2\)\]\) failed
+statement error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'nth_value' function: coercion from \[Int32, Int64, Int64\] to the signature OneOf\(\[Any\(0\), Any\(1\), Any\(2\)\]\) failed
 select
 c9,
 nth_value(c5, 2, 3) over (order by c9) as nv1

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -571,7 +571,7 @@ select repeat('-1.2', arrow_cast(3, 'Int32'));
 ----
 -1.2-1.2-1.2
 
-query error DataFusion error: Error during planning: Internal error: Function repeat expects TypeSignatureClass::Native\(LogicalType\(Native\(Int64\), Int64\)\) but received Float64
+query error DataFusion error: Error during planning: Internal error: Function 'repeat' expects TypeSignatureClass::Native\(LogicalType\(Native\(Int64\), Int64\)\) but received Float64
 select repeat('-1.2', 3.2);
 
 query T

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -571,7 +571,7 @@ select repeat('-1.2', arrow_cast(3, 'Int32'));
 ----
 -1.2-1.2-1.2
 
-query error DataFusion error: Error during planning: Internal error: For function repeat expect TypeSignatureClass::Native\(LogicalType\(Native\(Int64\), Int64\)\) but received Float64
+query error DataFusion error: Error during planning: Internal error: Function repeat expects TypeSignatureClass::Native\(LogicalType\(Native\(Int64\), Int64\)\) but received Float64
 select repeat('-1.2', 3.2);
 
 query T

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -571,7 +571,7 @@ select repeat('-1.2', arrow_cast(3, 'Int32'));
 ----
 -1.2-1.2-1.2
 
-query error DataFusion error: Error during planning: Internal error: Expect TypeSignatureClass::Native\(LogicalType\(Native\(Int64\), Int64\)\) but received Float64
+query error DataFusion error: Error during planning: Internal error: For function repeat expect TypeSignatureClass::Native\(LogicalType\(Native\(Int64\), Int64\)\) but received Float64
 select repeat('-1.2', 3.2);
 
 query T

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -842,7 +842,7 @@ SELECT greatest(-1, 1, 2.3, 123456789, 3 + 5, -(-4), abs(-9.0))
 123456789
 
 
-query error greatest does not support zero arguments
+query error 'greatest' does not support zero argument
 SELECT greatest()
 
 query I
@@ -1040,7 +1040,7 @@ SELECT least(-1, 1, 2.3, 123456789, 3 + 5, -(-4), abs(-9.0))
 -1
 
 
-query error least does not support zero arguments
+query error 'least' does not support zero arguments
 SELECT least()
 
 query I

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -126,15 +126,15 @@ statement error
 SELECT abs(1, 2);
 
 # abs: unsupported argument type
-query error DataFusion error: Error during planning: Function abs expects NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: Function 'abs' expects NativeType::Numeric but received NativeType::String
 SELECT abs('foo');
 
 # abs: numeric string
 # TODO: In Postgres, '-1.2' is unknown type and interpreted to float8 so they don't fail on this query
-query error DataFusion error: Error during planning: Function abs expects NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: Function 'abs' expects NativeType::Numeric but received NativeType::String
 select abs('-1.2');
 
-query error DataFusion error: Error during planning: Function abs expects NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: Function 'abs' expects NativeType::Numeric but received NativeType::String
 select abs(arrow_cast('-1.2', 'Utf8'));
 
 statement ok

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -134,7 +134,7 @@ SELECT abs('foo');
 query error DataFusion error: Error during planning: Function abs expects NativeType::Numeric but received NativeType::String
 select abs('-1.2');
 
-query error DataFusion error: Error during planning: Function abs expected NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: Function abs expects NativeType::Numeric but received NativeType::String
 select abs(arrow_cast('-1.2', 'Utf8'));
 
 statement ok

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -126,15 +126,15 @@ statement error
 SELECT abs(1, 2);
 
 # abs: unsupported argument type
-query error DataFusion error: Error during planning: For function abs the signature expected NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: Function abs expects NativeType::Numeric but received NativeType::String
 SELECT abs('foo');
 
 # abs: numeric string
 # TODO: In Postgres, '-1.2' is unknown type and interpreted to float8 so they don't fail on this query
-query error DataFusion error: Error during planning: For function abs the signature expected NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: Function abs expects NativeType::Numeric but received NativeType::String
 select abs('-1.2');
 
-query error DataFusion error: Error during planning: For function abs the signature expected NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: Function abs expected NativeType::Numeric but received NativeType::String
 select abs(arrow_cast('-1.2', 'Utf8'));
 
 statement ok

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -126,15 +126,15 @@ statement error
 SELECT abs(1, 2);
 
 # abs: unsupported argument type
-query error DataFusion error: Error during planning: The signature expected NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: For function abs the signature expected NativeType::Numeric but received NativeType::String
 SELECT abs('foo');
 
 # abs: numeric string
 # TODO: In Postgres, '-1.2' is unknown type and interpreted to float8 so they don't fail on this query
-query error DataFusion error: Error during planning: The signature expected NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: For function abs the signature expected NativeType::Numeric but received NativeType::String
 select abs('-1.2');
 
-query error DataFusion error: Error during planning: The signature expected NativeType::Numeric but received NativeType::String
+query error DataFusion error: Error during planning: For function abs the signature expected NativeType::Numeric but received NativeType::String
 select abs(arrow_cast('-1.2', 'Utf8'));
 
 statement ok

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1945,7 +1945,7 @@ select position('' in '')
 ----
 1
 
-query error DataFusion error: Error during planning: For function strpos the signature expected NativeType::String but received NativeType::Int64
+query error DataFusion error: Error during planning: Function strpos expected NativeType::String but received NativeType::Int64
 select position(1 in 1)
 
 query I

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1945,7 +1945,7 @@ select position('' in '')
 ----
 1
 
-query error DataFusion error: Error during planning: Function strpos expects NativeType::String but received NativeType::Int64
+query error DataFusion error: Error during planning: Function 'strpos' expects NativeType::String but received NativeType::Int64
 select position(1 in 1)
 
 query I

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1945,7 +1945,7 @@ select position('' in '')
 ----
 1
 
-query error DataFusion error: Error during planning: Function strpos expected NativeType::String but received NativeType::Int64
+query error DataFusion error: Error during planning: Function strpos expects NativeType::String but received NativeType::Int64
 select position(1 in 1)
 
 query I

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1945,7 +1945,7 @@ select position('' in '')
 ----
 1
 
-query error DataFusion error: Error during planning: The signature expected NativeType::String but received NativeType::Int64
+query error DataFusion error: Error during planning: For function strpos the signature expected NativeType::String but received NativeType::Int64
 select position(1 in 1)
 
 query I


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

Function signature error messages do not include the function name making for debugging issues very difficult in a system with dataframes with hundreds of function calls.

## What changes are included in this PR?

Updated error messages and tests.

## Are these changes tested?

Yes

## Are there any user-facing changes?

Unless you count updated error messages, no.