### PR TITLE
dependabot: group arrow/parquet minor/patch bumps, remove limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,19 +21,30 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
     target-branch: main
     labels: [auto-dependencies]
     ignore:
-      # arrow is bumped manually
+      # major version bumps of arrow* and parquet are handled manually
       - dependency-name: "arrow*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "parquet"
+        update-types: ["version-update:semver-major"]
     groups:
+      # minor and patch bumps of arrow* and parquet are grouped
+      arrow-parquet:
+        applies-to: version-updates
+        patterns:
+          - "arrow*"
+          - "parquet"
+        update-types:
+          - "minor"
+          - "patch"
       proto:
         applies-to: version-updates
         patterns:
           - "prost*"
           - "pbjson*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,7 +44,6 @@ updates:
         patterns:
           - "prost*"
           - "pbjson*"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Which issue does this PR close?

None.

## Rationale for this change

It would be nice if minor/patch bumps of `arrow*` and `parquet` are grouped. In addition major parquet bumps should be ignored too, because they are grouped in the manual major bump of arrow crates.

I removed the limit because sometimes dependabot PRs can't be merged directly, and these open PRs shouldn't block other updates to the `Cargo.lock` file (to make sure we're testing with updated dependencies in CI).

## What changes are included in this PR?

Updates to the dependabot config.

## Are these changes tested?

No.