### PR TITLE
Add an example of boundary analysis simple expressions.

### DIFF
--- a/datafusion-examples/examples/expr_api.rs
+++ b/datafusion-examples/examples/expr_api.rs
@@ -321,7 +321,6 @@ fn boundary_analysis_and_selectivity_demo() -> Result<()> {
     )?;
 
     // The analysis will return better bounds thanks to the column statistics.
-    // TODO:
     assert_eq!(
         analysis
             .boundaries

--- a/datafusion-examples/examples/expr_api.rs
+++ b/datafusion-examples/examples/expr_api.rs
@@ -322,10 +322,11 @@ fn boundary_analysis_and_selectivity_demo() -> Result<()> {
 
     // The analysis will return better bounds thanks to the column statistics.
     assert_eq!(
-        analysis
-            .boundaries
-            .get(0)
-            .and_then(|boundary| Some(boundary.interval.clone().unwrap().into_bounds())),
+        analysis.boundaries.first().map(|boundary| boundary
+            .interval
+            .clone()
+            .unwrap()
+            .into_bounds()),
         Some((
             ScalarValue::Int64(Some(5000)),
             ScalarValue::Int64(Some(10000))
@@ -339,12 +340,9 @@ fn boundary_analysis_and_selectivity_demo() -> Result<()> {
     //
     // (a' - b' + 1) / (a - b)
     // (10000 - 5000 + 1) / (10000 - 1)
-    assert_eq!(
-        analysis
-            .selectivity
-            .is_some_and(|selectivity| selectivity >= 0.5 && selectivity <= 6.),
-        true
-    );
+    assert!(analysis
+        .selectivity
+        .is_some_and(|selectivity| (0.5..=0.6).contains(&selectivity)));
 
     Ok(())
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of #3929 (see the recent followup discussion).

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The goal of this change is to add an example to explain data flow during boundary analysis this is mostly to help us get a better intuition for how we should proceed next for #4158 and #4159.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

In `datafusion-examples/examples/expr_api.rs` there is now a new function that explains data flow during boundary analysis and selectivity calculation. To allow contributors to better understand the implementation as it exists, documented in the design doc of #3929, I used the same demonstrating example.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
The change re-uses parts of the API that is already covered by existing tests.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes, this introduces a new example.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
