### PR TITLE
Fix: External sort failing on `StringView` due to shared buffers

### DIFF
--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -23,9 +23,11 @@ use std::sync::{Arc, LazyLock};
 
 #[cfg(feature = "extended_tests")]
 mod memory_limit_validation;
-use arrow::array::{ArrayRef, DictionaryArray, RecordBatch};
+use arrow::array::{ArrayRef, DictionaryArray, Int32Array, RecordBatch, StringViewArray};
 use arrow::compute::SortOptions;
 use arrow::datatypes::{Int32Type, SchemaRef};
+use arrow::util::pretty;
+use arrow_schema::{DataType, Field, Schema};
 use datafusion::assert_batches_eq;
 use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::datasource::source::DataSourceExec;
@@ -41,14 +43,15 @@ use datafusion_catalog::streaming::StreamingTable;
 use datafusion_catalog::Session;
 use datafusion_common::{assert_contains, Result};
 use datafusion_execution::memory_pool::{
-    GreedyMemoryPool, MemoryPool, TrackConsumersPool,
+    FairSpillPool, GreedyMemoryPool, MemoryPool, TrackConsumersPool,
 };
 use datafusion_execution::TaskContext;
-use datafusion_expr::{Expr, TableType};
+use datafusion_expr::{col, Expr, TableType};
 use datafusion_physical_expr::{LexOrdering, PhysicalSortExpr};
 use datafusion_physical_optimizer::join_selection::JoinSelection;
 use datafusion_physical_optimizer::PhysicalOptimizerRule;
 use datafusion_physical_plan::spill::get_record_batch_memory_size;
+use rand::Rng;
 use test_utils::AccessLogGenerator;
 
 use async_trait::async_trait;
@@ -401,6 +404,69 @@ async fn oom_with_tracked_consumer_pool() {
         ))
         .run()
         .await
+}
+
+/// For regression case: if spilled `StringViewArray`'s buffer will be referenced by
+/// other batches which are also need to be spilled, then the spill writer will
+/// repeatedly write out the same buffer, and after reading back, each batch's size
+/// will explode.
+///
+/// This test setup will cause 10 spills, each spill will sort around 20 batches.
+/// If there is memory explosion for spilled record batch, this test will fail.
+#[tokio::test]
+async fn test_stringview_external_sort() {
+    let mut rng = rand::thread_rng();
+    let array_length = 1000;
+    let num_batches = 200;
+    // Batches contain two columns: random 100-byte string, and random i32
+    let mut batches = Vec::with_capacity(num_batches);
+
+    for _ in 0..num_batches {
+        let strings: Vec<String> = (0..array_length)
+            .map(|_| {
+                (0..100)
+                    .map(|_| rng.gen_range(0..=u8::MAX) as char)
+                    .collect()
+            })
+            .collect();
+
+        let string_array = StringViewArray::from(strings);
+        let array_ref: ArrayRef = Arc::new(string_array);
+
+        let random_numbers: Vec<i32> =
+            (0..array_length).map(|_| rng.gen_range(0..=1000)).collect();
+        let int_array = Int32Array::from(random_numbers);
+        let int_array_ref: ArrayRef = Arc::new(int_array);
+
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("strings", DataType::Utf8View, false),
+                Field::new("random_numbers", DataType::Int32, false),
+            ])),
+            vec![array_ref, int_array_ref],
+        )
+        .unwrap();
+        batches.push(batch);
+    }
+
+    // Run a sql query that sorts the batches by the int column
+    let schema = batches[0].schema();
+    let table = MemTable::try_new(schema, vec![batches]).unwrap();
+    let builder = RuntimeEnvBuilder::new()
+        .with_memory_pool(Arc::new(FairSpillPool::new(60 * 1024 * 1024)));
+    let runtime = builder.build_arc().unwrap();
+
+    let config = SessionConfig::new().with_sort_spill_reservation_bytes(40 * 1024 * 1024);
+
+    let ctx = SessionContext::new_with_config_rt(config, runtime);
+    ctx.register_table("t", Arc::new(table)).unwrap();
+
+    let df = ctx
+        .sql("explain analyze SELECT * FROM t ORDER BY random_numbers")
+        .await
+        .unwrap();
+
+    let results = df.collect().await.expect("Query execution failed");
 }
 
 /// Run the query with the specified memory limit,

--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -26,7 +26,6 @@ mod memory_limit_validation;
 use arrow::array::{ArrayRef, DictionaryArray, Int32Array, RecordBatch, StringViewArray};
 use arrow::compute::SortOptions;
 use arrow::datatypes::{Int32Type, SchemaRef};
