### PR TITLE
Fix CI fail for extended test (by freeing up more disk space in CI runner)

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -39,43 +39,54 @@ jobs:
   linux-build-lib:
     name: linux build test
     runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
         with:
-          rust-version: stable
+          submodules: true
+          fetch-depth: 1
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup default stable
+      - name: Install Protobuf Compiler
+        run: sudo apt-get install -y protobuf-compiler
       - name: Prepare cargo build
         run: |
           cargo check --profile ci --all-targets
           cargo clean
 
-#  # Run extended tests (with feature 'extended_tests')
-#  # Disabling as it is running out of disk space
-#  # see https://github.com/apache/datafusion/issues/14576
-#  linux-test-extended:
-#    name: cargo test 'extended_tests' (amd64)
-#    needs: linux-build-lib
-#    runs-on: ubuntu-latest
-#    container:
-#      image: amd64/rust
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          submodules: true
-#          fetch-depth: 1
-#      - name: Setup Rust toolchain
-#        uses: ./.github/actions/setup-builder
-#        with:
-#          rust-version: stable
-#      - name: Run tests (excluding doctests)
-#        run: cargo test --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --workspace --lib --tests --bins --features avro,json,backtrace,extended_tests
-#      - name: Verify Working Directory Clean
-#        run: git diff --exit-code
-#      - name: Cleanup
-#        run: cargo clean
+  # Run extended tests (with feature 'extended_tests')
+  linux-test-extended:
+    name: cargo test 'extended_tests' (amd64)
+    needs: linux-build-lib
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 1
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup default stable
+      - name: Install Protobuf Compiler
+        run: sudo apt-get install -y protobuf-compiler
+      # For debugging, test binaries can be large.
+      - name: Show available disk space
+        run: |
+          df -h
+      - name: Run tests (excluding doctests)
+        env:
+          RUST_BACKTRACE: 1
+        run: cargo test --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --workspace --lib --tests --bins --features avro,json,backtrace,extended_tests
+      - name: Verify Working Directory Clean
+        run: git diff --exit-code
+      - name: Cleanup
+        run: cargo clean
 
   # Check answers are correct when hash values collide
   hash-collisions:
@@ -95,7 +106,7 @@ jobs:
       - name: Run tests
         run: |
           cd datafusion
-          cargo test  --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-sqllogictest --workspace --lib --tests --features=force_hash_collisions,avro,extended_tests
+          cargo test  --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-sqllogictest --workspace --lib --tests --features=force_hash_collisions,avro
           cargo clean
 
   sqllogictest-sqlite:

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -67,7 +67,7 @@ jobs:
           submodules: true
           fetch-depth: 1
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
       - name: Install Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -67,7 +67,7 @@ jobs:
           submodules: true
           fetch-depth: 1
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f1
       - name: Install Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/datafusion/core/tests/memory_limit/memory_limit_validation/sort_mem_validation.rs
+++ b/datafusion/core/tests/memory_limit/memory_limit_validation/sort_mem_validation.rs
@@ -69,8 +69,8 @@ fn sort_with_mem_limit_2_cols_2_runner() {
     spawn_test_process("sort_with_mem_limit_2_cols_2");
 }
 
-/// `spawn_test_process` might trigger multiple recompilation, and the test binary
-/// size might grow indifinitely. This initilizer ensures recompilation is only done
+/// `spawn_test_process` might trigger multiple recompilations and the test binary
+/// size might grow indefinitely. This initializer ensures recompilation is only done
 /// once and the target size is bounded.
 ///
 /// TODO: This is a hack, can be cleaned up if we have a better way to let multiple

--- a/datafusion/core/tests/memory_limit/memory_limit_validation/sort_mem_validation.rs
+++ b/datafusion/core/tests/memory_limit/memory_limit_validation/sort_mem_validation.rs
@@ -21,11 +21,13 @@
 //! This file is organized as:
 //! - Test runners that spawn individual test processes
 //! - Test cases that contain the actual validation logic
+use log::info;
+use std::sync::Once;
 use std::{process::Command, str};
 
-use log::info;
-
 use crate::memory_limit::memory_limit_validation::utils;
+
+static INIT: Once = Once::new();
 
 // ===========================================================================
 // Test runners:
@@ -67,10 +69,35 @@ fn sort_with_mem_limit_2_cols_2_runner() {
     spawn_test_process("sort_with_mem_limit_2_cols_2");
 }
 
+/// `spawn_test_process` might trigger multiple recompilation, and the test binary
+/// size might grow indifinitely. This initilizer ensures recompilation is only done
+/// once and the target size is bounded.
+///
+/// TODO: This is a hack, can be cleaned up if we have a better way to let multiple
+/// test cases run in different processes (instead of different threads by default)
+fn init_once() {
+    INIT.call_once(|| {
+        let _ = Command::new("cargo")
+            .arg("test")
+            .arg("--no-run")
+            .arg("--package")
+            .arg("datafusion")
+            .arg("--test")
+            .arg("core_integration")
+            .arg("--features")
+            .arg("extended_tests")
+            .env("DATAFUSION_TEST_MEM_LIMIT_VALIDATION", "1")
+            .output()
+            .expect("Failed to execute test command");
+    });
+}
+
 /// Helper function that executes a test in a separate process with the required environment
 /// variable set. Memory limit validation tasks need to measure memory resident set
 /// size (RSS), so they must run in a separate process.
 fn spawn_test_process(test: &str) {
+    init_once();
+
     let test_path = format!(
         "memory_limit::memory_limit_validation::sort_mem_validation::{}",
         test


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/14680

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
CI for extended tests are failing because there is not enough disk space for CI runners, test binaries take lots of disk space.

This PR frees up more disk space on CI runner (12GB -> 45GB). 
Before, after setting up Rust dependencies, there is only 12GB disk space left to run the tests, I think this can run into trouble if we want extended tests to do more stuff in the future.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. CI change
- Directly running test on Github CI runner, instead of Docker container, and manually setup Rust dependencies.
- Applied Github Action https://github.com/jlumbroso/free-disk-space to delete unnecessary files on CI runner.
2. Test change
Memory validation test causes recompilations (I didn't find a direct fix 🤦🏼 ), and it caused large disk space usage. Before it can cause multiple recompilations (if we add more similar test cases, disk usage can continue grow).
This PR did uses a singleton (`init_once`) to make sure recompilation happens exactly once, and the disk usage won't grow indefinitely.

## Are these changes tested?
I tested on my local clone, and it works
https://github.com/2010YOUY01/arrow-datafusion/actions/runs/13387132954/job/37386562838

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
