### PR TITLE
fix: case-sensitive quoted identifiers in DELETE statements

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1711,12 +1711,8 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         let table_source = self.context_provider.get_table_source(table_ref.clone())?;
         let schema = (*table_source.schema()).clone();
         let schema = DFSchema::try_from(schema)?;
-        let scan = LogicalPlanBuilder::scan(
-            object_name_to_string(&table_name),
-            table_source,
-            None,
-        )?
-        .build()?;
+        let scan =
+            LogicalPlanBuilder::scan(table_ref.clone(), table_source, None)?.build()?;
         let mut planner_context = PlannerContext::new();
 
         let source = match predicate_expr {

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -557,6 +557,19 @@ Dml: op=[Delete] table=[person]
 }
 
 #[test]
+fn plan_delete_quoted_identifier_case_sensitive() {
+    let sql =
+        "DELETE FROM \"SomeCatalog\".\"SomeSchema\".\"UPPERCASE_test\" WHERE \"Id\" = 1";
+    let plan = r#"
+Dml: op=[Delete] table=[SomeCatalog.SomeSchema.UPPERCASE_test]
+  Filter: Id = Int64(1)
+    TableScan: SomeCatalog.SomeSchema.UPPERCASE_test
+    "#
+    .trim();
+    quick_test(sql, plan);
+}
+
+#[test]
 fn select_column_does_not_exist() {
     let sql = "SELECT doesnotexist FROM person";
     let err = logical_plan(sql).expect_err("query should have failed");


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #14583.

## Rationale for this change

When executing DELETE statements with case-sensitive quoted table names, the table name was incorrectly being normalized to lowercase during table scan creation.

The issue was introduced in commit 8b716d3 where the table name was being converted to a string before being passed to `LogicalPlanBuilder::scan()`. This caused it to be treated as a new SQL identifier and normalized again, losing case sensitivity.

## What changes are included in this PR?

- Fixed DELETE statement handling to preserve case-sensitivity of table names by passing the already available and normalized `TableReference` directly to `LogicalPlanBuilder::scan()` instead of converting to string first

## Are these changes tested?

Yes, added a new test in `datafusion/sql/tests/sql_integration.rs`:
- `plan_delete_quoted_identifier_case_sensitive()`: verifies case-sensitive identifiers handling in DELETE statements

## Are there any user-facing changes?

Users implementing ExecutionPlans for deletion will now get a correct table reference.

No breaking changes or API changes are included.