### PR TITLE
Add dependency checks to verify-release-candidate script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -18,6 +18,37 @@
 # under the License.
 #
 
+# Check that required dependencies are installed
+check_dependencies() {
+  local missing_deps=0
+  local required_deps=("curl" "git" "gpg" "cc" "protoc")
+  
+  # Either shasum or sha256sum/sha512sum are required
+  local has_sha_tools=0
+
+  for dep in "${required_deps[@]}"; do
+    if ! command -v $dep &> /dev/null; then
+      echo "Error: $dep is not installed or not in PATH"
+      missing_deps=1
+    fi
+  done
+  
+  # Check for either shasum or sha256sum/sha512sum
+  if command -v shasum &> /dev/null; then
+    has_sha_tools=1
+  elif command -v sha256sum &> /dev/null && command -v sha512sum &> /dev/null; then
+    has_sha_tools=1
+  else
+    echo "Error: Neither shasum nor sha256sum/sha512sum are installed or in PATH"
+    missing_deps=1
+  fi
+  
+  if [ $missing_deps -ne 0 ]; then
+    echo "Please install missing dependencies and try again"
+    exit 1
+  fi
+}
+
 case $# in
   2) VERSION="$1"
      RC_NUMBER="$2"
@@ -30,6 +61,9 @@ esac
 set -e
 set -x
 set -o pipefail
+
+# Add the dependency check early in the script execution
+check_dependencies
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 ARROW_DIR="$(dirname $(dirname ${SOURCE_DIR}))"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Check all build dependencies are available before running the script.

Background: I'll use a separate docker to verify the release candidate. And I always forget to install some of the build dependencies. Then I need to install it and restart from the very beginning. I list all the things I'm aware of (or need to be installed in a fresh ubuntu image) and check them before the build starts.

## What changes are included in this PR?

A new function `check_dependencies` in `dev/release/verify-release-candidate.sh` that checks build dependencies in advance.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, I use this version to verify 46.0.0 RC2 release

## Are there any user-facing changes?



no 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
