### PR TITLE
Fix CI job test-datafusion-pyarrow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -389,7 +389,7 @@ jobs:
   test-datafusion-pyarrow:
     name: cargo test pyarrow (amd64)
     needs: linux-build-lib
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: amd64/rust:bullseye # Workaround https://github.com/actions/setup-python/issues/721
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -399,7 +399,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.8.18"
       - name: Install PyArrow
         run: |
           echo "LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -391,7 +391,7 @@ jobs:
     needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
-      image: amd64/rust:bullseye # Workaround https://github.com/actions/setup-python/issues/721
+      image: amd64/rust
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -391,19 +391,16 @@ jobs:
     needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
-      image: amd64/rust
+      image: amd64/rust:bullseye # Use the bullseye tag image which comes with python3.9
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 1
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.8.18"
       - name: Install PyArrow
         run: |
           echo "LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          python -m pip install pyarrow
+          python3 -m pip install pyarrow
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -400,6 +400,8 @@ jobs:
       - name: Install PyArrow
         run: |
           echo "LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          apt-get update
+          apt-get install python3-pip -y
           python3 -m pip install pyarrow
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder


### PR DESCRIPTION
Solves #14776 

CI job `test-datafusion-pyarrow` pins to ubuntu-20.04. This MR changes it back to ubuntu-latest and fix the failing CI