### PR TITLE
bug: improve schema checking for `insert into` cases

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -1007,6 +1007,8 @@ pub trait SchemaExt {
     ///
     /// Use [DFSchema]::equivalent_names_and_types for stricter semantic type
     /// equivalence checking.
+    ///
+    /// It is only used by insert into cases.
     fn logically_equivalent_names_and_types(&self, other: &Self) -> Result<()>;
 }
 
@@ -1028,7 +1030,9 @@ impl SchemaExt for Schema {
             })
     }
 
+    // It is only used by insert into cases.
     fn logically_equivalent_names_and_types(&self, other: &Self) -> Result<()> {
+        // case 1 : schema length mismatch
         if self.fields().len() != other.fields().len() {
             _plan_err!(
                 "Inserting query must have the same schema length as the table. \
@@ -1037,6 +1041,8 @@ impl SchemaExt for Schema {
                 other.fields().len()
             )
         } else {
+            // case 2 : schema length match, but fields mismatch
+            // check if the fields name are the same and have the same data types
             self.fields()
                 .iter()
                 .zip(other.fields().iter())

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -1041,16 +1041,7 @@ impl SchemaExt for Schema {
                 .iter()
                 .zip(other.fields().iter())
                 .try_for_each(|(f1, f2)| {
-                    // only check the case when the table field is not nullable and the insert data field is nullable
-                    if !f1.is_nullable() && f2.is_nullable() {
-                        _plan_err!(
-                            "Inserting query must have the same schema nullability as the table. \
-                            Expected table field '{}' nullability: {}, got field: '{}', nullability: {}",
-                            f1.name(),
-                            f1.is_nullable(),
-                            f2.name(),
-                            f2.is_nullable())
-                    } else if f1.name() != f2.name() || !DFSchema::datatype_is_logically_equal(f1.data_type(), f2.data_type()) {
+                    if f1.name() != f2.name() || !DFSchema::datatype_is_logically_equal(f1.data_type(), f2.data_type()) {
                         _plan_err!(
                             "Inserting query schema mismatch: Expected table field '{}' with type {:?}, \
                             but got '{}' with type {:?}.",

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -996,27 +996,8 @@ impl TableProvider for ListingTable {
         insert_op: InsertOp,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Check that the schema of the plan matches the schema of this table.
-        if !self
-            .schema()
-            .logically_equivalent_names_and_types(&input.schema())
-        {
-            // Return an error if schema of the input query does not match with the table schema.
-            return plan_err!(
-                "Inserting query must have the same schema with the table. \
-                Expected: {:?}, got: {:?}",
-                self.schema()
-                    .fields()
-                    .iter()
-                    .map(|field| field.data_type())
-                    .collect::<Vec<_>>(),
-                input
-                    .schema()
-                    .fields()
-                    .iter()
-                    .map(|field| field.data_type())
-                    .collect::<Vec<_>>()
-            );
-        }
+        self.schema()
+            .logically_equivalent_names_and_types(&input.schema())?;
 
         let table_path = &self.table_paths()[0];
         if !table_path.is_collection() {

--- a/datafusion/core/src/datasource/memory.rs
+++ b/datafusion/core/src/datasource/memory.rs
@@ -278,26 +278,9 @@ impl TableProvider for MemTable {
 
         // Create a physical plan from the logical plan.
         // Check that the schema of the plan matches the schema of this table.
-        if !self
-            .schema()
-            .logically_equivalent_names_and_types(&input.schema())
-        {
-            return plan_err!(
-                "Inserting query must have the same schema with the table. \
-                Expected: {:?}, got: {:?}",
-                self.schema()
-                    .fields()
-                    .iter()
-                    .map(|field| field.data_type())
-                    .collect::<Vec<_>>(),
-                input
-                    .schema()
-                    .fields()
-                    .iter()
-                    .map(|field| field.data_type())
-                    .collect::<Vec<_>>()
-            );
-        }
+        self.schema()
+            .logically_equivalent_names_and_types(&input.schema())?;
+
         if insert_op != InsertOp::Append {
             return not_impl_err!("{insert_op} not implemented for MemoryTable yet");
         }

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -5289,8 +5289,7 @@ async fn test_insert_into_checking() -> Result<()> {
 
     // There are three cases we need to check
     // 1. The len of the schema of the plan and the schema of the table should be the same
-    // 2. The nullable flag of the schema of the plan and the schema of the table should be the same
-    // 3. The datatype of the schema of the plan and the schema of the table should be the same
+    // 2. The datatype of the schema of the plan and the schema of the table should be the same
 
     // Test case 1:
     let write_df = session_ctx.sql("values (1, 2), (3, 4)").await.unwrap();
@@ -5308,22 +5307,6 @@ async fn test_insert_into_checking() -> Result<()> {
         }
     }
 
-    // Test case 2:
-    let write_df = session_ctx.sql("values (null), (12)").await.unwrap();
-
-    match write_df
-        .write_table("t", DataFrameWriteOptions::new())
-        .await
-    {
-        Ok(_) => {}
-        Err(e) => {
-            assert_contains!(
-                e.to_string(),
-                "Inserting query must have the same schema nullability as the table."
-            );
-        }
-    }
-
     // Setting nullable to true
     // Make sure the nullable check go through
     let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, true)]));
@@ -5334,7 +5317,7 @@ async fn test_insert_into_checking() -> Result<()> {
     let initial_table = Arc::new(MemTable::try_new(schema.clone(), vec![vec![]])?);
     session_ctx.register_table("t", initial_table.clone())?;
 
-    // Test case 3:
+    // Test case 2:
     let write_df = session_ctx.sql("values ('a123'), ('b456')").await.unwrap();
 
     match write_df

--- a/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
+++ b/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
@@ -220,10 +220,38 @@ set datafusion.execution.batch_size = 4;
 
 # Inserting into nullable table with batch_size specified above
 # to prevent creation on single in-memory batch
+
+# Test error case: the error case is expected here, as the table c5 is not nullable
+# and the query tries to insert a nullable value
 statement ok
 CREATE TABLE aggregate_test_100_null (
   c2  TINYINT NOT NULL,
   c5  INT NOT NULL,
+  c3  SMALLINT,
+  c11 FLOAT
+);
+
+statement error
+INSERT INTO aggregate_test_100_null
+SELECT
+  c2,
+  c5,
+  CASE WHEN c1 = 'e' THEN NULL ELSE c3 END as c3,
+  CASE WHEN c1 = 'a' THEN NULL ELSE c11 END as c11
+FROM aggregate_test_100;
+----
+DataFusion error: Internal error: Inserting query must have the same schema nullability as the table. Expected table field 'c5' nullability: false, got field: 'c5', nullability: true.
+This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+
+
+statement ok
+drop table aggregate_test_100_null;
+
+# Test successful insert case which c5 is nullable
+statement ok
+CREATE TABLE aggregate_test_100_null (
+  c2  TINYINT NOT NULL,
+  c5  INT,
   c3  SMALLINT,
   c11 FLOAT
 );
@@ -506,7 +534,7 @@ SELECT
   avg(c11) FILTER (WHERE c2 != 5)
 FROM aggregate_test_100 GROUP BY c1 ORDER BY c1;
 ----
-a 2.5 0.449071887467    
+a 2.5 0.449071887467
 b 2.642857142857 0.445486298629
 c 2.421052631579 0.422882117723
 d 2.125 0.518706191331

--- a/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
+++ b/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
@@ -221,36 +221,10 @@ set datafusion.execution.batch_size = 4;
 # Inserting into nullable table with batch_size specified above
 # to prevent creation on single in-memory batch
 
-# Test error case: the error case is expected here, as the table c5 is not nullable
-# and the query tries to insert a nullable value
 statement ok
 CREATE TABLE aggregate_test_100_null (
   c2  TINYINT NOT NULL,
   c5  INT NOT NULL,
-  c3  SMALLINT,
-  c11 FLOAT
-);
-
-statement error
-INSERT INTO aggregate_test_100_null
-SELECT
-  c2,
-  c5,
-  CASE WHEN c1 = 'e' THEN NULL ELSE c3 END as c3,
-  CASE WHEN c1 = 'a' THEN NULL ELSE c11 END as c11
-FROM aggregate_test_100;
-----
-DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'c5' nullability: false, got field: 'c5', nullability: true
-
-
-statement ok
-drop table aggregate_test_100_null;
-
-# Test successful insert case which c5 is nullable
-statement ok
-CREATE TABLE aggregate_test_100_null (
-  c2  TINYINT NOT NULL,
-  c5  INT,
   c3  SMALLINT,
   c11 FLOAT
 );

--- a/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
+++ b/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
@@ -240,8 +240,7 @@ SELECT
   CASE WHEN c1 = 'a' THEN NULL ELSE c11 END as c11
 FROM aggregate_test_100;
 ----
-DataFusion error: Internal error: Inserting query must have the same schema nullability as the table. Expected table field 'c5' nullability: false, got field: 'c5', nullability: true.
-This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'c5' nullability: false, got field: 'c5', nullability: true
 
 
 statement ok

--- a/datafusion/sqllogictest/test_files/insert.slt
+++ b/datafusion/sqllogictest/test_files/insert.slt
@@ -299,7 +299,7 @@ insert into table_without_values(field1) values(3);
 statement error
 insert into table_without_values(field2) values(300);
 ----
-DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'field1' nullability: false, got field: 'field1', nullability: true
+DataFusion error: Execution error: Invalid batch column at '0' has null but schema specifies non-nullable
 
 
 statement error Invalid argument error: Column 'column1' is declared as non-nullable but contains null values
@@ -374,7 +374,7 @@ insert into test_column_defaults values(1, 10, 100, 'ABC', now())
 statement error
 insert into test_column_defaults(a) values(2)
 ----
-DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+DataFusion error: Execution error: Invalid batch column at '1' has null but schema specifies non-nullable
 
 
 query I

--- a/datafusion/sqllogictest/test_files/insert.slt
+++ b/datafusion/sqllogictest/test_files/insert.slt
@@ -296,8 +296,11 @@ insert into table_without_values(field1) values(3);
 1
 
 # insert NULL values for the missing column (field1), but column is non-nullable
-statement error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'field1' nullability: false, got field: 'field1', nullability: true
+statement error
 insert into table_without_values(field2) values(300);
+----
+DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'field1' nullability: false, got field: 'field1', nullability: true
+
 
 statement error Invalid argument error: Column 'column1' is declared as non-nullable but contains null values
 insert into table_without_values values(NULL, 300);
@@ -368,8 +371,11 @@ insert into test_column_defaults values(1, 10, 100, 'ABC', now())
 ----
 1
 
-statement error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+statement error
 insert into test_column_defaults(a) values(2)
+----
+DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+
 
 query I
 insert into test_column_defaults(b) values(20)

--- a/datafusion/sqllogictest/test_files/insert.slt
+++ b/datafusion/sqllogictest/test_files/insert.slt
@@ -296,7 +296,7 @@ insert into table_without_values(field1) values(3);
 1
 
 # insert NULL values for the missing column (field1), but column is non-nullable
-statement error Execution error: Invalid batch column at '0' has null but schema specifies non-nullable
+statement error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'field1' nullability: false, got field: 'field1', nullability: true
 insert into table_without_values(field2) values(300);
 
 statement error Invalid argument error: Column 'column1' is declared as non-nullable but contains null values
@@ -358,7 +358,7 @@ statement ok
 create table test_column_defaults(
   a int,
   b int not null default null,
-  c int default 100*2+300, 
+  c int default 100*2+300,
   d text default lower('DEFAULT_TEXT'),
   e timestamp default now()
 )
@@ -368,7 +368,7 @@ insert into test_column_defaults values(1, 10, 100, 'ABC', now())
 ----
 1
 
-statement error DataFusion error: Execution error: Invalid batch column at '1' has null but schema specifies non-nullable
+statement error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'b' nullability: false, got field: 'b', nullability: true
 insert into test_column_defaults(a) values(2)
 
 query I
@@ -412,7 +412,7 @@ statement ok
 create table test_column_defaults(
   a int,
   b int not null default null,
-  c int default 100*2+300, 
+  c int default 100*2+300,
   d text default lower('DEFAULT_TEXT'),
   e timestamp default now()
 ) as values(1, 10, 100, 'ABC', now())

--- a/datafusion/sqllogictest/test_files/insert_to_external.slt
+++ b/datafusion/sqllogictest/test_files/insert_to_external.slt
@@ -61,16 +61,17 @@ LOCATION 'test_files/scratch/insert_to_external/parquet_types_partitioned/'
 PARTITIONED BY (b);
 
 #query error here because PARTITIONED BY (b) will make the b nullable to false
-query error
+query I
 insert into dictionary_encoded_parquet_partitioned
 select * from dictionary_encoded_values
 ----
-DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'b' nullability: false, got field: 'b', nullability: true
-
+2
 
 query TT
 select * from dictionary_encoded_parquet_partitioned order by (a);
 ----
+a foo
+b bar
 
 statement ok
 CREATE EXTERNAL TABLE dictionary_encoded_arrow_partitioned(
@@ -82,12 +83,11 @@ LOCATION 'test_files/scratch/insert_to_external/arrow_dict_partitioned/'
 PARTITIONED BY (b);
 
 #query error here because PARTITIONED BY (b) will make the b nullable to false
-query error
+query I
 insert into dictionary_encoded_arrow_partitioned
 select * from dictionary_encoded_values
 ----
-DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'b' nullability: false, got field: 'b', nullability: true
-
+2
 
 statement ok
 CREATE EXTERNAL TABLE dictionary_encoded_arrow_test_readback(
@@ -99,10 +99,13 @@ LOCATION 'test_files/scratch/insert_to_external/arrow_dict_partitioned/b=bar/';
 query T
 select * from dictionary_encoded_arrow_test_readback;
 ----
+b
 
 query TT
 select * from dictionary_encoded_arrow_partitioned order by (a);
 ----
+a foo
+b bar
 
 
 # test_insert_into
@@ -545,7 +548,7 @@ insert into table_without_values(field1) values(3);
 statement error
 insert into table_without_values(field2) values(300);
 ----
-DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'field1' nullability: false, got field: 'field1', nullability: true
+DataFusion error: Execution error: Invalid batch column at '0' has null but schema specifies non-nullable
 
 
 statement error Invalid argument error: Column 'column1' is declared as non-nullable but contains null values
@@ -586,7 +589,7 @@ insert into test_column_defaults values(1, 10, 100, 'ABC', now())
 statement error
 insert into test_column_defaults(a) values(2)
 ----
-DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+DataFusion error: Execution error: Invalid batch column at '1' has null but schema specifies non-nullable
 
 
 query I

--- a/datafusion/sqllogictest/test_files/insert_to_external.slt
+++ b/datafusion/sqllogictest/test_files/insert_to_external.slt
@@ -60,9 +60,12 @@ STORED AS parquet
 LOCATION 'test_files/scratch/insert_to_external/parquet_types_partitioned/'
 PARTITIONED BY (b);
 
-query error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+query error
 insert into dictionary_encoded_parquet_partitioned
 select * from dictionary_encoded_values
+----
+DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+
 
 query TT
 select * from dictionary_encoded_parquet_partitioned order by (a);
@@ -77,9 +80,12 @@ STORED AS arrow
 LOCATION 'test_files/scratch/insert_to_external/arrow_dict_partitioned/'
 PARTITIONED BY (b);
 
-query error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+query error
 insert into dictionary_encoded_arrow_partitioned
 select * from dictionary_encoded_values
+----
+DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+
 
 statement ok
 CREATE EXTERNAL TABLE dictionary_encoded_arrow_test_readback(
@@ -534,8 +540,11 @@ insert into table_without_values(field1) values(3);
 1
 
 # insert NULL values for the missing column (field1), but column is non-nullable
-statement error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'field1' nullability: false, got field: 'field1', nullability: true
+statement error
 insert into table_without_values(field2) values(300);
+----
+DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'field1' nullability: false, got field: 'field1', nullability: true
+
 
 statement error Invalid argument error: Column 'column1' is declared as non-nullable but contains null values
 insert into table_without_values values(NULL, 300);
@@ -572,8 +581,11 @@ insert into test_column_defaults values(1, 10, 100, 'ABC', now())
 ----
 1
 
-statement error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+statement error
 insert into test_column_defaults(a) values(2)
+----
+DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table. Expected table field 'b' nullability: false, got field: 'b', nullability: true
+
 
 query I
 insert into test_column_defaults(b) values(20)

--- a/datafusion/sqllogictest/test_files/insert_to_external.slt
+++ b/datafusion/sqllogictest/test_files/insert_to_external.slt
@@ -60,17 +60,13 @@ STORED AS parquet
 LOCATION 'test_files/scratch/insert_to_external/parquet_types_partitioned/'
 PARTITIONED BY (b);
 
-query I
+query error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'b' nullability: false, got field: 'b', nullability: true
 insert into dictionary_encoded_parquet_partitioned
 select * from dictionary_encoded_values
-----
-2
 
 query TT
 select * from dictionary_encoded_parquet_partitioned order by (a);
 ----
-a foo
-b bar
 
 statement ok
 CREATE EXTERNAL TABLE dictionary_encoded_arrow_partitioned(
@@ -81,11 +77,9 @@ STORED AS arrow
 LOCATION 'test_files/scratch/insert_to_external/arrow_dict_partitioned/'
 PARTITIONED BY (b);
 
-query I
+query error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'b' nullability: false, got field: 'b', nullability: true
 insert into dictionary_encoded_arrow_partitioned
 select * from dictionary_encoded_values
-----
-2
 
 statement ok
 CREATE EXTERNAL TABLE dictionary_encoded_arrow_test_readback(
@@ -97,13 +91,10 @@ LOCATION 'test_files/scratch/insert_to_external/arrow_dict_partitioned/b=bar/';
 query T
 select * from dictionary_encoded_arrow_test_readback;
 ----
-b
 
 query TT
 select * from dictionary_encoded_arrow_partitioned order by (a);
 ----
-a foo
-b bar
 
 
 # test_insert_into
@@ -543,7 +534,7 @@ insert into table_without_values(field1) values(3);
 1
 
 # insert NULL values for the missing column (field1), but column is non-nullable
-statement error Execution error: Invalid batch column at '0' has null but schema specifies non-nullable
+statement error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'field1' nullability: false, got field: 'field1', nullability: true
 insert into table_without_values(field2) values(300);
 
 statement error Invalid argument error: Column 'column1' is declared as non-nullable but contains null values
@@ -581,7 +572,7 @@ insert into test_column_defaults values(1, 10, 100, 'ABC', now())
 ----
 1
 
-statement error DataFusion error: Execution error: Invalid batch column at '1' has null but schema specifies non-nullable
+statement error DataFusion error: Error during planning: Inserting query must have the same schema nullability as the table\. Expected table field 'b' nullability: false, got field: 'b', nullability: true
 insert into test_column_defaults(a) values(2)
 
 query I

--- a/datafusion/sqllogictest/test_files/insert_to_external.slt
+++ b/datafusion/sqllogictest/test_files/insert_to_external.slt
@@ -60,6 +60,7 @@ STORED AS parquet
 LOCATION 'test_files/scratch/insert_to_external/parquet_types_partitioned/'
 PARTITIONED BY (b);
 
+#query error here because PARTITIONED BY (b) will make the b nullable to false
 query error
 insert into dictionary_encoded_parquet_partitioned
 select * from dictionary_encoded_values
@@ -80,6 +81,7 @@ STORED AS arrow
 LOCATION 'test_files/scratch/insert_to_external/arrow_dict_partitioned/'
 PARTITIONED BY (b);
 
+#query error here because PARTITIONED BY (b) will make the b nullable to false
 query error
 insert into dictionary_encoded_arrow_partitioned
 select * from dictionary_encoded_values


### PR DESCRIPTION
## Which issue does this PR close?

Describe the bug
In, https://github.com/apache/datafusion/issues/14394, it was reported that while attempting to implement a DataSink different schemas for the record batches were being given than per the RecordBatchStream.

A fix for the given example, an INSERT INTO ... VALUES query, was merged (https://github.com/apache/datafusion/pull/14472). However, this issue likely arises when the schema of the source of an INSERT statement contain fields that differ from the table schema in terms of nullability. That is, the problem is not just limited to INSERT INTO ... VALUES statements.

- Closes [#14550](https://github.com/apache/datafusion/issues/14550)

## What changes are included in this PR?
Add a separate nullable checking besides the original checking which only include the name and datatype.
Improve the error message to including more info about the error.


We will improve the checking for the 3 cases, also improve the error message.

There are three cases we need to check
   1. The len of the schema of the plan and the schema of the table should be the same
   
2 **(The nullable flag of the schema of the plan and the schema of the table should be the same)** This is not needed, we have checking in execution plan.
   
   3. The datatype of the schema of the plan and the schema of the table should be the same

## Are these changes tested?
Yes

## Are there any user-facing changes?
No
