### PR TITLE
Improve benchmark documentation

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -329,7 +329,37 @@ Your benchmark should create and use an instance of `BenchmarkRun` defined in `b
 
 # Benchmarks
 
-The output of `dfbench` help includes a description of each benchmark, which is reproduced here for convenience
+The output of `dfbench` help includes a description of each benchmark, which is reproduced here for convenience.
+
+## Cancellation
+
+Test performance of cancelling queries
+Queries in DataFusion should stop executing "quickly" after they are
+cancelled (the output stream is dropped).
+
+The queries are executed on a synthetic dataset generated during
+the benchmark execution that is an anonymized version of a
+real-world data set.
+
+The query is an anonymized version of a real-world query, and the
+test starts the query then cancels it and reports how long it takes
+for the runtime to fully exit.
+
+Example output:
+
+```
+Using 7 files found on disk
+Starting to load data into in-memory object store
+Done loading data into in-memory object store
+in main, sleeping
+Starting spawned
+Creating logical plan...
+Creating physical plan...
+Executing physical plan...
+Getting results...
+cancelling thread
+done dropping runtime in 83.531417ms
+```
 
 ## ClickBench
 

--- a/benchmarks/src/cancellation.rs
+++ b/benchmarks/src/cancellation.rs
@@ -97,7 +97,7 @@ impl RunOpt {
         println!("Done loading data into in-memory object store");
 
         let mut rundata = BenchmarkRun::new();
-        rundata.start_new_case("Arglebargle");
+        rundata.start_new_case("Cancellation");
 
         for i in 0..self.common.iterations {
             let elapsed = run_test(self.wait_time, Arc::clone(&store))?;

--- a/benchmarks/src/cancellation.rs
+++ b/benchmarks/src/cancellation.rs
@@ -47,6 +47,9 @@ use tokio_util::sync::CancellationToken;
 
 /// Test performance of cancelling queries
 ///
+/// Queries in DataFusion should stop executing "quickly" after they are
+/// cancelled (the output stream is dropped).
+///
 /// The queries are executed on a synthetic dataset generated during
 /// the benchmark execution that is an anonymized version of a
 /// real-world data set.


### PR DESCRIPTION
## Which issue does this PR close?

This is a follow-on to https://github.com/apache/datafusion/pull/14818.

## Rationale for this change

There were some further improvements to the documentation that @alamb and I noticed after #14818 was merged in.

## What changes are included in this PR?

I noticed there was a label with the text "Arglebargle" that I put in there before I knew where that text ended up (it's a heading in the `bench.sh` output)

[@alamb had a suggestion in the previous PR](https://github.com/apache/datafusion/pull/14818#discussion_r1972019358) that I've now taken

[In my next PR, @alamb noticed I forgot to add this benchmark's description to `benchmarks/README.md`](https://github.com/apache/datafusion/pull/15030#discussion_r1982252416)

## Are these changes tested?

Nope, they're just docs :)

## Are there any user-facing changes?

These are the docs :)