### PR TITLE
refactor: replace OnceLock with LazyLock

### DIFF
--- a/datafusion/functions/src/math/monotonicity.rs
+++ b/datafusion/functions/src/math/monotonicity.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 use datafusion_common::{exec_err, Result, ScalarValue};
 use datafusion_expr::interval_arithmetic::Interval;
@@ -38,18 +38,18 @@ pub fn acos_order(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-static DOCUMENTATION_ACOS: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_ACOS: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the arc cosine or inverse cosine of a number.",
+        "acos(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_acos_doc() -> &'static Documentation {
-    DOCUMENTATION_ACOS.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the arc cosine or inverse cosine of a number.",
-            "acos(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_ACOS
 }
 
 /// Non-decreasing for x ≥ 1, undefined otherwise.
@@ -69,18 +69,18 @@ pub fn acosh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-static DOCUMENTATION_ACOSH: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_ACOSH: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+            "Returns the area hyperbolic cosine or inverse hyperbolic cosine of a number.",
+
+        "acosh(numeric_expression)")
+        .with_standard_argument("numeric_expression", Some("Numeric"))
+        .build()
+});
 
 pub fn get_acosh_doc() -> &'static Documentation {
-    DOCUMENTATION_ACOSH.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-                "Returns the area hyperbolic cosine or inverse hyperbolic cosine of a number.",
-
-            "acosh(numeric_expression)")
-            .with_standard_argument("numeric_expression", Some("Numeric"))
-            .build()
-    })
+    &*DOCUMENTATION_ACOSH
 }
 
 /// Non-decreasing on the interval \[−1, 1\], undefined otherwise.
@@ -98,18 +98,18 @@ pub fn asin_order(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-static DOCUMENTATION_ASIN: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_ASIN: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the arc sine or inverse sine of a number.",
+        "asin(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_asin_doc() -> &'static Documentation {
-    DOCUMENTATION_ASIN.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the arc sine or inverse sine of a number.",
-            "asin(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_ASIN
 }
 
 /// Non-decreasing for all real numbers.
@@ -117,18 +117,18 @@ pub fn asinh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_ASINH: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_ASINH: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the area hyperbolic sine or inverse hyperbolic sine of a number.",
+        "asinh(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_asinh_doc() -> &'static Documentation {
-    DOCUMENTATION_ASINH.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the area hyperbolic sine or inverse hyperbolic sine of a number.",
-            "asinh(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_ASINH
 }
 
 /// Non-decreasing for all real numbers.
@@ -136,18 +136,18 @@ pub fn atan_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_ATAN: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_ATAN: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the arc tangent or inverse tangent of a number.",
+        "atan(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_atan_doc() -> &'static Documentation {
-    DOCUMENTATION_ATAN.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the arc tangent or inverse tangent of a number.",
-            "atan(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_ATAN
 }
 
 /// Non-decreasing on the interval \[−1, 1\], undefined otherwise.
@@ -165,18 +165,18 @@ pub fn atanh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-static DOCUMENTATION_ATANH: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_ATANH: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+            "Returns the area hyperbolic tangent or inverse hyperbolic tangent of a number.",
+
+        "atanh(numeric_expression)")
+        .with_standard_argument("numeric_expression", Some("Numeric"))
+        .build()
+});
 
 pub fn get_atanh_doc() -> &'static Documentation {
-    DOCUMENTATION_ATANH.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-                "Returns the area hyperbolic tangent or inverse hyperbolic tangent of a number.",
-
-            "atanh(numeric_expression)")
-            .with_standard_argument("numeric_expression", Some("Numeric"))
-            .build()
-    })
+    &*DOCUMENTATION_ATANH
 }
 
 /// Order depends on the quadrant.
@@ -185,21 +185,21 @@ pub fn atan2_order(_input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(SortProperties::Unordered)
 }
 
-static DOCUMENTATION_ATANH2: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_ATANH2: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+            "Returns the arc tangent or inverse tangent of `expression_y / expression_x`.",
+
+        "atan2(expression_y, expression_x)")
+        .with_argument("expression_y", r#"First numeric expression to operate on.
+Can be a constant, column, or function, and any combination of arithmetic operators."#)
+        .with_argument("expression_x", r#"Second numeric expression to operate on.
+Can be a constant, column, or function, and any combination of arithmetic operators."#)
+        .build()
+});
 
 pub fn get_atan2_doc() -> &'static Documentation {
