### PR TITLE
cli: Add nested expressions

### DIFF
--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -37,6 +37,7 @@ datafusion = { workspace = true, features = [
     "avro",
     "crypto_expressions",
     "datetime_expressions",
+    "nested_expressions",
     "encoding_expressions",
     "parquet",
     "recursive_protection",

--- a/datafusion-cli/tests/cli_integration.rs
+++ b/datafusion-cli/tests/cli_integration.rs
@@ -47,6 +47,10 @@ fn init() {
     ["--command", "show datafusion.execution.batch_size", "--format", "json", "-q", "-b", "1"],
     "[{\"name\":\"datafusion.execution.batch_size\",\"value\":\"1\"}]\n"
 )]
+#[case::exec_from_commands(
+    ["--command", "select array_slice([1,2,3], 1, 2)", "--format", "json", "-q"],
+    "[{\"make_array(Int64(1),Int64(2),Int64(3))[Int64(1):Int64(2)]\":[1,2]}]\n"
+)]
 #[test]
 fn cli_quick_test<'a>(
     #[case] args: impl IntoIterator<Item = &'a str>,


### PR DESCRIPTION
## Which issue does this PR close?

None

## Rationale for this change

Without this I am unable to use nested expressions with the CLI.

## What changes are included in this PR?

The `nested_expressions` feature is added to the CLI

## Are these changes tested?

No, but it's only a cargo.toml change.

## Are there any user-facing changes?

No
