### PR TITLE
Add `downcast_to_source` method for `DataSourceExec`

### DIFF
--- a/datafusion-examples/examples/parquet_exec_visitor.rs
+++ b/datafusion-examples/examples/parquet_exec_visitor.rs
@@ -98,24 +98,16 @@ impl ExecutionPlanVisitor for ParquetExecVisitor {
     fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
         // If needed match on a specific `ExecutionPlan` node type
         if let Some(data_source_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
-            let data_source = data_source_exec.data_source();
-            if let Some(file_config) =
-                data_source.as_any().downcast_ref::<FileScanConfig>()
+            if let Some((file_config, _)) =
+                data_source_exec.downcast_to_source::<ParquetSource>()
             {
-                if file_config
-                    .file_source()
-                    .as_any()
-                    .downcast_ref::<ParquetSource>()
-                    .is_some()
-                {
-                    self.file_groups = Some(file_config.file_groups.clone());
+                self.file_groups = Some(file_config.file_groups.clone());
 
-                    let metrics = match data_source_exec.metrics() {
-                        None => return Ok(true),
-                        Some(metrics) => metrics,
-                    };
-                    self.bytes_scanned = metrics.sum_by_name("bytes_scanned");
-                }
+                let metrics = match data_source_exec.metrics() {
+                    None => return Ok(true),
+                    Some(metrics) => metrics,
+                };
+                self.bytes_scanned = metrics.sum_by_name("bytes_scanned");
             }
         }
         Ok(true)

--- a/datafusion-examples/examples/parquet_exec_visitor.rs
+++ b/datafusion-examples/examples/parquet_exec_visitor.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::ListingOptions;
-use datafusion::datasource::physical_plan::{FileGroup, FileScanConfig, ParquetSource};
+use datafusion::datasource::physical_plan::{FileGroup, ParquetSource};
 use datafusion::datasource::source::DataSourceExec;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionContext;

--- a/datafusion-examples/examples/parquet_exec_visitor.rs
+++ b/datafusion-examples/examples/parquet_exec_visitor.rs
@@ -99,7 +99,7 @@ impl ExecutionPlanVisitor for ParquetExecVisitor {
         // If needed match on a specific `ExecutionPlan` node type
         if let Some(data_source_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
             if let Some((file_config, _)) =
-                data_source_exec.downcast_to_source::<ParquetSource>()
+                data_source_exec.downcast_to_file_source::<ParquetSource>()
             {
                 self.file_groups = Some(file_config.file_groups.clone());
 

--- a/datafusion/core/src/test_util/parquet.rs
+++ b/datafusion/core/src/test_util/parquet.rs
@@ -201,18 +201,11 @@ impl TestParquetFile {
     /// on the first one it finds
     pub fn parquet_metrics(plan: &Arc<dyn ExecutionPlan>) -> Option<MetricsSet> {
         if let Some(data_source_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
-            let data_source = data_source_exec.data_source();
-            if let Some(maybe_parquet) =
-                data_source.as_any().downcast_ref::<FileScanConfig>()
+            if data_source_exec
+                .downcast_to_source::<ParquetSource>()
+                .is_some()
             {
-                if maybe_parquet
-                    .file_source()
-                    .as_any()
-                    .downcast_ref::<ParquetSource>()
-                    .is_some()
-                {
-                    return data_source_exec.metrics();
-                }
+                return data_source_exec.metrics();
             }
         }
 

--- a/datafusion/core/src/test_util/parquet.rs
+++ b/datafusion/core/src/test_util/parquet.rs
@@ -202,7 +202,7 @@ impl TestParquetFile {
     pub fn parquet_metrics(plan: &Arc<dyn ExecutionPlan>) -> Option<MetricsSet> {
         if let Some(data_source_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
             if data_source_exec
-                .downcast_to_source::<ParquetSource>()
+                .downcast_to_file_source::<ParquetSource>()
                 .is_some()
             {
                 return data_source_exec.metrics();

--- a/datafusion/core/tests/parquet/utils.rs
+++ b/datafusion/core/tests/parquet/utils.rs
@@ -17,7 +17,7 @@
 
 //! Utilities for parquet tests
 
-use datafusion::datasource::physical_plan::{FileScanConfig, ParquetSource};
+use datafusion::datasource::physical_plan::ParquetSource;
 use datafusion::datasource::source::DataSourceExec;
 use datafusion_physical_plan::metrics::MetricsSet;
 use datafusion_physical_plan::{accept, ExecutionPlan, ExecutionPlanVisitor};
@@ -48,18 +48,11 @@ impl ExecutionPlanVisitor for MetricsFinder {
     type Error = std::convert::Infallible;
     fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
         if let Some(data_source_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
-            let data_source = data_source_exec.data_source();
-            if let Some(file_config) =
-                data_source.as_any().downcast_ref::<FileScanConfig>()
+            if data_source_exec
+                .downcast_to_source::<ParquetSource>()
+                .is_some()
             {
-                if file_config
-                    .file_source()
-                    .as_any()
-                    .downcast_ref::<ParquetSource>()
-                    .is_some()
-                {
-                    self.metrics = data_source_exec.metrics();
-                }
+                self.metrics = data_source_exec.metrics();
             }
         }
         // stop searching once we have found the metrics

--- a/datafusion/core/tests/parquet/utils.rs
+++ b/datafusion/core/tests/parquet/utils.rs
@@ -49,7 +49,7 @@ impl ExecutionPlanVisitor for MetricsFinder {
     fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
         if let Some(data_source_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
             if data_source_exec
-                .downcast_to_source::<ParquetSource>()
+                .downcast_to_file_source::<ParquetSource>()
                 .is_some()
             {
                 self.metrics = data_source_exec.metrics();

--- a/datafusion/core/tests/sql/path_partition.rs
+++ b/datafusion/core/tests/sql/path_partition.rs
@@ -88,7 +88,7 @@ async fn parquet_partition_pruning_filter() -> Result<()> {
     let exec = table.scan(&ctx.state(), None, &filters, None).await?;
     let data_source_exec = exec.as_any().downcast_ref::<DataSourceExec>().unwrap();
     if let Some((_, parquet_config)) =
-        data_source_exec.downcast_to_source::<ParquetSource>()
+        data_source_exec.downcast_to_file_source::<ParquetSource>()
     {
         let pred = parquet_config.predicate().unwrap();
         // Only the last filter should be pushdown to TableScan

--- a/datafusion/core/tests/sql/path_partition.rs
+++ b/datafusion/core/tests/sql/path_partition.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::DataType;
 use datafusion::datasource::listing::ListingTableUrl;
-use datafusion::datasource::physical_plan::{FileScanConfig, ParquetSource};
+use datafusion::datasource::physical_plan::ParquetSource;
 use datafusion::datasource::source::DataSourceExec;
 use datafusion::{
     datasource::{
@@ -87,29 +87,22 @@ async fn parquet_partition_pruning_filter() -> Result<()> {
     ];
     let exec = table.scan(&ctx.state(), None, &filters, None).await?;
     let data_source_exec = exec.as_any().downcast_ref::<DataSourceExec>().unwrap();
-    let data_source = data_source_exec.data_source();
-    let file_source = data_source
-        .as_any()
-        .downcast_ref::<FileScanConfig>()
-        .unwrap();
-    let parquet_config = file_source
-        .file_source()
-        .as_any()
-        .downcast_ref::<ParquetSource>()
-        .unwrap();
-    let pred = parquet_config.predicate().unwrap();
-    // Only the last filter should be pushdown to TableScan
-    let expected = Arc::new(BinaryExpr::new(
-        Arc::new(Column::new_with_schema("id", &exec.schema()).unwrap()),
-        Operator::Gt,
-        Arc::new(Literal::new(ScalarValue::Int32(Some(1)))),
-    ));
+    if let Some((_, parquet_config)) =
+        data_source_exec.downcast_to_source::<ParquetSource>()
+    {
+        let pred = parquet_config.predicate().unwrap();
+        // Only the last filter should be pushdown to TableScan
+        let expected = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new_with_schema("id", &exec.schema()).unwrap()),
+            Operator::Gt,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(1)))),
+        ));
 
-    assert!(pred.as_any().is::<BinaryExpr>());
-    let pred = pred.as_any().downcast_ref::<BinaryExpr>().unwrap();
+        assert!(pred.as_any().is::<BinaryExpr>());
+        let pred = pred.as_any().downcast_ref::<BinaryExpr>().unwrap();
 
-    assert_eq!(pred, expected.as_ref());
-
+        assert_eq!(pred, expected.as_ref());
+    }
     Ok(())
 }
 

--- a/datafusion/datasource/src/source.rs
+++ b/datafusion/datasource/src/source.rs
@@ -233,7 +233,7 @@ impl DataSourceExec {
     }
 
     /// Downcast the `DataSourceExec` to a specific file source
-    pub fn downcast_to_source<T: 'static>(&self) -> Option<(&FileScanConfig, &T)> {
+    pub fn downcast_to_file_source<T: 'static>(&self) -> Option<(&FileScanConfig, &T)> {
         self.data_source()
             .as_any()
             .downcast_ref::<FileScanConfig>()

--- a/datafusion/datasource/src/source.rs
+++ b/datafusion/datasource/src/source.rs
@@ -232,7 +232,11 @@ impl DataSourceExec {
         )
     }
 
-    /// Downcast the `DataSourceExec` to a specific file source
+    /// Downcast the `DataSourceExec`'s `data_source` to a specific file source
+    ///
+    /// Returns `None` if
+    /// 1. the datasource is not scanning files (`FileScanConfig`)
+    /// 2. The [`FileScanConfig::file_source`] is not of type `T`
     pub fn downcast_to_file_source<T: 'static>(&self) -> Option<(&FileScanConfig, &T)> {
         self.data_source()
             .as_any()

--- a/datafusion/datasource/src/source.rs
+++ b/datafusion/datasource/src/source.rs
@@ -29,6 +29,7 @@ use datafusion_physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
 };
 
+use crate::file_scan_config::FileScanConfig;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{Constraints, Statistics};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
@@ -229,5 +230,19 @@ impl DataSourceExec {
             EmissionType::Incremental,
             Boundedness::Bounded,
         )
+    }
+
+    /// Downcast the `DataSourceExec` to a specific file source
+    pub fn downcast_to_source<T: 'static>(&self) -> Option<(&FileScanConfig, &T)> {
+        self.data_source()
+            .as_any()
+            .downcast_ref::<FileScanConfig>()
+            .and_then(|file_scan_conf| {
+                file_scan_conf
+                    .file_source()
+                    .as_any()
+                    .downcast_ref::<T>()
+                    .map(|source| (file_scan_conf, source))
+            })
     }
 }

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -1715,31 +1715,27 @@ impl AsExecutionPlan for protobuf::PhysicalPlanNode {
 
         #[cfg(feature = "parquet")]
         if let Some(exec) = plan.downcast_ref::<DataSourceExec>() {
-            let data_source_exec = exec.data_source();
-            if let Some(maybe_parquet) =
-                data_source_exec.as_any().downcast_ref::<FileScanConfig>()
+            if let Some((maybe_parquet, conf)) =
+                exec.downcast_to_source::<ParquetSource>()
             {
-                let source = maybe_parquet.file_source();
-                if let Some(conf) = source.as_any().downcast_ref::<ParquetSource>() {
-                    let predicate = conf
-                        .predicate()
-                        .map(|pred| serialize_physical_expr(pred, extension_codec))
-                        .transpose()?;
-                    return Ok(protobuf::PhysicalPlanNode {
-                        physical_plan_type: Some(PhysicalPlanType::ParquetScan(
-                            protobuf::ParquetScanExecNode {
-                                base_conf: Some(serialize_file_scan_config(
-                                    maybe_parquet,
-                                    extension_codec,
-                                )?),
-                                predicate,
-                                parquet_options: Some(
-                                    conf.table_parquet_options().try_into()?,
-                                ),
-                            },
-                        )),
-                    });
-                }
+                let predicate = conf
+                    .predicate()
+                    .map(|pred| serialize_physical_expr(pred, extension_codec))
+                    .transpose()?;
+                return Ok(protobuf::PhysicalPlanNode {
+                    physical_plan_type: Some(PhysicalPlanType::ParquetScan(
+                        protobuf::ParquetScanExecNode {
+                            base_conf: Some(serialize_file_scan_config(
+                                maybe_parquet,
+                                extension_codec,
+                            )?),
+                            predicate,
+                            parquet_options: Some(
+                                conf.table_parquet_options().try_into()?,
+                            ),
+                        },
+                    )),
+                });
             }
         }
 

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -1716,7 +1716,7 @@ impl AsExecutionPlan for protobuf::PhysicalPlanNode {
         #[cfg(feature = "parquet")]
         if let Some(exec) = plan.downcast_ref::<DataSourceExec>() {
             if let Some((maybe_parquet, conf)) =
-                exec.downcast_to_source::<ParquetSource>()
+                exec.downcast_to_file_source::<ParquetSource>()
             {
                 let predicate = conf
                     .predicate()

--- a/datafusion/substrait/src/physical_plan/producer.rs
+++ b/datafusion/substrait/src/physical_plan/producer.rs
@@ -57,7 +57,7 @@ pub fn to_substrait_rel(
         {
             let mut substrait_files = vec![];
             for (partition_index, files) in file_config.file_groups.iter().enumerate() {
-                for file in files {
+                for file in files.iter() {
                     substrait_files.push(FileOrFiles {
                         partition_index: partition_index.try_into().unwrap(),
                         start: 0,

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -129,20 +129,6 @@ if let Some(datasource_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
 # */
 ```
 
-There's also a more convenient helper method `downcast_to_file_source` on `DataSourceExec`
-that simplifies accessing both the config and file source in one call.
-
-```rust
-# /* comment to avoid running
-if let Some(datasource_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
-  if let Some((scan_config, parquet_source)) = datasource_exec.downcast_to_file_source::<ParquetSource>() {
-    // scan_config contains FileGroups and other FileScanConfig information
-    // parquet_source contains PruningPredicates and parquet options
-  }
-}
-# */
-```
-
 ### Cookbook: Changes to `ParquetExecBuilder`
 
 Likewise code that builds `ParquetExec` using the `ParquetExecBuilder` such as

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -129,6 +129,19 @@ if let Some(datasource_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
 # */
 ```
 
+There's also a more convenient helper method `downcast_to_file_source` on `DataSourceExec`
+that simplifies accessing both the config and file source in one call.
+```rust
+# /* comment to avoid running
+if let Some(datasource_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
+  if let Some((scan_config, parquet_source)) = datasource_exec.downcast_to_file_source::<ParquetSource>() {
+    // scan_config contains FileGroups and other FileScanConfig information
+    // parquet_source contains PruningPredicates and parquet options
+  }
+}
+# */
+```
+
 ### Cookbook: Changes to `ParquetExecBuilder`
 
 Likewise code that builds `ParquetExec` using the `ParquetExecBuilder` such as

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -131,6 +131,7 @@ if let Some(datasource_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
 
 There's also a more convenient helper method `downcast_to_file_source` on `DataSourceExec`
 that simplifies accessing both the config and file source in one call.
+
 ```rust
 # /* comment to avoid running
 if let Some(datasource_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {


### PR DESCRIPTION
## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When I upgraded the df46, It was annoying for me to do the following thing(a series of `downcast_ref`) and it's also easy to call the wrong method, such as mixing `file_source()` and `data_source()`:

```rust
if let Some(scan_config) = self.data_source().as_any().downcast_ref::<FileScanConfig>() {
      if let Some(parquet_source) = scan_config
          .file_source()
          .as_any()
          .downcast_ref::<ParquetSource>(){...}
```


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add the `downcast_to_source` method for `DataSourceExec` to make life easy

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, I replace the existing code with the new method.
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

It'll be useful for users to upgrade df46.
