### PR TITLE
FIX : some benchmarks are failing

### DIFF
--- a/datafusion/core/benches/distinct_query_sql.rs
+++ b/datafusion/core/benches/distinct_query_sql.rs
@@ -121,8 +121,7 @@ async fn distinct_with_limit(
 fn run(rt: &Runtime, plan: Arc<dyn ExecutionPlan>, ctx: Arc<TaskContext>) {
     criterion::black_box(
         rt.block_on(distinct_with_limit(plan.clone(), ctx.clone()))
-            .unwrap(),
-    );
+    ).unwrap();
 }
 
 pub async fn create_context_sampled_data(

--- a/datafusion/core/benches/distinct_query_sql.rs
+++ b/datafusion/core/benches/distinct_query_sql.rs
@@ -119,9 +119,8 @@ async fn distinct_with_limit(
 }
 
 fn run(rt: &Runtime, plan: Arc<dyn ExecutionPlan>, ctx: Arc<TaskContext>) {
-    criterion::black_box(
-        rt.block_on(distinct_with_limit(plan.clone(), ctx.clone()))
-    ).unwrap();
+    criterion::black_box(rt.block_on(distinct_with_limit(plan.clone(), ctx.clone())))
+        .unwrap();
 }
 
 pub async fn create_context_sampled_data(

--- a/datafusion/core/benches/distinct_query_sql.rs
+++ b/datafusion/core/benches/distinct_query_sql.rs
@@ -141,6 +141,7 @@ pub async fn create_context_sampled_data(
 }
 
 fn criterion_benchmark_limited_distinct_sampled(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
     let limit = 10;
     let partitions = 100;
     let samples = 100_000;
@@ -149,7 +150,6 @@ fn criterion_benchmark_limited_distinct_sampled(c: &mut Criterion) {
     c.bench_function(
         format!("distinct query with {} partitions and {} samples per partition with limit {}", partitions, samples, limit).as_str(),
         |b| b.iter(|| {
-            let rt = Runtime::new().unwrap();
             let (plan, ctx) = rt.block_on(
                 create_context_sampled_data(sql.as_str(), partitions, samples)
             ).unwrap();
@@ -164,7 +164,6 @@ fn criterion_benchmark_limited_distinct_sampled(c: &mut Criterion) {
     c.bench_function(
         format!("distinct query with {} partitions and {} samples per partition with limit {}", partitions, samples, limit).as_str(),
         |b| b.iter(|| {
-            let rt = Runtime::new().unwrap();
             let (plan, ctx) = rt.block_on(
                 create_context_sampled_data(sql.as_str(), partitions, samples)
             ).unwrap();
@@ -179,7 +178,6 @@ fn criterion_benchmark_limited_distinct_sampled(c: &mut Criterion) {
     c.bench_function(
         format!("distinct query with {} partitions and {} samples per partition with limit {}", partitions, samples, limit).as_str(),
         |b| b.iter(|| {
-            let rt = Runtime::new().unwrap();
             let (plan, ctx) = rt.block_on(
                 create_context_sampled_data(sql.as_str(), partitions, samples)
             ).unwrap();

--- a/datafusion/core/benches/distinct_query_sql.rs
+++ b/datafusion/core/benches/distinct_query_sql.rs
@@ -118,12 +118,11 @@ async fn distinct_with_limit(
     Ok(())
 }
 
-fn run(plan: Arc<dyn ExecutionPlan>, ctx: Arc<TaskContext>) {
-    let rt = Runtime::new().unwrap();
+fn run(rt: &Runtime, plan: Arc<dyn ExecutionPlan>, ctx: Arc<TaskContext>) {
     criterion::black_box(
-        rt.block_on(async { distinct_with_limit(plan.clone(), ctx.clone()).await }),
-    )
-    .unwrap();
+        rt.block_on(distinct_with_limit(plan.clone(), ctx.clone()))
+            .unwrap(),
+    );
 }
 
 pub async fn create_context_sampled_data(
@@ -144,59 +143,50 @@ pub async fn create_context_sampled_data(
 }
 
 fn criterion_benchmark_limited_distinct_sampled(c: &mut Criterion) {
-    let rt = Runtime::new().unwrap();
-
     let limit = 10;
     let partitions = 100;
     let samples = 100_000;
     let sql =
         format!("select DISTINCT trace_id from traces group by trace_id limit {limit};");
-
-    let distinct_trace_id_100_partitions_100_000_samples_limit_100 = rt.block_on(async {
-        create_context_sampled_data(sql.as_str(), partitions, samples)
-            .await
-            .unwrap()
-    });
-
     c.bench_function(
         format!("distinct query with {} partitions and {} samples per partition with limit {}", partitions, samples, limit).as_str(),
-        |b| b.iter(|| run(distinct_trace_id_100_partitions_100_000_samples_limit_100.0.clone(),
-                                   distinct_trace_id_100_partitions_100_000_samples_limit_100.1.clone())),
+        |b| b.iter(|| {
+            let rt = Runtime::new().unwrap();
+            let (plan, ctx) = rt.block_on(
+                create_context_sampled_data(sql.as_str(), partitions, samples)
+            ).unwrap();
+            run(&rt, plan.clone(), ctx.clone())
+        }),
     );
 
     let partitions = 10;
     let samples = 1_000_000;
     let sql =
         format!("select DISTINCT trace_id from traces group by trace_id limit {limit};");
-
-    let distinct_trace_id_10_partitions_1_000_000_samples_limit_10 = rt.block_on(async {
-        create_context_sampled_data(sql.as_str(), partitions, samples)
-            .await
-            .unwrap()
-    });
-
     c.bench_function(
         format!("distinct query with {} partitions and {} samples per partition with limit {}", partitions, samples, limit).as_str(),
-        |b| b.iter(|| run(distinct_trace_id_10_partitions_1_000_000_samples_limit_10.0.clone(),
-                                   distinct_trace_id_10_partitions_1_000_000_samples_limit_10.1.clone())),
+        |b| b.iter(|| {
+            let rt = Runtime::new().unwrap();
+            let (plan, ctx) = rt.block_on(
+                create_context_sampled_data(sql.as_str(), partitions, samples)
+            ).unwrap();
+            run(&rt, plan.clone(), ctx.clone())
+        }),
     );
 
     let partitions = 1;
     let samples = 10_000_000;
     let sql =
         format!("select DISTINCT trace_id from traces group by trace_id limit {limit};");
-
-    let rt = Runtime::new().unwrap();
-    let distinct_trace_id_1_partition_10_000_000_samples_limit_10 = rt.block_on(async {
-        create_context_sampled_data(sql.as_str(), partitions, samples)
-            .await
-            .unwrap()
-    });
-
     c.bench_function(
         format!("distinct query with {} partitions and {} samples per partition with limit {}", partitions, samples, limit).as_str(),
-        |b| b.iter(|| run(distinct_trace_id_1_partition_10_000_000_samples_limit_10.0.clone(),
-                                   distinct_trace_id_1_partition_10_000_000_samples_limit_10.1.clone())),
+        |b| b.iter(|| {
+            let rt = Runtime::new().unwrap();
+            let (plan, ctx) = rt.block_on(
+                create_context_sampled_data(sql.as_str(), partitions, samples)
+            ).unwrap();
+            run(&rt, plan.clone(), ctx.clone())
+        }),
     );
 }
 

--- a/datafusion/core/benches/topk_aggregate.rs
+++ b/datafusion/core/benches/topk_aggregate.rs
@@ -103,36 +103,34 @@ fn criterion_benchmark(c: &mut Criterion) {
     let partitions = 10;
     let samples = 1_000_000;
 
-    let rt = Runtime::new().unwrap();
-    let topk_real = rt.block_on(async {
-        create_context(limit, partitions, samples, false, true)
-            .await
-            .unwrap()
-    });
-    let topk_asc = rt.block_on(async {
-        create_context(limit, partitions, samples, true, true)
-            .await
-            .unwrap()
-    });
-    let real = rt.block_on(async {
-        create_context(limit, partitions, samples, false, false)
-            .await
-            .unwrap()
-    });
-    let asc = rt.block_on(async {
-        create_context(limit, partitions, samples, true, false)
-            .await
-            .unwrap()
-    });
-
     c.bench_function(
         format!("aggregate {} time-series rows", partitions * samples).as_str(),
-        |b| b.iter(|| run(real.0.clone(), real.1.clone(), false)),
+        |b| {
+            b.iter(|| {
+                let rt = Runtime::new().unwrap();
+                let real = rt.block_on(async {
+                    create_context(limit, partitions, samples, false, false)
+                        .await
+                        .unwrap()
+                });
+                run(real.0.clone(), real.1.clone(), false)
+            })
+        },
     );
 
     c.bench_function(
         format!("aggregate {} worst-case rows", partitions * samples).as_str(),
-        |b| b.iter(|| run(asc.0.clone(), asc.1.clone(), true)),
+        |b| {
+            b.iter(|| {
+                let rt = Runtime::new().unwrap();
+                let asc = rt.block_on(async {
+                    create_context(limit, partitions, samples, true, false)
+                        .await
+                        .unwrap()
+                });
+                run(asc.0.clone(), asc.1.clone(), true)
+            })
+        },
     );
 
     c.bench_function(
@@ -141,7 +139,17 @@ fn criterion_benchmark(c: &mut Criterion) {
             partitions * samples
         )
         .as_str(),
-        |b| b.iter(|| run(topk_real.0.clone(), topk_real.1.clone(), false)),
+        |b| {
+            b.iter(|| {
+                let rt = Runtime::new().unwrap();
+                let topk_real = rt.block_on(async {
+                    create_context(limit, partitions, samples, false, true)
+                        .await
+                        .unwrap()
+                });
+                run(topk_real.0.clone(), topk_real.1.clone(), false)
+            })
+        },
     );
 
     c.bench_function(
@@ -150,7 +158,17 @@ fn criterion_benchmark(c: &mut Criterion) {
             partitions * samples
         )
         .as_str(),
-        |b| b.iter(|| run(topk_asc.0.clone(), topk_asc.1.clone(), true)),
+        |b| {
+            b.iter(|| {
+                let rt = Runtime::new().unwrap();
+                let topk_asc = rt.block_on(async {
+                    create_context(limit, partitions, samples, true, true)
+                        .await
+                        .unwrap()
+                });
+                run(topk_asc.0.clone(), topk_asc.1.clone(), true)
+            })
+        },
     );
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15213 .

## Rationale for this change

It is not certain, but it seems that plan creation and `collect()` should share the same runtime.. It is presumed that the issue occurred because RepartitionExec lazily polls within the runtime.
- https://github.com/apache/datafusion/blob/main/datafusion/physical-plan/src/repartition/mod.rs#L165-L177
- https://github.com/apache/datafusion/pull/10009

I will add more details if I find anything additional.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Move the `Runtime::new()` into`bench_function`
- Ensure that plan creation (`ctx.sql()`) and `collect()` share the same runtime.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes. below test are succeded
- `cargo bench -p datafusion --bench topk_aggregate`
- `cargo bench -p datafusion --bench distinct_query_sql`
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
