### PR TITLE
CI Red: Fix union in view table test

### DIFF
--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -896,7 +896,7 @@ INSERT INTO u2 VALUES (20, 20), (40, 40);
 
 statement ok
 CREATE VIEW v1 AS
-SELECT y FROM u1 UNION ALL SELECT y FROM u2  ORDER BY y;
+SELECT y FROM u1 UNION ALL SELECT y FROM u2 ORDER BY y;
 
 query I
 SELECT * FROM (SELECT y FROM u1 UNION ALL SELECT y FROM u2) ORDER BY y;
@@ -907,11 +907,56 @@ SELECT * FROM (SELECT y FROM u1 UNION ALL SELECT y FROM u2) ORDER BY y;
 20
 40
 
+query TT
+explain SELECT * FROM (SELECT y FROM u1 UNION ALL SELECT y FROM u2) ORDER BY y;
+----
+logical_plan
+01)Sort: y ASC NULLS LAST
+02)--Union
+03)----Projection: CAST(u1.y AS Int64) AS y
+04)------TableScan: u1 projection=[y]
+05)----TableScan: u2 projection=[y]
+physical_plan
+01)SortPreservingMergeExec: [y@0 ASC NULLS LAST]
+02)--UnionExec
+03)----SortExec: expr=[y@0 ASC NULLS LAST], preserve_partitioning=[true]
+04)------ProjectionExec: expr=[CAST(y@0 AS Int64) as y]
+05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------DataSourceExec: partitions=1, partition_sizes=[1]
+07)----SortExec: expr=[y@0 ASC NULLS LAST], preserve_partitioning=[false]
+08)------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# optimize_subquery_sort in create_relation removes Sort so the result is not sorted.
 query I
 SELECT * FROM v1;
 ----
-1
-3
-3
 20
 40
+3
+3
+1
+
+query TT
+explain SELECT * FROM v1;
+----
+logical_plan
+01)SubqueryAlias: v1
+02)--Union
+03)----Projection: CAST(u1.y AS Int64) AS y
+04)------TableScan: u1 projection=[y]
+05)----TableScan: u2 projection=[y]
+physical_plan
+01)UnionExec
+02)--ProjectionExec: expr=[CAST(y@0 AS Int64) as y]
+03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+05)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+statement count 0
+drop view v1;
+
+statement count 0
+drop table u1;
+
+statement count 0
+drop table u2;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This CI failure is caused by the conflict with https://github.com/apache/datafusion/pull/15135, so is not detected

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
