### PR TITLE
Draft: Use take-in kernel in repartitioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,12 +246,14 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84ef243634a39fb6e9d1710737e7a5ef96c9bacabd2326859ff889bc9ef755e5"
 dependencies = [
  "arrow-arith",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast 54.2.0",
+ "arrow-cast",
  "arrow-csv",
  "arrow-data",
  "arrow-ipc",
@@ -268,7 +270,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f420c6aef51dad2e4a96ce29c0ec90ad84880bdb60b321c74c652a6be07b93f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -280,7 +284,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24bda5ff6461a4ff9739959b3d57b377f45e3f878f7be1a4f28137c0a8f339fa"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -295,7 +301,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6ed265c73f134a583d02c3cab5e16afab9446d8048ede8707e31f85fad58a0"
 dependencies = [
  "bytes",
  "half",
@@ -304,7 +312,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c648572391edcef10e5fd458db70ba27ed6f71bcaee04397d0cfb100b34f8b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -322,31 +332,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-cast"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac7eba5a987f8b4a7d9629206ba48e19a1991762795bbe5d08497b7736017ee"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "atoi",
- "base64 0.22.1",
- "chrono",
- "half",
- "lexical-core",
- "num",
- "ryu",
-]
-
-[[package]]
 name = "arrow-csv"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a02fb265a6d8011a7d3ad1a36f25816ad0a3bb04cb8e9fe7929c165b98c0cbcd"
 dependencies = [
  "arrow-array",
- "arrow-cast 54.2.0",
+ "arrow-cast",
  "arrow-schema",
  "chrono",
  "csv",
@@ -357,7 +349,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2cebf504bb6a92a134a87fff98f01b14fbb3a93ecf7aef90cd0f888c5fffa4"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -367,12 +361,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecab6e2ed46c553354ffbc6cb76ac3eaa61dc07bd13d7de8ece233933bcf679"
 dependencies = [
  "arrow-arith",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast 54.2.0",
+ "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-ord",
@@ -392,7 +388,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6405b287671c88846e7751f7291f717b164911474cabac6d3d8614d5aa7374"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -404,25 +402,31 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5329bf9e7390cbb6b117ddd4d82e94c5362ea4cab5095697139429f36a38350c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
- "arrow-cast 54.2.0",
+ "arrow-cast",
  "arrow-data",
  "arrow-schema",
  "chrono",
  "half",
  "indexmap 2.7.1",
  "lexical-core",
+ "memchr",
  "num",
  "serde",
  "serde_json",
+ "simdutf8",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e103c13d4b80da28339c1d7aa23dd85bd59f42158acc45d39eeb6770627909ce"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -433,7 +437,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170549a11b8534f3097a0619cfe89c42812345dc998bcf81128fc700b84345b8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -444,14 +450,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5c53775bba63f319189f366d2b86e9a8889373eb198f07d8544938fc9f8ed9a"
 dependencies = [
  "bitflags 2.8.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a99003b2eb562b8d9c99dfb672306f15e94b20d3734179d596895703e821dcf"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -463,7 +473,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "54.2.0"
+version = "54.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fdb130ee8325f4cd8262e19bb6baa3cbcef2b2573c4bee8c6fda7ea08199d7"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1261,9 +1273,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1271,7 +1283,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -4040,7 +4052,7 @@ dependencies = [
  "ahash 0.8.11",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast 54.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
@@ -6785,6 +6797,12 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
- "arrow-select 54.2.0",
+ "arrow-select",
  "arrow-string",
  "half",
  "pyo3",
@@ -310,7 +310,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "arrow-select 54.2.0",
+ "arrow-select",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -331,7 +331,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "arrow-select 54.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-select",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -378,7 +378,7 @@ dependencies = [
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
- "arrow-select 54.2.0",
+ "arrow-select",
  "arrow-string",
  "base64 0.22.1",
  "bytes",
@@ -428,7 +428,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "arrow-select 54.2.0",
+ "arrow-select",
 ]
 
 [[package]]
@@ -462,20 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-select"
-version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac265273864a820c4a179fc67182ccc41ea9151b97024e1be956f0f2369c2539"
-dependencies = [
- "ahash 0.8.11",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num",
-]
-
-[[package]]
 name = "arrow-string"
 version = "54.2.0"
 dependencies = [
@@ -483,7 +469,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "arrow-select 54.2.0",
+ "arrow-select",
  "memchr",
  "num",
  "regex",
@@ -4058,7 +4044,7 @@ dependencies = [
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
- "arrow-select 54.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-select",
  "base64 0.22.1",
  "brotli",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,14 +246,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6422e12ac345a0678d7a17e316238e3a40547ae7f92052b77bd86d5e0239f3fc"
+version = "54.2.0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
+ "arrow-cast 54.2.0",
  "arrow-csv",
  "arrow-data",
  "arrow-ipc",
@@ -261,7 +259,7 @@ dependencies = [
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
- "arrow-select",
+ "arrow-select 54.2.0",
  "arrow-string",
  "half",
  "pyo3",
@@ -270,9 +268,7 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cf34bb1f48c41d3475927bcc7be498665b8e80b379b88f62a840337f8b8248"
+version = "54.2.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -285,8 +281,6 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a4a6d2896083cfbdf84a71a863b22460d0708f8206a8373c52e326cc72ea1a"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -302,8 +296,6 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef870583ce5e4f3b123c181706f2002fb134960f9a911900f64ba4830c7a43a"
 dependencies = [
  "bytes",
  "half",
@@ -312,15 +304,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626e65bd42636a84a238bed49d09c8777e3d825bf81f5087a70111c2831d9870"
+version = "54.2.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "arrow-select",
+ "arrow-select 54.2.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -332,13 +322,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-csv"
-version = "54.1.0"
+name = "arrow-cast"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c8f959f7a1389b1dbd883cdcd37c3ed12475329c111912f7f69dad8195d8c6"
+checksum = "1ac7eba5a987f8b4a7d9629206ba48e19a1991762795bbe5d08497b7736017ee"
 dependencies = [
  "arrow-array",
- "arrow-cast",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select 54.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "54.2.0"
+dependencies = [
+ "arrow-array",
+ "arrow-cast 54.2.0",
  "arrow-schema",
  "chrono",
  "csv",
@@ -350,8 +358,6 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b095e8a4f3c309544935d53e04c3bfe4eea4e71c3de6fe0416d1f08bb4441a83"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -361,20 +367,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b3aaba47ed4b6146563c8b79ad0f7aa283f794cde0c057c656291b81196746"
+version = "54.2.0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
+ "arrow-cast 54.2.0",
  "arrow-data",
  "arrow-ipc",
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
- "arrow-select",
+ "arrow-select 54.2.0",
  "arrow-string",
  "base64 0.22.1",
  "bytes",
@@ -389,8 +393,6 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c63da4afedde2b25ef69825cd4663ca76f78f79ffe2d057695742099130ff6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -402,13 +404,11 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35de94f165ed8830aede72c35f238763794f0d49c69d30c44d49c9834267ff8c"
+version = "54.2.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
+ "arrow-cast 54.2.0",
  "arrow-data",
  "arrow-schema",
  "chrono",
@@ -422,22 +422,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa06e5f267dc53efbacb933485c79b6fc1685d3ffbe870a16ce4e696fb429da"
+version = "54.2.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "arrow-select",
+ "arrow-select 54.2.0",
 ]
 
 [[package]]
 name = "arrow-row"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f1144bb456a2f9d82677bd3abcea019217e572fc8f07de5a7bac4b2c56eb2c"
+version = "54.2.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -449,17 +445,27 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "54.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f40f6be8f78af1ab610db7d9b236e21d587b7168e368a36275d2e5670096735"
 dependencies = [
  "bitflags 2.8.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "54.1.0"
+version = "54.2.0"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f690752fdbd2dee278b5f1636fefad8f2f7134c85e20fd59c4199e15a39a6807"
+checksum = "ac265273864a820c4a179fc67182ccc41ea9151b97024e1be956f0f2369c2539"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -471,15 +477,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fff9cd745a7039b66c47ecaf5954460f9fa12eed628f65170117ea93e64ee0"
+version = "54.2.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "arrow-select",
+ "arrow-select 54.2.0",
  "memchr",
  "num",
  "regex",
@@ -2573,7 +2577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3470,7 +3474,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4050,11 +4054,11 @@ dependencies = [
  "ahash 0.8.11",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
+ "arrow-cast 54.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
- "arrow-select",
+ "arrow-select 54.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.22.1",
  "brotli",
  "bytes",
@@ -4639,7 +4643,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5061,7 +5065,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5624,7 +5628,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5859,7 +5863,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6734,7 +6738,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,14 +190,3 @@ large_futures = "warn"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
 unused_qualifications = "deny"
-
-[patch.crates-io]
-arrow = { path = "../arrow-rs/arrow" }
-arrow-array = { path = "../arrow-rs/arrow-array" }
-arrow-buffer = { path = "../arrow-rs/arrow-buffer" }
-arrow-data = { path = "../arrow-rs/arrow-data" }
-arrow-flight = { path = "../arrow-rs/arrow-flight" }
-arrow-ipc = { path = "../arrow-rs/arrow-ipc" }
-arrow-ord = { path = "../arrow-rs/arrow-ord" }
-arrow-schema = { path = "../arrow-rs/arrow-schema" }
-arrow-select = { path = "../arrow-rs/arrow-select" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,3 +190,13 @@ large_futures = "warn"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
 unused_qualifications = "deny"
+
+[patch.crates-io]
+arrow = { path = "../arrow-rs/arrow" }
+arrow-array = { path = "../arrow-rs/arrow-array" }
+arrow-buffer = { path = "../arrow-rs/arrow-buffer" }
+arrow-data = { path = "../arrow-rs/arrow-data" }
+arrow-flight = { path = "../arrow-rs/arrow-flight" }
+arrow-ipc = { path = "../arrow-rs/arrow-ipc" }
+arrow-ord = { path = "../arrow-rs/arrow-ord" }
+arrow-schema = { path = "../arrow-rs/arrow-schema" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,3 +200,4 @@ arrow-flight = { path = "../arrow-rs/arrow-flight" }
 arrow-ipc = { path = "../arrow-rs/arrow-ipc" }
 arrow-ord = { path = "../arrow-rs/arrow-ord" }
 arrow-schema = { path = "../arrow-rs/arrow-schema" }
+arrow-select = { path = "../arrow-rs/arrow-select" }

--- a/datafusion/physical-optimizer/src/coalesce_batches.rs
+++ b/datafusion/physical-optimizer/src/coalesce_batches.rs
@@ -63,15 +63,7 @@ impl PhysicalOptimizerRule for CoalesceBatches {
             let wrap_in_coalesce = plan_any.downcast_ref::<FilterExec>().is_some()
                 || plan_any.downcast_ref::<HashJoinExec>().is_some()
                 // Don't need to add CoalesceBatchesExec after a round robin RepartitionExec
-                || plan_any
-                    .downcast_ref::<RepartitionExec>()
-                    .map(|repart_exec| {
-                        !matches!(
-                            repart_exec.partitioning().clone(),
-                            Partitioning::RoundRobinBatch(_)
-                        )
-                    })
-                    .unwrap_or(false);
+;
             if wrap_in_coalesce {
                 Ok(Transformed::yes(Arc::new(CoalesceBatchesExec::new(
                     plan,


### PR DESCRIPTION
Combined with https://github.com/apache/arrow-rs/pull/7325, tries to use the take_in kernel in repartitioning. The goal is to elide the coalesce step after repartitioning.