### PR TITLE
feat: Support serde for FileScanConfig `batch_size`

### DIFF
--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -997,6 +997,7 @@ message FileScanExecConf {
   reserved 10;
 
   datafusion_common.Constraints constraints = 11;
+  optional uint64 batch_size = 12;
 }
 
 message ParquetScanExecNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -5780,6 +5780,9 @@ impl serde::Serialize for FileScanExecConf {
         if self.constraints.is_some() {
             len += 1;
         }
+        if self.batch_size.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion.FileScanExecConf", len)?;
         if !self.file_groups.is_empty() {
             struct_ser.serialize_field("fileGroups", &self.file_groups)?;
@@ -5808,6 +5811,11 @@ impl serde::Serialize for FileScanExecConf {
         if let Some(v) = self.constraints.as_ref() {
             struct_ser.serialize_field("constraints", v)?;
         }
+        if let Some(v) = self.batch_size.as_ref() {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("batchSize", ToString::to_string(&v).as_str())?;
+        }
         struct_ser.end()
     }
 }
@@ -5831,6 +5839,8 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
             "output_ordering",
             "outputOrdering",
             "constraints",
+            "batch_size",
+            "batchSize",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -5844,6 +5854,7 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
             ObjectStoreUrl,
             OutputOrdering,
             Constraints,
+            BatchSize,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5874,6 +5885,7 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
                             "objectStoreUrl" | "object_store_url" => Ok(GeneratedField::ObjectStoreUrl),
                             "outputOrdering" | "output_ordering" => Ok(GeneratedField::OutputOrdering),
                             "constraints" => Ok(GeneratedField::Constraints),
+                            "batchSize" | "batch_size" => Ok(GeneratedField::BatchSize),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -5902,6 +5914,7 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
                 let mut object_store_url__ = None;
                 let mut output_ordering__ = None;
                 let mut constraints__ = None;
+                let mut batch_size__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::FileGroups => {
@@ -5961,6 +5974,14 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
                             }
                             constraints__ = map_.next_value()?;
                         }
+                        GeneratedField::BatchSize => {
+                            if batch_size__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("batchSize"));
+                            }
+                            batch_size__ = 
+                                map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| x.0)
+                            ;
+                        }
                     }
                 }
                 Ok(FileScanExecConf {
@@ -5973,6 +5994,7 @@ impl<'de> serde::Deserialize<'de> for FileScanExecConf {
                     object_store_url: object_store_url__.unwrap_or_default(),
                     output_ordering: output_ordering__.unwrap_or_default(),
                     constraints: constraints__,
+                    batch_size: batch_size__,
                 })
             }
         }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1517,6 +1517,8 @@ pub struct FileScanExecConf {
     pub output_ordering: ::prost::alloc::vec::Vec<PhysicalSortExprNodeCollection>,
     #[prost(message, optional, tag = "11")]
     pub constraints: ::core::option::Option<super::datafusion_common::Constraints>,
+    #[prost(uint64, optional, tag = "12")]
+    pub batch_size: ::core::option::Option<u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ParquetScanExecNode {

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -544,7 +544,8 @@ pub fn parse_protobuf_file_scan_config(
         .with_projection(projection)
         .with_limit(proto.limit.as_ref().map(|sl| sl.limit as usize))
         .with_table_partition_cols(table_partition_cols)
-        .with_output_ordering(output_ordering);
+        .with_output_ordering(output_ordering)
+        .with_batch_size(proto.batch_size.map(|s| s as usize));
     Ok(config)
 }
 

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -530,6 +530,7 @@ pub fn serialize_file_scan_config(
             })
             .collect::<Vec<_>>(),
         constraints: Some(conf.constraints.clone().into()),
+        batch_size: conf.batch_size.map(|s| s as u64),
     })
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes None.
- Reference [Support serde for batch_size](https://github.com/apache/datafusion/pull/15311#discussion_r2004114426)

## Rationale for this change
Support serde for FileScanConfig `batch_size`

> When `FileScanConfig` call `open(..)`, will set `batch_size` for `file_source`, so this PR add `batch_size` property for struct `FileScanConfig` to support serde `batch_size` to proto.

https://github.com/apache/datafusion/blob/19dd46d3c65e3160c0fb949880bc3e960434e96d/datafusion/datasource/src/file_scan_config.rs#L172-L190

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
