### PR TITLE
Fix config_namespace macro symbol usage

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -2094,22 +2094,3 @@ mod tests {
         assert_eq!(parsed_metadata.get("key_dupe"), Some(&Some("B".into())));
     }
 }
-
-#[cfg(test)]
-mod tests_isolated {
-    // The point of this test is to check that the config_namespace! macro
-    // can compile without any surrounding `use` statements. Hence putting
-    // it into its own test module.
-    #[test]
-    fn check_config_namespace_macro() {
-        use crate::config_namespace;
-
-        config_namespace! {
-            /// A config section
-            pub struct Foo {
-                /// Some doc comments
-                pub bar: bool, default = true
-            }
-        }
-    }
-}

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -108,6 +108,7 @@ use crate::{DataFusionError, Result};
 /// ```
 ///
 /// NB: Misplaced commas may result in nonsensical errors
+#[macro_export]
 macro_rules! config_namespace {
     (
         $(#[doc = $struct_d:tt])* // Struct-level documentation attributes
@@ -138,8 +139,8 @@ macro_rules! config_namespace {
             )*
         }
 
-        impl ConfigField for $struct_name {
-            fn set(&mut self, key: &str, value: &str) -> Result<()> {
+        impl $crate::config::ConfigField for $struct_name {
+            fn set(&mut self, key: &str, value: &str) -> $crate::error::Result<()> {
                 let (key, rem) = key.split_once('.').unwrap_or((key, ""));
                 match key {
                     $(
@@ -154,13 +155,13 @@ macro_rules! config_namespace {
                             }
                         },
                     )*
-                    _ => return _config_err!(
+                    _ => return $crate::error::_config_err!(
                         "Config value \"{}\" not found on {}", key, stringify!($struct_name)
                     )
                 }
             }
 
-            fn visit<V: Visit>(&self, v: &mut V, key_prefix: &str, _description: &'static str) {
+            fn visit<V: $crate::config::Visit>(&self, v: &mut V, key_prefix: &str, _description: &'static str) {
                 $(
                     let key = format!(concat!("{}.", stringify!($field_name)), key_prefix);
                     let desc = concat!($($d),*).trim();
@@ -2091,5 +2092,24 @@ mod tests {
         table_config.set("format.metadata::key_dupe", "B").unwrap();
         let parsed_metadata = table_config.parquet.key_value_metadata;
         assert_eq!(parsed_metadata.get("key_dupe"), Some(&Some("B".into())));
+    }
+}
+
+#[cfg(test)]
+mod tests_isolated {
+    // The point of this test is to check that the config_namespace! macro
+    // can compile without any surrounding `use` statements. Hence putting
+    // it into its own test module.
+    #[test]
+    fn check_config_namespace_macro() {
+        use crate::config_namespace;
+
+        config_namespace! {
+            /// A config section
+            pub struct Foo {
+                /// Some doc comments
+                pub bar: bool, default = true
+            }
+        }
     }
 }

--- a/datafusion/core/tests/macro_hygiene/mod.rs
+++ b/datafusion/core/tests/macro_hygiene/mod.rs
@@ -49,3 +49,19 @@ mod record_batch {
         record_batch!(("column_name", Int32, vec![1, 2, 3])).unwrap();
     }
 }
+
+mod config_namespace {
+    // NO other imports!
+    use datafusion_common::config_namespace;
+
+    #[test]
+    fn test_macro() {
+        config_namespace! {
+            /// A config section
+            pub struct Foo {
+                /// Some doc comments
+                pub bar: bool, default = true
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `config_namespace` macro was relying on a few symbols being properly imported before its used. This removes that need by referring to the symbols directly with the `$crate` prefix.

## Which issue does this PR close?

- Closes #14518.

## Rationale for this change

The `config_namespace!` macro relied on symbols being properly imported. This fixes that issue.

## What changes are included in this PR?

1. Fix `config_namespace!` to not require imported symbols being available.
2. Re-add the inadvertently removed `#[macro_export]` attribute.

## Are these changes tested?

Yes. There's an isolated test to show that the macro now works without any `use` statements.

## Are there any user-facing changes?

Some folks might get "unused import" diagnostics/warnings after this change, maybe?