### PR TITLE
Bump MSRV to 1.82, toolchain to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ homepage = "https://datafusion.apache.org"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/datafusion"
-rust-version = "1.81.0"
+rust-version = "1.82.0"
 version = "45.0.0"
 
 [workspace.dependencies]

--- a/datafusion/common/src/table_reference.rs
+++ b/datafusion/common/src/table_reference.rs
@@ -193,8 +193,7 @@ impl TableReference {
         match self {
             TableReference::Bare { table } => **table == *other.table(),
             TableReference::Partial { schema, table } => {
-                **table == *other.table()
-                    && other.schema().map_or(true, |s| *s == **schema)
+                **table == *other.table() && other.schema().is_none_or(|s| *s == **schema)
             }
             TableReference::Full {
                 catalog,
@@ -202,8 +201,8 @@ impl TableReference {
                 table,
             } => {
                 **table == *other.table()
-                    && other.schema().map_or(true, |s| *s == **schema)
-                    && other.catalog().map_or(true, |c| *c == **catalog)
+                    && other.schema().is_none_or(|s| *s == **schema)
+                    && other.catalog().is_none_or(|c| *c == **catalog)
             }
         }
     }

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -832,7 +832,7 @@ pub fn exprlist_len(
                             .enumerate()
                             .filter_map(|(idx, field)| {
                                 let (maybe_table_ref, _) = schema.qualified_field(idx);
-                                if maybe_table_ref.map_or(true, |q| q == qualifier) {
+                                if maybe_table_ref.is_none_or(|q| q == qualifier) {
                                     Some((maybe_table_ref.cloned(), Arc::clone(field)))
                                 } else {
                                     None

--- a/datafusion/physical-expr-common/src/sort_expr.rs
+++ b/datafusion/physical-expr-common/src/sort_expr.rs
@@ -172,13 +172,11 @@ impl PhysicalSortExpr {
         let nullable = self.expr.nullable(schema).unwrap_or(true);
         self.expr.eq(&requirement.expr)
             && if nullable {
-                requirement
-                    .options
-                    .map_or(true, |opts| self.options == opts)
+                requirement.options.is_none_or(|opts| self.options == opts)
             } else {
                 requirement
                     .options
-                    .map_or(true, |opts| self.options.descending == opts.descending)
+                    .is_none_or(|opts| self.options.descending == opts.descending)
             }
     }
 }
@@ -293,7 +291,7 @@ impl PhysicalSortRequirement {
         self.expr.eq(&other.expr)
             && other
                 .options
-                .map_or(true, |other_opts| self.options == Some(other_opts))
+                .is_none_or(|other_opts| self.options == Some(other_opts))
     }
 
     #[deprecated(since = "43.0.0", note = "use  LexRequirement::from_lex_ordering")]

--- a/datafusion/physical-expr/src/equivalence/properties.rs
+++ b/datafusion/physical-expr/src/equivalence/properties.rs
@@ -640,7 +640,7 @@ impl EquivalenceProperties {
                         req.expr.eq(&existing.expr)
                             && req
                                 .options
-                                .map_or(true, |req_opts| req_opts == existing.options)
+                                .is_none_or(|req_opts| req_opts == existing.options)
                     },
                 )
         })

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,5 +19,5 @@
 # to compile this workspace and run CI jobs.
 
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #14808.

## Rationale for this change

Rust `1.85.0` is now the latest stable release.

## What changes are included in this PR?

- Bumps the MSRV to `1.82.0`
- Bumps the version in `rust-toolchain.toml` to `1.85.0`

## Are these changes tested?

CI.

## Are there any user-facing changes?

Yes, MSRV bump.
