### PR TITLE
Fix: New Datafusion-cli streaming printing way should handle corner case for only one small batch which lines are less than max_rows

### DIFF
--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -126,7 +126,6 @@ impl PrintOptions {
 
         while let Some(batch) = stream.next().await {
             let batch = batch?;
-            println!("batch: {:?}", batch);
             let batch_rows = batch.num_rows();
 
             if !max_rows_reached && total_count < max_rows {
@@ -152,7 +151,6 @@ impl PrintOptions {
                             print_options
                                 .format
                                 .print_header(&schema, &widths, writer)?;
-                            header_printed = true;
                         }
                         for preview_batch in preview_batches.drain(..) {
                             print_options.format.print_batch_with_widths(
@@ -191,19 +189,20 @@ impl PrintOptions {
                 let widths = print_options
                     .format
                     .compute_column_widths(&preview_batches, schema.clone())?;
-                precomputed_widths = Some(widths.clone());
+                precomputed_widths = Some(widths);
                 if !header_printed {
                     print_options.format.print_header(
                         &schema,
                         precomputed_widths.as_ref().unwrap(),
                         writer,
                     )?;
-                    header_printed = true;
                 }
                 for preview_batch in preview_batches.drain(..) {
-                    print_options
-                        .format
-                        .print_batch_with_widths(&preview_batch, precomputed_widths.as_ref().unwrap(), writer)?;
+                    print_options.format.print_batch_with_widths(
+                        &preview_batch,
+                        precomputed_widths.as_ref().unwrap(),
+                        writer,
+                    )?;
                 }
             }
             if let Some(ref widths) = precomputed_widths {

--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -126,6 +126,7 @@ impl PrintOptions {
 
         while let Some(batch) = stream.next().await {
             let batch = batch?;
+            println!("batch: {:?}", batch);
             let batch_rows = batch.num_rows();
 
             if !max_rows_reached && total_count < max_rows {
@@ -190,13 +191,19 @@ impl PrintOptions {
                 let widths = print_options
                     .format
                     .compute_column_widths(&preview_batches, schema.clone())?;
-                precomputed_widths = Some(widths);
+                precomputed_widths = Some(widths.clone());
                 if !header_printed {
                     print_options.format.print_header(
                         &schema,
                         precomputed_widths.as_ref().unwrap(),
                         writer,
                     )?;
+                    header_printed = true;
+                }
+                for preview_batch in preview_batches.drain(..) {
+                    print_options
+                        .format
+                        .print_batch_with_widths(&preview_batch, precomputed_widths.as_ref().unwrap(), writer)?;
                 }
             }
             if let Some(ref widths) = precomputed_widths {

--- a/datafusion-cli/tests/cli_integration.rs
+++ b/datafusion-cli/tests/cli_integration.rs
@@ -47,6 +47,12 @@ fn init() {
     ["--command", "show datafusion.execution.batch_size", "--format", "json", "-q", "-b", "1"],
     "[{\"name\":\"datafusion.execution.batch_size\",\"value\":\"1\"}]\n"
 )]
+
+/// Add case fixed issue: https://github.com/apache/datafusion/issues/14920
+#[case::exec_from_commands(
+    ["--command", "SELECT * FROM generate_series(1, 5) t1(v1) ORDER BY v1 DESC;", "--format", "table", "-q"],
+    "+----+\n| v1 |\n+----+\n| 5  |\n| 4  |\n| 3  |\n| 2  |\n| 1  |\n+----+\n"
+)]
 #[test]
 fn cli_quick_test<'a>(
     #[case] args: impl IntoIterator<Item = &'a str>,


### PR DESCRIPTION
## Which issue does this PR close?


- closes #14920

## Rationale for this change

When we only have one batch and size < max_rows, also size < preview limit, we should collect it at the end.


## What changes are included in this PR?

When we only have one batch and size < max_rows, also size < preview limit, we should collect it at the end.


Add the collect logic at the end.

## Are these changes tested?
Yes

Testing result

```rust
> select * from a;
Error during planning: table 'datafusion.public.a' not found
> CREATE EXTERNAL TABLE IF NOT EXISTS lineitem (
        l_orderkey BIGINT,
        l_partkey BIGINT,
        l_suppkey BIGINT,
        l_linenumber INTEGER,
        l_quantity DECIMAL(15, 2),
        l_extendedprice DECIMAL(15, 2),
        l_discount DECIMAL(15, 2),
        l_tax DECIMAL(15, 2),
        l_returnflag VARCHAR,
        l_linestatus VARCHAR,
        l_shipdate DATE,
        l_commitdate DATE,
        l_receiptdate DATE,
        l_shipinstruct VARCHAR,
        l_shipmode VARCHAR,
        l_comment VARCHAR
) STORED AS parquet
LOCATION '/Users/zhuqi/arrow-datafusion/benchmarks/data/tpch_sf10/lineitem';
0 row(s) fetched.
Elapsed 0.007 seconds.

> select l_comment from lineitem limit 1;
+--------------------------+
| l_comment                |
+--------------------------+
| nic packages. regular re |
+--------------------------+
1 row(s) fetched.
Elapsed 0.087 seconds.
```



## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
