### PR TITLE
Fix no effect metrics bug in ParquetSource

### DIFF
--- a/datafusion/datasource-parquet/src/source.rs
+++ b/datafusion/datasource-parquet/src/source.rs
@@ -296,10 +296,9 @@ impl ParquetSource {
         self
     }
 
-    fn with_metrics(&self, metrics: ExecutionPlanMetricsSet) -> Self {
-        let mut conf = self.clone();
-        conf.metrics = metrics;
-        conf
+    fn with_metrics(mut self, metrics: ExecutionPlanMetricsSet) -> Self {
+        self.metrics = metrics;
+        self
     }
 
     /// Set predicate information, also sets pruning_predicate and page_pruning_predicate attributes
@@ -314,7 +313,7 @@ impl ParquetSource {
         let predicate_creation_errors =
             MetricBuilder::new(&metrics).global_counter("num_predicate_creation_errors");
 
-        conf.with_metrics(metrics);
+        conf = conf.with_metrics(metrics);
         conf.predicate = Some(Arc::clone(&predicate));
 
         match PruningPredicate::try_new(Arc::clone(&predicate), Arc::clone(&file_schema))


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

Currently setting metrics to parquet source has no effect, this pr fixes this.

The old `with_metrics` method was quite weird, and very easy to misuse. I changed it to consume `self` so that it's clear that we must use the returned value.

Btw, the bug was find by copilot review when I'm porting some of the code to LiquidCache, quite cool:

<img width="894" alt="image" src="https://github.com/user-attachments/assets/a5202a92-3087-4181-9ae7-5a85272c30d2" />

Here's the original link: https://github.com/XiangpengHao/liquid-cache/pull/136#discussion_r2017318959

I think it's generally helpful for code review, not sure how it can work in DataFusion though.
(cc @alamb this probably another LLM fever I caught recently :-)


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
