### PR TITLE
optimize performance of the repeat function (up to 50% faster)

### DIFF
--- a/datafusion/functions/src/string/repeat.rs
+++ b/datafusion/functions/src/string/repeat.rs
@@ -156,15 +156,15 @@ where
         |(string, number)| -> Result<(), DataFusionError> {
             match (string, number) {
                 (Some(string), Some(number)) if number >= 0 => {
-                    let item_capcaity = string.len() * number as usize;
-                    if item_capcaity > max_str_len {
+                    let item_capacity = string.len() * number as usize;
+                    if item_capacity > max_str_len {
                         return exec_err!(
                             "string size overflow on repeat, max size is {}, but got {}",
                             max_str_len,
                             number as usize * string.len()
                         );
                     }
-                    total_capacity += item_capcaity;
+                    total_capacity += item_capacity;
                 }
                 _ => (),
             }


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #14610.
## Rationale for this change
## What changes are included in this PR?
By calculating the length in advance and allocating memory accordingly, the repeat function achieves improved performance to a certain degree.

The following are the local test results:
```txt
repeat 3 times/repeat_string_view [size=1024, repeat_times=3]
                        time:   [40.286 µs 40.438 µs 40.607 µs]
                        change: [-0.1541% +0.4780% +1.0910%] (p = 0.17 > 0.05)
                        No change in performance detected.
repeat 3 times/repeat_string [size=1024, repeat_times=3]
                        time:   [38.556 µs 38.744 µs 38.944 µs]
                        change: [-10.201% -8.3456% -6.4266%] (p = 0.00 < 0.05)
                        Performance has improved.
repeat 3 times/repeat_large_string [size=1024, repeat_times=3]
                        time:   [30.212 µs 30.365 µs 30.523 µs]
                        change: [-3.3156% -2.5561% -1.7929%] (p = 0.00 < 0.05)
                        Performance has improved.

repeat 30 times/repeat_string_view [size=1024, repeat_times=30]
                        time:   [74.830 µs 75.354 µs 75.885 µs]
                        change: [-51.695% -51.232% -50.754%] (p = 0.00 < 0.05)
                        Performance has improved.
repeat 30 times/repeat_string [size=1024, repeat_times=30]
                        time:   [73.079 µs 73.638 µs 74.246 µs]
                        change: [-53.258% -52.647% -52.008%] (p = 0.00 < 0.05)
                        Performance has improved.
repeat 30 times/repeat_large_string [size=1024, repeat_times=30]
                        time:   [74.278 µs 74.651 µs 75.251 µs]
                        change: [-52.307% -51.550% -50.794%] (p = 0.00 < 0.05)
                        Performance has improved.

repeat 1073741824 times/repeat_string overflow [size=1024, repeat_times=1073741824]
                        time:   [155.57 ns 156.74 ns 157.77 ns]
                        change: [-29.625% -28.588% -27.670%] (p = 0.00 < 0.05)
                        Performance has improved.

repeat 3 times/repeat_string_view [size=4096, repeat_times=3]
                        time:   [158.52 µs 159.74 µs 161.16 µs]
                        change: [-8.5460% -7.5443% -6.4563%] (p = 0.00 < 0.05)
                        Performance has improved.
repeat 3 times/repeat_string [size=4096, repeat_times=3]
                        time:   [155.23 µs 156.10 µs 156.95 µs]
                        change: [-10.086% -9.3897% -8.7024%] (p = 0.00 < 0.05)
                        Performance has improved.
repeat 3 times/repeat_large_string [size=4096, repeat_times=3]
                        time:   [118.43 µs 119.50 µs 120.71 µs]
                        change: [-13.262% -12.286% -11.215%] (p = 0.00 < 0.05)
                        Performance has improved.

repeat 30 times/repeat_string_view [size=4096, repeat_times=30]
                        time:   [407.53 µs 411.95 µs 416.35 µs]
                        change: [-38.905% -37.817% -36.784%] (p = 0.00 < 0.05)
                        Performance has improved.
repeat 30 times/repeat_string [size=4096, repeat_times=30]
                        time:   [400.81 µs 404.55 µs 408.14 µs]
                        change: [-40.494% -39.392% -38.262%] (p = 0.00 < 0.05)
                        Performance has improved.
repeat 30 times/repeat_large_string [size=4096, repeat_times=30]
                        time:   [407.21 µs 412.32 µs 417.80 µs]
                        change: [-37.954% -37.020% -36.066%] (p = 0.00 < 0.05)
                        Performance has improved.

repeat 1073741824 times/repeat_string overflow [size=4096, repeat_times=1073741824]
                        time:   [150.92 ns 152.68 ns 154.44 ns]
                        change: [-31.467% -30.488% -29.483%] (p = 0.00 < 0.05)
                        Performance has improved.
```
## Are these changes tested?
Yes.
## Are there any user-facing changes?
None.