### PR TITLE
Fix link to Volcano paper

### DIFF
--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -407,7 +407,7 @@
 //! See the [implementors of `ExecutionPlan`] for a list of physical operators available.
 //!
 //! [`RepartitionExec`]: https://docs.rs/datafusion/latest/datafusion/physical_plan/repartition/struct.RepartitionExec.html
-//! [Volcano style]: https://w6113.github.io/files/papers/volcanoparallelism-89.pdf
+//! [Volcano style]: https://doi.org/10.1145/93605.98720
 //! [Morsel-Driven Parallelism]: https://db.in.tum.de/~leis/papers/morsels.pdf
 //! [DataFusion paper in SIGMOD 2024]: https://github.com/apache/datafusion/files/15149988/DataFusion_Query_Engine___SIGMOD_2024-FINAL-mk4.pdf
 //! [such as DuckDB]: https://github.com/duckdb/duckdb/issues/1583


### PR DESCRIPTION
## Rationale for this change

The link from [the datafusion docs](https://docs.rs/datafusion/46.0.1/datafusion/index.html#execution) to the paper "Encapsulation of parallelism in the Volcano query processing system" was broken.

## What changes are included in this PR?

This PR changes the link from https://w6113.github.io/files/papers/volcanoparallelism-89.pdf (which is broken) to https://doi.org/10.1145/93605.98720 (which should "never" break).

A free PDF is available at the new link.

The Volcano paper is cited twice in the `datafusion` codebase. PR #14497 fixed one of the two citations. This new PR fixes the other citation :slightly_smiling_face:.