### PR TITLE
Re-enable github discussion

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,6 +24,7 @@ notifications:
   commits: commits@datafusion.apache.org
   issues: github@datafusion.apache.org
   pullrequests: github@datafusion.apache.org
+  discussions: github@datafusion.apache.org
   jira_options: link label worklog
 github:
   description: "Apache DataFusion SQL Query Engine"
@@ -44,6 +45,7 @@ github:
     rebase: false
   features:
     issues: true
+    discussions: true
   protected_branches:
     main:
       required_pull_request_reviews:


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/15235

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This PR follows the fix in `arrow-rs` https://github.com/apache/arrow-rs/pull/7288/files, and try to bring back the GitHub discussion section

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
