### PR TITLE
cli: Add nested expressions

### DIFF
--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -38,6 +38,7 @@ datafusion = { workspace = true, features = [
     "crypto_expressions",
     "datetime_expressions",
     "encoding_expressions",
+    "nested_expressions",
     "parquet",
     "recursive_protection",
     "regex_expressions",


### PR DESCRIPTION
This commit adds nested expressions to the CLI by default so users can run functions like `array_slice` and other nested expressions.

## Which issue does this PR close?

None

## Rationale for this change

It can be confusing for users that nested expressions don't work in the CLI by default. The error message is not that helpful either, for example:

```
DataFusion CLI v45.0.0
> select array_slice([1,2,3], 1, 2);
Error during planning: Invalid function 'array_slice'.
Did you mean 'array_agg'?
```

This PR enables them by default to avoid this confusion.

## Are these changes tested?

No

## Are there any user-facing changes?

No
