### PR TITLE
docs: Improve docs on AggregateFunctionExpr construction

### DIFF
--- a/datafusion/physical-expr/src/aggregate.rs
+++ b/datafusion/physical-expr/src/aggregate.rs
@@ -134,13 +134,14 @@ impl AggregateExprBuilder {
 
         let data_type = fun.return_type(&input_exprs_types)?;
         let is_nullable = fun.is_nullable();
-        let name =
-            match alias {
-                None => return internal_err!(
+        let name = match alias {
+            None => {
+                return internal_err!(
                     "AggregateExprBuilder::alias must be provided prior to calling build"
-                ),
-                Some(alias) => alias,
-            };
+                )
+            }
+            Some(alias) => alias,
+        };
 
         Ok(AggregateFunctionExpr {
             fun: Arc::unwrap_or_clone(fun),

--- a/datafusion/physical-expr/src/aggregate.rs
+++ b/datafusion/physical-expr/src/aggregate.rs
@@ -134,10 +134,13 @@ impl AggregateExprBuilder {
 
         let data_type = fun.return_type(&input_exprs_types)?;
         let is_nullable = fun.is_nullable();
-        let name = match alias {
-            None => return internal_err!("alias should be provided"),
-            Some(alias) => alias,
-        };
+        let name =
+            match alias {
+                None => return internal_err!(
+                    "AggregateExprBuilder::alias must be provided prior to calling build"
+                ),
+                Some(alias) => alias,
+            };
 
         Ok(AggregateFunctionExpr {
             fun: Arc::unwrap_or_clone(fun),

--- a/datafusion/physical-expr/src/aggregate.rs
+++ b/datafusion/physical-expr/src/aggregate.rs
@@ -91,6 +91,9 @@ impl AggregateExprBuilder {
         }
     }
 
+    /// Constructs an `AggregateFunctionExpr` from the builder
+    /// 
+    /// Note that an [`Self::alias`] must be provided before calling this method.
     pub fn build(self) -> Result<AggregateFunctionExpr> {
         let Self {
             fun,

--- a/datafusion/physical-expr/src/aggregate.rs
+++ b/datafusion/physical-expr/src/aggregate.rs
@@ -199,6 +199,8 @@ impl AggregateExprBuilder {
 }
 
 /// Physical aggregate expression of a UDAF.
+/// 
+/// Instances are constructed via [`AggregateExprBuilder`].
 #[derive(Debug, Clone)]
 pub struct AggregateFunctionExpr {
     fun: AggregateUDF,

--- a/datafusion/physical-expr/src/aggregate.rs
+++ b/datafusion/physical-expr/src/aggregate.rs
@@ -92,7 +92,7 @@ impl AggregateExprBuilder {
     }
 
     /// Constructs an `AggregateFunctionExpr` from the builder
-    /// 
+    ///
     /// Note that an [`Self::alias`] must be provided before calling this method.
     pub fn build(self) -> Result<AggregateFunctionExpr> {
         let Self {
@@ -202,7 +202,7 @@ impl AggregateExprBuilder {
 }
 
 /// Physical aggregate expression of a UDAF.
-/// 
+///
 /// Instances are constructed via [`AggregateExprBuilder`].
 #[derive(Debug, Clone)]
 pub struct AggregateFunctionExpr {


### PR DESCRIPTION
I stumbled on some missing documentation while trying to construct a AggregateFunctionExpr

1. AggregateFunctionExpr didn't link to AggregateExprBuilder, which seems to be the only way to construct it
2. AggregateExprBuilder did not specify that providing an alias is required.

This PR should fix both those issues.