### PR TITLE
Support `EXPLAIN ... FORMAT <indent | tree | json | graphviz > ...`

### DIFF
--- a/datafusion-examples/examples/planner_api.rs
+++ b/datafusion-examples/examples/planner_api.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use datafusion::error::Result;
-use datafusion::logical_expr::{LogicalPlan, PlanType};
-use datafusion::physical_plan::{displayable, DisplayFormatType};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::displayable;
 use datafusion::physical_planner::DefaultPhysicalPlanner;
 use datafusion::prelude::*;
 
@@ -77,13 +77,7 @@ async fn to_physical_plan_in_one_api_demo(
 
     println!(
         "Physical plan direct from logical plan:\n\n{}\n\n",
-        displayable(physical_plan.as_ref())
-            .to_stringified(
-                false,
-                PlanType::InitialPhysicalPlan,
-                DisplayFormatType::Default
-            )
-            .plan
+        displayable(physical_plan.as_ref()).indent(false)
     );
 
     Ok(())
@@ -123,13 +117,7 @@ async fn to_physical_plan_step_by_step_demo(
         .await?;
     println!(
         "Final physical plan:\n\n{}\n\n",
-        displayable(physical_plan.as_ref())
-            .to_stringified(
-                false,
-                PlanType::InitialPhysicalPlan,
-                DisplayFormatType::Default
-            )
-            .plan
+        displayable(physical_plan.as_ref()).indent(false)
     );
 
     // Call the physical optimizer with an existing physical plan (in this
@@ -142,13 +130,7 @@ async fn to_physical_plan_step_by_step_demo(
         planner.optimize_physical_plan(physical_plan, &ctx.state(), |_, _| {})?;
     println!(
         "Optimized physical plan:\n\n{}\n\n",
-        displayable(physical_plan.as_ref())
-            .to_stringified(
-                false,
-                PlanType::InitialPhysicalPlan,
-                DisplayFormatType::Default
-            )
-            .plan
+        displayable(physical_plan.as_ref()).indent(false)
     );
 
     Ok(())

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -577,6 +577,7 @@ impl SessionState {
                     return Ok(LogicalPlan::Explain(Explain {
                         verbose: e.verbose,
                         plan: Arc::clone(&e.plan),
+                        explain_format: e.explain_format.clone(),
                         stringified_plans,
                         schema: Arc::clone(&e.schema),
                         logical_optimization_succeeded: false,
@@ -612,6 +613,7 @@ impl SessionState {
 
             Ok(LogicalPlan::Explain(Explain {
                 verbose: e.verbose,
+                explain_format: e.explain_format.clone(),
                 plan,
                 stringified_plans,
                 schema: Arc::clone(&e.schema),

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -19,7 +19,6 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::datasource::file_format::file_type_to_format;
@@ -78,8 +77,8 @@ use datafusion_expr::expr::{
 use datafusion_expr::expr_rewriter::unnormalize_cols;
 use datafusion_expr::logical_plan::builder::wrap_projection_for_join_if_necessary;
 use datafusion_expr::{
-    Analyze, DescribeTable, DmlStatement, Explain, Extension, FetchType, Filter,
-    JoinType, RecursiveQuery, SkipType, SortExpr, StringifiedPlan, WindowFrame,
+    Analyze, DescribeTable, DmlStatement, Explain, ExplainFormat, Extension, FetchType,
+    Filter, JoinType, RecursiveQuery, SkipType, SortExpr, StringifiedPlan, WindowFrame,
     WindowFrameBound, WriteOp,
 };
 use datafusion_physical_expr::aggregate::{AggregateExprBuilder, AggregateFunctionExpr};
@@ -1740,18 +1739,62 @@ impl DefaultPhysicalPlanner {
         let mut stringified_plans = vec![];
 
         let config = &session_state.config_options().explain;
-        let explain_format = DisplayFormatType::from_str(&config.format)?;
+        let explain_format = &e.explain_format;
 
-        let skip_logical_plan =
-            config.physical_plan_only || explain_format == DisplayFormatType::TreeRender;
+        match explain_format {
+            ExplainFormat::Indent => { /* fall through */ }
+            ExplainFormat::Tree => {
+                // Tree render does not try to explain errors,
+                let physical_plan = self
+                    .create_initial_plan(e.plan.as_ref(), session_state)
+                    .await?;
 
-        if !skip_logical_plan {
+                let optimized_plan = self.optimize_physical_plan(
+                    physical_plan,
+                    session_state,
+                    |_plan, _optimizer| {},
+                )?;
+
+                stringified_plans.push(
+                    displayable(optimized_plan.as_ref()).to_stringified(
+                        e.verbose,
+                        FinalPhysicalPlan,
+                        DisplayFormatType::TreeRender,
+                    ),
+                );
+            }
+            ExplainFormat::PostgresJSON => {
+                stringified_plans.push(StringifiedPlan::new(
+                    FinalLogicalPlan,
+                    e.plan.display_pg_json().to_string(),
+                ));
+            }
+            ExplainFormat::Graphviz => {
+                stringified_plans.push(StringifiedPlan::new(
+                    FinalLogicalPlan,
+                    e.plan.display_graphviz().to_string(),
+                ));
+            }
+        };
+
+        if !stringified_plans.is_empty() {
+            return Ok(Arc::new(ExplainExec::new(
+                Arc::clone(e.schema.inner()),
+                stringified_plans,
+                e.verbose,
+            )));
+        }
+
+        // The indent mode is quite sophisticated, and handles quite a few
+        // different cases / options for displaying the plan.
+        if !config.physical_plan_only {
             stringified_plans.clone_from(&e.stringified_plans);
             if e.logical_optimization_succeeded {
                 stringified_plans.push(e.plan.to_stringified(FinalLogicalPlan));
             }
         }
 
+        let display_format = DisplayFormatType::Default;
         if !config.logical_plan_only && e.logical_optimization_succeeded {
             match self
                 .create_initial_plan(e.plan.as_ref(), session_state)
@@ -1766,7 +1809,7 @@ impl DefaultPhysicalPlanner {
                             .to_stringified(
                                 e.verbose,
                                 InitialPhysicalPlan,
-                                explain_format,
+                                display_format,
                             ),
                     );
 
@@ -1780,7 +1823,7 @@ impl DefaultPhysicalPlanner {
                                     .to_stringified(
                                         e.verbose,
                                         InitialPhysicalPlanWithStats,
-                                        explain_format,
+                                        display_format,
                                     ),
                             );
                         }
@@ -1791,7 +1834,7 @@ impl DefaultPhysicalPlanner {
                                     .to_stringified(
                                         e.verbose,
                                         InitialPhysicalPlanWithSchema,
-                                        explain_format,
+                                        display_format,
                                     ),
                             );
                         }
@@ -1807,7 +1850,7 @@ impl DefaultPhysicalPlanner {
                                 displayable(plan)
                                     .set_show_statistics(config.show_statistics)
                                     .set_show_schema(config.show_schema)
-                                    .to_stringified(e.verbose, plan_type, explain_format),
+                                    .to_stringified(e.verbose, plan_type, display_format),
                             );
                         },
                     );
@@ -1821,7 +1864,7 @@ impl DefaultPhysicalPlanner {
                                     .to_stringified(
                                         e.verbose,
                                         FinalPhysicalPlan,
-                                        explain_format,
+                                        display_format,
                                     ),
                             );
 
@@ -1835,7 +1878,7 @@ impl DefaultPhysicalPlanner {
                                             .to_stringified(
                                                 e.verbose,
                                                 FinalPhysicalPlanWithStats,
-                                                explain_format,
+                                                display_format,
                                             ),
                                     );
                                 }
@@ -1846,7 +1889,7 @@ impl DefaultPhysicalPlanner {
                                             .to_stringified(
                                                 e.verbose,
                                                 FinalPhysicalPlanWithSchema,
-                                                explain_format,
+                                                display_format,
                                             ),
                                     );
                                 }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -78,8 +78,9 @@ use datafusion_expr::expr::{
 use datafusion_expr::expr_rewriter::unnormalize_cols;
 use datafusion_expr::logical_plan::builder::wrap_projection_for_join_if_necessary;
 use datafusion_expr::{
-    DescribeTable, DmlStatement, Extension, FetchType, Filter, JoinType, RecursiveQuery,
-    SkipType, SortExpr, StringifiedPlan, WindowFrame, WindowFrameBound, WriteOp,
+    Analyze, DescribeTable, DmlStatement, Explain, Extension, FetchType, Filter,
+    JoinType, RecursiveQuery, SkipType, SortExpr, StringifiedPlan, WindowFrame,
+    WindowFrameBound, WriteOp,
 };
 use datafusion_physical_expr::aggregate::{AggregateExprBuilder, AggregateFunctionExpr};
 use datafusion_physical_expr::expressions::Literal;
@@ -177,16 +178,17 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
         logical_plan: &LogicalPlan,
         session_state: &SessionState,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        match self.handle_explain(logical_plan, session_state).await? {
-            Some(plan) => Ok(plan),
-            None => {
-                let plan = self
-                    .create_initial_plan(logical_plan, session_state)
-                    .await?;
-
-                self.optimize_physical_plan(plan, session_state, |_, _| {})
-            }
+        if let Some(plan) = self
+            .handle_explain_or_analyze(logical_plan, session_state)
+            .await?
+        {
+            return Ok(plan);
         }
+        let plan = self
+            .create_initial_plan(logical_plan, session_state)
+            .await?;
+
+        self.optimize_physical_plan(plan, session_state, |_, _| {})
     }
 
     /// Create a physical expression from a logical expression
@@ -1715,167 +1717,179 @@ impl DefaultPhysicalPlanner {
     /// Returns
     /// Some(plan) if optimized, and None if logical_plan was not an
     /// explain (and thus needs to be optimized as normal)
-    async fn handle_explain(
+    async fn handle_explain_or_analyze(
         &self,
         logical_plan: &LogicalPlan,
         session_state: &SessionState,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
-        if let LogicalPlan::Explain(e) = logical_plan {
-            use PlanType::*;
-            let mut stringified_plans = vec![];
+        let execution_plan = match logical_plan {
+            LogicalPlan::Explain(e) => self.handle_explain(e, session_state).await?,
+            LogicalPlan::Analyze(a) => self.handle_analyze(a, session_state).await?,
+            _ => return Ok(None),
+        };
+        Ok(Some(execution_plan))
+    }
 
-            let config = &session_state.config_options().explain;
-            let explain_format = DisplayFormatType::from_str(&config.format)?;
+    /// Planner for `LogicalPlan::Explain`
+    async fn handle_explain(
+        &self,
+        e: &Explain,
+        session_state: &SessionState,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        use PlanType::*;
+        let mut stringified_plans = vec![];
 
-            let skip_logical_plan = config.physical_plan_only
-                || explain_format == DisplayFormatType::TreeRender;
+        let config = &session_state.config_options().explain;
+        let explain_format = DisplayFormatType::from_str(&config.format)?;
 
-            if !skip_logical_plan {
-                stringified_plans.clone_from(&e.stringified_plans);
-                if e.logical_optimization_succeeded {
-                    stringified_plans.push(e.plan.to_stringified(FinalLogicalPlan));
-                }
+        let skip_logical_plan =
+            config.physical_plan_only || explain_format == DisplayFormatType::TreeRender;
+
+        if !skip_logical_plan {
+            stringified_plans.clone_from(&e.stringified_plans);
+            if e.logical_optimization_succeeded {
+                stringified_plans.push(e.plan.to_stringified(FinalLogicalPlan));
             }
+        }
 
-            if !config.logical_plan_only && e.logical_optimization_succeeded {
-                match self
-                    .create_initial_plan(e.plan.as_ref(), session_state)
-                    .await
-                {
-                    Ok(input) => {
-                        // Include statistics / schema if enabled
-                        stringified_plans.push(
-                            displayable(input.as_ref())
-                                .set_show_statistics(config.show_statistics)
-                                .set_show_schema(config.show_schema)
-                                .to_stringified(
-                                    e.verbose,
-                                    InitialPhysicalPlan,
-                                    explain_format,
-                                ),
-                        );
+        if !config.logical_plan_only && e.logical_optimization_succeeded {
+            match self
+                .create_initial_plan(e.plan.as_ref(), session_state)
+                .await
+            {
+                Ok(input) => {
+                    // Include statistics / schema if enabled
+                    stringified_plans.push(
+                        displayable(input.as_ref())
+                            .set_show_statistics(config.show_statistics)
+                            .set_show_schema(config.show_schema)
+                            .to_stringified(
+                                e.verbose,
+                                InitialPhysicalPlan,
+                                explain_format,
+                            ),
+                    );
 
-                        // Show statistics + schema in verbose output even if not
-                        // explicitly requested
-                        if e.verbose {
-                            if !config.show_statistics {
-                                stringified_plans.push(
-                                    displayable(input.as_ref())
-                                        .set_show_statistics(true)
-                                        .to_stringified(
-                                            e.verbose,
-                                            InitialPhysicalPlanWithStats,
-                                            explain_format,
-                                        ),
-                                );
-                            }
-                            if !config.show_schema {
-                                stringified_plans.push(
-                                    displayable(input.as_ref())
-                                        .set_show_schema(true)
-                                        .to_stringified(
-                                            e.verbose,
-                                            InitialPhysicalPlanWithSchema,
-                                            explain_format,
-                                        ),
-                                );
-                            }
+                    // Show statistics + schema in verbose output even if not
+                    // explicitly requested
+                    if e.verbose {
+                        if !config.show_statistics {
+                            stringified_plans.push(
+                                displayable(input.as_ref())
+                                    .set_show_statistics(true)
+                                    .to_stringified(
+                                        e.verbose,
+                                        InitialPhysicalPlanWithStats,
+                                        explain_format,
+                                    ),
+                            );
                         }
+                        if !config.show_schema {
+                            stringified_plans.push(
+                                displayable(input.as_ref())
+                                    .set_show_schema(true)
+                                    .to_stringified(
+                                        e.verbose,
+                                        InitialPhysicalPlanWithSchema,
+                                        explain_format,
+                                    ),
+                            );
+                        }
+                    }
 
-                        let optimized_plan = self.optimize_physical_plan(
-                            input,
-                            session_state,
-                            |plan, optimizer| {
-                                let optimizer_name = optimizer.name().to_string();
-                                let plan_type = OptimizedPhysicalPlan { optimizer_name };
-                                stringified_plans.push(
-                                    displayable(plan)
-                                        .set_show_statistics(config.show_statistics)
-                                        .set_show_schema(config.show_schema)
-                                        .to_stringified(
-                                            e.verbose,
-                                            plan_type,
-                                            explain_format,
-                                        ),
-                                );
-                            },
-                        );
-                        match optimized_plan {
-                            Ok(input) => {
-                                // This plan will includes statistics if show_statistics is on
-                                stringified_plans.push(
-                                    displayable(input.as_ref())
-                                        .set_show_statistics(config.show_statistics)
-                                        .set_show_schema(config.show_schema)
-                                        .to_stringified(
-                                            e.verbose,
-                                            FinalPhysicalPlan,
-                                            explain_format,
-                                        ),
-                                );
+                    let optimized_plan = self.optimize_physical_plan(
+                        input,
+                        session_state,
+                        |plan, optimizer| {
+                            let optimizer_name = optimizer.name().to_string();
+                            let plan_type = OptimizedPhysicalPlan { optimizer_name };
+                            stringified_plans.push(
+                                displayable(plan)
+                                    .set_show_statistics(config.show_statistics)
+                                    .set_show_schema(config.show_schema)
+                                    .to_stringified(e.verbose, plan_type, explain_format),
+                            );
+                        },
+                    );
+                    match optimized_plan {
+                        Ok(input) => {
+                            // This plan will includes statistics if show_statistics is on
+                            stringified_plans.push(
+                                displayable(input.as_ref())
+                                    .set_show_statistics(config.show_statistics)
+                                    .set_show_schema(config.show_schema)
+                                    .to_stringified(
+                                        e.verbose,
+                                        FinalPhysicalPlan,
+                                        explain_format,
+                                    ),
+                            );
 
-                                // Show statistics + schema in verbose output even if not
-                                // explicitly requested
-                                if e.verbose {
-                                    if !config.show_statistics {
-                                        stringified_plans.push(
-                                            displayable(input.as_ref())
-                                                .set_show_statistics(true)
-                                                .to_stringified(
-                                                    e.verbose,
-                                                    FinalPhysicalPlanWithStats,
-                                                    explain_format,
-                                                ),
-                                        );
-                                    }
-                                    if !config.show_schema {
-                                        stringified_plans.push(
-                                            displayable(input.as_ref())
-                                                .set_show_schema(true)
-                                                .to_stringified(
-                                                    e.verbose,
-                                                    FinalPhysicalPlanWithSchema,
-                                                    explain_format,
-                                                ),
-                                        );
-                                    }
+                            // Show statistics + schema in verbose output even if not
+                            // explicitly requested
+                            if e.verbose {
+                                if !config.show_statistics {
+                                    stringified_plans.push(
+                                        displayable(input.as_ref())
+                                            .set_show_statistics(true)
+                                            .to_stringified(
+                                                e.verbose,
+                                                FinalPhysicalPlanWithStats,
+                                                explain_format,
+                                            ),
+                                    );
+                                }
+                                if !config.show_schema {
+                                    stringified_plans.push(
+                                        displayable(input.as_ref())
+                                            .set_show_schema(true)
+                                            .to_stringified(
+                                                e.verbose,
+                                                FinalPhysicalPlanWithSchema,
+                                                explain_format,
+                                            ),
+                                    );
                                 }
                             }
-                            Err(DataFusionError::Context(optimizer_name, e)) => {
-                                let plan_type = OptimizedPhysicalPlan { optimizer_name };
-                                stringified_plans
-                                    .push(StringifiedPlan::new(plan_type, e.to_string()))
-                            }
-                            Err(e) => return Err(e),
                         }
-                    }
-                    Err(err) => {
-                        stringified_plans.push(StringifiedPlan::new(
-                            PhysicalPlanError,
-                            err.strip_backtrace(),
-                        ));
+                        Err(DataFusionError::Context(optimizer_name, e)) => {
+                            let plan_type = OptimizedPhysicalPlan { optimizer_name };
+                            stringified_plans
+                                .push(StringifiedPlan::new(plan_type, e.to_string()))
+                        }
+                        Err(e) => return Err(e),
                     }
                 }
+                Err(err) => {
+                    stringified_plans.push(StringifiedPlan::new(
+                        PhysicalPlanError,
+                        err.strip_backtrace(),
+                    ));
+                }
             }
-
-            Ok(Some(Arc::new(ExplainExec::new(
-                SchemaRef::new(e.schema.as_ref().to_owned().into()),
-                stringified_plans,
-                e.verbose,
-            ))))
-        } else if let LogicalPlan::Analyze(a) = logical_plan {
-            let input = self.create_physical_plan(&a.input, session_state).await?;
-            let schema = SchemaRef::new((*a.schema).clone().into());
-            let show_statistics = session_state.config_options().explain.show_statistics;
-            Ok(Some(Arc::new(AnalyzeExec::new(
-                a.verbose,
-                show_statistics,
-                input,
-                schema,
-            ))))
-        } else {
-            Ok(None)
         }
+
+        Ok(Arc::new(ExplainExec::new(
+            Arc::clone(e.schema.inner()),
+            stringified_plans,
+            e.verbose,
+        )))
+    }
+
+    async fn handle_analyze(
+        &self,
+        a: &Analyze,
+        session_state: &SessionState,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let input = self.create_physical_plan(&a.input, session_state).await?;
+        let schema = SchemaRef::new((*a.schema).clone().into());
+        let show_statistics = session_state.config_options().explain.show_statistics;
+        Ok(Arc::new(AnalyzeExec::new(
+            a.verbose,
+            show_statistics,
+            input,
+            schema,
+        )))
     }
 
     /// Optimize a physical plan by applying each physical optimizer,

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -46,7 +46,7 @@ use crate::{
 };
 
 use super::dml::InsertOp;
-use super::plan::ColumnUnnestList;
+use super::plan::{ColumnUnnestList, ExplainFormat};
 use arrow::compute::can_cast_types;
 use arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
 use datafusion_common::display::ToStringifiedPlan;
@@ -1211,6 +1211,7 @@ impl LogicalPlanBuilder {
             Ok(Self::new(LogicalPlan::Explain(Explain {
                 verbose,
                 plan: self.plan,
+                explain_format: ExplainFormat::Indent,
                 stringified_plans,
                 schema,
                 logical_optimization_succeeded: false,

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -38,9 +38,9 @@ pub use ddl::{
 pub use dml::{DmlStatement, WriteOp};
 pub use plan::{
     projection_schema, Aggregate, Analyze, ColumnUnnestList, DescribeTable, Distinct,
-    DistinctOn, EmptyRelation, Explain, Extension, FetchType, Filter, Join,
-    JoinConstraint, JoinType, Limit, LogicalPlan, Partitioning, PlanType, Projection,
-    RecursiveQuery, Repartition, SkipType, Sort, StringifiedPlan, Subquery,
+    DistinctOn, EmptyRelation, Explain, ExplainFormat, Extension, FetchType, Filter,
+    Join, JoinConstraint, JoinType, Limit, LogicalPlan, Partitioning, PlanType,
+    Projection, RecursiveQuery, Repartition, SkipType, Sort, StringifiedPlan, Subquery,
     SubqueryAlias, TableScan, ToStringifiedPlan, Union, Unnest, Values, Window,
 };
 pub use statement::{

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -21,6 +21,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
+use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 
 use super::dml::CopyTo;
@@ -1084,6 +1085,7 @@ impl LogicalPlan {
                 Ok(LogicalPlan::Explain(Explain {
                     verbose: e.verbose,
                     plan: Arc::new(input),
+                    explain_format: e.explain_format.clone(),
                     stringified_plans: e.stringified_plans.clone(),
                     schema: Arc::clone(&e.schema),
                     logical_optimization_succeeded: e.logical_optimization_succeeded,
@@ -2924,12 +2926,167 @@ impl PartialOrd for DescribeTable {
     }
 }
 
+/// Output formats for controlling for Explain plans
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ExplainFormat {
+    /// Indent mode
+    ///
+    /// Example:
+    /// ```text
+    /// > explain format indent select x from values (1) t(x);
+    /// +---------------+-----------------------------------------------------+
+    /// | plan_type     | plan                                                |
+    /// +---------------+-----------------------------------------------------+
+    /// | logical_plan  | SubqueryAlias: t                                    |
+    /// |               |   Projection: column1 AS x                          |
+    /// |               |     Values: (Int64(1))                              |
+    /// | physical_plan | ProjectionExec: expr=[column1@0 as x]               |
+    /// |               |   DataSourceExec: partitions=1, partition_sizes=[1] |
+    /// |               |                                                     |
+    /// +---------------+-----------------------------------------------------+
+    /// ```
+    Indent,
+    /// Tree mode
+    ///
+    /// Example:
+    /// ```text
+    /// > explain format tree select x from values (1) t(x);
+    /// +---------------+-------------------------------+
+    /// | plan_type     | plan                          |
+    /// +---------------+-------------------------------+
+    /// | physical_plan | ┌───────────────────────────┐ |
+    /// |               | │       ProjectionExec      │ |
+    /// |               | │    --------------------   │ |
+    /// |               | │        x: column1@0       │ |
+    /// |               | └─────────────┬─────────────┘ |
+    /// |               | ┌─────────────┴─────────────┐ |
+    /// |               | │       DataSourceExec      │ |
+    /// |               | │    --------------------   │ |
+    /// |               | │         bytes: 128        │ |
+    /// |               | │       format: memory      │ |
+    /// |               | │          rows: 1          │ |
+    /// |               | └───────────────────────────┘ |
+    /// |               |                               |
+    /// +---------------+-------------------------------+
+    /// ```
+    Tree,
+    /// Postgres Json mode
+    ///
+    /// A displayable structure that produces plan in postgresql JSON format.
+    ///
+    /// Users can use this format to visualize the plan in existing plan
+    /// visualization tools, for example [dalibo](https://explain.dalibo.com/)
+    ///
+    /// Example:
+    /// ```text
+    /// > explain format pgjson select x from values (1) t(x);
+    /// +--------------+--------------------------------------+
+    /// | plan_type    | plan                                 |
+    /// +--------------+--------------------------------------+
+    /// | logical_plan | [                                    |
+    /// |              |   {                                  |
+    /// |              |     "Plan": {                        |
+    /// |              |       "Alias": "t",                  |
+    /// |              |       "Node Type": "Subquery",       |
+    /// |              |       "Output": [                    |
+    /// |              |         "x"                          |
+    /// |              |       ],                             |
+    /// |              |       "Plans": [                     |
+    /// |              |         {                            |
+    /// |              |           "Expressions": [           |
+    /// |              |             "column1 AS x"           |
+    /// |              |           ],                         |
+    /// |              |           "Node Type": "Projection", |
+    /// |              |           "Output": [                |
+    /// |              |             "x"                      |
+    /// |              |           ],                         |
+    /// |              |           "Plans": [                 |
+    /// |              |             {                        |
+    /// |              |               "Node Type": "Values", |
+    /// |              |               "Output": [            |
+    /// |              |                 "column1"            |
+    /// |              |               ],                     |
+    /// |              |               "Plans": [],           |
+    /// |              |               "Values": "(Int64(1))" |
+    /// |              |             }                        |
+    /// |              |           ]                          |
+    /// |              |         }                            |
+    /// |              |       ]                              |
+    /// |              |     }                                |
+    /// |              |   }                                  |
+    /// |              | ]                                    |
+    /// +--------------+--------------------------------------+
+    /// ```
+    PostgresJSON,
+    /// Graphviz mode
+    ///
+    /// Example:
+    /// ```text
+    /// > explain format graphviz select x from values (1) t(x);
+    /// +--------------+------------------------------------------------------------------------+
+    /// | plan_type    | plan                                                                   |
+    /// +--------------+------------------------------------------------------------------------+
+    /// | logical_plan |                                                                        |
+    /// |              | // Begin DataFusion GraphViz Plan,                                     |
+    /// |              | // display it online here: https://dreampuf.github.io/GraphvizOnline   |
+    /// |              |                                                                        |
+    /// |              | digraph {                                                              |
+    /// |              |   subgraph cluster_1                                                   |
+    /// |              |   {                                                                    |
+    /// |              |     graph[label="LogicalPlan"]                                         |
+    /// |              |     2[shape=box label="SubqueryAlias: t"]                              |
+    /// |              |     3[shape=box label="Projection: column1 AS x"]                      |
+    /// |              |     2 -> 3 [arrowhead=none, arrowtail=normal, dir=back]                |
+    /// |              |     4[shape=box label="Values: (Int64(1))"]                            |
+    /// |              |     3 -> 4 [arrowhead=none, arrowtail=normal, dir=back]                |
+    /// |              |   }                                                                    |
+    /// |              |   subgraph cluster_5                                                   |
+    /// |              |   {                                                                    |
+    /// |              |     graph[label="Detailed LogicalPlan"]                                |
+    /// |              |     6[shape=box label="SubqueryAlias: t\nSchema: [x:Int64;N]"]         |
+    /// |              |     7[shape=box label="Projection: column1 AS x\nSchema: [x:Int64;N]"] |
+    /// |              |     6 -> 7 [arrowhead=none, arrowtail=normal, dir=back]                |
+    /// |              |     8[shape=box label="Values: (Int64(1))\nSchema: [column1:Int64;N]"] |
+    /// |              |     7 -> 8 [arrowhead=none, arrowtail=normal, dir=back]                |
+    /// |              |   }                                                                    |
+    /// |              | }                                                                      |
+    /// |              | // End DataFusion GraphViz Plan                                        |
+    /// |              |                                                                        |
+    /// +--------------+------------------------------------------------------------------------+
+    /// ```
+    Graphviz,
+}
+
+/// Implement  parsing strings to `ExplainFormat`
+impl FromStr for ExplainFormat {
+    type Err = DataFusionError;
+
+    fn from_str(format: &str) -> std::result::Result<Self, Self::Err> {
+        match format.to_lowercase().as_str() {
+            "indent" => Ok(ExplainFormat::Indent),
+            "tree" => Ok(ExplainFormat::Tree),
+            "pgjson" => Ok(ExplainFormat::PostgresJSON),
+            "graphviz" => Ok(ExplainFormat::Graphviz),
+            _ => {
+                plan_err!("Invalid explain format. Expected 'indent', 'tree', 'pgjson' or 'graphviz'. Got '{format}'")
+            }
+        }
+    }
+}
+
 /// Produces a relation with string representations of
 /// various parts of the plan
+///
+/// See [the documentation] for more information
+///
+/// [the documentation]: https://datafusion.apache.org/user-guide/sql/explain.html
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Explain {
     /// Should extra (detailed, intermediate plans) be included?
     pub verbose: bool,
+    /// Output format for explain, if specified.
+    /// If none, defaults to `text`
+    pub explain_format: ExplainFormat,
     /// The logical plan that is being EXPLAIN'd
     pub plan: Arc<LogicalPlan>,
     /// Represent the various stages plans have gone through

--- a/datafusion/expr/src/logical_plan/tree_node.rs
+++ b/datafusion/expr/src/logical_plan/tree_node.rs
@@ -202,6 +202,7 @@ impl TreeNode for LogicalPlan {
             .update_data(LogicalPlan::Distinct),
             LogicalPlan::Explain(Explain {
                 verbose,
+                explain_format: format,
                 plan,
                 stringified_plans,
                 schema,
@@ -209,6 +210,7 @@ impl TreeNode for LogicalPlan {
             }) => plan.map_elements(f)?.update_data(|plan| {
                 LogicalPlan::Explain(Explain {
                     verbose,
+                    explain_format: format,
                     plan,
                     stringified_plans,
                     schema,

--- a/datafusion/physical-plan/src/display.rs
+++ b/datafusion/physical-plan/src/display.rs
@@ -19,13 +19,12 @@
 //! [`crate::displayable`] for examples of how to format
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt;
 use std::fmt::Formatter;
-use std::{fmt, str::FromStr};
 
 use arrow::datatypes::SchemaRef;
 
 use datafusion_common::display::{GraphvizBuilder, PlanType, StringifiedPlan};
-use datafusion_common::DataFusionError;
 use datafusion_expr::display_schema;
 use datafusion_physical_expr::LexOrdering;
 
@@ -39,7 +38,7 @@ pub enum DisplayFormatType {
     /// Default, compact format. Example: `FilterExec: c12 < 10.0`
     ///
     /// This format is designed to provide a detailed textual description
-    /// of all rele
+    /// of all parts of the plan.
     Default,
     /// Verbose, showing all available details.
     ///
@@ -77,21 +76,6 @@ pub enum DisplayFormatType {
     /// └───────────────────────────┘
     ///  ```
     TreeRender,
-}
-
-impl FromStr for DisplayFormatType {
-    type Err = DataFusionError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "indent" => Ok(Self::Default),
-            "tree" => Ok(Self::TreeRender),
-            _ => Err(DataFusionError::Configuration(format!(
-                "Invalid explain format: {}",
-                s
-            ))),
-        }
-    }
 }
 
 /// Wraps an `ExecutionPlan` with various methods for formatting

--- a/datafusion/physical-plan/src/display.rs
+++ b/datafusion/physical-plan/src/display.rs
@@ -24,7 +24,7 @@ use std::fmt::Formatter;
 
 use arrow::datatypes::SchemaRef;
 
-use datafusion_common::display::GraphvizBuilder;
+use datafusion_common::display::{GraphvizBuilder, PlanType, StringifiedPlan};
 use datafusion_expr::display_schema;
 use datafusion_physical_expr::LexOrdering;
 
@@ -310,6 +310,21 @@ impl<'a> DisplayableExecutionPlan<'a> {
             show_metrics: self.show_metrics,
             show_statistics: self.show_statistics,
             show_schema: self.show_schema,
+        }
+    }
+
+    #[deprecated(since = "47.0.0", note = "indent() or tree_render() instead")]
+    pub fn to_stringified(
+        &self,
+        verbose: bool,
+        plan_type: PlanType,
+        explain_format: DisplayFormatType,
+    ) -> StringifiedPlan {
+        match (&explain_format, &plan_type) {
+            (DisplayFormatType::TreeRender, PlanType::FinalPhysicalPlan) => {
+                StringifiedPlan::new(plan_type, self.tree_render().to_string())
+            }
+            _ => StringifiedPlan::new(plan_type, self.indent(verbose).to_string()),
         }
     }
 }

--- a/datafusion/physical-plan/src/display.rs
+++ b/datafusion/physical-plan/src/display.rs
@@ -24,7 +24,7 @@ use std::fmt::Formatter;
 
 use arrow::datatypes::SchemaRef;
 
-use datafusion_common::display::{GraphvizBuilder, PlanType, StringifiedPlan};
+use datafusion_common::display::GraphvizBuilder;
 use datafusion_expr::display_schema;
 use datafusion_physical_expr::LexOrdering;
 
@@ -264,6 +264,9 @@ impl<'a> DisplayableExecutionPlan<'a> {
         }
     }
 
+    /// Formats the plan using a ASCII art like tree
+    ///
+    /// See [`DisplayFormatType::TreeRender`] for more details.
     pub fn tree_render(&self) -> impl fmt::Display + 'a {
         struct Wrapper<'a> {
             plan: &'a dyn ExecutionPlan,
@@ -307,21 +310,6 @@ impl<'a> DisplayableExecutionPlan<'a> {
             show_metrics: self.show_metrics,
             show_statistics: self.show_statistics,
             show_schema: self.show_schema,
-        }
-    }
-
-    /// format as a `StringifiedPlan`
-    pub fn to_stringified(
-        &self,
-        verbose: bool,
-        plan_type: PlanType,
-        explain_format: DisplayFormatType,
-    ) -> StringifiedPlan {
-        match (&explain_format, &plan_type) {
-            (DisplayFormatType::TreeRender, PlanType::FinalPhysicalPlan) => {
-                StringifiedPlan::new(plan_type, self.tree_render().to_string())
-            }
-            _ => StringifiedPlan::new(plan_type, self.indent(verbose).to_string()),
         }
     }
 }

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -16,6 +16,9 @@
 // under the License.
 
 //! [`DFParser`]: DataFusion SQL Parser based on [`sqlparser`]
+//!
+//! This parser implements DataFusion specific statements such as
+//! `CREATE EXTERNAL TABLE`
 
 use std::collections::VecDeque;
 use std::fmt;
@@ -43,12 +46,23 @@ fn parse_file_type(s: &str) -> Result<String, ParserError> {
     Ok(s.to_uppercase())
 }
 
-/// DataFusion specific EXPLAIN (needed so we can EXPLAIN datafusion
-/// specific COPY and other statements)
+/// DataFusion specific `EXPLAIN`
+///
+/// Syntax:
+/// ```sql
+/// EXPLAIN <ANALYZE> <VERBOSE> [FORMAT format] statement
+///```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExplainStatement {
+    /// `EXPLAIN ANALYZE ..`
     pub analyze: bool,
+    /// `EXPLAIN .. VERBOSE ..`
     pub verbose: bool,
+    /// `EXPLAIN .. FORMAT `
+    pub format: Option<String>,
+    /// The statement to analyze. Note this is a DataFusion [`Statement`] (not a
+    /// [`sqlparser::ast::Statement`] so that we can `EXPLAIN`  `COPY` and other
+    /// DataFusion specific statements
     pub statement: Box<Statement>,
 }
 
@@ -57,6 +71,7 @@ impl fmt::Display for ExplainStatement {
         let Self {
             analyze,
             verbose,
+            format,
             statement,
         } = self;
 
@@ -66,6 +81,9 @@ impl fmt::Display for ExplainStatement {
         }
         if *verbose {
             write!(f, "VERBOSE ")?;
+        }
+        if let Some(format) = format.as_ref() {
+            write!(f, "FORMAT {format} ")?;
         }
 
         write!(f, "{statement}")
@@ -446,7 +464,6 @@ impl<'a> DFParser<'a> {
                         self.parse_copy()
                     }
                     Keyword::EXPLAIN => {
-                        // (TODO parse all supported statements)
                         self.parser.next_token(); // EXPLAIN
                         self.parse_explain()
                     }
@@ -620,13 +637,33 @@ impl<'a> DFParser<'a> {
     pub fn parse_explain(&mut self) -> Result<Statement, ParserError> {
         let analyze = self.parser.parse_keyword(Keyword::ANALYZE);
         let verbose = self.parser.parse_keyword(Keyword::VERBOSE);
+        let format = self.parse_explain_format()?;
+
         let statement = self.parse_statement()?;
 
         Ok(Statement::Explain(ExplainStatement {
             statement: Box::new(statement),
             analyze,
             verbose,
+            format,
         }))
+    }
+
+    pub fn parse_explain_format(&mut self) -> Result<Option<String>, ParserError> {
+        if !self.parser.parse_keyword(Keyword::FORMAT) {
+            return Ok(None);
+        }
+
+        let next_token = self.parser.next_token();
+        let format = match next_token.token {
+            Token::Word(w) => Ok(w.value),
+            Token::SingleQuotedString(w) => Ok(w),
+            Token::DoubleQuotedString(w) => Ok(w),
+            _ => self
+                .parser
+                .expected("an explain format such as TREE", next_token),
+        }?;
+        Ok(Some(format))
     }
 
     /// Parse a SQL `CREATE` statement handling `CREATE EXTERNAL TABLE`
@@ -1543,6 +1580,7 @@ mod tests {
             let expected = Statement::Explain(ExplainStatement {
                 analyze,
                 verbose,
+                format: None,
                 statement: Box::new(expected_copy),
             });
             assert_eq!(verified_stmt(sql), expected);

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -434,3 +434,135 @@ drop table t1;
 
 statement ok
 drop table t2;
+
+## Tests for explain format
+
+statement ok
+create table foo (x int, y int) as values (1,2), (1,3), (2,4);
+
+# defaults to indent mode
+query TT
+explain select * from values (1);
+----
+logical_plan Values: (Int64(1))
+physical_plan DataSourceExec: partitions=1, partition_sizes=[1]
+
+# can explicitly request indent mode
+query TT
+explain format indent select * from values (1);
+----
+logical_plan Values: (Int64(1))
+physical_plan DataSourceExec: partitions=1, partition_sizes=[1]
+
+# tree mode
+query TT
+explain format tree select * from values (1);
+----
+physical_plan
+01)┌───────────────────────────┐
+02)│       DataSourceExec      │
+03)│    --------------------   │
+04)│         bytes: 128        │
+05)│       format: memory      │
+06)│          rows: 1          │
+07)└───────────────────────────┘
+
+# is not case sensitive
+query TT
+explain format TrEE select * from values (1);
+----
+physical_plan
+01)┌───────────────────────────┐
+02)│       DataSourceExec      │
+03)│    --------------------   │
+04)│         bytes: 128        │
+05)│       format: memory      │
+06)│          rows: 1          │
+07)└───────────────────────────┘
+
+# wrapped in single quotes
+query TT
+explain format 'tree' select * from values (1);
+----
+physical_plan
+01)┌───────────────────────────┐
+02)│       DataSourceExec      │
+03)│    --------------------   │
+04)│         bytes: 128        │
+05)│       format: memory      │
+06)│          rows: 1          │
+07)└───────────────────────────┘
+
+# wrapped in double quotes
+query TT
+explain format "tree" select * from values (1);
+----
+physical_plan
+01)┌───────────────────────────┐
+02)│       DataSourceExec      │
+03)│    --------------------   │
+04)│         bytes: 128        │
+05)│       format: memory      │
+06)│          rows: 1          │
+07)└───────────────────────────┘
+
+# number is not a valid format
+query error DataFusion error: SQL error: ParserError\("Expected: an explain format such as TREE, found: 123 at Line: 1, Column: 16"\)
+explain format 123 select * from values (1);
+
+# verbose tree mode not supported
+query error DataFusion error: Error during planning: EXPLAIN VERBOSE with FORMAT is not supported
+explain verbose format tree select * from values (1);
+
+# no such thing as json mode
+query error DataFusion error: Error during planning: Invalid explain format\. Expected 'indent', 'tree', 'pgjson' or 'graphviz'\. Got 'json'
+explain format json select * from values (1);
+
+query error DataFusion error: Error during planning: Invalid explain format\. Expected 'indent', 'tree', 'pgjson' or 'graphviz'\. Got 'foo'
+explain format foo select * from values (1);
+
+# pgjson mode
+query TT
+explain format pgjson select * from values (1);
+----
+logical_plan
+01)[
+02)--{
+03)----"Plan": {
+04)------"Node Type": "Values",
+05)------"Output": [
+06)--------"column1"
+07)------],
+08)------"Plans": [],
+09)------"Values": "(Int64(1))"
+10)----}
+11)--}
+12)]
+
+# graphviz mode
+query TT
+explain format graphviz select * from values (1);
+----
+logical_plan
+01)
+02)// Begin DataFusion GraphViz Plan,
+03)// display it online here: https://dreampuf.github.io/GraphvizOnline
+04)
+05)digraph {
+06)--subgraph cluster_1
+07)--{
+08)----graph[label="LogicalPlan"]
+09)----2[shape=box label="Values: (Int64(1))"]
+10)--}
+11)--subgraph cluster_3
+12)--{
+13)----graph[label="Detailed LogicalPlan"]
+14)----4[shape=box label="Values: (Int64(1))\nSchema: [column1:Int64;N]"]
+15)--}
+16)}
+17)// End DataFusion GraphViz Plan
+
+# unknown mode
+
+statement ok
+drop table foo;

