### PR TITLE
[TEST] Test running with different toolchains

### DIFF
--- a/docs/source/contributor-guide/howtos.md
+++ b/docs/source/contributor-guide/howtos.md
@@ -19,6 +19,12 @@
 
 # HOWTOs
 
+## How to update the version of Rust used in CI tests
+
+- Make a PR to update the [rust-toolchain] file in the root of the repository:
+
+[rust-toolchain]: https://github.com/apache/datafusion/blob/main/rust-toolchain.toml
+
 ## How to add a new scalar function
 
 Below is a checklist of what you need to do to add a new scalar function to DataFusion:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file specifies the default version of Rust used
+# to compile this workspace and run CI jobs.
+
+[toolchain]
+channel = "1.84.1"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,5 +19,5 @@
 # to compile this workspace and run CI jobs.
 
 [toolchain]
-channel = "1.84.0"
+channel = "1.83.0"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,5 +19,5 @@
 # to compile this workspace and run CI jobs.
 
 [toolchain]
-channel = "1.84.1"
+channel = "1.84.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This is a PR to test that modifying the `rust-toolchain.toml` file will really use a different toolchain

Aka it is a test for this PR: 
- https://github.com/apache/datafusion/pull/14655

Looks promising:
https://github.com/apache/datafusion/actions/runs/13316965071/job/37193269066?pr=14656#step:4:114

```

info: using existing install for 'stable-x86_64-unknown-linux-gnu'
info: default toolchain set to 'stable-x86_64-unknown-linux-gnu'

  stable-x86_64-unknown-linux-gnu unchanged - rustc 1.84.1 (e71f9a9a9 2025-01-27)

info: note that the toolchain '1.84.0-x86_64-unknown-linux-gnu' is currently in use (overridden by '/__w/datafusion/datafusion/rust-toolchain.toml')
+ timeout 120 rustup component add rustfmt
info: syncing channel updates for '1.84.0-x86_64-unknown-linux-gnu'
```