### PR TITLE
docs: update documentation for Final GroupBy in accumulator.rs

### DIFF
--- a/datafusion/expr-common/src/accumulator.rs
+++ b/datafusion/expr-common/src/accumulator.rs
@@ -109,6 +109,7 @@ pub trait Accumulator: Send + Sync + Debug {
     ///                  │(AggregateMode::Final)   │      state() is called for each
     ///                  │                         │      group and the resulting
     ///                  └─────────────────────────┘      RecordBatches passed to the
+    ///                                                   Final GroupBy via merge_batch()
     ///                               ▲
     ///                               │
     ///              ┌────────────────┴───────────────┐


### PR DESCRIPTION
I think this is what the "passed to the" part is missing but I might be wrong.