-    DOCUMENTATION_ATANH2.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-                "Returns the arc tangent or inverse tangent of `expression_y / expression_x`.",
-
-            "atan2(expression_y, expression_x)")
-            .with_argument("expression_y", r#"First numeric expression to operate on.
-  Can be a constant, column, or function, and any combination of arithmetic operators."#)
-            .with_argument("expression_x", r#"Second numeric expression to operate on.
-  Can be a constant, column, or function, and any combination of arithmetic operators."#)
-            .build()
-    })
+    &*DOCUMENTATION_ATANH2
 }
 
 /// Non-decreasing for all real numbers.
@@ -207,18 +207,18 @@ pub fn cbrt_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_CBRT: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_CBRT: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the cube root of a number.",
+        "cbrt(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_cbrt_doc() -> &'static Documentation {
-    DOCUMENTATION_CBRT.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the cube root of a number.",
-            "cbrt(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_CBRT
 }
 
 /// Non-decreasing for all real numbers.
@@ -226,18 +226,18 @@ pub fn ceil_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_CEIL: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_CEIL: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the nearest integer greater than or equal to a number.",
+        "ceil(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_ceil_doc() -> &'static Documentation {
-    DOCUMENTATION_CEIL.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the nearest integer greater than or equal to a number.",
-            "ceil(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_CEIL
 }
 
 /// Non-increasing on \[0, π\] and then non-decreasing on \[π, 2π\].
@@ -247,18 +247,18 @@ pub fn cos_order(_input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(SortProperties::Unordered)
 }
 
-static DOCUMENTATION_COS: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_COS: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the cosine of a number.",
+        "cos(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_cos_doc() -> &'static Documentation {
-    DOCUMENTATION_COS.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the cosine of a number.",
-            "cos(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_COS
 }
 
 /// Non-decreasing for x ≥ 0 and symmetrically non-increasing for x ≤ 0.
@@ -277,18 +277,18 @@ pub fn cosh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-static DOCUMENTATION_COSH: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_COSH: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the hyperbolic cosine of a number.",
+        "cosh(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_cosh_doc() -> &'static Documentation {
-    DOCUMENTATION_COSH.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the hyperbolic cosine of a number.",
-            "cosh(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_COSH
 }
 
 /// Non-decreasing function that converts radians to degrees.
@@ -296,18 +296,18 @@ pub fn degrees_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_DEGREES: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_DEGREES: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Converts radians to degrees.",
+        "degrees(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_degrees_doc() -> &'static Documentation {
-    DOCUMENTATION_DEGREES.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Converts radians to degrees.",
-            "degrees(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_DEGREES
 }
 
 /// Non-decreasing for all real numbers.
@@ -315,18 +315,18 @@ pub fn exp_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_EXP: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_EXP: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the base-e exponential of a number.",
+        "exp(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_exp_doc() -> &'static Documentation {
-    DOCUMENTATION_EXP.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the base-e exponential of a number.",
-            "exp(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_EXP
 }
 
 /// Non-decreasing for all real numbers.
