### PR TITLE
fix: Substrait serializer clippy error: not calling truncate

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -41,6 +41,7 @@ pbjson-types = { workspace = true }
 prost = { workspace = true }
 substrait = { version = "0.53", features = ["serde"] }
 url = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
 
 [dev-dependencies]
 datafusion = { workspace = true, features = ["nested_expressions"] }

--- a/datafusion/substrait/src/serializer.rs
+++ b/datafusion/substrait/src/serializer.rs
@@ -31,7 +31,7 @@ use std::path::Path;
 /// Plans a sql and serializes the generated logical plan to bytes.
 /// The bytes are then written into a file at `path`.
 ///
-/// Returns an error if the file already exists and is not empty.
+/// Returns an error if the file already exists.
 pub async fn serialize(
     sql: &str,
     ctx: &SessionContext,
@@ -39,10 +39,7 @@ pub async fn serialize(
 ) -> Result<()> {
     let protobuf_out = serialize_bytes(sql, ctx).await;
 
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)?;
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
     file.write_all(&protobuf_out?)?;
     Ok(())
 }

--- a/datafusion/substrait/src/serializer.rs
+++ b/datafusion/substrait/src/serializer.rs
@@ -39,17 +39,9 @@ pub async fn serialize(
 ) -> Result<()> {
     let protobuf_out = serialize_bytes(sql, ctx).await;
 
-    if std::fs::metadata(path.as_ref()).is_ok_and(|meta| meta.len() > 0) {
-        return Err(DataFusionError::Substrait(format!(
-            "Failed to encode plan: the file {} already exists and is not empty",
-            path.as_ref().display()
-        )));
-    }
-
     let mut file = OpenOptions::new()
-        .create(true)
         .write(true)
-        .truncate(true)
+        .create_new(true)
         .open(path)?;
     file.write_all(&protobuf_out?)?;
     Ok(())

--- a/datafusion/substrait/src/serializer.rs
+++ b/datafusion/substrait/src/serializer.rs
@@ -41,9 +41,9 @@ pub async fn serialize(
 
     if std::fs::metadata(path.as_ref()).is_ok_and(|meta| meta.len() > 0) {
         return Err(DataFusionError::Substrait(format!(
-            "Failed to encode substrait plan: the file {} already exists and is not empty", 
-            path.as_ref().display())
-        ));
+            "Failed to encode plan: the file {} already exists and is not empty",
+            path.as_ref().display()
+        )));
     }
 
     let mut file = OpenOptions::new()
@@ -62,9 +62,9 @@ pub async fn serialize_bytes(sql: &str, ctx: &SessionContext) -> Result<Vec<u8>>
     let proto = producer::to_substrait_plan(&plan, &ctx.state())?;
 
     let mut protobuf_out = Vec::<u8>::new();
-    proto.encode(&mut protobuf_out).map_err(|e| {
-        DataFusionError::Substrait(format!("Failed to encode substrait plan: {e}"))
-    })?;
+    proto
+        .encode(&mut protobuf_out)
+        .map_err(|e| DataFusionError::Substrait(format!("Failed to encode plan: {e}")))?;
     Ok(protobuf_out)
 }
 
@@ -81,6 +81,6 @@ pub async fn deserialize(path: impl AsRef<Path>) -> Result<Box<Plan>> {
 /// Deserializes a plan from the bytes.
 pub async fn deserialize_bytes(proto_bytes: Vec<u8>) -> Result<Box<Plan>> {
     Ok(Box::new(Message::decode(&*proto_bytes).map_err(|e| {
-        DataFusionError::Substrait(format!("Failed to decode substrait plan: {e}"))
+        DataFusionError::Substrait(format!("Failed to decode plan: {e}"))
     })?))
 }

--- a/datafusion/substrait/src/serializer.rs
+++ b/datafusion/substrait/src/serializer.rs
@@ -27,10 +27,13 @@ use substrait::proto::Plan;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 
-#[allow(clippy::suspicious_open_options)]
 pub async fn serialize(sql: &str, ctx: &SessionContext, path: &str) -> Result<()> {
     let protobuf_out = serialize_bytes(sql, ctx).await;
-    let mut file = OpenOptions::new().create(true).write(true).open(path)?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)?;
     file.write_all(&protobuf_out?)?;
     Ok(())
 }

--- a/datafusion/substrait/tests/cases/serialize.rs
+++ b/datafusion/substrait/tests/cases/serialize.rs
@@ -17,6 +17,7 @@
 
 #[cfg(test)]
 mod tests {
+    use datafusion::common::assert_contains;
     use datafusion::datasource::provider_as_source;
     use datafusion::logical_expr::LogicalPlanBuilder;
     use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
@@ -30,6 +31,30 @@ mod tests {
     use substrait::proto::plan_rel::RelType;
     use substrait::proto::rel_common::{Emit, EmitKind};
     use substrait::proto::{rel, RelCommon};
+
+    #[tokio::test]
+    async fn serialize_to_file() -> Result<()> {
+        let ctx = create_context().await?;
+        let path = "tests/serialize_to_file.bin";
+        let sql = "SELECT a, b FROM data";
+
+        // Test case 1: serializing to a non-existing file should succeed.
+        serializer::serialize(sql, &ctx, path).await?;
+        serializer::deserialize(path).await?;
+
+        // Test case 2: serializing to a non-empty file should fail.
+        let got = serializer::serialize(sql, &ctx, path).await.unwrap_err();
+        assert_contains!(got.to_string(), "already exists and is not empty");
+
+        // Test case 3: serializing to an empty file should succeed.
+        let _ = fs::File::create(path)?; // `create` will truncate the file.
+        serializer::serialize(sql, &ctx, path).await?;
+        serializer::deserialize(path).await?;
+
+        fs::remove_file(path)?;
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn serialize_simple_select() -> Result<()> {

--- a/datafusion/substrait/tests/cases/serialize.rs
+++ b/datafusion/substrait/tests/cases/serialize.rs
@@ -42,14 +42,9 @@ mod tests {
         serializer::serialize(sql, &ctx, path).await?;
         serializer::deserialize(path).await?;
 
-        // Test case 2: serializing to a non-empty file should fail.
+        // Test case 3: serializing to an existing file should fail.
         let got = serializer::serialize(sql, &ctx, path).await.unwrap_err();
-        assert_contains!(got.to_string(), "already exists and is not empty");
-
-        // Test case 3: serializing to an empty file should succeed.
-        let _ = fs::File::create(path)?; // `create` will truncate the file.
-        serializer::serialize(sql, &ctx, path).await?;
-        serializer::deserialize(path).await?;
+        assert_contains!(got.to_string(), "File exists");
 
         fs::remove_file(path)?;
 

--- a/datafusion/substrait/tests/cases/serialize.rs
+++ b/datafusion/substrait/tests/cases/serialize.rs
@@ -42,7 +42,7 @@ mod tests {
         serializer::serialize(sql, &ctx, path).await?;
         serializer::deserialize(path).await?;
 
-        // Test case 3: serializing to an existing file should fail.
+        // Test case 2: serializing to an existing file should fail.
         let got = serializer::serialize(sql, &ctx, path).await.unwrap_err();
         assert_contains!(got.to_string(), "File exists");
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #9727 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It's reasonable to always truncate an existing file before serializing a plan. 
On the other hand, the following `deserialize` method always read the file to end which does not consider the case that the file is not truncated before serialization.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Applied a clippy suggestion by adding a `truncate(true)`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Tested by clippy

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
