### PR TITLE
feat: implement contextualized ObjectStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,6 +3955,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.2"
+source = "git+https://github.com/waynr/arrow-rs?branch=object_store/introduce-extensions#41ca3a42a4f0d623e45188817e62e6f21aa48a5b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.2"
-source = "git+https://github.com/waynr/arrow-rs?branch=object_store/introduce-extensions#41ca3a42a4f0d623e45188817e62e6f21aa48a5b"
+source = "git+https://github.com/waynr/arrow-rs?rev=3c4a84376a25af362597dad66821ff55777fd370#3c4a84376a25af362597dad66821ff55777fd370"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,8 +3955,6 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,3 +190,6 @@ large_futures = "warn"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
 unused_qualifications = "deny"
+
+[patch.crates-io]
+object_store = { path = "../../../apache/arrow-rs/object_store" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,4 +192,5 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
 unused_qualifications = "deny"
 
 [patch.crates-io]
-object_store = { path = "../../../apache/arrow-rs/object_store" }
+#object_store = { path = "../../../apache/arrow-rs/object_store" }
+object_store = { git = "https://github.com/waynr/arrow-rs", branch = "object_store/introduce-extensions" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,4 +193,5 @@ unused_qualifications = "deny"
 
 [patch.crates-io]
 #object_store = { path = "../../../apache/arrow-rs/object_store" }
-object_store = { git = "https://github.com/waynr/arrow-rs", branch = "object_store/introduce-extensions" }
+#object_store = { git = "https://github.com/waynr/arrow-rs", branch = "object_store/introduce-extensions" }
+object_store = { git = "https://github.com/waynr/arrow-rs", rev = "3c4a84376a25af362597dad66821ff55777fd370" }

--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -571,6 +571,13 @@ impl SessionConfig {
             .cloned()
             .map(|ext| Arc::downcast(ext).expect("TypeId unique"))
     }
+
+    /// Get ObjectStore-compatible extensions.
+    pub fn clone_extensions_for_object_store(&self) -> object_store::Extensions {
+        let exts: HashMap<TypeId, Arc<dyn Any + Send + Sync + 'static>> =
+            self.extensions.clone().into_iter().collect();
+        exts.into()
+    }
 }
 
 impl From<ConfigOptions> for SessionConfig {


### PR DESCRIPTION
- **chore(temporary): patch objectstore with local path**
- **feat: implement ContextualizedObjectStore that passes along session state via GetOptions**
- **chore: update temporary object_store patch rev**

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- [ ] Closes https://github.com/apache/datafusion/issues/14804.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See https://github.com/apache/datafusion/issues/14804

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Introduce new `ContextualizedObjectStore` type that implements `object_store::ObjectStore`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I haven't written any tests for this behavior in datafusion yet and would like guidance from maintainers with respect to what kind of testing they think would be good here.

I also still need to manually test that this does the thing I want it to do with respect to tracing in a caching `ObjectStore` implementation in https://github.com/influxdata/influxdb

## Are there any user-facing changes?

Only if the user registers a custom `ObjectStore` implementation with datafusion and wants to pass opaque data (like tracing spans) from various places in the call stack leading up to query execution -- after this they will have access to that data in their custom implementation of `ObjectStore.get_opts` when called during query execution.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
