### PR TITLE
[WIP] Attempt piping through field metadata in as many places as possible

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -22,7 +22,7 @@ mod struct_builder;
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::Infallible;
 use std::fmt;
 use std::hash::Hash;
@@ -1410,6 +1410,28 @@ impl ScalarValue {
                 );
             }
         })
+    }
+
+    /// return the [`Field`] of this `ScalarValue`
+    pub fn field(&self) -> Field {
+        match self {
+            ScalarValue::Extension(storage, name, metadata) => {
+                let mut metadata_fields = HashMap::from([(
+                    "ARROW:extension:name".to_string(),
+                    name.to_string(),
+                )]);
+
+                if let Some(metadata_value) = metadata {
+                    metadata_fields.insert(
+                        "ARROW:extension:metadata".to_string(),
+                        metadata_value.to_string(),
+                    );
+                }
+
+                Field::new("", storage.data_type(), true).with_metadata(metadata_fields)
+            },
+            _ => Field::new("", self.data_type(), true)
+        }
     }
 
     /// return the [`DataType`] of this `ScalarValue`

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -327,7 +327,7 @@ pub enum Expr {
     Placeholder(Placeholder),
     /// A place holder which hold a reference to a qualified field
     /// in the outer query, used for correlated sub queries.
-    OuterReferenceColumn(DataType, Column),
+    OuterReferenceColumn(Field, Column),
     /// Unnest expression
     Unnest(Unnest),
 }

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -29,7 +29,7 @@ use crate::utils::expr_to_columns;
 use crate::Volatility;
 use crate::{udaf, ExprSchemable, Operator, Signature, WindowFrame, WindowUDF};
 
-use arrow::datatypes::{DataType, FieldRef};
+use arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::cse::{HashNode, NormalizeEq, Normalizeable};
 use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeContainer, TreeNodeRecursion,
@@ -228,7 +228,7 @@ pub enum Expr {
     /// A named reference to a qualified field in a schema.
     Column(Column),
     /// A named reference to a variable in a registry.
-    ScalarVariable(DataType, Vec<String>),
+    ScalarVariable(Field, Vec<String>),
     /// A constant value.
     Literal(ScalarValue),
     /// A binary expression such as "age > 21"

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -68,7 +68,7 @@ pub fn col(ident: impl Into<Column>) -> Expr {
 /// Create an out reference column which hold a reference that has been resolved to a field
 /// outside of the current plan.
 pub fn out_ref_col(dt: DataType, ident: impl Into<Column>) -> Expr {
-    Expr::OuterReferenceColumn(dt, ident.into())
+    Expr::OuterReferenceColumn(Field::new("", dt, true), ident.into())
 }
 
 /// Create an unqualified column expression from the provided name, without normalizing

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -114,7 +114,7 @@ impl ExprSchemable for Expr {
             Expr::Negative(expr) => expr.get_type(schema),
             Expr::Column(c) => Ok(schema.data_type(c)?.clone()),
             Expr::OuterReferenceColumn(ty, _) => Ok(ty.clone()),
-            Expr::ScalarVariable(ty, _) => Ok(ty.clone()),
+            Expr::ScalarVariable(field, _) => Ok(field.data_type().clone()),
             Expr::Literal(l) => Ok(l.data_type()),
             Expr::Case(case) => {
                 for (_, then_expr) in &case.when_then_expr {
@@ -378,7 +378,7 @@ impl ExprSchemable for Expr {
                 .data_type_and_nullable(c)
                 .map(|(d, n)| (d.clone(), n)),
             Expr::OuterReferenceColumn(ty, _) => Ok((ty.clone(), true)),
-            Expr::ScalarVariable(ty, _) => Ok((ty.clone(), true)),
+            Expr::ScalarVariable(field, _) => Ok((field.data_type().clone(), true)),
             Expr::Literal(l) => Ok((l.data_type(), l.is_null())),
             Expr::IsNull(_)
             | Expr::IsNotNull(_)

--- a/datafusion/proto-common/src/to_proto/mod.rs
+++ b/datafusion/proto-common/src/to_proto/mod.rs
@@ -635,6 +635,9 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     ))),
                 })
             }
+            ScalarValue::Extension(_, _, _) => Err(Error::General(format!(
+                "Proto serialization error: {val} not yet supported"
+            ))),
         }
     }
 }