@@ -334,18 +334,18 @@ pub fn floor_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_FLOOR: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_FLOOR: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the nearest integer less than or equal to a number.",
+        "floor(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_floor_doc() -> &'static Documentation {
-    DOCUMENTATION_FLOOR.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the nearest integer less than or equal to a number.",
-            "floor(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_FLOOR
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
@@ -362,18 +362,18 @@ pub fn ln_order(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-static DOCUMENTATION_LN: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_LN: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the natural logarithm of a number.",
+        "ln(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_ln_doc() -> &'static Documentation {
-    DOCUMENTATION_LN.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the natural logarithm of a number.",
-            "ln(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_LN
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
@@ -390,18 +390,18 @@ pub fn log2_order(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-static DOCUMENTATION_LOG2: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_LOG2: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the base-2 logarithm of a number.",
+        "log2(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_log2_doc() -> &'static Documentation {
-    DOCUMENTATION_LOG2.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the base-2 logarithm of a number.",
-            "log2(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_LOG2
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
@@ -418,18 +418,18 @@ pub fn log10_order(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-static DOCUMENTATION_LOG10: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_LOG10: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the base-10 logarithm of a number.",
+        "log10(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_log10_doc() -> &'static Documentation {
-    DOCUMENTATION_LOG10.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the base-10 logarithm of a number.",
-            "log10(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_LOG10
 }
 
 /// Non-decreasing for all real numbers x.
@@ -437,18 +437,18 @@ pub fn radians_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_RADIONS: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_RADIONS: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Converts degrees to radians.",
+        "radians(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_radians_doc() -> &'static Documentation {
-    DOCUMENTATION_RADIONS.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Converts degrees to radians.",
-            "radians(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_RADIONS
 }
 
 /// Non-decreasing on \[0, π\] and then non-increasing on \[π, 2π\].
@@ -458,18 +458,18 @@ pub fn sin_order(_input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(SortProperties::Unordered)
 }
 
-static DOCUMENTATION_SIN: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_SIN: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the sine of a number.",
+        "sin(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_sin_doc() -> &'static Documentation {
-    DOCUMENTATION_SIN.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the sine of a number.",
-            "sin(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_SIN
 }
 
 /// Non-decreasing for all real numbers.
@@ -477,18 +477,18 @@ pub fn sinh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_SINH: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_SINH: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the hyperbolic sine of a number.",
+        "sinh(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_sinh_doc() -> &'static Documentation {
-    DOCUMENTATION_SINH.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the hyperbolic sine of a number.",
-            "sinh(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_SINH
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
@@ -505,18 +505,18 @@ pub fn sqrt_order(input: &[ExprProperties]) -> Result<SortProperties> {
     }
 }
 
-static DOCUMENTATION_SQRT: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_SQRT: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the square root of a number.",
+        "sqrt(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_sqrt_doc() -> &'static Documentation {
-    DOCUMENTATION_SQRT.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the square root of a number.",
-            "sqrt(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_SQRT
 }
 
 /// Non-decreasing between vertical asymptotes at x = k * π ± π / 2 for any
@@ -526,18 +526,18 @@ pub fn tan_order(_input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(SortProperties::Unordered)
 }
 
-static DOCUMENTATION_TAN: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_TAN: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the tangent of a number.",
+        "tan(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_tan_doc() -> &'static Documentation {
-    DOCUMENTATION_TAN.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the tangent of a number.",
-            "tan(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_TAN
 }
 
 /// Non-decreasing for all real numbers.
@@ -545,18 +545,18 @@ pub fn tanh_order(input: &[ExprProperties]) -> Result<SortProperties> {
     Ok(input[0].sort_properties)
 }
 
-static DOCUMENTATION_TANH: OnceLock<Documentation> = OnceLock::new();
+static DOCUMENTATION_TANH: LazyLock<Documentation> = LazyLock::new(|| {
+    Documentation::builder(
+        DOC_SECTION_MATH,
+        "Returns the hyperbolic tangent of a number.",
+        "tanh(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
+});
 
 pub fn get_tanh_doc() -> &'static Documentation {
-    DOCUMENTATION_TANH.get_or_init(|| {
-        Documentation::builder(
-            DOC_SECTION_MATH,
-            "Returns the hyperbolic tangent of a number.",
-            "tanh(numeric_expression)",
-        )
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
-    })
+    &*DOCUMENTATION_TANH
 }
 
 #[cfg(test)]

--- a/datafusion/functions/src/math/monotonicity.rs
+++ b/datafusion/functions/src/math/monotonicity.rs
@@ -49,7 +49,7 @@ static DOCUMENTATION_ACOS: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_acos_doc() -> &'static Documentation {
-    &*DOCUMENTATION_ACOS
+    &DOCUMENTATION_ACOS
 }
 
 /// Non-decreasing for x ≥ 1, undefined otherwise.
