### PR TITLE
fix: we are missing the unlimited case for bounded streaming when usi…

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -269,6 +269,11 @@ pub(super) async fn exec_and_print(
                         reservation.try_grow(get_record_batch_memory_size(&batch))?;
                         results.push(batch);
                     }
+                } else if let MaxRows::Unlimited = print_options.maxrows {
+                    // Collect all results for unlimited maxrows
+                    // Try to grow the reservation to accommodate the batch in memory
+                    reservation.try_grow(get_record_batch_memory_size(&batch))?;
+                    results.push(batch);
                 }
                 row_count += curr_num_rows;
             }

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -258,19 +258,16 @@ pub(super) async fn exec_and_print(
             let mut stream = execute_stream(physical_plan, task_ctx.clone())?;
             let mut results = vec![];
             let mut row_count = 0_usize;
+            let max_rows = match print_options.maxrows {
+                MaxRows::Unlimited => usize::MAX,
+                MaxRows::Limited(n) => n,
+            };
             while let Some(batch) = stream.next().await {
                 let batch = batch?;
                 let curr_num_rows = batch.num_rows();
-                if let MaxRows::Limited(max_rows) = print_options.maxrows {
-                    // Stop collecting results if the number of rows exceeds the limit
-                    // results batch should include the last batch that exceeds the limit
-                    if row_count < max_rows + curr_num_rows {
-                        // Try to grow the reservation to accommodate the batch in memory
-                        reservation.try_grow(get_record_batch_memory_size(&batch))?;
-                        results.push(batch);
-                    }
-                } else if let MaxRows::Unlimited = print_options.maxrows {
-                    // Collect all results for unlimited maxrows
+                // Stop collecting results if the number of rows exceeds the limit
+                // results batch should include the last batch that exceeds the limit
+                if row_count < max_rows + curr_num_rows {
                     // Try to grow the reservation to accommodate the batch in memory
                     reservation.try_grow(get_record_batch_memory_size(&batch))?;
                     results.push(batch);


### PR DESCRIPTION
…ng datafusion-cli

## Which issue does this PR close?


- Closes [#14814](https://github.com/apache/datafusion/issues/14814)

## Rationale for this change

## What changes are included in this PR?
Add unlimited case for bounded streaming.

## Are these changes tested?

Yes

The following result will not be empty, before this PR is empty.
```rust
/usr/bin/time -l cargo run --release --   -m 20G --mem-pool-type fair  --maxrows inf -f '/Users/zhuqi/arrow-datafusion/benchmarks/data/external_sort.sql'
```


## Are there any user-facing changes?
Support unlimited case for bounded streaming