### PR TITLE
Clean up hash_join's ExecutionPlan::execute

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -791,6 +791,13 @@ impl ExecutionPlan for HashJoinExec {
             );
         }
 
+        if self.mode == PartitionMode::Auto {
+            return plan_err!(
+                "Invalid HashJoinExec, unsupported PartitionMode {:?} in execute()",
+                PartitionMode::Auto
+            );
+        }
+
         let join_metrics = BuildProbeJoinMetrics::new(partition, &self.metrics);
         let left_fut = match self.mode {
             PartitionMode::CollectLeft => self.left_fut.once(|| {
@@ -825,12 +832,7 @@ impl ExecutionPlan for HashJoinExec {
                     1,
                 ))
             }
-            PartitionMode::Auto => {
-                return plan_err!(
-                    "Invalid HashJoinExec, unsupported PartitionMode {:?} in execute()",
-                    PartitionMode::Auto
-                );
-            }
+            PartitionMode::Auto => unreachable!(),
         };
 
         let batch_size = context.session_config().batch_size();

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -943,7 +943,6 @@ fn coalesce_partitions_if_needed(plan: Arc<dyn ExecutionPlan>) -> Arc<dyn Execut
 
 /// Reads the left (build) side of the input, buffering it in memory, to build a
 /// hash table (`LeftJoinData`)
-#[allow(clippy::too_many_arguments)]
 async fn collect_left_input(
     random_state: RandomState,
     left_stream: SendableRecordBatchStream,

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -791,13 +791,6 @@ impl ExecutionPlan for HashJoinExec {
             );
         }
 
-        if self.mode == PartitionMode::Auto {
-            return plan_err!(
-                "Invalid HashJoinExec, unsupported PartitionMode {:?} in execute()",
-                PartitionMode::Auto
-            );
-        }
-
         let join_metrics = BuildProbeJoinMetrics::new(partition, &self.metrics);
         let left_fut = match self.mode {
             PartitionMode::CollectLeft => {
@@ -836,7 +829,12 @@ impl ExecutionPlan for HashJoinExec {
                     1,
                 ))
             }
-            PartitionMode::Auto => unreachable!(),
+            PartitionMode::Auto => {
+                return plan_err!(
+                    "Invalid HashJoinExec, unsupported PartitionMode {:?} in execute()",
+                    PartitionMode::Auto
+                );
+            }
         };
 
         let batch_size = context.session_config().batch_size();


### PR DESCRIPTION
## Rationale for this change + What changes are included in this PR?

The logic of HashJoin's `execute` implements differs from the other operators - The recursive call to the `execute` step of the build side are delayed until `collect_left_join` is poll'ed. This PR changes that to make it more alike to the standard implementations of `execute`.

## Are these changes tested?

No changes in behaviour are expected.

## Are there any user-facing changes?

No