### PR TITLE
chore: remove ScalarUDFImpl::return_type_from_exprs

### DIFF
--- a/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
@@ -795,7 +795,7 @@ impl ScalarUDFImpl for TakeUDF {
         &self.signature
     }
     fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
-        not_impl_err!("Not called because the return_type_from_exprs is implemented")
+        not_impl_err!("Not called because the return_type_from_args is implemented")
     }
 
     /// This function returns the type of the first or second argument based on

--- a/datafusion/functions-nested/src/extract.rs
+++ b/datafusion/functions-nested/src/extract.rs
@@ -1037,34 +1037,6 @@ mod tests {
             fixed_size_list_type
         );
 
-        // ScalarUDFImpl::return_type_from_exprs with typed exprs
-        assert_eq!(
-            udf.return_type_from_exprs(
-                &[
-                    cast(Expr::Literal(ScalarValue::Null), array_type.clone()),
-                    cast(Expr::Literal(ScalarValue::Null), index_type.clone()),
-                ],
-                &schema,
-                &[array_type.clone(), index_type.clone()]
-            )
-            .unwrap(),
-            fixed_size_list_type
-        );
-
-        // ScalarUDFImpl::return_type_from_exprs with exprs not carrying type
-        assert_eq!(
-            udf.return_type_from_exprs(
-                &[
-                    Expr::Column(Column::new_unqualified("my_array")),
-                    Expr::Column(Column::new_unqualified("my_index")),
-                ],
-                &schema,
-                &[array_type.clone(), index_type.clone()]
-            )
-            .unwrap(),
-            fixed_size_list_type
-        );
-
         // Via ExprSchemable::get_type (e.g. SimplifyInfo)
         let udf_expr = Expr::ScalarFunction(ScalarFunction {
             func: array_element_udf(),

--- a/datafusion/functions/src/core/union_extract.rs
+++ b/datafusion/functions/src/core/union_extract.rs
@@ -82,8 +82,8 @@ impl ScalarUDFImpl for UnionExtractFun {
     }
 
     fn return_type(&self, _: &[DataType]) -> Result<DataType> {
-        // should be using return_type_from_exprs and not calling the default implementation
-        internal_err!("union_extract should return type from exprs")
+        // should be using return_type_from_args and not calling the default implementation
+        internal_err!("union_extract should return type from args")
     }
 
     fn return_type_from_args(&self, args: ReturnTypeArgs) -> Result<ReturnInfo> {

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -36,10 +36,6 @@ mod partitioning;
 mod physical_expr;
 pub mod planner;
 mod scalar_function;
-pub mod udf {
-    #[allow(deprecated)]
-    pub use crate::scalar_function::create_physical_expr;
-}
 pub mod statistics;
 pub mod utils;
 pub mod window;

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -39,12 +39,12 @@ use crate::PhysicalExpr;
 
 use arrow::array::{Array, RecordBatch};
 use arrow::datatypes::{DataType, Schema};
-use datafusion_common::{internal_err, DFSchema, Result, ScalarValue};
+use datafusion_common::{internal_err, Result, ScalarValue};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::sort_properties::ExprProperties;
 use datafusion_expr::type_coercion::functions::data_types_with_scalar_udf;
 use datafusion_expr::{
-    expr_vec_fmt, ColumnarValue, Expr, ReturnTypeArgs, ScalarFunctionArgs, ScalarUDF,
+    expr_vec_fmt, ColumnarValue, ReturnTypeArgs, ScalarFunctionArgs, ScalarUDF,
 };
 
 /// Physical expression of a scalar function
@@ -260,36 +260,4 @@ impl PhysicalExpr for ScalarFunctionExpr {
             preserves_lex_ordering,
         })
     }
-}
-
-/// Create a physical expression for the UDF.
-#[deprecated(since = "45.0.0", note = "use ScalarFunctionExpr::new() instead")]
-pub fn create_physical_expr(
-    fun: &ScalarUDF,
-    input_phy_exprs: &[Arc<dyn PhysicalExpr>],
-    input_schema: &Schema,
-    args: &[Expr],
-    input_dfschema: &DFSchema,
-) -> Result<Arc<dyn PhysicalExpr>> {
-    let input_expr_types = input_phy_exprs
-        .iter()
-        .map(|e| e.data_type(input_schema))
-        .collect::<Result<Vec<_>>>()?;
-
-    // verify that input data types is consistent with function's `TypeSignature`
-    data_types_with_scalar_udf(&input_expr_types, fun)?;
-
-    // Since we have arg_types, we don't need args and schema.
-    let return_type =
-        fun.return_type_from_exprs(args, input_dfschema, &input_expr_types)?;
-
-    Ok(Arc::new(
-        ScalarFunctionExpr::new(
-            fun.name(),
-            Arc::new(fun.clone()),
-            input_phy_exprs.to_vec(),
-            return_type,
-        )
-        .with_nullable(fun.is_nullable(args, input_dfschema)),
-    ))
 }

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -27,7 +27,7 @@ pub use datafusion_execution::{RecordBatchStream, SendableRecordBatchStream};
 pub use datafusion_expr::{Accumulator, ColumnarValue};
 pub use datafusion_physical_expr::window::WindowExpr;
 pub use datafusion_physical_expr::{
-    expressions, udf, Distribution, Partitioning, PhysicalExpr,
+    expressions, Distribution, Partitioning, PhysicalExpr,
 };
 
 use std::any::Any;

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -35,7 +35,7 @@ pub use datafusion_expr::{Accumulator, ColumnarValue};
 pub use datafusion_physical_expr::window::WindowExpr;
 use datafusion_physical_expr::PhysicalSortExpr;
 pub use datafusion_physical_expr::{
-    expressions, udf, Distribution, Partitioning, PhysicalExpr,
+    expressions, Distribution, Partitioning, PhysicalExpr,
 };
 
 pub use crate::display::{DefaultDisplay, DisplayAs, DisplayFormatType, VerboseDisplay};


### PR DESCRIPTION
use `return_type_from_args` instead

## Which issue does this PR close?


- Closes #14729

## Rationale for this change

Implementing `return_type_from_exprs` is almost harmful, since it's not used by DataFusion for anything. Implementing it instead of `return_type` or `return_type_from_args` leads to code that compiles but fails at runtime.

## What changes are included in this PR?

Removes `return_type_from_exprs` completely. This leads to compile failures for anyone who's mistakenly still using it.

Also removes `create_physical_expr` command which was using this `return_type_from_exprs`. Given it's also marked as deprecated I didn't check if it could be rewritten to use `return_type_from_args` instead, but if that's possible, we can do it as well to reduce the impact.

## Are these changes tested?

Existing tests

## Are there any user-facing changes?

Yes, BREAKING CHANGE: ScalarUDFImpl::return_type_from_exprs is removed, also `create_physical_expr` is removed.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
