### PR TITLE
support simple/cross lateral joins

### DIFF
--- a/datafusion/optimizer/src/decorrelate.rs
+++ b/datafusion/optimizer/src/decorrelate.rs
@@ -67,7 +67,7 @@ pub struct PullUpCorrelatedExpr {
     pub pull_up_having_expr: Option<Expr>,
     /// whether we have converted a scalar aggregation into a group aggregation. When unnesting
     /// lateral joins, we need to produce a left outer join in such cases.
-    pub pulled_up_scalar_agg: bool
+    pub pulled_up_scalar_agg: bool,
 }
 
 impl Default for PullUpCorrelatedExpr {

--- a/datafusion/optimizer/src/decorrelate.rs
+++ b/datafusion/optimizer/src/decorrelate.rs
@@ -65,6 +65,9 @@ pub struct PullUpCorrelatedExpr {
     pub collected_count_expr_map: HashMap<LogicalPlan, ExprResultMap>,
     /// pull up having expr, which must be evaluated after the Join
     pub pull_up_having_expr: Option<Expr>,
+    /// whether we have converted a scalar aggregation into a group aggregation. When unnesting
+    /// lateral joins, we need to produce a left outer join in such cases.
+    pub pulled_up_scalar_agg: bool
 }
 
 impl Default for PullUpCorrelatedExpr {
@@ -85,6 +88,7 @@ impl PullUpCorrelatedExpr {
             need_handle_count_bug: false,
             collected_count_expr_map: HashMap::new(),
             pull_up_having_expr: None,
+            pulled_up_scalar_agg: false,
         }
     }
 
@@ -307,6 +311,11 @@ impl TreeNodeRewriter for PullUpCorrelatedExpr {
                         // add the unmatched rows indicator to the Aggregation's group expressions
                         missing_exprs.push(un_matched_row);
                     }
+                }
+                if aggregate.group_expr.is_empty() {
+                    // TODO: how do we handle the case where we have pulled multiple aggregations? For example,
+                    // a group agg with a scalar agg as child.
+                    self.pulled_up_scalar_agg = true;
                 }
                 let new_plan = LogicalPlanBuilder::from((*aggregate.input).clone())
                     .aggregate(missing_exprs, aggregate.aggr_expr.to_vec())?

--- a/datafusion/optimizer/src/decorrelate_lateral_join.rs
+++ b/datafusion/optimizer/src/decorrelate_lateral_join.rs
@@ -21,12 +21,11 @@ use std::collections::BTreeSet;
 
 use crate::decorrelate::PullUpCorrelatedExpr;
 use crate::optimizer::ApplyOrder;
-use crate::utils::replace_qualified_name;
 use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_expr::lit;
 
 use datafusion_common::tree_node::{
-    Transformed, TransformedResult, TreeNode, TreeNodeRecursion, TreeNodeVisitor,
+    Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
 };
 use datafusion_common::Result;
 use datafusion_expr::logical_plan::JoinType;
