### PR TITLE
[branch-46] Update ring to v0.17.13 (#15063)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,9 +4937,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",


### PR DESCRIPTION
## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/15151
- Related to https://github.com/apache/datafusion/issues/15122

## Rationale for this change
We are making a 46.0.1 patchset release with some bug fixes

I would like to  get a clean CI run on 46, but the rustsec check is failing due to an older dependency we have fixed on main

Here is an example failure
https://github.com/apache/datafusion/actions/runs/13857186054/job/38776531902?pr=15227

## What changes are included in this PR?
- Backport https://github.com/apache/datafusion/pull/15063

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
