### PR TITLE
Handle columns in with_new_exprs with a Join

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -4685,7 +4685,7 @@ digraph {
             let LogicalPlan::Join(join) = join
                 .with_new_exprs(
                     join.expressions(),
-                    join.inputs().into_iter().map(|x| x.clone()).collect(),
+                    join.inputs().into_iter().cloned().collect(),
                 )
                 .unwrap()
             else {
@@ -4700,7 +4700,7 @@ digraph {
             let LogicalPlan::Join(join) = join
                 .with_new_exprs(
                     join.expressions(),
-                    join.inputs().into_iter().map(|x| x.clone()).collect(),
+                    join.inputs().into_iter().cloned().collect(),
                 )
                 .unwrap()
             else {
@@ -4718,7 +4718,7 @@ digraph {
             let LogicalPlan::Join(join) = join
                 .with_new_exprs(
                     join.expressions(),
-                    join.inputs().into_iter().map(|x| x.clone()).collect(),
+                    join.inputs().into_iter().cloned().collect(),
                 )
                 .unwrap()
             else {
@@ -4741,7 +4741,7 @@ digraph {
                         col("t2.b"),
                         lit(true),
                     ],
-                    join.inputs().into_iter().map(|x| x.clone()).collect(),
+                    join.inputs().into_iter().cloned().collect(),
                 )
                 .unwrap()
             else {
@@ -4761,7 +4761,7 @@ digraph {
             );
             let res = join.with_new_exprs(
                 vec![col("t1.a").eq(col("t2.a")), col("t1.b")],
-                join.inputs().into_iter().map(|x| x.clone()).collect(),
+                join.inputs().into_iter().cloned().collect(),
             );
             assert!(res.is_err());
         }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -4682,13 +4682,13 @@ digraph {
 
         {
             let join = create_test_join(vec![(col("t1.a"), (col("t2.a")))], None);
-            let join = join
+            let LogicalPlan::Join(join) = join
                 .with_new_exprs(
                     join.expressions(),
                     join.inputs().into_iter().map(|x| x.clone()).collect(),
                 )
-                .unwrap();
-            let LogicalPlan::Join(join) = join else {
+                .unwrap()
+            else {
                 unreachable!()
             };
             assert_eq!(join.on, vec![(col("t1.a"), (col("t2.a")))]);
@@ -4697,13 +4697,13 @@ digraph {
 
         {
             let join = create_test_join(vec![], Some(col("t1.a").gt(col("t2.a"))));
-            let join = join
+            let LogicalPlan::Join(join) = join
                 .with_new_exprs(
                     join.expressions(),
                     join.inputs().into_iter().map(|x| x.clone()).collect(),
                 )
-                .unwrap();
-            let LogicalPlan::Join(join) = join else {
+                .unwrap()
+            else {
                 unreachable!()
             };
             assert_eq!(join.on, vec![]);
@@ -4715,13 +4715,13 @@ digraph {
                 vec![(col("t1.a"), (col("t2.a")))],
                 Some(col("t1.b").gt(col("t2.b"))),
             );
-            let join = join
+            let LogicalPlan::Join(join) = join
                 .with_new_exprs(
                     join.expressions(),
                     join.inputs().into_iter().map(|x| x.clone()).collect(),
                 )
-                .unwrap();
-            let LogicalPlan::Join(join) = join else {
+                .unwrap()
+            else {
                 unreachable!()
             };
             assert_eq!(join.on, vec![(col("t1.a"), (col("t2.a")))]);
@@ -4733,7 +4733,7 @@ digraph {
                 vec![(col("t1.a"), (col("t2.a"))), (col("t1.b"), (col("t2.b")))],
                 None,
             );
-            let join = join
+            let LogicalPlan::Join(join) = join
                 .with_new_exprs(
                     vec![
                         col("t1.a").eq(col("t2.a")),
@@ -4743,8 +4743,8 @@ digraph {
                     ],
                     join.inputs().into_iter().map(|x| x.clone()).collect(),
                 )
-                .unwrap();
-            let LogicalPlan::Join(join) = join else {
+                .unwrap()
+            else {
                 unreachable!()
             };
             assert_eq!(

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -4647,7 +4647,7 @@ digraph {
     }
 
     #[test]
-    fn test_join_with_new_exprs() -> Result<()> {
+    fn test_join_with_new_exprs() {
         fn create_test_join(on: Vec<(Expr, Expr)>, filter: Option<Expr>) -> LogicalPlan {
             let schema = Schema::new(vec![
                 Field::new("a", DataType::Int32, false),
@@ -4765,7 +4765,5 @@ digraph {
             );
             assert!(res.is_err());
         }
-
-        Ok(())
     }
 }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -917,7 +917,7 @@ impl LogicalPlan {
                 // The first part of expr is equi-exprs,
                 // and the struct of each equi-expr is like `left-expr = right-expr`.
                 assert_eq!(expr.len(), equi_expr_count);
-                let mut new_on = Vec::new();
+                let mut new_on = Vec::with_capacity(on.len());
                 let mut iter = expr.into_iter();
                 while let Some(left) = iter.next() {
                     let Some(right) = iter.next() else {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #14999

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Account for columns in any comparisons to the `equi_join_count`. Eg a pair of columns can be compared to one equi_join. Then check for column pairs while creating the new `on` expression.

## Are these changes tested?
Yes, I've added some unit tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
`with_new_exprs` with a column will no longer return an error if the other conditions are correct.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