-use arrow::util::pretty;
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::assert_batches_eq;
 use datafusion::datasource::memory::MemorySourceConfig;
@@ -46,7 +45,7 @@ use datafusion_execution::memory_pool::{
     FairSpillPool, GreedyMemoryPool, MemoryPool, TrackConsumersPool,
 };
 use datafusion_execution::TaskContext;
-use datafusion_expr::{col, Expr, TableType};
+use datafusion_expr::{Expr, TableType};
 use datafusion_physical_expr::{LexOrdering, PhysicalSortExpr};
 use datafusion_physical_optimizer::join_selection::JoinSelection;
 use datafusion_physical_optimizer::PhysicalOptimizerRule;
@@ -466,7 +465,7 @@ async fn test_stringview_external_sort() {
         .await
         .unwrap();
 
-    let results = df.collect().await.expect("Query execution failed");
+    let _ = df.collect().await.expect("Query execution failed");
 }
 
 /// Run the query with the specified memory limit,

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -461,7 +461,7 @@ impl ExternalSorter {
                     new_columns.push(Arc::new(new_array));
                     arr_mutated = true;
                 } else {
-                    new_columns.push(array.clone());
+                    new_columns.push(Arc::clone(array));
                 }
             }
 
@@ -1478,7 +1478,7 @@ mod tests {
         // Processing 840 KB of data using 400 KB of memory requires at least 2 spills
         // It will spill roughly 18000 rows and 800 KBytes.
         // We leave a little wiggle room for the actual numbers.
-        assert!((2..=10).contains(&spill_count));
+        assert!((12..=18).contains(&spill_count));
         assert!((15000..=20000).contains(&spilled_rows));
         assert!((700000..=900000).contains(&spilled_bytes));
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow up to https://github.com/apache/datafusion/pull/14644, this PR fixes an unsolved failing case for external sort. It's found by https://github.com/apache/datafusion/issues/12136#issuecomment-2656449956.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Recap for major steps for external sort (there are detailed doc in datafusion/physical-plan/src/sorts/sort.rs)
1. Inside each partition, input batches will be buffered until it reaches the memory limit.
2. When OOM is triggered, all buffered batches will be sorted one by one, and finally merged into one large sorted run (though physically it's chunked into many small batches)
3. Spill the sorted run to disk. After reading all inputs, read back spilled batches and merge into the final result. Since only one batch is needed for each spilled sorted run to generate the final result, the memory overhead is reduced in this step.

The problem is: if step 2 is done on batches with `StringViewArray` columns, the sorted array will only reorder the `view`s (string prefix plus pointer into range in the payload buffer, if this element is long), and the underlying buffers won't be moved.
When reading back spilled batches from a single sorted run, it's required to read one batch by one batch, otherwise memory pressure won't be reduced. As a result, the spill writer has to write all referenced `buffer`s for each batch, and many buffers will be written multiple times. The size of the spilled batch would explode, and some memory-limited sort query can fail due to this reason.

## Reproducer
Under `benchmarks/`, run
```
cargo run --profile release-nonlto --bin dfbench -- sort-tpch  -p '/Users/yongting/Code/datafusion/benchmarks/data/tpch_sf10' -o '/tmp/main.json' -q 10 --iterations 1 --partitions 4 --memory-limit 5000M --debug
```
### Main branch result (20GB spilled)
```
SortExec: expr=[l_orderkey@0 ASC NULLS LAST, l_suppkey@1 ASC NULLS LAST, l_linenumber@2 ASC NULLS LAST, l_comment@3 ASC NULLS LAST], preserve_partitioning=[true], metrics=[output_rows=59986052, elapsed_compute=12.965460651s, spill_count=24, spilled_bytes=19472334146, spilled_rows=51202072]
```
Q10 iteration 0 took 12839.6 ms and returned 59986052 rows
Q10 avg time: 12839.60 ms
### PR result (12GB spilled)
```
SortExec: expr=[l_orderkey@0 ASC NULLS LAST, l_suppkey@1 ASC NULLS LAST, l_linenumber@2 ASC NULLS LAST, l_comment@3 ASC NULLS LAST], preserve_partitioning=[true], metrics=[output_rows=59986052, elapsed_compute=15.363745389s, spill_count=48, spilled_bytes=12600523712, spilled_rows=55216152]
```
Q10 iteration 0 took 9424.3 ms and returned 59986052 rows
Q10 avg time: 9424.33 ms

## What changes are included in this PR?

Before spilling, `StringViewArray` columns must be permutated the way described above, so this PR reorganize the array to sequential order before spilling.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Added one unit regression test. This test fails without the change.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
6. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
