### PR TITLE
Remove deprecated function `OptimizerRule::try_optimize`

### DIFF
--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -69,8 +69,6 @@ pub use analyzer::{Analyzer, AnalyzerRule};
 pub use optimizer::{
     ApplyOrder, Optimizer, OptimizerConfig, OptimizerContext, OptimizerRule,
 };
-#[allow(deprecated)]
-pub use utils::optimize_children;
 
 pub(crate) mod join_key_set;
 mod plan_signature;

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -81,15 +81,13 @@ pub trait OptimizerRule: Debug {
     }
 
     /// Does this rule support rewriting owned plans (rather than by reference)?
+    #[deprecated(since = "47.0.0", note = "This method is no longer used")]
     fn supports_rewrite(&self) -> bool {
         true
     }
 
     /// Try to rewrite `plan` to an optimized form, returning `Transformed::yes`
     /// if the plan was rewritten and `Transformed::no` if it was not.
-    ///
-    /// Note: this function is only called if [`Self::supports_rewrite`] returns
-    /// true.
     fn rewrite(
         &self,
         _plan: LogicalPlan,

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -62,7 +62,6 @@ impl OptimizerRule for SimplifyExpressions {
         true
     }
 
-    /// if supports_owned returns true, the Optimizer calls [`Self::rewrite`]
     fn rewrite(
         &self,
         plan: LogicalPlan,

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -62,8 +62,7 @@ impl OptimizerRule for SimplifyExpressions {
         true
     }
 
-    /// if supports_owned returns true, the Optimizer calls
-    /// [`Self::rewrite`] instead of [`Self::try_optimize`]
+    /// if supports_owned returns true, the Optimizer calls [`Self::rewrite`]
     fn rewrite(
         &self,
         plan: LogicalPlan,

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -19,8 +19,6 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 
-use crate::{OptimizerConfig, OptimizerRule};
-
 use crate::analyzer::type_coercion::TypeCoercionRewriter;
 use arrow::array::{new_null_array, Array, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema};
@@ -37,44 +35,6 @@ use std::sync::Arc;
 /// Re-export of `NamesPreserver` for backwards compatibility,
 /// as it was initially placed here and then moved elsewhere.
 pub use datafusion_expr::expr_rewriter::NamePreserver;
-
-/// Convenience rule for writing optimizers: recursively invoke
-/// optimize on plan's children and then return a node of the same
-/// type. Useful for optimizer rules which want to leave the type
-/// of plan unchanged but still apply to the children.
-/// This also handles the case when the `plan` is a [`LogicalPlan::Explain`].
-///
-/// Returning `Ok(None)` indicates that the plan can't be optimized by the `optimizer`.
-#[deprecated(
-    since = "40.0.0",
-    note = "please use OptimizerRule::apply_order with ApplyOrder::BottomUp instead"
-)]
-pub fn optimize_children(
-    optimizer: &impl OptimizerRule,
-    plan: &LogicalPlan,
-    config: &dyn OptimizerConfig,
-) -> Result<Option<LogicalPlan>> {
-    let mut new_inputs = Vec::with_capacity(plan.inputs().len());
-    let mut plan_is_changed = false;
-    for input in plan.inputs() {
-        if optimizer.supports_rewrite() {
-            let new_input = optimizer.rewrite(input.clone(), config)?;
-            plan_is_changed = plan_is_changed || new_input.transformed;
-            new_inputs.push(new_input.data);
-        } else {
-            #[allow(deprecated)]
-            let new_input = optimizer.try_optimize(input, config)?;
-            plan_is_changed = plan_is_changed || new_input.is_some();
-            new_inputs.push(new_input.unwrap_or_else(|| input.clone()))
-        }
-    }
-    if plan_is_changed {
-        let exprs = plan.expressions();
-        plan.with_new_exprs(exprs, new_inputs).map(Some)
-    } else {
-        Ok(None)
-    }
-}
 
 /// Returns true if `expr` contains all columns in `schema_cols`
 pub(crate) fn has_all_column_refs(expr: &Expr, schema_cols: &HashSet<Column>) -> bool {


### PR DESCRIPTION
Follow up for #15027

---

1. Cleanup deprecated function in `optimizer`
2. Inlined `optimize_plan_node`

---

I've also noticed that, all `supports_rewrite` return true and not used anywhere, should we also remove it?