### PR TITLE
Validate and unpack function arguments tersely

### DIFF
--- a/datafusion/functions/src/core/arrow_cast.rs
+++ b/datafusion/functions/src/core/arrow_cast.rs
@@ -25,6 +25,7 @@ use datafusion_common::{
 use datafusion_common::{exec_datafusion_err, DataFusionError};
 use std::any::Any;
 
+use crate::utils::take_function_args;
 use datafusion_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion_expr::{
     ColumnarValue, Documentation, Expr, ReturnInfo, ReturnTypeArgs, ScalarUDFImpl,
@@ -117,10 +118,9 @@ impl ScalarUDFImpl for ArrowCastFunc {
     fn return_type_from_args(&self, args: ReturnTypeArgs) -> Result<ReturnInfo> {
         let nullable = args.nullables.iter().any(|&nullable| nullable);
 
-        // Length check handled in the signature
-        debug_assert_eq!(args.scalar_arguments.len(), 2);
+        let [_, type_arg] = take_function_args(self.name(), args.scalar_arguments)?;
 
-        args.scalar_arguments[1]
+        type_arg
             .and_then(|sv| sv.try_as_str().flatten().filter(|s| !s.is_empty()))
             .map_or_else(
                 || {

--- a/datafusion/functions/src/core/arrowtypeof.rs
+++ b/datafusion/functions/src/core/arrowtypeof.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::utils::take_function_args;
 use arrow::datatypes::DataType;
-use datafusion_common::{exec_err, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::{ColumnarValue, Documentation};
 use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
 use datafusion_macros::user_doc;
@@ -80,14 +81,8 @@ impl ScalarUDFImpl for ArrowTypeOfFunc {
         args: &[ColumnarValue],
         _number_rows: usize,
     ) -> Result<ColumnarValue> {
-        if args.len() != 1 {
-            return exec_err!(
-                "arrow_typeof function requires 1 arguments, got {}",
-                args.len()
-            );
-        }
-
-        let input_data_type = args[0].data_type();
+        let [arg] = take_function_args(self.name(), args)?;
+        let input_data_type = arg.data_type();
         Ok(ColumnarValue::Scalar(ScalarValue::from(format!(
             "{input_data_type}"
         ))))

--- a/datafusion/functions/src/core/getfield.rs
+++ b/datafusion/functions/src/core/getfield.rs
@@ -111,7 +111,7 @@ impl ScalarUDFImpl for GetFieldFunc {
             }
         };
 
-        Ok(format!("{}[{}]", base, name))
+        Ok(format!("{base}[{name}]"))
     }
 
     fn schema_name(&self, args: &[Expr]) -> Result<String> {

--- a/datafusion/functions/src/core/getfield.rs
+++ b/datafusion/functions/src/core/getfield.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::utils::take_function_args;
 use arrow::array::{
     make_array, Array, Capacities, MutableArrayData, Scalar, StringArray,
 };
@@ -99,14 +100,9 @@ impl ScalarUDFImpl for GetFieldFunc {
     }
 
     fn display_name(&self, args: &[Expr]) -> Result<String> {
-        if args.len() != 2 {
-            return exec_err!(
-                "get_field function requires 2 arguments, got {}",
-                args.len()
-            );
-        }
+        let [base, field_name] = take_function_args(self.name(), args)?;
 
-        let name = match &args[1] {
+        let name = match field_name {
             Expr::Literal(name) => name,
             _ => {
                 return exec_err!(
@@ -115,7 +111,7 @@ impl ScalarUDFImpl for GetFieldFunc {
             }
         };
 
-        Ok(format!("{}[{}]", args[0], name))
+        Ok(format!("{}[{}]", base, name))
     }
 
     fn schema_name(&self, args: &[Expr]) -> Result<String> {

--- a/datafusion/functions/src/core/nullif.rs
+++ b/datafusion/functions/src/core/nullif.rs
@@ -16,15 +16,17 @@
 // under the License.
 
 use arrow::datatypes::DataType;
-use datafusion_common::{exec_err, Result};
+use datafusion_common::Result;
 use datafusion_expr::{ColumnarValue, Documentation};
 
+use crate::utils::take_function_args;
 use arrow::compute::kernels::cmp::eq;
 use arrow::compute::kernels::nullif::nullif;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
 use datafusion_macros::user_doc;
 use std::any::Any;
+
 #[user_doc(
     doc_section(label = "Conditional Functions"),
     description = "Returns _null_ if _expression1_ equals _expression2_; otherwise it returns _expression1_.
@@ -119,14 +121,7 @@ impl ScalarUDFImpl for NullIfFunc {
 ///       1 - if the left is equal to this expr2, then the result is NULL, otherwise left value is passed.
 ///
 fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    if args.len() != 2 {
-        return exec_err!(
-            "{:?} args were supplied but NULLIF takes exactly two args",
-            args.len()
-        );
-    }
-
-    let (lhs, rhs) = (&args[0], &args[1]);
+    let [lhs, rhs] = take_function_args("nullif", args)?;
 
     match (lhs, rhs) {
         (ColumnarValue::Array(lhs), ColumnarValue::Scalar(rhs)) => {

--- a/datafusion/functions/src/core/nvl.rs
+++ b/datafusion/functions/src/core/nvl.rs
@@ -15,16 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::utils::take_function_args;
 use arrow::array::Array;
 use arrow::compute::is_not_null;
 use arrow::compute::kernels::zip::zip;
 use arrow::datatypes::DataType;
-use datafusion_common::{internal_err, Result};
+use datafusion_common::Result;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion_macros::user_doc;
 use std::sync::Arc;
+
 #[user_doc(
     doc_section(label = "Conditional Functions"),
     description = "Returns _expression2_ if _expression1_ is NULL otherwise it returns _expression1_.",
@@ -133,13 +135,8 @@ impl ScalarUDFImpl for NVLFunc {
 }
 
 fn nvl_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    if args.len() != 2 {
-        return internal_err!(
-            "{:?} args were supplied but NVL/IFNULL takes exactly two args",
-            args.len()
-        );
-    }
-    let (lhs_array, rhs_array) = match (&args[0], &args[1]) {
+    let [lhs, rhs] = take_function_args("nvl/ifnull", args)?;
+    let (lhs_array, rhs_array) = match (lhs, rhs) {
         (ColumnarValue::Array(lhs), ColumnarValue::Scalar(rhs)) => {
             (Arc::clone(lhs), rhs.to_array_of_size(lhs.len())?)
         }

--- a/datafusion/functions/src/core/nvl2.rs
+++ b/datafusion/functions/src/core/nvl2.rs
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::utils::take_function_args;
 use arrow::array::Array;
 use arrow::compute::is_not_null;
 use arrow::compute::kernels::zip::zip;
 use arrow::datatypes::DataType;
-use datafusion_common::{exec_err, internal_err, Result};
+use datafusion_common::{internal_err, Result};
 use datafusion_expr::{
     type_coercion::binary::comparison_coercion, ColumnarValue, Documentation,
     ScalarUDFImpl, Signature, Volatility,
@@ -104,27 +105,19 @@ impl ScalarUDFImpl for NVL2Func {
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        if arg_types.len() != 3 {
-            return exec_err!(
-                "NVL2 takes exactly three arguments, but got {}",
-                arg_types.len()
-            );
-        }
-        let new_type = arg_types.iter().skip(1).try_fold(
-            arg_types.first().unwrap().clone(),
-            |acc, x| {
-                // The coerced types found by `comparison_coercion` are not guaranteed to be
-                // coercible for the arguments. `comparison_coercion` returns more loose
-                // types that can be coerced to both `acc` and `x` for comparison purpose.
-                // See `maybe_data_types` for the actual coercion.
-                let coerced_type = comparison_coercion(&acc, x);
-                if let Some(coerced_type) = coerced_type {
-                    Ok(coerced_type)
-                } else {
-                    internal_err!("Coercion from {acc:?} to {x:?} failed.")
-                }
-            },
-        )?;
+        let [a, b, c] = take_function_args(self.name(), arg_types)?;
+        let new_type = [b, c].iter().try_fold(a.clone(), |acc, x| {
+            // The coerced types found by `comparison_coercion` are not guaranteed to be
+            // coercible for the arguments. `comparison_coercion` returns more loose
+            // types that can be coerced to both `acc` and `x` for comparison purpose.
+            // See `maybe_data_types` for the actual coercion.
+            let coerced_type = comparison_coercion(&acc, x);
+            if let Some(coerced_type) = coerced_type {
+                Ok(coerced_type)
+            } else {
+                internal_err!("Coercion from {acc:?} to {x:?} failed.")
+            }
+        })?;
         Ok(vec![new_type; arg_types.len()])
     }
 

--- a/datafusion/functions/src/core/version.rs
+++ b/datafusion/functions/src/core/version.rs
@@ -17,13 +17,15 @@
 
 //! [`VersionFunc`]: Implementation of the `version` function.
 
+use crate::utils::take_function_args;
 use arrow::datatypes::DataType;
-use datafusion_common::{internal_err, plan_err, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion_macros::user_doc;
 use std::any::Any;
+
 #[user_doc(
     doc_section(label = "Other Functions"),
     description = "Returns the version of DataFusion.",
@@ -70,11 +72,8 @@ impl ScalarUDFImpl for VersionFunc {
     }
 
     fn return_type(&self, args: &[DataType]) -> Result<DataType> {
-        if args.is_empty() {
-            Ok(DataType::Utf8)
-        } else {
-            plan_err!("version expects no arguments")
-        }
+        let [] = take_function_args(self.name(), args)?;
+        Ok(DataType::Utf8)
     }
 
     fn invoke_batch(
@@ -82,9 +81,7 @@ impl ScalarUDFImpl for VersionFunc {
         args: &[ColumnarValue],
         _number_rows: usize,
     ) -> Result<ColumnarValue> {
-        if !args.is_empty() {
-            return internal_err!("{} function does not accept arguments", self.name());
-        }
+        let [] = take_function_args(self.name(), args)?;
         // TODO it would be great to add rust version and arrow version,
         // but that requires a `build.rs` script and/or adding a version const to arrow-rs
         let version = format!(

--- a/datafusion/functions/src/crypto/basic.rs
+++ b/datafusion/functions/src/crypto/basic.rs
@@ -24,6 +24,7 @@ use blake2::{Blake2b512, Blake2s256, Digest};
 use blake3::Hasher as Blake3;
 use datafusion_common::cast::as_binary_array;
 
+use crate::utils::take_function_args;
 use arrow::compute::StringArrayType;
 use datafusion_common::plan_err;
 use datafusion_common::{
@@ -41,14 +42,8 @@ macro_rules! define_digest_function {
     ($NAME: ident, $METHOD: ident, $DOC: expr) => {
         #[doc = $DOC]
         pub fn $NAME(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-            if args.len() != 1 {
-                return exec_err!(
-                    "{:?} args were supplied but {} takes exactly one argument",
-                    args.len(),
-                    DigestAlgorithm::$METHOD.to_string()
-                );
-            }
-            digest_process(&args[0], DigestAlgorithm::$METHOD)
+            let [data] = take_function_args(&DigestAlgorithm::$METHOD.to_string(), args)?;
+            digest_process(data, DigestAlgorithm::$METHOD)
         }
     };
 }
@@ -114,13 +109,8 @@ pub enum DigestAlgorithm {
 /// Second argument is the algorithm to use.
 /// Standard algorithms are md5, sha1, sha224, sha256, sha384 and sha512.
 pub fn digest(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    if args.len() != 2 {
-        return exec_err!(
-            "{:?} args were supplied but digest takes exactly two arguments",
-            args.len()
-        );
-    }
-    let digest_algorithm = match &args[1] {
+    let [data, digest_algorithm] = take_function_args("digest", args)?;
+    let digest_algorithm = match digest_algorithm {
         ColumnarValue::Scalar(scalar) => match scalar.try_as_str() {
             Some(Some(method)) => method.parse::<DigestAlgorithm>(),
             _ => exec_err!("Unsupported data type {scalar:?} for function digest"),
@@ -129,7 +119,7 @@ pub fn digest(args: &[ColumnarValue]) -> Result<ColumnarValue> {
             internal_err!("Digest using dynamically decided method is not yet supported")
         }
     }?;
-    digest_process(&args[0], digest_algorithm)
+    digest_process(data, digest_algorithm)
 }
 
 impl FromStr for DigestAlgorithm {
@@ -175,15 +165,8 @@ impl fmt::Display for DigestAlgorithm {
 
 /// computes md5 hash digest of the given input
 pub fn md5(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    if args.len() != 1 {
-        return exec_err!(
-            "{:?} args were supplied but {} takes exactly one argument",
-            args.len(),
-            DigestAlgorithm::Md5
-        );
-    }
-
-    let value = digest_process(&args[0], DigestAlgorithm::Md5)?;
+    let [data] = take_function_args("md5", args)?;
+    let value = digest_process(data, DigestAlgorithm::Md5)?;
 
     // md5 requires special handling because of its unique utf8 return type
     Ok(match value {

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -28,6 +28,7 @@ use arrow::datatypes::DataType::{
 use arrow::datatypes::TimeUnit::{Microsecond, Millisecond, Nanosecond, Second};
 use arrow::datatypes::{DataType, TimeUnit};
 
+use crate::utils::take_function_args;
 use datafusion_common::not_impl_err;
 use datafusion_common::{
     cast::{
@@ -140,10 +141,9 @@ impl ScalarUDFImpl for DatePartFunc {
     }
 
     fn return_type_from_args(&self, args: ReturnTypeArgs) -> Result<ReturnInfo> {
-        // Length check handled in the signature
-        debug_assert_eq!(args.scalar_arguments.len(), 2);
+        let [field, _] = take_function_args(self.name(), args.scalar_arguments)?;
 
-        args.scalar_arguments[0]
+        field
             .and_then(|sv| {
                 sv.try_as_str()
                     .flatten()

--- a/datafusion/functions/src/datetime/make_date.rs
+++ b/datafusion/functions/src/datetime/make_date.rs
@@ -26,6 +26,7 @@ use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::{Date32, Int32, Int64, UInt32, UInt64, Utf8, Utf8View};
 use chrono::prelude::*;
 
+use crate::utils::take_function_args;
 use datafusion_common::{exec_err, Result, ScalarValue};
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
@@ -111,13 +112,6 @@ impl ScalarUDFImpl for MakeDateFunc {
         args: &[ColumnarValue],
         _number_rows: usize,
     ) -> Result<ColumnarValue> {
-        if args.len() != 3 {
-            return exec_err!(
-                "make_date function requires 3 arguments, got {}",
-                args.len()
-            );
-        }
-
         // first, identify if any of the arguments is an Array. If yes, store its `len`,
         // as any scalar will need to be converted to an array of len `len`.
         let len = args
@@ -127,9 +121,11 @@ impl ScalarUDFImpl for MakeDateFunc {
                 ColumnarValue::Array(a) => Some(a.len()),
             });
 
-        let years = args[0].cast_to(&Int32, None)?;
-        let months = args[1].cast_to(&Int32, None)?;
-        let days = args[2].cast_to(&Int32, None)?;
+        let [years, months, days] = take_function_args(self.name(), args)?;
+
+        let years = years.cast_to(&Int32, None)?;
+        let months = months.cast_to(&Int32, None)?;
+        let days = days.cast_to(&Int32, None)?;
 
         let scalar_value_fn = |col: &ColumnarValue| -> Result<i32> {
             let ColumnarValue::Scalar(s) = col else {

--- a/datafusion/functions/src/lib.rs
+++ b/datafusion/functions/src/lib.rs
@@ -1,4 +1,5 @@
 // Licensed to the Apache Software Foundation (ASF) under one
+// Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file

--- a/datafusion/functions/src/lib.rs
+++ b/datafusion/functions/src/lib.rs
@@ -1,5 +1,4 @@
 // Licensed to the Apache Software Foundation (ASF) under one
-// Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file

--- a/datafusion/functions/src/lib.rs
+++ b/datafusion/functions/src/lib.rs
@@ -139,7 +139,7 @@ pub mod planner;
 
 pub mod strings;
 
-mod utils;
+pub mod utils;
 
 /// Fluent-style API for creating `Expr`s
 pub mod expr_fn {

--- a/datafusion/functions/src/math/abs.rs
+++ b/datafusion/functions/src/math/abs.rs
@@ -20,13 +20,14 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use crate::utils::take_function_args;
 use arrow::array::{
     ArrayRef, Decimal128Array, Decimal256Array, Float32Array, Float64Array, Int16Array,
     Int32Array, Int64Array, Int8Array,
 };
 use arrow::datatypes::DataType;
 use arrow::error::ArrowError;
-use datafusion_common::{exec_err, internal_datafusion_err, not_impl_err, Result};
+use datafusion_common::{internal_datafusion_err, not_impl_err, Result};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
 use datafusion_expr::{
@@ -34,12 +35,12 @@ use datafusion_expr::{
 };
 use datafusion_macros::user_doc;
 
-type MathArrayFunction = fn(&Vec<ArrayRef>) -> Result<ArrayRef>;
+type MathArrayFunction = fn(&ArrayRef) -> Result<ArrayRef>;
 
 macro_rules! make_abs_function {
     ($ARRAY_TYPE:ident) => {{
-        |args: &Vec<ArrayRef>| {
-            let array = downcast_named_arg!(&args[0], "abs arg", $ARRAY_TYPE);
+        |input: &ArrayRef| {
+            let array = downcast_named_arg!(&input, "abs arg", $ARRAY_TYPE);
             let res: $ARRAY_TYPE = array.unary(|x| x.abs());
             Ok(Arc::new(res) as ArrayRef)
         }
@@ -48,8 +49,8 @@ macro_rules! make_abs_function {
 
 macro_rules! make_try_abs_function {
     ($ARRAY_TYPE:ident) => {{
-        |args: &Vec<ArrayRef>| {
-            let array = downcast_named_arg!(&args[0], "abs arg", $ARRAY_TYPE);
+        |input: &ArrayRef| {
+            let array = downcast_named_arg!(&input, "abs arg", $ARRAY_TYPE);
             let res: $ARRAY_TYPE = array.try_unary(|x| {
                 x.checked_abs().ok_or_else(|| {
                     ArrowError::ComputeError(format!(
@@ -66,11 +67,11 @@ macro_rules! make_try_abs_function {
 
 macro_rules! make_decimal_abs_function {
     ($ARRAY_TYPE:ident) => {{
-        |args: &Vec<ArrayRef>| {
-            let array = downcast_named_arg!(&args[0], "abs arg", $ARRAY_TYPE);
+        |input: &ArrayRef| {
+            let array = downcast_named_arg!(&input, "abs arg", $ARRAY_TYPE);
             let res: $ARRAY_TYPE = array
                 .unary(|x| x.wrapping_abs())
-                .with_data_type(args[0].data_type().clone());
+                .with_data_type(input.data_type().clone());
             Ok(Arc::new(res) as ArrayRef)
         }
     }};
@@ -94,7 +95,7 @@ fn create_abs_function(input_data_type: &DataType) -> Result<MathArrayFunction> 
         | DataType::UInt8
         | DataType::UInt16
         | DataType::UInt32
-        | DataType::UInt64 => Ok(|args: &Vec<ArrayRef>| Ok(Arc::clone(&args[0]))),
+        | DataType::UInt64 => Ok(|input: &ArrayRef| Ok(Arc::clone(input))),
 
         // Decimal types
         DataType::Decimal128(_, _) => Ok(make_decimal_abs_function!(Decimal128Array)),
@@ -172,15 +173,12 @@ impl ScalarUDFImpl for AbsFunc {
         _number_rows: usize,
     ) -> Result<ColumnarValue> {
         let args = ColumnarValue::values_to_arrays(args)?;
+        let [input] = take_function_args(self.name(), args)?;
 
-        if args.len() != 1 {
-            return exec_err!("abs function requires 1 argument, got {}", args.len());
-        }
-
-        let input_data_type = args[0].data_type();
+        let input_data_type = input.data_type();
         let abs_fun = create_abs_function(input_data_type)?;
 
-        abs_fun(&args).map(ColumnarValue::Array)
+        abs_fun(&input).map(ColumnarValue::Array)
     }
 
     fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -43,7 +43,7 @@ use datafusion_expr::ColumnarValue;
 /// let twenty = ColumnarValue::from(ScalarValue::from(20i32));
 /// let args = vec![ten.clone()];
 /// let err = my_function(&args).unwrap_err();
-/// assert_eq!(err.to_string(), "my_function function requires 2 arguments, got 1");
+/// assert_eq!(err.to_string(), "Execution error: my_function function requires 2 arguments, got 1");
 /// // Calling the function with 2 arguments works great
 /// let args = vec![ten, twenty];
 /// my_function(&args).unwrap();

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -30,6 +30,7 @@ use datafusion_expr::ColumnarValue;
 /// # use datafusion_common::ScalarValue;
 /// # use datafusion_common::Result;
 /// # use datafusion_expr_common::columnar_value::ColumnarValue;
+/// # use datafusion_functions::utils::take_function_args;
 /// fn my_function(args: &[ColumnarValue]) -> Result<()> {
 ///   // function expects 2 args, so create a 2-element array
 ///   let [arg1, arg2] = take_function_args("my_function", args)?;
@@ -41,7 +42,7 @@ use datafusion_expr::ColumnarValue;
 /// let ten = ColumnarValue::from(ScalarValue::from(10i32));
 /// let twenty = ColumnarValue::from(ScalarValue::from(20i32));
 /// let args = vec![ten.clone()];
-///  let err = my_function(&args).unwrap_err();
+/// let err = my_function(&args).unwrap_err();
 /// assert_eq!(err.to_string(), "my_function function requires 2 arguments, got 1");
 /// // Calling the function with 2 arguments works great
 /// let args = vec![ten, twenty];

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -24,6 +24,29 @@ use datafusion_expr::ColumnarValue;
 
 /// Converts a collection of function arguments into an fixed-size array of length N
 /// producing a reasonable error message in case of unexpected number of arguments.
+///
+/// # Example
+/// ```
+/// # use datafusion_common::ScalarValue;
+/// # use datafusion_common::Result;
+/// # use datafusion_expr_common::columnar_value::ColumnarValue;
+/// fn my_function(args: &[ColumnarValue]) -> Result<()> {
+///   // function expects 2 args, so create a 2-element array
+///   let [arg1, arg2] = take_function_args("my_function", args)?;
+///   // ... do stuff..
+///   Ok(())
+/// }
+/// 
+/// // Calling the function with 1 argument produces an error: 
+/// let ten = ColumnarValue::from(ScalarValue::from(10i32));
+/// let twenty = ColumnarValue::from(ScalarValue::from(20i32));
+/// let args = vec![ten.clone()];
+///  let err = my_function(&args).unwrap_err();
+/// assert_eq!(err.to_string(), "my_function function requires 2 arguments, got 1");
+/// // Calling the function with 2 arguments works great
+/// let args = vec![ten, twenty];
+/// my_function(&args).unwrap();
+/// ```
 pub fn take_function_args<const N: usize, T>(
     function_name: &str,
     args: impl IntoIterator<Item = T>,

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -36,8 +36,8 @@ use datafusion_expr::ColumnarValue;
 ///   // ... do stuff..
 ///   Ok(())
 /// }
-/// 
-/// // Calling the function with 1 argument produces an error: 
+///
+/// // Calling the function with 1 argument produces an error:
 /// let ten = ColumnarValue::from(ScalarValue::from(10i32));
 /// let twenty = ColumnarValue::from(ScalarValue::from(20i32));
 /// let args = vec![ten.clone()];


### PR DESCRIPTION
Add a `take_function_args` helper that provides convenient unpacking of function arguments along with validation that the provided argument count matches the expected.  A few functions are updated to leverage the new pattern to demonstrate its usefulness.
