### PR TITLE
chore(deps): group `prost` and `pbjson` dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,12 @@ updates:
       # arrow is bumped manually
       - dependency-name: "arrow*"
         update-types: ["version-update:semver-major"]
+    groups:
+      proto:
+        applies-to: version-updates
+        patterns:
+          - "prost*"
+          - "pbjson*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Which issue does this PR close?

None.

## Rationale for this change

Groups PRs like the ones listed into one:
- https://github.com/apache/datafusion/pull/14621
- https://github.com/apache/datafusion/pull/14622
- https://github.com/apache/datafusion/pull/14623

## What changes are included in this PR?

Dependabot config update to group `prost*` and `pbjson*` updates.

## Are these changes tested?

No.

## Are there any user-facing changes?

No.