### PR TITLE
Optimize `gcd` for array and scalar case by avoiding `make_scalar_function` where has unnecessary conversion between scalar and array

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -116,7 +116,7 @@ required-features = ["string_expressions"]
 [[bench]]
 harness = false
 name = "gcd"
-required-features = []
+required-features = ["math_expressions"]
 
 [[bench]]
 harness = false

--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -115,6 +115,11 @@ required-features = ["string_expressions"]
 
 [[bench]]
 harness = false
+name = "gcd"
+required-features = []
+
+[[bench]]
+harness = false
 name = "uuid"
 required-features = ["string_expressions"]
 

--- a/datafusion/functions/benches/gcd.rs
+++ b/datafusion/functions/benches/gcd.rs
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate criterion;
+
+use arrow::{
+    array::{ArrayRef, Int64Array},
+    datatypes::DataType,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datafusion_common::ScalarValue;
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs};
+use datafusion_functions::math::gcd;
+use rand::Rng;
+use std::sync::Arc;
+
+fn generate_i64_array(n_rows: usize) -> ArrayRef {
+    let mut rng = rand::thread_rng();
+    let values = (0..n_rows)
+        .map(|_| rng.gen_range(0..1000))
+        .collect::<Vec<_>>();
+    Arc::new(Int64Array::from(values)) as ArrayRef
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let n_rows = 100000;
+    let array_a = ColumnarValue::Array(generate_i64_array(n_rows));
+    let array_b = ColumnarValue::Array(generate_i64_array(n_rows));
+    let udf = gcd();
+
+    c.bench_function("gcd both array", |b| {
+        b.iter(|| {
+            black_box(
+                udf.invoke_with_args(ScalarFunctionArgs {
+                    args: vec![array_a.clone(), array_b.clone()],
+                    number_rows: 0,
+                    return_type: &DataType::Int64,
+                })
+                .expect("date_bin should work on valid values"),
+            )
+        })
+    });
+
+    // 10! = 3628800
+    let scalar_b = ColumnarValue::Scalar(ScalarValue::Int64(Some(3628800)));
+
+    c.bench_function("gcd array and scalar", |b| {
+        b.iter(|| {
+            black_box(
+                udf.invoke_with_args(ScalarFunctionArgs {
+                    args: vec![array_a.clone(), scalar_b.clone()],
+                    number_rows: 0,
+                    return_type: &DataType::Int64,
+                })
+                .expect("date_bin should work on valid values"),
+            )
+        })
+    });
+
+    // scalar and scalar
+    let scalar_a = ColumnarValue::Scalar(ScalarValue::Int64(Some(3628800)));
+
+    c.bench_function("gcd both scalar", |b| {
+        b.iter(|| {
+            black_box(
+                udf.invoke_with_args(ScalarFunctionArgs {
+                    args: vec![scalar_a.clone(), scalar_b.clone()],
+                    number_rows: 0,
+                    return_type: &DataType::Int64,
+                })
+                .expect("date_bin should work on valid values"),
+            )
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/functions/src/math/gcd.rs
+++ b/datafusion/functions/src/math/gcd.rs
@@ -15,18 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{ArrayRef, Int64Array};
+use arrow::array::{new_null_array, ArrayRef, AsArray, Int64Array};
 use arrow::error::ArrowError;
 use std::any::Any;
 use std::mem::swap;
 use std::sync::Arc;
 
-use arrow::datatypes::DataType;
-use arrow::datatypes::DataType::Int64;
+use arrow::datatypes::{DataType, Int64Type};
 
-use crate::utils::make_scalar_function;
 use datafusion_common::{
     arrow_datafusion_err, exec_err, internal_datafusion_err, DataFusionError, Result,
+    ScalarValue,
 };
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
@@ -54,9 +53,12 @@ impl Default for GcdFunc {
 
 impl GcdFunc {
     pub fn new() -> Self {
-        use DataType::*;
         Self {
-            signature: Signature::uniform(2, vec![Int64], Volatility::Immutable),
+            signature: Signature::uniform(
+                2,
+                vec![DataType::Int64],
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -75,11 +77,33 @@ impl ScalarUDFImpl for GcdFunc {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(Int64)
+        Ok(DataType::Int64)
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        make_scalar_function(gcd, vec![])(&args.args)
+        let args: [ColumnarValue; 2] = args.args.try_into().map_err(|_| {
+            internal_datafusion_err!("Expected 2 arguments for function gcd")
+        })?;
+
+        match args {
+            [ColumnarValue::Array(a), ColumnarValue::Array(b)] => 
+                compute_gcd_for_arrays(&a, &b),
+            [ColumnarValue::Scalar(ScalarValue::Int64(a)), ColumnarValue::Scalar(ScalarValue::Int64(b))] => {
+                match (a, b) {
+                    (Some(a), Some(b)) => Ok(ColumnarValue::Scalar(ScalarValue::Int64(
+                        Some(compute_gcd(a, b)?),
+                    ))),
+                    _ => Ok(ColumnarValue::Scalar(ScalarValue::Int64(None))),
+                }
+            }
+            [ColumnarValue::Array(a), ColumnarValue::Scalar(ScalarValue::Int64(b))] => {
+                compute_gcd_with_scalar(&a, b)
+            }
+            [ColumnarValue::Scalar(ScalarValue::Int64(a)), ColumnarValue::Array(b)] => {
+                compute_gcd_with_scalar(&b, a)
+            }
+            _ => exec_err!("Unsupported argument types for function gcd"),
+        }
     }
 
     fn documentation(&self) -> Option<&Documentation> {
@@ -87,24 +111,35 @@ impl ScalarUDFImpl for GcdFunc {
     }
 }
 
-/// Gcd SQL function
-fn gcd(args: &[ArrayRef]) -> Result<ArrayRef> {
-    match args[0].data_type() {
-        Int64 => {
-            let arg1 = downcast_named_arg!(&args[0], "x", Int64Array);
-            let arg2 = downcast_named_arg!(&args[1], "y", Int64Array);
+fn compute_gcd_for_arrays(a: &ArrayRef, b: &ArrayRef) -> Result<ColumnarValue> {
+    let result: Result<Int64Array> = a
+        .as_primitive::<Int64Type>()
+        .iter()
+        .zip(b.as_primitive::<Int64Type>().iter())
+        .map(|(a, b)| match (a, b) {
+            (Some(a), Some(b)) => Ok(Some(compute_gcd(a, b)?)),
+            _ => Ok(None),
+        })
+        .collect();
+    
+    result.map(|arr| ColumnarValue::Array(Arc::new(arr) as ArrayRef))
+}
 
-            Ok(arg1
+fn compute_gcd_with_scalar(arr: &ArrayRef, scalar: Option<i64>) -> Result<ColumnarValue> {
+    match scalar {
+        Some(scalar_value) => {
+            let result: Result<Int64Array> = arr
+                .as_primitive::<Int64Type>()
                 .iter()
-                .zip(arg2.iter())
-                .map(|(a1, a2)| match (a1, a2) {
-                    (Some(a1), Some(a2)) => Ok(Some(compute_gcd(a1, a2)?)),
+                .map(|val| match val {
+                    Some(val) => Ok(Some(compute_gcd(val, scalar_value)?)),
                     _ => Ok(None),
                 })
-                .collect::<Result<Int64Array>>()
-                .map(Arc::new)? as ArrayRef)
+                .collect();
+            
+            result.map(|arr| ColumnarValue::Array(Arc::new(arr) as ArrayRef))
         }
-        other => exec_err!("Unsupported data type {other:?} for function gcd"),
+        None => Ok(ColumnarValue::Array(new_null_array(&DataType::Int64, arr.len()))),
     }
 }
 
@@ -142,51 +177,4 @@ pub fn compute_gcd(x: i64, y: i64) -> Result<i64> {
             "Signed integer overflow in GCD({x}, {y})"
         )))
     })
-}
-
-#[cfg(test)]
-mod test {
-    use std::sync::Arc;
-
-    use arrow::{
-        array::{ArrayRef, Int64Array},
-        error::ArrowError,
-    };
-
-    use crate::math::gcd::gcd;
-    use datafusion_common::{cast::as_int64_array, DataFusionError};
-
-    #[test]
-    fn test_gcd_i64() {
-        let args: Vec<ArrayRef> = vec![
-            Arc::new(Int64Array::from(vec![0, 3, 25, -16])), // x
-            Arc::new(Int64Array::from(vec![0, -2, 15, 8])),  // y
-        ];
-
-        let result = gcd(&args).expect("failed to initialize function gcd");
-        let ints = as_int64_array(&result).expect("failed to initialize function gcd");
-
-        assert_eq!(ints.len(), 4);
-        assert_eq!(ints.value(0), 0);
-        assert_eq!(ints.value(1), 1);
-        assert_eq!(ints.value(2), 5);
-        assert_eq!(ints.value(3), 8);
-    }
-
-    #[test]
-    fn overflow_on_both_param_i64_min() {
-        let args: Vec<ArrayRef> = vec![
-            Arc::new(Int64Array::from(vec![i64::MIN])), // x
-            Arc::new(Int64Array::from(vec![i64::MIN])), // y
-        ];
-
-        match gcd(&args) {
-            // we expect a overflow
-            Err(DataFusionError::ArrowError(ArrowError::ComputeError(_), _)) => {}
-            Err(_) => {
-                panic!("failed to initialize function gcd")
-            }
-            Ok(_) => panic!("GCD({0}, {0}) should have overflown", i64::MIN),
-        };
-    }
 }

--- a/datafusion/functions/src/math/gcd.rs
+++ b/datafusion/functions/src/math/gcd.rs
@@ -23,9 +23,7 @@ use std::any::Any;
 use std::mem::swap;
 use std::sync::Arc;
 
-use datafusion_common::{
-    exec_err, internal_datafusion_err, internal_err, Result, ScalarValue,
-};
+use datafusion_common::{exec_err, internal_datafusion_err, Result, ScalarValue};
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
     Volatility,
@@ -114,13 +112,6 @@ impl ScalarUDFImpl for GcdFunc {
 fn compute_gcd_for_arrays(a: &ArrayRef, b: &ArrayRef) -> Result<ColumnarValue> {
     let a = a.as_primitive::<Int64Type>();
     let b = b.as_primitive::<Int64Type>();
-    if a.len() != b.len() {
-        return internal_err!(
-            "Length of arguments for function gcd do not match: {} vs {}",
-            a.len(),
-            b.len()
-        );
-    }
     try_binary(a, b, compute_gcd)
         .map(|arr: PrimitiveArray<Int64Type>| {
             ColumnarValue::Array(Arc::new(arr) as ArrayRef)

--- a/datafusion/functions/src/math/gcd.rs
+++ b/datafusion/functions/src/math/gcd.rs
@@ -86,8 +86,9 @@ impl ScalarUDFImpl for GcdFunc {
         })?;
 
         match args {
-            [ColumnarValue::Array(a), ColumnarValue::Array(b)] => 
-                compute_gcd_for_arrays(&a, &b),
+            [ColumnarValue::Array(a), ColumnarValue::Array(b)] => {
+                compute_gcd_for_arrays(&a, &b)
+            }
             [ColumnarValue::Scalar(ScalarValue::Int64(a)), ColumnarValue::Scalar(ScalarValue::Int64(b))] => {
                 match (a, b) {
                     (Some(a), Some(b)) => Ok(ColumnarValue::Scalar(ScalarValue::Int64(
@@ -121,7 +122,7 @@ fn compute_gcd_for_arrays(a: &ArrayRef, b: &ArrayRef) -> Result<ColumnarValue> {
             _ => Ok(None),
         })
         .collect();
-    
+
     result.map(|arr| ColumnarValue::Array(Arc::new(arr) as ArrayRef))
 }
 
@@ -136,10 +137,13 @@ fn compute_gcd_with_scalar(arr: &ArrayRef, scalar: Option<i64>) -> Result<Column
                     _ => Ok(None),
                 })
                 .collect();
-            
+
             result.map(|arr| ColumnarValue::Array(Arc::new(arr) as ArrayRef))
         }
-        None => Ok(ColumnarValue::Array(new_null_array(&DataType::Int64, arr.len()))),
+        None => Ok(ColumnarValue::Array(new_null_array(
+            &DataType::Int64,
+            arr.len(),
+        ))),
     }
 }
 

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -623,12 +623,12 @@ select
 1 1 1
 
 # gcd with columns and expresions
-query II rowsort
+query II
 select gcd(a, b), gcd(c*d + 1, abs(e)) + f from signed_integers;
 ----
 1 11
-1 13
 2 -10
+1 13
 NULL NULL
 
 # gcd(i64::MIN, i64::MIN)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

`make_scalar_function` convert scalar to array and call function kernel. However, we don't need to convert to array and can directly compute on it. This improve the gcd performance in array vs scalar case

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
