### PR TITLE
Add Upgrade Guide for DataFusion 46.0.0

### DIFF
--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -1097,3 +1097,9 @@ doc_comment::doctest!(
     "../../../docs/source/library-user-guide/working-with-exprs.md",
     library_user_guide_working_with_exprs
 );
+
+#[cfg(doctest)]
+doc_comment::doctest!(
+    "../../../docs/source/library-user-guide/upgrading.md",
+    library_user_guide_upgrading
+);

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -133,7 +133,9 @@ To get started, see
    library-user-guide/profiling
    library-user-guide/query-optimizer
    library-user-guide/api-health
-.. _toc.contributor-guide:
+   library-user-guide/upgrading
+
+.. .. _toc.contributor-guide:
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -1,0 +1,45 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Upgrade Guides
+
+## DataFusion `46.0.0`
+
+See more information
+- Change PR [PR #14224](https://github.com/apache/datafusion/pull/14224)
+- Example of an Upgrade [PR in delta-rs](https://github.com/delta-io/delta-rs/pull/3261)
+
+### `ParquetExec`, `AvroExec`, `CsvExec`, `JsonExec` deprecated
+
+DataFusion 46 has a major change to how the built in DataSources are organized. The 
+
+### Cookbook: Changes to `ParquetExecBuilder`
+
+#### Old pattern:
+```test
+TODO
+```
+
+#### New Pattern
+
+
+```test
+TODO
+```
+


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related to https://github.com/apache/datafusion/issues/14123
- Related to https://github.com/apache/datafusion/pull/14224


## Rationale for this change

As we have discussed in tickets, it would be good to have help users upgrade to new DataFusion versions, especially when major / disruptive API changes  like https://github.com/apache/datafusion/pull/14224 are included
- Related to https://github.com/apache/datafusion/issues/13525
- Related to https://github.com/apache/datafusion/issues/13661

## What changes are included in this PR?

1. Add a upgrade guide section:
![Screenshot 2025-02-26 at 6 44 38 AM](https://github.com/user-attachments/assets/f33e4bca-bba6-4756-93dc-2048bf76cf09)
2. Add details on the upgrade to 46.0.0 

## Are these changes tested?

I build the docs manually

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
