### PR TITLE
replace TypeSignature::String with TypeSignature::Coercible

### DIFF
--- a/datafusion/functions-nested/src/string.rs
+++ b/datafusion/functions-nested/src/string.rs
@@ -24,7 +24,6 @@ use arrow::array::{
     UInt8Array,
 };
 use arrow::datatypes::{DataType, Field};
-use datafusion_expr::TypeSignature;
 
 use datafusion_common::{
     internal_datafusion_err, not_impl_err, plan_err, DataFusionError, Result,
@@ -44,8 +43,10 @@ use arrow::datatypes::DataType::{
 };
 use datafusion_common::cast::{as_large_list_array, as_list_array};
 use datafusion_common::exec_err;
+use datafusion_common::types::logical_string;
 use datafusion_expr::{
-    ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
+    Coercion, ColumnarValue, Documentation, ScalarUDFImpl, Signature, TypeSignature,
+    TypeSignatureClass, Volatility,
 };
 use datafusion_functions::{downcast_arg, downcast_named_arg};
 use datafusion_macros::user_doc;
@@ -251,7 +252,17 @@ impl StringToArray {
     pub fn new() -> Self {
         Self {
             signature: Signature::one_of(
-                vec![TypeSignature::String(2), TypeSignature::String(3)],
+                vec![
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    ]),
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    ]),
+                ],
                 Volatility::Immutable,
             ),
             aliases: vec![String::from("string_to_list")],

--- a/datafusion/functions/src/regex/regexplike.rs
+++ b/datafusion/functions/src/regex/regexplike.rs
@@ -21,12 +21,15 @@ use arrow::array::{Array, ArrayRef, AsArray, GenericStringArray};
 use arrow::compute::kernels::regexp;
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::{LargeUtf8, Utf8, Utf8View};
-use datafusion_common::exec_err;
-use datafusion_common::ScalarValue;
-use datafusion_common::{arrow_datafusion_err, plan_err};
-use datafusion_common::{internal_err, DataFusionError, Result};
-use datafusion_expr::{ColumnarValue, Documentation, TypeSignature};
-use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
+use datafusion_common::types::logical_string;
+use datafusion_common::{
+    arrow_datafusion_err, exec_err, internal_err, plan_err, DataFusionError, Result,
+    ScalarValue,
+};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarUDFImpl, Signature, TypeSignature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_macros::user_doc;
 
 use std::any::Any;
@@ -79,7 +82,17 @@ impl RegexpLikeFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::one_of(
-                vec![TypeSignature::String(2), TypeSignature::String(3)],
+                vec![
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    ]),
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    ]),
+                ],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/string/bit_length.rs
+++ b/datafusion/functions/src/string/bit_length.rs
@@ -20,9 +20,13 @@ use arrow::datatypes::DataType;
 use std::any::Any;
 
 use crate::utils::utf8_to_int_type;
-use datafusion_common::{utils::take_function_args, Result, ScalarValue};
-use datafusion_expr::{ColumnarValue, Documentation, Volatility};
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature};
+use datafusion_common::types::logical_string;
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{Result, ScalarValue};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_macros::user_doc;
 
 #[user_doc(
@@ -55,7 +59,12 @@ impl Default for BitLengthFunc {
 impl BitLengthFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::string(1, Volatility::Immutable),
+            signature: Signature::coercible(
+                vec![Coercion::new_exact(TypeSignatureClass::Native(
+                    logical_string(),
+                ))],
+                Volatility::Immutable,
+            ),
         }
     }
 }

--- a/datafusion/functions/src/string/contains.rs
+++ b/datafusion/functions/src/string/contains.rs
@@ -20,12 +20,12 @@ use arrow::array::{Array, ArrayRef, AsArray};
 use arrow::compute::contains as arrow_contains;
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::{Boolean, LargeUtf8, Utf8, Utf8View};
-use datafusion_common::exec_err;
-use datafusion_common::DataFusionError;
-use datafusion_common::Result;
+use datafusion_common::types::logical_string;
+use datafusion_common::{exec_err, DataFusionError, Result};
+use datafusion_expr::binary::{binary_to_string_coercion, string_coercion};
 use datafusion_expr::{
-    ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
-    Volatility,
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
 };
 use datafusion_macros::user_doc;
 use std::any::Any;
