### PR TITLE
refactor!: consistent null handling in coercible signatures

### DIFF
--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -263,10 +263,6 @@ impl TypeSignatureClass {
         self: &TypeSignatureClass,
         logical_type: &NativeType,
     ) -> bool {
-        if logical_type == &NativeType::Null {
-            return true;
-        }
-
         match self {
             TypeSignatureClass::Native(t) if t.native() == logical_type => true,
             TypeSignatureClass::Timestamp if logical_type.is_timestamp() => true,

--- a/datafusion/functions-nested/src/string.rs
+++ b/datafusion/functions-nested/src/string.rs
@@ -43,7 +43,7 @@ use arrow::datatypes::DataType::{
 };
 use datafusion_common::cast::{as_large_list_array, as_list_array};
 use datafusion_common::exec_err;
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_expr::{
     Coercion, ColumnarValue, Documentation, ScalarUDFImpl, Signature, TypeSignature,
     TypeSignatureClass, Volatility,
@@ -255,11 +255,19 @@ impl StringToArray {
                 vec![
                     TypeSignature::Coercible(vec![
                         Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
                     ]),
                     TypeSignature::Coercible(vec![
                         Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
                         Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
                     ]),
                 ],

--- a/datafusion/functions/src/crypto/digest.rs
+++ b/datafusion/functions/src/crypto/digest.rs
@@ -19,7 +19,7 @@
 use super::basic::{digest, utf8_or_binary_to_binary_type};
 use arrow::datatypes::DataType;
 use datafusion_common::{
-    types::{logical_binary, logical_string},
+    types::{logical_binary, logical_null, logical_string, NativeType},
     Result,
 };
 use datafusion_expr::{
@@ -72,12 +72,28 @@ impl DigestFunc {
             signature: Signature::one_of(
                 vec![
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
                     ]),
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_binary())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_binary()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::Binary,
+                        ),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
                     ]),
                 ],
                 Volatility::Immutable,

--- a/datafusion/functions/src/crypto/md5.rs
+++ b/datafusion/functions/src/crypto/md5.rs
@@ -20,7 +20,7 @@ use crate::crypto::basic::md5;
 use arrow::datatypes::DataType;
 use datafusion_common::{
     plan_err,
-    types::{logical_binary, logical_string, NativeType},
+    types::{logical_binary, logical_null, logical_string, NativeType},
     Result,
 };
 use datafusion_expr::{
@@ -62,12 +62,18 @@ impl Md5Func {
                 vec![
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_string())],
+                        vec![
+                            TypeSignatureClass::Native(logical_string()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::String,
                     )]),
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_binary())],
+                        vec![
+                            TypeSignatureClass::Native(logical_binary()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::Binary,
                     )]),
                 ],

--- a/datafusion/functions/src/crypto/sha224.rs
+++ b/datafusion/functions/src/crypto/sha224.rs
@@ -19,7 +19,7 @@
 use super::basic::{sha224, utf8_or_binary_to_binary_type};
 use arrow::datatypes::DataType;
 use datafusion_common::{
-    types::{logical_binary, logical_string, NativeType},
+    types::{logical_binary, logical_null, logical_string, NativeType},
     Result,
 };
 use datafusion_expr::{
@@ -62,12 +62,18 @@ impl SHA224Func {
                 vec![
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_string())],
+                        vec![
+                            TypeSignatureClass::Native(logical_string()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::String,
                     )]),
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_binary())],
+                        vec![
+                            TypeSignatureClass::Native(logical_binary()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::Binary,
                     )]),
                 ],

--- a/datafusion/functions/src/crypto/sha256.rs
+++ b/datafusion/functions/src/crypto/sha256.rs
@@ -19,7 +19,7 @@
 use super::basic::{sha256, utf8_or_binary_to_binary_type};
 use arrow::datatypes::DataType;
 use datafusion_common::{
-    types::{logical_binary, logical_string, NativeType},
+    types::{logical_binary, logical_null, logical_string, NativeType},
     Result,
 };
 use datafusion_expr::{
@@ -61,12 +61,18 @@ impl SHA256Func {
                 vec![
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_string())],
+                        vec![
+                            TypeSignatureClass::Native(logical_string()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::String,
                     )]),
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_binary())],
+                        vec![
+                            TypeSignatureClass::Native(logical_binary()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::Binary,
                     )]),
                 ],

