### PR TITLE
Minor: exclude datafusion-cli testing for mac

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -491,7 +491,7 @@ jobs:
         uses: ./.github/actions/setup-macos-aarch64-builder
       - name: Run tests (excluding doctests)
         shell: bash
-        run: cargo test --profile ci --lib --tests --bins --features avro,json,backtrace,integration-tests
+        run: cargo test --profile ci --exclude datafusion-cli --workspace --lib --tests --bins --features avro,json,backtrace,integration-tests
 
   test-datafusion-pyarrow:
     name: cargo test pyarrow (amd64)


### PR DESCRIPTION
## Which issue does this PR close?

- Closes [#15226](https://github.com/apache/datafusion/issues/15226)

## Rationale for this change

exclude datafusion-cli testing for mac

## What changes are included in this PR?

exclude datafusion-cli testing for mac

## Are these changes tested?

yes

## Are there any user-facing changes?

exclude datafusion-cli testing for mac
