### PR TITLE
 Migrate physical plan tests to `insta` (Part-2)

### DIFF
--- a/datafusion/physical-plan/src/aggregates/topk/heap.rs
+++ b/datafusion/physical-plan/src/aggregates/topk/heap.rs
@@ -485,6 +485,8 @@ pub fn new_heap(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use super::*;
 
     #[test]
@@ -494,10 +496,9 @@ mod tests {
         heap.append_or_replace(1, 1, &mut map);
 
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=1 idx=0, bucket=1
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
 
         Ok(())
     }
@@ -514,11 +515,10 @@ val=1 idx=0, bucket=1
         assert_eq!(map, vec![(2, 0), (1, 1)]);
 
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=2 idx=0, bucket=2
 └── val=1 idx=1, bucket=1
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
 
         Ok(())
     }
@@ -532,22 +532,20 @@ val=2 idx=0, bucket=2
         heap.append_or_replace(2, 2, &mut map);
         heap.append_or_replace(3, 3, &mut map);
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=3 idx=0, bucket=3
 ├── val=1 idx=1, bucket=1
 └── val=2 idx=2, bucket=2
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
 
         let mut map = vec![];
         heap.append_or_replace(0, 0, &mut map);
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=2 idx=0, bucket=2
 ├── val=1 idx=1, bucket=1
 └── val=0 idx=2, bucket=0
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
         assert_eq!(map, vec![(2, 0), (0, 2)]);
 
         Ok(())
@@ -563,24 +561,22 @@ val=2 idx=0, bucket=2
         heap.append_or_replace(3, 3, &mut map);
         heap.append_or_replace(4, 4, &mut map);
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=4 idx=0, bucket=4
 ├── val=3 idx=1, bucket=3
 │   └── val=1 idx=3, bucket=1
 └── val=2 idx=2, bucket=2
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
 
         let mut map = vec![];
         heap.replace_if_better(1, 0, &mut map);
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=4 idx=0, bucket=4
 ├── val=1 idx=1, bucket=1
 │   └── val=0 idx=3, bucket=3
 └── val=2 idx=2, bucket=2
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
         assert_eq!(map, vec![(1, 1), (3, 3)]);
 
         Ok(())
@@ -595,11 +591,10 @@ val=4 idx=0, bucket=4
         heap.append_or_replace(2, 2, &mut map);
 
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=2 idx=0, bucket=2
 └── val=1 idx=1, bucket=1
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
 
         assert_eq!(heap.worst_val(), Some(&2));
         assert_eq!(heap.worst_map_idx(), 2);
@@ -616,11 +611,10 @@ val=2 idx=0, bucket=2
         heap.append_or_replace(2, 2, &mut map);
 
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=2 idx=0, bucket=2
 └── val=1 idx=1, bucket=1
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
 
         let (vals, map_idxs) = heap.drain();
         assert_eq!(vals, vec![1, 2]);
@@ -639,20 +633,18 @@ val=2 idx=0, bucket=2
         heap.append_or_replace(2, 2, &mut map);
 
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=2 idx=0, bucket=2
 └── val=1 idx=1, bucket=1
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
 
         let numbers = vec![(0, 1), (1, 2)];
         heap.renumber(numbers.as_slice());
         let actual = heap.to_string();
-        let expected = r#"
+        assert_snapshot!(actual, @r#"
 val=2 idx=0, bucket=1
 └── val=1 idx=1, bucket=2
-        "#;
-        assert_eq!(actual.trim(), expected.trim());
+            "#);
 
         Ok(())
     }

--- a/datafusion/physical-plan/src/aggregates/topk/snapshots/datafusion_physical_plan__aggregates__topk__heap__tests__val=1 idx=0, bucket=1.snap
+++ b/datafusion/physical-plan/src/aggregates/topk/snapshots/datafusion_physical_plan__aggregates__topk__heap__tests__val=1 idx=0, bucket=1.snap
@@ -1,0 +1,5 @@
+---
+source: datafusion/physical-plan/src/aggregates/topk/heap.rs
+expression: "r#\"\nval=1 idx=0, bucket=1\n            \"#.trim()"
+---
+val=1 idx=0, bucket=1

