### PR TITLE
bug: Remove array_slice two arg variant

### DIFF
--- a/datafusion/functions-nested/src/extract.rs
+++ b/datafusion/functions-nested/src/extract.rs
@@ -331,11 +331,6 @@ impl ArraySlice {
                 vec![
                     TypeSignature::ArraySignature(
                         ArrayFunctionSignature::ArrayAndIndexes(
-                            NonZeroUsize::new(1).expect("1 is non-zero"),
-                        ),
-                    ),
-                    TypeSignature::ArraySignature(
-                        ArrayFunctionSignature::ArrayAndIndexes(
                             NonZeroUsize::new(2).expect("2 is non-zero"),
                         ),
                     ),

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1850,15 +1850,11 @@ select array_slice(arrow_cast(make_array(1, 2, 3, 4, 5), 'LargeList(Int64)'), 0,
 [] []
 
 # array_slice scalar function #11 (with NULL-NULL)
-query ??
+query error
 select array_slice(make_array(1, 2, 3, 4, 5), NULL), array_slice(make_array('h', 'e', 'l', 'l', 'o'), NULL);
-----
-NULL NULL
 
-query ??
+query error
 select array_slice(arrow_cast(make_array(1, 2, 3, 4, 5), 'LargeList(Int64)'), NULL), array_slice(arrow_cast(make_array('h', 'e', 'l', 'l', 'o'), 'LargeList(Utf8)'), NULL);
-----
-NULL NULL
 
 # array_slice scalar function #12 (with zero and negative number)
 query ??


### PR DESCRIPTION
In 3dfce7d33c19d6e7941b58cb7e83194c066347ca I misunderstood an existing test and accidentally added a variant of `array_slice` that accepts two arguments. This variant is not valid and only works if one of the arguments are null. This commit fixes the problem by removing the two argument variant.

## Which issue does this PR close?

Related to #10548

## Rationale for this change

Fixes a mistake in my previous RP.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No
