### PR TITLE
fix: External sort failing on an edge case

### DIFF
--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -468,14 +468,14 @@ async fn test_stringview_external_sort() {
     let _ = df.collect().await.expect("Query execution failed");
 }
 
-/// This test case is for the regression case:
+/// This test case is for a previously detected bug:
 /// When `ExternalSorter` has read all input batches
 /// - It has spilled many sorted runs to disk
 /// - Its in-memory buffer for batches is almost full
-/// The regression implementation will try to merge the spills and in-memory batches
-/// right away, without spilling the in-memory batches first, caused OOM.
+/// The previous implementation will try to merge the spills and in-memory batches
+/// together, without spilling the in-memory batches first, causing OOM.
 #[tokio::test]
-async fn test_external_sort_regression() {
+async fn test_in_mem_buffer_almost_full() {
     let config = SessionConfig::new()
         .with_sort_spill_reservation_bytes(3000000)
         .with_target_partitions(1);

--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -487,7 +487,7 @@ async fn test_external_sort_regression() {
     let ctx = SessionContext::new_with_config_rt(config, runtime);
 
     let query = "select * from generate_series(1,9000000) as t1(v1) order by v1;";
-    let df = ctx.sql(&query).await.unwrap();
+    let df = ctx.sql(query).await.unwrap();
 
     // Check not fail
     let _ = df.collect().await.unwrap();

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -497,8 +497,8 @@ impl ExternalSorter {
     /// # Arguments
     ///
     /// * `force_spill` - If true, the method will spill the in-memory batches
-    /// even if the memory usage has not dropped by a factor of 2. Otherwise it will
-    /// only spill when the memory usage has dropped by the pre-defined factor.
+    ///   even if the memory usage has not dropped by a factor of 2. Otherwise it will
+    ///   only spill when the memory usage has dropped by the pre-defined factor.
     ///
     async fn sort_or_spill_in_mem_batches(&mut self, force_spill: bool) -> Result<()> {
         // Release the memory reserved for merge back to the pool so

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -307,7 +307,7 @@ impl ExternalSorter {
 
         let size = get_reserved_byte_for_record_batch(&input);
         if self.reservation.try_grow(size).is_err() {
-            self.sort_or_spill_in_mem_batches().await?;
+            self.sort_or_spill_in_mem_batches(false).await?;
             // We've already freed more than half of reserved memory,
             // so we can grow the reservation again. There's nothing we can do
             // if this try_grow fails.
@@ -332,7 +332,7 @@ impl ExternalSorter {
     ///
     /// 2. A combined streaming merge incorporating both in-memory
     ///    batches and data from spill files on disk.
-    fn sort(&mut self) -> Result<SendableRecordBatchStream> {
+    async fn sort(&mut self) -> Result<SendableRecordBatchStream> {
         // Release the memory reserved for merge back to the pool so
         // there is some left when `in_mem_sort_stream` requests an
         // allocation.
@@ -340,10 +340,12 @@ impl ExternalSorter {
 
         if self.spilled_before() {
             let mut streams = vec![];
+
+            // Sort `in_mem_batches` and spill it first. If there are many
+            // `in_mem_batches` and the memory limit is almost reached, merging
+            // them with the spilled files at the same time might cause OOM.
             if !self.in_mem_batches.is_empty() {
-                let in_mem_stream =
-                    self.in_mem_sort_stream(self.metrics.baseline.intermediate())?;
-                streams.push(in_mem_stream);
+                self.sort_or_spill_in_mem_batches(true).await?;
             }
 
             for spill in self.spills.drain(..) {
@@ -488,11 +490,17 @@ impl ExternalSorter {
     /// the memory usage has dropped by a factor of 2, then we don't have
     /// to spill. Otherwise, we spill to free up memory for inserting
     /// more batches.
-    ///
     /// The factor of 2 aims to avoid a degenerate case where the
     /// memory required for `fetch` is just under the memory available,
-    // causing repeated re-sorting of data
-    async fn sort_or_spill_in_mem_batches(&mut self) -> Result<()> {
+    /// causing repeated re-sorting of data
+    ///
+    /// # Arguments
+    ///
+    /// * `force_spill` - If true, the method will spill the in-memory batches
+    /// even if the memory usage has not dropped by a factor of 2. Otherwise it will
+    /// only spill when the memory usage has dropped by the pre-defined factor.
+    ///
+    async fn sort_or_spill_in_mem_batches(&mut self, force_spill: bool) -> Result<()> {
         // Release the memory reserved for merge back to the pool so
         // there is some left when `in_mem_sort_stream` requests an
         // allocation. At the end of this function, memory will be
@@ -529,7 +537,7 @@ impl ExternalSorter {
         // Sorting may free up some memory especially when fetch is `Some`. If we have
         // not freed more than 50% of the memory, then we have to spill to free up more
         // memory for inserting more batches.
-        if self.reservation.size() > before / 2 {
+        if (self.reservation.size() > before / 2) || force_spill {
             // We have not freed more than 50% of the memory, so we have to spill to
             // free up more memory
             self.spill().await?;
@@ -1114,7 +1122,7 @@ impl ExecutionPlan for SortExec {
                             let batch = batch?;
                             sorter.insert_batch(batch).await?;
                         }
-                        sorter.sort()
+                        sorter.sort().await
                     })
                     .try_flatten(),
                 )))
@@ -1409,7 +1417,7 @@ mod tests {
         // bytes. We leave a little wiggle room for the actual numbers.
         assert!((3..=10).contains(&spill_count));
         assert!((9000..=10000).contains(&spilled_rows));
-        assert!((36000..=40000).contains(&spilled_bytes));
+        assert!((38000..=42000).contains(&spilled_bytes));
 
         let columns = result[0].columns();
 
@@ -1482,7 +1490,7 @@ mod tests {
         //  `number_of_batches / (sort_spill_reservation_bytes / batch_size)`
         assert!((12..=18).contains(&spill_count));
         assert!((15000..=20000).contains(&spilled_rows));
-        assert!((700000..=900000).contains(&spilled_bytes));
+        assert!((900000..=1000000).contains(&spilled_bytes));
 
         // Verify that the result is sorted
         let concated_result = concat_batches(&schema, &result)?;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I came across one sorting query with memory limit fail indefinitely, here is a simpler reproducer (running in `datafusion-cli` with commit 75977692c)
```sh
# Compile datafusion-cli
cargo run --profile release-nonlto -- --mem-pool-type fair -m 10M
```
2 sort queries are executed: Q1 get executed with no issue, Q2 has smaller input size than Q1, but it failed.
```
DataFusion CLI v46.0.0
> set datafusion.execution.sort_spill_reservation_bytes = 3000000;
0 row(s) fetched.
Elapsed 0.001 seconds.

> select * from generate_series(1,10000000) as t1(v1) order by v1;
...Query succeed

> select * from generate_series(1,9000000) as t1(v1) order by v1;
Resources exhausted: Failed to allocate additional 65536 bytes for ExternalSorterMerge[0] with 0 bytes already allocated for this reservation - 49152 bytes remain available for the total pool
```

### Query failure reason
At the final stage of sorting, all buffered in-memory batches and all the spilled files will be sort-preserving merged at the same time, and this caused the issue.
https://github.com/apache/datafusion/blob/75977692c12bda72301ccf65067532c5135fbd5c/datafusion/physical-plan/src/sorts/sort.rs#L342-L355
For example, there is one workload, let's say it's executing in a single partition. It's memory limit can hold 10 batches.
- Sorting 100 batches can be executed without issue:
    - Every time 10 batches are read, mempool is full and one spill file will be written to disk
    - Finally, there are 10 spill files, only one batch of each file is required to load to memory at the same time, so there is enough memory budget to do the final merging.
- Sorting 49 batches fails:
    - When the input is exhausted, there are 9 in-mem batches and 4 spill files. 9 + 4 batches are required to load to memory for final merging, it exceeds the memory pool limit which is around 10 batches.

A common workaround I believe is to set `datafusion.execution.sort_spill_reservation_bytes` to larger, its used for extra space for merging. However, workloads' row/batch size can vary drastically, also it's possible to see the case in-memory batches has almost reached the memory limit but not yet triggered on spilling, so this parameter is very tricky to configure it correct.
To make this simpler, we can always spill the in-memory batches (if it has spilled previously) at the final stage.

## What changes are included in this PR?

Change the final sort-preserving merge logic of sorting: when it has spilled before, always spill all in-mem batches first, then start the merging phase.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Regression test is added

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
