### PR TITLE
Fix/15236

### DIFF
--- a/datafusion/sqllogictest/test_files/union_by_name.slt
+++ b/datafusion/sqllogictest/test_files/union_by_name.slt
@@ -54,13 +54,13 @@ INSERT INTO t2 VALUES (2, 2), (4, 4);
 
 # Test binding
 query I
-SELECT t1.x FROM t1 UNION BY NAME SELECT x FROM t1 ORDER BY t1.x;
+SELECT t1.x FROM t1 UNION BY NAME SELECT x FROM t1 ORDER BY x;
 ----
 1
 3
 
 query I
-SELECT t1.x FROM t1 UNION ALL BY NAME SELECT x FROM t1 ORDER BY t1.x;
+SELECT t1.x FROM t1 UNION ALL BY NAME SELECT x FROM t1 ORDER BY x;
 ----
 1
 1
@@ -70,13 +70,13 @@ SELECT t1.x FROM t1 UNION ALL BY NAME SELECT x FROM t1 ORDER BY t1.x;
 3
 
 query I
-SELECT x FROM t1 UNION BY NAME SELECT x FROM t1 ORDER BY t1.x;
+SELECT x FROM t1 UNION BY NAME SELECT x FROM t1 ORDER BY x;
 ----
 1
 3
 
 query I
-SELECT x FROM t1 UNION ALL BY NAME SELECT x FROM t1 ORDER BY t1.x;
+SELECT x FROM t1 UNION ALL BY NAME SELECT x FROM t1 ORDER BY x;
 ----
 1
 1
@@ -287,3 +287,31 @@ SELECT '0' as c UNION ALL BY NAME SELECT 0 as c;
 ----
 0
 0
+
+# Regression tests for https://github.com/apache/datafusion/issues/15236
+# Ensure that the correct output is produced even if the width of an input node's
+# schema is the same as the resulting schema width after the union is applied.
+
+statement ok
+create table t3 (x varchar(255), y varchar(255), z varchar(255));
+
+statement ok
+create table t4 (x varchar(255), y varchar(255), z varchar(255));
+
+statement ok
+insert into t3 values ('a', 'b', 'c');
+
+statement ok
+insert into t4 values ('a', 'b', 'c');
+
+query TTTT rowsort
+select t3.x, t3.y, t3.z from t3 union by name select t3.z, t3.y, t3.x, 'd' as zz from t3;
+----
+a b c NULL
+a b c d
+
+query TTTT rowsort
+select t3.x, t3.y, t3.z from t3 union by name select t4.z, t4.y, t4.x, 'd' as zz from t4;
+----
+a b c NULL
+a b c d


### PR DESCRIPTION
## Which issue does this PR close?

Closes #15236 

## Rationale for this change

An assumption made by a predicate while re-writing union inputs is incorrect.

Even if an input node's schema has the same width as the final schema, we still want to wrap the input with a projection as ordering is this doesn't guarantee ordering.

## Are these changes tested?

Yes

## Are there any user-facing changes?

N/A