### PR TITLE
fix: unparse for subqueryalias

### DIFF
--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -17,7 +17,6 @@
 
 use super::*;
 use datafusion_common::ScalarValue;
-use datafusion_sql::unparser::plan_to_sql;
 
 #[tokio::test]
 async fn test_list_query_parameters() -> Result<()> {
@@ -350,49 +349,4 @@ async fn test_version_function() {
     assert_eq!(version.len(), 1);
 
     assert_eq!(version.value(0), expected_version);
-}
-
-#[tokio::test]
-async fn test_unparse_subqueryalias() -> Result<()> {
-    let ctx = SessionContext::new();
-    let sql = r#"
-SELECT
-  customer_view.c_custkey,
-  customer_view.c_name,
-  customer_view.custkey_plus
-FROM
-  (
-    SELECT
-      customer.c_custkey,
-      customer.c_name,
-      customer.custkey_plus
-    FROM
-      (
-        SELECT
-          customer.c_custkey,
-          CAST(customer.c_custkey AS BIGINT) + 1 AS custkey_plus,
-          customer.c_name
-        FROM
-          (
-            SELECT
-              customer.c_custkey AS c_custkey,
-              customer.c_name AS c_name
-            FROM
-              customer
-          ) AS customer
-      ) AS customer
-  ) AS customer_view
-    "#;
-    /// Return a RecordBatch with made up data about customer
-    fn customer() -> RecordBatch {
-        let custkey: ArrayRef = Arc::new(Int64Array::from(vec![1]));
-        let name: ArrayRef = Arc::new(StringArray::from_iter_values([""]));
-        RecordBatch::try_from_iter(vec![("c_custkey", custkey), ("c_name", name)])
-            .unwrap()
-    }
-    ctx.register_batch("customer", customer())?;
-    let plan = ctx.sql(sql).await?.into_optimized_plan()?;
-    let sql = plan_to_sql(&plan)?;
-    assert_eq!(sql.to_string(), "SELECT customer_view.c_custkey, customer_view.c_name, customer_view.custkey_plus FROM (SELECT customer.c_custkey, (CAST(customer.c_custkey AS BIGINT) + 1) AS custkey_plus, customer.c_name FROM (SELECT customer.c_custkey, customer.c_name FROM customer AS customer) AS customer) AS customer_view");
-    Ok(())
 }

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -988,14 +988,14 @@ impl Unparser<'_> {
                     &subquery_alias.input,
                     Some(subquery_alias.alias.clone()),
                     already_projected,
-                );
+                )?;
                 if let Some(alias) = alias {
-                    if let Ok(Some(plan)) = ret {
+                    if let Some(plan) = ret {
                         let plan = LogicalPlanBuilder::new(plan).alias(alias)?.build()?;
                         return Ok(Some(plan));
                     }
                 }
-                ret
+                Ok(ret)
             }
             // SubqueryAlias could be rewritten to a plan with a projection as the top node by [rewrite::subquery_alias_inner_query_and_columns].
             // The inner table scan could be a scan with pushdown operations.

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -21,7 +21,7 @@ use datafusion_expr::test::function_stub::{
     count_udaf, max_udaf, min_udaf, sum, sum_udaf,
 };
 use datafusion_expr::{
-    col, lit, table_scan, wildcard, EmptyRelation, Expr, Extension, LogicalPlan,
+    cast, col, lit, table_scan, wildcard, EmptyRelation, Expr, Extension, LogicalPlan,
     LogicalPlanBuilder, Union, UserDefinedLogicalNode, UserDefinedLogicalNodeCore,
 };
 use datafusion_functions::unicode;
@@ -37,6 +37,7 @@ use datafusion_sql::unparser::dialect::{
 use datafusion_sql::unparser::{expr_to_sql, plan_to_sql, Unparser};
 use sqlparser::ast::Statement;
 use std::hash::Hash;
+use std::ops::Add;
 use std::sync::Arc;
 use std::{fmt, vec};
 
@@ -1685,5 +1686,68 @@ fn test_unparse_optimized_multi_union() -> Result<()> {
         panic!("Expected error")
     }
 
+    Ok(())
+}
+
+/// Test unparse the optimized plan from the following SQL:
+/// ```
+/// SELECT
+///   customer_view.c_custkey,
+///   customer_view.c_name,
+///   customer_view.custkey_plus
+/// FROM
+///   (
+///     SELECT
+///       customer.c_custkey,
+///       customer.c_name,
+///       customer.custkey_plus
+///     FROM
+///       (
+///         SELECT
+///           customer.c_custkey,
+///           CAST(customer.c_custkey AS BIGINT) + 1 AS custkey_plus,
+///           customer.c_name
+///         FROM
+///           (
+///             SELECT
+///               customer.c_custkey AS c_custkey,
+///               customer.c_name AS c_name
+///             FROM
+///               customer
+///           ) AS customer
+///       ) AS customer
+///   ) AS customer_view
+/// ```
+#[test]
+fn test_unparse_subquery_alias_with_table_pushdown() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("c_custkey", DataType::Int32, false),
+        Field::new("c_name", DataType::Utf8, false),
+    ]);
+
+    let table_scan = table_scan(Some("customer"), &schema, Some(vec![0, 1]))?.build()?;
+
+    let plan = LogicalPlanBuilder::from(table_scan)
+        .alias("customer")?
+        .project(vec![
+            col("customer.c_custkey"),
+            cast(col("customer.c_custkey"), DataType::Int64)
+                .add(lit(1))
+                .alias("custkey_plus"),
+            col("customer.c_name"),
+        ])?
+        .alias("customer")?
+        .project(vec![
+            col("customer.c_custkey"),
+            col("customer.c_name"),
+            col("customer.custkey_plus"),
+        ])?
+        .alias("customer_view")?
+        .build()?;
+
+    let unparser = Unparser::default();
+    let sql = unparser.plan_to_sql(&plan)?;
+    let expected = "SELECT customer_view.c_custkey, customer_view.c_name, customer_view.custkey_plus FROM (SELECT customer.c_custkey, (CAST(customer.c_custkey AS BIGINT) + 1) AS custkey_plus, customer.c_name FROM (SELECT customer.c_custkey, customer.c_name FROM customer AS customer) AS customer) AS customer_view";
+    assert_eq!(sql.to_string(), expected);
     Ok(())
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #13272.

## Rationale for this change

the qualifier is incorrect for subqueryalias when unparsing.

## What changes are included in this PR?

wrap with subqueryalias if alias is passed when unparsing.

## Are these changes tested?

Unittest

## Are there any user-facing changes?

No