### PR TITLE
Saner handling of nulls inside arrays

### DIFF
--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -885,12 +885,16 @@ impl Signature {
     }
 
     /// Specialized [Signature] for functions that take a fixed number of arrays.
-    pub fn arrays(n: usize, volatility: Volatility) -> Self {
+    pub fn arrays(
+        n: usize,
+        coercion: Option<ListCoercion>,
+        volatility: Volatility,
+    ) -> Self {
         Signature {
             type_signature: TypeSignature::ArraySignature(
                 ArrayFunctionSignature::Array {
                     arguments: vec![ArrayFunctionArgument::Array; n],
-                    array_coercion: Some(ListCoercion::FixedSizedListToList),
+                    array_coercion: coercion,
                 },
             ),
             volatility,
@@ -939,7 +943,7 @@ impl Signature {
 
     /// Specialized [Signature] for ArrayEmpty and similar functions.
     pub fn array(volatility: Volatility) -> Self {
-        Signature::arrays(1, volatility)
+        Signature::arrays(1, Some(ListCoercion::FixedSizedListToList), volatility)
     }
 }
 

--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -843,6 +843,7 @@ impl Signature {
             volatility,
         }
     }
+
     /// Any one of a list of [TypeSignature]s.
     pub fn one_of(type_signatures: Vec<TypeSignature>, volatility: Volatility) -> Self {
         Signature {
@@ -850,6 +851,7 @@ impl Signature {
             volatility,
         }
     }
+
     /// Specialized Signature for ArrayAppend and similar functions
     pub fn array_and_element(volatility: Volatility) -> Self {
         Signature {
@@ -865,6 +867,39 @@ impl Signature {
             volatility,
         }
     }
+
+    /// Specialized Signature for ArrayPrepend and similar functions
+    pub fn element_and_array(volatility: Volatility) -> Self {
+        Signature {
+            type_signature: TypeSignature::ArraySignature(
+                ArrayFunctionSignature::Array {
+                    arguments: vec![
+                        ArrayFunctionArgument::Element,
+                        ArrayFunctionArgument::Array,
+                    ],
+                    array_coercion: Some(ListCoercion::FixedSizedListToList),
+                },
+            ),
+            volatility,
+        }
+    }
+
+    /// Specialized Signature for ArrayUnion and similar functions
+    pub fn array_and_array(volatility: Volatility) -> Self {
+        Signature {
+            type_signature: TypeSignature::ArraySignature(
+                ArrayFunctionSignature::Array {
+                    arguments: vec![
+                        ArrayFunctionArgument::Array,
+                        ArrayFunctionArgument::Array,
+                    ],
+                    array_coercion: Some(ListCoercion::FixedSizedListToList),
+                },
+            ),
+            volatility,
+        }
+    }
+
     /// Specialized Signature for Array functions with an optional index
     pub fn array_and_element_and_optional_index(volatility: Volatility) -> Self {
         Signature {
@@ -898,7 +933,7 @@ impl Signature {
                         ArrayFunctionArgument::Array,
                         ArrayFunctionArgument::Index,
                     ],
-                    array_coercion: None,
+                    array_coercion: Some(ListCoercion::FixedSizedListToList),
                 },
             ),
             volatility,
@@ -910,7 +945,7 @@ impl Signature {
             type_signature: TypeSignature::ArraySignature(
                 ArrayFunctionSignature::Array {
                     arguments: vec![ArrayFunctionArgument::Array],
-                    array_coercion: None,
+                    array_coercion: Some(ListCoercion::FixedSizedListToList),
                 },
             ),
             volatility,

--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -852,7 +852,7 @@ impl Signature {
         }
     }
 
-    /// Specialized Signature for ArrayAppend and similar functions
+    /// Specialized [Signature] for ArrayAppend and similar functions.
     pub fn array_and_element(volatility: Volatility) -> Self {
         Signature {
             type_signature: TypeSignature::ArraySignature(
@@ -868,7 +868,7 @@ impl Signature {
         }
     }
 
-    /// Specialized Signature for ArrayPrepend and similar functions
+    /// Specialized [Signature] for ArrayPrepend and similar functions.
     pub fn element_and_array(volatility: Volatility) -> Self {
         Signature {
             type_signature: TypeSignature::ArraySignature(
@@ -884,15 +884,12 @@ impl Signature {
         }
     }
 
-    /// Specialized Signature for ArrayUnion and similar functions
-    pub fn array_and_array(volatility: Volatility) -> Self {
+    /// Specialized [Signature] for functions that take a fixed number of arrays.
+    pub fn arrays(n: usize, volatility: Volatility) -> Self {
         Signature {
             type_signature: TypeSignature::ArraySignature(
                 ArrayFunctionSignature::Array {
-                    arguments: vec![
-                        ArrayFunctionArgument::Array,
-                        ArrayFunctionArgument::Array,
-                    ],
+                    arguments: vec![ArrayFunctionArgument::Array; n],
                     array_coercion: Some(ListCoercion::FixedSizedListToList),
                 },
             ),
@@ -900,7 +897,7 @@ impl Signature {
         }
     }
 
-    /// Specialized Signature for Array functions with an optional index
+    /// Specialized [Signature] for Array functions with an optional index.
     pub fn array_and_element_and_optional_index(volatility: Volatility) -> Self {
         Signature {
             type_signature: TypeSignature::OneOf(vec![
@@ -924,7 +921,7 @@ impl Signature {
         }
     }
 
-    /// Specialized Signature for ArrayElement and similar functions
+    /// Specialized [Signature] for ArrayElement and similar functions.
     pub fn array_and_index(volatility: Volatility) -> Self {
         Signature {
             type_signature: TypeSignature::ArraySignature(
@@ -939,17 +936,10 @@ impl Signature {
             volatility,
         }
     }
-    /// Specialized Signature for ArrayEmpty and similar functions
+
+    /// Specialized [Signature] for ArrayEmpty and similar functions.
     pub fn array(volatility: Volatility) -> Self {
-        Signature {
-            type_signature: TypeSignature::ArraySignature(
-                ArrayFunctionSignature::Array {
-                    arguments: vec![ArrayFunctionArgument::Array],
-                    array_coercion: Some(ListCoercion::FixedSizedListToList),
-                },
-            ),
-            volatility,
-        }
+        Signature::arrays(1, volatility)
     }
 }
 

--- a/datafusion/functions-nested/src/cardinality.rs
+++ b/datafusion/functions-nested/src/cardinality.rs
@@ -141,7 +141,7 @@ pub fn cardinality_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
             generic_map_cardinality(map_array)
         }
         arg_type => {
-            exec_err!("cardinality does not support an argument of type '{arg_type}'")
+            exec_err!("cardinality does not support type {arg_type}")
         }
     }
 }

--- a/datafusion/functions-nested/src/cardinality.rs
+++ b/datafusion/functions-nested/src/cardinality.rs
@@ -23,12 +23,12 @@ use arrow::array::{
 };
 use arrow::datatypes::{
     DataType,
-    DataType::{FixedSizeList, LargeList, List, Map, UInt64},
+    DataType::{LargeList, List, Map, Null, UInt64},
 };
 use datafusion_common::cast::{as_large_list_array, as_list_array, as_map_array};
-use datafusion_common::utils::take_function_args;
+use datafusion_common::exec_err;
+use datafusion_common::utils::{take_function_args, ListCoercion};
 use datafusion_common::Result;
-use datafusion_common::{exec_err, plan_err};
 use datafusion_expr::{
     ArrayFunctionArgument, ArrayFunctionSignature, ColumnarValue, Documentation,
     ScalarUDFImpl, Signature, TypeSignature, Volatility,
@@ -52,7 +52,7 @@ impl Cardinality {
                 vec![
                     TypeSignature::ArraySignature(ArrayFunctionSignature::Array {
                         arguments: vec![ArrayFunctionArgument::Array],
-                        array_coercion: None,
+                        array_coercion: Some(ListCoercion::FixedSizedListToList),
                     }),
                     TypeSignature::ArraySignature(ArrayFunctionSignature::MapArray),
                 ],
@@ -103,13 +103,8 @@ impl ScalarUDFImpl for Cardinality {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        Ok(match arg_types[0] {
-            List(_) | LargeList(_) | FixedSizeList(_, _) | Map(_, _) => UInt64,
-            _ => {
-                return plan_err!("The cardinality function can only accept List/LargeList/FixedSizeList/Map.");
-            }
-        })
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(UInt64)
     }
 
     fn invoke_with_args(
@@ -131,21 +126,22 @@ impl ScalarUDFImpl for Cardinality {
 /// Cardinality SQL function
 pub fn cardinality_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     let [array] = take_function_args("cardinality", args)?;
-    match &array.data_type() {
+    match array.data_type() {
+        Null => Ok(Arc::new(UInt64Array::from_value(0, array.len()))),
         List(_) => {
-            let list_array = as_list_array(&array)?;
+            let list_array = as_list_array(array)?;
             generic_list_cardinality::<i32>(list_array)
         }
         LargeList(_) => {
-            let list_array = as_large_list_array(&array)?;
+            let list_array = as_large_list_array(array)?;
             generic_list_cardinality::<i64>(list_array)
         }
         Map(_, _) => {
-            let map_array = as_map_array(&array)?;
+            let map_array = as_map_array(array)?;
             generic_map_cardinality(map_array)
         }
-        other => {
-            exec_err!("cardinality does not support type '{:?}'", other)
+        arg_type => {
+            exec_err!("cardinality does not support an argument of type '{arg_type}'")
         }
     }
 }

--- a/datafusion/functions-nested/src/concat.rs
+++ b/datafusion/functions-nested/src/concat.rs
@@ -296,10 +296,7 @@ impl ScalarUDFImpl for ArrayConcat {
                 DataType::Null | DataType::List(_) | DataType::FixedSizeList(..) => (),
                 DataType::LargeList(_) => large_list = true,
                 arg_type => {
-                    return plan_err!(
-                        "{} does not support an argument of type {arg_type}",
-                        self.name()
-                    )
+                    return plan_err!("{} does not support type {arg_type}", self.name())
                 }
             }
 
@@ -446,28 +443,22 @@ fn concat_internal<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 /// Array_append SQL function
 pub(crate) fn array_append_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     let [array, values] = take_function_args("array_append", args)?;
-
     match array.data_type() {
         DataType::Null => make_array_inner(&[Arc::clone(values)]),
         DataType::List(_) => general_append_and_prepend::<i32>(args, true),
         DataType::LargeList(_) => general_append_and_prepend::<i64>(args, true),
-        arg_type => {
-            exec_err!("array_append does not support an argument of type {arg_type}")
-        }
+        arg_type => exec_err!("array_append does not support type {arg_type}"),
     }
 }
 
 /// Array_prepend SQL function
 pub(crate) fn array_prepend_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     let [values, array] = take_function_args("array_prepend", args)?;
-
     match array.data_type() {
         DataType::Null => make_array_inner(&[Arc::clone(values)]),
         DataType::List(_) => general_append_and_prepend::<i32>(args, false),
         DataType::LargeList(_) => general_append_and_prepend::<i64>(args, false),
-        arg_type => {
-            exec_err!("array_prepend does not support an argument of type {arg_type}")
-        }
+        arg_type => exec_err!("array_prepend does not support type {arg_type}"),
     }
 }
 

--- a/datafusion/functions-nested/src/concat.rs
+++ b/datafusion/functions-nested/src/concat.rs
@@ -17,29 +17,31 @@
 
 //! [`ScalarUDFImpl`] definitions for `array_append`, `array_prepend` and `array_concat` functions.
 
+use std::any::Any;
 use std::sync::Arc;
-use std::{any::Any, cmp::Ordering};
 
+use crate::make_array::make_array_inner;
+use crate::utils::{align_array_dimensions, check_datatypes, make_scalar_function};
 use arrow::array::{
-    Array, ArrayRef, Capacities, GenericListArray, MutableArrayData, NullBufferBuilder,
-    OffsetSizeTrait,
+    Array, ArrayRef, Capacities, GenericListArray, MutableArrayData, NullArray,
+    NullBufferBuilder, OffsetSizeTrait,
 };
 use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::{DataType, Field};
-use datafusion_common::utils::ListCoercion;
+use datafusion_common::utils::{
+    base_type, coerced_type_with_base_type_only, ListCoercion,
+};
 use datafusion_common::Result;
 use datafusion_common::{
     cast::as_generic_list_array,
-    exec_err, not_impl_err, plan_err,
+    exec_err, plan_err,
     utils::{list_ndims, take_function_args},
 };
+use datafusion_expr::binary::type_union_resolution;
 use datafusion_expr::{
-    ArrayFunctionArgument, ArrayFunctionSignature, ColumnarValue, Documentation,
-    ScalarUDFImpl, Signature, TypeSignature, Volatility,
+    ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion_macros::user_doc;
-
-use crate::utils::{align_array_dimensions, check_datatypes, make_scalar_function};
 
 make_udf_expr_and_func!(
     ArrayAppend,
@@ -106,7 +108,12 @@ impl ScalarUDFImpl for ArrayAppend {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        Ok(arg_types[0].clone())
+        let [array_type, element_type] = take_function_args(self.name(), arg_types)?;
+        if array_type.is_null() {
+            Ok(DataType::new_list(element_type.clone(), true))
+        } else {
+            Ok(array_type.clone())
+        }
     }
 
     fn invoke_with_args(
@@ -166,18 +173,7 @@ impl Default for ArrayPrepend {
 impl ArrayPrepend {
     pub fn new() -> Self {
         Self {
-            signature: Signature {
-                type_signature: TypeSignature::ArraySignature(
-                    ArrayFunctionSignature::Array {
-                        arguments: vec![
-                            ArrayFunctionArgument::Element,
-                            ArrayFunctionArgument::Array,
-                        ],
-                        array_coercion: Some(ListCoercion::FixedSizedListToList),
-                    },
-                ),
-                volatility: Volatility::Immutable,
-            },
+            signature: Signature::element_and_array(Volatility::Immutable),
             aliases: vec![
                 String::from("list_prepend"),
                 String::from("array_push_front"),
@@ -201,7 +197,12 @@ impl ScalarUDFImpl for ArrayPrepend {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        Ok(arg_types[1].clone())
+        let [element_type, array_type] = take_function_args(self.name(), arg_types)?;
+        if array_type.is_null() {
+            Ok(DataType::new_list(element_type.clone(), true))
+        } else {
+            Ok(array_type.clone())
+        }
     }
 
     fn invoke_with_args(
@@ -263,7 +264,7 @@ impl Default for ArrayConcat {
 impl ArrayConcat {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_any(Volatility::Immutable),
+            signature: Signature::user_defined(Volatility::Immutable),
             aliases: vec![
                 String::from("array_cat"),
                 String::from("list_concat"),
@@ -287,39 +288,43 @@ impl ScalarUDFImpl for ArrayConcat {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        let mut expr_type = DataType::Null;
         let mut max_dims = 0;
+        let mut large_list = false;
+        let mut element_types = Vec::with_capacity(arg_types.len());
         for arg_type in arg_types {
-            let DataType::List(field) = arg_type else {
-                return plan_err!(
-                    "The array_concat function can only accept list as the args."
-                );
-            };
-            if !field.data_type().equals_datatype(&DataType::Null) {
-                let dims = list_ndims(arg_type);
-                expr_type = match max_dims.cmp(&dims) {
-                    Ordering::Greater => expr_type,
-                    Ordering::Equal => {
-                        if expr_type == DataType::Null {
-                            arg_type.clone()
-                        } else if !expr_type.equals_datatype(arg_type) {
-                            return plan_err!(
-                            "It is not possible to concatenate arrays of different types. Expected: {}, got: {}", expr_type, arg_type
-                                );
-                        } else {
-                            expr_type
-                        }
-                    }
-
-                    Ordering::Less => {
-                        max_dims = dims;
-                        arg_type.clone()
-                    }
-                };
+            match arg_type {
+                DataType::Null | DataType::List(_) | DataType::FixedSizeList(..) => (),
+                DataType::LargeList(_) => large_list = true,
+                arg_type => {
+                    return plan_err!(
+                        "{} does not support an argument of type {arg_type}",
+                        self.name()
+                    )
+                }
             }
+
+            max_dims = max_dims.max(list_ndims(arg_type));
+            element_types.push(base_type(arg_type))
         }
 
-        Ok(expr_type)
+        if max_dims == 0 {
+            Ok(DataType::Null)
+        } else if let Some(mut return_type) = type_union_resolution(&element_types) {
+            for _ in 1..max_dims {
+                return_type = DataType::new_list(return_type, true)
+            }
+
+            if large_list {
+                Ok(DataType::new_large_list(return_type, true))
+            } else {
+                Ok(DataType::new_list(return_type, true))
+            }
+        } else {
+            plan_err!(
+                "Failed to unify argument types of {}: {arg_types:?}",
+                self.name()
+            )
+        }
     }
 
     fn invoke_with_args(
@@ -333,6 +338,16 @@ impl ScalarUDFImpl for ArrayConcat {
         &self.aliases
     }
 
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        let base_type = base_type(&self.return_type(arg_types)?);
+        let coercion = Some(&ListCoercion::FixedSizedListToList);
+        let arg_types = arg_types.iter().map(|arg_type| {
+            coerced_type_with_base_type_only(arg_type, &base_type, coercion)
+        });
+
+        Ok(arg_types.collect())
+    }
+
     fn documentation(&self) -> Option<&Documentation> {
         self.doc()
     }
@@ -341,24 +356,27 @@ impl ScalarUDFImpl for ArrayConcat {
 /// Array_concat/Array_cat SQL function
 pub(crate) fn array_concat_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.is_empty() {
-        return exec_err!("array_concat expects at least one arguments");
+        return exec_err!("array_concat expects at least one argument");
     }
 
-    let mut new_args = vec![];
+    let mut all_null = true;
+    let mut large_list = false;
     for arg in args {
-        let ndim = list_ndims(arg.data_type());
-        let base_type = datafusion_common::utils::base_type(arg.data_type());
-        if ndim == 0 {
-            return not_impl_err!("Array is not type '{base_type:?}'.");
+        match arg.data_type() {
+            DataType::Null => continue,
+            DataType::LargeList(_) => large_list = true,
+            _ => (),
         }
-        if !base_type.eq(&DataType::Null) {
-            new_args.push(Arc::clone(arg));
-        }
+
+        all_null = false
     }
 
-    match &args[0].data_type() {
-        DataType::LargeList(_) => concat_internal::<i64>(new_args.as_slice()),
-        _ => concat_internal::<i32>(new_args.as_slice()),
+    if all_null {
+        Ok(Arc::new(NullArray::new(args[0].len())))
+    } else if large_list {
+        concat_internal::<i64>(args)
+    } else {
+        concat_internal::<i32>(args)
     }
 }
 
@@ -427,21 +445,29 @@ fn concat_internal<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Array_append SQL function
 pub(crate) fn array_append_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
-    let [array, _] = take_function_args("array_append", args)?;
+    let [array, values] = take_function_args("array_append", args)?;
 
     match array.data_type() {
+        DataType::Null => make_array_inner(&[Arc::clone(values)]),
+        DataType::List(_) => general_append_and_prepend::<i32>(args, true),
         DataType::LargeList(_) => general_append_and_prepend::<i64>(args, true),
-        _ => general_append_and_prepend::<i32>(args, true),
+        arg_type => {
+            exec_err!("array_append does not support an argument of type {arg_type}")
+        }
     }
 }
 
 /// Array_prepend SQL function
 pub(crate) fn array_prepend_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
-    let [_, array] = take_function_args("array_prepend", args)?;
+    let [values, array] = take_function_args("array_prepend", args)?;
 
     match array.data_type() {
+        DataType::Null => make_array_inner(&[Arc::clone(values)]),
+        DataType::List(_) => general_append_and_prepend::<i32>(args, false),
         DataType::LargeList(_) => general_append_and_prepend::<i64>(args, false),
-        _ => general_append_and_prepend::<i32>(args, false),
+        arg_type => {
+            exec_err!("array_prepend does not support an argument of type {arg_type}")
+        }
     }
 }
 

--- a/datafusion/functions-nested/src/dimension.rs
+++ b/datafusion/functions-nested/src/dimension.rs
@@ -19,7 +19,6 @@
 
 use arrow::array::{
     Array, ArrayRef, GenericListArray, ListArray, OffsetSizeTrait, UInt64Array,
-    UInt64Builder,
 };
 use arrow::datatypes::{
     DataType,
@@ -220,17 +219,10 @@ pub fn array_ndims_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     fn general_list_ndims<O: OffsetSizeTrait>(
         array: &GenericListArray<O>,
     ) -> Result<ArrayRef> {
-        let mut builder = UInt64Builder::with_capacity(array.len());
         let ndims = list_ndims(array.data_type());
-        for arr in array.iter() {
-            if arr.is_some() {
-                builder.append_value(ndims)
-            } else {
-                builder.append_null()
-            }
-        }
-
-        Ok(Arc::new(builder.finish()))
+        let data = vec![ndims; array.len()];
+        let result = UInt64Array::new(data.into(), array.nulls().cloned());
+        Ok(Arc::new(result))
     }
 
     match array.data_type() {

--- a/datafusion/functions-nested/src/dimension.rs
+++ b/datafusion/functions-nested/src/dimension.rs
@@ -19,18 +19,20 @@
 
 use arrow::array::{
     Array, ArrayRef, GenericListArray, ListArray, OffsetSizeTrait, UInt64Array,
+    UInt64Builder,
 };
 use arrow::datatypes::{
     DataType,
-    DataType::{FixedSizeList, LargeList, List, UInt64},
-    Field, UInt64Type,
+    DataType::{LargeList, List, Null, UInt64},
+    UInt64Type,
 };
 use std::any::Any;
 
 use datafusion_common::cast::{as_large_list_array, as_list_array};
-use datafusion_common::{exec_err, plan_err, utils::take_function_args, Result};
+use datafusion_common::{exec_err, utils::take_function_args, Result};
 
 use crate::utils::{compute_array_dims, make_scalar_function};
+use datafusion_common::utils::list_ndims;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
@@ -95,15 +97,8 @@ impl ScalarUDFImpl for ArrayDims {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        Ok(match arg_types[0] {
-            List(_) | LargeList(_) | FixedSizeList(_, _) => {
-                List(Arc::new(Field::new_list_field(UInt64, true)))
-            }
-            _ => {
-                return plan_err!("The array_dims function can only accept List/LargeList/FixedSizeList.");
-            }
-        })
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::new_list(UInt64, true))
     }
 
     fn invoke_with_args(
@@ -174,13 +169,8 @@ impl ScalarUDFImpl for ArrayNdims {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        Ok(match arg_types[0] {
-            List(_) | LargeList(_) | FixedSizeList(_, _) => UInt64,
-            _ => {
-                return plan_err!("The array_ndims function can only accept List/LargeList/FixedSizeList.");
-            }
-        })
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(UInt64)
     }
 
     fn invoke_with_args(
@@ -204,59 +194,57 @@ pub fn array_dims_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     let [array] = take_function_args("array_dims", args)?;
 
     let data = match array.data_type() {
-        List(_) => {
-            let array = as_list_array(&array)?;
-            array
-                .iter()
-                .map(compute_array_dims)
-                .collect::<Result<Vec<_>>>()?
-        }
-        LargeList(_) => {
-            let array = as_large_list_array(&array)?;
-            array
-                .iter()
-                .map(compute_array_dims)
-                .collect::<Result<Vec<_>>>()?
-        }
-        array_type => {
-            return exec_err!("array_dims does not support type '{array_type:?}'");
+        List(_) => as_list_array(&array)?
+            .iter()
+            .map(compute_array_dims)
+            .collect::<Result<Vec<_>>>()?,
+        LargeList(_) => as_large_list_array(&array)?
+            .iter()
+            .map(compute_array_dims)
+            .collect::<Result<Vec<_>>>()?,
+        arg_type => {
+            return exec_err!(
+                "array_dims does not support an argument of type {arg_type}"
+            );
         }
     };
 
     let result = ListArray::from_iter_primitive::<UInt64Type, _, _>(data);
-
-    Ok(Arc::new(result) as ArrayRef)
+    Ok(Arc::new(result))
 }
 
 /// Array_ndims SQL function
 pub fn array_ndims_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
-    let [array_dim] = take_function_args("array_ndims", args)?;
+    let [array] = take_function_args("array_ndims", args)?;
 
     fn general_list_ndims<O: OffsetSizeTrait>(
         array: &GenericListArray<O>,
     ) -> Result<ArrayRef> {
-        let mut data = Vec::new();
-        let ndims = datafusion_common::utils::list_ndims(array.data_type());
-
+        let mut builder = UInt64Builder::with_capacity(array.len());
+        let ndims = list_ndims(array.data_type());
         for arr in array.iter() {
             if arr.is_some() {
-                data.push(Some(ndims))
+                builder.append_value(ndims)
             } else {
-                data.push(None)
+                builder.append_null()
             }
         }
 
-        Ok(Arc::new(UInt64Array::from(data)) as ArrayRef)
+        Ok(Arc::new(builder.finish()))
     }
-    match array_dim.data_type() {
+
+    match array.data_type() {
+        Null => Ok(Arc::new(UInt64Array::new_null(array.len()))),
         List(_) => {
-            let array = as_list_array(&array_dim)?;
+            let array = as_list_array(array)?;
             general_list_ndims::<i32>(array)
         }
         LargeList(_) => {
-            let array = as_large_list_array(&array_dim)?;
+            let array = as_large_list_array(array)?;
             general_list_ndims::<i64>(array)
         }
-        array_type => exec_err!("array_ndims does not support type {array_type:?}"),
+        arg_type => {
+            exec_err!("array_ndims does not support an argument of type type {arg_type}")
+        }
     }
 }

--- a/datafusion/functions-nested/src/distance.rs
+++ b/datafusion/functions-nested/src/distance.rs
@@ -23,21 +23,22 @@ use arrow::array::{
 };
 use arrow::datatypes::{
     DataType,
-    DataType::{FixedSizeList, Float64, LargeList, List},
+    DataType::{FixedSizeList, LargeList, List, Null},
 };
 use datafusion_common::cast::{
     as_float32_array, as_float64_array, as_generic_list_array, as_int32_array,
     as_int64_array,
 };
-use datafusion_common::utils::coerced_fixed_size_list_to_list;
+use datafusion_common::utils::{coerced_type_with_base_type_only, ListCoercion};
 use datafusion_common::{
-    exec_err, internal_datafusion_err, utils::take_function_args, Result,
+    exec_err, internal_datafusion_err, plan_err, utils::take_function_args, Result,
 };
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion_functions::{downcast_arg, downcast_named_arg};
 use datafusion_macros::user_doc;
+use itertools::Itertools;
 use std::any::Any;
 use std::sync::Arc;
 
@@ -104,24 +105,29 @@ impl ScalarUDFImpl for ArrayDistance {
         &self.signature
     }
 
-    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        match arg_types[0] {
-            List(_) | LargeList(_) | FixedSizeList(_, _) => Ok(Float64),
-            _ => exec_err!("The array_distance function can only accept List/LargeList/FixedSizeList."),
-        }
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Float64)
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         let [_, _] = take_function_args(self.name(), arg_types)?;
-        let mut result = Vec::new();
-        for arg_type in arg_types {
-            match arg_type {
-                List(_) | LargeList(_) | FixedSizeList(_, _) => result.push(coerced_fixed_size_list_to_list(arg_type)),
-                _ => return exec_err!("The array_distance function can only accept List/LargeList/FixedSizeList."),
+        let coercion = Some(&ListCoercion::FixedSizedListToList);
+        let arg_types = arg_types.iter().map(|arg_type| {
+            if matches!(arg_type, Null | List(_) | LargeList(_) | FixedSizeList(..)) {
+                Ok(coerced_type_with_base_type_only(
+                    arg_type,
+                    &DataType::Float64,
+                    coercion,
+                ))
+            } else {
+                plan_err!(
+                    "{} does not support an argument of type {arg_type}",
+                    self.name()
+                )
             }
-        }
+        });
 
-        Ok(result)
+        arg_types.try_collect()
     }
 
     fn invoke_with_args(
@@ -143,11 +149,11 @@ impl ScalarUDFImpl for ArrayDistance {
 pub fn array_distance_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     let [array1, array2] = take_function_args("array_distance", args)?;
 
-    match (&array1.data_type(), &array2.data_type()) {
+    match (array1.data_type(), array2.data_type()) {
         (List(_), List(_)) => general_array_distance::<i32>(args),
         (LargeList(_), LargeList(_)) => general_array_distance::<i64>(args),
-        (array_type1, array_type2) => {
-            exec_err!("array_distance does not support types '{array_type1:?}' and '{array_type2:?}'")
+        (arg_type1, arg_type2) => {
+            exec_err!("array_distance does not support arguments of type {arg_type1} and {arg_type2:?}")
         }
     }
 }
@@ -243,7 +249,7 @@ fn compute_array_distance(
 /// Converts an array of any numeric type to a Float64Array.
 fn convert_to_f64_array(array: &ArrayRef) -> Result<Float64Array> {
     match array.data_type() {
-        Float64 => Ok(as_float64_array(array)?.clone()),
+        DataType::Float64 => Ok(as_float64_array(array)?.clone()),
         DataType::Float32 => {
             let array = as_float32_array(array)?;
             let converted: Float64Array =

--- a/datafusion/functions-nested/src/distance.rs
+++ b/datafusion/functions-nested/src/distance.rs
@@ -120,10 +120,7 @@ impl ScalarUDFImpl for ArrayDistance {
                     coercion,
                 ))
             } else {
-                plan_err!(
-                    "{} does not support an argument of type {arg_type}",
-                    self.name()
-                )
+                plan_err!("{} does not support type {arg_type}", self.name())
             }
         });
 
@@ -148,12 +145,11 @@ impl ScalarUDFImpl for ArrayDistance {
 
 pub fn array_distance_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     let [array1, array2] = take_function_args("array_distance", args)?;
-
     match (array1.data_type(), array2.data_type()) {
         (List(_), List(_)) => general_array_distance::<i32>(args),
         (LargeList(_), LargeList(_)) => general_array_distance::<i64>(args),
         (arg_type1, arg_type2) => {
-            exec_err!("array_distance does not support arguments of type {arg_type1} and {arg_type2:?}")
+            exec_err!("array_distance does not support types {arg_type1} and {arg_type2}")
         }
     }
 }

--- a/datafusion/functions-nested/src/extract.rs
+++ b/datafusion/functions-nested/src/extract.rs
@@ -224,6 +224,10 @@ where
     i64: TryInto<O>,
 {
     let values = array.values();
+    if values.data_type().is_null() {
+        return Ok(Arc::new(NullArray::new(array.len())));
+    }
+
     let original_data = values.to_data();
     let capacity = Capacities::Array(original_data.len());
 

--- a/datafusion/functions-nested/src/extract.rs
+++ b/datafusion/functions-nested/src/extract.rs
@@ -165,10 +165,7 @@ impl ScalarUDFImpl for ArrayElement {
         match &arg_types[0] {
             Null => Ok(Null),
             List(field) | LargeList(field) => Ok(field.data_type().clone()),
-            arg_type => plan_err!(
-                "{} does not support an argument of type {arg_type}",
-                self.name()
-            ),
+            arg_type => plan_err!("{} does not support type {arg_type}", self.name()),
         }
     }
 
@@ -211,7 +208,7 @@ fn array_element_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
             general_array_element::<i64>(array, indexes)
         }
         arg_type => {
-            exec_err!("array_element does not support an argument of type {arg_type}")
+            exec_err!("array_element does not support type {arg_type}")
         }
     }
 }

--- a/datafusion/functions-nested/src/set_ops.rs
+++ b/datafusion/functions-nested/src/set_ops.rs
@@ -17,9 +17,11 @@
 
 //! [`ScalarUDFImpl`] definitions for array_union, array_intersect and array_distinct functions.
 
-use crate::make_array::{empty_array_type, make_array_inner};
 use crate::utils::make_scalar_function;
-use arrow::array::{new_empty_array, Array, ArrayRef, GenericListArray, OffsetSizeTrait};
+use arrow::array::{
+    new_null_array, Array, ArrayRef, GenericListArray, LargeListArray, ListArray,
+    OffsetSizeTrait,
+};
 use arrow::buffer::OffsetBuffer;
 use arrow::compute;
 use arrow::datatypes::DataType::{FixedSizeList, LargeList, List, Null};
@@ -104,7 +106,7 @@ impl Default for ArrayUnion {
 impl ArrayUnion {
     pub fn new() -> Self {
         Self {
-            signature: Signature::any(2, Volatility::Immutable),
+            signature: Signature::array_and_array(Volatility::Immutable),
             aliases: vec![String::from("list_union")],
         }
     }
@@ -124,8 +126,10 @@ impl ScalarUDFImpl for ArrayUnion {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        match (&arg_types[0], &arg_types[1]) {
-            (&Null, dt) => Ok(dt.clone()),
+        let [array1, array2] = take_function_args(self.name(), arg_types)?;
+        match (array1, array2) {
+            (Null, Null) => Ok(DataType::new_list(Null, true)),
+            (Null, dt) => Ok(dt.clone()),
             (dt, Null) => Ok(dt.clone()),
             (dt, _) => Ok(dt.clone()),
         }
@@ -183,7 +187,7 @@ pub(super) struct ArrayIntersect {
 impl ArrayIntersect {
     pub fn new() -> Self {
         Self {
-            signature: Signature::any(2, Volatility::Immutable),
+            signature: Signature::array_and_array(Volatility::Immutable),
             aliases: vec![String::from("list_intersect")],
         }
     }
@@ -203,10 +207,12 @@ impl ScalarUDFImpl for ArrayIntersect {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        match (arg_types[0].clone(), arg_types[1].clone()) {
-            (Null, Null) | (Null, _) => Ok(Null),
-            (_, Null) => Ok(empty_array_type()),
-            (dt, _) => Ok(dt),
+        let [array1, array2] = take_function_args(self.name(), arg_types)?;
+        match (array1, array2) {
+            (Null, Null) => Ok(DataType::new_list(Null, true)),
+            (Null, dt) => Ok(dt.clone()),
+            (dt, Null) => Ok(dt.clone()),
+            (dt, _) => Ok(dt.clone()),
         }
     }
 
@@ -347,80 +353,76 @@ fn generic_set_lists<OffsetSize: OffsetSizeTrait>(
     field: Arc<Field>,
     set_op: SetOp,
 ) -> Result<ArrayRef> {
-    if matches!(l.value_type(), Null) {
+    if l.is_empty() || l.value_type().is_null() {
         let field = Arc::new(Field::new_list_field(r.value_type(), true));
         return general_array_distinct::<OffsetSize>(r, &field);
-    } else if matches!(r.value_type(), Null) {
+    } else if r.is_empty() || r.value_type().is_null() {
         let field = Arc::new(Field::new_list_field(l.value_type(), true));
         return general_array_distinct::<OffsetSize>(l, &field);
-    }
-
-    // Handle empty array at rhs case
-    // array_union(arr, []) -> arr;
-    // array_intersect(arr, []) -> [];
-    if r.value_length(0).is_zero() {
-        if set_op == SetOp::Union {
-            return Ok(Arc::new(l.clone()) as ArrayRef);
-        } else {
-            return Ok(Arc::new(r.clone()) as ArrayRef);
-        }
     }
 
     if l.value_type() != r.value_type() {
         return internal_err!("{set_op:?} is not implemented for '{l:?}' and '{r:?}'");
     }
 
-    let dt = l.value_type();
-
     let mut offsets = vec![OffsetSize::usize_as(0)];
     let mut new_arrays = vec![];
-
-    let converter = RowConverter::new(vec![SortField::new(dt)])?;
+    let converter = RowConverter::new(vec![SortField::new(l.value_type())])?;
     for (first_arr, second_arr) in l.iter().zip(r.iter()) {
-        if let (Some(first_arr), Some(second_arr)) = (first_arr, second_arr) {
-            let l_values = converter.convert_columns(&[first_arr])?;
-            let r_values = converter.convert_columns(&[second_arr])?;
+        let l_values = if let Some(first_arr) = first_arr {
+            converter.convert_columns(&[first_arr])?
+        } else {
+            converter.convert_columns(&[])?
+        };
 
-            let l_iter = l_values.iter().sorted().dedup();
-            let values_set: HashSet<_> = l_iter.clone().collect();
-            let mut rows = if set_op == SetOp::Union {
-                l_iter.collect::<Vec<_>>()
-            } else {
-                vec![]
-            };
-            for r_val in r_values.iter().sorted().dedup() {
-                match set_op {
-                    SetOp::Union => {
-                        if !values_set.contains(&r_val) {
-                            rows.push(r_val);
-                        }
+        let r_values = if let Some(second_arr) = second_arr {
+            converter.convert_columns(&[second_arr])?
+        } else {
+            converter.convert_columns(&[])?
+        };
+
+        let l_iter = l_values.iter().sorted().dedup();
+        let values_set: HashSet<_> = l_iter.clone().collect();
+        let mut rows = if set_op == SetOp::Union {
+            l_iter.collect()
+        } else {
+            vec![]
+        };
+
+        for r_val in r_values.iter().sorted().dedup() {
+            match set_op {
+                SetOp::Union => {
+                    if !values_set.contains(&r_val) {
+                        rows.push(r_val);
                     }
-                    SetOp::Intersect => {
-                        if values_set.contains(&r_val) {
-                            rows.push(r_val);
-                        }
+                }
+                SetOp::Intersect => {
+                    if values_set.contains(&r_val) {
+                        rows.push(r_val);
                     }
                 }
             }
-
-            let last_offset = match offsets.last().copied() {
-                Some(offset) => offset,
-                None => return internal_err!("offsets should not be empty"),
-            };
-            offsets.push(last_offset + OffsetSize::usize_as(rows.len()));
-            let arrays = converter.convert_rows(rows)?;
-            let array = match arrays.first() {
-                Some(array) => Arc::clone(array),
-                None => {
-                    return internal_err!("{set_op}: failed to get array from rows");
-                }
-            };
-            new_arrays.push(array);
         }
+
+        let last_offset = match offsets.last() {
+            Some(offset) => *offset,
+            None => return internal_err!("offsets should not be empty"),
+        };
+
+        offsets.push(last_offset + OffsetSize::usize_as(rows.len()));
+        let arrays = converter.convert_rows(rows)?;
+        let array = match arrays.first() {
+            Some(array) => Arc::clone(array),
+            None => {
+                return internal_err!("{set_op}: failed to get array from rows");
+            }
+        };
+
+        new_arrays.push(array);
     }
 
     let offsets = OffsetBuffer::new(offsets.into());
-    let new_arrays_ref = new_arrays.iter().map(|v| v.as_ref()).collect::<Vec<_>>();
+    let new_arrays_ref: Vec<_> = new_arrays.iter().map(|v| v.as_ref()).collect();
     let values = compute::concat(&new_arrays_ref)?;
     let arr = GenericListArray::<OffsetSize>::try_new(field, offsets, values, None)?;
     Ok(Arc::new(arr))
@@ -431,38 +433,59 @@ fn general_set_op(
     array2: &ArrayRef,
     set_op: SetOp,
 ) -> Result<ArrayRef> {
+    fn empty_array(data_type: &DataType, len: usize, large: bool) -> Result<ArrayRef> {
+        let field = Arc::new(Field::new_list_field(data_type.clone(), true));
+        let values = new_null_array(data_type, len);
+        if large {
+            Ok(Arc::new(LargeListArray::try_new(
+                field,
+                OffsetBuffer::new_zeroed(len),
+                values,
+                None,
+            )?))
+        } else {
+            Ok(Arc::new(ListArray::try_new(
+                field,
+                OffsetBuffer::new_zeroed(len),
+                values,
+                None,
+            )?))
+        }
+    }
+
     match (array1.data_type(), array2.data_type()) {
+        (Null, Null) => Ok(Arc::new(ListArray::new_null(
+            Arc::new(Field::new_list_field(Null, true)),
+            array1.len(),
+        ))),
         (Null, List(field)) => {
             if set_op == SetOp::Intersect {
-                return Ok(new_empty_array(&Null));
+                return empty_array(field.data_type(), array1.len(), false);
             }
             let array = as_list_array(&array2)?;
             general_array_distinct::<i32>(array, field)
         }
-
         (List(field), Null) => {
             if set_op == SetOp::Intersect {
-                return make_array_inner(&[]);
+                return empty_array(field.data_type(), array1.len(), false);
             }
             let array = as_list_array(&array1)?;
             general_array_distinct::<i32>(array, field)
         }
         (Null, LargeList(field)) => {
             if set_op == SetOp::Intersect {
-                return Ok(new_empty_array(&Null));
+                return empty_array(field.data_type(), array1.len(), true);
             }
             let array = as_large_list_array(&array2)?;
             general_array_distinct::<i64>(array, field)
         }
         (LargeList(field), Null) => {
             if set_op == SetOp::Intersect {
-                return make_array_inner(&[]);
+                return empty_array(field.data_type(), array1.len(), true);
             }
             let array = as_large_list_array(&array1)?;
             general_array_distinct::<i64>(array, field)
         }
-        (Null, Null) => Ok(new_empty_array(&Null)),
-
         (List(field), List(_)) => {
             let array1 = as_list_array(&array1)?;
             let array2 = as_list_array(&array2)?;

--- a/datafusion/functions-nested/src/set_ops.rs
+++ b/datafusion/functions-nested/src/set_ops.rs
@@ -106,7 +106,7 @@ impl Default for ArrayUnion {
 impl ArrayUnion {
     pub fn new() -> Self {
         Self {
-            signature: Signature::array_and_array(Volatility::Immutable),
+            signature: Signature::arrays(2, Volatility::Immutable),
             aliases: vec![String::from("list_union")],
         }
     }
@@ -187,7 +187,7 @@ pub(super) struct ArrayIntersect {
 impl ArrayIntersect {
     pub fn new() -> Self {
         Self {
-            signature: Signature::array_and_array(Volatility::Immutable),
+            signature: Signature::arrays(2, Volatility::Immutable),
             aliases: vec![String::from("list_intersect")],
         }
     }

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -172,6 +172,12 @@ pub fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         return Ok(Arc::clone(&args[0]));
     }
 
+    let list_array = as_list_array(&args[0])?;
+    let row_count = list_array.len();
+    if row_count == 0 || list_array.value_type().is_null() {
+        return Ok(Arc::clone(&args[0]));
+    }
+
     if args[1..].iter().any(|array| array.is_null(0)) {
         return Ok(new_null_array(args[0].data_type(), args[0].len()));
     }
@@ -195,12 +201,6 @@ pub fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         }
         _ => return exec_err!("array_sort expects 1 to 3 arguments"),
     };
-
-    let list_array = as_list_array(&args[0])?;
-    let row_count = list_array.len();
-    if row_count == 0 || list_array.value_type().is_null() {
-        return Ok(Arc::clone(&args[0]));
-    }
 
     let mut array_lengths = vec![];
     let mut arrays = vec![];

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -21,11 +21,11 @@ use crate::utils::make_scalar_function;
 use arrow::array::{new_null_array, Array, ArrayRef, ListArray, NullBufferBuilder};
 use arrow::buffer::OffsetBuffer;
 use arrow::compute::SortColumn;
-use arrow::datatypes::DataType::{FixedSizeList, LargeList, List};
 use arrow::datatypes::{DataType, Field};
 use arrow::{compute, compute::SortOptions};
 use datafusion_common::cast::{as_list_array, as_string_array};
-use datafusion_common::{exec_err, Result};
+use datafusion_common::utils::ListCoercion;
+use datafusion_common::{exec_err, plan_err, Result};
 use datafusion_expr::{
     ArrayFunctionArgument, ArrayFunctionSignature, ColumnarValue, Documentation,
     ScalarUDFImpl, Signature, TypeSignature, Volatility,
@@ -93,14 +93,14 @@ impl ArraySort {
                 vec![
                     TypeSignature::ArraySignature(ArrayFunctionSignature::Array {
                         arguments: vec![ArrayFunctionArgument::Array],
-                        array_coercion: None,
+                        array_coercion: Some(ListCoercion::FixedSizedListToList),
                     }),
                     TypeSignature::ArraySignature(ArrayFunctionSignature::Array {
                         arguments: vec![
                             ArrayFunctionArgument::Array,
                             ArrayFunctionArgument::String,
                         ],
-                        array_coercion: None,
+                        array_coercion: Some(ListCoercion::FixedSizedListToList),
                     }),
                     TypeSignature::ArraySignature(ArrayFunctionSignature::Array {
                         arguments: vec![
@@ -108,7 +108,7 @@ impl ArraySort {
                             ArrayFunctionArgument::String,
                             ArrayFunctionArgument::String,
                         ],
-                        array_coercion: None,
+                        array_coercion: Some(ListCoercion::FixedSizedListToList),
                     }),
                 ],
                 Volatility::Immutable,
@@ -133,17 +133,16 @@ impl ScalarUDFImpl for ArraySort {
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         match &arg_types[0] {
-            List(field) | FixedSizeList(field, _) => Ok(List(Arc::new(
-                Field::new_list_field(field.data_type().clone(), true),
-            ))),
-            LargeList(field) => Ok(LargeList(Arc::new(Field::new_list_field(
-                field.data_type().clone(),
-                true,
-            )))),
             DataType::Null => Ok(DataType::Null),
-            _ => exec_err!(
-                "Not reachable, data_type should be List, LargeList or FixedSizeList"
-            ),
+            DataType::List(field) => {
+                Ok(DataType::new_list(field.data_type().clone(), true))
+            }
+            arg_type => {
+                plan_err!(
+                    "{} does not support an argument of type {arg_type}",
+                    self.name()
+                )
+            }
         }
     }
 
@@ -167,6 +166,10 @@ impl ScalarUDFImpl for ArraySort {
 pub fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     if args.is_empty() || args.len() > 3 {
         return exec_err!("array_sort expects one to three arguments");
+    }
+
+    if args[0].data_type().is_null() {
+        return Ok(Arc::clone(&args[0]));
     }
 
     if args[1..].iter().any(|array| array.is_null(0)) {
@@ -195,7 +198,7 @@ pub fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 
     let list_array = as_list_array(&args[0])?;
     let row_count = list_array.len();
-    if row_count == 0 {
+    if row_count == 0 || list_array.value_type().is_null() {
         return Ok(Arc::clone(&args[0]));
     }
 

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -138,10 +138,7 @@ impl ScalarUDFImpl for ArraySort {
                 Ok(DataType::new_list(field.data_type().clone(), true))
             }
             arg_type => {
-                plan_err!(
-                    "{} does not support an argument of type {arg_type}",
-                    self.name()
-                )
+                plan_err!("{} does not support type {arg_type}", self.name())
             }
         }
     }

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -4429,7 +4429,7 @@ select array_union([[null]], []);
 ----
 [[]]
 
-query error DataFusion error: Error during planning: Failed to unify argument types of array_union:
+query error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'array_union' function:
 select array_union(arrow_cast([[null]], 'LargeList(List(Int64))'), arrow_cast([], 'LargeList(Int64)'));
 
 # array_union scalar function #8

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1204,7 +1204,7 @@ select array_element([1, 2], NULL);
 ----
 NULL
 
-query I
+query ?
 select array_element(NULL, 2);
 ----
 NULL
@@ -1448,7 +1448,7 @@ select array_max(make_array(5, 3, 4, NULL, 6, NULL));
 ----
 6
 
-query I
+query ?
 select array_max(make_array(NULL, NULL));
 ----
 NULL
@@ -1512,7 +1512,7 @@ select array_max(arrow_cast(make_array(1, 2, 3), 'FixedSizeList(3, Int64)')), ar
 ----
 3 1
 
-query I
+query ?
 select array_max(make_array());
 ----
 NULL
@@ -2177,7 +2177,7 @@ select array_any_value(1), array_any_value('a'), array_any_value(NULL);
 
 # array_any_value scalar function #1 (with null and non-null elements)
 
-query ITII
+query IT?I
 select array_any_value(make_array(NULL, 1, 2, 3, 4, 5)), array_any_value(make_array(NULL, 'h', 'e', 'l', 'l', 'o')), array_any_value(make_array(NULL, NULL)), array_any_value(make_array(NULL, NULL, 1, 2, 3));
 ----
 1 h NULL 1
@@ -2435,11 +2435,15 @@ select array_append(null, 1);
 ----
 [1]
 
-query error
+query ?
 select array_append(null, [2, 3]);
+----
+[[2, 3]]
 
-query error
+query ?
 select array_append(null, [[4]]);
+----
+[[[4]]]
 
 query ????
 select
@@ -2716,8 +2720,10 @@ select array_prepend(null, [[1,2,3]]);
 # DuckDB: [[]]
 # ClickHouse: [[]]
 # TODO: We may also return [[]]
-query error
+query ?
 select array_prepend([], []);
+----
+[[]]
 
 query ?
 select array_prepend(null, null);
@@ -3080,22 +3086,26 @@ select array_concat(
 ----
 [1, 2, 3]
 
-# Concatenating Mixed types (doesn't work)
-query error DataFusion error: Error during planning: It is not possible to concatenate arrays of different types\. Expected: List\(Field \{ name: "item", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: \{\} \}\), got: List\(Field \{ name: "item", data_type: LargeUtf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: \{\} \}\)
+# Concatenating Mixed types
+query ?
 select array_concat(
   [arrow_cast('1', 'Utf8'), arrow_cast('2', 'Utf8')],
   [arrow_cast('3', 'LargeUtf8')]
 );
+----
+[1, 2, 3]
 
-# Concatenating Mixed types (doesn't work)
-query error DataFusion error: Error during planning: It is not possible to concatenate arrays of different types\. Expected: List\(Field \{ name: "item", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: \{\} \}\), got: List\(Field \{ name: "item", data_type: Utf8View, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: \{\} \}\)
+# Concatenating Mixed types
+query ?
 select array_concat(
   [arrow_cast('1', 'Utf8'), arrow_cast('2', 'Utf8')],
   [arrow_cast('3', 'Utf8View')]
 );
+----
+[1, 2, 3]
 
 # array_concat error
-query error DataFusion error: Error during planning: The array_concat function can only accept list as the args\.
+query error DataFusion error: Error during planning: Execution error: Function 'array_concat' user-defined coercion failed with "Error during planning: array_concat does not support an argument of type Int64"
 select array_concat(1, 2);
 
 # array_concat scalar function #1
@@ -3406,15 +3416,11 @@ SELECT array_position(arrow_cast([1, 1, 100, 1, 1], 'LargeList(Int32)'), 100)
 ----
 3
 
-query I
+query error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'array_position' function: coercion from
 SELECT array_position([1, 2, 3], 'foo')
-----
-NULL
 
-query I
+query error DataFusion error: Error during planning: Failed to coerce arguments to satisfy a call to 'array_position' function: coercion from
 SELECT array_position([1, 2, 3], 'foo', 2)
-----
-NULL
 
 # list_position scalar function #5 (function alias `array_position`)
 query III
@@ -4376,7 +4382,8 @@ select array_union(arrow_cast([1, 2, 3, 4], 'LargeList(Int64)'), arrow_cast([5, 
 statement ok
 CREATE TABLE arrays_with_repeating_elements_for_union
 AS VALUES
-  ([1], [2]),
+  ([0, 1, 1], []),
+  ([1, 1], [2]),
   ([2, 3], [3]),
   ([3], [3, 4])
 ;
@@ -4384,6 +4391,7 @@ AS VALUES
 query ?
 select array_union(column1, column2) from arrays_with_repeating_elements_for_union;
 ----
+[0, 1]
 [1, 2]
 [2, 3]
 [3, 4]
@@ -4391,6 +4399,7 @@ select array_union(column1, column2) from arrays_with_repeating_elements_for_uni
 query ?
 select array_union(arrow_cast(column1, 'LargeList(Int64)'), arrow_cast(column2, 'LargeList(Int64)')) from arrays_with_repeating_elements_for_union;
 ----
+[0, 1]
 [1, 2]
 [2, 3]
 [3, 4]
@@ -4413,12 +4422,10 @@ select array_union(arrow_cast([], 'LargeList(Int64)'), arrow_cast([], 'LargeList
 query ?
 select array_union([[null]], []);
 ----
-[[NULL]]
+[[]]
 
-query ?
+query error DataFusion error: Error during planning: Failed to unify argument types of array_union:
 select array_union(arrow_cast([[null]], 'LargeList(List(Int64))'), arrow_cast([], 'LargeList(Int64)'));
-----
-[[NULL]]
 
 # array_union scalar function #8
 query ?
@@ -6428,12 +6435,12 @@ select array_intersect(arrow_cast([1, 1, 2, 2, 3, 3], 'LargeList(Int64)'), null)
 query ?
 select array_intersect(null, [1, 1, 2, 2, 3, 3]);
 ----
-NULL
+[]
 
 query ?
 select array_intersect(null, arrow_cast([1, 1, 2, 2, 3, 3], 'LargeList(Int64)'));
 ----
-NULL
+[]
 
 query ?
 select array_intersect([], null);
@@ -6458,12 +6465,12 @@ select array_intersect(arrow_cast([], 'LargeList(Int64)'), null);
 query ?
 select array_intersect(null, []);
 ----
-NULL
+[]
 
 query ?
 select array_intersect(null, arrow_cast([], 'LargeList(Int64)'));
 ----
-NULL
+[]
 
 query ?
 select array_intersect(null, null);

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1435,6 +1435,12 @@ NULL 23
 NULL 43
 5 NULL
 
+# array_element of empty array
+query T
+select coalesce(array_element([], 1), array_element(NULL, 1), 'ok');
+----
+ok
+
 
 ## array_max
 # array_max scalar function #1 (with positive index)

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -3115,7 +3115,7 @@ select
 [1, 2, 3] List(Field { name: "item", data_type: Utf8View, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
 
 # array_concat error
-query error DataFusion error: Error during planning: Execution error: Function 'array_concat' user-defined coercion failed with "Error during planning: array_concat does not support an argument of type Int64"
+query error DataFusion error: Error during planning: Execution error: Function 'array_concat' user-defined coercion failed with "Error during planning: array_concat does not support type Int64"
 select array_concat(1, 2);
 
 # array_concat scalar function #1

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -3101,13 +3101,12 @@ select array_concat(
 [1, 2, 3]
 
 # Concatenating Mixed types
-query ?
-select array_concat(
-  [arrow_cast('1', 'Utf8'), arrow_cast('2', 'Utf8')],
-  [arrow_cast('3', 'Utf8View')]
-);
+query ?T
+select
+    array_concat([arrow_cast('1', 'Utf8'), arrow_cast('2', 'Utf8')], [arrow_cast('3', 'Utf8View')]),
+    arrow_typeof(array_concat([arrow_cast('1', 'Utf8'), arrow_cast('2', 'Utf8')], [arrow_cast('3', 'Utf8View')]));
 ----
-[1, 2, 3]
+[1, 2, 3] List(Field { name: "item", data_type: Utf8View, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })
 
 # array_concat error
 query error DataFusion error: Error during planning: Execution error: Function 'array_concat' user-defined coercion failed with "Error during planning: array_concat does not support an argument of type Int64"

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2348,6 +2348,11 @@ NULL
 [NULL, 51, 52, 54, 55, 56, 57, 58, 59, 60]
 [61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
 
+# test with empty table
+query ?
+select array_sort(column1, 'DESC', 'NULLS FIRST') from arrays_values where false;
+----
+
 # test with empty array
 query ?
 select array_sort([]);

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -91,12 +91,12 @@ select * from unnest(null);
 
 
 ## Unnest empty array in select list
-query I
+query ?
 select unnest([]);
 ----
 
 ## Unnest empty array in from clause
-query I
+query ?
 select * from unnest([]);
 ----
 
@@ -243,7 +243,7 @@ query error DataFusion error: This feature is not implemented: unnest\(\) does n
 select unnest(null) from unnest_table;
 
 ## Multiple unnest functions in selection
-query II
+query ?I
 select unnest([]), unnest(NULL::int[]);
 ----
 
@@ -263,10 +263,10 @@ NULL 10 NULL
 NULL NULL 17
 NULL NULL 18
 
-query IIIT
-select
-    unnest(column1), unnest(column2) + 2,
-    column3 * 10, unnest(array_remove(column1, '4'))
+query IIII
+select 
+    unnest(column1), unnest(column2) + 2, 
+    column3 * 10, unnest(array_remove(column1, 4))
 from unnest_table;
 ----
 1 9 10 1
@@ -316,7 +316,7 @@ select * from unnest(
 2 b NULL NULL
 NULL c NULL NULL
 
-query II
+query ?I
 select * from unnest([], NULL::int[]);
 ----
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of #7142

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

#10790 changed empty arrays to default to `Int64` but that is just a band-aid which creates other problems downstream, e.g. type errors when nesting expressions. It also introduced a bug (and possible panic) in `array_union` and `array_intersect` which are fixed here.

Apart from that, from a type-theoretical PoV empty arrays **should** indeed be typed as `Array<Null>` because `Null` is coercible to any other type and by extension (immutable arrays are covariant) `Array<Null>` is coercible to any other array type.

The crux of the problem is that Arrow is incapable of dealing with the mismatching array types that arise from this encoding. To workaround this limitation of Arrow, we unify array function argument types in advance and coerce them to the common type. In addition, we handle `DataType::Null` explicitly in Array functions for the case when all arguments are empty arrays or nulls.

## What changes are included in this PR?

We use the existing `type_union_resolution` type unification algorithm to handle array function arguments. This is a more robust and consistent approach as opposed to implementing custom coercion rules. Depending on the function we unify either the base types (because some functions work on arrays of arbitrary dimensions) or the array / element types. Then we coerce all arguments to the common type. We still need to handle the edge case when all arguments are nulls or empty arrays explicitly in the array function implementations.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes, I have amended the `array.slt` tests accordingly.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

Yes, there are some changes in array function semantics that can be seen in the updated tests:
* More expressions involving empty arrays and null arrays now work out of the box
* Fixed bugs in `array_union` and `array_intersect` (which are now also commutative)
* Some type-incorrect expressions no longer compile (e.g. `array_position(Array<Int64>, Utf8)`)

I also extended the public API of `Signature` with more helper methods and by default it coerces fixed-size lists to non-fixed-size lists because most array functions don't preserve the arity of lists (e.g. append, prepend, concat, union, intersection, etc.)

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
