### PR TITLE
make DefaultSubstraitProducer public

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -368,7 +368,7 @@ pub trait SubstraitProducer: Send + Sync + Sized {
     }
 }
 
-struct DefaultSubstraitProducer<'a> {
+pub struct DefaultSubstraitProducer<'a> {
     extensions: Extensions,
     serializer_registry: &'a dyn SerializerRegistry,
 }


### PR DESCRIPTION
## Which issue does this PR close?

None

## Rationale for this change

the DefaultSubstraitProducer should be available for datafusion_substrait users

## What changes are included in this PR?

make DefaultSubstraitProducer public

## Are these changes tested?

no behavior changes, it just makes a struct `pub`

---

Not sure why this was not public on the first place, if I'm missing some context please let me know
