### PR TITLE
Always install correct version of rust in CI

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -17,14 +17,13 @@
 
 name: Prepare Rust Builder
 description: 'Prepare Rust Build Environment'
-inputs:
-  rust-version:
-    description: 'version of rust to install (e.g. stable)'
-    required: true
-    default: 'stable'
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 1
     - name: Install Build Dependencies
       shell: bash
       run: |
@@ -36,9 +35,9 @@ runs:
       # rustfmt is needed for the substrait build script
       run: |
         RETRY=("ci/scripts/retry" timeout 120)
-        echo "Installing ${{ inputs.rust-version }}"
-        "${RETRY[@]}" rustup toolchain install ${{ inputs.rust-version }}
-        "${RETRY[@]}" rustup default ${{ inputs.rust-version }}
+        echo "Installing Rust ..."
+        # install toolchain specified by rust-toolchain.toml
+        "${RETRY[@]}" rustup toolchain install 
         "${RETRY[@]}" rustup component add rustfmt
     - name: Configure rust runtime env
       uses: ./.github/actions/setup-rust-runtime

--- a/.github/actions/setup-macos-aarch64-builder/action.yaml
+++ b/.github/actions/setup-macos-aarch64-builder/action.yaml
@@ -17,14 +17,13 @@
 
 name: Prepare Rust Builder for MacOS
 description: 'Prepare Rust Build Environment for MacOS'
-inputs:
-  rust-version:
-    description: 'version of rust to install (e.g. stable)'
-    required: true
-    default: 'stable'
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 1
     - name: Install protobuf compiler
       shell: bash
       run: |
@@ -39,9 +38,7 @@ runs:
     - name: Setup Rust toolchain
       shell: bash
       run: |
-        rustup update stable
-        rustup toolchain install stable
-        rustup default stable
+        rustup toolchain install
         rustup component add rustfmt
     - name: Setup rust cache
       uses: Swatinem/rust-cache@v2

--- a/.github/actions/setup-macos-builder/action.yaml
+++ b/.github/actions/setup-macos-builder/action.yaml
@@ -17,14 +17,13 @@
 
 name: Prepare Rust Builder for MacOS
 description: 'Prepare Rust Build Environment for MacOS'
-inputs:
-  rust-version:
-    description: 'version of rust to install (e.g. stable)'
-    required: true
-    default: 'stable'
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 1
     - name: Install protobuf compiler
       shell: bash
       run: |
@@ -39,9 +38,8 @@ runs:
     - name: Setup Rust toolchain
       shell: bash
       run: |
-        rustup update stable
-        rustup toolchain install stable
-        rustup default stable
+        # install version of rust in rust-toolchain.toml
+        rustup toolchain install
         rustup component add rustfmt
     - name: Configure rust runtime env
       uses: ./.github/actions/setup-rust-runtime        

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -28,8 +28,11 @@ concurrency:
 #
 # We still run them as they provide important coverage to ensure correctness
 # in the (very rare) event of a hash failure or sqlite library query failure.
-on:
-  push:
+
+# TEMP for testing
+on: [push, pull_request]
+# on:
+# push:
 
 jobs:
   # Check crate compiles and base cargo check passes
@@ -37,17 +40,14 @@ jobs:
     name: linux build test
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
       - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 1
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source $HOME/.cargo/env
-          rustup default stable
-      - name: Install Protobuf Compiler
-        run: sudo apt-get install -y protobuf-compiler
       - name: Prepare cargo build
         run: |
           cargo check --profile ci --all-targets
@@ -65,13 +65,10 @@ jobs:
           fetch-depth: 1
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source $HOME/.cargo/env
-          rustup default stable
-      - name: Install Protobuf Compiler
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
       # For debugging, test binaries can be large.
       - name: Show available disk space
         run: |

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -40,14 +40,14 @@ jobs:
     name: linux build test
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
       - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 1
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
       - name: Prepare cargo build
         run: |
           cargo check --profile ci --all-targets

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -117,8 +117,11 @@ test_source_distribution() {
 
   # build and test rust
 
+  # install the needed version of rust defined in rust-toolchain.toml
+  rustup toolchain install
+
   # raises on any formatting errors
-  rustup component add rustfmt --toolchain stable
+  rustup component add rustfmt
   cargo fmt --all -- --check
 
   # Clone testing repositories into the expected location


### PR DESCRIPTION
TODO remove the unused parameter to setup builder sript

## Which issue does this PR close?

- Follow on to https://github.com/apache/datafusion/pull/14990
- Related to https://github.com/apache/datafusion/issues/14982

## Rationale for this change

We now use the rust-toolchain.toml file to specify what version of rust to use 

However, the recently released `rustup` version no longer automatically installs this toolchain

https://github.com/rust-lang/rustup/blob/f00c3d1fbcbe8d3ae2411e63ca906bc9b69e43d1/CHANGELOG.md?plain=1#L9-L17

Thus to ensure we have the correct toolchain installed, we need to run `rustup toolchain install`


## What changes are included in this PR?

1. Call `rustup toolchain install` as part of the builder setup
1. Let's move this change into the builder setup job and reduce some re

## Are these changes tested?
By CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
