### PR TITLE
Speed up `uuid` UDF (40x faster)

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -110,6 +110,11 @@ required-features = ["encoding_expressions"]
 
 [[bench]]
 harness = false
+name = "uuid"
+required-features = ["string_expressions"]
+
+[[bench]]
+harness = false
 name = "regx"
 required-features = ["regex_expressions"]
 

--- a/datafusion/functions/benches/uuid.rs
+++ b/datafusion/functions/benches/uuid.rs
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate criterion;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datafusion_functions::string;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let uuid = string::uuid();
+    c.bench_function("uuid", |b| {
+        b.iter(|| black_box(uuid.invoke_batch(&[], 1024)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -720,6 +720,14 @@ select count(distinct u) from uuid_table;
 ----
 2
 
+# must be valid uuidv4 format
+query B
+SELECT REGEXP_LIKE(uuid(),
+       '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+       AS is_valid;
+----
+true
+
 statement ok
 drop table uuid_table
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
It seems to be faster to generate random u128's in bulk, and then converting them to Uuids.

However, we are not exactly using the same random number generator. `Uuid::new_v4()` is using `getrandom`. In this PR, we are using `rand`.

```
$ cargo bench -p datafusion-functions --bench uuid
uuid                    time:   [19.516 µs 19.541 µs 19.565 µs]
                        change: [-97.652% -97.648% -97.643%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes, existing tests. And added a new test for UUIDv4 format.

## Are there any user-facing changes?

Yes, faster uuid() UDF.