@@ -52,7 +51,7 @@ impl OptimizerRule for DecorrelateLateralJoin {
     fn rewrite(
         &self,
         plan: LogicalPlan,
-        config: &dyn OptimizerConfig,
+        _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
         // Find cross joins with outer column references on the right side (i.e., the apply operator).
         let LogicalPlan::Join(join) = &plan else {

--- a/datafusion/optimizer/src/decorrelate_lateral_join.rs
+++ b/datafusion/optimizer/src/decorrelate_lateral_join.rs
@@ -1,0 +1,106 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`DecorrelateLateralJoin`] decorrelates logical plans produced by lateral joins.
+
+use crate::optimizer::ApplyOrder;
+use crate::{decorrelate_predicate_subquery, OptimizerConfig, OptimizerRule};
+
+use datafusion_common::tree_node::{Transformed, TreeNodeRecursion, TreeNodeVisitor};
+use datafusion_common::Result;
+use datafusion_expr::logical_plan::JoinType;
+use datafusion_expr::LogicalPlan;
+
+/// Optimizer rule for rewriting lateral joins to joins
+#[derive(Default, Debug)]
+pub struct DecorrelateLateralJoin {}
+
+impl DecorrelateLateralJoin {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl OptimizerRule for DecorrelateLateralJoin {
+    fn supports_rewrite(&self) -> bool {
+        true
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>> {
+        // Find cross joins with outer column references on the right side (i.e., the apply operator).
+        let LogicalPlan::Join(join) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        if join.join_type != JoinType::Inner {
+            return Ok(Transformed::no(plan));
+        }
+        // TODO: this makes the rule to be quadratic to the number of nodes, in theory, we can build this property
+        // bottom-up.
+        if !plan_contains_outer_reference(&join.right) {
+            return Ok(Transformed::no(plan));
+        }
+        // The right side contains outer references, we need to decorrelate it.
+        let LogicalPlan::Subquery(subquery) = &*join.right else {
+            return Ok(Transformed::no(plan));
+        };
+        let alias = config.alias_generator();
+        let Some(new_plan) = decorrelate_predicate_subquery::build_join(
+            &join.left,
+            subquery.subquery.as_ref(),
+            None,
+            join.join_type,
+            alias.next("__lateral_sq"),
+        )?
+        else {
+            return Ok(Transformed::no(plan));
+        };
+        Ok(Transformed::new(new_plan, true, TreeNodeRecursion::Jump))
+    }
+
+    fn name(&self) -> &str {
+        "decorrelate_lateral_join"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::TopDown)
+    }
+}
+
+fn plan_contains_outer_reference(plan: &LogicalPlan) -> bool {
+    struct Visitor {
+        contains: bool,
+    }
+    impl<'n> TreeNodeVisitor<'n> for Visitor {
+        type Node = LogicalPlan;
+        fn f_down(&mut self, plan: &'n LogicalPlan) -> Result<TreeNodeRecursion> {
+            if plan.contains_outer_reference() {
+                self.contains = true;
+                Ok(TreeNodeRecursion::Stop)
+            } else {
+                Ok(TreeNodeRecursion::Continue)
+            }
+        }
+    }
+    let mut visitor = Visitor { contains: false };
+    plan.visit_with_subqueries(&mut visitor).unwrap();
+    visitor.contains
+}

--- a/datafusion/optimizer/src/decorrelate_lateral_join.rs
+++ b/datafusion/optimizer/src/decorrelate_lateral_join.rs
@@ -60,10 +60,8 @@ impl OptimizerRule for DecorrelateLateralJoin {
         if join.join_type != JoinType::Inner {
             return Ok(Transformed::no(plan));
         }
-        // TODO: this makes the rule to be quadratic to the number of nodes, in theory, we can build this property
-        // bottom-up.
         if !plan_contains_outer_reference(&join.right) {
-            return Ok(Transformed::no(plan));
+            return Ok(Transformed::new(plan, false, TreeNodeRecursion::Jump));
         }
         // The right side contains outer references, we need to decorrelate it.
         let LogicalPlan::Subquery(subquery) = &*join.right else {

--- a/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
+++ b/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
@@ -311,7 +311,7 @@ fn mark_join(
     )
 }
 
-pub(crate) fn build_join(
+fn build_join(
     left: &LogicalPlan,
     subquery: &LogicalPlan,
     in_predicate_opt: Option<Expr>,

--- a/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
+++ b/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
@@ -311,7 +311,7 @@ fn mark_join(
     )
 }
 
-fn build_join(
+pub(crate) fn build_join(
     left: &LogicalPlan,
     subquery: &LogicalPlan,
     in_predicate_opt: Option<Expr>,

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -34,6 +34,7 @@
 pub mod analyzer;
 pub mod common_subexpr_eliminate;
 pub mod decorrelate;
+pub mod decorrelate_lateral_join;
 pub mod decorrelate_predicate_subquery;
 pub mod eliminate_cross_join;
 pub mod eliminate_duplicated_expr;

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -33,6 +33,7 @@ use datafusion_common::{internal_err, DFSchema, DataFusionError, HashSet, Result
 use datafusion_expr::logical_plan::LogicalPlan;
 
 use crate::common_subexpr_eliminate::CommonSubexprEliminate;
+use crate::decorrelate_lateral_join::DecorrelateLateralJoin;
 use crate::decorrelate_predicate_subquery::DecorrelatePredicateSubquery;
 use crate::eliminate_cross_join::EliminateCrossJoin;
 use crate::eliminate_duplicated_expr::EliminateDuplicatedExpr;
@@ -248,6 +249,7 @@ impl Optimizer {
             Arc::new(EliminateJoin::new()),
             Arc::new(DecorrelatePredicateSubquery::new()),
             Arc::new(ScalarSubqueryToJoin::new()),
+            Arc::new(DecorrelateLateralJoin::new()),
             Arc::new(ExtractEquijoinPredicate::new()),
             Arc::new(EliminateDuplicatedExpr::new()),
             Arc::new(EliminateFilter::new()),

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -187,6 +187,7 @@ logical_plan after replace_distinct_aggregate SAME TEXT AS ABOVE
 logical_plan after eliminate_join SAME TEXT AS ABOVE
 logical_plan after decorrelate_predicate_subquery SAME TEXT AS ABOVE
 logical_plan after scalar_subquery_to_join SAME TEXT AS ABOVE
+logical_plan after decorrelate_lateral_join SAME TEXT AS ABOVE
 logical_plan after extract_equijoin_predicate SAME TEXT AS ABOVE
 logical_plan after eliminate_duplicated_expr SAME TEXT AS ABOVE
 logical_plan after eliminate_filter SAME TEXT AS ABOVE
@@ -212,6 +213,7 @@ logical_plan after replace_distinct_aggregate SAME TEXT AS ABOVE
 logical_plan after eliminate_join SAME TEXT AS ABOVE
 logical_plan after decorrelate_predicate_subquery SAME TEXT AS ABOVE
 logical_plan after scalar_subquery_to_join SAME TEXT AS ABOVE
+logical_plan after decorrelate_lateral_join SAME TEXT AS ABOVE
 logical_plan after extract_equijoin_predicate SAME TEXT AS ABOVE
 logical_plan after eliminate_duplicated_expr SAME TEXT AS ABOVE
 logical_plan after eliminate_filter SAME TEXT AS ABOVE

--- a/datafusion/sqllogictest/test_files/join.slt.part
+++ b/datafusion/sqllogictest/test_files/join.slt.part
@@ -1406,56 +1406,49 @@ FROM t0,
 LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
 ----
 logical_plan
-01)Projection: t0.v0, t0.v1, sum(t1.v1)
-02)--Left Join: t0.v0 = t1.v0
-03)----TableScan: t0 projection=[v0, v1]
-04)----Projection: sum(t1.v1), t1.v0
-05)------Aggregate: groupBy=[[t1.v0]], aggr=[[sum(t1.v1)]]
-06)--------TableScan: t1 projection=[v0, v1]
-physical_plan
-01)ProjectionExec: expr=[v0@1 as v0, v1@2 as v1, sum(t1.v1)@0 as sum(t1.v1)]
-02)--CoalesceBatchesExec: target_batch_size=8192
-03)----HashJoinExec: mode=CollectLeft, join_type=Right, on=[(v0@1, v0@0)], projection=[sum(t1.v1)@0, v0@2, v1@3]
-04)------CoalescePartitionsExec
-05)--------ProjectionExec: expr=[sum(t1.v1)@1 as sum(t1.v1), v0@0 as v0]
-06)----------AggregateExec: mode=FinalPartitioned, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
-07)------------CoalesceBatchesExec: target_batch_size=8192
-08)--------------RepartitionExec: partitioning=Hash([v0@0], 4), input_partitions=4
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-10)------------------AggregateExec: mode=Partial, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
-11)--------------------DataSourceExec: partitions=1, partition_sizes=[1]
-12)------DataSourceExec: partitions=1, partition_sizes=[1]
+01)Cross Join: 
+02)--TableScan: t0 projection=[v0, v1]
+03)--Subquery:
+04)----Aggregate: groupBy=[[]], aggr=[[sum(t1.v1)]]
+05)------Projection: t1.v1
+06)--------Filter: outer_ref(t0.v0) = t1.v0
+07)----------TableScan: t1 projection=[v0, v1]
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(Int64, Column { relation: Some(Bare { table: "t0" }), name: "v0" })
 
