### PR TITLE
Split out `datafusion-substrait` and `datafusion-proto` CI feature checks, increase coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,8 +129,9 @@ jobs:
           rust-version: stable
       - name: Check datafusion-proto (no-default-features)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-proto
-      - name: Check datafusion-proto (json)
-        run: cargo check --profile ci --all-targets --no-default-features -p datafusion-proto --features=json
+      # fails due to https://github.com/apache/datafusion/issues/15157
+      #- name: Check datafusion-proto (json)
+      #  run: cargo check --profile ci --all-targets --no-default-features -p datafusion-proto --features=json
       - name: Check datafusion-proto (parquet)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-proto --features=parquet
       - name: Check datafusion-proto (avro)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,9 +66,12 @@ jobs:
           # the changes to `Cargo.lock` after building with the updated manifest.
           cargo check --profile ci --workspace --all-targets --features integration-tests --locked
 
-  # cargo check common, functions and substrait with no default features
-  linux-cargo-check-no-default-features:
-    name: cargo check no default features
+  # Check datafusion-common features
+  #
+  # Ensure via `cargo check` that the crate can be built with a
+  # subset of the features packages enabled.
+  linux-datafusion-common-features:
+    name: cargo check datafusion-common features
     needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
@@ -79,28 +82,63 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
-      - name: Check datafusion without default features
-        # Some of the test binaries require the parquet feature still
-        #run: cargo check --all-targets --no-default-features -p datafusion
-        run: cargo check --profile ci --no-default-features -p datafusion
-
-      - name: Check datafusion-common without default features
+      - name: Check datafusion-common (no-default-features)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-common
+        # Note: don't check other feature flags as datafusion-common is not typically used standalone
 
-      - name: Check datafusion-functions without default features
-        run: cargo check --profile ci --all-targets --no-default-features -p datafusion-functions
-
-      - name: Check datafusion-substrait without default features
+  # Check datafusion-substrait features
+  #
+  # Ensure via `cargo check` that the crate can be built with a
+  # subset of the features packages enabled.
+  linux-datafusion-substrait-features:
+    name: cargo check datafusion-substrait features
+    needs: linux-build-lib
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Check datafusion-substrait (no-default-features)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait
+      - name: Check datafusion-substrait (physical)
+        run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait --features=physical
+      - name: Check datafusion-substrait (protoc)
+        run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait --features=protoc
 
-      - name: Check workspace in debug mode
-        run: cargo check --profile ci --all-targets --workspace
+  # Check datafusion-proto features
+  #
+  # Ensure via `cargo check` that the crate can be built with a
+  # subset of the features packages enabled.
+  linux-datafusion-proto-features:
+    name: cargo check datafusion-proto features
+    needs: linux-build-lib
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Check datafusion-proto (no-default-features)
+        run: cargo check --profile ci --all-targets --no-default-features -p datafusion-proto
+      - name: Check datafusion-proto (json)
+        run: cargo check --profile ci --all-targets --no-default-features -p datafusion-proto --features=json
+      - name: Check datafusion-proto (parquet)
+        run: cargo check --profile ci --all-targets --no-default-features -p datafusion-proto --features=parquet
+      - name: Check datafusion-proto (avro)
+        run: cargo check --profile ci --all-targets --no-default-features -p datafusion-proto --features=avro
 
-      - name: Check workspace with additional features
-        run: cargo check --profile ci --workspace --benches --features avro,json,integration-tests
 
-  # cargo check datafusion to ensure that the datafusion crate can be built with only a
-  # subset of the function packages enabled.
+  # Check datafusion crate features
+  #
+  # Ensure via `cargo check` that the crate can be built with a
+  # subset of the features packages enabled.
   linux-cargo-check-datafusion:
     name: cargo check datafusion
     needs: linux-build-lib
@@ -113,6 +151,9 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Check datafusion (no-default-features)
+        run: cargo check --all-targets --no-default-features -p datafusion
+
       - name: Check datafusion (nested_expressions)
         run: cargo check --profile ci --no-default-features --features=nested_expressions -p datafusion
 
@@ -134,8 +175,10 @@ jobs:
       - name: Check datafusion (string_expressions)
         run: cargo check --profile ci --no-default-features --features=string_expressions -p datafusion
 
-  # cargo check datafusion-functions to ensure that the datafusion-functions crate can be built with
-  # only a subset of the function packages enabled.
+  # Check datafusion-functions crate features
+  #
+  # Ensure via `cargo check` that the crate can be built with a
+  # subset of the features packages enabled.
   linux-cargo-check-datafusion-functions:
     name: cargo check functions
     needs: linux-build-lib
@@ -148,6 +191,9 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Check datafusion-functions (no-default-features)
+        run: cargo check --profile ci --all-targets --no-default-features -p datafusion-functions
+
       - name: Check datafusion-functions (crypto)
         run: cargo check --profile ci --all-targets --no-default-features --features=crypto_expressions -p datafusion-functions
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,7 +152,9 @@ jobs:
         with:
           rust-version: stable
       - name: Check datafusion (no-default-features)
-        run: cargo check --all-targets --no-default-features -p datafusion
+        # Some of the test binaries require the parquet feature still
+        #run: cargo check --all-targets --no-default-features -p datafusion
+        run: cargo check --profile ci --no-default-features -p datafusion
 
       - name: Check datafusion (nested_expressions)
         run: cargo check --profile ci --no-default-features --features=nested_expressions -p datafusion

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,10 +106,10 @@ jobs:
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait
       - name: Check datafusion-substrait (physical)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait --features=physical
-      - name: Install Protobuf Compiler
+      - name: Install cmake
         run: |
-          apt-get update
-          apt-get install -y protobuf-compiler
+          # note the builder setup runs apt-get update / installs protobuf compiler
+          apt-get install -y cmake
       - name: Check datafusion-substrait (protoc)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait --features=protoc
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,6 +106,8 @@ jobs:
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait
       - name: Check datafusion-substrait (physical)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait --features=physical
+      - name: Install Protobuf Compiler
+        run: sudo apt-get install -y protobuf-compiler
       - name: Check datafusion-substrait (protoc)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait --features=protoc
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,7 +107,9 @@ jobs:
       - name: Check datafusion-substrait (physical)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait --features=physical
       - name: Install Protobuf Compiler
-        run: sudo apt-get install -y protobuf-compiler
+        run: |
+          apt-get update
+          apt-get install -y protobuf-compiler
       - name: Check datafusion-substrait (protoc)
         run: cargo check --profile ci --all-targets --no-default-features -p datafusion-substrait --features=protoc
 


### PR DESCRIPTION
## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/15155

## Rationale for this change
The coverage for feature flags needs to be improved, as explained on https://github.com/apache/datafusion/issues/15155


## What changes are included in this PR?

1. Move the checks for datafusion-substrait and datafusion-proto into their own jobs
2. Consolidate the 'no default features' check into the per-crate checks 

Note I will make a follow on PR to add additional coverage for flags in `datafusion-functions` and `datafusion` but I am trying to keep this PR reasonably sized

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
