### PR TITLE
Minor: Keep debug symbols for `release-nonlto` build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ url = "2.5.4"
 [profile.release]
 codegen-units = 1
 lto = true
-strip = true
+strip = true      # Eliminate debug information to minimize binary size
 
 # the release profile takes a long time to build so we can use this profile during development to save time
 # cargo build --profile release-nonlto
@@ -183,6 +183,7 @@ lto = false
 opt-level = 3
 overflow-checks = false
 rpath = false
+strip = false            # Retain debug info for flamegraphs
 
 [profile.ci]
 inherits = "dev"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
`release-nonlto` build produces binaries with performance close to `--release` build, but compiles faster. This compilation profile is used for easier development and benchmarking.
Now it by default strips the debug symbols, as a consequence, If a flamegraph is collected using this `release-nonlto` build, useful function names will not displayed.

### Reproducer:
`sudo cargo flamegraph --profile release-nonlto --bin dfbench -- sort-tpch -p /Users/yongting/Code/datafusion/benchmarks/data/tpch_sf10 -q 3`
The generated flamegraph will look like:
![image](https://github.com/user-attachments/assets/f2df64c1-56f6-437d-aa40-ea03ed60377a)

If we keep the symbol names, the flamegraph will be generated with function names in the call stack.
![image](https://github.com/user-attachments/assets/7663131b-d880-4934-8c31-caae760eeffd)

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Changed `cargo.toml` to keep debug symbols in `release-nonlto` build.
## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Tested manually in the above example.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No.