### PR TITLE
Workaround verification script error for branch-46

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -118,7 +118,8 @@ test_source_distribution() {
   # build and test rust
 
   # raises on any formatting errors
-  rustup component add rustfmt --toolchain stable
+  rustup toolchain install 1.85.0
+  rustup component add rustfmt --toolchain 1.85.0
   cargo fmt --all -- --check
 
   # Clone testing repositories into the expected location

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -117,9 +117,12 @@ test_source_distribution() {
 
   # build and test rust
 
+  # Temporarily remove rust-toolchain.toml
+  # work around for https://github.com/apache/datafusion/issues/14982
+  rm rust-toolchain.toml
+
   # raises on any formatting errors
-  rustup toolchain install 1.85.0
-  rustup component add rustfmt --toolchain 1.85.0
+  rustup component add rustfmt --toolchain stable
   cargo fmt --all -- --check
 
   # Clone testing repositories into the expected location


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/14982

## Rationale for this change

I am not sure why but the verification script started failing (see https://github.com/apache/datafusion/issues/14982)

Could also be related to 
- https://github.com/apache/datafusion/pull/14655

## What changes are included in this PR?

Remove rust toolchain toml override file

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
