### PR TITLE
Documentation: Plan custom expressions

### DIFF
--- a/docs/source/library-user-guide/adding-udfs.md
+++ b/docs/source/library-user-guide/adding-udfs.md
@@ -1197,7 +1197,7 @@ See example below:
 # // Define the custom planner
 # struct MyCustomPlanner;
 
-// Implement ExprPlanner for cutom operator logic
+// Implement ExprPlanner to add support for the `->` custom operator
 impl ExprPlanner for MyCustomPlanner {
     fn plan_binary_op(
         &self,

--- a/docs/source/library-user-guide/adding-udfs.md
+++ b/docs/source/library-user-guide/adding-udfs.md
@@ -1170,7 +1170,7 @@ To extend DataFusion with support for custom operators not natively available, y
 
 1. Implement the `ExprPlanner` trait: This allows you to define custom logic for planning expressions that DataFusion doesn't natively recognize. The trait provides the necessary interface to translate logical expressions into physical execution plans.
 
-   For a detailed documentation please see: [Trait ExprPlanner](https://docs.rs/datafusion/latest/datafusion/logical_expr/planner/trait.ExprPlanner.html)
+   For detailed documentation please see: [Trait ExprPlanner](https://docs.rs/datafusion/latest/datafusion/logical_expr/planner/trait.ExprPlanner.html)
 
 2. Register your custom planner: Integrate your implementation with DataFusion's `SessionContext` to ensure your custom planning logic is invoked during the query optimization and execution planning phase.
 

--- a/docs/source/library-user-guide/adding-udfs.md
+++ b/docs/source/library-user-guide/adding-udfs.md
@@ -1162,7 +1162,7 @@ async fn main() -> Result<()> {
 
 ## Custom Expression Planning
 
-DataFusion provides native support for common SQL operators by default such as `+`, `-`, `||`. However it does not provide support for other operators such as `@>`. To override DataFusion's default handling or support unsupported operators, developers can extend DataFusion  by implementing custom expression planning,  a core feature of DataFusion
+DataFusion provides native support for common SQL operators by default such as `+`, `-`, `||`. However it does not provide support for other operators such as `@>`. To override DataFusion's default handling or support unsupported operators, developers can extend DataFusion by implementing custom expression planning, a core feature of DataFusion
 
 ### Implementing Custom Expression Planning
 

--- a/docs/source/library-user-guide/adding-udfs.md
+++ b/docs/source/library-user-guide/adding-udfs.md
@@ -1174,7 +1174,7 @@ To extend DataFusion with support for custom operators not natively available, y
 
 2. Register your custom planner: Integrate your implementation with DataFusion's `SessionContext` to ensure your custom planning logic is invoked during the query optimization and execution planning phase.
 
-   For a detailed documentation please see: [fn register_expr_planner](https://docs.rs/datafusion/latest/datafusion/execution/trait.FunctionRegistry.html#method.register_expr_planner)
+   For a detailed documentation see: [fn register_expr_planner](https://docs.rs/datafusion/latest/datafusion/execution/trait.FunctionRegistry.html#method.register_expr_planner)
 
 See example below:
 

--- a/docs/source/library-user-guide/adding-udfs.md
+++ b/docs/source/library-user-guide/adding-udfs.md
@@ -1231,16 +1231,18 @@ async fn main() -> Result<()> {
     ctx.register_expr_planner(Arc::new(MyCustomPlanner))?;
     let results = ctx.sql("select 'foo'->'bar';").await?.collect().await?;
 
+    let expected = [
+         "+----------------------------+",
+         "| Utf8(\"foo\") || Utf8(\"bar\") |",
+         "+----------------------------+",
+         "| foobar                     |",
+         "+----------------------------+",
+     ];
+    assert_batches_eq!(&expected, &results);
+
     pretty::print_batches(&results)?;
     Ok(())
 }
-
-// "+----------------------------+",
-// "| Utf8(\"foo\") || Utf8(\"bar\") |",
-// "+----------------------------+",
-// "| foobar                     |",
-// "+----------------------------+",
-
 ```
 
 [1]: https://github.com/apache/datafusion/blob/main/datafusion-examples/examples/simple_udf.rs

--- a/docs/source/library-user-guide/adding-udfs.md
+++ b/docs/source/library-user-guide/adding-udfs.md
@@ -1226,7 +1226,7 @@ use datafusion::arrow::util::pretty;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let config = SessionContext::new().set_str("datafusion.sql_parser.dialect", "postgres");
+    let config = SessionConfig::new().set_str("datafusion.sql_parser.dialect", "postgres");
     let mut ctx = SessionContext::new_with_config(config);
     ctx.register_expr_planner(Arc::new(MyCustomPlanner))?;
     let results = ctx.sql("select 'foo'->'bar';").await?.collect().await?;

--- a/docs/source/library-user-guide/adding-udfs.md
+++ b/docs/source/library-user-guide/adding-udfs.md
@@ -1168,7 +1168,7 @@ DataFusion provides native support for common SQL operators by default such as `
 
 To extend DataFusion with support for custom operators not natively available, you need to:
 
-1. Implement the `ExprPlanner` trait: This allows you to define custom logic for planning expressions that DataFusion doesn't natively recognize. The trait provides the necessary interface to translate logical expressions into physical execution plans.
+1. Implement the `ExprPlanner` trait: This allows you to define custom logic for planning expressions that DataFusion doesn't natively recognize. The trait provides the necessary interface to translate SQL AST nodes into logical `Expr`.
 
    For detailed documentation please see: [Trait ExprPlanner](https://docs.rs/datafusion/latest/datafusion/logical_expr/planner/trait.ExprPlanner.html)
 

--- a/docs/source/library-user-guide/adding-udfs.md
+++ b/docs/source/library-user-guide/adding-udfs.md
@@ -1162,7 +1162,7 @@ async fn main() -> Result<()> {
 
 ## Custom Expression Planning
 
-DataFusion provides native support for a limited set of SQL operators by default. For operators not natively defined, developers can extend DataFusion's functionality by implementing custom expression planning. This extensibility is a core feature of DataFusion, allowing it to be customized for particular workloads and requirements.
+DataFusion provides native support for common SQL operators by default such as `+`, `-`, `||`. However it does not provide support for other operators such as `@>`. To override DataFusion's default handling or support unsupported operators, developers can extend DataFusion  by implementing custom expression planning,  a core feature of DataFusion
 
 ### Implementing Custom Expression Planning
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes [#15267](https://github.com/apache/datafusion/issues/15267) .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This PR adds documentation for using the `ExprPlanner` API to plan custom expressions, as requested in #15267. Clear documentation with an example will help users extend DataFusion to support custom operators like PostgreSQL's `->`.

## What changes are included in this PR?
- Added a new section `## Custom Expression Planning` to document
- Included an introduction explaining what `ExprPlanner` does and why it’s useful.
- Provided a step-by-step example showing how to implement and register an `ExprPlanner` to make the `->` operator concatenate strings (e.g., `'foo'->'bar'` outputs `foobar`).
- Linked to relevant API docs (`ExprPlanner` and `FunctionRegistry`) for further reading.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Yes, since this is an documentation chang

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
