### PR TITLE
Fix/improve wildcard error 15004

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -181,7 +181,7 @@ pub enum SchemaError {
         field: Box<Column>,
         valid_fields: Vec<Column>,
     },
-    GroupByColumnInvalid {
+    GroupByOrAggregateColumnInvalid {
         column: String,
     },
 }
@@ -263,7 +263,7 @@ impl Display for SchemaError {
                     )
                 }
             }
-            Self::GroupByColumnInvalid { column } => {
+            Self::GroupByOrAggregateColumnInvalid { column } => {
                 write!(
                     f,
                     "While expanding wildcard, column '{}' must appear in the GROUP BY clause or must be part of an aggregate function",

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -164,18 +164,25 @@ macro_rules! context {
 #[derive(Debug)]
 pub enum SchemaError {
     /// Schema contains a (possibly) qualified and unqualified field with same unqualified name
-    AmbiguousReference { field: Column },
+    AmbiguousReference {
+        field: Column,
+    },
     /// Schema contains duplicate qualified field name
     DuplicateQualifiedField {
         qualifier: Box<TableReference>,
         name: String,
     },
     /// Schema contains duplicate unqualified field name
-    DuplicateUnqualifiedField { name: String },
+    DuplicateUnqualifiedField {
+        name: String,
+    },
     /// No field with this name
     FieldNotFound {
         field: Box<Column>,
         valid_fields: Vec<Column>,
+    },
+    GroupByColumnInvalid {
+        column: String,
     },
 }
 
@@ -255,6 +262,13 @@ impl Display for SchemaError {
                         field.quoted_flat_name()
                     )
                 }
+            }
+            Self::GroupByColumnInvalid { column } => {
+                write!(
+                    f,
+                    "While expanding wildcard, column '{}' must appear in the GROUP BY clause or must be part of an aggregate function",
+                    column
+                )
             }
         }
     }

--- a/datafusion/optimizer/src/analyzer/expand_wildcard_rule.rs
+++ b/datafusion/optimizer/src/analyzer/expand_wildcard_rule.rs
@@ -152,12 +152,6 @@ fn expand_exprlist(input: &LogicalPlan, expr: Vec<Expr>) -> Result<Vec<Expr>> {
 
                     projected_expr.extend(expanded);
                 } else {
-                    validate_columns_in_group_by_or_aggregate(
-                        has_group_by,
-                        &vec![e.clone()],
-                        &group_by_columns,
-                        &aggregate_columns,
-                    )?;
                     projected_expr.push(e.clone());
                 }
             }
