### PR TITLE
chore: Strip debuginfo symbols for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ inherits = "release"
 lto = false
 opt-level = 3
 overflow-checks = false
-panic = 'unwind'
+panic = 'abort'
 rpath = false
 strip = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,8 @@ url = "2.5.4"
 [profile.release]
 codegen-units = 1
 lto = true
+debug = false
+strip = true
 
 # the release profile takes a long time to build so we can use this profile during development to save time
 # cargo build --profile release-nonlto
@@ -173,6 +175,7 @@ opt-level = 3
 overflow-checks = false
 panic = 'unwind'
 rpath = false
+strip = true
 
 [profile.ci]
 inherits = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,9 +159,7 @@ url = "2.5.4"
 [profile.release]
 codegen-units = 1
 lto = true
-debug = false
 strip = true
-panic = "abort"
 
 # the release profile takes a long time to build so we can use this profile during development to save time
 # cargo build --profile release-nonlto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ codegen-units = 1
 lto = true
 debug = false
 strip = true
+panic = "abort"
 
 # the release profile takes a long time to build so we can use this profile during development to save time
 # cargo build --profile release-nonlto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,16 +167,13 @@ panic = "abort"
 # cargo build --profile release-nonlto
 [profile.release-nonlto]
 codegen-units = 16
-debug = false
 debug-assertions = false
 incremental = false
 inherits = "release"
 lto = false
 opt-level = 3
 overflow-checks = false
-panic = 'abort'
 rpath = false
-strip = true
 
 [profile.ci]
 inherits = "dev"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #13816.

Minimizing the DF binary size from 60M to 50M by stripping debuginfo.

Removing unwind panic saves 10 more MB

The stripped binary has the biggest methods for std panic



## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
