### PR TITLE
Make Substrait Schema Structs always non-nullable

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -1039,7 +1039,7 @@ fn to_substrait_named_struct(schema: &DFSchemaRef) -> Result<NamedStruct> {
             .map(|f| to_substrait_type(f.data_type(), f.is_nullable()))
             .collect::<Result<_>>()?,
         type_variation_reference: DEFAULT_TYPE_VARIATION_REF,
-        nullability: r#type::Nullability::Unspecified as i32,
+        nullability: r#type::Nullability::Required as i32,
     };
 
     Ok(NamedStruct {


### PR DESCRIPTION
## Which issue does this PR close?

- Fixes #12244

## Rationale for this change

https://github.com/apache/datafusion/issues/12244 reported a larger problem with plan generation which was mostly but not completely fixed by https://github.com/apache/datafusion/pull/12245. As noted in https://github.com/apache/datafusion/issues/12244, invalid plans could be still be generated.

## What changes are included in this PR?

Structs for Schemas are set to always non-nullable.

## Are these changes tested?

Yes. I ran the substrait-validator CLI over a plan generated from datafusion built with this patch.

## Are there any user-facing changes?

No.