@@ -222,7 +216,7 @@ fn validate_columns_in_group_by_or_aggregate(
                 let name = &col.name;
                 if !group_by_columns.contains(e) && !aggregate_columns.contains(e) {
                     return Err(SchemaError(
-                        datafusion_common::SchemaError::GroupByColumnInvalid {
+                        datafusion_common::SchemaError::GroupByOrAggregateColumnInvalid {
                             column: (name.clone().to_string()),
                         },
                         Box::new(None),

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -102,10 +102,10 @@ impl CheckColumnsSatisfyExprsPurpose {
     fn message_prefix(&self) -> &'static str {
         match self {
             CheckColumnsSatisfyExprsPurpose::ProjectionMustReferenceAggregate => {
-                "Projection references non-aggregate values"
+                "Column in SELECT must be in GROUP BY or an aggregate function"
             }
             CheckColumnsSatisfyExprsPurpose::HavingMustReferenceAggregate => {
-                "HAVING clause references non-aggregate values"
+                "Column in HAVING must be in GROUP BY or an aggregate function"
             }
         }
     }
@@ -159,7 +159,7 @@ fn check_column_satisfies_expr(
 ) -> Result<()> {
     if !columns.contains(expr) {
         return plan_err!(
-            "{}: Expression {} could not be resolved from available columns: {}",
+            "{}: Expression {} could not be resolved from available columns: {}, it must be in GROUP BY or an aggregate function",
             purpose.message_prefix(),
             expr,
             expr_vec_fmt!(columns)
@@ -169,7 +169,7 @@ fn check_column_satisfies_expr(
                 purpose.diagnostic_message(expr),
                 expr.spans().and_then(|spans| spans.first()),
             )
-            .with_help(format!("add '{expr}' to GROUP BY clause"), None);
+            .with_help(format!("Either add '{expr}' to GROUP BY clause, or use an aggregare function like ANY_VALUE({expr})"), None);
             err.with_diagnostic(diagnostic)
         });
     }
@@ -496,30 +496,30 @@ impl TreeNodeRewriter for RecursiveUnnestRewriter<'_> {
     ///
     /// For example an expr of **unnest(unnest(column1)) + unnest(unnest(unnest(column2)))**
     /// ```text
-    ///                         ┌──────────────────┐           
-    ///                         │    binaryexpr    │           
-    ///                         │                  │           
-    ///                         └──────────────────┘           
-    ///                f_down  / /            │ │              
-    ///                       / / f_up        │ │              
-    ///                      / /        f_down│ │f_up          
-    ///                  unnest               │ │              
-    ///                                       │ │              
-    ///       f_down  / / f_up(rewriting)     │ │              
-    ///              / /                                       
-    ///             / /                      unnest            
-    ///         unnest                                         
-    ///                           f_down  / / f_up(rewriting)  
-    /// f_down / /f_up                   / /                   
-    ///       / /                       / /                    
-    ///      / /                    unnest                     
-    ///   column1                                              
-    ///                     f_down / /f_up                     
-    ///                           / /                          
-    ///                          / /                           
-    ///                       column2                          
+    ///                         ┌──────────────────┐
+    ///                         │    binaryexpr    │
+    ///                         │                  │
+    ///                         └──────────────────┘
+    ///                f_down  / /            │ │
+    ///                       / / f_up        │ │
+    ///                      / /        f_down│ │f_up
+    ///                  unnest               │ │
+    ///                                       │ │
+    ///       f_down  / / f_up(rewriting)     │ │
+    ///              / /
+    ///             / /                      unnest
+    ///         unnest
+    ///                           f_down  / / f_up(rewriting)
+    /// f_down / /f_up                   / /
+    ///       / /                       / /
+    ///      / /                    unnest
+    ///   column1
+    ///                     f_down / /f_up
+    ///                           / /
+    ///                          / /
+    ///                       column2
     /// ```
-    ///         
+    ///
     fn f_up(&mut self, expr: Expr) -> Result<Transformed<Expr>> {
         if let Expr::Unnest(ref traversing_unnest) = expr {
             if traversing_unnest == self.top_most_unnest.as_ref().unwrap() {

--- a/datafusion/sql/tests/cases/diagnostic.rs
+++ b/datafusion/sql/tests/cases/diagnostic.rs
@@ -190,7 +190,7 @@ fn test_missing_non_aggregate_in_group_by() -> Result<()> {
     assert_eq!(diag.span, Some(spans["a"]));
     assert_eq!(
         diag.helps[0].message,
-        "add 'person.first_name' to GROUP BY clause"
+        "Either add 'person.first_name' to GROUP BY clause, or use an aggregare function like ANY_VALUE(person.first_name)"
     );
     Ok(())
 }

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -950,7 +950,7 @@ fn select_with_having_refers_to_invalid_column() {
                    HAVING first_name = 'M'";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-            "Error during planning: HAVING clause references non-aggregate values: Expression person.first_name could not be resolved from available columns: person.id, max(person.age)",
+            "Error during planning: Column in HAVING must be in GROUP BY or an aggregate function: Expression person.first_name could not be resolved from available columns: person.id, max(person.age), it must be in GROUP BY or an aggregate function",
             err.strip_backtrace()
         );
 }
@@ -974,7 +974,7 @@ fn select_with_having_with_aggregate_not_in_select() {
                    HAVING MAX(age) > 100";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-            "Error during planning: Projection references non-aggregate values: Expression person.first_name could not be resolved from available columns: max(person.age)",
+            "Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: Expression person.first_name could not be resolved from available columns: max(person.age), it must be in GROUP BY or an aggregate function",
             err.strip_backtrace()
         );
 }
@@ -1010,7 +1010,7 @@ fn select_aggregate_with_having_referencing_column_not_in_select() {
                    HAVING first_name = 'M'";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-        "Error during planning: HAVING clause references non-aggregate values: Expression person.first_name could not be resolved from available columns: count(*)",
+        "Error during planning: Column in HAVING must be in GROUP BY or an aggregate function: Expression person.first_name could not be resolved from available columns: count(*), it must be in GROUP BY or an aggregate function",
         err.strip_backtrace()
     );
 }
@@ -1131,7 +1131,7 @@ fn select_aggregate_with_group_by_with_having_referencing_column_not_in_group_by
                    HAVING MAX(age) > 10 AND last_name = 'M'";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-        "Error during planning: HAVING clause references non-aggregate values: Expression person.last_name could not be resolved from available columns: person.first_name, max(person.age)",
+        "Error during planning: Column in HAVING must be in GROUP BY or an aggregate function: Expression person.last_name could not be resolved from available columns: person.first_name, max(person.age), it must be in GROUP BY or an aggregate function",
         err.strip_backtrace()
     );
 }
@@ -1563,7 +1563,7 @@ fn select_simple_aggregate_with_groupby_non_column_expression_nested_and_not_res
     let sql = "SELECT ((age + 1) / 2) * (age + 9), MIN(first_name) FROM person GROUP BY age + 1";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-        "Error during planning: Projection references non-aggregate values: Expression person.age could not be resolved from available columns: person.age + Int64(1), min(person.first_name)",
+        "Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: Expression person.age could not be resolved from available columns: person.age + Int64(1), min(person.first_name), it must be in GROUP BY or an aggregate function",
             err.strip_backtrace()
         );
 }
@@ -1573,7 +1573,7 @@ fn select_simple_aggregate_with_groupby_non_column_expression_and_its_column_sel
     let sql = "SELECT age, MIN(first_name) FROM person GROUP BY age + 1";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-        "Error during planning: Projection references non-aggregate values: Expression person.age could not be resolved from available columns: person.age + Int64(1), min(person.first_name)",
+        "Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: Expression person.age could not be resolved from available columns: person.age + Int64(1), min(person.first_name), it must be in GROUP BY or an aggregate function",
             err.strip_backtrace()
         );
 }
