### PR TITLE
Allow constructing ScalarUDF from shared implementation

### DIFF
--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -119,9 +119,12 @@ impl AggregateUDF {
     where
         F: AggregateUDFImpl + 'static,
     {
-        Self {
-            inner: Arc::new(fun),
-        }
+        Self::new_from_shared_impl(Arc::new(fun))
+    }
+
+    /// Create a new `AggregateUDF` from a `[AggregateUDFImpl]` trait object
+    pub fn new_from_shared_impl(fun: Arc<dyn AggregateUDFImpl>) -> AggregateUDF {
+        Self { inner: fun }
     }
 
     /// Return the underlying [`AggregateUDFImpl`] trait object for this function

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -91,9 +91,12 @@ impl ScalarUDF {
     where
         F: ScalarUDFImpl + 'static,
     {
-        Self {
-            inner: Arc::new(fun),
-        }
+        Self::new_from_shared_impl(Arc::new(fun))
+    }
+
+    /// Create a new `ScalarUDF` from a `[ScalarUDFImpl]` trait object
+    pub fn new_from_shared_impl(fun: Arc<dyn ScalarUDFImpl>) -> ScalarUDF {
+        Self { inner: fun }
     }
 
     /// Return the underlying [`ScalarUDFImpl`] trait object for this function

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -100,9 +100,12 @@ impl WindowUDF {
     where
         F: WindowUDFImpl + 'static,
     {
-        Self {
-            inner: Arc::new(fun),
-        }
+        Self::new_from_shared_impl(Arc::new(fun))
+    }
+
+    /// Create a new `WindowUDF` from a `[WindowUDFImpl]` trait object
+    pub fn new_from_shared_impl(fun: Arc<dyn WindowUDFImpl>) -> WindowUDF {
+        Self { inner: fun }
     }
 
     /// Return the underlying [`WindowUDFImpl`] trait object for this function


### PR DESCRIPTION
When composing or decorating functions, it's useful to operate on Impl trait objects (dyn ScalarUDFImpl) instead of the Expr-level adapter (ScalarUDF). However, before the change, it was impossible to construct `ScalarUDF` from `Arc<dyn ScalarUDFImpl>`, even though the use of `Arc` is already part of the type API. This commit allows constructing the scalar from a shared impl object.
