### PR TITLE
Update GitHub CI run image for license check job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ on:
 jobs:
   # Check license header
   license-header-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Check License Header
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub runs include this warning

    The Ubuntu-20.04 brownout takes place from 2025-02-01.
    For more details, see https://github.com/actions/runner-images/issues/11101

`test-datafusion-pyarrow` doesn't work on the latest image, needs to be
fixed separately.