@@ -60,7 +60,13 @@ impl Default for ContainsFunc {
 impl ContainsFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::string(2, Volatility::Immutable),
+            signature: Signature::coercible(
+                vec![
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                ],
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -93,28 +99,51 @@ impl ScalarUDFImpl for ContainsFunc {
 
 /// use `arrow::compute::contains` to do the calculation for contains
 pub fn contains(args: &[ArrayRef]) -> Result<ArrayRef, DataFusionError> {
-    match (args[0].data_type(), args[1].data_type()) {
-        (Utf8View, Utf8View) => {
-            let mod_str = args[0].as_string_view();
-            let match_str = args[1].as_string_view();
-            let res = arrow_contains(mod_str, match_str)?;
-            Ok(Arc::new(res) as ArrayRef)
+    if let Some(coercion_data_type) =
+        string_coercion(args[0].data_type(), args[1].data_type()).or_else(|| {
+            binary_to_string_coercion(args[0].data_type(), args[1].data_type())
+        })
+    {
+        let arg0 = if args[0].data_type() == &coercion_data_type {
+            Arc::clone(&args[0])
+        } else {
+            arrow::compute::kernels::cast::cast(&args[0], &coercion_data_type)?
+        };
+        let arg1 = if args[1].data_type() == &coercion_data_type {
+            Arc::clone(&args[1])
+        } else {
+            arrow::compute::kernels::cast::cast(&args[1], &coercion_data_type)?
+        };
+
+        match coercion_data_type {
+            Utf8View => {
+                let mod_str = arg0.as_string_view();
+                let match_str = arg1.as_string_view();
+                let res = arrow_contains(mod_str, match_str)?;
+                Ok(Arc::new(res) as ArrayRef)
+            }
+            Utf8 => {
+                let mod_str = arg0.as_string::<i32>();
+                let match_str = arg1.as_string::<i32>();
+                let res = arrow_contains(mod_str, match_str)?;
+                Ok(Arc::new(res) as ArrayRef)
+            }
+            LargeUtf8 => {
+                let mod_str = arg0.as_string::<i64>();
+                let match_str = arg1.as_string::<i64>();
+                let res = arrow_contains(mod_str, match_str)?;
+                Ok(Arc::new(res) as ArrayRef)
+            }
+            other => {
+                exec_err!("Unsupported data type {other:?} for function `contains`.")
+            }
         }
-        (Utf8, Utf8) => {
-            let mod_str = args[0].as_string::<i32>();
-            let match_str = args[1].as_string::<i32>();
-            let res = arrow_contains(mod_str, match_str)?;
-            Ok(Arc::new(res) as ArrayRef)
-        }
-        (LargeUtf8, LargeUtf8) => {
-            let mod_str = args[0].as_string::<i64>();
-            let match_str = args[1].as_string::<i64>();
-            let res = arrow_contains(mod_str, match_str)?;
-            Ok(Arc::new(res) as ArrayRef)
-        }
-        other => {
-            exec_err!("Unsupported data type {other:?} for function `contains`.")
-        }
+    } else {
+        exec_err!(
+            "Unsupported data type {:?}, {:?} for function `contains`.",
+            args[0].data_type(),
+            args[1].data_type()
+        )
     }
 }
 

--- a/datafusion/functions/src/string/ends_with.rs
+++ b/datafusion/functions/src/string/ends_with.rs
@@ -22,9 +22,13 @@ use arrow::array::ArrayRef;
 use arrow::datatypes::DataType;
 
 use crate::utils::make_scalar_function;
+use datafusion_common::types::logical_string;
 use datafusion_common::{internal_err, Result};
-use datafusion_expr::{ColumnarValue, Documentation, Volatility};
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature};
+use datafusion_expr::binary::{binary_to_string_coercion, string_coercion};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_macros::user_doc;
 
 #[user_doc(
@@ -62,7 +66,13 @@ impl Default for EndsWithFunc {
 impl EndsWithFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::string(2, Volatility::Immutable),
+            signature: Signature::coercible(
+                vec![
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                ],
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -103,9 +113,28 @@ impl ScalarUDFImpl for EndsWithFunc {
 /// Returns true if string ends with suffix.
 /// ends_with('alphabet', 'abet') = 't'
 pub fn ends_with(args: &[ArrayRef]) -> Result<ArrayRef> {
-    let result = arrow::compute::kernels::comparison::ends_with(&args[0], &args[1])?;
-
-    Ok(Arc::new(result) as ArrayRef)
+    if let Some(coercion_data_type) =
+        string_coercion(args[0].data_type(), args[1].data_type()).or_else(|| {
+            binary_to_string_coercion(args[0].data_type(), args[1].data_type())
+        })
+    {
+        let arg0 = if args[0].data_type() == &coercion_data_type {
+            Arc::clone(&args[0])
+        } else {
+            arrow::compute::kernels::cast::cast(&args[0], &coercion_data_type)?
+        };
+        let arg1 = if args[1].data_type() == &coercion_data_type {
+            Arc::clone(&args[1])
+        } else {
+            arrow::compute::kernels::cast::cast(&args[1], &coercion_data_type)?
+        };
+        let result = arrow::compute::kernels::comparison::ends_with(&arg0, &arg1)?;
+        Ok(Arc::new(result) as ArrayRef)
+    } else {
+        internal_err!(
+            "Unsupported data types for ends_with. Expected Utf8, LargeUtf8 or Utf8View"
+        )
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/functions/src/string/levenshtein.rs
+++ b/datafusion/functions/src/string/levenshtein.rs
@@ -23,10 +23,17 @@ use arrow::datatypes::DataType;
 
 use crate::utils::{make_scalar_function, utf8_to_int_type};
 use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
+use datafusion_common::types::logical_string;
 use datafusion_common::utils::datafusion_strsim;
-use datafusion_common::{exec_err, utils::take_function_args, Result};
-use datafusion_expr::{ColumnarValue, Documentation};
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{exec_err, Result};
+use datafusion_expr::type_coercion::binary::{
+    binary_to_string_coercion, string_coercion,
+};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_macros::user_doc;
 
 #[user_doc(
@@ -64,7 +71,13 @@ impl Default for LevenshteinFunc {
 impl LevenshteinFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::string(2, Volatility::Immutable),
+            signature: Signature::coercible(
+                vec![
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                ],
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -83,7 +96,13 @@ impl ScalarUDFImpl for LevenshteinFunc {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        utf8_to_int_type(&arg_types[0], "levenshtein")
+        if let Some(coercion_data_type) = string_coercion(&arg_types[0], &arg_types[1])
+            .or_else(|| binary_to_string_coercion(&arg_types[0], &arg_types[1]))
+        {
+            utf8_to_int_type(&coercion_data_type, "levenshtein")
+        } else {
+            exec_err!("Unsupported data types for levenshtein. Expected Utf8, LargeUtf8 or Utf8View")
+        }
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -107,60 +126,79 @@ impl ScalarUDFImpl for LevenshteinFunc {
 
 ///Returns the Levenshtein distance between the two given strings.
 /// LEVENSHTEIN('kitten', 'sitting') = 3
-pub fn levenshtein<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+fn levenshtein<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     let [str1, str2] = take_function_args("levenshtein", args)?;
 
-    match str1.data_type() {
-        DataType::Utf8View => {
-            let str1_array = as_string_view_array(&str1)?;
-            let str2_array = as_string_view_array(&str2)?;
-            let result = str1_array
-                .iter()
-                .zip(str2_array.iter())
-                .map(|(string1, string2)| match (string1, string2) {
-                    (Some(string1), Some(string2)) => {
-                        Some(datafusion_strsim::levenshtein(string1, string2) as i32)
-                    }
-                    _ => None,
-                })
-                .collect::<Int32Array>();
-            Ok(Arc::new(result) as ArrayRef)
+    if let Some(coercion_data_type) =
+        string_coercion(args[0].data_type(), args[1].data_type()).or_else(|| {
+            binary_to_string_coercion(args[0].data_type(), args[1].data_type())
+        })
+    {
+        let str1 = if str1.data_type() == &coercion_data_type {
+            Arc::clone(str1)
+        } else {
+            arrow::compute::kernels::cast::cast(&str1, &coercion_data_type)?
+        };
+        let str2 = if str2.data_type() == &coercion_data_type {
+            Arc::clone(str2)
+        } else {
+            arrow::compute::kernels::cast::cast(&str2, &coercion_data_type)?
+        };
+
+        match coercion_data_type {
+            DataType::Utf8View => {
+                let str1_array = as_string_view_array(&str1)?;
+                let str2_array = as_string_view_array(&str2)?;
+                let result = str1_array
+                    .iter()
+                    .zip(str2_array.iter())
+                    .map(|(string1, string2)| match (string1, string2) {
+                        (Some(string1), Some(string2)) => {
+                            Some(datafusion_strsim::levenshtein(string1, string2) as i32)
+                        }
+                        _ => None,
+                    })
+                    .collect::<Int32Array>();
+                Ok(Arc::new(result) as ArrayRef)
+            }
+            DataType::Utf8 => {
+                let str1_array = as_generic_string_array::<T>(&str1)?;
+                let str2_array = as_generic_string_array::<T>(&str2)?;
+                let result = str1_array
+                    .iter()
+                    .zip(str2_array.iter())
+                    .map(|(string1, string2)| match (string1, string2) {
+                        (Some(string1), Some(string2)) => {
+                            Some(datafusion_strsim::levenshtein(string1, string2) as i32)
+                        }
+                        _ => None,
+                    })
+                    .collect::<Int32Array>();
+                Ok(Arc::new(result) as ArrayRef)
+            }
+            DataType::LargeUtf8 => {
+                let str1_array = as_generic_string_array::<T>(&str1)?;
+                let str2_array = as_generic_string_array::<T>(&str2)?;
+                let result = str1_array
+                    .iter()
+                    .zip(str2_array.iter())
+                    .map(|(string1, string2)| match (string1, string2) {
+                        (Some(string1), Some(string2)) => {
+                            Some(datafusion_strsim::levenshtein(string1, string2) as i64)
+                        }
+                        _ => None,
+                    })
+                    .collect::<Int64Array>();
+                Ok(Arc::new(result) as ArrayRef)
+            }
+            other => {
+                exec_err!(
+                    "levenshtein was called with {other} datatype arguments. It requires Utf8View, Utf8 or LargeUtf8."
+                )
+            }
         }
-        DataType::Utf8 => {
-            let str1_array = as_generic_string_array::<T>(&str1)?;
-            let str2_array = as_generic_string_array::<T>(&str2)?;
-            let result = str1_array
-                .iter()
-                .zip(str2_array.iter())
-                .map(|(string1, string2)| match (string1, string2) {
-                    (Some(string1), Some(string2)) => {
-                        Some(datafusion_strsim::levenshtein(string1, string2) as i32)
-                    }
-                    _ => None,
-                })
-                .collect::<Int32Array>();
-            Ok(Arc::new(result) as ArrayRef)
-        }
-        DataType::LargeUtf8 => {
-            let str1_array = as_generic_string_array::<T>(&str1)?;
-            let str2_array = as_generic_string_array::<T>(&str2)?;
-            let result = str1_array
-                .iter()
-                .zip(str2_array.iter())
-                .map(|(string1, string2)| match (string1, string2) {
-                    (Some(string1), Some(string2)) => {
-                        Some(datafusion_strsim::levenshtein(string1, string2) as i64)
-                    }
-                    _ => None,
-                })
-                .collect::<Int64Array>();
-            Ok(Arc::new(result) as ArrayRef)
-        }
-        other => {
-            exec_err!(
-                "levenshtein was called with {other} datatype arguments. It requires Utf8View, Utf8 or LargeUtf8."
-            )
-        }
+    } else {
+        exec_err!("Unsupported data types for levenshtein. Expected Utf8, LargeUtf8 or Utf8View")
     }
 }
 

--- a/datafusion/functions/src/string/lower.rs
+++ b/datafusion/functions/src/string/lower.rs
@@ -20,9 +20,12 @@ use std::any::Any;
 
 use crate::string::common::to_lower;
 use crate::utils::utf8_to_str_type;
+use datafusion_common::types::logical_string;
 use datafusion_common::Result;
-use datafusion_expr::{ColumnarValue, Documentation};
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_macros::user_doc;
 
 #[user_doc(
@@ -55,7 +58,12 @@ impl Default for LowerFunc {
 impl LowerFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::string(1, Volatility::Immutable),
+            signature: Signature::coercible(
+                vec![Coercion::new_exact(TypeSignatureClass::Native(
+                    logical_string(),
+                ))],
+                Volatility::Immutable,
+            ),
         }
     }
 }

--- a/datafusion/functions/src/string/octet_length.rs
+++ b/datafusion/functions/src/string/octet_length.rs
@@ -20,9 +20,13 @@ use arrow::datatypes::DataType;
 use std::any::Any;
 
 use crate::utils::utf8_to_int_type;
-use datafusion_common::{utils::take_function_args, Result, ScalarValue};
-use datafusion_expr::{ColumnarValue, Documentation, Volatility};
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature};
+use datafusion_common::types::logical_string;
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{Result, ScalarValue};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_macros::user_doc;
 
 #[user_doc(
@@ -55,7 +59,12 @@ impl Default for OctetLengthFunc {
 impl OctetLengthFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::string(1, Volatility::Immutable),
+            signature: Signature::coercible(
+                vec![Coercion::new_exact(TypeSignatureClass::Native(
+                    logical_string(),
+                ))],
+                Volatility::Immutable,
+            ),
         }
     }
 }

--- a/datafusion/functions/src/string/replace.rs
+++ b/datafusion/functions/src/string/replace.rs
@@ -23,9 +23,15 @@ use arrow::datatypes::DataType;
 
 use crate::utils::{make_scalar_function, utf8_to_str_type};
 use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
+use datafusion_common::types::logical_string;
 use datafusion_common::{exec_err, Result};
-use datafusion_expr::{ColumnarValue, Documentation, Volatility};
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature};
+use datafusion_expr::type_coercion::binary::{
+    binary_to_string_coercion, string_coercion,
+};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_macros::user_doc;
 #[user_doc(
     doc_section(label = "String Functions"),
@@ -60,7 +66,14 @@ impl Default for ReplaceFunc {
 impl ReplaceFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::string(3, Volatility::Immutable),
+            signature: Signature::coercible(
+                vec![
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                ],
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -79,19 +92,64 @@ impl ScalarUDFImpl for ReplaceFunc {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        utf8_to_str_type(&arg_types[0], "replace")
+        if let Some(coercion_data_type) = string_coercion(&arg_types[0], &arg_types[1])
+            .and_then(|dt| string_coercion(&dt, &arg_types[2]))
+            .or_else(|| {
+                binary_to_string_coercion(&arg_types[0], &arg_types[1])
+                    .and_then(|dt| binary_to_string_coercion(&dt, &arg_types[2]))
+            })
+        {
+            utf8_to_str_type(&coercion_data_type, "replace")
+        } else {
+            exec_err!("Unsupported data types for replace. Expected Utf8, LargeUtf8 or Utf8View")
+        }
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        match args.args[0].data_type() {
-            DataType::Utf8 => make_scalar_function(replace::<i32>, vec![])(&args.args),
-            DataType::LargeUtf8 => {
-                make_scalar_function(replace::<i64>, vec![])(&args.args)
+        let data_types = args
+            .args
+            .iter()
+            .map(|arg| arg.data_type())
+            .collect::<Vec<_>>();
+
+        if let Some(coercion_type) = string_coercion(&data_types[0], &data_types[1])
+            .and_then(|dt| string_coercion(&dt, &data_types[2]))
+            .or_else(|| {
+                binary_to_string_coercion(&data_types[0], &data_types[1])
+                    .and_then(|dt| binary_to_string_coercion(&dt, &data_types[2]))
+            })
+        {
+            let mut converted_args = Vec::with_capacity(args.args.len());
+            for arg in &args.args {
+                if arg.data_type() == coercion_type {
+                    converted_args.push(arg.clone());
+                } else {
+                    let converted = arg.cast_to(&coercion_type, None)?;
+                    converted_args.push(converted);
+                }
             }
-            DataType::Utf8View => make_scalar_function(replace_view, vec![])(&args.args),
-            other => {
-                exec_err!("Unsupported data type {other:?} for function replace")
+
+            match coercion_type {
+                DataType::Utf8 => {
+                    make_scalar_function(replace::<i32>, vec![])(&converted_args)
+                }
+                DataType::LargeUtf8 => {
+                    make_scalar_function(replace::<i64>, vec![])(&converted_args)
+                }
+                DataType::Utf8View => {
+                    make_scalar_function(replace_view, vec![])(&converted_args)
+                }
+                other => exec_err!(
+                    "Unsupported coercion data type {other:?} for function replace"
+                ),
             }
+        } else {
+            exec_err!(
+                "Unsupported data type {:?}, {:?}, {:?} for function replace.",
+                data_types[0],
+                data_types[1],
+                data_types[2]
+            )
         }
     }
 
@@ -117,6 +175,7 @@ fn replace_view(args: &[ArrayRef]) -> Result<ArrayRef> {
 
     Ok(Arc::new(result) as ArrayRef)
 }
+
 /// Replaces all occurrences in string of substring from with substring to.
 /// replace('abcdefabcdef', 'cd', 'XX') = 'abXXefabXXef'
 fn replace<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {

--- a/datafusion/functions/src/string/upper.rs
+++ b/datafusion/functions/src/string/upper.rs
@@ -18,9 +18,12 @@
 use crate::string::common::to_upper;
 use crate::utils::utf8_to_str_type;
 use arrow::datatypes::DataType;
+use datafusion_common::types::logical_string;
 use datafusion_common::Result;
-use datafusion_expr::{ColumnarValue, Documentation};
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_macros::user_doc;
 use std::any::Any;
 
@@ -54,7 +57,12 @@ impl Default for UpperFunc {
 impl UpperFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::string(1, Volatility::Immutable),
+            signature: Signature::coercible(
+                vec![Coercion::new_exact(TypeSignatureClass::Native(
+                    logical_string(),
+                ))],
+                Volatility::Immutable,
+            ),
         }
     }
 }

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -25,9 +25,12 @@ use arrow::datatypes::DataType;
 
 use crate::utils::{make_scalar_function, utf8_to_str_type};
 use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
+use datafusion_common::types::logical_string;
 use datafusion_common::{exec_err, Result};
-use datafusion_expr::{ColumnarValue, Documentation, Volatility};
-use datafusion_expr::{ScalarUDFImpl, Signature};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarUDFImpl, Signature, TypeSignatureClass,
+    Volatility,
+};
 use datafusion_macros::user_doc;
 
 #[user_doc(
@@ -61,7 +64,12 @@ impl Default for InitcapFunc {
 impl InitcapFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::string(1, Volatility::Immutable),
+            signature: Signature::coercible(
+                vec![Coercion::new_exact(TypeSignatureClass::Native(
+                    logical_string(),
+                ))],
+                Volatility::Immutable,
+            ),
         }
     }
 }

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1927,7 +1927,7 @@ select position('' in '')
 ----
 1
 
-query error DataFusion error: Error during planning: Function 'strpos' expects NativeType::String but received NativeType::Int64
+query error DataFusion error: Error during planning: Internal error: Expect TypeSignatureClass::Native\(LogicalType\(Native\(String\), String\)\) but received NativeType::Int64, DataType: Int64
 select position(1 in 1)
 
 query I

--- a/datafusion/sqllogictest/test_files/string/string_view.slt
+++ b/datafusion/sqllogictest/test_files/string/string_view.slt
@@ -660,7 +660,7 @@ EXPLAIN SELECT
 FROM test;
 ----
 logical_plan
-01)Projection: contains(test.column1_utf8view, Utf8View("foo")) AS c1, contains(test.column1_utf8view, test.column2_utf8view) AS c2, contains(test.column1_utf8view, CAST(test.column2_large_utf8 AS Utf8View)) AS c3, contains(CAST(test.column1_utf8 AS Utf8View), test.column2_utf8view) AS c4, contains(test.column1_utf8, test.column2_utf8) AS c5, contains(CAST(test.column1_utf8 AS LargeUtf8), test.column2_large_utf8) AS c6, contains(CAST(test.column1_large_utf8 AS Utf8View), test.column1_utf8view) AS c7, contains(test.column1_large_utf8, CAST(test.column2_utf8 AS LargeUtf8)) AS c8, contains(test.column1_large_utf8, test.column2_large_utf8) AS c9
+01)Projection: contains(test.column1_utf8view, Utf8("foo")) AS c1, contains(test.column1_utf8view, test.column2_utf8view) AS c2, contains(test.column1_utf8view, test.column2_large_utf8) AS c3, contains(test.column1_utf8, test.column2_utf8view) AS c4, contains(test.column1_utf8, test.column2_utf8) AS c5, contains(test.column1_utf8, test.column2_large_utf8) AS c6, contains(test.column1_large_utf8, test.column1_utf8view) AS c7, contains(test.column1_large_utf8, test.column2_utf8) AS c8, contains(test.column1_large_utf8, test.column2_large_utf8) AS c9
 02)--TableScan: test projection=[column1_utf8, column2_utf8, column1_large_utf8, column2_large_utf8, column1_utf8view, column2_utf8view]
 
 ## Ensure no casts for ENDS_WITH
@@ -671,7 +671,7 @@ EXPLAIN SELECT
 FROM test;
 ----
 logical_plan
-01)Projection: ends_with(test.column1_utf8view, Utf8View("foo")) AS c1, ends_with(test.column2_utf8view, test.column2_utf8view) AS c2
+01)Projection: ends_with(test.column1_utf8view, Utf8("foo")) AS c1, ends_with(test.column2_utf8view, test.column2_utf8view) AS c2
 02)--TableScan: test projection=[column1_utf8view, column2_utf8view]
 
 ## Ensure no casts for LEVENSHTEIN
@@ -682,7 +682,7 @@ EXPLAIN SELECT
 FROM test;
 ----
 logical_plan
-01)Projection: levenshtein(test.column1_utf8view, Utf8View("foo")) AS c1, levenshtein(test.column1_utf8view, test.column2_utf8view) AS c2
+01)Projection: levenshtein(test.column1_utf8view, Utf8("foo")) AS c1, levenshtein(test.column1_utf8view, test.column2_utf8view) AS c2
 02)--TableScan: test projection=[column1_utf8view, column2_utf8view]
 
 ## Ensure no casts for LOWER
