### PR TITLE
Add note about upgrade guide into the release notes

### DIFF
--- a/dev/changelog/46.0.0.md
+++ b/dev/changelog/46.0.0.md
@@ -21,6 +21,10 @@ under the License.
 
 This release consists of 288 commits from 79 contributors. See credits at the end of this changelog for more information.
 
+Please see the [Upgrade Guide] for help updating to DataFusion `46.0.0`
+
+[upgrade guide]: https://datafusion.apache.org/library-user-guide/upgrading.html#datafusion-46-0-0
+
 **Breaking changes:**
 
 - bug: Fix NULL handling in array_slice, introduce `NullHandling` enum to `Signature` [#14289](https://github.com/apache/datafusion/pull/14289) (jkosh44)


### PR DESCRIPTION
Add a link to 
- https://github.com/apache/datafusion/pull/14891
- Part of https://github.com/apache/datafusion/pull/14979

See rendered: https://github.com/alamb/datafusion/blob/alamb/upgrade_guide/dev/changelog/46.0.0.md

In the release notes to help people find it easier

FYI @xudong963 