### PR TITLE
TESTING (NOT FOR MERGE) Test arrow/parquet 54.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,9 +246,8 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755b6da235ac356a869393c23668c663720b8749dd6f15e52b6c214b4b964cc7"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -270,9 +269,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64656a1e0b13ca766f8440752e9a93e11014eec7b67909986f83ed0ab1fe37b8"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -284,9 +282,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a4a6d2896083cfbdf84a71a863b22460d0708f8206a8373c52e326cc72ea1a"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -301,9 +298,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef870583ce5e4f3b123c181706f2002fb134960f9a911900f64ba4830c7a43a"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "bytes",
  "half",
@@ -312,9 +308,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac7eba5a987f8b4a7d9629206ba48e19a1991762795bbe5d08497b7736017ee"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -333,9 +328,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f12542b8164398fc9ec595ff783c4cf6044daa89622c5a7201be920e4c0d4c"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -349,9 +343,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b095e8a4f3c309544935d53e04c3bfe4eea4e71c3de6fe0416d1f08bb4441a83"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -361,9 +354,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7806ee3d229ee866013e83446e937ab3c8a9e6a664b259d41dd960b309c5d0"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -388,9 +380,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c63da4afedde2b25ef69825cd4663ca76f78f79ffe2d057695742099130ff6"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -402,9 +393,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9551d9400532f23a370cabbea1dc5a53c49230397d41f96c4c8eedf306199305"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -422,9 +412,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c07223476f8219d1ace8cd8d85fa18c4ebd8d945013f25ef5c72e85085ca4ee"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -435,9 +424,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b194b38bfd89feabc23e798238989c6648b2506ad639be42ec8eb1658d82c4"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -448,18 +436,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f40f6be8f78af1ab610db7d9b236e21d587b7168e368a36275d2e5670096735"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "bitflags 2.8.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac265273864a820c4a179fc67182ccc41ea9151b97024e1be956f0f2369c2539"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -471,9 +457,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44c8eed43be4ead49128370f7131f054839d3d6003e52aebf64322470b8fbd0"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4056,9 +4041,8 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761c44d824fe83106e0600d2510c07bf4159a4985bf0569b513ea4288dc1b4fb"
+version = "54.2.1"
+source = "git+https://github.com/apache/arrow-rs.git?tag=54.2.1#3f564688cbcd8351e18b35c6286c97f5dd0a8606"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,3 +191,21 @@ large_futures = "warn"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
 unused_qualifications = "deny"
+
+
+## Temporary arrow-rs patch until 52.1.0 is released
+
+[patch.crates-io]
+arrow = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", tag = "54.2.1" }
+


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/arrow-rs/issues/7209


## Rationale for this change
I am using this PR to verify the 54.2.1 arrow hotfix


## What changes are included in this PR?


Without this PR, the following command fails:

```shell

andrewlamb@Andrews-MacBook-Pro-2:~/Software/datafusion$ cargo install --path datafusion-cli/
  Installing datafusion-cli v45.0.0 (/Users/andrewlamb/Software/datafusion/datafusion-cli)
    Updating crates.io index
...

   Compiling hyper-rustls v0.24.2
error[E0034]: multiple applicable items in scope
   --> /Users/andrewlamb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-arith-54.2.0/src/temporal.rs:92:36
    |
92  |         DatePart::Quarter => |d| d.quarter() as i32,
    |                                    ^^^^^^^ multiple `quarter` found
    |
note: candidate #1 is defined in the trait `ChronoDateExt`
   --> /Users/andrewlamb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-arith-54.2.0/src/temporal.rs:638:5
    |
638 |     fn quarter(&self) -> u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
note: candidate #2 is defined in the trait `Datelike`
   --> /Users/andrewlamb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/chrono-0.4.40/src/traits.rs:47:5
    |
47  |     fn quarter(&self) -> u32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
help: disambiguate the method for candidate #1
    |
92  |         DatePart::Quarter => |d| ChronoDateExt::quarter(&d) as i32,
    |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
help: disambiguate the method for candidate #2
    |
92  |         DatePart::Quarter => |d| Datelike::quarter(&d) as i32,
    |                                  ~~~~~~~~~~~~~~~~~~~~~

   Compiling apache-avro v0.17.0
For more information about this error, try `rustc --explain E0034`.
```

With this PR, building succeeds:

```shell
andrewlamb@Andrews-MacBook-Pro-2:~/Software/datafusion$ cargo install --path datafusion-cli/
...
```


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