@@ -784,7 +784,7 @@ EXPLAIN SELECT
 FROM test;
 ----
 logical_plan
-01)Projection: regexp_like(test.column1_utf8view, Utf8View("^https?://(?:www\.)?([^/]+)/.*$")) AS k
+01)Projection: regexp_like(test.column1_utf8view, Utf8("^https?://(?:www\.)?([^/]+)/.*$")) AS k
 02)--TableScan: test projection=[column1_utf8view]
 
 ## Ensure no casts for REGEXP_MATCH
@@ -825,7 +825,7 @@ EXPLAIN SELECT
 FROM test;
 ----
 logical_plan
-01)Projection: replace(test.column1_utf8view, Utf8View("foo"), Utf8View("bar")) AS c1, replace(test.column1_utf8view, test.column2_utf8view, Utf8View("bar")) AS c2
+01)Projection: replace(test.column1_utf8view, Utf8("foo"), Utf8("bar")) AS c1, replace(test.column1_utf8view, test.column2_utf8view, Utf8("bar")) AS c2
 02)--TableScan: test projection=[column1_utf8view, column2_utf8view]
 
 ## Ensure no casts for REVERSE
@@ -906,7 +906,7 @@ EXPLAIN SELECT
 FROM test;
 ----
 logical_plan
-01)Projection: strpos(test.column1_utf8view, Utf8View("f")) AS c, strpos(test.column1_utf8view, test.column2_utf8view) AS c2
+01)Projection: strpos(test.column1_utf8view, Utf8("f")) AS c, strpos(test.column1_utf8view, test.column2_utf8view) AS c2
 02)--TableScan: test projection=[column1_utf8view, column2_utf8view]
 
 ## Ensure no casts for SUBSTR
@@ -1078,7 +1078,7 @@ EXPLAIN SELECT
 FROM test;
 ----
 logical_plan
-01)Projection: string_to_array(test.column1_utf8view, Utf8View(",")) AS c
+01)Projection: string_to_array(test.column1_utf8view, Utf8(",")) AS c
 02)--TableScan: test projection=[column1_utf8view]
 
 ## Ensure no unexpected casts for array_to_string


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #14759.
## Rationale for this change
## What changes are included in this PR?
This PR will deprecate all uses of `TypeSignature::String` in the codebase.
## Are these changes tested?
Yes.
## Are there any user-facing changes?
No.