### PR TITLE
[WIP] chore: Add detailed error for sum::coerce_type

### DIFF
--- a/datafusion/common/src/spans.rs
+++ b/datafusion/common/src/spans.rs
@@ -33,6 +33,13 @@ pub struct Location {
     pub column: u64,
 }
 
+impl Location {
+    /// Creates a new [`Location`] from its line and column information.
+    pub fn new(line: u64, column: u64) -> Self {
+        Self { line, column }
+    }
+}
+
 impl fmt::Debug for Location {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Location({},{})", self.line, self.column)

--- a/datafusion/expr/src/test/function_stub.rs
+++ b/datafusion/expr/src/test/function_stub.rs
@@ -26,6 +26,7 @@ use arrow::datatypes::{
 };
 
 use datafusion_common::{exec_err, not_impl_err, utils::take_function_args, Result};
+use datafusion_common::{Diagnostic, Spans};
 
 use crate::type_coercion::aggregates::{avg_return_type, coerce_avg_type, NUMERICS};
 use crate::Volatility::Immutable;
@@ -95,13 +96,35 @@ pub fn avg(expr: Expr) -> Expr {
 #[derive(Debug)]
 pub struct Sum {
     signature: Signature,
+    /// Original source code location, if known
+    pub spans: Spans,
 }
 
 impl Sum {
     pub fn new() -> Self {
         Self {
             signature: Signature::user_defined(Immutable),
+            spans: Spans::new(),
         }
+    }
+
+    /// Returns a reference to the set of locations in the SQL query where this
+    /// column appears, if known.
+    pub fn spans(&self) -> &Spans {
+        &self.spans
+    }
+
+    /// Returns a mutable reference to the set of locations in the SQL query
+    /// where this column appears, if known.
+    pub fn spans_mut(&mut self) -> &mut Spans {
+        &mut self.spans
+    }
+
+    /// Replaces the set of locations in the SQL query where this column
+    /// appears, if known.
+    pub fn with_spans(mut self, spans: Spans) -> Self {
+        self.spans = spans;
+        self
     }
 }
 
@@ -130,9 +153,9 @@ impl AggregateUDFImpl for Sum {
         // Refer to https://www.postgresql.org/docs/8.2/functions-aggregate.html doc
         // smallint, int, bigint, real, double precision, decimal, or interval.
 
-        fn coerced_type(data_type: &DataType) -> Result<DataType> {
+        fn coerced_type(sum: &Sum, data_type: &DataType) -> Result<DataType> {
             match data_type {
-                DataType::Dictionary(_, v) => coerced_type(v),
+                DataType::Dictionary(_, v) => coerced_type(&sum, v),
                 // in the spark, the result type is DECIMAL(min(38,precision+10), s)
                 // ref: https://github.com/apache/spark/blob/fcf636d9eb8d645c24be3db2d599aba2d7e2955a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala#L66
                 DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => {
@@ -141,11 +164,18 @@ impl AggregateUDFImpl for Sum {
                 dt if dt.is_signed_integer() => Ok(DataType::Int64),
                 dt if dt.is_unsigned_integer() => Ok(DataType::UInt64),
                 dt if dt.is_floating() => Ok(DataType::Float64),
-                _ => exec_err!("Sum not supported for {}", data_type),
+                _ => exec_err!("Sum not supported for {}", data_type)
+                    .map_err(|err| {
+                        let diagnostic = Diagnostic::new_error(
+                            format!("Coercion only supports integer and floating point values"),
+                            sum.spans().first(),
+                        );
+                        err.with_diagnostic(diagnostic)
+                    }),
             }
         }
 
-        Ok(vec![coerced_type(array)?])
+        Ok(vec![coerced_type(&self, array)?])
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {

--- a/datafusion/expr/src/test/function_stub.rs
+++ b/datafusion/expr/src/test/function_stub.rs
@@ -164,14 +164,15 @@ impl AggregateUDFImpl for Sum {
                 dt if dt.is_signed_integer() => Ok(DataType::Int64),
                 dt if dt.is_unsigned_integer() => Ok(DataType::UInt64),
                 dt if dt.is_floating() => Ok(DataType::Float64),
-                _ => exec_err!("Sum not supported for {}", data_type)
-                    .map_err(|err| {
-                        let diagnostic = Diagnostic::new_error(
-                            format!("Coercion only supports integer and floating point values"),
-                            sum.spans().first(),
-                        );
-                        err.with_diagnostic(diagnostic)
-                    }),
+                _ => exec_err!("Sum not supported for {}", data_type).map_err(|err| {
+                    let diagnostic = Diagnostic::new_error(
+                        format!(
+                            "Coercion only supports integer and floating point values"
+                        ),
+                        sum.spans().first(),
+                    );
+                    err.with_diagnostic(diagnostic)
+                }),
             }
         }
 

--- a/datafusion/functions-aggregate/src/sum.rs
+++ b/datafusion/functions-aggregate/src/sum.rs
@@ -166,14 +166,15 @@ impl AggregateUDFImpl for Sum {
                 dt if dt.is_signed_integer() => Ok(DataType::Int64),
                 dt if dt.is_unsigned_integer() => Ok(DataType::UInt64),
                 dt if dt.is_floating() => Ok(DataType::Float64),
-                _ => exec_err!("Sum not supported for {}", data_type)
-                    .map_err(|err| {
-                        let diagnostic = Diagnostic::new_error(
-                            format!("Coercion only supports integer and floating point values"),
-                            sum.spans().first(),
-                        );
-                        err.with_diagnostic(diagnostic)
-                    }),
+                _ => exec_err!("Sum not supported for {}", data_type).map_err(|err| {
+                    let diagnostic = Diagnostic::new_error(
+                        format!(
+                            "Coercion only supports integer and floating point values"
+                        ),
+                        sum.spans().first(),
+                    );
+                    err.with_diagnostic(diagnostic)
+                }),
             }
         }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/14431

## What changes are included in this PR?

This PR integrates `Diagnostic` into `Sum::coerce_type`.

Reading through the code, there're quite a few function worth updating for "invalid function argument type" category, this PR only updates one particular function.