@@ -72,15 +72,15 @@ pub fn acosh_order(input: &[ExprProperties]) -> Result<SortProperties> {
 static DOCUMENTATION_ACOSH: LazyLock<Documentation> = LazyLock::new(|| {
     Documentation::builder(
         DOC_SECTION_MATH,
-            "Returns the area hyperbolic cosine or inverse hyperbolic cosine of a number.",
-
-        "acosh(numeric_expression)")
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
+        "Returns the area hyperbolic cosine or inverse hyperbolic cosine of a number.",
+        "acosh(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
 });
 
 pub fn get_acosh_doc() -> &'static Documentation {
-    &*DOCUMENTATION_ACOSH
+    &DOCUMENTATION_ACOSH
 }
 
 /// Non-decreasing on the interval \[−1, 1\], undefined otherwise.
@@ -109,7 +109,7 @@ static DOCUMENTATION_ASIN: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_asin_doc() -> &'static Documentation {
-    &*DOCUMENTATION_ASIN
+    &DOCUMENTATION_ASIN
 }
 
 /// Non-decreasing for all real numbers.
@@ -128,7 +128,7 @@ static DOCUMENTATION_ASINH: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_asinh_doc() -> &'static Documentation {
-    &*DOCUMENTATION_ASINH
+    &DOCUMENTATION_ASINH
 }
 
 /// Non-decreasing for all real numbers.
@@ -147,7 +147,7 @@ static DOCUMENTATION_ATAN: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_atan_doc() -> &'static Documentation {
-    &*DOCUMENTATION_ATAN
+    &DOCUMENTATION_ATAN
 }
 
 /// Non-decreasing on the interval \[−1, 1\], undefined otherwise.
@@ -168,15 +168,15 @@ pub fn atanh_order(input: &[ExprProperties]) -> Result<SortProperties> {
 static DOCUMENTATION_ATANH: LazyLock<Documentation> = LazyLock::new(|| {
     Documentation::builder(
         DOC_SECTION_MATH,
-            "Returns the area hyperbolic tangent or inverse hyperbolic tangent of a number.",
-
-        "atanh(numeric_expression)")
-        .with_standard_argument("numeric_expression", Some("Numeric"))
-        .build()
+        "Returns the area hyperbolic tangent or inverse hyperbolic tangent of a number.",
+        "atanh(numeric_expression)",
+    )
+    .with_standard_argument("numeric_expression", Some("Numeric"))
+    .build()
 });
 
 pub fn get_atanh_doc() -> &'static Documentation {
-    &*DOCUMENTATION_ATANH
+    &DOCUMENTATION_ATANH
 }
 
 /// Order depends on the quadrant.
@@ -188,18 +188,24 @@ pub fn atan2_order(_input: &[ExprProperties]) -> Result<SortProperties> {
 static DOCUMENTATION_ATANH2: LazyLock<Documentation> = LazyLock::new(|| {
     Documentation::builder(
         DOC_SECTION_MATH,
-            "Returns the arc tangent or inverse tangent of `expression_y / expression_x`.",
-
-        "atan2(expression_y, expression_x)")
-        .with_argument("expression_y", r#"First numeric expression to operate on.
-Can be a constant, column, or function, and any combination of arithmetic operators."#)
-        .with_argument("expression_x", r#"Second numeric expression to operate on.
-Can be a constant, column, or function, and any combination of arithmetic operators."#)
-        .build()
+        "Returns the arc tangent or inverse tangent of `expression_y / expression_x`.",
+        "atan2(expression_y, expression_x)",
+    )
+    .with_argument(
+        "expression_y",
+        r#"First numeric expression to operate on.
+Can be a constant, column, or function, and any combination of arithmetic operators."#,
+    )
+    .with_argument(
+        "expression_x",
+        r#"Second numeric expression to operate on.
+Can be a constant, column, or function, and any combination of arithmetic operators."#,
+    )
+    .build()
 });
 
 pub fn get_atan2_doc() -> &'static Documentation {
-    &*DOCUMENTATION_ATANH2
+    &DOCUMENTATION_ATANH2
 }
 
 /// Non-decreasing for all real numbers.
@@ -218,7 +224,7 @@ static DOCUMENTATION_CBRT: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_cbrt_doc() -> &'static Documentation {
-    &*DOCUMENTATION_CBRT
+    &DOCUMENTATION_CBRT
 }
 
 /// Non-decreasing for all real numbers.
@@ -237,7 +243,7 @@ static DOCUMENTATION_CEIL: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_ceil_doc() -> &'static Documentation {
-    &*DOCUMENTATION_CEIL
+    &DOCUMENTATION_CEIL
 }
 
 /// Non-increasing on \[0, π\] and then non-decreasing on \[π, 2π\].