--- a/datafusion/functions/src/crypto/sha384.rs
+++ b/datafusion/functions/src/crypto/sha384.rs
@@ -19,7 +19,7 @@
 use super::basic::{sha384, utf8_or_binary_to_binary_type};
 use arrow::datatypes::DataType;
 use datafusion_common::{
-    types::{logical_binary, logical_string, NativeType},
+    types::{logical_binary, logical_null, logical_string, NativeType},
     Result,
 };
 use datafusion_expr::{
@@ -61,12 +61,18 @@ impl SHA384Func {
                 vec![
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_string())],
+                        vec![
+                            TypeSignatureClass::Native(logical_string()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::String,
                     )]),
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_binary())],
+                        vec![
+                            TypeSignatureClass::Native(logical_binary()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::Binary,
                     )]),
                 ],

--- a/datafusion/functions/src/crypto/sha512.rs
+++ b/datafusion/functions/src/crypto/sha512.rs
@@ -19,7 +19,7 @@
 use super::basic::{sha512, utf8_or_binary_to_binary_type};
 use arrow::datatypes::DataType;
 use datafusion_common::{
-    types::{logical_binary, logical_string, NativeType},
+    types::{logical_binary, logical_null, logical_string, NativeType},
     Result,
 };
 use datafusion_expr::{
@@ -61,12 +61,18 @@ impl SHA512Func {
                 vec![
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_string())],
+                        vec![
+                            TypeSignatureClass::Native(logical_string()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::String,
                     )]),
                     TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_binary()),
-                        vec![TypeSignatureClass::Native(logical_binary())],
+                        vec![
+                            TypeSignatureClass::Native(logical_binary()),
+                            TypeSignatureClass::Native(logical_null()),
+                        ],
                         NativeType::Binary,
                     )]),
                 ],

--- a/datafusion/functions/src/regex/regexplike.rs
+++ b/datafusion/functions/src/regex/regexplike.rs
@@ -21,7 +21,7 @@ use arrow::array::{Array, ArrayRef, AsArray, GenericStringArray};
 use arrow::compute::kernels::regexp;
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::{LargeUtf8, Utf8, Utf8View};
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{
     arrow_datafusion_err, exec_err, internal_err, plan_err, DataFusionError, Result,
     ScalarValue,
@@ -84,12 +84,28 @@ impl RegexpLikeFunc {
             signature: Signature::one_of(
                 vec![
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
                     ]),
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
                         Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
                     ]),
                 ],

--- a/datafusion/functions/src/string/ascii.rs
+++ b/datafusion/functions/src/string/ascii.rs
@@ -19,7 +19,7 @@ use crate::utils::make_scalar_function;
 use arrow::array::{ArrayAccessor, ArrayIter, ArrayRef, AsArray, Int32Array};
 use arrow::datatypes::DataType;
 use arrow::error::ArrowError;
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{internal_err, Result};
 use datafusion_expr::{ColumnarValue, Documentation, TypeSignatureClass};
 use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
@@ -64,9 +64,11 @@ impl AsciiFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact(TypeSignatureClass::Native(
-                    logical_string(),
-                ))],
+                vec![Coercion::new_implicit(
+                    TypeSignatureClass::Native(logical_string()),
+                    vec![TypeSignatureClass::Native(logical_null())],
+                    NativeType::String,
+                )],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/string/bit_length.rs
+++ b/datafusion/functions/src/string/bit_length.rs
@@ -20,7 +20,7 @@ use arrow::datatypes::DataType;
 use std::any::Any;
 
 use crate::utils::utf8_to_int_type;
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::{
@@ -60,9 +60,11 @@ impl BitLengthFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact(TypeSignatureClass::Native(
-                    logical_string(),
-                ))],
+                vec![Coercion::new_implicit(
+                    TypeSignatureClass::Native(logical_string()),
+                    vec![TypeSignatureClass::Native(logical_null())],
+                    NativeType::String,
+                )],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/string/btrim.rs
+++ b/datafusion/functions/src/string/btrim.rs
@@ -19,7 +19,7 @@ use crate::string::common::*;
 use crate::utils::{make_scalar_function, utf8_to_str_type};
 use arrow::array::{ArrayRef, OffsetSizeTrait};
 use arrow::datatypes::DataType;
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{exec_err, Result};
 use datafusion_expr::function::Hint;
 use datafusion_expr::{
@@ -83,11 +83,21 @@ impl BTrimFunc {
             signature: Signature::one_of(
                 vec![
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
                     ]),
-                    TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
                     )]),
                 ],
                 Volatility::Immutable,