--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -38,13 +38,14 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         if id.value.starts_with('@') {
             // TODO: figure out if ScalarVariables should be insensitive.
             let var_names = vec![id.value];
+            // TODO: dropping extension information
             let ty = self
                 .context_provider
                 .get_variable_type(&var_names)
                 .ok_or_else(|| {
                     plan_datafusion_err!("variable {var_names:?} has no type information")
                 })?;
-            Ok(Expr::ScalarVariable(ty, var_names))
+            Ok(Expr::ScalarVariable(Field::new("", ty, true), var_names))
         } else {
             // Don't use `col()` here because it will try to
             // interpret names with '.' as if they were
@@ -112,6 +113,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 .into_iter()
                 .map(|id| self.ident_normalizer.normalize(id))
                 .collect();
+            // TODO: dropping extension information
             let ty = self
                 .context_provider
                 .get_variable_type(&var_names)
@@ -120,7 +122,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         "variable {var_names:?} has no type information"
                     ))
                 })?;
-            Ok(Expr::ScalarVariable(ty, var_names))
+            Ok(Expr::ScalarVariable(Field::new("", ty, true), var_names))
         } else {
             let ids = ids
                 .into_iter()

--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -76,7 +76,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 {
                     // Found an exact match on a qualified name in the outer plan schema, so this is an outer reference column
                     return Ok(Expr::OuterReferenceColumn(
-                        field.data_type().clone(),
+                        field.clone().with_name("").with_nullable(true),
                         Column::from((qualifier, field)),
                     ));
                 }
@@ -184,7 +184,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 Some((field, qualifier, _nested_names)) => {
                                     // Found an exact match on a qualified name in the outer plan schema, so this is an outer reference column
                                     Ok(Expr::OuterReferenceColumn(
-                                        field.data_type().clone(),
+                                        field.clone().with_name("").with_nullable(true),
                                         Column::from((qualifier, field)),
                                     ))
                                 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1283,6 +1283,7 @@ impl Unparser<'_> {
             ScalarValue::Map(_) => not_impl_err!("Unsupported scalar: {v:?}"),
             ScalarValue::Union(..) => not_impl_err!("Unsupported scalar: {v:?}"),
             ScalarValue::Dictionary(_k, v) => self.scalar_to_sql(v),
+            ScalarValue::Extension(_, _, _) => not_impl_err!("Unsupported scalar: {v:?}")
         }
     }
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1283,7 +1283,7 @@ impl Unparser<'_> {
             ScalarValue::Map(_) => not_impl_err!("Unsupported scalar: {v:?}"),
             ScalarValue::Union(..) => not_impl_err!("Unsupported scalar: {v:?}"),
             ScalarValue::Dictionary(_k, v) => self.scalar_to_sql(v),
-            ScalarValue::Extension(_, _, _) => not_impl_err!("Unsupported scalar: {v:?}")
+            ScalarValue::Extension(_, _, _) => not_impl_err!("Unsupported scalar: {v:?}"),
         }
     }
 
@@ -2012,12 +2012,15 @@ mod tests {
                 r#"TRY_CAST(a AS INTEGER UNSIGNED)"#,
             ),
             (
-                Expr::ScalarVariable(Int8, vec![String::from("@a")]),
+                Expr::ScalarVariable(
+                    Field::new("", Int8, true),
+                    vec![String::from("@a")],
+                ),
                 r#"@a"#,
             ),
             (
                 Expr::ScalarVariable(
-                    Int8,
+                    Field::new("", Int8, true),
                     vec![String::from("@root"), String::from("foo")],
                 ),
                 r#"@root.foo"#,


### PR DESCRIPTION
As discussed in #12644 and on a recent DataFusion sync, a lightweight mechanism to patch in user-defined type support is to use the `Field` rather than the `DataType` in as many places as possible.

This is a very in-progress experiment...I know there is also work on LogicalType that may also be able to solve this (as would adding an `Extension` member to the arrow-rs `DataType` enum). I figured experimenting in public might be productive but am happy to go back to experimenting in private if that is less confusing!

## Which issue does this PR close?

- Closes #12644 (if the experiments in this PR work!)

## Rationale for this change

Most database systems have the concept of a "user defined type" that can act as first-class types (or close to them). The exact things that can be customized about this vary by system but usually include the ability to define new functions whose signature matches that type, add overloads to existing functions (notably: cast), or sort/display values in a particular way.

Arrow has the concept of an "extension type", which is implemented in the C data interface and IPC formats as two `Field` metadata fields: `ARROW:extension:name` and `ARROW:extension:metadata`. In arrow-rs there is the `ExtensionType` which provides a means by which to (at least) centralize the serialization and deserialization of `ARROW:extension:metadata`.

## What changes are included in this PR?

Experiments on the way towards replacing `DataType` with `Field` where possible.

## Are these changes tested?

If this is ever more than just an experiment, they will be!

## Are there any user-facing changes?

If this is ever more than just an experiment, there will be!
