### PR TITLE
fix: date_trunc bench broken by #15049

### DIFF
--- a/datafusion/functions/benches/date_trunc.rs
+++ b/datafusion/functions/benches/date_trunc.rs
@@ -46,11 +46,14 @@ fn criterion_benchmark(c: &mut Criterion) {
             ColumnarValue::Scalar(ScalarValue::Utf8(Some("minute".to_string())));
         let timestamps = ColumnarValue::Array(timestamps_array);
         let udf = date_trunc();
-        let return_type = &udf.return_type(&[timestamps.data_type()]).unwrap();
+        let args = vec![precision, timestamps];
+        let return_type = &udf
+            .return_type(&args.iter().map(|arg| arg.data_type()).collect::<Vec<_>>())
+            .unwrap();
         b.iter(|| {
             black_box(
                 udf.invoke_with_args(ScalarFunctionArgs {
-                    args: vec![precision.clone(), timestamps.clone()],
+                    args: args.clone(),
                     number_rows: batch_len,
                     return_type,
                 })


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15167

## Rationale for this change

Got broken in https://github.com/apache/datafusion/pull/15049, as the call for return_type was only providing one data type instead of two.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?


`cargo bench --bench date_trunc` runs sucessfully after this

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
