### PR TITLE
Minor: Add Development Environment to Documentation Index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -141,7 +141,7 @@ To get started, see
 
    contributor-guide/index
    contributor-guide/communication
-   contributor-guide/getting_started
+   contributor-guide/development_environment
    contributor-guide/architecture
    contributor-guide/testing
    contributor-guide/howtos


### PR DESCRIPTION
## Which issue does this PR close?


## Rationale for this change

I found the that the setting up development environment page wasn't linked in the table of contents

![Screenshot 2025-02-26 at 6 26 27 AM](https://github.com/user-attachments/assets/266ed643-3fa1-4eee-aa24-ca55f79ced9b)

running `cd docs && ./build.sh` also shows an error

```
reading sources... [100%] user-guide/sql/write_options
/Users/andrewlamb/Software/datafusion/docs/temp/index.rst:138: WARNING: toctree contains reference to nonexisting document 'contributor-guide/getting_started'
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/andrewlamb/Software/datafusion/docs/temp/contributor-guide/development_environment.md: WARNING: document isn't included in any toctree
```

I think this may have been introduced in https://github.com/apache/datafusion/pull/14694
## What changes are included in this PR?
Fix the index:


## Are these changes tested?
I tested them lcal
![Screenshot 2025-02-26 at 6 27 40 AM](https://github.com/user-attachments/assets/2c60bad9-3e82-4a16-aa55-968c9a42d4a3)

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
