### PR TITLE
Minor: Add `backtrace` feature in datafusion-cli

### DIFF
--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -30,6 +30,10 @@ rust-version = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+default = []
+backtrace = ["datafusion/backtrace"]
+
 [dependencies]
 arrow = { workspace = true }
 async-trait = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
We can build `datafusion` with `backtrace` feature to display full backtrace when an error is thrown. See https://datafusion.apache.org/user-guide/crate-configuration.html#enable-backtraces.
This PR propagates this feature to `datafusion-cli`, when compiling `datafusion-cli` with `--features=backtrace` flag, the same feature will be passed to inner `datafusion` crate.

## What changes are included in this PR?

Add `backtrace` feature to `datafusion-cli` build option, and it's only pass through to build `datafusion`.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Tested manually.
Without `backtrace` feature:
```sh
yongting@Mac ~/C/d/datafusion-cli (cli-backtrace *)> RUST_BACKTRACE=1 cargo run
DataFusion CLI v46.0.0
> select to_car();
Error during planning: Invalid function 'to_car'.
Did you mean 'to_char'?
>
```
With `backtrace` feature enabled:
```sh
yongting@Mac ~/C/d/datafusion-cli (cli-backtrace *)> RUST_BACKTRACE=1 cargo run --features=backtrace
DataFusion CLI v46.0.0
> select to_car();
Error during planning: Invalid function 'to_car'.
Did you mean 'to_char'?

backtrace:    0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/backtrace.rs:331:13
   3: datafusion_common::error::DataFusionError::get_back_trace
             at /Users/yongting/Code/datafusion/datafusion/common/src/error.rs:473:30
   4: datafusion_sql::expr::function::<impl datafusion_sql::planner::SqlToRel<S>>::sql_function_to_expr
             at /Users/yongting/Code/datafusion/datafusion/sql/src/expr/function.rs:404:13
   5: datafusion_sql::expr::<impl datafusion_sql::planner::SqlToRel<S>>::sql_expr_to_logical_expr_internal::{{closure}}
             at /Users/yongting/Code/datafusion/datafusion/sql/src/expr/mod.rs:481:17
   6: stacker::maybe_grow
......
```



## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
