### PR TITLE
Fix verification script and extended tests due to `rustup` changes

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -29,8 +29,8 @@ runs:
       shell: bash
       run: |
         RETRY=("ci/scripts/retry" timeout 120)
-        "${RETRY[@]}" apt-get update
-        "${RETRY[@]}" apt-get install -y protobuf-compiler
+        "${RETRY[@]}" sudo apt-get update
+        "${RETRY[@]}" sudo apt-get install -y protobuf-compiler
     - name: Setup Rust toolchain
       shell: bash
       # rustfmt is needed for the substrait build script

--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -29,8 +29,8 @@ runs:
       shell: bash
       run: |
         RETRY=("ci/scripts/retry" timeout 120)
-        "${RETRY[@]}" sudo apt-get update
-        "${RETRY[@]}" sudo apt-get install -y protobuf-compiler
+        "${RETRY[@]}" apt-get update
+        "${RETRY[@]}" apt-get install -y protobuf-compiler
     - name: Setup Rust toolchain
       shell: bash
       # rustfmt is needed for the substrait build script

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -39,17 +39,19 @@ jobs:
   linux-build-lib:
     name: linux build test
     runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
+    # note: do not use amd/rust container to preserve disk space
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 1
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup toolchain default
+      - name: Install Protobuf Compiler
+        run: sudo apt-get install -y protobuf-compiler
       - name: Prepare cargo build
         run: |
           cargo check --profile ci --all-targets
@@ -60,8 +62,7 @@ jobs:
     name: cargo test 'extended_tests' (amd64)
     needs: linux-build-lib
     runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
+    # note: do not use amd/rust container to preserve disk space
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,10 +70,13 @@ jobs:
           fetch-depth: 1
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup toolchain install
+      - name: Install Protobuf Compiler
+        run: sudo apt-get install -y protobuf-compiler
       # For debugging, test binaries can be large.
       - name: Show available disk space
         run: |

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -28,11 +28,8 @@ concurrency:
 #
 # We still run them as they provide important coverage to ensure correctness
 # in the (very rare) event of a hash failure or sqlite library query failure.
-
-# TEMP for testing
-on: [push, pull_request]
-# on:
-# push:
+on:
+  push:
 
 jobs:
   # Check crate compiles and base cargo check passes

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -86,8 +86,6 @@ jobs:
   hash-collisions:
     name: cargo test hash collisions (amd64)
     runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -39,6 +39,8 @@ jobs:
   linux-build-lib:
     name: linux build test
     runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,6 +60,8 @@ jobs:
     name: cargo test 'extended_tests' (amd64)
     needs: linux-build-lib
     runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
     steps:
       - uses: actions/checkout@v4
         with:
@@ -86,6 +90,8 @@ jobs:
   hash-collisions:
     name: cargo test hash collisions (amd64)
     runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -28,8 +28,11 @@ concurrency:
 #
 # We still run them as they provide important coverage to ensure correctness
 # in the (very rare) event of a hash failure or sqlite library query failure.
-on:
-  push:
+
+# TEMP for testing
+on: [push, pull_request]
+# on:
+# push:
 
 jobs:
   # Check crate compiles and base cargo check passes
@@ -37,17 +40,14 @@ jobs:
     name: linux build test
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
       - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 1
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source $HOME/.cargo/env
-          rustup default stable
-      - name: Install Protobuf Compiler
-        run: sudo apt-get install -y protobuf-compiler
       - name: Prepare cargo build
         run: |
           cargo check --profile ci --all-targets
@@ -65,13 +65,10 @@ jobs:
           fetch-depth: 1
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source $HOME/.cargo/env
-          rustup default stable
-      - name: Install Protobuf Compiler
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
       # For debugging, test binaries can be large.
       - name: Show available disk space
         run: |

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source $HOME/.cargo/env
-          rustup toolchain default
+          rustup toolchain install
       - name: Install Protobuf Compiler
         run: sudo apt-get install -y protobuf-compiler
       - name: Prepare cargo build

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -40,14 +40,14 @@ jobs:
     name: linux build test
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
       - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 1
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
       - name: Prepare cargo build
         run: |
           cargo check --profile ci --all-targets

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -117,8 +117,11 @@ test_source_distribution() {
 
   # build and test rust
 
+  # install the needed version of rust defined in rust-toolchain.toml
+  rustup toolchain install
+
   # raises on any formatting errors
-  rustup component add rustfmt --toolchain stable
+  rustup component add rustfmt
   cargo fmt --all -- --check
 
   # Clone testing repositories into the expected location


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/pull/14985
- Closes https://github.com/apache/datafusion/issues/14982


## Rationale for this change


`rustup` previously would automatically install the toolchain (version of rust) that
was needed if it wasn't already installed.

However, the recently released rustup version changes this behavior

https://github.com/rust-lang/rustup/blob/f00c3d1fbcbe8d3ae2411e63ca906bc9b69e43d1/CHANGELOG.md?plain=1#L9-L17

Thus to ensure we have the correct toolchain installed, we need to run `rustup toolchain install`


## What changes are included in this PR?
* Update the verification script to call `rustup toolchain install` per release notes
* Update the extended test to use the standard builder setup rather than their own special thing

## Are these changes tested?
* I verified manually that this change fixes the verification script run for the  46.0.0 RC
* I tested extended tests with CI in XXXX

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