-query III
+query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(Int64, Column \{ relation: Some\(Bare \{ table: "t0" \}\), name: "v0" \}\)
 SELECT *
 FROM t0,
 LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
-----
-1 1 1
-1 2 1
-3 3 7
-4 4 NULL
 
 query TT
 explain SELECT * FROM t0, LATERAL (SELECT * FROM t1 WHERE t0.v0 = t1.v0);
 ----
 logical_plan
-01)Inner Join: t0.v0 = t1.v0
+01)Cross Join: 
 02)--TableScan: t0 projection=[v0, v1]
-03)--TableScan: t1 projection=[v0, v1]
-physical_plan
-01)CoalesceBatchesExec: target_batch_size=8192
-02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(v0@0, v0@0)]
-03)----DataSourceExec: partitions=1, partition_sizes=[1]
-04)----DataSourceExec: partitions=1, partition_sizes=[1]
+03)--Subquery:
+04)----Filter: outer_ref(t0.v0) = t1.v0
+05)------TableScan: t1 projection=[v0, v1]
+physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(Int64, Column { relation: Some(Bare { table: "t0" }), name: "v0" })
+
+query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(Int64, Column \{ relation: Some\(Bare \{ table: "t0" \}\), name: "v0" \}\)
+SELECT * FROM t0, LATERAL (SELECT * FROM t1 WHERE t0.v0 = t1.v0);
+
+query III
+SELECT * FROM t0, LATERAL (SELECT 1);
+----
+1 1 1
+1 2 1
+3 3 1
+4 4 1
 
 query IIII
