### PR TITLE
fix: the average time for clickbench query compute should use new vec to make it compute for each query

### DIFF
--- a/benchmarks/src/clickbench.rs
+++ b/benchmarks/src/clickbench.rs
@@ -129,9 +129,9 @@ impl RunOpt {
         self.register_hits(&ctx).await?;
 
         let iterations = self.common.iterations;
-        let mut millis = Vec::with_capacity(iterations);
         let mut benchmark_run = BenchmarkRun::new();
         for query_id in query_range {
+            let mut millis = Vec::with_capacity(iterations);
             benchmark_run.start_new_case(&format!("Query {query_id}"));
             let sql = queries.get_query(query_id)?;
             println!("Q{query_id}: {sql}");


### PR DESCRIPTION
## Which issue does this PR close?

- Closes [#15471](https://github.com/apache/datafusion/issues/15471)

## Rationale for this change

The average time for clickbench query compute should use new vec to make it compute for each query


## What changes are included in this PR?

The average time for clickbench query compute should use new vec to make it compute for each query

## Are these changes tested?

Yes

```rust
Q42: SELECT DATE_TRUNC('minute', to_timestamp_seconds("EventTime")) AS M, COUNT(*) AS PageViews FROM hits WHERE "CounterID" = 62 AND "EventDate"::INT::DATE >= '2013-07-14' AND "EventDate"::INT::DATE <= '2013-07-15' AND "IsRefresh" = 0 AND "DontCountHits" = 0 GROUP BY DATE_TRUNC('minute', to_timestamp_seconds("EventTime")) ORDER BY DATE_TRUNC('minute', M) LIMIT 10 OFFSET 1000;
Query 42 iteration 0 took 56.9 ms and returned 10 rows
Query 42 iteration 1 took 54.6 ms and returned 10 rows
Query 42 iteration 2 took 56.5 ms and returned 10 rows
Query 42 iteration 3 took 54.4 ms and returned 10 rows
Query 42 iteration 4 took 50.4 ms and returned 10 rows
Query 42 avg time: 54.57 ms
```

Before this PR:
```rust
Q42: SELECT DATE_TRUNC('minute', to_timestamp_seconds("EventTime")) AS M, COUNT(*) AS PageViews FROM hits WHERE "CounterID" = 62 AND "EventDate"::INT::DATE >= '2013-07-14' AND "EventDate"::INT::DATE <= '2013-07-15' AND "IsRefresh" = 0 AND "DontCountHits" = 0 GROUP BY DATE_TRUNC('minute', to_timestamp_seconds("EventTime")) ORDER BY DATE_TRUNC('minute', M) LIMIT 10 OFFSET 1000;
Query 42 iteration 0 took 52.7 ms and returned 10 rows
Query 42 iteration 1 took 48.1 ms and returned 10 rows
Query 42 iteration 2 took 53.8 ms and returned 10 rows
Query 42 iteration 3 took 52.8 ms and returned 10 rows
Query 42 iteration 4 took 50.2 ms and returned 10 rows
Query 42 avg time: 1121.93 ms
```

## Are there any user-facing changes?

Fix the wrong average time.