--- a/datafusion/functions/src/string/contains.rs
+++ b/datafusion/functions/src/string/contains.rs
@@ -20,7 +20,7 @@ use arrow::array::{Array, ArrayRef, AsArray};
 use arrow::compute::contains as arrow_contains;
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::{Boolean, LargeUtf8, Utf8, Utf8View};
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{exec_err, DataFusionError, Result};
 use datafusion_expr::binary::{binary_to_string_coercion, string_coercion};
 use datafusion_expr::{
@@ -63,7 +63,11 @@ impl ContainsFunc {
             signature: Signature::coercible(
                 vec![
                     Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
                 ],
                 Volatility::Immutable,
             ),

--- a/datafusion/functions/src/string/ends_with.rs
+++ b/datafusion/functions/src/string/ends_with.rs
@@ -22,7 +22,7 @@ use arrow::array::ArrayRef;
 use arrow::datatypes::DataType;
 
 use crate::utils::make_scalar_function;
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{internal_err, Result};
 use datafusion_expr::binary::{binary_to_string_coercion, string_coercion};
 use datafusion_expr::{
@@ -68,8 +68,16 @@ impl EndsWithFunc {
         Self {
             signature: Signature::coercible(
                 vec![
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
                 ],
                 Volatility::Immutable,
             ),

--- a/datafusion/functions/src/string/levenshtein.rs
+++ b/datafusion/functions/src/string/levenshtein.rs
@@ -23,7 +23,7 @@ use arrow::datatypes::DataType;
 
 use crate::utils::{make_scalar_function, utf8_to_int_type};
 use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::utils::datafusion_strsim;
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{exec_err, Result};
@@ -73,8 +73,16 @@ impl LevenshteinFunc {
         Self {
             signature: Signature::coercible(
                 vec![
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
                 ],
                 Volatility::Immutable,
             ),

--- a/datafusion/functions/src/string/lower.rs
+++ b/datafusion/functions/src/string/lower.rs
@@ -20,7 +20,7 @@ use std::any::Any;
 
 use crate::string::common::to_lower;
 use crate::utils::utf8_to_str_type;
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::Result;
 use datafusion_expr::{
     Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
@@ -59,9 +59,11 @@ impl LowerFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact(TypeSignatureClass::Native(
-                    logical_string(),
-                ))],
+                vec![Coercion::new_implicit(
+                    TypeSignatureClass::Native(logical_string()),
+                    vec![TypeSignatureClass::Native(logical_null())],
+                    NativeType::String,
+                )],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/string/ltrim.rs
+++ b/datafusion/functions/src/string/ltrim.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use crate::string::common::*;
 use crate::utils::{make_scalar_function, utf8_to_str_type};
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{exec_err, Result};
 use datafusion_expr::function::Hint;
 use datafusion_expr::{
@@ -88,11 +88,21 @@ impl LtrimFunc {
             signature: Signature::one_of(
                 vec![
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
                     ]),
-                    TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
                     )]),
                 ],
                 Volatility::Immutable,

--- a/datafusion/functions/src/string/octet_length.rs
+++ b/datafusion/functions/src/string/octet_length.rs
@@ -20,7 +20,7 @@ use arrow::datatypes::DataType;
 use std::any::Any;
 
 use crate::utils::utf8_to_int_type;
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::{
@@ -60,9 +60,11 @@ impl OctetLengthFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact(TypeSignatureClass::Native(
-                    logical_string(),
-                ))],
+                vec![Coercion::new_implicit(
+                    TypeSignatureClass::Native(logical_string()),
+                    vec![TypeSignatureClass::Native(logical_null())],
+                    NativeType::String,
+                )],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/string/repeat.rs
+++ b/datafusion/functions/src/string/repeat.rs
@@ -26,7 +26,7 @@ use arrow::array::{
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::{LargeUtf8, Utf8, Utf8View};
 use datafusion_common::cast::as_int64_array;
-use datafusion_common::types::{logical_int64, logical_string, NativeType};
+use datafusion_common::types::{logical_int64, logical_null, logical_string, NativeType};
 use datafusion_common::{exec_err, DataFusionError, Result};
 use datafusion_expr::{ColumnarValue, Documentation, Volatility};
 use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature};
@@ -67,7 +67,11 @@ impl RepeatFunc {
         Self {
             signature: Signature::coercible(
                 vec![
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
                     // Accept all integer types but cast them to i64
                     Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_int64()),

--- a/datafusion/functions/src/string/replace.rs
+++ b/datafusion/functions/src/string/replace.rs
@@ -23,7 +23,7 @@ use arrow::datatypes::DataType;
 
 use crate::utils::{make_scalar_function, utf8_to_str_type};
 use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{exec_err, Result};
 use datafusion_expr::type_coercion::binary::{
     binary_to_string_coercion, string_coercion,
@@ -68,9 +68,21 @@ impl ReplaceFunc {
         Self {
             signature: Signature::coercible(
                 vec![
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
                 ],
                 Volatility::Immutable,
             ),

--- a/datafusion/functions/src/string/rtrim.rs
+++ b/datafusion/functions/src/string/rtrim.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use crate::string::common::*;
 use crate::utils::{make_scalar_function, utf8_to_str_type};
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{exec_err, Result};
 use datafusion_expr::function::Hint;
 use datafusion_expr::{
@@ -88,11 +88,21 @@ impl RtrimFunc {
             signature: Signature::one_of(
                 vec![
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
+                        Coercion::new_implicit(
+                            TypeSignatureClass::Native(logical_string()),
+                            vec![TypeSignatureClass::Native(logical_null())],
+                            NativeType::String,
+                        ),
                     ]),
-                    TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignature::Coercible(vec![Coercion::new_implicit(
                         TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
                     )]),
                 ],
                 Volatility::Immutable,

--- a/datafusion/functions/src/string/starts_with.rs
+++ b/datafusion/functions/src/string/starts_with.rs
@@ -26,7 +26,7 @@ use datafusion_expr::type_coercion::binary::{
 };
 
 use crate::utils::make_scalar_function;
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{internal_err, Result, ScalarValue};
 use datafusion_expr::{
     cast, Coercion, ColumnarValue, Documentation, Expr, Like, ScalarFunctionArgs,
@@ -90,8 +90,16 @@ impl StartsWithFunc {
         Self {
             signature: Signature::coercible(
                 vec![
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
                 ],
                 Volatility::Immutable,
             ),

--- a/datafusion/functions/src/string/upper.rs
+++ b/datafusion/functions/src/string/upper.rs
@@ -18,7 +18,7 @@
 use crate::string::common::to_upper;
 use crate::utils::utf8_to_str_type;
 use arrow::datatypes::DataType;
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::Result;
 use datafusion_expr::{
     Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
@@ -58,9 +58,11 @@ impl UpperFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact(TypeSignatureClass::Native(
-                    logical_string(),
-                ))],
+                vec![Coercion::new_implicit(
+                    TypeSignatureClass::Native(logical_string()),
+                    vec![TypeSignatureClass::Native(logical_null())],
+                    NativeType::String,
+                )],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::DataType;
 
 use crate::utils::{make_scalar_function, utf8_to_str_type};
 use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{exec_err, Result};
 use datafusion_expr::{
     Coercion, ColumnarValue, Documentation, ScalarUDFImpl, Signature, TypeSignatureClass,
@@ -65,9 +65,11 @@ impl InitcapFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact(TypeSignatureClass::Native(
-                    logical_string(),
-                ))],
+                vec![Coercion::new_implicit(
+                    TypeSignatureClass::Native(logical_string()),
+                    vec![TypeSignatureClass::Native(logical_null())],
+                    NativeType::String,
+                )],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/unicode/strpos.rs
+++ b/datafusion/functions/src/unicode/strpos.rs
@@ -23,7 +23,7 @@ use arrow::array::{
     ArrayRef, ArrowPrimitiveType, AsArray, PrimitiveArray, StringArrayType,
 };
 use arrow::datatypes::{ArrowNativeType, DataType, Int32Type, Int64Type};
-use datafusion_common::types::logical_string;
+use datafusion_common::types::{logical_null, logical_string, NativeType};
 use datafusion_common::{exec_err, internal_err, Result};
 use datafusion_expr::{
     Coercion, ColumnarValue, Documentation, ScalarUDFImpl, Signature, TypeSignatureClass,
@@ -64,8 +64,16 @@ impl StrposFunc {
         Self {
             signature: Signature::coercible(
                 vec![
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
+                    Coercion::new_implicit(
+                        TypeSignatureClass::Native(logical_string()),
+                        vec![TypeSignatureClass::Native(logical_null())],
+                        NativeType::String,
+                    ),
                 ],
                 Volatility::Immutable,
             ),

--- a/datafusion/sqllogictest/test_files/information_schema.slt
+++ b/datafusion/sqllogictest/test_files/information_schema.slt
@@ -736,8 +736,11 @@ select specific_name, data_type, ordinal_position, parameter_mode, rid from info
 repeat Int64 2 IN 0
 repeat Int64 2 IN 1
 repeat Int64 2 IN 2
+repeat Int64 2 IN 3
 repeat LargeUtf8 1 IN 1
 repeat LargeUtf8 1 OUT 1
+repeat Null 1 IN 3
+repeat Null 1 OUT 3
 repeat Utf8 1 IN 0
 repeat Utf8 1 OUT 0
 repeat Utf8 1 OUT 2

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -41,6 +41,7 @@ If your function uses a coercible signature ([`Signature::Coercible`]) and shoul
 Before:
 
 ```rust
+# /* comment out so they don't run
 pub fn new() -> Self {
     Self {
         signature: Signature::coercible(
@@ -51,11 +52,13 @@ pub fn new() -> Self {
         ),
     }
 }
+# */
 ```
 
 After:
 
 ```rust
+# /* comment out so they don't run
 use datafusion_common::types::{logical_null, NativeType};
 
 pub fn new() -> Self {
@@ -70,6 +73,7 @@ pub fn new() -> Self {
         ),
     }
 }
+# */
 ```
 
 ---
@@ -93,11 +97,11 @@ TypeSignature::Coercible(vec![Coercion::new_implicit(
 
 You can view [PR #15404] for more examples and implementation details.
 
-[`TypeSignatureClass`]: https://docs.rs/datafusion-expr/latest/datafusion_expr/enum.TypeSignatureClass.html
-[`NativeType::Null`]: https://docs.rs/datafusion-common/latest/datafusion_common/types/enum.NativeType.html#variant.Null
-[`Signature::Coercible`]: https://docs.rs/datafusion-expr/latest/datafusion_expr/enum.TypeSignature.html#variant.Coercible
-[`Coercion::Implicit`]: https://docs.rs/datafusion-expr/latest/datafusion_expr/enum.Coercion.html#variant.Implicit
-[`PR #15404`]: https://github.com/apache/datafusion/pull/15404
+[`typesignatureclass`]: https://docs.rs/datafusion-expr/latest/datafusion_expr/enum.TypeSignatureClass.html
+[`nativetype::null`]: https://docs.rs/datafusion-common/latest/datafusion_common/types/enum.NativeType.html#variant.Null
+[`signature::coercible`]: https://docs.rs/datafusion-expr/latest/datafusion_expr/enum.TypeSignature.html#variant.Coercible
+[`coercion::implicit`]: https://docs.rs/datafusion-expr/latest/datafusion_expr/enum.Coercion.html#variant.Implicit
+[`pr #15404`]: https://github.com/apache/datafusion/pull/15404
 
 ## DataFusion `46.0.0`
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15013.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Currently, there is a special case for null handling in `TypeSignatureClass::matches_native_type`, which causes inconsistencies and issues between `TypeSignatureClass::matches_native_type` and `TypeSignatureClass::default_casted_type` (it will hit the else match arm which returns an error)  when `self` is not a `TypeSignatureClass::Native`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Remove the special handling of null case in `TypeSignatureClass::matches_native_type`
2. Add `TypeSignatureClass::Native(logical_null())` where the argument is nullable and it was not originally supplied.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
These changes should be covered in existing test.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes, if the user rely on the special null case handling behavior of 'TypeSignatureClass::Native`, they will need to transform the usage to `Coercible::new_implicit` and add a `TypeSignatureClass::Native(logical_null())`.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->