### PR TITLE
Implement faster join traversal

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -1242,7 +1242,7 @@ fn lookup_join_hashmap(
     offset: JoinHashMapOffset,
 ) -> Result<(UInt64Array, UInt32Array, Option<JoinHashMapOffset>)> {
     let (probe_indices, build_indices, next_offset) = build_hashmap
-        .get_matched_indices_with_limit_offset(hashes_buffer, None, limit, offset);
+        .get_matched_indices_with_limit_offset(hashes_buffer, limit, offset);
 
     let build_indices: UInt64Array = build_indices.into();
     let probe_indices: UInt32Array = probe_indices.into();

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -1241,8 +1241,8 @@ fn lookup_join_hashmap(
     limit: usize,
     offset: JoinHashMapOffset,
 ) -> Result<(UInt64Array, UInt32Array, Option<JoinHashMapOffset>)> {
-    let (probe_indices, build_indices, next_offset) = build_hashmap
-        .get_matched_indices_with_limit_offset(hashes_buffer, limit, offset);
+    let (probe_indices, build_indices, next_offset) =
+        build_hashmap.get_matched_indices_with_limit_offset(hashes_buffer, limit, offset);
 
     let build_indices: UInt64Array = build_indices.into();
     let probe_indices: UInt32Array = probe_indices.into();

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -1988,12 +1988,7 @@ mod tests {
 
         let expected_batch_count = if cfg!(not(feature = "force_hash_collisions")) {
             // Expected number of hash table matches = 3
-            // in case batch_size is 1 - additional empty batch for remaining 3-2 row
-            let mut expected_batch_count = div_ceil(3, batch_size);
-            if batch_size == 1 {
-                expected_batch_count += 1;
-            }
-            expected_batch_count
+            div_ceil(3, batch_size)
         } else {
             // With hash collisions enabled, all records will match each other
             // and filtered later.

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -2058,12 +2058,7 @@ mod tests {
 
         let expected_batch_count = if cfg!(not(feature = "force_hash_collisions")) {
             // Expected number of hash table matches = 3
-            // in case batch_size is 1 - additional empty batch for remaining 3-2 row
-            let mut expected_batch_count = div_ceil(3, batch_size);
-            if batch_size == 1 {
-                expected_batch_count += 1;
-            }
-            expected_batch_count
+            div_ceil(3, batch_size)
         } else {
             // With hash collisions enabled, all records will match each other
             // and filtered later.

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -277,7 +277,7 @@ pub trait JoinHashMapType {
             }
         }
 
-        // iterate the next items 
+        // iterate the next items
         while let Some((input_index, match_row_idx)) = todo.pop_front() {
             input_indices.push(input_index as u32);
             match_indices.push(match_row_idx);

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -253,7 +253,7 @@ pub trait JoinHashMapType {
             }
         }
 
-        return next_items;
+        next_items
     }
 
     /// Matches hashes with taking batch size into account


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
We can speed up finding matching indices by separating the lookups and chain traversal.

- Closes #.

Todo
- [x] Implement outputting in batches
- [x] Keep ordering of results(?)
- [ ] Run more benchmarks (e.g. h2o join / imdb ...)

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

This simplifies the algorithm for traversing the chain and makes it more vectorizable.


```
--------------------
Benchmark tpch_sf10.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃      main ┃ join_vectorization ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  981.31ms │           952.00ms │     no change │
│ QQuery 2     │  157.88ms │           152.47ms │     no change │
│ QQuery 3     │  475.15ms │           472.37ms │     no change │
│ QQuery 4     │  240.46ms │           231.75ms │     no change │
│ QQuery 5     │  700.03ms │           684.56ms │     no change │
│ QQuery 6     │  157.46ms │           155.71ms │     no change │
│ QQuery 7     │ 1072.19ms │          1017.78ms │ +1.05x faster │
│ QQuery 8     │  740.30ms │           757.31ms │     no change │
│ QQuery 9     │ 1189.08ms │          1172.25ms │     no change │
│ QQuery 10    │  666.24ms │           681.22ms │     no change │
│ QQuery 11    │  101.91ms │           100.25ms │     no change │
│ QQuery 12    │  338.89ms │           325.82ms │     no change │
│ QQuery 13    │  475.00ms │           464.34ms │     no change │
│ QQuery 14    │  266.15ms │           264.06ms │     no change │
│ QQuery 15    │  442.98ms │           447.49ms │     no change │
│ QQuery 16    │  111.29ms │           114.29ms │     no change │
│ QQuery 17    │ 1249.82ms │          1257.36ms │     no change │
│ QQuery 18    │ 2052.52ms │          1772.82ms │ +1.16x faster │
│ QQuery 19    │  464.19ms │           456.00ms │     no change │
│ QQuery 20    │  470.89ms │           453.13ms │     no change │
│ QQuery 21    │ 1637.42ms │          1572.06ms │     no change │
│ QQuery 22    │  156.41ms │           145.56ms │ +1.07x faster │
└──────────────┴───────────┴────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Benchmark Summary                 ┃            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Total Time (main)                 │ 14147.60ms │
│ Total Time (join_vectorization)   │ 13650.61ms │
│ Average Time (main)               │   643.07ms │
│ Average Time (join_vectorization) │   620.48ms │
│ Queries Faster                    │          3 │
│ Queries Slower                    │          0 │
│ Queries with No Change            │         19 │
└───────────────────────────────────┴────────────┘

--------------------
Benchmark tpch_mem_sf10.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃      main ┃ join_vectorization ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │  770.46ms │           774.09ms │     no change │
│ QQuery 2     │  125.30ms │           123.01ms │     no change │
│ QQuery 3     │  259.14ms │           247.91ms │     no change │
│ QQuery 4     │  134.04ms │           124.88ms │ +1.07x faster │
│ QQuery 5     │  525.49ms │           516.03ms │     no change │
│ QQuery 6     │   45.93ms │            39.85ms │ +1.15x faster │
│ QQuery 7     │ 1079.09ms │           836.97ms │ +1.29x faster │
│ QQuery 8     │  336.17ms │           327.84ms │     no change │
│ QQuery 9     │  881.10ms │           843.84ms │     no change │
│ QQuery 10    │  406.44ms │           383.09ms │ +1.06x faster │
│ QQuery 11    │   94.73ms │            87.25ms │ +1.09x faster │
│ QQuery 12    │  280.55ms │           264.89ms │ +1.06x faster │
│ QQuery 13    │  292.29ms │           279.96ms │     no change │
│ QQuery 14    │   47.03ms │            48.84ms │     no change │
│ QQuery 15    │  137.05ms │           136.95ms │     no change │
│ QQuery 16    │   94.72ms │            84.73ms │ +1.12x faster │
│ QQuery 17    │  910.07ms │           909.83ms │     no change │
│ QQuery 18    │ 3759.48ms │          3194.88ms │ +1.18x faster │
│ QQuery 19    │  183.15ms │           178.16ms │     no change │
│ QQuery 20    │  242.99ms │           239.17ms │     no change │
│ QQuery 21    │ 1582.68ms │          1505.24ms │     no change │
│ QQuery 22    │   95.75ms │            97.84ms │     no change │
└──────────────┴───────────┴────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Benchmark Summary                 ┃            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Total Time (main)                 │ 12283.64ms │
│ Total Time (join_vectorization)   │ 11245.27ms │
│ Average Time (main)               │   558.35ms │
│ Average Time (join_vectorization) │   511.15ms │
│ Queries Faster                    │          8 │
│ Queries Slower                    │          0 │
│ Queries with No Change            │         14 │
└───────────────────────────────────┴────────────┘

````

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