--- a/docs/source/user-guide/sql/explain.md
+++ b/docs/source/user-guide/sql/explain.md
@@ -31,6 +31,7 @@ EXPLAIN [ANALYZE] [VERBOSE] [FORMAT format] statement
 
 Shows the execution plan of a statement.
 If you need more detailed output, use `EXPLAIN VERBOSE`.
+Note that `EXPLAIN VERBOSE` only supports the `indent` format.
 
 ### `indent` format (default)
 
@@ -232,8 +233,9 @@ Elapsed 0.010 seconds.
 
 ## `EXPLAIN ANALYZE`
 
-Shows the execution plan and metrics of a statement.
-If you need more information output, use `EXPLAIN ANALYZE VERBOSE`. Only the `indent` format is supported for `EXPLAIN ANALYZE`.
+Shows the execution plan and metrics of a statement. If you need more
+information output, use `EXPLAIN ANALYZE VERBOSE`. Note that `EXPLAIN ANALYZE`
+only supports the `indent` format.
 
 ```sql
 EXPLAIN ANALYZE SELECT SUM(x) FROM table GROUP BY b;

--- a/docs/source/user-guide/sql/explain.md
+++ b/docs/source/user-guide/sql/explain.md
@@ -21,41 +21,219 @@
 
 The `EXPLAIN` command shows the logical and physical execution plan for the specified SQL statement.
 
-See the [Reading Explain Plans](../explain-usage.md) page for more information on how to interpret these plans.
+## Syntax
 
 <pre>
-EXPLAIN [ANALYZE] [VERBOSE] statement
+EXPLAIN [ANALYZE] [VERBOSE] [FORMAT format] statement
 </pre>
 
-## EXPLAIN
+## `EXPLAIN`
 
 Shows the execution plan of a statement.
 If you need more detailed output, use `EXPLAIN VERBOSE`.
 
-```sql
-EXPLAIN SELECT SUM(x) FROM table GROUP BY b;
+### `indent` format (default)
 
