### PR TITLE
Minor: deprecate unused index mod

### DIFF
--- a/datafusion/physical-plan/src/sorts/index.rs
+++ b/datafusion/physical-plan/src/sorts/index.rs
@@ -50,6 +50,7 @@
 ///   RecordBatches
 /// ```
 #[derive(Debug, Clone)]
+#[deprecated(since = "46.0.0", note = "unused and will be removed in the future")]
 pub struct RowIndex {
     /// The index of the stream (uniquely identifies the stream)
     pub stream_idx: usize,

--- a/datafusion/physical-plan/src/sorts/mod.rs
+++ b/datafusion/physical-plan/src/sorts/mod.rs
@@ -25,5 +25,3 @@ pub mod sort;
 pub mod sort_preserving_merge;
 mod stream;
 pub mod streaming_merge;
-
-pub use index::RowIndex;

--- a/datafusion/physical-plan/src/sorts/mod.rs
+++ b/datafusion/physical-plan/src/sorts/mod.rs
@@ -19,7 +19,6 @@
 
 mod builder;
 mod cursor;
-mod index;
 mod merge;
 pub mod partial_sort;
 pub mod sort;


### PR DESCRIPTION
## Which issue does this PR close?

This is a minor change for remove unused index file and mod.


## Are there any user-facing changes?

no
