### PR TITLE
Restore lazy evaluation of fallible CASE 

### DIFF
--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -581,6 +581,12 @@ struct Options {
         help = "IGNORED (for compatibility with built-in rust test runner)"
     )]
     ignored: bool,
+
+    #[clap(
+        long,
+        help = "IGNORED (for compatibility with built-in rust test runner)"
+    )]
+    nocapture: bool,
 }
 
 impl Options {

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -467,7 +467,18 @@ FROM t;
 ----
 [{foo: blarg}]
 
+query II
+SELECT v, CASE WHEN v != 0 THEN 10/v ELSE 42 END FROM (VALUES (0), (1), (2)) t(v)
+----
+0 42
+1 10
+2 5
 
+query II
+SELECT v, CASE WHEN v < 0 THEN 10/0 ELSE 1 END FROM (VALUES (1), (2)) t(v)
+----
+1 1
+2 1
 
 statement ok
 drop table t


### PR DESCRIPTION
## Which issue does this PR close?



- Closes https://github.com/apache/datafusion/issues/15384

## Rationale for this change

Commit https://github.com/apache/datafusion/commit/0f4b8b136ceb9132fd6b6595bd6a09a09707f5d9 (https://github.com/apache/datafusion/pull/13953) introduced a new
optimized evaluation mode for CASE expression with exactly one WHEN-THEN
clause and ELSE clause being present. Apparently, the new mode did not
take into account expensive or fallible expressions, as it
unconditionally evaluated both branches. This is definitely incorrect
for fallible expressions. For these, fallback to the original execution
mode.

## What changes are included in this PR?

fix so that CASE is lazy again

## Are these changes tested?

slt

## Are there any user-facing changes?

yes
