### PR TITLE
Disable extended tests (`extended_tests`) that are failing on runner

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -52,28 +52,30 @@ jobs:
           cargo check --profile ci --all-targets
           cargo clean
 
-  # Run extended tests (with feature 'extended_tests')
-  linux-test-extended:
-    name: cargo test 'extended_tests' (amd64)
-    needs: linux-build-lib
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 1
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-      - name: Run tests (excluding doctests)
-        run: cargo test --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --workspace --lib --tests --bins --features avro,json,backtrace,extended_tests
-      - name: Verify Working Directory Clean
-        run: git diff --exit-code
-      - name: Cleanup
-        run: cargo clean
+#  # Run extended tests (with feature 'extended_tests')
+#  # Disabling as it is running out of disk space
+#  # see https://github.com/apache/datafusion/issues/14576
+#  linux-test-extended:
+#    name: cargo test 'extended_tests' (amd64)
+#    needs: linux-build-lib
+#    runs-on: ubuntu-latest
+#    container:
+#      image: amd64/rust
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          submodules: true
+#          fetch-depth: 1
+#      - name: Setup Rust toolchain
+#        uses: ./.github/actions/setup-builder
+#        with:
+#          rust-version: stable
+#      - name: Run tests (excluding doctests)
+#        run: cargo test --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --workspace --lib --tests --bins --features avro,json,backtrace,extended_tests
+#      - name: Verify Working Directory Clean
+#        run: git diff --exit-code
+#      - name: Cleanup
+#        run: cargo clean
 
   # Check answers are correct when hash values collide
   hash-collisions:


### PR DESCRIPTION
## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/14576

## Rationale for this change

These tests are failing on main due to out of disk space (see https://github.com/apache/datafusion/issues/14576)

Here is an example: https://github.com/apache/datafusion/actions/runs/13261520752/job/37019301867
![Screenshot 2025-02-11 at 6 49 44 AM](https://github.com/user-attachments/assets/64eb75b7-f16d-4394-a62f-55a84f3b4b12)

## What changes are included in this PR?

1. Disable failing tests

## Are these changes tested?

No

## Are there any user-facing changes?

Hopefully we'll get the tests passing again on main
