### PR TITLE
Bigquery col alias

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1034,10 +1034,17 @@ impl Unparser<'_> {
         match expr {
             Expr::Alias(Alias { expr, name, .. }) => {
                 let inner = self.expr_to_sql(expr)?;
-
-                Ok(ast::SelectItem::ExprWithAlias {
+                
+                // Determine the alias name to use
+                let alias_name = if let Some(new_name) = self.dialect.col_alias_overrides(self, name)? {
+                    new_name.to_string()
+                } else {
+                    name.to_string()
+                };
+            
+                return Ok(ast::SelectItem::ExprWithAlias {
                     expr: inner,
-                    alias: self.new_ident_quoted_if_needs(name.to_string()),
+                    alias: self.new_ident_quoted_if_needs(alias_name),
                 })
             }
             _ => {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -32,7 +32,7 @@ use datafusion_functions_window::rank::rank_udwf;
 use datafusion_sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_sql::unparser::dialect::{
     CustomDialectBuilder, DefaultDialect as UnparserDefaultDialect, DefaultDialect,
-    Dialect as UnparserDialect, MySqlDialect as UnparserMySqlDialect, SqliteDialect,
+    Dialect as UnparserDialect, MySqlDialect as UnparserMySqlDialect, SqliteDialect, BigQueryDialect as UnparserBigqueryDialect
 };
 use datafusion_sql::unparser::{expr_to_sql, plan_to_sql, Unparser};
 use sqlparser::ast::Statement;
@@ -54,7 +54,7 @@ use datafusion_sql::unparser::extension_unparser::{
     UnparseToStatementResult, UnparseWithinStatementResult,
     UserDefinedLogicalNodeUnparser,
 };
-use sqlparser::dialect::{Dialect, GenericDialect, MySqlDialect};
+use sqlparser::dialect::{Dialect, GenericDialect, MySqlDialect, PostgreSqlDialect};
 use sqlparser::parser::Parser;
 
 #[test]
@@ -536,6 +536,12 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             parser_dialect: Box::new(GenericDialect {}),
             unparser_dialect: Box::new(SqliteDialect {}),
         },
+        TestStatementWithDialect {
+            sql: "select min(*) as \"min(*)\" from (select 1 as a)",
+            expected: "SELECT min(*) AS `col_1` FROM (SELECT 1 AS `a`)",
+            parser_dialect: Box::new(PostgreSqlDialect {}),
+            unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
+        },  
         TestStatementWithDialect {
             sql: "SELECT * FROM UNNEST([1,2,3])",
             expected: r#"SELECT * FROM (SELECT UNNEST([1, 2, 3]) AS "UNNEST(make_array(Int64(1),Int64(2),Int64(3)))")"#,

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -283,7 +283,7 @@ fn roundtrip_crossjoin() -> Result<()> {
 }
 
 #[test]
-fn roundtrip_statement_with_dialect() -> Result<()> {
+fn roundtrip_statement_with_dialect() -> Result<()> { 
     struct TestStatementWithDialect {
         sql: &'static str,
         expected: &'static str,
@@ -541,7 +541,19 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             expected: "SELECT min(*) AS `col_1` FROM (SELECT 1 AS `a`)",
             parser_dialect: Box::new(PostgreSqlDialect {}),
             unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
-        },  
+        }, 
+        TestStatementWithDialect {
+            sql: "select a as \"a*\", b as \"b@\" from (select 1 as a , 2 as b)",
+            expected: "SELECT `a` AS `col_1`, `b` AS `col_2` FROM (SELECT 1 AS `a`, 2 AS `b`)",
+            parser_dialect: Box::new(PostgreSqlDialect {}),
+            unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
+        },
+        TestStatementWithDialect {
+            sql: "select a as \"a*\", b , c as \"c@\" from (select 1 as a , 2 as b, 3 as c)",
+            expected: "SELECT `a` AS `col_1`, `b`, `c` AS `col_2` FROM (SELECT 1 AS `a`, 2 AS `b`, 3 AS `c`)",
+            parser_dialect: Box::new(PostgreSqlDialect {}),
+            unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
+        },
         TestStatementWithDialect {
             sql: "SELECT * FROM UNNEST([1,2,3])",
             expected: r#"SELECT * FROM (SELECT UNNEST([1, 2, 3]) AS "UNNEST(make_array(Int64(1),Int64(2),Int64(3)))")"#,


### PR DESCRIPTION
## Which issue does this PR close?
https://github.com/Canner/wren-engine/issues/1089

## Rationale for this change
Add an additional unparser rule for every dialect to allow dialects to override column aliases.

## What changes are included in this PR?
Rewrite BigQuery column aliases.

## Are these changes tested?
In datafusion/sql/tests/cases/plan_to_sql.rs using `roundtrip_statement_with_dialect`.