### PR TITLE
Revert modification of build dependency

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -30,7 +30,7 @@ runs:
       run: |
         RETRY=("ci/scripts/retry" timeout 120)
         "${RETRY[@]}" apt-get update
-        "${RETRY[@]}" apt-get install -y protobuf-compiler cmake
+        "${RETRY[@]}" apt-get install -y protobuf-compiler
     - name: Setup Rust toolchain
       shell: bash
       # rustfmt is needed for the substrait build script


### PR DESCRIPTION
## Which issue does this PR close?


- Closes [#14435](https://github.com/apache/datafusion/issues/14435)

## Rationale for this change

Remove unused build dependency `cmake`

## What changes are included in this PR?

```
.github/actions/setup-builder/action.yaml
```

## Are these changes tested?

Yes

## Are there any user-facing changes?

No