### PR TITLE
Minor: remove unused `AutoFinishBzEncoder`

### DIFF
--- a/datafusion/core/src/test/mod.rs
+++ b/datafusion/core/src/test/mod.rs
@@ -96,28 +96,6 @@ pub fn scan_partitioned_csv(
     Ok(config.new_exec())
 }
 
-/// Auto finish the wrapped BzEncoder on drop
-#[cfg(feature = "compression")]
-struct AutoFinishBzEncoder<W: Write>(BzEncoder<W>);
-
-#[cfg(feature = "compression")]
-impl<W: Write> Write for AutoFinishBzEncoder<W> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.write(buf)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.0.flush()
-    }
-}
-
-#[cfg(feature = "compression")]
-impl<W: Write> Drop for AutoFinishBzEncoder<W> {
-    fn drop(&mut self) {
-        let _ = self.0.try_finish();
-    }
-}
-
 /// Returns file groups [`Vec<Vec<PartitionedFile>>`] for scanning `partitions` of `filename`
 pub fn partitioned_file_groups(
     path: &str,
@@ -159,10 +137,9 @@ pub fn partitioned_file_groups(
                 Box::new(encoder)
             }
             #[cfg(feature = "compression")]
-            FileCompressionType::BZIP2 => Box::new(AutoFinishBzEncoder(BzEncoder::new(
-                file,
-                BzCompression::default(),
-            ))),
+            FileCompressionType::BZIP2 => {
+                Box::new(BzEncoder::new(file, BzCompression::default()))
+            }
             #[cfg(not(feature = "compression"))]
             FileCompressionType::GZIP
             | FileCompressionType::BZIP2


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Follow-up of [chore(deps): bump bzip2 from 0.5.0 to 0.5.1 #14620](https://github.com/apache/datafusion/pull/14620)

The auto-finish on drop feature has been added back in bzip2 0.5.1, so there's no need to keep our implementation.
> [3f3bb54](https://github.com/trifectatechfoundation/bzip2-rs/commit/3f3bb54746ff1afee6a6039018dc9c6c2d832b7b) Add finisher drop implementation to BzEncoder
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
