### PR TITLE
Include struct name on FileScanConfig debug impl

### DIFF
--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -609,11 +609,13 @@ impl FileScanConfig {
 
 impl Debug for FileScanConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "FileScanConfig {{")?;
         write!(f, "object_store_url={:?}, ", self.object_store_url)?;
 
         write!(f, "statistics={:?}, ", self.statistics)?;
 
-        DisplayAs::fmt_as(self, DisplayFormatType::Verbose, f)
+        DisplayAs::fmt_as(self, DisplayFormatType::Verbose, f)?;
+        write!(f, "}}")
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of
- Related to https://github.com/delta-io/delta-rs/pull/3261
- Related to https://github.com/apache/datafusion/issues/14123
- Follow on to https://github.com/apache/datafusion/pull/14224
- Related to https://github.com/apache/datafusion/pull/14882

## Rationale for this change

When working on upgrading delta-rs to use the new DataSourceExec I was super confused that the source printed out like this
```
object_store_url=...
```
Without the struct name 🤯 


## What changes are included in this PR?

Add the struct name

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
