### PR TITLE
Fix: to_char Function Now Correctly Handles DATE Values in DataFusion

### DIFF
--- a/datafusion/functions/src/datetime/to_char.rs
+++ b/datafusion/functions/src/datetime/to_char.rs
@@ -212,14 +212,6 @@ fn _to_char_scalar(
     let is_scalar_expression = matches!(&expression, ColumnarValue::Scalar(_));
     let array = expression.into_array(1)?;
 
-    // fix https://github.com/apache/datafusion/issues/14884
-    // If the input date/time is null, return a null Utf8 result.
-    if array.is_null(0) {
-        return Ok(match is_scalar_expression {
-            true => ColumnarValue::Scalar(ScalarValue::Utf8(None)),
-            false => ColumnarValue::Array(new_null_array(&Utf8, array.len())),
-        });
-    }
     if format.is_none() {
         if is_scalar_expression {
             return Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)));

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -2848,6 +2848,26 @@ SELECT to_char(null, '%d-%m-%Y');
 NULL
 
 query T
+SELECT to_char(date_column, '%Y-%m-%d')
+FROM (VALUES 
+    (DATE '2020-09-01'),
+    (NULL)
+) AS t(date_column);
+----
+2020-09-01
+NULL
+
+query T
+SELECT to_char(date_column, '%Y-%m-%d')
+FROM (VALUES 
+    (NULL),
+    (DATE '2020-09-01')
+) AS t(date_column);
+----
+NULL
+2020-09-01
+
+query T
 SELECT to_char(column1, column2)
 FROM
 (VALUES ('2024-01-01 06:00:00'::timestamp, null), ('2025-01-01 23:59:58'::timestamp, '%d:%m:%Y %H-%M-%S'));


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #14969.

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

## Rationale for this change

After #14908, the `to_char` function was incorrectly returning `NULL` for valid `DATE` values due to improper handling of the `DATE` type. This fix ensures that `to_char` correctly formats non-null `DATE` values while preserving `NULL` values as expected.

This is a re-implementation of #14908

## What changes are included in this PR?

- Fixed the `to_char` function to properly process `DATE` values.
- Added slt test cases to verify correct behavior when formatting `DATE` values.

## Are these changes tested?

Yes, new test cases have been added to confirm that:
1. `to_char` correctly formats valid `DATE` values.
2. `NULL` values remain unaffected.

## Are there any user-facing changes?

No breaking changes. Users will now see correctly formatted `DATE` values when using `to_char`, instead of unexpected `NULL` results.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->