### PR TITLE
updatted github action by change version tag to sha hashes

### DIFF
--- a/.github/actions/setup-macos-aarch64-builder/action.yaml
+++ b/.github/actions/setup-macos-aarch64-builder/action.yaml
@@ -16,12 +16,12 @@
 # under the License.
 
 name: Prepare Rust Builder for MacOS
-description: 'Prepare Rust Build Environment for MacOS'
+description: "Prepare Rust Build Environment for MacOS"
 inputs:
   rust-version:
-    description: 'version of rust to install (e.g. stable)'
+    description: "version of rust to install (e.g. stable)"
     required: true
-    default: 'stable'
+    default: "stable"
 runs:
   using: "composite"
   steps:
@@ -44,6 +44,6 @@ runs:
         rustup default stable
         rustup component add rustfmt
     - name: Setup rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
     - name: Configure rust runtime env
-      uses: ./.github/actions/setup-rust-runtime        
+      uses: ./.github/actions/setup-rust-runtime

--- a/.github/actions/setup-rust-runtime/action.yaml
+++ b/.github/actions/setup-rust-runtime/action.yaml
@@ -16,18 +16,18 @@
 # under the License.
 
 name: Setup Rust Runtime
-description: 'Setup Rust Runtime Environment'
+description: "Setup Rust Runtime Environment"
 runs:
   using: "composite"
   steps:
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd
     - name: Configure runtime env
       shell: bash
       # do not produce debug symbols to keep memory usage down
       # hardcoding other profile params to avoid profile override values
       # More on Cargo profiles https://doc.rust-lang.org/cargo/reference/profiles.html?profile-settings#profile-settings
-      # 
+      #
       # Set debuginfo=line-tables-only as debuginfo=0 causes immensely slow build
       # See for more details: https://github.com/rust-lang/rust/issues/119560
       run: |
@@ -35,4 +35,3 @@ runs:
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV 
         echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
         echo "RUSTFLAGS=-C debuginfo=line-tables-only -C incremental=false" >> $GITHUB_ENV
-     

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -28,7 +28,7 @@ jobs:
     name: Check License Header
     steps:
       - uses: actions/checkout@v4
-      - uses: korandoru/hawkeye@v6
+      - uses: korandoru/hawkeye@dd74178a96f27b1121447c6b4a4ccfce180d5bf7
 
   prettier:
     name: Use prettier to check formatting of documents

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
     name: Check License Header
     steps:
       - uses: actions/checkout@v4
-      - uses: korandoru/hawkeye@v6
+      - uses: korandoru/hawkeye@dd74178a96f27b1121447c6b4a4ccfce180d5bf7
 
   # Check crate compiles and base cargo check passes
   linux-build-lib:
@@ -152,7 +152,6 @@ jobs:
         run: cargo check --profile ci --no-default-features -p datafusion-proto --features=parquet
       - name: Check datafusion-proto (avro)
         run: cargo check --profile ci --no-default-features -p datafusion-proto --features=avro
-
 
   # Check datafusion crate features
   #
@@ -323,7 +322,6 @@ jobs:
       - name: Minio Output
         if: ${{ !cancelled() }}
         run: docker logs minio-container
-
 
   linux-test-example:
     name: cargo examples (amd64)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #[15298](https://github.com/apache/datafusion/issues/15298).

## Rationale for this change
This update strengthens the security of GitHub workflows by substituting version tags with precise SHA hashes for actions. This modification reduces the risks tied to supply chain attacks by guaranteeing that only validated action versions are utilized in the workflows. This method adheres to industry best practices for safeguarding CI/CD pipelines.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Replaced version tags with specific SHA hashes for actions in the GitHub workflows.

Original:
[dev.yml](https://github.com/apache/datafusion/blob/main/.github/workflows/dev.yml) -> - uses: korandoru/hawkeye@v6
[rust.yml](https://github.com/apache/datafusion/blob/main/.github/workflows/rust.yml) -> - uses: korandoru/hawkeye@v6
[setup-macos-aarch64-builder/action.yaml](https://github.com/apache/datafusion/blob/main/.github/actions/setup-macos-aarch64-builder/action.yaml) -> uses: Swatinem/rust-cache@v2
[setup-rust-runtime/action.yaml](https://github.com/apache/datafusion/blob/main/.github/actions/setup-rust-runtime/action.yaml) -> uses: mozilla-actions/sccache-action@v0.0.4

Update:
[dev.yml](https://github.com/apache/datafusion/blob/main/.github/workflows/dev.yml) -> - uses: korandoru/hawkeye@dd74178a96f27b1121447c6b4a4ccfce180d5bf7
[rust.yml](https://github.com/apache/datafusion/blob/main/.github/workflows/rust.yml) -> - uses: korandoru/hawkeye@dd74178a96f27b1121447c6b4a4ccfce180d5bf7
[setup-macos-aarch64-builder/action.yaml](https://github.com/apache/datafusion/blob/main/.github/actions/setup-macos-aarch64-builder/action.yaml) -> uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
[setup-rust-runtime/action.yaml](https://github.com/apache/datafusion/blob/main/.github/actions/setup-rust-runtime/action.yaml) -> uses: uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, the changes are tested to ensure that the GitHub workflows function correctly with the specified SHA hashes.
Where I got this Hash:
korandoru/hawkeye@dd74178a96f27b1121447c6b4a4ccfce180d5bf7:

This is implemented in v6 of the original GitHub Action, but it redirects to v6.0.1. Consequently, I’ve bound the hash to v6.0.1 here for consistency and security.

https://github.com/korandoru/hawkeye/commit/dd74178a96f27b1121447c6b4a4ccfce180d5bf7
<img width="655" alt="image" src="https://github.com/user-attachments/assets/f4ce0107-4bd4-42fb-a0b6-11e9b568f6fd" />


Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6:

This is implemented in v2 of the original GitHub Action, but it redirects to v2.7.8. Consequently, I’ve bound the hash to v2.7.8 here for consistency and security.

https://github.com/Swatinem/rust-cache/commit/9d47c6ad4b02e050fd481d890b2ea34778fd09d6
<img width="655" alt="image" src="https://github.com/user-attachments/assets/af1c38df-c034-495a-affb-d9251ade2b19" />


mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd:

https://github.com/mozilla-actions/sccache-action/commit/2e7f9ec7921547d4b46598398ca573513895d0bd
This is implemented in v0.0.4 of the original GitHub Action, so that I just bound the hash to v0.0.4 here for consistency and security.

<img width="659" alt="image" src="https://github.com/user-attachments/assets/098cc6a1-2713-4dfe-8ddf-4f6118eabdfe" />



<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No, all of that is under github action

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
