### PR TITLE
feat: implement GroupsAccumulator for `count(DISTINCT)` aggr

### DIFF
--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/accumulate.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/accumulate.rs
@@ -15,7 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! [`GroupsAccumulator`] helpers: [`NullState`] and [`accumulate_indices`]
+//! [`GroupsAccumulator`] helpers: [`NullState`] and [`accumulate_indices`]-like functions.
+//!
+//! This mod provides various kinds of helper functions to work with [`GroupsAccumulator`],
+//! here is a quick summary of the functions provided and their purpose/differences:
+//! - [`accumulate`]: Accumulate a single, primitive value per group.
+//! - [`accumulate_multiple`]: Accumulate multiple, primitive values per group.
+//! - [`accumulate_indices`]: Accumulate indices only (without actual value) per group.
 //!
 //! [`GroupsAccumulator`]: datafusion_expr_common::groups_accumulator::GroupsAccumulator
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -2302,6 +2302,12 @@ SELECT count(c1, c2) FROM test
 query error DataFusion error: This feature is not implemented: COUNT DISTINCT with multiple arguments
 SELECT count(distinct c1, c2) FROM test
 
+# count(distinct) and count() together
+query II
+SELECT count(c1), count(distinct c1) FROM test
+----
+4 3
+
 # count_null
 query III
 SELECT count(null), count(null, null), count(distinct null) FROM test


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to #5472

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Implement group accumulator for distinct count aggr fn. In `hits.parquet` dataset from clickbench, it can gain ~5x performance improve for query like `select "RegionID", COUNT("UserID"), COUNT(DISTINCT "UserID") as u FROM hits GROUP BY "RegionID" ORDER BY u DESC LIMIT 10;`:

After:
```sql
> select "RegionID", COUNT("UserID"), COUNT(DISTINCT "UserID") as u FROM hits GROUP BY "RegionID" ORDER BY u DESC LIMIT 10;
+----------+--------------------+---------+
| RegionID | count(hits.UserID) | u       |
+----------+--------------------+---------+
| 229      | 18295832           | 2845673 |
| 2        | 6687587            | 1081016 |
| 208      | 4261812            | 831676  |
| 169      | 3320229            | 604583  |
| 184      | 1755192            | 322661  |
| 158      | 1318059            | 307152  |
| 34       | 1792369            | 299479  |
| 55       | 1426901            | 286525  |
| 107      | 1516690            | 272448  |
| 42       | 1542717            | 243181  |
+----------+--------------------+---------+
10 row(s) fetched. 
Elapsed 1.941 seconds.
```
Before:
```
Elapsed 11.828 seconds.
```

For queries with only one distinct count (like q5 from clickbench), optimize rule `single_distinct_to_groupby` will rewrite the distinct column to group by column, which avoids the need for this group accumulator. For scenarios exceeding that rule, this group accumulator can improve a lot.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

implement `GroupsAccumulator` for distinct count.

## Are these changes tested?

yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
no