### PR TITLE
Fix wasm32 build on version 46

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -259,6 +259,10 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq clang
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build with wasm-pack

--- a/datafusion/datasource-parquet/Cargo.toml
+++ b/datafusion/datasource-parquet/Cargo.toml
@@ -52,7 +52,7 @@ object_store = { workspace = true }
 parking_lot = { workspace = true }
 parquet = { workspace = true }
 rand = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true }
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -466,7 +466,6 @@ impl FileFormat for ParquetFormat {
 }
 
 /// Coerces the file schema if the table schema uses a view type.
-#[cfg(not(target_arch = "wasm32"))]
 pub fn coerce_file_schema_to_view_type(
     table_schema: &Schema,
     file_schema: &Schema,
@@ -516,7 +515,6 @@ pub fn coerce_file_schema_to_view_type(
 /// If the table schema uses a string type, coerce the file schema to use a string type.
 ///
 /// See [ParquetFormat::binary_as_string] for details
-#[cfg(not(target_arch = "wasm32"))]
 pub fn coerce_file_schema_to_string_type(
     table_schema: &Schema,
     file_schema: &Schema,

--- a/datafusion/wasmtest/Cargo.toml
+++ b/datafusion/wasmtest/Cargo.toml
@@ -45,7 +45,7 @@ chrono = { version = "0.4", features = ["wasmbind"] }
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.1", optional = true }
-datafusion = { workspace = true }
+datafusion = { workspace = true, features = ["parquet"] }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-execution = { workspace = true }
 datafusion-expr = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/15150

## Rationale for this change

I encountered a compile error when trying to upgrade DataFusion to V46 for [paruqet viewer](https://parquet-viewer.xiangpeng.systems).

I think the bug was accidentally introduced in https://github.com/apache/datafusion/pull/14464 cc @logan-keede 
 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Reverted the wasm32 gate as it should work for wasm32. I also enabled the `parquet` feature for wasm-test so that we can capture the bug in ci.

I also removed the fs feature on tokio, as I don't think parquet datasource relies on it, which breaks wasm build.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
