### PR TITLE
Fix the null handling for to_char function

### DIFF
--- a/datafusion/functions/src/datetime/to_char.rs
+++ b/datafusion/functions/src/datetime/to_char.rs
@@ -680,26 +680,6 @@ mod tests {
     }
 
     #[test]
-    fn test_to_char_input_none_scalar() {
-        let args = datafusion_expr::ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Date32(None)),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%Y-%m-%d".to_string()))),
-            ],
-            number_rows: 1,
-            return_type: &DataType::Utf8,
-        };
-        let result = ToCharFunc::new()
-            .invoke_with_args(args)
-            .expect("Expected no error");
-        if let ColumnarValue::Scalar(ScalarValue::Utf8(date)) = result {
-            assert!(date.is_none());
-        } else {
-            panic!("Expected a scalar value");
-        }
-    }
-
-    #[test]
     fn test_to_char_input_none_array() {
         let date_array = Arc::new(Date32Array::from(vec![Some(18506), None])) as ArrayRef;
         let format_array =

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -2845,7 +2845,7 @@ NULL
 query T
 SELECT to_char(null, '%d-%m-%Y');
 ----
-(empty)
+NULL
 
 query T
 SELECT to_char(column1, column2)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #14884.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Currently, when passing a NULL value to to_char, it returns an empty string instead of NULL. [This behavior differs from PostgreSQL, Spark, DuckDb](https://github.com/apache/datafusion/issues/14884#issuecomment-2686313231), which returns NULL when given a NULL input. Aligning with common practise ensures consistency and expected behavior for users relying on SQL standards.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Modify to_char function implementation to return NULL when the input is NULL.

Update relevant test cases to validate the correct behavior.

Ensure consistent behavior across different data types.
## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, test cases have been added to check the NULL behavior of to_char.

Existing test cases have been updated where necessary.

Verified that the changes do not introduce regressions.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Users who previously received an empty string when calling to_char(NULL, format) will now receive NULL, aligning with PostgreSQL behavior.

No breaking changes to public APIs, but behavior will be corrected to match expected SQL standards.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
