### PR TITLE
minor: check size overflow before string repeat build

### DIFF
--- a/datafusion/functions/benches/repeat.rs
+++ b/datafusion/functions/benches/repeat.rs
@@ -159,6 +159,29 @@ fn criterion_benchmark(c: &mut Criterion) {
         );
 
         group.finish();
+
+        // REPEAT overflow
+        let repeat_times = 1073741824;
+        let mut group = c.benchmark_group(format!("repeat {} times", repeat_times));
+        group.sampling_mode(SamplingMode::Flat);
+        group.sample_size(10);
+        group.measurement_time(Duration::from_secs(10));
+
+        let args = create_args::<i32>(size, 2, repeat_times, false);
+        group.bench_function(
+            format!(
+                "repeat_string overflow [size={}, repeat_times={}]",
+                size, repeat_times
+            ),
+            |b| {
+                b.iter(|| {
+                    // TODO use invoke_with_args
+                    black_box(repeat.invoke_batch(&args, size))
+                })
+            },
+        );
+
+        group.finish();
     }
 }
 

--- a/datafusion/functions/src/string/repeat.rs
+++ b/datafusion/functions/src/string/repeat.rs
@@ -145,7 +145,7 @@ fn repeat(args: &[ArrayRef]) -> Result<ArrayRef> {
 fn repeat_impl<'a, T, S>(
     string_array: S,
     number_array: &Int64Array,
-    max_size: usize,
+    max_str_len: usize,
 ) -> Result<ArrayRef>
 where
     T: OffsetSizeTrait,
@@ -156,10 +156,10 @@ where
         |(string, number)| -> Result<(), DataFusionError> {
             match (string, number) {
                 (Some(string), Some(number)) if number >= 0 => {
-                    if number as usize * string.len() > max_size {
+                    if number as usize * string.len() > max_str_len {
                         return exec_err!(
                             "string size overflow on repeat, max size is {}, but got {}",
-                            max_size,
+                            max_str_len,
                             number as usize * string.len()
                         );
                     } else {


### PR DESCRIPTION
## Which issue does this PR close?

minor fix

## Rationale for this change

Check string size overflow before string repeat build to fail fast and save memory.

## What changes are included in this PR?

check max size in string repeat function

## Are these changes tested?

added unit test

## Are there any user-facing changes?

More friendly error message