### PR TITLE
Attach diagnostic for wrong arg number error

### DIFF
--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -1005,13 +1005,24 @@ pub fn take_function_args_with_diag<const N: usize, T>(
             v.len()
         );
 
-        let diagnostic = Diagnostic::new_error(
+        let mut diagnostic = Diagnostic::new_error(
             format!(
                 "Wrong number of arguments for {} function call",
                 function_name
             ),
             function_call_site,
         );
+        diagnostic.add_note(
+            format!(
+                "Function {} takes exactly {} {}, but {} were provided",
+                function_name,
+                N,
+                if N == 1 { "argument" } else { "arguments" },
+                v.len(),
+            ),
+            None,
+        );
+
         base_error.with_diagnostic(diagnostic)
     })
 }

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -990,7 +990,7 @@ pub fn take_function_args<const N: usize, T>(
     })
 }
 
-pub fn take_function_args_with_span<const N: usize, T>(
+pub fn take_function_args_with_diag<const N: usize, T>(
     function_name: &str,
     args: impl IntoIterator<Item = T>,
     function_call_site: Option<Span>,

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -439,6 +439,11 @@ impl ExprSchemable for Expr {
                             "{} {}",
                             match err {
                                 DataFusionError::Plan(msg) => msg,
+                                DataFusionError::Diagnostic(_, boxed_err) =>
+                                    match *boxed_err {
+                                        DataFusionError::Plan(msg) => msg,
+                                        _ => boxed_err.to_string(),
+                                    },
                                 err => err.to_string(),
                             },
                             utils::generate_signature_error_msg(

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -164,7 +164,6 @@ impl ExprSchemable for Expr {
                     .collect::<Result<Vec<_>>>()?;
                 let new_types = data_types_with_aggregate_udf(&data_types, func)
                     .map_err(|err| {
-                        dbg!(&err);
                         let diagnostic = err.diagnostic().cloned();
 
                         let err = plan_datafusion_err!(

--- a/datafusion/expr/src/test/function_stub.rs
+++ b/datafusion/expr/src/test/function_stub.rs
@@ -26,7 +26,7 @@ use arrow::datatypes::{
 };
 
 use datafusion_common::{
-    exec_err, not_impl_err, utils::take_function_args_with_span, Result,
+    exec_err, not_impl_err, utils::take_function_args_with_diag, Result,
 };
 
 use crate::type_coercion::aggregates::{avg_return_type, coerce_avg_type, NUMERICS};
@@ -127,7 +127,7 @@ impl AggregateUDFImpl for Sum {
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        let [array] = take_function_args_with_span(self.name(), arg_types, None)?;
+        let [array] = take_function_args_with_diag(self.name(), arg_types, None)?;
 
         // Refer to https://www.postgresql.org/docs/8.2/functions-aggregate.html doc
         // smallint, int, bigint, real, double precision, decimal, or interval.

--- a/datafusion/expr/src/test/function_stub.rs
+++ b/datafusion/expr/src/test/function_stub.rs
@@ -25,7 +25,9 @@ use arrow::datatypes::{
     DataType, Field, DECIMAL128_MAX_PRECISION, DECIMAL256_MAX_PRECISION,
 };
 
-use datafusion_common::{exec_err, not_impl_err, utils::take_function_args, Result};
+use datafusion_common::{
+    exec_err, not_impl_err, utils::take_function_args_with_span, Result,
+};
 
 use crate::type_coercion::aggregates::{avg_return_type, coerce_avg_type, NUMERICS};
 use crate::Volatility::Immutable;
@@ -125,7 +127,7 @@ impl AggregateUDFImpl for Sum {
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        let [array] = take_function_args(self.name(), arg_types)?;
+        let [array] = take_function_args_with_span(self.name(), arg_types, None)?;
 
         // Refer to https://www.postgresql.org/docs/8.2/functions-aggregate.html doc
         // smallint, int, bigint, real, double precision, decimal, or interval.

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -345,7 +345,7 @@ pub fn check_function_length_with_diag(
                 }
             }
 
-            if !all_results.is_empty() {
+            if all_results.len() == signatures.len() {
                 // Create error for no matching signature
                 let error_message = format!(
                     "Function '{}' has no matching signature for {} arguments",

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -774,30 +774,10 @@ fn get_valid_types(
                 }
             }
         },
-        TypeSignature::Nullary => {
-            // if !current_types.is_empty() {
-            //     return plan_err!(
-            //         "The function '{function_name}' expected zero argument but received {}",
-            //         current_types.len()
-            //     );
-            // }
-            vec![vec![]]
-        }
-        TypeSignature::Any(number) => {
-            // if current_types.is_empty() {
-            //     return plan_err!(
-            //         "The function '{function_name}' expected at least one argument but received 0"
-            //     );
-            // }
+        TypeSignature::Nullary => vec![vec![]],
 
-            // if current_types.len() != *number {
-            //     return plan_err!(
-            //         "The function '{function_name}' expected {number} arguments but received {}",
-            //         current_types.len()
-            //     );
-            // }
-            vec![(0..*number).map(|i| current_types[i].clone()).collect()]
-        }
+        TypeSignature::Any(number) => vec![(0..*number).map(|i| current_types[i].clone()).collect()],
+        
         TypeSignature::OneOf(types) => types
             .iter()
             .filter_map(|t| get_valid_types(function_name, t, current_types).ok())

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -272,52 +272,57 @@ pub fn check_function_length_with_diag(
         | TypeSignature::Numeric(num)
         | TypeSignature::String(num)
         | TypeSignature::Comparable(num)
-        | TypeSignature::Any(num)
-            if current_types.len() != *num =>
-        {
-            return create_error(
-                &format!("expects {} arguments", num),
-                current_types.len(),
-            );
+        | TypeSignature::Any(num) => {
+            if current_types.len() != *num {
+                return create_error(
+                    &format!("expects {} arguments", num),
+                    current_types.len(),
+                );
+            }
         }
         // Length-based signature types
-        TypeSignature::Exact(types) if current_types.len() != types.len() => {
-            return create_error(
-                &format!("expects {} arguments", types.len()),
-                current_types.len(),
-            );
+        TypeSignature::Exact(types) => {
+            if current_types.len() != types.len() {
+                return create_error(
+                    &format!("expects {} arguments", types.len()),
+                    current_types.len(),
+                );
+            }
         }
-        TypeSignature::Coercible(types) if current_types.len() != types.len() => {
-            return create_error(
-                &format!("expects {} arguments", types.len()),
-                current_types.len(),
-            );
+        TypeSignature::Coercible(types) => {
+            if current_types.len() != types.len() {
+                return create_error(
+                    &format!("expects {} arguments", types.len()),
+                    current_types.len(),
+                );
+            }
         }
 
         // Zero argument signature type
-        TypeSignature::Nullary if !current_types.is_empty() => {
-            return create_error("expects zero arguments", current_types.len());
+        TypeSignature::Nullary => {
+            if !current_types.is_empty() {
+                return create_error("expects zero arguments", current_types.len());
+            }
         }
 
         // Array signature types
         TypeSignature::ArraySignature(array_signature) => match array_signature {
-            ArrayFunctionSignature::Array { arguments, .. }
-                if current_types.len() != arguments.len() =>
-            {
-                return create_error(
-                    &format!("expects {} arguments", arguments.len()),
-                    current_types.len(),
-                );
+            ArrayFunctionSignature::Array { arguments, .. } => {
+                if current_types.len() != arguments.len() {
+                    return create_error(
+                        &format!("expects {} arguments", arguments.len()),
+                        current_types.len(),
+                    );
+                }
             }
-            ArrayFunctionSignature::RecursiveArray | ArrayFunctionSignature::MapArray
-                if current_types.len() != 1 =>
-            {
-                return create_error(
-                    "expects exactly one array argument",
-                    current_types.len(),
-                );
+            ArrayFunctionSignature::RecursiveArray | ArrayFunctionSignature::MapArray => {
+                if current_types.len() != 1 {
+                    return create_error(
+                        "expects exactly one array argument",
+                        current_types.len(),
+                    );
+                }
             }
-            _ => {}
         },
 
         // Multiple signature type
@@ -340,7 +345,7 @@ pub fn check_function_length_with_diag(
                 }
             }
 
-            if all_results.is_empty() {
+            if !all_results.is_empty() {
                 // Create error for no matching signature
                 let error_message = format!(
                     "Function '{}' has no matching signature for {} arguments",

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -21,11 +21,11 @@ use arrow::{
     compute::can_cast_types,
     datatypes::{DataType, Field, TimeUnit},
 };
+use datafusion_common::types::LogicalType;
 use datafusion_common::utils::{coerced_fixed_size_list_to_list, ListCoercion};
-use datafusion_common::{diagnostic, types::LogicalType};
 use datafusion_common::{
     exec_err, internal_datafusion_err, internal_err, plan_err, types::NativeType,
-    utils::list_ndims, Diagnostic, Result, Span,
+    utils::list_ndims, Result,
 };
 use datafusion_expr_common::signature::ArrayFunctionArgument;
 use datafusion_expr_common::{
@@ -301,7 +301,6 @@ fn get_valid_types_with_aggregate_udf(
         TypeSignature::UserDefined => match func.coerce_types(current_types) {
             Ok(coerced_types) => vec![coerced_types],
             Err(e) => {
-                dbg!(&e);
                 let diagnostic = e.diagnostic().cloned();
 
                 return exec_err!(

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -305,7 +305,7 @@ fn get_valid_types_with_aggregate_udf(
                     "Function '{}' user-defined coercion failed with {:?}",
                     func.name(),
                     e.strip_backtrace()
-                )
+                );
             }
         },
         TypeSignature::OneOf(signatures) => signatures

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -21,11 +21,11 @@ use arrow::{
     compute::can_cast_types,
     datatypes::{DataType, Field, TimeUnit},
 };
-use datafusion_common::types::LogicalType;
 use datafusion_common::utils::{coerced_fixed_size_list_to_list, ListCoercion};
+use datafusion_common::{diagnostic, types::LogicalType};
 use datafusion_common::{
     exec_err, internal_datafusion_err, internal_err, plan_err, types::NativeType,
-    utils::list_ndims, Result,
+    utils::list_ndims, Diagnostic, Result, Span,
 };
 use datafusion_expr_common::signature::ArrayFunctionArgument;
 use datafusion_expr_common::{
@@ -301,11 +301,21 @@ fn get_valid_types_with_aggregate_udf(
         TypeSignature::UserDefined => match func.coerce_types(current_types) {
             Ok(coerced_types) => vec![coerced_types],
             Err(e) => {
+                dbg!(&e);
+                let diagnostic = e.diagnostic().cloned();
+
                 return exec_err!(
                     "Function '{}' user-defined coercion failed with {:?}",
                     func.name(),
                     e.strip_backtrace()
-                );
+                )
+                .map_err(|e| {
+                    if let Some(diagnostic) = diagnostic {
+                        e.with_diagnostic(diagnostic)
+                    } else {
+                        e
+                    }
+                });
             }
         },
         TypeSignature::OneOf(signatures) => signatures

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -327,25 +327,20 @@ pub fn check_function_length_with_diag(
 
         // Multiple signature type
         TypeSignature::OneOf(signatures) => {
-            // For OneOf, we need to check if ANY of the signatures match
-            // If none match, we'll return an error with all collected diagnostics
-            let mut all_results = Vec::new();
-
-            // Try each signature
-            for sig in signatures {
-                let result = check_function_length_with_diag(
+            // Filter out signatures that are not match the current types length
+            signatures.iter().any(|signature| {
+                match check_function_length_with_diag(
                     function_name,
-                    sig,
+                    signature,
                     current_types,
                     function_call_site,
-                );
-                match result {
-                    Ok(()) => return Ok(()), // If any signature matches, return success immediately
-                    Err(err) => all_results.push(err),
+                ) {
+                    Ok(()) => true,
+                    Err(_) => false,
                 }
-            }
+            });
 
-            if all_results.len() == signatures.len() {
+            if signatures.is_empty() {
                 // Create error for no matching signature
                 let error_message = format!(
                     "Function '{}' has no matching signature for {} arguments",

--- a/datafusion/functions-aggregate/src/sum.rs
+++ b/datafusion/functions-aggregate/src/sum.rs
@@ -33,9 +33,8 @@ use arrow::datatypes::{
     DECIMAL128_MAX_PRECISION, DECIMAL256_MAX_PRECISION,
 };
 use arrow::{array::ArrayRef, datatypes::Field};
-use datafusion_common::Spans;
 use datafusion_common::{
-    exec_err, not_impl_err, utils::take_function_args_with_span, Result, ScalarValue,
+    exec_err, not_impl_err, utils::take_function_args_with_diag, Result, ScalarValue,
 };
 use datafusion_expr::function::AccumulatorArgs;
 use datafusion_expr::function::StateFieldsArgs;
@@ -98,27 +97,13 @@ macro_rules! downcast_sum {
 #[derive(Debug)]
 pub struct Sum {
     signature: Signature,
-
-    /// Original source code location, if known
-    pub spans: Spans,
 }
 
 impl Sum {
     pub fn new() -> Self {
         Self {
             signature: Signature::user_defined(Volatility::Immutable),
-            spans: Spans::new(),
         }
-    }
-
-    pub fn spans(&self) -> &Spans {
-        &self.spans
-    }
-
-    /// Returns a mutable reference to the set of locations in the SQL query
-    /// where this column appears, if known.
-    pub fn spans_mut(&mut self) -> &mut Spans {
-        &mut self.spans
     }
 }
 
@@ -142,8 +127,7 @@ impl AggregateUDFImpl for Sum {
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        let [args] =
-            take_function_args_with_span(self.name(), arg_types, self.spans().first())?;
+        let [args] = take_function_args_with_diag(self.name(), arg_types, None)?;
 
         // Refer to https://www.postgresql.org/docs/8.2/functions-aggregate.html doc
         // smallint, int, bigint, real, double precision, decimal, or interval.

--- a/datafusion/sql/tests/cases/diagnostic.rs
+++ b/datafusion/sql/tests/cases/diagnostic.rs
@@ -20,11 +20,14 @@ use insta::assert_snapshot;
 use std::{collections::HashMap, sync::Arc};
 
 use datafusion_common::{Diagnostic, Location, Result, Span};
+use datafusion_expr::test::function_stub::sum_udaf;
 use datafusion_sql::{
     parser::{DFParser, DFParserBuilder},
     planner::{ParserOptions, SqlToRel},
 };
 use regex::Regex;
+use sqlparser::ast::{Expr as SQLExpr, SelectItem, SetExpr, Statement};
+use sqlparser::{dialect::GenericDialect, parser::Parser};
 
 use crate::{MockContextProvider, MockSessionState};
 
@@ -40,14 +43,19 @@ fn do_query(sql: &'static str) -> Diagnostic {
     };
     let state = MockSessionState::default()
         .with_scalar_function(Arc::new(string::concat().as_ref().clone()));
+
+    let state = MockSessionState::default().with_aggregate_function(sum_udaf());
     let context = MockContextProvider { state };
     let sql_to_rel = SqlToRel::new_with_options(&context, options);
     match sql_to_rel.statement_to_plan(statement) {
         Ok(_) => panic!("expected error"),
-        Err(err) => match err.diagnostic() {
-            Some(diag) => diag.clone(),
-            None => panic!("expected diagnostic"),
-        },
+        Err(err) => {
+            dbg!(&err);
+            match err.diagnostic() {
+                Some(diag) => diag.clone(),
+                None => panic!("expected diagnostic"),
+            }
+        }
     }
 }
 
@@ -131,6 +139,62 @@ fn get_spans(query: &'static str) -> HashMap<String, Span> {
     }
 
     spans
+}
+
+#[test]
+fn trace_function_call_error() {
+    let dialect = GenericDialect {};
+    let sql = "SELECT /*a*/sum(1, 2)/*a*/";
+    let statement = Parser::new(&dialect)
+        .try_with_sql(sql)
+        .expect("unable to create parser")
+        .parse_statement()
+        .expect("unable to parse query");
+
+    let options = ParserOptions {
+        collect_spans: true,
+        ..ParserOptions::default()
+    };
+
+    let state = MockSessionState::default().with_aggregate_function(sum_udaf());
+    let context = MockContextProvider { state };
+    let sql_to_rel = SqlToRel::new_with_options(&context, options);
+
+    // 追蹤函數處理過程
+    match statement {
+        Statement::Query(ref query) => {
+            if let SetExpr::Select(select) = query.body.as_ref() {
+                println!("Processing SELECT statement");
+                for expr in &select.projection {
+                    if let SelectItem::UnnamedExpr(expr) = expr {
+                        println!("Processing expression: {:?}", expr);
+                        // 這裡會進到函數處理
+                        if let SQLExpr::Function(func) = expr {
+                            println!("Function name: {:?}", func.name);
+                            println!("Function args: {:?}", func.args);
+                        }
+                    }
+                }
+            }
+        }
+        _ => panic!("Expected Query"),
+    }
+
+    let result = sql_to_rel.sql_statement_to_plan(statement);
+    println!("Final result: {:?}", result);
+}
+
+#[test]
+fn test_wrong_argument_number() -> Result<()> {
+    let query = "SELECT /*a*/sum(1, 2)/*a*/";
+    let spans = get_spans(query);
+    let diag = do_query(query);
+    assert_eq!(
+        diag.message,
+        "Wrong number of arguments for sum function call"
+    );
+    assert_eq!(diag.span, Some(spans["a"]));
+    Ok(())
 }
 
 #[test]

--- a/datafusion/sql/tests/cases/diagnostic.rs
+++ b/datafusion/sql/tests/cases/diagnostic.rs
@@ -26,7 +26,6 @@ use datafusion_sql::{
     planner::{ParserOptions, SqlToRel},
 };
 use regex::Regex;
-use sqlparser::ast::{Expr as SQLExpr, SelectItem, SetExpr, Statement};
 use sqlparser::{dialect::GenericDialect, parser::Parser};
 
 use crate::{MockContextProvider, MockSessionState};
@@ -48,13 +47,10 @@ fn do_query(sql: &'static str) -> Diagnostic {
     let sql_to_rel = SqlToRel::new_with_options(&context, options);
     match sql_to_rel.statement_to_plan(statement) {
         Ok(_) => panic!("expected error"),
-        Err(err) => {
-            dbg!(&err);
-            match err.diagnostic() {
-                Some(diag) => diag.clone(),
-                None => panic!("expected diagnostic"),
-            }
-        }
+        Err(err) => match err.diagnostic() {
+            Some(diag) => diag.clone(),
+            None => panic!("expected diagnostic"),
+        },
     }
 }
 

--- a/datafusion/sql/tests/cases/diagnostic.rs
+++ b/datafusion/sql/tests/cases/diagnostic.rs
@@ -19,6 +19,7 @@ use datafusion_functions::string;
 use insta::assert_snapshot;
 use std::{collections::HashMap, sync::Arc};
 
+use crate::{MockContextProvider, MockSessionState};
 use datafusion_common::{Diagnostic, Location, Result, Span};
 use datafusion_expr::test::function_stub::sum_udaf;
 use datafusion_sql::{
@@ -26,9 +27,6 @@ use datafusion_sql::{
     planner::{ParserOptions, SqlToRel},
 };
 use regex::Regex;
-use sqlparser::{dialect::GenericDialect, parser::Parser};
-
-use crate::{MockContextProvider, MockSessionState};
 
 fn do_query(sql: &'static str) -> Diagnostic {
     let statement = DFParserBuilder::new(sql)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #14432 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

well explained in the issue.
## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Create a new function `take_function_args_with_diag`, which can accept span info and rerun `DataFusionError::Diagnostic`.
2.  To prevent diagnostic info loss because the error macros "flatten" the inner error to a string, diagnostic was cloned and reattached to a new error in different layers
3.  Add a new test

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
