### PR TITLE
Fix Clippy 1.85 warnings

### DIFF
--- a/datafusion/core/tests/execution/logical_plan.rs
+++ b/datafusion/core/tests/execution/logical_plan.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Logical plans need to provide stable semantics, as downstream projects
+//! create them and depend on them. Test executable semantics of logical plans.
+
 use arrow::array::Int64Array;
 use arrow::datatypes::{DataType, Field};
 use datafusion::execution::session_state::SessionStateBuilder;
@@ -29,9 +32,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::Deref;
 use std::sync::Arc;
-
-///! Logical plans need to provide stable semantics, as downstream projects
-///! create them and depend on them. Test executable semantics of logical plans.
 
 #[tokio::test]
 async fn count_only_nulls() -> Result<()> {

--- a/datafusion/execution/src/runtime_env.rs
+++ b/datafusion/execution/src/runtime_env.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 use crate::cache::cache_manager::{CacheManager, CacheManagerConfig};
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::Result;
 use object_store::ObjectStore;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -150,9 +150,7 @@ impl RuntimeEnv {
     /// registry. See [`ObjectStoreRegistry::get_store`] for more
     /// details.
     pub fn object_store(&self, url: impl AsRef<Url>) -> Result<Arc<dyn ObjectStore>> {
-        self.object_store_registry
-            .get_store(url.as_ref())
-            .map_err(DataFusionError::from)
+        self.object_store_registry.get_store(url.as_ref())
     }
 }
 

--- a/datafusion/physical-expr-common/src/binary_map.rs
+++ b/datafusion/physical-expr-common/src/binary_map.rs
@@ -384,7 +384,7 @@ where
 
             // value is "small"
             let payload = if value.len() <= SHORT_VALUE_LEN {
-                let inline = value.iter().fold(0usize, |acc, &x| acc << 8 | x as usize);
+                let inline = value.iter().fold(0usize, |acc, &x| (acc << 8) | x as usize);
 
                 // is value is already present in the set?
                 let entry = self.map.find_mut(hash, |header| {

--- a/datafusion/sql/src/expr/value.rs
+++ b/datafusion/sql/src/expr/value.rs
@@ -304,7 +304,7 @@ fn try_decode_hex_literal(s: &str) -> Option<Vec<u8>> {
     for i in (start_idx..hex_bytes.len()).step_by(2) {
         let high = try_decode_hex_char(hex_bytes[i])?;
         let low = try_decode_hex_char(hex_bytes[i + 1])?;
-        decoded_bytes.push(high << 4 | low);
+        decoded_bytes.push((high << 4) | low);
     }
 
     Some(decoded_bytes)

--- a/test-utils/src/array_gen/string.rs
+++ b/test-utils/src/array_gen/string.rs
@@ -97,7 +97,6 @@ fn random_string(rng: &mut StdRng, max_len: usize) -> String {
             let len = rng.gen_range(1..=max_len);
             rng.sample_iter::<char, _>(rand::distributions::Standard)
                 .take(len)
-                .map(char::from)
                 .collect::<String>()
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

- related to #1557 

## Rationale for this change

Rust 1.85 was released.

## What changes are included in this PR?

Clippy 1.85 warning fixes.

## Are these changes tested?

In CI.

## Are there any user-facing changes?

No.