--- a/datafusion/physical-plan/src/aggregates/topk/snapshots/datafusion_physical_plan__aggregates__topk__heap__tests__val=1 idx=0, bucket=1.snap
+++ b/datafusion/physical-plan/src/aggregates/topk/snapshots/datafusion_physical_plan__aggregates__topk__heap__tests__val=1 idx=0, bucket=1.snap
@@ -1,5 +1,0 @@
----
-source: datafusion/physical-plan/src/aggregates/topk/heap.rs
-expression: "r#\"\nval=1 idx=0, bucket=1\n            \"#.trim()"
----
-val=1 idx=0, bucket=1

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -1047,13 +1047,15 @@ pub(crate) mod tests {
     use arrow::array::Int32Array;
     use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field};
-    use datafusion_common::{assert_batches_sorted_eq, assert_contains, ScalarValue};
+    use datafusion_common::test_util::batches_to_sort_string;
+    use datafusion_common::{assert_contains, ScalarValue};
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{BinaryExpr, Literal};
     use datafusion_physical_expr::{Partitioning, PhysicalExpr};
     use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
 
+    use insta::assert_snapshot;
     use rstest::rstest;
 
     fn build_table(
@@ -1216,15 +1218,13 @@ pub(crate) mod tests {
         )
         .await?;
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
-        let expected = [
-            "+----+----+----+----+----+----+",
-            "| a1 | b1 | c1 | a2 | b2 | c2 |",
-            "+----+----+----+----+----+----+",
-            "| 5  | 5  | 50 | 2  | 2  | 80 |",
-            "+----+----+----+----+----+----+",
-        ];
-
-        assert_batches_sorted_eq!(expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +----+----+----+----+----+----+
+            | a1 | b1 | c1 | a2 | b2 | c2 |
+            +----+----+----+----+----+----+
+            | 5  | 5  | 50 | 2  | 2  | 80 |
+            +----+----+----+----+----+----+
+            "#);
 
         Ok(())
     }
@@ -1245,17 +1245,15 @@ pub(crate) mod tests {
         )
         .await?;
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
-        let expected = [
-            "+----+----+-----+----+----+----+",
-            "| a1 | b1 | c1  | a2 | b2 | c2 |",
-            "+----+----+-----+----+----+----+",
-            "| 11 | 8  | 110 |    |    |    |",
-            "| 5  | 5  | 50  | 2  | 2  | 80 |",
-            "| 9  | 8  | 90  |    |    |    |",
-            "+----+----+-----+----+----+----+",
-        ];
-
-        assert_batches_sorted_eq!(expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +----+----+-----+----+----+----+
+            | a1 | b1 | c1  | a2 | b2 | c2 |
+            +----+----+-----+----+----+----+
+            | 11 | 8  | 110 |    |    |    |
+            | 5  | 5  | 50  | 2  | 2  | 80 |
+            | 9  | 8  | 90  |    |    |    |
+            +----+----+-----+----+----+----+
+            "#);
 
         Ok(())
     }
@@ -1276,17 +1274,15 @@ pub(crate) mod tests {
         )
         .await?;
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
-        let expected = [
-            "+----+----+----+----+----+-----+",
-            "| a1 | b1 | c1 | a2 | b2 | c2  |",
-            "+----+----+----+----+----+-----+",
-            "|    |    |    | 10 | 10 | 100 |",
-            "|    |    |    | 12 | 10 | 40  |",
-            "| 5  | 5  | 50 | 2  | 2  | 80  |",
-            "+----+----+----+----+----+-----+",
-        ];
-
-        assert_batches_sorted_eq!(expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +----+----+----+----+----+-----+
+            | a1 | b1 | c1 | a2 | b2 | c2  |
+            +----+----+----+----+----+-----+
+            |    |    |    | 10 | 10 | 100 |
+            |    |    |    | 12 | 10 | 40  |
+            | 5  | 5  | 50 | 2  | 2  | 80  |
+            +----+----+----+----+----+-----+
+            "#);
 
         Ok(())
     }
@@ -1307,19 +1303,17 @@ pub(crate) mod tests {
         )
         .await?;
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
-        let expected = [
-            "+----+----+-----+----+----+-----+",
-            "| a1 | b1 | c1  | a2 | b2 | c2  |",
-            "+----+----+-----+----+----+-----+",
-            "|    |    |     | 10 | 10 | 100 |",
-            "|    |    |     | 12 | 10 | 40  |",
-            "| 11 | 8  | 110 |    |    |     |",
-            "| 5  | 5  | 50  | 2  | 2  | 80  |",
-            "| 9  | 8  | 90  |    |    |     |",
-            "+----+----+-----+----+----+-----+",
-        ];
-
-        assert_batches_sorted_eq!(expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +----+----+-----+----+----+-----+
+            | a1 | b1 | c1  | a2 | b2 | c2  |
+            +----+----+-----+----+----+-----+
+            |    |    |     | 10 | 10 | 100 |
+            |    |    |     | 12 | 10 | 40  |
+            | 11 | 8  | 110 |    |    |     |
+            | 5  | 5  | 50  | 2  | 2  | 80  |
+            | 9  | 8  | 90  |    |    |     |
+            +----+----+-----+----+----+-----+
+            "#);
 
         Ok(())
     }
@@ -1340,15 +1334,13 @@ pub(crate) mod tests {
         )
         .await?;
         assert_eq!(columns, vec!["a1", "b1", "c1"]);
-        let expected = [
-            "+----+----+----+",
-            "| a1 | b1 | c1 |",
-            "+----+----+----+",
-            "| 5  | 5  | 50 |",
-            "+----+----+----+",
-        ];
-
-        assert_batches_sorted_eq!(expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +----+----+----+
+            | a1 | b1 | c1 |
+            +----+----+----+
+            | 5  | 5  | 50 |
+            +----+----+----+
+            "#);
 
         Ok(())
     }
@@ -1369,16 +1361,14 @@ pub(crate) mod tests {
         )
         .await?;
         assert_eq!(columns, vec!["a1", "b1", "c1"]);
-        let expected = [
-            "+----+----+-----+",
-            "| a1 | b1 | c1  |",
-            "+----+----+-----+",
-            "| 11 | 8  | 110 |",
-            "| 9  | 8  | 90  |",
-            "+----+----+-----+",
-        ];
-
-        assert_batches_sorted_eq!(expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +----+----+-----+
+            | a1 | b1 | c1  |
+            +----+----+-----+
+            | 11 | 8  | 110 |
+            | 9  | 8  | 90  |
+            +----+----+-----+
+            "#);
 
         Ok(())
     }
@@ -1399,15 +1389,13 @@ pub(crate) mod tests {
         )
         .await?;
         assert_eq!(columns, vec!["a2", "b2", "c2"]);
-        let expected = [
-            "+----+----+----+",
-            "| a2 | b2 | c2 |",
-            "+----+----+----+",
-            "| 2  | 2  | 80 |",
-            "+----+----+----+",
-        ];
-
-        assert_batches_sorted_eq!(expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +----+----+----+
+            | a2 | b2 | c2 |
+            +----+----+----+
+            | 2  | 2  | 80 |
+            +----+----+----+
+            "#);
 
         Ok(())
     }
@@ -1428,16 +1416,14 @@ pub(crate) mod tests {
         )
         .await?;
         assert_eq!(columns, vec!["a2", "b2", "c2"]);
-        let expected = [
-            "+----+----+-----+",
-            "| a2 | b2 | c2  |",
-            "+----+----+-----+",
-            "| 10 | 10 | 100 |",
-            "| 12 | 10 | 40  |",
-            "+----+----+-----+",
-        ];
-
-        assert_batches_sorted_eq!(expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +----+----+-----+
+            | a2 | b2 | c2  |
+            +----+----+-----+
+            | 10 | 10 | 100 |
+            | 12 | 10 | 40  |
+            +----+----+-----+
+            "#);
 
         Ok(())
     }
@@ -1458,17 +1444,15 @@ pub(crate) mod tests {
         )
         .await?;
         assert_eq!(columns, vec!["a1", "b1", "c1", "mark"]);
-        let expected = [
-            "+----+----+-----+-------+",
-            "| a1 | b1 | c1  | mark  |",
-            "+----+----+-----+-------+",
-            "| 11 | 8  | 110 | false |",
-            "| 5  | 5  | 50  | true  |",
-            "| 9  | 8  | 90  | false |",
-            "+----+----+-----+-------+",
-        ];
-
-        assert_batches_sorted_eq!(expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +----+----+-----+-------+
+            | a1 | b1 | c1  | mark  |
+            +----+----+-----+-------+
+            | 11 | 8  | 110 | false |
+            | 5  | 5  | 50  | true  |
+            | 9  | 8  | 90  | false |
+            +----+----+-----+-------+
+            "#);
 
         Ok(())
     }

--- a/datafusion/physical-plan/src/joins/sort_merge_join.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join.rs
@@ -2280,19 +2280,19 @@ fn fetch_right_columns_from_batch_by_idxs(
             .map(|column| take(column, &buffered_indices, None))
             .collect::<Result<Vec<_>, ArrowError>>()
             .map_err(Into::<DataFusionError>::into)?),
-            // If the batch was spilled to disk, less likely
-            (Some(spill_file), None) => {
-                let mut buffered_cols: Vec<ArrayRef> =
-                    Vec::with_capacity(buffered_indices.len());
+        // If the batch was spilled to disk, less likely
+        (Some(spill_file), None) => {
+            let mut buffered_cols: Vec<ArrayRef> =
+                Vec::with_capacity(buffered_indices.len());
 
-                let file = BufReader::new(File::open(spill_file.path())?);
-                let reader = StreamReader::try_new(file, None)?;
+            let file = BufReader::new(File::open(spill_file.path())?);
+            let reader = StreamReader::try_new(file, None)?;
 
-                for batch in reader {
-                    batch?.columns().iter().for_each(|column| {
-                        buffered_cols.extend(take(column, &buffered_indices, None))
-                    });
-                }
+            for batch in reader {
+                batch?.columns().iter().for_each(|column| {
+                    buffered_cols.extend(take(column, &buffered_indices, None))
+                });
+            }
 
                 Ok(buffered_cols)
             }

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -1078,9 +1078,11 @@ mod tests {
     use arrow::array::{ArrayRef, StringArray, UInt32Array};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::cast::as_string_array;
-    use datafusion_common::{arrow_datafusion_err, assert_batches_sorted_eq, exec_err};
+    use datafusion_common::test_util::{batches_to_sort_string, batches_to_string};
+    use datafusion_common::{arrow_datafusion_err, exec_err};
     use datafusion_common_runtime::JoinSet;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
+    use insta::assert_snapshot;
 
     #[tokio::test]
     async fn one_to_many_round_robin() -> Result<()> {
@@ -1333,23 +1335,58 @@ mod tests {
 
         let exec = RepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
 
-        let expected = vec![
-            "+------------------+",
-            "| my_awesome_field |",
-            "+------------------+",
-            "| foo              |",
-            "| bar              |",
-            "| frob             |",
-            "| baz              |",
-            "+------------------+",
-        ];
+        // The results are different from what is expected in snapshots thus i am not using
+        // batches_to_sort_string but rather using batches_to_string
+        //
+        //assert_snapshot!(batches_to_sort_string(&expected_batches), @r#"
+        //    +------------------+
+        //    | my_awesome_field |
+        //    +------------------+
+        //    | foo              |
+        //    | bar              |
+        //    | frob             |
+        //    | baz              |
+        //    +------------------+
+        //    "#);
 
-        assert_batches_sorted_eq!(&expected, &expected_batches);
+        assert_snapshot!(batches_to_string(&expected_batches), @r#"
+            +------------------+
+            | my_awesome_field |
+            +------------------+
+            | foo              |
+            | bar              |
+            | frob             |
+            | baz              |
+            +------------------+
+            "#);
 
         let output_stream = exec.execute(0, task_ctx).unwrap();
         let batches = crate::common::collect(output_stream).await.unwrap();
 
-        assert_batches_sorted_eq!(&expected, &batches);
+        // The results are different from what is expected in snapshots thus i am not using
+        // batches_to_sort_string but rather using batches_sort_string
+        //
+        //assert_snapshot!(batches_to_sort_string(&batches), @r#"
+        //    +------------------+
+        //    | my_awesome_field |
+        //    +------------------+
+        //    | foo              |
+        //    | bar              |
+        //    | frob             |
+        //    | baz              |
+        //    +------------------+
+        //    "#);
+
+        assert_snapshot!(batches_to_string(&batches), @r#"
+            +------------------+
+            | my_awesome_field |
+            +------------------+
+            | foo              |
+            | bar              |
+            | frob             |
+            | baz              |
+            +------------------+
+            "#);
     }
 
     #[tokio::test]
@@ -1383,18 +1420,16 @@ mod tests {
         // output stream 1 should *not* error and have one of the input batches
         let batches = crate::common::collect(output_stream1).await.unwrap();
 
-        let expected = vec![
-            "+------------------+",
-            "| my_awesome_field |",
-            "+------------------+",
-            "| baz              |",
-            "| frob             |",
-            "| gaz              |",
-            "| grob             |",
-            "+------------------+",
-        ];
-
-        assert_batches_sorted_eq!(&expected, &batches);
+        assert_snapshot!(batches_to_sort_string(&batches), @r#"
+            +------------------+
+            | my_awesome_field |
+            +------------------+
+            | baz              |
+            | frob             |
+            | gaz              |
+            | grob             |
+            +------------------+
+            "#);
     }
 
     #[tokio::test]

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -1078,7 +1078,7 @@ mod tests {
     use arrow::array::{ArrayRef, StringArray, UInt32Array};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::cast::as_string_array;
-    use datafusion_common::test_util::{batches_to_sort_string, batches_to_string};
+    use datafusion_common::test_util::batches_to_sort_string;
     use datafusion_common::{arrow_datafusion_err, exec_err};
     use datafusion_common_runtime::JoinSet;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
@@ -1335,58 +1335,30 @@ mod tests {
 
         let exec = RepartitionExec::try_new(Arc::new(input), partitioning).unwrap();
 
-        // The results are different from what is expected in snapshots thus i am not using
-        // batches_to_sort_string but rather using batches_to_string
-        //
-        //assert_snapshot!(batches_to_sort_string(&expected_batches), @r#"
-        //    +------------------+
-        //    | my_awesome_field |
-        //    +------------------+
-        //    | foo              |
-        //    | bar              |
-        //    | frob             |
-        //    | baz              |
-        //    +------------------+
-        //    "#);
-
-        assert_snapshot!(batches_to_string(&expected_batches), @r#"
-            +------------------+
-            | my_awesome_field |
-            +------------------+
-            | foo              |
-            | bar              |
-            | frob             |
-            | baz              |
-            +------------------+
-            "#);
+        assert_snapshot!(batches_to_sort_string(&expected_batches), @r"
+        +------------------+
+        | my_awesome_field |
+        +------------------+
+        | bar              |
+        | baz              |
+        | foo              |
+        | frob             |
+        +------------------+
+        ");
 
         let output_stream = exec.execute(0, task_ctx).unwrap();
         let batches = crate::common::collect(output_stream).await.unwrap();
 
-        // The results are different from what is expected in snapshots thus i am not using
-        // batches_to_sort_string but rather using batches_sort_string
-        //
-        //assert_snapshot!(batches_to_sort_string(&batches), @r#"
-        //    +------------------+
-        //    | my_awesome_field |
-        //    +------------------+
-        //    | foo              |
-        //    | bar              |
-        //    | frob             |
-        //    | baz              |
-        //    +------------------+
-        //    "#);
-
-        assert_snapshot!(batches_to_string(&batches), @r#"
-            +------------------+
-            | my_awesome_field |
-            +------------------+
-            | foo              |
-            | bar              |
-            | frob             |
-            | baz              |
-            +------------------+
-            "#);
+        assert_snapshot!(batches_to_sort_string(&batches), @r"
+        +------------------+
+        | my_awesome_field |
+        +------------------+
+        | bar              |
+        | baz              |
+        | foo              |
+        | frob             |
+        +------------------+
+        ");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #15248.

## Rationale for this change

Completely migrate physical plan tests to `insta`

## What changes are included in this PR?

Migrating from `assert_batches_sorted_eq` and `assert_batches_eq` to `assert_snapshot` in physical-plan tests

## Are these changes tested?

Yes, they are

## Are there any user-facing changes?

No, they are not