-+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_type     | plan                                                                                                                                                           |
-+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan  | Projection: #SUM(table.x)                                                                                                                                        |
-|               |   Aggregate: groupBy=[[#table.b]], aggr=[[SUM(#table.x)]]                                                                                                          |
-|               |     TableScan: table projection=[x, b]                                                                                                                           |
-| physical_plan | ProjectionExec: expr=[SUM(table.x)@1 as SUM(table.x)]                                                                                                              |
-|               |   AggregateExec: mode=FinalPartitioned, gby=[b@0 as b], aggr=[SUM(table.x)]                                                                                      |
-|               |     CoalesceBatchesExec: target_batch_size=4096                                                                                                                |
-|               |       RepartitionExec: partitioning=Hash([Column { name: "b", index: 0 }], 16)                                                                                 |
-|               |         AggregateExec: mode=Partial, gby=[b@1 as b], aggr=[SUM(table.x)]                                                                                         |
-|               |           RepartitionExec: partitioning=RoundRobinBatch(16)                                                                                                    |
-|               |             DataSourceExec: file_groups={1 group: [[/tmp/table.csv]]}, projection=[x, b], has_header=false                                            |
-|               |                                                                                                                                                                |
-+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+The `indent` format shows both the logical and physical plan, with one line for
+each operator in the plan. Child plans are indented to show the hierarchy.
+
+See [Reading Explain Plans](../explain-usage.md) for more information on how to interpret these plans.
+
+```sql
+> CREATE TABLE t(x int, b int) AS VALUES (1, 2), (2, 3);
+0 row(s) fetched.
+Elapsed 0.004 seconds.
+
+> EXPLAIN SELECT SUM(x) FROM t GROUP BY b;
++---------------+-------------------------------------------------------------------------------+
+| plan_type     | plan                                                                          |
++---------------+-------------------------------------------------------------------------------+
+| logical_plan  | Projection: sum(t.x)                                                          |
+|               |   Aggregate: groupBy=[[t.b]], aggr=[[sum(CAST(t.x AS Int64))]]                |
+|               |     TableScan: t projection=[x, b]                                            |
+| physical_plan | ProjectionExec: expr=[sum(t.x)@1 as sum(t.x)]                                 |
+|               |   AggregateExec: mode=FinalPartitioned, gby=[b@0 as b], aggr=[sum(t.x)]       |
+|               |     CoalesceBatchesExec: target_batch_size=8192                               |
+|               |       RepartitionExec: partitioning=Hash([b@0], 16), input_partitions=16      |
+|               |         RepartitionExec: partitioning=RoundRobinBatch(16), input_partitions=1 |
+|               |           AggregateExec: mode=Partial, gby=[b@1 as b], aggr=[sum(t.x)]        |
+|               |             DataSourceExec: partitions=1, partition_sizes=[1]                 |
+|               |                                                                               |
++---------------+-------------------------------------------------------------------------------+
+2 row(s) fetched.
+Elapsed 0.004 seconds.
 ```
 
-## EXPLAIN ANALYZE
+### `tree` format
+
+The `tree` format is modeled after [DuckDB plans] and is designed to be easier
+to see the high level structure of the plan
+
+[duckdb plans]: https://duckdb.org/docs/stable/guides/meta/explain.html
+
+```sql
+> EXPLAIN FORMAT TREE SELECT SUM(x) FROM t GROUP BY b;
++---------------+-------------------------------+
+| plan_type     | plan                          |
++---------------+-------------------------------+
+| physical_plan | ┌───────────────────────────┐ |
+|               | │       ProjectionExec      │ |
+|               | │    --------------------   │ |
+|               | │    sum(t.x): sum(t.x)@1   │ |
+|               | └─────────────┬─────────────┘ |
+|               | ┌─────────────┴─────────────┐ |
+|               | │       AggregateExec       │ |
+|               | │    --------------------   │ |
+|               | │       aggr: sum(t.x)      │ |
+|               | │     group_by: b@0 as b    │ |
+|               | │                           │ |
+|               | │           mode:           │ |
+|               | │      FinalPartitioned     │ |
+|               | └─────────────┬─────────────┘ |
+|               | ┌─────────────┴─────────────┐ |
+|               | │    CoalesceBatchesExec    │ |
+|               | └─────────────┬─────────────┘ |
+|               | ┌─────────────┴─────────────┐ |
+|               | │      RepartitionExec      │ |
+|               | │    --------------------   │ |
+|               | │  output_partition_count:  │ |
+|               | │             16            │ |
+|               | │                           │ |
+|               | │    partitioning_scheme:   │ |
+|               | │      Hash([b@0], 16)      │ |
+|               | └─────────────┬─────────────┘ |
+|               | ┌─────────────┴─────────────┐ |
+|               | │      RepartitionExec      │ |
+|               | │    --------------------   │ |
+|               | │  output_partition_count:  │ |
+|               | │             1             │ |
+|               | │                           │ |
+|               | │    partitioning_scheme:   │ |
+|               | │    RoundRobinBatch(16)    │ |
+|               | └─────────────┬─────────────┘ |
+|               | ┌─────────────┴─────────────┐ |
+|               | │       AggregateExec       │ |
+|               | │    --------------------   │ |
+|               | │       aggr: sum(t.x)      │ |
+|               | │     group_by: b@1 as b    │ |
+|               | │       mode: Partial       │ |
+|               | └─────────────┬─────────────┘ |
+|               | ┌─────────────┴─────────────┐ |
+|               | │       DataSourceExec      │ |
+|               | │    --------------------   │ |
+|               | │         bytes: 224        │ |
+|               | │       format: memory      │ |
+|               | │          rows: 1          │ |
+|               | └───────────────────────────┘ |
+|               |                               |
++---------------+-------------------------------+
+1 row(s) fetched.
+Elapsed 0.016 seconds.
+```
+
+### `pgjson` format
+
+The `pgjson` format is modeled after [Postgres JSON] format.
+
+You can use this format to visualize the plan in existing plan visualization
+tools, such as [dalibo]
+
+[postgres json]: https://www.postgresql.org/docs/current/sql-explain.html
+[dalibo]: https://explain.dalibo.com/
+
+```sql
+> EXPLAIN FORMAT PGJSON SELECT SUM(x) FROM t GROUP BY b;
++--------------+----------------------------------------------------+
+| plan_type    | plan                                               |
++--------------+----------------------------------------------------+
+| logical_plan | [                                                  |
+|              |   {                                                |
+|              |     "Plan": {                                      |
+|              |       "Expressions": [                             |
+|              |         "sum(t.x)"                                 |
+|              |       ],                                           |
+|              |       "Node Type": "Projection",                   |
+|              |       "Output": [                                  |
+|              |         "sum(t.x)"                                 |
+|              |       ],                                           |
+|              |       "Plans": [                                   |
+|              |         {                                          |
+|              |           "Aggregates": "sum(CAST(t.x AS Int64))", |
+|              |           "Group By": "t.b",                       |
+|              |           "Node Type": "Aggregate",                |
+|              |           "Output": [                              |
+|              |             "b",                                   |
+|              |             "sum(t.x)"                             |
+|              |           ],                                       |
+|              |           "Plans": [                               |
+|              |             {                                      |
+|              |               "Node Type": "TableScan",            |
+|              |               "Output": [                          |
+|              |                 "x",                               |
+|              |                 "b"                                |
+|              |               ],                                   |
+|              |               "Plans": [],                         |
+|              |               "Relation Name": "t"                 |
+|              |             }                                      |
+|              |           ]                                        |
+|              |         }                                          |
+|              |       ]                                            |
+|              |     }                                              |
+|              |   }                                                |
+|              | ]                                                  |
++--------------+----------------------------------------------------+
+1 row(s) fetched.
+Elapsed 0.008 seconds.
+```
+
+### `graphviz` format
+
+The `graphviz` format uses the [DOT language] that can be used with [Graphviz] to
+generate a visual representation of the plan.
+
+[dot language]: https://graphviz.org/doc/info/lang.html
+[graphviz]: https://graphviz.org/
+
+```sql
+> EXPLAIN FORMAT GRAPHVIZ SELECT SUM(x) FROM t GROUP BY b;
++--------------+------------------------------------------------------------------------------------------------------------------------------+
+| plan_type    | plan                                                                                                                         |
++--------------+------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan |                                                                                                                              |
+|              | // Begin DataFusion GraphViz Plan,                                                                                           |
+|              | // display it online here: https://dreampuf.github.io/GraphvizOnline                                                         |
+|              |                                                                                                                              |
+|              | digraph {                                                                                                                    |
+|              |   subgraph cluster_1                                                                                                         |
+|              |   {                                                                                                                          |
+|              |     graph[label="LogicalPlan"]                                                                                               |
+|              |     2[shape=box label="Projection: sum(t.x)"]                                                                                |
+|              |     3[shape=box label="Aggregate: groupBy=[[t.b]], aggr=[[sum(CAST(t.x AS Int64))]]"]                                        |
+|              |     2 -> 3 [arrowhead=none, arrowtail=normal, dir=back]                                                                      |
+|              |     4[shape=box label="TableScan: t projection=[x, b]"]                                                                      |
+|              |     3 -> 4 [arrowhead=none, arrowtail=normal, dir=back]                                                                      |
+|              |   }                                                                                                                          |
+|              |   subgraph cluster_5                                                                                                         |
+|              |   {                                                                                                                          |
+|              |     graph[label="Detailed LogicalPlan"]                                                                                      |
+|              |     6[shape=box label="Projection: sum(t.x)\nSchema: [sum(t.x):Int64;N]"]                                                    |
+|              |     7[shape=box label="Aggregate: groupBy=[[t.b]], aggr=[[sum(CAST(t.x AS Int64))]]\nSchema: [b:Int32;N, sum(t.x):Int64;N]"] |
+|              |     6 -> 7 [arrowhead=none, arrowtail=normal, dir=back]                                                                      |
+|              |     8[shape=box label="TableScan: t projection=[x, b]\nSchema: [x:Int32;N, b:Int32;N]"]                                      |
+|              |     7 -> 8 [arrowhead=none, arrowtail=normal, dir=back]                                                                      |
+|              |   }                                                                                                                          |
+|              | }                                                                                                                            |
+|              | // End DataFusion GraphViz Plan                                                                                              |
+|              |                                                                                                                              |
++--------------+------------------------------------------------------------------------------------------------------------------------------+
+1 row(s) fetched.
+Elapsed 0.010 seconds.
+```
+
+## `EXPLAIN ANALYZE`
 
 Shows the execution plan and metrics of a statement.
-If you need more information output, use `EXPLAIN ANALYZE VERBOSE`.
+If you need more information output, use `EXPLAIN ANALYZE VERBOSE`. Only the `indent` format is supported for `EXPLAIN ANALYZE`.
 
 ```sql
 EXPLAIN ANALYZE SELECT SUM(x) FROM table GROUP BY b;

--- a/docs/source/user-guide/sql/explain.md
+++ b/docs/source/user-guide/sql/explain.md
@@ -33,6 +33,12 @@ Shows the execution plan of a statement.
 If you need more detailed output, use `EXPLAIN VERBOSE`.
 Note that `EXPLAIN VERBOSE` only supports the `indent` format.
 
+The optional `[FORMAT format]` clause controls how the plan is displayed as
+explained below. If this clause is not specified, the plan is displayed using
+the format from the [configuration value] `datafusion.explain.format`.
+
+[configuration value]: ../configs.md
+
 ### `indent` format (default)
 
 The `indent` format shows both the logical and physical plan, with one line for


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/15021
- Closes https://github.com/apache/datafusion/issues/219

## Rationale for this change

I would like to be able to see more of the great explain plan code that DataFusion already has (see https://github.com/apache/datafusion/issues/15021 for details)

## What changes are included in this PR?

Changes:
- [x] Parser support `EXPLAIN VERBOSE FORMAT ...`
- [x] Support `indent` mode
- [x] Support `tree` mode
- [x] Support `pgjson` mode
- [x] Support `graphviz` mode
- [x] Update documentation
- [x]  Add sqllogictests

Here is an example

```sql
> explain format text select * from values(1) t(x);
Invalid or Unsupported Configuration: Invalid explain format: text
> explain format indent select * from values(1) t(x);
+---------------+-----------------------------------------------------+
| plan_type     | plan                                                |
+---------------+-----------------------------------------------------+
| logical_plan  | SubqueryAlias: t                                    |
|               |   Projection: column1 AS x                          |
|               |     Values: (Int64(1))                              |
| physical_plan | ProjectionExec: expr=[column1@0 as x]               |
|               |   DataSourceExec: partitions=1, partition_sizes=[1] |
|               |                                                     |
+---------------+-----------------------------------------------------+
2 row(s) fetched.
Elapsed 0.013 seconds.

> explain format tree select * from values(1) t(x);
+---------------+-------------------------------+
| plan_type     | plan                          |
+---------------+-------------------------------+
| physical_plan | ┌───────────────────────────┐ |
|               | │       ProjectionExec      │ |
|               | │    --------------------   │ |
|               | │        x: column1@0       │ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │       DataSourceExec      │ |
|               | │    --------------------   │ |
|               | │         bytes: 128        │ |
|               | │       format: memory      │ |
|               | │          rows: 1          │ |
|               | └───────────────────────────┘ |
|               |                               |
+---------------+-------------------------------+
1 row(s) fetched.
Elapsed 0.011 seconds.
```

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
