### PR TITLE
Early exit on column normalisation to improve DataFrame performance

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -1801,7 +1801,8 @@ impl DataFrame {
             .iter()
             .map(|(qualifier, field)| {
                 if qualifier.eq(&qualifier_rename) && field.as_ref() == field_rename {
-                    col(Column::from((qualifier, field))).alias(new_name)
+                    col(Column::from((qualifier, field)))
+                        .alias_qualified(qualifier.cloned(), new_name)
                 } else {
                     col(Column::from((qualifier, field)))
                 }

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -835,7 +835,8 @@ impl LogicalPlanBuilder {
         column: impl Into<Column>,
     ) -> Result<Column> {
         let column = column.into();
-        if column.relation.is_some() { // column is already normalized
+        if column.relation.is_some() {
+            // column is already normalized
             return Ok(column);
         }
 

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -834,10 +834,15 @@ impl LogicalPlanBuilder {
         plan: &LogicalPlan,
         column: impl Into<Column>,
     ) -> Result<Column> {
+        let column = column.into();
+        if column.relation.is_some() { // column is already normalized
+            return Ok(column);
+        }
+
         let schema = plan.schema();
         let fallback_schemas = plan.fallback_normalize_schemas();
         let using_columns = plan.using_columns()?;
-        column.into().normalize_with_schemas_and_ambiguity_check(
+        column.normalize_with_schemas_and_ambiguity_check(
             &[&[schema], &fallback_schemas],
             &using_columns,
         )


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/datafusion/issues/14563 (probably more prs to come)


## Rationale for this change

Now, when normalizing the column, we always generate `plan.using_columns()` which is recursive and very expensive - and [may not be needed](https://github.com/apache/datafusion/blob/980931c5a70b8b08c918195803145f64f1ec901f/datafusion/common/src/column.rs#L224) if column is already normalized 

## What changes are included in this PR?

Exit early if column already has a relation set. Also, set the relation when `with_column_renamed` is called

## Are these changes tested?

Extended a test to assert references

## Are there any user-facing changes?

No