### PR TITLE
fix: Support datatype cast for insert api same as insert into sql

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -1034,7 +1034,7 @@ impl SchemaExt for Schema {
                 .iter()
                 .zip(other.fields().iter())
                 .try_for_each(|(f1, f2)| {
-                    if f1.name() != f2.name() || !DFSchema::datatype_is_logically_equal(f1.data_type(), f2.data_type()) {
+                    if f1.name() != f2.name() || (!DFSchema::datatype_is_logically_equal(f1.data_type(), f2.data_type()) && !can_cast_types(f2.data_type(), f1.data_type())) {
                         _plan_err!(
                             "Inserting query schema mismatch: Expected table field '{}' with type {:?}, \
                             but got '{}' with type {:?}.",


### PR DESCRIPTION
## Which issue does this PR close?

- Closes [#15015](https://github.com/apache/datafusion/issues/15015)

## Rationale for this change

Relax the datatype check to pass when we support cast, and the final map batch schema will automatically insert the the right schema datatype field.

## What changes are included in this PR?

Relax the datatype check to pass when we support cast, and the final map batch schema will automatically insert the the right schema datatype field.

## Are these changes tested?

Yes


## Are there any user-facing changes?

Support the consistent API which is same with sql insert into.
