### PR TITLE
Fix CI doctests on main

### DIFF
--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -4349,7 +4349,7 @@ Functions to work with the union data type, also know as tagged unions, variant 
 
 Returns the value of the given field in the union when selected, or NULL otherwise.
 
-```
+```sql
 union_extract(union, field_name)
 ```
 


### PR DESCRIPTION
## Which issue does this PR close?


 A small logical conflict came in from
- https://github.com/apache/datafusion/pull/12116


## Rationale for this change

CI is broken on main after merge of above

Example: https://github.com/apache/datafusion/actions/runs/13331376256/job/37236061495



## What changes are included in this PR?

I reran `./dev/update_function_docs.sh` and checked in the result

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