-SELECT * FROM t0, LATERAL (SELECT * FROM t1 WHERE t0.v0 = t1.v0);
+SELECT * FROM t0, LATERAL (SELECT * FROM t1 WHERE t1.v0 = 1);
 ----
 1 1 1 1
 1 2 1 1
-3 3 3 2
-3 3 3 5
+3 3 1 1
+4 4 1 1
 
 statement ok
 drop table t1;

--- a/datafusion/sqllogictest/test_files/join.slt.part
+++ b/datafusion/sqllogictest/test_files/join.slt.part
@@ -1406,33 +1406,56 @@ FROM t0,
 LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
 ----
 logical_plan
-01)Cross Join: 
-02)--TableScan: t0 projection=[v0, v1]
-03)--Subquery:
-04)----Aggregate: groupBy=[[]], aggr=[[sum(t1.v1)]]
-05)------Projection: t1.v1
-06)--------Filter: outer_ref(t0.v0) = t1.v0
-07)----------TableScan: t1 projection=[v0, v1]
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(Int64, Column { relation: Some(Bare { table: "t0" }), name: "v0" })
+01)Projection: t0.v0, t0.v1, sum(t1.v1)
+02)--Left Join: t0.v0 = t1.v0
+03)----TableScan: t0 projection=[v0, v1]
+04)----Projection: sum(t1.v1), t1.v0
+05)------Aggregate: groupBy=[[t1.v0]], aggr=[[sum(t1.v1)]]
+06)--------TableScan: t1 projection=[v0, v1]
+physical_plan
+01)ProjectionExec: expr=[v0@1 as v0, v1@2 as v1, sum(t1.v1)@0 as sum(t1.v1)]
+02)--CoalesceBatchesExec: target_batch_size=8192
+03)----HashJoinExec: mode=CollectLeft, join_type=Right, on=[(v0@1, v0@0)], projection=[sum(t1.v1)@0, v0@2, v1@3]
+04)------CoalescePartitionsExec
+05)--------ProjectionExec: expr=[sum(t1.v1)@1 as sum(t1.v1), v0@0 as v0]
+06)----------AggregateExec: mode=FinalPartitioned, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
+07)------------CoalesceBatchesExec: target_batch_size=8192
+08)--------------RepartitionExec: partitioning=Hash([v0@0], 4), input_partitions=4
+09)----------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+10)------------------AggregateExec: mode=Partial, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
+11)--------------------DataSourceExec: partitions=1, partition_sizes=[1]
+12)------DataSourceExec: partitions=1, partition_sizes=[1]
 
