### PR TITLE
Skip target in taplo checks

### DIFF
--- a/taplo.toml
+++ b/taplo.toml
@@ -18,6 +18,7 @@
 ## https://taplo.tamasfe.dev/configuration/file.html
 
 include = ["**/Cargo.toml"]
+exclude = ["target/*"]
 
 [formatting]
 # Align consecutive entries vertically.


### PR DESCRIPTION
`target` can contain arbitrary files. Contents depend on tools used and tests run, and may even include `Cargo.toml` files that are not properly formatted. The taplo check should never complain on files that are not meant to be part of the repository, and `target` contents clearly falls into that category.

`trybuild` is an example of a tool that creates cargo files inside target directory.
