### PR TITLE
docs: Add additional info about memory reservation to the doc of MemoryPool

### DIFF
--- a/datafusion/execution/src/memory_pool/mod.rs
+++ b/datafusion/execution/src/memory_pool/mod.rs
@@ -55,7 +55,10 @@ pub use pool::*;
 /// "large" amounts of memory (proportional to number of input rows), such as
 /// `GroupByHashExec`. It does NOT track and limit memory used internally by
 /// other operators such as `DataSourceExec` or the `RecordBatch`es that flow
-/// between operators.
+/// between operators. Furthermore, operators should not reserve memory for the
+/// batches they produce. Instead, if a parent operator needs to hold batches
+/// from its children in memory for an extended period, it is the parent
+/// operator's responsibility to reserve the necessary memory for those batches.
 ///
 /// In order to avoid allocating memory until the OS or the container system
 /// kills the process, DataFusion `ExecutionPlan`s (operators) that consume


### PR DESCRIPTION
## Which issue does this PR close?

This is not related to an issue. It is requested by this comment: https://github.com/apache/datafusion/pull/14644#issuecomment-2665613858

## Rationale for this change

There's a convention that ExecutionPlans do not reserve memory for the batches it produces, but it is not explicitly stated in the doc. We should explicitly point out those conventions in the doc to make it clear.

## What changes are included in this PR?

This change clarifies the general conventions that ExecutionPlans need to follow when using MemoryPool: memory for output batches are reserved by their consumers rather than their producers.

## Are these changes tested?

N/A for doc changes.

## Are there any user-facing changes?

No