-query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(Int64, Column \{ relation: Some\(Bare \{ table: "t0" \}\), name: "v0" \}\)
+query III
 SELECT *
 FROM t0,
 LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
+----
+1 1 1
+1 2 1
+3 3 7
+4 4 NULL
 
 query TT
 explain SELECT * FROM t0, LATERAL (SELECT * FROM t1 WHERE t0.v0 = t1.v0);
 ----
 logical_plan
-01)Cross Join: 
+01)Inner Join: t0.v0 = t1.v0
 02)--TableScan: t0 projection=[v0, v1]
-03)--Subquery:
-04)----Filter: outer_ref(t0.v0) = t1.v0
-05)------TableScan: t1 projection=[v0, v1]
-physical_plan_error This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn(Int64, Column { relation: Some(Bare { table: "t0" }), name: "v0" })
+03)--TableScan: t1 projection=[v0, v1]
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=8192
+02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(v0@0, v0@0)]
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
+04)----DataSourceExec: partitions=1, partition_sizes=[1]
 
-query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn\(Int64, Column \{ relation: Some\(Bare \{ table: "t0" \}\), name: "v0" \}\)
+query IIII
 SELECT * FROM t0, LATERAL (SELECT * FROM t1 WHERE t0.v0 = t1.v0);
+----
+1 1 1 1
+1 2 1 1
+3 3 3 2
+3 3 3 5
 
 query III
 SELECT * FROM t0, LATERAL (SELECT 1);

--- a/datafusion/sqllogictest/test_files/join.slt.part
+++ b/datafusion/sqllogictest/test_files/join.slt.part
@@ -1395,7 +1395,7 @@ statement ok
 CREATE TABLE t0(v0 BIGINT, v1 BIGINT);
 
 statement ok
-INSERT INTO t0(v0, v1) VALUES (1, 1), (1, 2), (3, 3);
+INSERT INTO t0(v0, v1) VALUES (1, 1), (1, 2), (3, 3), (4, 4);
 
 statement ok
 INSERT INTO t1(v0, v1) VALUES (1, 1), (3, 2), (3, 5);
@@ -1407,43 +1407,15 @@ LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
 ----
 logical_plan
 01)Projection: t0.v0, t0.v1, sum(t1.v1)
-02)--Inner Join: t0.v0 = __lateral_sq_1.v0
+02)--Left Join: t0.v0 = t1.v0
 03)----TableScan: t0 projection=[v0, v1]
-04)----SubqueryAlias: __lateral_sq_1
-05)------Projection: sum(t1.v1), t1.v0
-06)--------Aggregate: groupBy=[[t1.v0]], aggr=[[sum(t1.v1)]]
-07)----------TableScan: t1 projection=[v0, v1]
+04)----Projection: sum(t1.v1), t1.v0
+05)------Aggregate: groupBy=[[t1.v0]], aggr=[[sum(t1.v1)]]
+06)--------TableScan: t1 projection=[v0, v1]
 physical_plan
 01)ProjectionExec: expr=[v0@1 as v0, v1@2 as v1, sum(t1.v1)@0 as sum(t1.v1)]
 02)--CoalesceBatchesExec: target_batch_size=8192
