### PR TITLE
Add additional protobuf tests for 

### DIFF
--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -87,7 +87,7 @@ use datafusion::physical_plan::windows::{
 use datafusion::physical_plan::{
     displayable, ExecutionPlan, InputOrderMode, Partitioning, PhysicalExpr, Statistics,
 };
-use datafusion::prelude::SessionContext;
+use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion::scalar::ScalarValue;
 use datafusion_common::config::TableParquetOptions;
 use datafusion_common::file_options::csv_writer::CsvWriterOptions;
@@ -155,6 +155,31 @@ fn roundtrip_test_with_context(
     let codec = DefaultPhysicalExtensionCodec {};
     roundtrip_test_and_return(exec_plan, ctx, &codec)?;
     Ok(())
+}
+
+/// Perform a serde roundtrip for the specified sql query, and  assert that
+/// query results are identical.
+async fn roundtrip_test_sql_with_context(sql: &str, ctx: &SessionContext) -> Result<()> {
+    let codec = DefaultPhysicalExtensionCodec {};
+    let initial_plan = ctx.sql(sql).await?.create_physical_plan().await?;
+
+    roundtrip_test_and_return(initial_plan, ctx, &codec)?;
+    Ok(())
+}
+
+/// returns a SessionContext with `alltypes_plain` registered
+async fn all_types_context() -> Result<SessionContext> {
+    let ctx = SessionContext::new();
+
+    let testdata = datafusion::test_util::parquet_test_data();
+    ctx.register_parquet(
+        "alltypes_plain",
+        &format!("{testdata}/alltypes_plain.parquet"),
+        ParquetReadOptions::default(),
+    )
+    .await?;
+
+    Ok(ctx)
 }
 
 #[test]
@@ -1578,4 +1603,33 @@ async fn roundtrip_coalesce() -> Result<()> {
     );
 
     Ok(())
+}
+
+#[tokio::test]
+async fn roundtrip_parquet_select_star() -> Result<()> {
+    let ctx = all_types_context().await?;
+    let sql = "select * from alltypes_plain";
+    roundtrip_test_sql_with_context(sql, &ctx).await
+}
+
+#[tokio::test]
+async fn roundtrip_parquet_select_projection() -> Result<()> {
+    let ctx = all_types_context().await?;
+    let sql = "select string_col, timestamp_col from alltypes_plain";
+    roundtrip_test_sql_with_context(sql, &ctx).await
+}
+
+#[tokio::test]
+async fn roundtrip_parquet_select_star_predicate() -> Result<()> {
+    let ctx = all_types_context().await?;
+    let sql = "select * from alltypes_plain where id > 4";
+    roundtrip_test_sql_with_context(sql, &ctx).await
+}
+
+#[ignore = "Test failing due to https://github.com/apache/datafusion/issues/14679"]
+#[tokio::test]
+async fn roundtrip_parquet_select_projection_predicate() -> Result<()> {
+    let ctx = all_types_context().await?;
+    let sql = "select string_col, timestamp_col from alltypes_plain where id > 4";
+    roundtrip_test_sql_with_context(sql, &ctx).await
 }


### PR DESCRIPTION
## Which issue does this PR close?


- Part of https://github.com/apache/datafusion/issues/14679
- Related to https://github.com/apache/datafusion/pull/14685

## Rationale for this change

I wanted to help https://github.com/apache/datafusion/issues/14679 by increasing test coverage (and so we were more confident in the fix in https://github.com/apache/datafusion/pull/14685 @blaginin 🙏 )

@mkmik proposed some nice tests in https://github.com/apache/datafusion/issues/14679 so I think it would be good to add test coverage directly

## What changes are included in this PR?

1. Add tests that `SELECT ... ` from can be round tripped through protouf

## Are these changes tested?
They are only tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

There are no user facing changes