### PR TITLE
Do not swap with projection when file is partitioned

### DIFF
--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -267,24 +267,32 @@ impl DataSource for FileScanConfig {
         // If there is any non-column or alias-carrier expression, Projection should not be removed.
         // This process can be moved into CsvExec, but it would be an overlap of their responsibility.
 
-        Ok((all_alias_free_columns(projection.expr())
-            && self.table_partition_cols.is_empty())
-        .then(|| {
-            let file_scan = self.clone();
-            let source = Arc::clone(&file_scan.file_source);
-            let new_projections = new_projections_for_columns(
-                projection,
-                &file_scan
-                    .projection
-                    .clone()
-                    .unwrap_or((0..self.file_schema.fields().len()).collect()),
-            );
-            file_scan
-                // Assign projected statistics to source
-                .with_projection(Some(new_projections))
-                .with_source(source)
-                .build() as _
-        }))
+        let partitioned_columns_in_proj = projection.expr().iter().any(|(expr, _)| {
+            expr.as_any()
+                .downcast_ref::<Column>()
+                .map(|expr| expr.index() >= self.file_schema.fields().len())
+                .unwrap_or(false)
+        });
+
+        Ok(
+            (all_alias_free_columns(projection.expr()) && !partitioned_columns_in_proj)
+                .then(|| {
+                    let file_scan = self.clone();
+                    let source = Arc::clone(&file_scan.file_source);
+                    let new_projections = new_projections_for_columns(
+                        projection,
+                        &file_scan
+                            .projection
+                            .clone()
+                            .unwrap_or((0..self.file_schema.fields().len()).collect()),
+                    );
+                    file_scan
+                        // Assign projected statistics to source
+                        .with_projection(Some(new_projections))
+                        .with_source(source)
+                        .build() as _
+                }),
+        )
     }
 }
 

--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -266,7 +266,10 @@ impl DataSource for FileScanConfig {
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
         // If there is any non-column or alias-carrier expression, Projection should not be removed.
         // This process can be moved into CsvExec, but it would be an overlap of their responsibility.
-        Ok(all_alias_free_columns(projection.expr()).then(|| {
+
+        Ok((all_alias_free_columns(projection.expr())
+            && self.table_partition_cols.is_empty())
+        .then(|| {
             let file_scan = self.clone();
             let source = Arc::clone(&file_scan.file_source);
             let new_projections = new_projections_for_columns(


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/delta-io/delta-rs/pull/3261#issuecomment-2691373678
- Fixes https://github.com/apache/datafusion/issues/14957



## Rationale for this change 

I feel like there should be a way to apply swapping even if the file is partitioned - but submitting a hotfix since it's a release blocker

## What changes are included in this PR?


## Are these changes tested?

Added a test

## Are there any user-facing changes?

No