-03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(v0@1, v0@0)], projection=[sum(t1.v1)@0, v0@2, v1@3]
-04)------CoalescePartitionsExec
-05)--------ProjectionExec: expr=[sum(t1.v1)@1 as sum(t1.v1), v0@0 as v0]
-06)----------AggregateExec: mode=FinalPartitioned, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
-07)------------CoalesceBatchesExec: target_batch_size=8192
-08)--------------RepartitionExec: partitioning=Hash([v0@0], 4), input_partitions=4
-09)----------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-10)------------------AggregateExec: mode=Partial, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
-11)--------------------DataSourceExec: partitions=1, partition_sizes=[1]
-12)------DataSourceExec: partitions=1, partition_sizes=[1]
-
-query TT
-explain SELECT *
-FROM t0,
-LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
-----
-logical_plan
-01)Projection: t0.v0, t0.v1, sum(t1.v1)
-02)--Inner Join: t0.v0 = __lateral_sq_1.v0
-03)----TableScan: t0 projection=[v0, v1]
-04)----SubqueryAlias: __lateral_sq_1
-05)------Projection: sum(t1.v1), t1.v0
-06)--------Aggregate: groupBy=[[t1.v0]], aggr=[[sum(t1.v1)]]
-07)----------TableScan: t1 projection=[v0, v1]
-physical_plan
-01)ProjectionExec: expr=[v0@1 as v0, v1@2 as v1, sum(t1.v1)@0 as sum(t1.v1)]
-02)--CoalesceBatchesExec: target_batch_size=8192
-03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(v0@1, v0@0)], projection=[sum(t1.v1)@0, v0@2, v1@3]
+03)----HashJoinExec: mode=CollectLeft, join_type=Right, on=[(v0@1, v0@0)], projection=[sum(t1.v1)@0, v0@2, v1@3]
 04)------CoalescePartitionsExec
 05)--------ProjectionExec: expr=[sum(t1.v1)@1 as sum(t1.v1), v0@0 as v0]
 06)----------AggregateExec: mode=FinalPartitioned, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
@@ -1462,6 +1434,28 @@ LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
 1 1 1
 1 2 1
 3 3 7
+4 4 NULL
+
+query TT
+explain SELECT * FROM t0, LATERAL (SELECT * FROM t1 WHERE t0.v0 = t1.v0);
+----
+logical_plan
+01)Inner Join: t0.v0 = t1.v0
+02)--TableScan: t0 projection=[v0, v1]
+03)--TableScan: t1 projection=[v0, v1]
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=8192
+02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(v0@0, v0@0)]
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
+04)----DataSourceExec: partitions=1, partition_sizes=[1]
+
+query IIII
+SELECT * FROM t0, LATERAL (SELECT * FROM t1 WHERE t0.v0 = t1.v0);
+----
+1 1 1 1
+1 2 1 1
+3 3 3 2
+3 3 3 5
 
 statement ok
 drop table t1;

--- a/datafusion/sqllogictest/test_files/join.slt.part
+++ b/datafusion/sqllogictest/test_files/join.slt.part
@@ -1387,3 +1387,84 @@ set datafusion.execution.target_partitions = 4;
 
 statement ok
 set datafusion.optimizer.repartition_joins = false;
