### PR TITLE
Reject `RESPECT NULLS` and `IGNORE NULLS` for aggregate functions

### DIFF
--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -5863,15 +5863,11 @@ SELECT FIRST_VALUE(column1) FROM t;
 ----
 NULL
 
-query I
+query error DataFusion error: Error during planning: RESPECT NULLS and IGNORE NULLS are not supported for aggregate functions
 SELECT FIRST_VALUE(column1) RESPECT NULLS FROM t;
-----
-NULL
 
-query I
+query error DataFusion error: Error during planning: RESPECT NULLS and IGNORE NULLS are not supported for aggregate functions
 SELECT FIRST_VALUE(column1) IGNORE NULLS FROM t;
-----
-3
 
 statement ok
 DROP TABLE t;
@@ -5893,15 +5889,11 @@ SELECT FIRST_VALUE(column1 ORDER BY column2) FROM t;
 ----
 NULL
 
-query I
+query error DataFusion error: Error during planning: RESPECT NULLS and IGNORE NULLS are not supported for aggregate functions
 SELECT FIRST_VALUE(column1 ORDER BY column2) RESPECT NULLS FROM t;
-----
-NULL
 
-query I
+query error DataFusion error: Error during planning: RESPECT NULLS and IGNORE NULLS are not supported for aggregate functions
 SELECT FIRST_VALUE(column1 ORDER BY column2) IGNORE NULLS FROM t;
-----
-4
 
 statement ok
 DROP TABLE t;
@@ -5915,15 +5907,11 @@ SELECT LAST_VALUE(column1) FROM t;
 ----
 NULL
 
-query I
+query error DataFusion error: Error during planning: RESPECT NULLS and IGNORE NULLS are not supported for aggregate functions
 SELECT LAST_VALUE(column1) RESPECT NULLS FROM t;
-----
-NULL
 
-query I
+query error DataFusion error: Error during planning: RESPECT NULLS and IGNORE NULLS are not supported for aggregate functions
 SELECT LAST_VALUE(column1) IGNORE NULLS FROM t;
-----
-4
 
 statement ok
 DROP TABLE t;
@@ -5945,15 +5933,11 @@ SELECT LAST_VALUE(column1 ORDER BY column2 DESC) FROM t;
 ----
 NULL
 
-query I
+query error DataFusion error: Error during planning: RESPECT NULLS and IGNORE NULLS are not supported for aggregate functions
 SELECT LAST_VALUE(column1 ORDER BY column2 DESC) RESPECT NULLS FROM t;
-----
-NULL
 
-query I
+query error DataFusion error: Error during planning: RESPECT NULLS and IGNORE NULLS are not supported for aggregate functions
 SELECT LAST_VALUE(column1 ORDER BY column2 DESC) IGNORE NULLS FROM t;
-----
-3
 
 statement ok
 DROP TABLE t;


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


- Partial fix for #15006

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

As per the issue says

> In the SQL standard, RESPECT NULLS and IGNORE NULLS are options to be set for the lead, lag, first_value, last_value and nth_value window functions.



## What changes are included in this PR?

Adds validation to prevent using `RESPECT NULLS` and `IGNORE NULLS` with aggregate functions

One thing to note that is:

> That being said, part of the weirdness here is that DataFusion defines first_value both as an [aggregate function](https://github.com/apache/datafusion/blob/main/datafusion/functions-aggregate/src/first_last.rs) and as a [window function](https://github.com/apache/datafusion/blob/dd0fd889ea603f929accb99002e2f99280823f5c/datafusion/functions-window/src/nth_value.rs#L41-L46).

Accroding to the sqllogic test, this should only affect aggregate function. 


## Are these changes tested?

Essisting tests have coverd the cases

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Maybe? If one uses `RESPECT NULLS` and `IGNORE NULLS` with aggregate functions then this is a breaking change
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
