### PR TITLE
Implement `tree` explain for FilterExec

### DIFF
--- a/datafusion/physical-plan/src/display.rs
+++ b/datafusion/physical-plan/src/display.rs
@@ -37,10 +37,41 @@ use super::{accept, ExecutionPlan, ExecutionPlanVisitor};
 #[derive(Debug, Clone, Copy)]
 pub enum DisplayFormatType {
     /// Default, compact format. Example: `FilterExec: c12 < 10.0`
+    ///
+    /// This format is designed to provide a detailed textual description
+    /// of all rele
     Default,
-    /// Verbose, showing all available details
+    /// Verbose, showing all available details.
+    ///
+    /// This form is even more detailed than [`Self::Default`]
     Verbose,
-    /// TreeRender, display plan like a tree.
+    /// TreeRender, displayed in the `tree` explain type.
+    ///
+    /// This format is inspired by DuckDB's explain plans. The information
+    /// presented should be "user friendly", and contain only the most relevant
+    /// information for understanding a plan. It should NOT contain the same level
+    /// of detail information as the  [`Self::Default`] format.
+    ///
+    /// In this mode, each line contains a key=value pair.
+    /// Everything before the first `=` is treated as the key, and everything after the
+    /// first `=` is treated as the value.
+    ///
+    /// For example, if the output of `TreeRender` is this:
+    /// ```text
+    /// partition_sizes=[1]
+    /// partitions=1
+    /// ```
+    ///
+    /// It is rendered in the center of a box in the following way:
+    ///
+    /// ```text
+    /// ┌───────────────────────────┐
+    /// │       DataSourceExec      │
+    /// │    --------------------   │
+    /// │    partition_sizes: [1]   │
+    /// │       partitions: 1       │
+    /// └───────────────────────────┘
+    ///  ```
     TreeRender,
 }
 

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -330,8 +330,7 @@ impl DisplayAs for FilterExec {
                 write!(f, "FilterExec: {}{}", self.predicate, display_projections)
             }
             DisplayFormatType::TreeRender => {
-                // TODO: collect info
-                write!(f, "")
+                write!(f, "predicate={}", self.predicate)
             }
         }
     }

--- a/datafusion/sqllogictest/test_files/explain_tree.slt
+++ b/datafusion/sqllogictest/test_files/explain_tree.slt
@@ -74,13 +74,16 @@ physical_plan
 03)└─────────────┬─────────────┘
 04)┌─────────────┴─────────────┐
 05)│         FilterExec        │
-06)└─────────────┬─────────────┘
-07)┌─────────────┴─────────────┐
-08)│      RepartitionExec      │
+06)│    --------------------   │
+07)│         predicate:        │
+08)│    string_col@1 != foo    │
 09)└─────────────┬─────────────┘
 10)┌─────────────┴─────────────┐
-11)│       DataSourceExec      │
-12)└───────────────────────────┘
+11)│      RepartitionExec      │
+12)└─────────────┬─────────────┘
+13)┌─────────────┴─────────────┐
+14)│       DataSourceExec      │
+15)└───────────────────────────┘
 
 # Aggregate
 query TT
@@ -185,6 +188,32 @@ physical_plan
 26)│       DataSourceExec      ││       DataSourceExec      │
 27)└───────────────────────────┘└───────────────────────────┘
 
+# Long Filter (demonstrate what happens with wrapping)
+query TT
+explain SELECT int_col FROM table1
+WHERE string_col != 'foo' AND string_col != 'bar' AND string_col != 'a really long string constant'
+;
+----
+logical_plan
+01)Projection: table1.int_col
+02)--Filter: table1.string_col != Utf8("foo") AND table1.string_col != Utf8("bar") AND table1.string_col != Utf8("a really long string constant")
+03)----TableScan: table1 projection=[int_col, string_col], partial_filters=[table1.string_col != Utf8("foo"), table1.string_col != Utf8("bar"), table1.string_col != Utf8("a really long string constant")]
+physical_plan
+01)┌───────────────────────────┐
+02)│    CoalesceBatchesExec    │
+03)└─────────────┬─────────────┘
+04)┌─────────────┴─────────────┐
+05)│         FilterExec        │
+06)│    --------------------   │
+07)│         predicate:        │
+08)│string_col@1 != foo AND ...│
+09)└─────────────┬─────────────┘
+10)┌─────────────┴─────────────┐
+11)│      RepartitionExec      │
+12)└─────────────┬─────────────┘
+13)┌─────────────┴─────────────┐
+14)│       DataSourceExec      │
+15)└───────────────────────────┘
 
 
 # cleanup


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/15000
- Part of https://github.com/apache/datafusion/issues/14914


## Rationale for this change

Let's have nice explain plans! 

I wanted an example of how to make a tree explain plan so that I can file a bunch of follow on tickets for https://github.com/apache/datafusion/issues/14914 to share the work

## What changes are included in this PR?

1. Update comments about `ExplainFormat`
2. Implement for `FilterExec`
3. Update tests

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
tree explain is better
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