@@ -258,7 +264,7 @@ static DOCUMENTATION_COS: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_cos_doc() -> &'static Documentation {
-    &*DOCUMENTATION_COS
+    &DOCUMENTATION_COS
 }
 
 /// Non-decreasing for x ≥ 0 and symmetrically non-increasing for x ≤ 0.
@@ -288,7 +294,7 @@ static DOCUMENTATION_COSH: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_cosh_doc() -> &'static Documentation {
-    &*DOCUMENTATION_COSH
+    &DOCUMENTATION_COSH
 }
 
 /// Non-decreasing function that converts radians to degrees.
@@ -307,7 +313,7 @@ static DOCUMENTATION_DEGREES: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_degrees_doc() -> &'static Documentation {
-    &*DOCUMENTATION_DEGREES
+    &DOCUMENTATION_DEGREES
 }
 
 /// Non-decreasing for all real numbers.
@@ -326,7 +332,7 @@ static DOCUMENTATION_EXP: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_exp_doc() -> &'static Documentation {
-    &*DOCUMENTATION_EXP
+    &DOCUMENTATION_EXP
 }
 
 /// Non-decreasing for all real numbers.
@@ -345,7 +351,7 @@ static DOCUMENTATION_FLOOR: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_floor_doc() -> &'static Documentation {
-    &*DOCUMENTATION_FLOOR
+    &DOCUMENTATION_FLOOR
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
@@ -373,7 +379,7 @@ static DOCUMENTATION_LN: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_ln_doc() -> &'static Documentation {
-    &*DOCUMENTATION_LN
+    &DOCUMENTATION_LN
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
@@ -401,7 +407,7 @@ static DOCUMENTATION_LOG2: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_log2_doc() -> &'static Documentation {
-    &*DOCUMENTATION_LOG2
+    &DOCUMENTATION_LOG2
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
@@ -429,7 +435,7 @@ static DOCUMENTATION_LOG10: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_log10_doc() -> &'static Documentation {
-    &*DOCUMENTATION_LOG10
+    &DOCUMENTATION_LOG10
 }
 
 /// Non-decreasing for all real numbers x.
@@ -448,7 +454,7 @@ static DOCUMENTATION_RADIONS: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_radians_doc() -> &'static Documentation {
-    &*DOCUMENTATION_RADIONS
+    &DOCUMENTATION_RADIONS
 }
 
 /// Non-decreasing on \[0, π\] and then non-increasing on \[π, 2π\].
@@ -469,7 +475,7 @@ static DOCUMENTATION_SIN: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_sin_doc() -> &'static Documentation {
-    &*DOCUMENTATION_SIN
+    &DOCUMENTATION_SIN
 }
 
 /// Non-decreasing for all real numbers.
@@ -488,7 +494,7 @@ static DOCUMENTATION_SINH: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_sinh_doc() -> &'static Documentation {
-    &*DOCUMENTATION_SINH
+    &DOCUMENTATION_SINH
 }
 
 /// Non-decreasing for x ≥ 0, undefined otherwise.
@@ -516,7 +522,7 @@ static DOCUMENTATION_SQRT: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_sqrt_doc() -> &'static Documentation {
-    &*DOCUMENTATION_SQRT
+    &DOCUMENTATION_SQRT
 }
 
 /// Non-decreasing between vertical asymptotes at x = k * π ± π / 2 for any
@@ -537,7 +543,7 @@ static DOCUMENTATION_TAN: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_tan_doc() -> &'static Documentation {
-    &*DOCUMENTATION_TAN
+    &DOCUMENTATION_TAN
 }
 
 /// Non-decreasing for all real numbers.
@@ -556,7 +562,7 @@ static DOCUMENTATION_TANH: LazyLock<Documentation> = LazyLock::new(|| {
 });
 
 pub fn get_tanh_doc() -> &'static Documentation {
-    &*DOCUMENTATION_TANH
+    &DOCUMENTATION_TANH
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #11687 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
LazyLock is more ergonomic than OnceLock.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Replaces all OnceLock in monoticity.rs in `datafusion-functions` with their LazyLock equivalents.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes, by existing tests.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
