### PR TITLE
Workaround for compilation error due to rkyv#434.

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2869,7 +2869,11 @@ fn intersect_maps<'a>(
     let mut inputs = inputs.into_iter();
     let mut merged: HashMap<String, String> = inputs.next().cloned().unwrap_or_default();
     for input in inputs {
-        merged.retain(|k, v| input.get(k) == Some(v));
+        // The extra dereference below (`&*v`) is a workaround for https://github.com/rkyv/rkyv/issues/434.
+        // When this crate is used in a workspace that enables the `rkyv-64` feature in the `chrono` crate,
+        // this triggers a Rust compilation error:
+        // error[E0277]: can't compare `Option<&std::string::String>` with `Option<&mut std::string::String>`.
+        merged.retain(|k, v| input.get(k) == Some(&*v));
     }
     merged
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #14862

## Rationale for this change

When datafusion is used in a workspace that enables the `rkyv-64` feature in the `chrono` crate, this triggered a Rust compilation error:

```
error[E0277]: can't compare `Option<&std::string::String>` with `Option<&mut std::string::String>`.
```

The root cause of the error is incorrect type unification in the Rust compiler, as explained in https://github.com/rkyv/rkyv/issues/434.

## What changes are included in this PR?

The workaround pushes the compiler in the right direction by converting the mutable reference to an immutable one manually.

## Are these changes tested?

I don't think this requires additional tests.

## Are there any user-facing changes?

no