### PR TITLE
Use `equals_datatype` to compare type when type coercion

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -708,7 +708,7 @@ pub fn try_type_union_resolution_with_struct(
 /// strings.  For example when comparing `'2' > 1`,  the arguments will be
 /// coerced to `Utf8` for comparison
 pub fn comparison_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
-    if lhs_type == rhs_type {
+    if lhs_type.equals_datatype(rhs_type) {
         // same type => equality is possible
         return Some(lhs_type.clone());
     }

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1053,7 +1053,7 @@ mod test {
     use std::sync::Arc;
 
     use arrow::datatypes::DataType::Utf8;
-    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use arrow::datatypes::{DataType, Field, Schema, SchemaBuilder, TimeUnit};
 
     use crate::analyzer::type_coercion::{
         coerce_case_expression, TypeCoercion, TypeCoercionRewriter,
@@ -2088,6 +2088,31 @@ mod test {
             schema
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_map_with_diff_name() -> Result<()> {
+        let mut builder = SchemaBuilder::new();
+        builder.push(Field::new("key", Utf8, false));
+        builder.push(Field::new("value", DataType::Float64, true));
+        let struct_fields = builder.finish().fields;
+
+        let fields =
+            Field::new("entries", DataType::Struct(struct_fields.clone()), false);
+        let map_type_entries = DataType::Map(Arc::new(fields), false);
+
+        let fields = Field::new("key_value", DataType::Struct(struct_fields), false);
+        let may_type_cutsom = DataType::Map(Arc::new(fields), false);
+
+        let expr = col("a").eq(cast(col("a"), may_type_cutsom));
+        let empty = empty_with_type(map_type_entries);
+        let plan = LogicalPlan::Projection(Projection::try_new(vec![expr], empty)?);
+        let expected = "Projection: a = CAST(CAST(a AS Map(Field { name: \"key_value\", data_type: Struct([Field { name: \"key\", data_type: Utf8, \
+        nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"value\", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }]), \
+        nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, false)) AS Map(Field { name: \"entries\", data_type: Struct([Field { name: \"key\", data_type: Utf8, nullable: false, \
+        dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: \"value\", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }]), nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, false))\n  \
+        EmptyRelation";
+        assert_analyzed_plan_eq(Arc::new(TypeCoercion::new()), plan, expected)
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15351.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In the `delta-rs` case, they use a custom field name, `key_value`, for the map type.
https://github.com/delta-io/delta-rs/blob/30dd5edf9717f6545ffbc73e65b676b8adaa0a01/crates/core/src/kernel/arrow/mod.rs#L13

Then, we use `lhs_type = rhs_type` to compare the data type for type coercion checking. However, in the document of `MpaType`:
```rust
    /// In a field with Map type, the field has a child Struct field, which then
    /// has two children: key type and the second the value type. The names of the
    /// child fields may be respectively "entries", "key", and "value", but this is
    /// not enforced.
    Map(FieldRef, bool),
```
The field name doesn't matter actually. We should use `equals_datatype` to compare them instead.
```rust
    /// Compares the datatype with another, ignoring nested field names
    /// and metadata.
    pub fn equals_datatype(&self, other: &DataType) -> bool {
```


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
- Add the unit test.
- A reproduce code: https://github.com/apache/datafusion/issues/15351#issuecomment-2746211723
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
