### PR TITLE
chore: Fix test not to litter in repository

### DIFF
--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -250,7 +250,8 @@ mod tests {
 
     #[test]
     fn test_disk_manager_create_spill_folder() {
-        let config = DiskManagerConfig::new_specified(vec!["DOESNT_EXIST".into()]);
+        let dir = TempDir::new().unwrap();
+        let config = DiskManagerConfig::new_specified(vec![dir.path().to_owned()]);
 
         DiskManager::try_new(config)
             .unwrap()


### PR DESCRIPTION
Before the change, executing the test would create (and leave behind) the `datafusion/execution/DOESNT_EXIST` folder inside source repository.