@@ -1843,7 +1843,7 @@ fn select_7480_2() {
     let sql = "SELECT c1, c13, MIN(c12) FROM aggregate_test_100 GROUP BY c1";
     let err = logical_plan(sql).expect_err("query should have failed");
     assert_eq!(
-        "Error during planning: Projection references non-aggregate values: Expression aggregate_test_100.c13 could not be resolved from available columns: aggregate_test_100.c1, min(aggregate_test_100.c12)",
+        "Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: Expression aggregate_test_100.c13 could not be resolved from available columns: aggregate_test_100.c1, min(aggregate_test_100.c12), it must be in GROUP BY or an aggregate function",
         err.strip_backtrace()
     );
 }
@@ -3224,7 +3224,7 @@ fn lateral_left_join() {
 
 #[test]
 fn lateral_nested_left_join() {
-    let sql = "SELECT * FROM 
+    let sql = "SELECT * FROM
             j1, \
             (j2 LEFT JOIN LATERAL (SELECT * FROM j3 WHERE j1_id + j2_id = j3_id) AS j3 ON(true))";
     let expected = "Projection: *\

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -3468,7 +3468,7 @@ SELECT r.sn, SUM(l.amount), r.amount
 # to associate it with other fields, aggregate should contain all the composite columns
 # if any of the composite column is missing, we cannot use associated indices, inside select expression
 # below query should fail
-statement error DataFusion error: Error during planning: Projection references non\-aggregate values: Expression r\.amount could not be resolved from available columns: r\.sn, sum\(l\.amount\)
+statement error DataFusion error: Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: Expression r\.amount could not be resolved from available columns: r\.sn, sum\(l\.amount\), it must be in GROUP BY or an aggregate function
 SELECT r.sn, SUM(l.amount), r.amount
   FROM sales_global_with_composite_pk AS l
   JOIN sales_global_with_composite_pk AS r
@@ -3496,7 +3496,7 @@ NULL NULL NULL
 # left join shouldn't propagate right side constraint,
 # if right side is a unique key (unique and can contain null)
 # Please note that, above query and this one is same except the constraint in the table.
-statement error DataFusion error: Error during planning: Projection references non\-aggregate values: Expression r\.amount could not be resolved from available columns: r\.sn, sum\(r\.amount\)
+statement error DataFusion error: Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: Expression r\.amount could not be resolved from available columns: r\.sn, sum\(r\.amount\), it must be in GROUP BY or an aggregate function
 SELECT r.sn, r.amount, SUM(r.amount)
   FROM (SELECT *
     FROM sales_global_with_unique as l
@@ -3542,7 +3542,7 @@ SELECT column1, COUNT(*) as column2 FROM (VALUES (['a', 'b'], 1), (['c', 'd', 'e
 
 
 # primary key should be aware from which columns it is associated
-statement error DataFusion error: Error during planning: Projection references non\-aggregate values: Expression r\.sn could not be resolved from available columns: l\.sn, l\.zip_code, l\.country, l\.ts, l\.currency, l\.amount, sum\(l\.amount\)
+statement error DataFusion error: Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: Expression r\.sn could not be resolved from available columns: l\.sn, l\.zip_code, l\.country, l\.ts, l\.currency, l\.amount, sum\(l\.amount\), it must be in GROUP BY or an aggregate function
 SELECT l.sn, r.sn, SUM(l.amount), r.amount
   FROM sales_global_with_pk AS l
   JOIN sales_global_with_pk AS r
@@ -3633,7 +3633,7 @@ ORDER BY r.sn
 4 100 2022-01-03T10:00:00
 
 # after join, new window expressions shouldn't be associated with primary keys
-statement error DataFusion error: Error during planning: Projection references non\-aggregate values: Expression rn1 could not be resolved from available columns: r\.sn, r\.ts, r\.amount, sum\(r\.amount\)
+statement error DataFusion error: Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: Expression rn1 could not be resolved from available columns: r\.sn, r\.ts, r\.amount, sum\(r.amount\), it must be in GROUP BY or an aggregate function
 SELECT r.sn, SUM(r.amount), rn1
 FROM
   (SELECT r.ts, r.sn, r.amount,
@@ -5135,7 +5135,7 @@ statement ok
 CREATE TABLE test_case_expr(a INT, b TEXT) AS VALUES (1,'hello'), (2,'world')
 
 query T
-SELECT (CASE WHEN CONCAT(b, 'hello') = 'test' THEN 'good' ELSE 'bad' END) AS c 
+SELECT (CASE WHEN CONCAT(b, 'hello') = 'test' THEN 'good' ELSE 'bad' END) AS c
   FROM test_case_expr GROUP BY c;
 ----
 bad

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -32,14 +32,14 @@ AS VALUES
 
 statement ok
 CREATE TABLE nested_unnest_table
-AS VALUES 
+AS VALUES
     (struct('a', 'b', struct('c')), (struct('a', 'b', [10,20])), [struct('a', 'b')]),
     (struct('d', 'e', struct('f')), (struct('x', 'y', [30,40, 50])), null)
 ;
 
 statement ok
 CREATE TABLE recursive_unnest_table
-AS VALUES 
+AS VALUES
     (struct([1], 'a'), [[[1],[2]],[[1,1]]], [struct([1],[[1,2]])]),
     (struct([2], 'b'), [[[3,4],[5]],[[null,6],null,[7,8]]], [struct([2],[[3],[4]])])
 ;
@@ -264,9 +264,9 @@ NULL NULL 17
 NULL NULL 18
 
 query IIIT
-select 
-    unnest(column1), unnest(column2) + 2, 
-    column3 * 10, unnest(array_remove(column1, '4')) 
+select
+    unnest(column1), unnest(column2) + 2,
+    column3 * 10, unnest(array_remove(column1, '4'))
 from unnest_table;
 ----
 1 9 10 1
@@ -795,7 +795,7 @@ select unnest(unnest(column2)) c2, count(column3) from recursive_unnest_table gr
 [NULL, 6] 1
 NULL 1
 
-query error DataFusion error: Error during planning: Projection references non\-aggregate values
+query error DataFusion error: Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: Expression nested_unnest_table\.column1 could not be resolved from available columns: UNNEST\(nested_unnest_table\.column1\)\[c0\], it must be in GROUP BY or an aggregate function
 select unnest(column1) c1 from nested_unnest_table group by c1.c0;
 
 # TODO: this query should work. see issue: https://github.com/apache/datafusion/issues/12794
@@ -875,7 +875,7 @@ query TT
 explain select * from unnest_table u, unnest(u.column1);
 ----
 logical_plan
-01)Cross Join: 
+01)Cross Join:
 02)--SubqueryAlias: u
 03)----TableScan: unnest_table projection=[column1, column2, column3, column4, column5]
 04)--Subquery:


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes [#15004](https://github.com/apache/datafusion/issues/15004).

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The current error messages for non-aggregate columns in GROUP BY queries are technically accurate but not user-friendly. They use technical terminology like "non-aggregate values" without clearly explaining the problem or providing actionable solutions. This PR improves these error messages to be more intuitive and helpful, especially for users who might not be familiar with SQL aggregation concepts.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### added two function in to `expand_wildcard_rule.rs`:
1. `fn check_group_by_info(input: &LogicalPlan) -> (bool, Vec<Expr>, Vec<Expr>)`
- Detects if a query contains a GROUP BY clause
- Collects columns used in GROUP BY and in aggregate functions
- Returns a tuple of `(has_group_by, group_by_columns, aggregate_columns)`
2. `fn validate_columns_in_group_by_or_aggregate(has_group_by: bool, expanded: &Vec<Expr>, group_by_columns: &Vec<Expr>, aggregate_columns: &Vec<Expr>) -> Result<(), DataFusionError>`
- Verifies all selected columns appear either in the GROUP BY clause or within aggregate functions
- Returns a clear `SchemaError::GroupByColumnInvalid` error when validation fails
3. added a new `SchemaError` type to shows the error message - `datafusion_common::SchemaError::GroupByColumnInvalid`

### In datafusion/sql/src/utils.rs:

- Updated `message_prefix()` method to provide clearer error message prefixes
- Improved help text in `check_column_satisfies_expr()` to suggest specific solutions
- for easy understanding as requested in  [#15004](https://github.com/apache/datafusion/issues/15004)


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
- The new validation functions in `expand_wildcard_rule.rs` have been tested with test cases included at the bottom of the file. These tests verify both successful validation and proper error reporting.
- The message improvements in `datafusion/sql/src/utils.rs` modify only the error text, not the functional logic, so no additional tests were added for these changes.

Additional test cases are welcome to ensure comprehensive coverage.
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes. Users will now see more intuitive error messages when they encounter GROUP BY validation issues. For example, instead of seeing:
```
Error during planning: Projection references non-aggregate values: Expression foo.b could not be resolved from available columns: foo.a
```
They will see:
```
Error during planning: Column in SELECT must be grouped or aggregated: Expression foo.b could not be resolved from available columns: foo.a
```
This change makes errors more understandable and provides clearer guidance on how to fix the issue.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
