### PR TITLE
Format `Date32` to string given timestamp specifiers

### DIFF
--- a/datafusion/functions/src/datetime/to_char.rs
+++ b/datafusion/functions/src/datetime/to_char.rs
@@ -249,8 +249,8 @@ fn to_char_scalar(
             ))
         }
     } else {
-        // if the format attempt is with a Date32, it's possible the attempt failed because
-        // the format string contained time-specifiers, so we'll retry casting as Date64
+        // if the data type was a Date32, formatting could have failed because the format string
+        // contained datetime specifiers, so we'll retry by casting the date array as a timestamp array
         if data_type == &Date32 {
             return to_char_scalar(expression.clone().cast_to(&Date64, None)?, format);
         }
@@ -286,8 +286,8 @@ fn to_char_array(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         match result {
             Ok(value) => results.push(Some(value)),
             Err(e) => {
-                // if the format attempt is with a Date32, it's possible the attempt failed because
-                // the format string contained time-specifiers, so we'll retry the specific failed Date32 as a Date64
+                // if the data type was a Date32, formatting could have failed because the format string
+                // contained datetime specifiers, so we'll treat this specific date element as a timestamp
                 if data_type == &Date32 {
                     let failed_date_value = arrays[0].slice(idx, 1);
 

--- a/datafusion/functions/src/datetime/to_char.rs
+++ b/datafusion/functions/src/datetime/to_char.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use arrow::array::cast::AsArray;
 use arrow::array::{new_null_array, Array, ArrayRef, StringArray};
+use arrow::compute::cast;
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::{
     Date32, Date64, Duration, Time32, Time64, Timestamp, Utf8,
@@ -210,7 +211,7 @@ fn _to_char_scalar(
     // of the implementation in arrow-rs we need to convert it to an array
     let data_type = &expression.data_type();
     let is_scalar_expression = matches!(&expression, ColumnarValue::Scalar(_));
-    let array = expression.into_array(1)?;
+    let array = expression.clone().into_array(1)?;
 
     if format.is_none() {
         if is_scalar_expression {
@@ -247,6 +248,10 @@ fn _to_char_scalar(
             ))
         }
     } else {
+        if data_type == &Date32 {
+            return _to_char_scalar(expression.clone().cast_to(&Date64, None)?, format);
+        }
+
         exec_err!("{}", formatted.unwrap_err())
     }
 }
@@ -277,7 +282,25 @@ fn _to_char_array(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         let result = formatter.value(idx).try_to_string();
         match result {
             Ok(value) => results.push(Some(value)),
-            Err(e) => return exec_err!("{}", e),
+            Err(e) => {
+                if data_type == &Date32 {
+                    let format_options = match _build_format_options(&Date64, format) {
+                        Ok(value) => value,
+                        Err(value) => return value,
+                    };
+
+                    let array = cast(arrays[0].as_ref(), &Date64)?;
+                    let formatter =
+                        ArrayFormatter::try_new(array.as_ref(), &format_options)?;
+                    let result = formatter.value(idx).try_to_string();
+                    match result {
+                        Ok(value) => results.push(Some(value)),
+                        Err(e) => return exec_err!("{}", e),
+                    }
+                } else {
+                    return exec_err!("{}", e);
+                }
+            }
         }
     }
 
@@ -327,6 +350,11 @@ mod tests {
                 ScalarValue::Date32(Some(18506)),
                 ScalarValue::Utf8(Some("%Y::%m::%d".to_string())),
                 "2020::09::01".to_string(),
+            ),
+            (
+                ScalarValue::Date32(Some(18506)),
+                ScalarValue::Utf8(Some("%Y::%m::%d %S::%M::%H %f".to_string())),
+                "2020::09::01 00::00::00 000000000".to_string(),
             ),
             (
                 ScalarValue::Date64(Some(date.and_utc().timestamp_millis())),
@@ -406,6 +434,11 @@ mod tests {
                 ScalarValue::Date32(Some(18506)),
                 StringArray::from(vec!["%Y::%m::%d".to_string()]),
                 "2020::09::01".to_string(),
+            ),
+            (
+                ScalarValue::Date32(Some(18506)),
+                StringArray::from(vec!["%Y::%m::%d %S::%M::%H %f".to_string()]),
+                "2020::09::01 00::00::00 000000000".to_string(),
             ),
             (
                 ScalarValue::Date64(Some(date.and_utc().timestamp_millis())),
@@ -491,6 +524,14 @@ mod tests {
                 StringArray::from(vec!["2020::09::01", "2020::09::02"]),
             ),
             (
+                Arc::new(Date32Array::from(vec![18506, 18507])) as ArrayRef,
+                ScalarValue::Utf8(Some("%Y::%m::%d %S::%M::%H %f".to_string())),
+                StringArray::from(vec![
+                    "2020::09::01 00::00::00 000000000",
+                    "2020::09::02 00::00::00 000000000",
+                ]),
+            ),
+            (
                 Arc::new(Date64Array::from(vec![
                     date.and_utc().timestamp_millis(),
                     date2.and_utc().timestamp_millis(),
@@ -505,6 +546,25 @@ mod tests {
                 Arc::new(Date32Array::from(vec![18506, 18507])) as ArrayRef,
                 StringArray::from(vec!["%Y::%m::%d", "%d::%m::%Y"]),
                 StringArray::from(vec!["2020::09::01", "02::09::2020"]),
+            ),
+            (
+                Arc::new(Date32Array::from(vec![18506, 18507])) as ArrayRef,
+                StringArray::from(vec![
+                    "%Y::%m::%d %S::%M::%H %f",
+                    "%Y::%m::%d %S::%M::%H %f",
+                ]),
+                StringArray::from(vec![
+                    "2020::09::01 00::00::00 000000000",
+                    "2020::09::02 00::00::00 000000000",
+                ]),
+            ),
+            (
+                Arc::new(Date32Array::from(vec![18506, 18507])) as ArrayRef,
+                StringArray::from(vec!["%Y::%m::%d", "%Y::%m::%d %S::%M::%H %f"]),
+                StringArray::from(vec![
+                    "2020::09::01",
+                    "2020::09::02 00::00::00 000000000",
+                ]),
             ),
             (
                 Arc::new(Date64Array::from(vec![

--- a/datafusion/functions/src/datetime/to_char.rs
+++ b/datafusion/functions/src/datetime/to_char.rs
@@ -211,7 +211,7 @@ fn _to_char_scalar(
     // of the implementation in arrow-rs we need to convert it to an array
     let mut data_type = &expression.data_type();
     let is_scalar_expression = matches!(&expression, ColumnarValue::Scalar(_));
-    let mut array = expression.clone().into_array(1)?;
+    let mut array = expression.into_array(1)?;
 
     if format.is_none() {
         if is_scalar_expression {

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -2795,6 +2795,18 @@ select date_format(dates, date_format) from formats;
 05:04:2003
 
 query T
+select date_format(dates, time_format) from formats;
+----
+00-00-00
+00::00::00
+
+query T
+select date_format(dates, timestamp_format) from formats;
+----
+01:01:2000 00-00-00
+05:04:2003 00-00-00
+
+query T
 select to_char(times, time_format) from formats;
 ----
 23-45-01


### PR DESCRIPTION
- Closes https://github.com/apache/datafusion/issues/14536

## Rationale for this change

Datafusion currently errs when attempting to format a date using time-related specifiers. 

```sql
> select to_char('2023-09-04'::date, '%Y-%m-%dT%H:%M:%S%.3f');
Execution error: Cast error: Format error
```

However, Postgres supports this feature as it implicitly treats the date as a timestamp. 

Rather than eagerly casting every `Date32` to a `Date64` when calling `to_char`, this commit attempts to first format a `Date32` with the supplied format string. If the formatting fails, we try to reformat as a `Date64`. This way, only format strings with time-related specifiers endure the intermediary cast. 


All changes are tested, specifically for two different call sites: `_to_char_scalar` and `_to_char_array`.