+
+statement ok
+CREATE TABLE t1(v0 BIGINT, v1 BIGINT);
+
+statement ok
+CREATE TABLE t0(v0 BIGINT, v1 BIGINT);
+
+statement ok
+INSERT INTO t0(v0, v1) VALUES (1, 1), (1, 2), (3, 3);
+
+statement ok
+INSERT INTO t1(v0, v1) VALUES (1, 1), (3, 2), (3, 5);
+
+query TT
+explain SELECT *
+FROM t0,
+LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
+----
+logical_plan
+01)Projection: t0.v0, t0.v1, sum(t1.v1)
+02)--Inner Join: t0.v0 = __lateral_sq_1.v0
+03)----TableScan: t0 projection=[v0, v1]
+04)----SubqueryAlias: __lateral_sq_1
+05)------Projection: sum(t1.v1), t1.v0
+06)--------Aggregate: groupBy=[[t1.v0]], aggr=[[sum(t1.v1)]]
+07)----------TableScan: t1 projection=[v0, v1]
+physical_plan
+01)ProjectionExec: expr=[v0@1 as v0, v1@2 as v1, sum(t1.v1)@0 as sum(t1.v1)]
+02)--CoalesceBatchesExec: target_batch_size=8192
+03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(v0@1, v0@0)], projection=[sum(t1.v1)@0, v0@2, v1@3]
+04)------CoalescePartitionsExec
+05)--------ProjectionExec: expr=[sum(t1.v1)@1 as sum(t1.v1), v0@0 as v0]
+06)----------AggregateExec: mode=FinalPartitioned, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
+07)------------CoalesceBatchesExec: target_batch_size=8192
+08)--------------RepartitionExec: partitioning=Hash([v0@0], 4), input_partitions=4
+09)----------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+10)------------------AggregateExec: mode=Partial, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
+11)--------------------DataSourceExec: partitions=1, partition_sizes=[1]
+12)------DataSourceExec: partitions=1, partition_sizes=[1]
+
+query TT
+explain SELECT *
+FROM t0,
+LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
+----
+logical_plan
+01)Projection: t0.v0, t0.v1, sum(t1.v1)
+02)--Inner Join: t0.v0 = __lateral_sq_1.v0
+03)----TableScan: t0 projection=[v0, v1]
+04)----SubqueryAlias: __lateral_sq_1
+05)------Projection: sum(t1.v1), t1.v0
+06)--------Aggregate: groupBy=[[t1.v0]], aggr=[[sum(t1.v1)]]
+07)----------TableScan: t1 projection=[v0, v1]
+physical_plan
+01)ProjectionExec: expr=[v0@1 as v0, v1@2 as v1, sum(t1.v1)@0 as sum(t1.v1)]
+02)--CoalesceBatchesExec: target_batch_size=8192
+03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(v0@1, v0@0)], projection=[sum(t1.v1)@0, v0@2, v1@3]
+04)------CoalescePartitionsExec
+05)--------ProjectionExec: expr=[sum(t1.v1)@1 as sum(t1.v1), v0@0 as v0]
+06)----------AggregateExec: mode=FinalPartitioned, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
+07)------------CoalesceBatchesExec: target_batch_size=8192
+08)--------------RepartitionExec: partitioning=Hash([v0@0], 4), input_partitions=4
+09)----------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+10)------------------AggregateExec: mode=Partial, gby=[v0@0 as v0], aggr=[sum(t1.v1)]
+11)--------------------DataSourceExec: partitions=1, partition_sizes=[1]
+12)------DataSourceExec: partitions=1, partition_sizes=[1]
+
+query III
+SELECT *
+FROM t0,
+LATERAL (SELECT sum(v1) FROM t1 WHERE t0.v0 = t1.v0);
+----
+1 1 1
+1 2 1
+3 3 7
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t0;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- part of https://github.com/apache/datafusion/issues/10048

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add partial lateral join support.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The cross lateral join logical plan is like:

```
CrossJoin
  Left
  Right (with outer column reference)
```

We added a new rule `DecorrelateLateralJoin` to handle this case. We reuse the scalar/predicate subquery handling code for decorrelating lateral joins.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

New test case in sqllogictest.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Some lateral joins are now supported. Note that we still have some of them in `joins.slt` that cannot be planned, and can be fixed gradually.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
