### PR TITLE
experiment: Selectively remove CoalesceBatchesExec

### DIFF
--- a/benchmarks/hashagg-results.md
+++ b/benchmarks/hashagg-results.md
@@ -1,0 +1,446 @@
+
+## clickbench_1 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃  HASHAGG0 ┃ Change ┃ HASHAGG32 ┃ Change ┃ HASHAGG256 ┃ Change ┃ HASHAGG1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 0     │    0.27ms │     0.28ms │    +6% │    0.28ms │    +5% │    0.28ms │    +4% │     0.29ms │    +7% │      0.27ms │      ~ │
+│ QQuery 1     │   31.19ms │    32.61ms │    +4% │   33.92ms │    +8% │   32.68ms │    +4% │    31.75ms │      ~ │     32.34ms │      ~ │
+│ QQuery 2     │   51.36ms │    49.41ms │      ~ │   51.66ms │      ~ │   51.10ms │      ~ │    51.77ms │      ~ │     51.03ms │      ~ │
+│ QQuery 3     │   64.74ms │    67.49ms │    +4% │   67.43ms │    +4% │   64.27ms │      ~ │    64.47ms │      ~ │     63.16ms │      ~ │
+│ QQuery 4     │  409.63ms │   407.33ms │      ~ │  421.82ms │      ~ │  400.91ms │      ~ │   416.56ms │      ~ │    438.73ms │    +7% │
+│ QQuery 5     │  461.31ms │   456.98ms │      ~ │  463.26ms │      ~ │  472.63ms │      ~ │   472.77ms │      ~ │    470.03ms │      ~ │
+│ QQuery 6     │   29.89ms │    32.07ms │    +7% │   33.08ms │   +10% │   31.21ms │    +4% │    31.09ms │    +4% │     29.52ms │      ~ │
+│ QQuery 7     │   34.04ms │    35.41ms │    +4% │   35.62ms │    +4% │   37.16ms │    +9% │    35.18ms │      ~ │     34.66ms │      ~ │
+│ QQuery 8     │  494.60ms │   493.23ms │      ~ │  490.83ms │      ~ │  479.49ms │      ~ │   502.85ms │      ~ │    510.02ms │      ~ │
+│ QQuery 9     │  508.37ms │   520.18ms │      ~ │  500.33ms │      ~ │  530.49ms │    +4% │   523.04ms │      ~ │    517.80ms │      ~ │
+│ QQuery 10    │  128.61ms │   131.21ms │      ~ │  127.79ms │      ~ │  139.73ms │    +8% │   129.58ms │      ~ │    129.23ms │      ~ │
+│ QQuery 11    │  140.51ms │   148.69ms │    +5% │  145.57ms │      ~ │  143.28ms │      ~ │   139.91ms │      ~ │    145.31ms │      ~ │
+│ QQuery 12    │  495.69ms │   482.68ms │      ~ │  497.86ms │      ~ │  500.66ms │      ~ │   501.95ms │      ~ │    497.07ms │      ~ │
+│ QQuery 13    │  767.73ms │   766.02ms │      ~ │  774.43ms │      ~ │  769.23ms │      ~ │   791.70ms │      ~ │    783.01ms │      ~ │
+│ QQuery 14    │  470.49ms │   458.54ms │      ~ │  477.70ms │      ~ │  479.52ms │      ~ │   486.09ms │      ~ │    492.74ms │    +4% │
+│ QQuery 15    │  482.71ms │   477.44ms │      ~ │  487.63ms │      ~ │  487.11ms │      ~ │   505.11ms │    +4% │    497.94ms │      ~ │
+│ QQuery 16    │  943.89ms │   936.83ms │      ~ │  939.66ms │      ~ │  947.74ms │      ~ │   944.87ms │      ~ │    966.60ms │      ~ │
+│ QQuery 17    │  907.91ms │   930.29ms │      ~ │  913.00ms │      ~ │  916.88ms │      ~ │   915.44ms │      ~ │    930.51ms │      ~ │
+│ QQuery 18    │ 1836.69ms │  1870.40ms │      ~ │ 1771.92ms │      ~ │ 1777.57ms │      ~ │  1789.17ms │      ~ │   1793.51ms │      ~ │
+│ QQuery 19    │   64.63ms │    58.05ms │   -10% │   57.72ms │   -10% │   59.63ms │    -7% │    56.80ms │   -12% │     57.51ms │   -11% │
+│ QQuery 20    │  549.49ms │   525.23ms │    -4% │  517.85ms │    -5% │  526.70ms │    -4% │   523.41ms │    -4% │    533.24ms │      ~ │
+│ QQuery 21    │  660.70ms │   669.35ms │      ~ │  674.51ms │      ~ │  692.57ms │    +4% │   673.67ms │      ~ │    664.04ms │      ~ │
+│ QQuery 22    │ 1715.50ms │  1730.73ms │      ~ │ 1750.51ms │      ~ │ 1748.13ms │      ~ │  1794.39ms │    +4% │   1735.55ms │      ~ │
+│ QQuery 23    │ 6471.15ms │  6468.85ms │      ~ │ 6472.26ms │      ~ │ 6448.36ms │      ~ │  6526.21ms │      ~ │   6436.59ms │      ~ │
+│ QQuery 24    │  280.70ms │   290.26ms │      ~ │  283.30ms │      ~ │  281.20ms │      ~ │   284.59ms │      ~ │    278.74ms │      ~ │
+│ QQuery 25    │  257.45ms │   248.51ms │      ~ │  235.78ms │    -8% │  252.03ms │      ~ │   249.72ms │      ~ │    255.09ms │      ~ │
+│ QQuery 26    │  306.45ms │   314.66ms │      ~ │  311.52ms │      ~ │  317.62ms │      ~ │   306.57ms │      ~ │    309.00ms │      ~ │
+│ QQuery 27    │  692.88ms │   748.21ms │    +7% │  714.70ms │      ~ │  695.32ms │      ~ │   706.12ms │      ~ │    694.18ms │      ~ │
+│ QQuery 28    │ 4826.40ms │  4866.34ms │      ~ │ 4816.79ms │      ~ │ 4921.92ms │      ~ │  4986.14ms │      ~ │   4849.35ms │      ~ │
+│ QQuery 29    │  215.60ms │   212.96ms │      ~ │  217.68ms │      ~ │  207.21ms │      ~ │   229.35ms │    +6% │    217.72ms │      ~ │
+│ QQuery 30    │  461.25ms │   457.22ms │      ~ │  469.40ms │      ~ │  462.56ms │      ~ │   462.76ms │      ~ │    477.93ms │      ~ │
+│ QQuery 31    │  553.02ms │   556.01ms │      ~ │  557.06ms │      ~ │  552.24ms │      ~ │   562.06ms │      ~ │    551.76ms │      ~ │
+│ QQuery 32    │ 1751.35ms │  1765.71ms │      ~ │ 1779.03ms │      ~ │ 1765.37ms │      ~ │  1779.60ms │      ~ │   1756.35ms │      ~ │
+│ QQuery 33    │ 1860.68ms │  1868.21ms │      ~ │ 1830.39ms │      ~ │ 1815.34ms │      ~ │  1843.46ms │      ~ │   1823.71ms │      ~ │
+│ QQuery 34    │ 1852.96ms │  1866.21ms │      ~ │ 1856.65ms │      ~ │ 1848.38ms │      ~ │  1890.71ms │      ~ │   1854.66ms │      ~ │
+│ QQuery 35    │  626.89ms │   599.60ms │    -4% │  608.11ms │      ~ │  620.78ms │      ~ │   614.45ms │      ~ │    628.31ms │      ~ │
+│ QQuery 36    │  129.51ms │   140.12ms │    +8% │  130.78ms │      ~ │  137.67ms │    +6% │   131.43ms │      ~ │    131.73ms │      ~ │
+│ QQuery 37    │   88.59ms │    87.72ms │      ~ │   88.63ms │      ~ │   89.35ms │      ~ │    88.96ms │      ~ │     91.12ms │      ~ │
+│ QQuery 38    │   89.21ms │    90.56ms │      ~ │   87.94ms │      ~ │   92.07ms │      ~ │    93.41ms │    +4% │     92.07ms │      ~ │
+│ QQuery 39    │  222.97ms │   236.90ms │    +6% │  234.69ms │    +5% │  229.34ms │      ~ │   237.21ms │    +6% │    230.33ms │      ~ │
+│ QQuery 40    │   38.28ms │    38.54ms │      ~ │   38.24ms │      ~ │   38.59ms │      ~ │    39.02ms │      ~ │     39.12ms │      ~ │
+│ QQuery 41    │   37.19ms │    36.20ms │      ~ │   35.07ms │    -5% │   35.71ms │      ~ │    35.58ms │    -4% │     37.04ms │      ~ │
+│ QQuery 42    │   42.33ms │    40.34ms │    -4% │   43.91ms │      ~ │   44.35ms │    +4% │    46.88ms │   +10% │     41.25ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴────────────┴────────┴─────────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Benchmark Summary          ┃            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ Total Time (base)          │ 32054.83ms │
+│ Total Time (base-rerun)    │ 32213.60ms │
+│ Total Time (HASHAGG0)      │ 32046.35ms │
+│ Total Time (HASHAGG32)     │ 32144.36ms │
+│ Total Time (HASHAGG256)    │ 32496.05ms │
+│ Total Time (HASHAGG1024)   │ 32169.91ms │
+│ Average Time (base)        │   745.46ms │
+│ Average Time (base-rerun)  │   749.15ms │
+│ Queries Faster             │          4 │
+│ Queries Slower             │          9 │
+│ Queries with No Change     │         30 │
+│ Average Time (HASHAGG0)    │   745.26ms │
+│ Queries Faster             │          4 │
+│ Queries Slower             │          6 │
+│ Queries with No Change     │         33 │
+│ Average Time (HASHAGG32)   │   747.54ms │
+│ Queries Faster             │          2 │
+│ Queries Slower             │          9 │
+│ Queries with No Change     │         32 │
+│ Average Time (HASHAGG256)  │   755.72ms │
+│ Queries Faster             │          3 │
+│ Queries Slower             │          8 │
+│ Queries with No Change     │         32 │
+│ Average Time (HASHAGG1024) │   748.14ms │
+│ Queries Faster             │          1 │
+│ Queries Slower             │          2 │
+│ Queries with No Change     │         40 │
+└────────────────────────────┴────────────┘
+
+## clickbench_partitioned results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃  HASHAGG0 ┃ Change ┃ HASHAGG32 ┃ Change ┃ HASHAGG256 ┃ Change ┃ HASHAGG1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 0     │    1.41ms │     1.39ms │      ~ │    1.42ms │      ~ │    1.42ms │      ~ │     1.39ms │      ~ │      1.43ms │      ~ │
+│ QQuery 1     │   16.66ms │    16.27ms │      ~ │   16.15ms │      ~ │   16.30ms │      ~ │    15.93ms │    -4% │     15.70ms │    -5% │
+│ QQuery 2     │   39.83ms │    38.24ms │      ~ │   37.55ms │    -5% │   38.47ms │      ~ │    40.08ms │      ~ │     40.71ms │      ~ │
+│ QQuery 3     │   48.23ms │    48.86ms │      ~ │   48.26ms │      ~ │   46.23ms │    -4% │    50.55ms │    +4% │     48.63ms │      ~ │
+│ QQuery 4     │  389.42ms │   382.19ms │      ~ │  373.68ms │    -4% │  401.72ms │      ~ │   388.55ms │      ~ │    390.97ms │      ~ │
+│ QQuery 5     │  409.93ms │   413.22ms │      ~ │  413.39ms │      ~ │  426.99ms │    +4% │   420.50ms │      ~ │    409.10ms │      ~ │
+│ QQuery 6     │   15.53ms │    14.83ms │    -4% │   15.96ms │      ~ │   15.84ms │      ~ │    16.58ms │    +6% │     14.83ms │    -4% │
+│ QQuery 7     │   18.23ms │    18.25ms │      ~ │   18.70ms │      ~ │   18.31ms │      ~ │    18.44ms │      ~ │     19.35ms │    +6% │
+│ QQuery 8     │  464.55ms │   458.17ms │      ~ │  460.19ms │      ~ │  464.57ms │      ~ │   461.06ms │      ~ │    468.11ms │      ~ │
+│ QQuery 9     │  493.73ms │   484.49ms │      ~ │  494.93ms │      ~ │  491.58ms │      ~ │   484.72ms │      ~ │    490.85ms │      ~ │
+│ QQuery 10    │  123.75ms │   115.46ms │    -6% │  115.96ms │    -6% │  119.16ms │      ~ │   119.78ms │      ~ │    115.22ms │    -6% │
+│ QQuery 11    │  127.30ms │   132.39ms │      ~ │  131.23ms │      ~ │  133.28ms │    +4% │   131.45ms │      ~ │    132.21ms │      ~ │
+│ QQuery 12    │  447.91ms │   447.96ms │      ~ │  464.37ms │      ~ │  444.70ms │      ~ │   454.14ms │      ~ │    448.65ms │      ~ │
+│ QQuery 13    │  674.57ms │   662.34ms │      ~ │  673.01ms │      ~ │  672.60ms │      ~ │   691.69ms │      ~ │    684.62ms │      ~ │
+│ QQuery 14    │  430.16ms │   430.82ms │      ~ │  434.79ms │      ~ │  421.05ms │      ~ │   427.57ms │      ~ │    438.23ms │      ~ │
+│ QQuery 15    │  460.95ms │   475.36ms │      ~ │  462.06ms │      ~ │  461.32ms │      ~ │   462.85ms │      ~ │    453.28ms │      ~ │
+│ QQuery 16    │  919.83ms │   908.13ms │      ~ │  902.23ms │      ~ │  924.49ms │      ~ │   899.22ms │      ~ │    909.20ms │      ~ │
+│ QQuery 17    │  877.38ms │   886.52ms │      ~ │  880.74ms │      ~ │  886.99ms │      ~ │   880.20ms │      ~ │    902.43ms │      ~ │
+│ QQuery 18    │ 1778.87ms │  1768.27ms │      ~ │ 1784.00ms │      ~ │ 1831.23ms │      ~ │  1828.95ms │      ~ │   1794.52ms │      ~ │
+│ QQuery 19    │   41.17ms │    41.06ms │      ~ │   43.22ms │    +4% │   43.20ms │    +4% │    44.96ms │    +9% │     43.17ms │    +4% │
+│ QQuery 20    │  457.37ms │   464.49ms │      ~ │  466.98ms │      ~ │  481.34ms │    +5% │   478.85ms │    +4% │    462.04ms │      ~ │
+│ QQuery 21    │  553.79ms │   544.90ms │      ~ │  536.98ms │      ~ │  558.54ms │      ~ │   540.78ms │      ~ │    537.61ms │      ~ │
+│ QQuery 22    │ 1139.66ms │  1101.74ms │      ~ │ 1114.11ms │      ~ │ 1102.37ms │      ~ │  1074.46ms │    -5% │   1086.69ms │    -4% │
+│ QQuery 23    │ 6209.71ms │  6124.43ms │      ~ │ 6158.19ms │      ~ │ 6191.10ms │      ~ │  6130.16ms │      ~ │   6130.70ms │      ~ │
+│ QQuery 24    │  212.72ms │   215.80ms │      ~ │  208.48ms │      ~ │  217.56ms │      ~ │   224.21ms │    +5% │    212.47ms │      ~ │
+│ QQuery 25    │  174.14ms │   178.51ms │      ~ │  154.33ms │   -11% │  162.65ms │    -6% │   164.15ms │    -5% │    160.52ms │    -7% │
+│ QQuery 26    │  239.74ms │   244.47ms │      ~ │  236.90ms │      ~ │  239.09ms │      ~ │   243.29ms │      ~ │    238.87ms │      ~ │
+│ QQuery 27    │  621.53ms │   648.46ms │    +4% │  618.49ms │      ~ │  631.58ms │      ~ │   627.13ms │      ~ │    622.19ms │      ~ │
+│ QQuery 28    │ 4517.84ms │  4569.81ms │      ~ │ 4610.92ms │      ~ │ 4577.19ms │      ~ │  4582.45ms │      ~ │   4671.47ms │      ~ │
+│ QQuery 29    │  200.48ms │   201.42ms │      ~ │  196.43ms │      ~ │  194.77ms │      ~ │   187.06ms │    -6% │    192.61ms │      ~ │
+│ QQuery 30    │  404.06ms │   397.24ms │      ~ │  406.89ms │      ~ │  402.90ms │      ~ │   408.52ms │      ~ │    406.43ms │      ~ │
+│ QQuery 31    │  508.28ms │   515.77ms │      ~ │  513.07ms │      ~ │  500.25ms │      ~ │   511.35ms │      ~ │    506.23ms │      ~ │
+│ QQuery 32    │ 1795.68ms │  1796.02ms │      ~ │ 1782.62ms │      ~ │ 1765.08ms │      ~ │  1748.92ms │      ~ │   1789.79ms │      ~ │
+│ QQuery 33    │ 1812.84ms │  1797.98ms │      ~ │ 1800.54ms │      ~ │ 1788.04ms │      ~ │  1791.60ms │      ~ │   1764.79ms │      ~ │
+│ QQuery 34    │ 1896.58ms │  1820.08ms │    -4% │ 1814.14ms │    -4% │ 1781.56ms │    -6% │  1821.72ms │      ~ │   1781.69ms │    -6% │
+│ QQuery 35    │  614.27ms │   601.42ms │      ~ │  603.48ms │      ~ │  600.88ms │      ~ │   613.94ms │      ~ │    612.81ms │      ~ │
+│ QQuery 36    │   97.03ms │   101.78ms │    +4% │  107.14ms │   +10% │  106.33ms │    +9% │   107.17ms │   +10% │    106.66ms │    +9% │
+│ QQuery 37    │   44.10ms │    42.71ms │      ~ │   44.06ms │      ~ │   43.48ms │      ~ │    43.89ms │      ~ │     43.28ms │      ~ │
+│ QQuery 38    │   60.98ms │    61.00ms │      ~ │   61.84ms │      ~ │   61.69ms │      ~ │    60.23ms │      ~ │     60.98ms │      ~ │
+│ QQuery 39    │  206.42ms │   199.44ms │      ~ │  187.75ms │    -9% │  199.52ms │      ~ │   196.73ms │    -4% │    191.91ms │    -7% │
+│ QQuery 40    │   22.86ms │    24.80ms │    +8% │   24.59ms │    +7% │   24.66ms │    +7% │    24.20ms │    +5% │     25.14ms │    +9% │
+│ QQuery 41    │   22.30ms │    22.08ms │      ~ │   21.70ms │      ~ │   21.42ms │      ~ │    24.24ms │    +8% │     21.50ms │      ~ │
+│ QQuery 42    │   26.82ms │    29.02ms │    +8% │   29.44ms │    +9% │   28.76ms │    +7% │    28.43ms │    +5% │     28.53ms │    +6% │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴────────────┴────────┴─────────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Benchmark Summary          ┃            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ Total Time (base)          │ 29618.65ms │
+│ Total Time (base-rerun)    │ 29447.61ms │
+│ Total Time (HASHAGG0)      │ 29470.93ms │
+│ Total Time (HASHAGG32)     │ 29540.20ms │
+│ Total Time (HASHAGG256)    │ 29472.10ms │
+│ Total Time (HASHAGG1024)   │ 29476.11ms │
+│ Average Time (base)        │   688.81ms │
+│ Average Time (base-rerun)  │   684.83ms │
+│ Queries Faster             │          3 │
+│ Queries Slower             │          4 │
+│ Queries with No Change     │         36 │
+│ Average Time (HASHAGG0)    │   685.37ms │
+│ Queries Faster             │          6 │
+│ Queries Slower             │          4 │
+│ Queries with No Change     │         33 │
+│ Average Time (HASHAGG32)   │   686.98ms │
+│ Queries Faster             │          3 │
+│ Queries Slower             │          7 │
+│ Queries with No Change     │         33 │
+│ Average Time (HASHAGG256)  │   685.40ms │
+│ Queries Faster             │          5 │
+│ Queries Slower             │          9 │
+│ Queries with No Change     │         29 │
+│ Average Time (HASHAGG1024) │   685.49ms │
+│ Queries Faster             │          7 │
+│ Queries Slower             │          5 │
+│ Queries with No Change     │         31 │
+└────────────────────────────┴────────────┘
+
+## clickbench_extended results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃  HASHAGG0 ┃ Change ┃ HASHAGG32 ┃ Change ┃ HASHAGG256 ┃ Change ┃ HASHAGG1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 0     │  919.34ms │   858.85ms │    -6% │  855.00ms │    -6% │  868.53ms │    -5% │   863.30ms │    -6% │    874.25ms │    -4% │
+│ QQuery 1     │  240.76ms │   245.19ms │      ~ │  256.27ms │    +6% │  235.20ms │      ~ │   248.94ms │      ~ │    234.98ms │      ~ │
+│ QQuery 2     │  445.67ms │   459.20ms │      ~ │  471.59ms │    +5% │  461.19ms │      ~ │   465.82ms │    +4% │    491.51ms │   +10% │
+│ QQuery 3     │  253.06ms │   252.94ms │      ~ │  257.25ms │      ~ │  270.69ms │    +6% │   246.76ms │      ~ │    257.07ms │      ~ │
+│ QQuery 4     │  887.57ms │   904.68ms │      ~ │  892.31ms │      ~ │  897.75ms │      ~ │   918.72ms │      ~ │    898.94ms │      ~ │
+│ QQuery 5     │ 8249.61ms │  8189.48ms │      ~ │ 8321.68ms │      ~ │ 8233.07ms │      ~ │  8226.32ms │      ~ │   8207.45ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴────────────┴────────┴─────────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Benchmark Summary          ┃            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ Total Time (base)          │ 10996.01ms │
+│ Total Time (base-rerun)    │ 10910.33ms │
+│ Total Time (HASHAGG0)      │ 11054.10ms │
+│ Total Time (HASHAGG32)     │ 10966.43ms │
+│ Total Time (HASHAGG256)    │ 10969.86ms │
+│ Total Time (HASHAGG1024)   │ 10964.19ms │
+│ Average Time (base)        │  1832.67ms │
+│ Average Time (base-rerun)  │  1818.39ms │
+│ Queries Faster             │          1 │
+│ Queries Slower             │          0 │
+│ Queries with No Change     │          5 │
+│ Average Time (HASHAGG0)    │  1842.35ms │
+│ Queries Faster             │          1 │
+│ Queries Slower             │          2 │
+│ Queries with No Change     │          3 │
+│ Average Time (HASHAGG32)   │  1827.74ms │
+│ Queries Faster             │          1 │
+│ Queries Slower             │          1 │
+│ Queries with No Change     │          4 │
+│ Average Time (HASHAGG256)  │  1828.31ms │
+│ Queries Faster             │          1 │
+│ Queries Slower             │          1 │
+│ Queries with No Change     │          4 │
+│ Average Time (HASHAGG1024) │  1827.36ms │
+│ Queries Faster             │          1 │
+│ Queries Slower             │          1 │
+│ Queries with No Change     │          4 │
+└────────────────────────────┴────────────┘
+
+## tpch_sf1 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃     base ┃ base-rerun ┃ Change ┃ HASHAGG0 ┃ Change ┃ HASHAGG32 ┃ Change ┃ HASHAGG256 ┃ Change ┃ HASHAGG1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  73.03ms │    78.72ms │    +7% │  78.06ms │    +6% │   75.42ms │      ~ │    73.56ms │      ~ │     76.09ms │    +4% │
+│ QQuery 2     │  22.70ms │    23.29ms │      ~ │  23.04ms │      ~ │   22.78ms │      ~ │    23.00ms │      ~ │     23.48ms │      ~ │
+│ QQuery 3     │  30.18ms │    29.33ms │      ~ │  30.64ms │      ~ │   29.63ms │      ~ │    29.27ms │      ~ │     29.40ms │      ~ │
+│ QQuery 4     │  28.50ms │    28.48ms │      ~ │  28.07ms │      ~ │   27.46ms │      ~ │    29.19ms │      ~ │     28.49ms │      ~ │
+│ QQuery 5     │  51.25ms │    51.86ms │      ~ │  50.18ms │      ~ │   50.13ms │      ~ │    51.56ms │      ~ │     50.22ms │      ~ │
+│ QQuery 6     │  14.50ms │    15.16ms │    +4% │  14.89ms │      ~ │   15.21ms │    +4% │    14.77ms │      ~ │     14.78ms │      ~ │
+│ QQuery 7     │  79.08ms │    79.31ms │      ~ │  80.12ms │      ~ │   77.01ms │      ~ │    76.59ms │      ~ │     76.28ms │      ~ │
+│ QQuery 8     │  43.12ms │    44.35ms │      ~ │  44.11ms │      ~ │   44.83ms │      ~ │    41.88ms │      ~ │     43.84ms │      ~ │
+│ QQuery 9     │  62.03ms │    64.05ms │      ~ │  64.66ms │    +4% │   63.74ms │      ~ │    62.73ms │      ~ │     63.30ms │      ~ │
+│ QQuery 10    │  49.65ms │    50.23ms │      ~ │  52.10ms │    +4% │   49.41ms │      ~ │    52.28ms │    +5% │     52.16ms │    +5% │
+│ QQuery 11    │  16.97ms │    16.49ms │      ~ │  17.38ms │      ~ │   17.63ms │      ~ │    17.59ms │      ~ │     17.10ms │      ~ │
+│ QQuery 12    │  27.86ms │    28.28ms │      ~ │  27.79ms │      ~ │   28.68ms │      ~ │    28.51ms │      ~ │     27.99ms │      ~ │
+│ QQuery 13    │  30.88ms │    31.93ms │      ~ │  31.83ms │      ~ │   31.66ms │      ~ │    33.03ms │    +6% │     32.10ms │      ~ │
+│ QQuery 14    │  23.35ms │    24.01ms │      ~ │  23.50ms │      ~ │   23.17ms │      ~ │    24.11ms │      ~ │     24.61ms │    +5% │
+│ QQuery 15    │  33.71ms │    34.11ms │      ~ │  37.79ms │   +12% │   35.20ms │    +4% │    33.22ms │      ~ │     35.72ms │    +5% │
+│ QQuery 16    │  14.99ms │    14.53ms │      ~ │  14.98ms │      ~ │   15.57ms │      ~ │    14.59ms │      ~ │     15.39ms │      ~ │
+│ QQuery 17    │  64.29ms │    62.49ms │      ~ │  64.54ms │      ~ │   68.21ms │    +6% │    65.00ms │      ~ │     65.85ms │      ~ │
+│ QQuery 18    │ 109.76ms │   110.60ms │      ~ │ 111.15ms │      ~ │  109.35ms │      ~ │   108.47ms │      ~ │    107.64ms │      ~ │
+│ QQuery 19    │  43.47ms │    43.95ms │      ~ │  43.21ms │      ~ │   43.25ms │      ~ │    43.93ms │      ~ │     44.22ms │      ~ │
+│ QQuery 20    │  34.84ms │    33.56ms │      ~ │  33.53ms │      ~ │   34.73ms │      ~ │    35.72ms │      ~ │     34.74ms │      ~ │
+│ QQuery 21    │  92.47ms │    90.91ms │      ~ │  90.50ms │      ~ │  101.81ms │   +10% │    89.67ms │      ~ │     91.09ms │      ~ │
+│ QQuery 22    │  19.00ms │    18.73ms │      ~ │  18.73ms │      ~ │   19.35ms │      ~ │    19.77ms │    +4% │     19.41ms │      ~ │
+└──────────────┴──────────┴────────────┴────────┴──────────┴────────┴───────────┴────────┴────────────┴────────┴─────────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Benchmark Summary          ┃          ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ Total Time (base)          │ 965.62ms │
+│ Total Time (base-rerun)    │ 974.38ms │
+│ Total Time (HASHAGG0)      │ 980.79ms │
+│ Total Time (HASHAGG32)     │ 984.24ms │
+│ Total Time (HASHAGG256)    │ 968.43ms │
+│ Total Time (HASHAGG1024)   │ 973.88ms │
+│ Average Time (base)        │  43.89ms │
+│ Average Time (base-rerun)  │  44.29ms │
+│ Queries Faster             │        0 │
+│ Queries Slower             │        2 │
+│ Queries with No Change     │       20 │
+│ Average Time (HASHAGG0)    │  44.58ms │
+│ Queries Faster             │        0 │
+│ Queries Slower             │        4 │
+│ Queries with No Change     │       18 │
+│ Average Time (HASHAGG32)   │  44.74ms │
+│ Queries Faster             │        0 │
+│ Queries Slower             │        4 │
+│ Queries with No Change     │       18 │
+│ Average Time (HASHAGG256)  │  44.02ms │
+│ Queries Faster             │        0 │
+│ Queries Slower             │        3 │
+│ Queries with No Change     │       19 │
+│ Average Time (HASHAGG1024) │  44.27ms │
+│ Queries Faster             │        0 │
+│ Queries Slower             │        4 │
+│ Queries with No Change     │       18 │
+└────────────────────────────┴──────────┘
+
+## tpch_sf10 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃  HASHAGG0 ┃ Change ┃ HASHAGG32 ┃ Change ┃ HASHAGG256 ┃ Change ┃ HASHAGG1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  533.93ms │   543.70ms │      ~ │  564.81ms │    +5% │  546.28ms │      ~ │   548.13ms │      ~ │    557.77ms │    +4% │
+│ QQuery 2     │  153.11ms │   152.01ms │      ~ │  153.14ms │      ~ │  151.09ms │      ~ │   151.86ms │      ~ │    153.20ms │      ~ │
+│ QQuery 3     │  309.11ms │   311.16ms │      ~ │  310.83ms │      ~ │  314.12ms │      ~ │   310.73ms │      ~ │    312.05ms │      ~ │
+│ QQuery 4     │  236.14ms │   236.26ms │      ~ │  239.79ms │      ~ │  234.58ms │      ~ │   233.07ms │      ~ │    237.05ms │      ~ │
+│ QQuery 5     │  570.31ms │   566.66ms │      ~ │  569.79ms │      ~ │  572.04ms │      ~ │   572.23ms │      ~ │    566.51ms │      ~ │
+│ QQuery 6     │   92.47ms │    90.03ms │      ~ │   84.84ms │    -8% │   87.61ms │    -5% │    84.99ms │    -8% │     85.86ms │    -7% │
+│ QQuery 7     │  900.36ms │   914.47ms │      ~ │  912.96ms │      ~ │  863.46ms │    -4% │   852.08ms │    -5% │    857.44ms │    -4% │
+│ QQuery 8     │  528.16ms │   531.54ms │      ~ │  534.54ms │      ~ │  532.48ms │      ~ │   535.51ms │      ~ │    528.00ms │      ~ │
+│ QQuery 9     │ 1011.72ms │  1013.89ms │      ~ │ 1015.26ms │      ~ │  996.81ms │      ~ │   998.65ms │      ~ │    990.55ms │      ~ │
+│ QQuery 10    │  455.50ms │   440.61ms │      ~ │  452.30ms │      ~ │  445.14ms │      ~ │   453.53ms │      ~ │    441.35ms │      ~ │
+│ QQuery 11    │  135.66ms │   134.01ms │      ~ │  134.86ms │      ~ │  136.02ms │      ~ │   134.58ms │      ~ │    136.07ms │      ~ │
+│ QQuery 12    │  182.91ms │   183.39ms │      ~ │  179.87ms │      ~ │  186.28ms │      ~ │   186.18ms │      ~ │    184.96ms │      ~ │
+│ QQuery 13    │  388.11ms │   359.03ms │    -7% │  397.30ms │      ~ │  369.27ms │    -4% │   384.89ms │      ~ │    360.53ms │    -7% │
+│ QQuery 14    │  146.85ms │   150.79ms │      ~ │  151.84ms │      ~ │  148.21ms │      ~ │   150.82ms │      ~ │    147.30ms │      ~ │
+│ QQuery 15    │  224.77ms │   224.99ms │      ~ │  232.75ms │      ~ │  225.28ms │      ~ │   229.89ms │      ~ │    231.57ms │      ~ │
+│ QQuery 16    │   97.17ms │    98.08ms │      ~ │   97.59ms │      ~ │   98.66ms │      ~ │    97.26ms │      ~ │     97.86ms │      ~ │
+│ QQuery 17    │  808.27ms │   806.36ms │      ~ │  802.42ms │      ~ │  801.90ms │      ~ │   812.49ms │      ~ │    804.36ms │      ~ │
+│ QQuery 18    │ 1360.86ms │  1351.04ms │      ~ │ 1382.98ms │      ~ │ 1392.76ms │      ~ │  1362.57ms │      ~ │   1329.74ms │      ~ │
+│ QQuery 19    │  234.19ms │   246.01ms │    +5% │  236.43ms │      ~ │  240.65ms │      ~ │   237.62ms │      ~ │    238.65ms │      ~ │
+│ QQuery 20    │  277.69ms │   270.64ms │      ~ │  280.74ms │      ~ │  284.06ms │      ~ │   278.69ms │      ~ │    277.92ms │      ~ │
+│ QQuery 21    │ 1113.94ms │  1115.46ms │      ~ │ 1118.36ms │      ~ │ 1178.63ms │    +5% │  1117.09ms │      ~ │   1117.31ms │      ~ │
+│ QQuery 22    │   87.45ms │    85.63ms │      ~ │   88.04ms │      ~ │   88.26ms │      ~ │    89.61ms │      ~ │     87.46ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴────────────┴────────┴─────────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Benchmark Summary          ┃           ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ Total Time (base)          │ 9848.66ms │
+│ Total Time (base-rerun)    │ 9825.76ms │
+│ Total Time (HASHAGG0)      │ 9941.45ms │
+│ Total Time (HASHAGG32)     │ 9893.59ms │
+│ Total Time (HASHAGG256)    │ 9822.47ms │
+│ Total Time (HASHAGG1024)   │ 9743.51ms │
+│ Average Time (base)        │  447.67ms │
+│ Average Time (base-rerun)  │  446.63ms │
+│ Queries Faster             │         1 │
+│ Queries Slower             │         1 │
+│ Queries with No Change     │        20 │
+│ Average Time (HASHAGG0)    │  451.88ms │
+│ Queries Faster             │         1 │
+│ Queries Slower             │         1 │
+│ Queries with No Change     │        20 │
+│ Average Time (HASHAGG32)   │  449.71ms │
+│ Queries Faster             │         3 │
+│ Queries Slower             │         1 │
+│ Queries with No Change     │        18 │
+│ Average Time (HASHAGG256)  │  446.48ms │
+│ Queries Faster             │         2 │
+│ Queries Slower             │         0 │
+│ Queries with No Change     │        20 │
+│ Average Time (HASHAGG1024) │  442.89ms │
+│ Queries Faster             │         3 │
+│ Queries Slower             │         1 │
+│ Queries with No Change     │        18 │
+└────────────────────────────┴───────────┘
+
+## tpch_mem_sf1 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃     base ┃ base-rerun ┃ Change ┃ HASHAGG0 ┃ Change ┃ HASHAGG32 ┃ Change ┃ HASHAGG256 ┃ Change ┃ HASHAGG1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  56.34ms │    59.29ms │    +5% │  59.07ms │    +4% │   58.89ms │    +4% │    61.83ms │    +9% │     61.61ms │    +9% │
+│ QQuery 2     │  12.40ms │    12.50ms │      ~ │  12.35ms │      ~ │   12.27ms │      ~ │    13.03ms │    +5% │     12.48ms │      ~ │
+│ QQuery 3     │  27.76ms │    27.50ms │      ~ │  27.88ms │      ~ │   27.77ms │      ~ │    27.49ms │      ~ │     27.34ms │      ~ │
+│ QQuery 4     │   9.67ms │     9.48ms │      ~ │   9.72ms │      ~ │    9.83ms │      ~ │     9.77ms │      ~ │      9.69ms │      ~ │
+│ QQuery 5     │  35.95ms │    35.67ms │      ~ │  35.19ms │      ~ │   35.73ms │      ~ │    35.61ms │      ~ │     35.15ms │      ~ │
+│ QQuery 6     │   5.97ms │     5.68ms │    -4% │   6.23ms │    +4% │    5.87ms │      ~ │     5.63ms │    -5% │      6.05ms │      ~ │
+│ QQuery 7     │  79.05ms │    78.53ms │      ~ │  77.12ms │      ~ │   70.81ms │   -10% │    73.10ms │    -7% │     69.52ms │   -12% │
+│ QQuery 8     │  12.91ms │    12.66ms │      ~ │  13.84ms │    +7% │   13.56ms │    +5% │    12.09ms │    -6% │     11.69ms │    -9% │
+│ QQuery 9     │  34.59ms │    35.70ms │      ~ │  36.99ms │    +6% │   35.78ms │      ~ │    33.72ms │      ~ │     33.97ms │      ~ │
+│ QQuery 10    │  35.29ms │    35.90ms │      ~ │  36.13ms │      ~ │   35.12ms │      ~ │    36.22ms │      ~ │     36.79ms │    +4% │
+│ QQuery 11    │   6.10ms │     5.87ms │      ~ │   5.73ms │    -6% │    5.83ms │    -4% │     5.64ms │    -7% │      5.85ms │    -4% │
+│ QQuery 12    │  17.25ms │    22.07ms │   +27% │  17.44ms │      ~ │   15.52ms │   -10% │    16.19ms │    -6% │     17.72ms │      ~ │
+│ QQuery 13    │  12.83ms │    12.38ms │      ~ │  12.25ms │    -4% │   11.75ms │    -8% │    11.74ms │    -8% │     12.36ms │      ~ │
+│ QQuery 14    │   7.82ms │     7.61ms │      ~ │   6.72ms │   -14% │    5.39ms │   -31% │     8.41ms │    +7% │      6.67ms │   -14% │
+│ QQuery 15    │  10.85ms │    12.04ms │   +10% │  11.04ms │      ~ │   13.03ms │   +20% │    11.73ms │    +8% │     11.73ms │    +8% │
+│ QQuery 16    │  15.19ms │    12.35ms │   -18% │  13.31ms │   -12% │   11.73ms │   -22% │    13.29ms │   -12% │     11.59ms │   -23% │
+│ QQuery 17    │  45.52ms │    46.29ms │      ~ │  46.76ms │      ~ │   45.58ms │      ~ │    46.96ms │      ~ │     46.50ms │      ~ │
+│ QQuery 18    │ 148.40ms │   148.77ms │      ~ │ 150.06ms │      ~ │  130.43ms │   -12% │   136.55ms │    -7% │    139.03ms │    -6% │
+│ QQuery 19    │  19.62ms │    20.89ms │    +6% │  18.66ms │    -4% │   19.51ms │      ~ │    20.88ms │    +6% │     21.96ms │   +11% │
+│ QQuery 20    │  21.97ms │    23.23ms │    +5% │  22.22ms │      ~ │   22.09ms │      ~ │    21.86ms │      ~ │     25.31ms │   +15% │
+│ QQuery 21    │ 102.54ms │   101.28ms │      ~ │ 103.90ms │      ~ │   89.69ms │   -12% │    95.87ms │    -6% │     97.12ms │    -5% │
+│ QQuery 22    │  17.19ms │    18.08ms │    +5% │  18.48ms │    +7% │   17.68ms │      ~ │    17.33ms │      ~ │     17.87ms │      ~ │
+└──────────────┴──────────┴────────────┴────────┴──────────┴────────┴───────────┴────────┴────────────┴────────┴─────────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Benchmark Summary          ┃          ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ Total Time (base)          │ 735.22ms │
+│ Total Time (base-rerun)    │ 743.76ms │
+│ Total Time (HASHAGG0)      │ 741.10ms │
+│ Total Time (HASHAGG32)     │ 693.85ms │
+│ Total Time (HASHAGG256)    │ 714.96ms │
+│ Total Time (HASHAGG1024)   │ 718.00ms │
+│ Average Time (base)        │  33.42ms │
+│ Average Time (base-rerun)  │  33.81ms │
+│ Queries Faster             │        2 │
+│ Queries Slower             │        6 │
+│ Queries with No Change     │       14 │
+│ Average Time (HASHAGG0)    │  33.69ms │
+│ Queries Faster             │        5 │
+│ Queries Slower             │        5 │
+│ Queries with No Change     │       12 │
+│ Average Time (HASHAGG32)   │  31.54ms │
+│ Queries Faster             │        8 │
+│ Queries Slower             │        3 │
+│ Queries with No Change     │       11 │
+│ Average Time (HASHAGG256)  │  32.50ms │
+│ Queries Faster             │        9 │
+│ Queries Slower             │        5 │
+│ Queries with No Change     │        8 │
+│ Average Time (HASHAGG1024) │  32.64ms │
+│ Queries Faster             │        7 │
+│ Queries Slower             │        5 │
+│ Queries with No Change     │       10 │
+└────────────────────────────┴──────────┘
+
+## tpch_mem_sf10 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃  HASHAGG0 ┃ Change ┃ HASHAGG32 ┃ Change ┃ HASHAGG256 ┃ Change ┃ HASHAGG1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  628.05ms │   625.82ms │      ~ │  623.65ms │      ~ │  636.04ms │      ~ │   626.30ms │      ~ │    625.25ms │      ~ │
+│ QQuery 2     │  111.67ms │   110.78ms │      ~ │  111.42ms │      ~ │  111.31ms │      ~ │   111.62ms │      ~ │    110.61ms │      ~ │
+│ QQuery 3     │  265.51ms │   266.26ms │      ~ │  264.97ms │      ~ │  268.04ms │      ~ │   268.55ms │      ~ │    268.44ms │      ~ │
+│ QQuery 4     │   78.36ms │    79.05ms │      ~ │   78.39ms │      ~ │   79.13ms │      ~ │    77.93ms │      ~ │     78.90ms │      ~ │
+│ QQuery 5     │  438.22ms │   440.66ms │      ~ │  442.97ms │      ~ │  408.16ms │    -6% │   408.81ms │    -6% │    412.53ms │    -5% │
+│ QQuery 6     │   49.25ms │    49.29ms │      ~ │   49.03ms │      ~ │   48.51ms │      ~ │    48.56ms │      ~ │     49.24ms │      ~ │
+│ QQuery 7     │  910.22ms │   909.01ms │      ~ │  917.13ms │      ~ │  812.51ms │   -10% │   829.49ms │    -8% │    823.53ms │    -9% │
+│ QQuery 8     │  344.64ms │   344.93ms │      ~ │  345.15ms │      ~ │  341.58ms │      ~ │   343.42ms │      ~ │    342.91ms │      ~ │
+│ QQuery 9     │  781.32ms │   772.21ms │      ~ │  775.47ms │      ~ │  738.33ms │    -5% │   740.97ms │    -5% │    737.93ms │    -5% │
+│ QQuery 10    │  356.04ms │   357.06ms │      ~ │  359.89ms │      ~ │  350.10ms │      ~ │   354.79ms │      ~ │    354.40ms │      ~ │
+│ QQuery 11    │  103.69ms │   103.00ms │      ~ │  104.45ms │      ~ │  103.44ms │      ~ │   103.51ms │      ~ │    102.43ms │      ~ │
+│ QQuery 12    │  161.29ms │   162.11ms │      ~ │  161.07ms │      ~ │  144.46ms │   -10% │   157.01ms │      ~ │    157.05ms │      ~ │
+│ QQuery 13    │  187.74ms │   196.69ms │    +4% │  188.83ms │      ~ │  195.11ms │      ~ │   197.47ms │    +5% │    188.98ms │      ~ │
+│ QQuery 14    │   42.26ms │    43.01ms │      ~ │   43.30ms │      ~ │   42.93ms │      ~ │    42.82ms │      ~ │     42.58ms │      ~ │
+│ QQuery 15    │   89.82ms │    89.18ms │      ~ │   91.50ms │      ~ │   89.71ms │      ~ │    88.88ms │      ~ │     89.85ms │      ~ │
+│ QQuery 16    │   84.03ms │    85.20ms │      ~ │   85.45ms │      ~ │   82.76ms │      ~ │    85.08ms │      ~ │     83.52ms │      ~ │
+│ QQuery 17    │  708.59ms │   733.30ms │      ~ │  719.05ms │      ~ │  723.57ms │      ~ │   728.85ms │      ~ │    726.40ms │      ~ │
+│ QQuery 18    │ 1821.97ms │  1806.55ms │      ~ │ 1842.20ms │      ~ │ 2435.01ms │   +33% │  1697.15ms │    -6% │   1738.31ms │    -4% │
+│ QQuery 19    │  107.22ms │   107.08ms │      ~ │  106.73ms │      ~ │  107.86ms │      ~ │   109.88ms │      ~ │    108.67ms │      ~ │
+│ QQuery 20    │  195.15ms │   193.83ms │      ~ │  195.46ms │      ~ │  198.39ms │      ~ │   193.45ms │      ~ │    199.52ms │      ~ │
+│ QQuery 21    │ 1080.85ms │  1069.29ms │      ~ │ 1069.51ms │      ~ │ 1033.87ms │    -4% │  1003.16ms │    -7% │   1018.03ms │    -5% │
+│ QQuery 22    │   69.45ms │    68.21ms │      ~ │   68.47ms │      ~ │   68.71ms │      ~ │    68.47ms │      ~ │     68.64ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴────────────┴────────┴─────────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Benchmark Summary          ┃           ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ Total Time (base)          │ 8615.35ms │
+│ Total Time (base-rerun)    │ 8612.52ms │
+│ Total Time (HASHAGG0)      │ 8644.11ms │
+│ Total Time (HASHAGG32)     │ 9019.52ms │
+│ Total Time (HASHAGG256)    │ 8286.15ms │
+│ Total Time (HASHAGG1024)   │ 8327.71ms │
+│ Average Time (base)        │  391.61ms │
+│ Average Time (base-rerun)  │  391.48ms │
+│ Queries Faster             │         0 │
+│ Queries Slower             │         1 │
+│ Queries with No Change     │        21 │
+│ Average Time (HASHAGG0)    │  392.91ms │
+│ Queries Faster             │         0 │
+│ Queries Slower             │         0 │
+│ Queries with No Change     │        22 │
+│ Average Time (HASHAGG32)   │  409.98ms │
+│ Queries Faster             │         5 │
+│ Queries Slower             │         1 │
+│ Queries with No Change     │        16 │
+│ Average Time (HASHAGG256)  │  376.64ms │
+│ Queries Faster             │         5 │
+│ Queries Slower             │         1 │
+│ Queries with No Change     │        16 │
+│ Average Time (HASHAGG1024) │  378.53ms │
+│ Queries Faster             │         5 │
+│ Queries Slower             │         0 │
+│ Queries with No Change     │        17 │
+└────────────────────────────┴───────────┘

--- a/benchmarks/join-results.md
+++ b/benchmarks/join-results.md
@@ -1,0 +1,446 @@
+
+## clickbench_1 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     JOIN0 ┃ Change ┃    JOIN32 ┃ Change ┃   JOIN256 ┃ Change ┃  JOIN1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 0     │    0.27ms │     0.28ms │    +6% │    0.28ms │    +4% │    0.28ms │    +4% │    0.27ms │      ~ │    0.27ms │      ~ │
+│ QQuery 1     │   31.19ms │    32.61ms │    +4% │   33.06ms │    +5% │   31.78ms │      ~ │   32.74ms │    +4% │   31.65ms │      ~ │
+│ QQuery 2     │   51.36ms │    49.41ms │      ~ │   53.12ms │      ~ │   50.84ms │      ~ │   49.83ms │      ~ │   51.06ms │      ~ │
+│ QQuery 3     │   64.74ms │    67.49ms │    +4% │   63.79ms │      ~ │   64.44ms │      ~ │   61.51ms │    -5% │   60.98ms │    -5% │
+│ QQuery 4     │  409.63ms │   407.33ms │      ~ │  412.93ms │      ~ │  400.12ms │      ~ │  413.08ms │      ~ │  424.59ms │      ~ │
+│ QQuery 5     │  461.31ms │   456.98ms │      ~ │  461.37ms │      ~ │  475.03ms │      ~ │  455.82ms │      ~ │  481.67ms │    +4% │
+│ QQuery 6     │   29.89ms │    32.07ms │    +7% │   32.28ms │    +8% │   31.28ms │    +4% │   31.65ms │    +5% │   32.97ms │   +10% │
+│ QQuery 7     │   34.04ms │    35.41ms │    +4% │   33.06ms │      ~ │   35.85ms │    +5% │   34.53ms │      ~ │   35.67ms │    +4% │
+│ QQuery 8     │  494.60ms │   493.23ms │      ~ │  492.58ms │      ~ │  478.70ms │      ~ │  488.14ms │      ~ │  507.68ms │      ~ │
+│ QQuery 9     │  508.37ms │   520.18ms │      ~ │  520.43ms │      ~ │  518.37ms │      ~ │  526.88ms │      ~ │  525.98ms │      ~ │
+│ QQuery 10    │  128.61ms │   131.21ms │      ~ │  130.17ms │      ~ │  133.54ms │      ~ │  131.45ms │      ~ │  128.08ms │      ~ │
+│ QQuery 11    │  140.51ms │   148.69ms │    +5% │  143.46ms │      ~ │  147.09ms │    +4% │  149.78ms │    +6% │  142.50ms │      ~ │
+│ QQuery 12    │  495.69ms │   482.68ms │      ~ │  498.20ms │      ~ │  497.10ms │      ~ │  489.01ms │      ~ │  495.37ms │      ~ │
+│ QQuery 13    │  767.73ms │   766.02ms │      ~ │  770.25ms │      ~ │  772.51ms │      ~ │  775.52ms │      ~ │  766.19ms │      ~ │
+│ QQuery 14    │  470.49ms │   458.54ms │      ~ │  475.57ms │      ~ │  468.02ms │      ~ │  470.74ms │      ~ │  465.35ms │      ~ │
+│ QQuery 15    │  482.71ms │   477.44ms │      ~ │  495.67ms │      ~ │  492.91ms │      ~ │  482.83ms │      ~ │  475.52ms │      ~ │
+│ QQuery 16    │  943.89ms │   936.83ms │      ~ │  949.28ms │      ~ │  975.99ms │      ~ │  971.48ms │      ~ │  958.74ms │      ~ │
+│ QQuery 17    │  907.91ms │   930.29ms │      ~ │  923.07ms │      ~ │  925.64ms │      ~ │  918.41ms │      ~ │  937.67ms │      ~ │
+│ QQuery 18    │ 1836.69ms │  1870.40ms │      ~ │ 1825.16ms │      ~ │ 1774.97ms │      ~ │ 1798.35ms │      ~ │ 1839.74ms │      ~ │
+│ QQuery 19    │   64.63ms │    58.05ms │   -10% │   57.82ms │   -10% │   56.35ms │   -12% │   58.41ms │    -9% │   60.65ms │    -6% │
+│ QQuery 20    │  549.49ms │   525.23ms │    -4% │  517.04ms │    -5% │  542.43ms │      ~ │  530.93ms │      ~ │  526.51ms │    -4% │
+│ QQuery 21    │  660.70ms │   669.35ms │      ~ │  671.27ms │      ~ │  661.96ms │      ~ │  687.32ms │    +4% │  648.30ms │      ~ │
+│ QQuery 22    │ 1715.50ms │  1730.73ms │      ~ │ 1755.19ms │      ~ │ 1731.28ms │      ~ │ 1759.59ms │      ~ │ 1758.69ms │      ~ │
+│ QQuery 23    │ 6471.15ms │  6468.85ms │      ~ │ 6430.58ms │      ~ │ 6409.53ms │      ~ │ 6525.24ms │      ~ │ 6383.96ms │      ~ │
+│ QQuery 24    │  280.70ms │   290.26ms │      ~ │  278.68ms │      ~ │  279.22ms │      ~ │  284.72ms │      ~ │  285.43ms │      ~ │
+│ QQuery 25    │  257.45ms │   248.51ms │      ~ │  244.09ms │    -5% │  242.24ms │    -5% │  253.25ms │      ~ │  248.60ms │      ~ │
+│ QQuery 26    │  306.45ms │   314.66ms │      ~ │  306.42ms │      ~ │  304.49ms │      ~ │  313.58ms │      ~ │  312.78ms │      ~ │
+│ QQuery 27    │  692.88ms │   748.21ms │    +7% │  727.19ms │    +4% │  694.34ms │      ~ │  695.44ms │      ~ │  695.34ms │      ~ │
+│ QQuery 28    │ 4826.40ms │  4866.34ms │      ~ │ 4967.14ms │      ~ │ 4820.08ms │      ~ │ 4881.56ms │      ~ │ 4841.19ms │      ~ │
+│ QQuery 29    │  215.60ms │   212.96ms │      ~ │  236.30ms │    +9% │  211.85ms │      ~ │  221.05ms │      ~ │  218.37ms │      ~ │
+│ QQuery 30    │  461.25ms │   457.22ms │      ~ │  473.44ms │      ~ │  463.54ms │      ~ │  462.94ms │      ~ │  467.64ms │      ~ │
+│ QQuery 31    │  553.02ms │   556.01ms │      ~ │  564.48ms │      ~ │  543.98ms │      ~ │  555.12ms │      ~ │  553.84ms │      ~ │
+│ QQuery 32    │ 1751.35ms │  1765.71ms │      ~ │ 1791.68ms │      ~ │ 1766.20ms │      ~ │ 1763.46ms │      ~ │ 1812.68ms │      ~ │
+│ QQuery 33    │ 1860.68ms │  1868.21ms │      ~ │ 1841.83ms │      ~ │ 1832.49ms │      ~ │ 1813.68ms │      ~ │ 1810.16ms │      ~ │
+│ QQuery 34    │ 1852.96ms │  1866.21ms │      ~ │ 1855.35ms │      ~ │ 1811.96ms │      ~ │ 1852.60ms │      ~ │ 1850.05ms │      ~ │
+│ QQuery 35    │  626.89ms │   599.60ms │    -4% │  617.89ms │      ~ │  603.18ms │      ~ │  640.90ms │      ~ │  634.84ms │      ~ │
+│ QQuery 36    │  129.51ms │   140.12ms │    +8% │  141.97ms │    +9% │  125.90ms │      ~ │  126.16ms │      ~ │  133.65ms │      ~ │
+│ QQuery 37    │   88.59ms │    87.72ms │      ~ │   86.92ms │      ~ │   85.65ms │      ~ │   87.96ms │      ~ │   90.57ms │      ~ │
+│ QQuery 38    │   89.21ms │    90.56ms │      ~ │   98.30ms │   +10% │   88.33ms │      ~ │   89.45ms │      ~ │   88.73ms │      ~ │
+│ QQuery 39    │  222.97ms │   236.90ms │    +6% │  244.23ms │    +9% │  225.99ms │      ~ │  223.45ms │      ~ │  225.63ms │      ~ │
+│ QQuery 40    │   38.28ms │    38.54ms │      ~ │   40.79ms │    +6% │   39.28ms │      ~ │   38.93ms │      ~ │   39.14ms │      ~ │
+│ QQuery 41    │   37.19ms │    36.20ms │      ~ │   36.40ms │      ~ │   36.72ms │      ~ │   41.01ms │   +10% │   37.26ms │      ~ │
+│ QQuery 42    │   42.33ms │    40.34ms │    -4% │   42.80ms │      ~ │   41.38ms │      ~ │   38.93ms │    -8% │   41.85ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ Total Time (base)         │ 32054.83ms │
+│ Total Time (base-rerun)   │ 32213.60ms │
+│ Total Time (JOIN0)        │ 32341.49ms │
+│ Total Time (JOIN32)       │ 31892.82ms │
+│ Total Time (JOIN256)      │ 32227.67ms │
+│ Total Time (JOIN1024)     │ 32127.54ms │
+│ Average Time (base)       │   745.46ms │
+│ Average Time (base-rerun) │   749.15ms │
+│ Queries Faster            │          4 │
+│ Queries Slower            │          9 │
+│ Queries with No Change    │         30 │
+│ Average Time (JOIN0)      │   752.13ms │
+│ Queries Faster            │          3 │
+│ Queries Slower            │          9 │
+│ Queries with No Change    │         31 │
+│ Average Time (JOIN32)     │   741.69ms │
+│ Queries Faster            │          2 │
+│ Queries Slower            │          4 │
+│ Queries with No Change    │         37 │
+│ Average Time (JOIN256)    │   749.48ms │
+│ Queries Faster            │          3 │
+│ Queries Slower            │          5 │
+│ Queries with No Change    │         35 │
+│ Average Time (JOIN1024)   │   747.15ms │
+│ Queries Faster            │          3 │
+│ Queries Slower            │          3 │
+│ Queries with No Change    │         37 │
+└───────────────────────────┴────────────┘
+
+## clickbench_partitioned results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     JOIN0 ┃ Change ┃    JOIN32 ┃ Change ┃   JOIN256 ┃ Change ┃  JOIN1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 0     │    1.41ms │     1.39ms │      ~ │    1.41ms │      ~ │    1.45ms │      ~ │    1.57ms │   +11% │    1.35ms │    -4% │
+│ QQuery 1     │   16.66ms │    16.27ms │      ~ │   15.71ms │    -5% │   16.28ms │      ~ │   15.48ms │    -7% │   16.32ms │      ~ │
+│ QQuery 2     │   39.83ms │    38.24ms │      ~ │   41.74ms │    +4% │   40.07ms │      ~ │   40.29ms │      ~ │   38.28ms │      ~ │
+│ QQuery 3     │   48.23ms │    48.86ms │      ~ │   51.52ms │    +6% │   48.68ms │      ~ │   44.89ms │    -6% │   46.78ms │      ~ │
+│ QQuery 4     │  389.42ms │   382.19ms │      ~ │  391.83ms │      ~ │  389.40ms │      ~ │  404.87ms │      ~ │  390.86ms │      ~ │
+│ QQuery 5     │  409.93ms │   413.22ms │      ~ │  412.56ms │      ~ │  414.07ms │      ~ │  409.11ms │      ~ │  423.19ms │      ~ │
+│ QQuery 6     │   15.53ms │    14.83ms │    -4% │   15.63ms │      ~ │   14.66ms │    -5% │   16.43ms │    +5% │   16.61ms │    +6% │
+│ QQuery 7     │   18.23ms │    18.25ms │      ~ │   18.60ms │      ~ │   18.08ms │      ~ │   17.96ms │      ~ │   17.88ms │      ~ │
+│ QQuery 8     │  464.55ms │   458.17ms │      ~ │  470.33ms │      ~ │  465.26ms │      ~ │  476.60ms │      ~ │  462.85ms │      ~ │
+│ QQuery 9     │  493.73ms │   484.49ms │      ~ │  501.09ms │      ~ │  484.13ms │      ~ │  507.45ms │      ~ │  477.45ms │      ~ │
+│ QQuery 10    │  123.75ms │   115.46ms │    -6% │  116.82ms │    -5% │  116.20ms │    -6% │  117.74ms │    -4% │  118.60ms │    -4% │
+│ QQuery 11    │  127.30ms │   132.39ms │      ~ │  134.32ms │    +5% │  132.72ms │    +4% │  130.98ms │      ~ │  124.75ms │      ~ │
+│ QQuery 12    │  447.91ms │   447.96ms │      ~ │  436.89ms │      ~ │  447.49ms │      ~ │  457.80ms │      ~ │  455.71ms │      ~ │
+│ QQuery 13    │  674.57ms │   662.34ms │      ~ │  671.29ms │      ~ │  669.47ms │      ~ │  667.16ms │      ~ │  675.48ms │      ~ │
+│ QQuery 14    │  430.16ms │   430.82ms │      ~ │  432.54ms │      ~ │  428.77ms │      ~ │  431.53ms │      ~ │  422.48ms │      ~ │
+│ QQuery 15    │  460.95ms │   475.36ms │      ~ │  450.99ms │      ~ │  460.99ms │      ~ │  463.78ms │      ~ │  462.12ms │      ~ │
+│ QQuery 16    │  919.83ms │   908.13ms │      ~ │  916.42ms │      ~ │  918.10ms │      ~ │  923.40ms │      ~ │  912.00ms │      ~ │
+│ QQuery 17    │  877.38ms │   886.52ms │      ~ │  883.99ms │      ~ │  895.20ms │      ~ │  888.14ms │      ~ │  881.72ms │      ~ │
+│ QQuery 18    │ 1778.87ms │  1768.27ms │      ~ │ 1809.93ms │      ~ │ 1774.21ms │      ~ │ 1762.29ms │      ~ │ 1850.93ms │    +4% │
+│ QQuery 19    │   41.17ms │    41.06ms │      ~ │   43.51ms │    +5% │   44.08ms │    +7% │   42.26ms │      ~ │   43.67ms │    +6% │
+│ QQuery 20    │  457.37ms │   464.49ms │      ~ │  462.05ms │      ~ │  453.88ms │      ~ │  468.83ms │      ~ │  480.64ms │    +5% │
+│ QQuery 21    │  553.79ms │   544.90ms │      ~ │  543.05ms │      ~ │  550.12ms │      ~ │  539.75ms │      ~ │  551.68ms │      ~ │
+│ QQuery 22    │ 1139.66ms │  1101.74ms │      ~ │ 1087.00ms │    -4% │ 1119.32ms │      ~ │ 1096.50ms │      ~ │ 1077.95ms │    -5% │
+│ QQuery 23    │ 6209.71ms │  6124.43ms │      ~ │ 6136.43ms │      ~ │ 6150.72ms │      ~ │ 6128.13ms │      ~ │ 6073.31ms │      ~ │
+│ QQuery 24    │  212.72ms │   215.80ms │      ~ │  217.11ms │      ~ │  214.21ms │      ~ │  214.37ms │      ~ │  206.59ms │      ~ │
+│ QQuery 25    │  174.14ms │   178.51ms │      ~ │  162.56ms │    -6% │  161.39ms │    -7% │  164.62ms │    -5% │  165.53ms │    -4% │
+│ QQuery 26    │  239.74ms │   244.47ms │      ~ │  238.80ms │      ~ │  233.61ms │      ~ │  236.40ms │      ~ │  238.89ms │      ~ │
+│ QQuery 27    │  621.53ms │   648.46ms │    +4% │  623.80ms │      ~ │  645.33ms │      ~ │  637.55ms │      ~ │  606.58ms │      ~ │
+│ QQuery 28    │ 4517.84ms │  4569.81ms │      ~ │ 4650.59ms │      ~ │ 4698.92ms │    +4% │ 4585.91ms │      ~ │ 4685.39ms │      ~ │
+│ QQuery 29    │  200.48ms │   201.42ms │      ~ │  200.00ms │      ~ │  200.71ms │      ~ │  194.07ms │      ~ │  201.20ms │      ~ │
+│ QQuery 30    │  404.06ms │   397.24ms │      ~ │  414.35ms │      ~ │  411.12ms │      ~ │  408.99ms │      ~ │  410.07ms │      ~ │
+│ QQuery 31    │  508.28ms │   515.77ms │      ~ │  506.99ms │      ~ │  513.78ms │      ~ │  510.31ms │      ~ │  511.79ms │      ~ │
+│ QQuery 32    │ 1795.68ms │  1796.02ms │      ~ │ 1777.94ms │      ~ │ 1769.96ms │      ~ │ 1741.27ms │      ~ │ 1752.01ms │      ~ │
+│ QQuery 33    │ 1812.84ms │  1797.98ms │      ~ │ 1809.11ms │      ~ │ 1789.44ms │      ~ │ 1786.90ms │      ~ │ 1807.54ms │      ~ │
+│ QQuery 34    │ 1896.58ms │  1820.08ms │    -4% │ 1790.18ms │    -5% │ 1798.74ms │    -5% │ 1787.77ms │    -5% │ 1809.33ms │    -4% │
+│ QQuery 35    │  614.27ms │   601.42ms │      ~ │  608.33ms │      ~ │  605.88ms │      ~ │  609.10ms │      ~ │  598.43ms │      ~ │
+│ QQuery 36    │   97.03ms │   101.78ms │    +4% │  113.98ms │   +17% │  103.74ms │    +6% │  109.05ms │   +12% │  110.26ms │   +13% │
+│ QQuery 37    │   44.10ms │    42.71ms │      ~ │   44.46ms │      ~ │   44.44ms │      ~ │   43.92ms │      ~ │   44.16ms │      ~ │
+│ QQuery 38    │   60.98ms │    61.00ms │      ~ │   61.36ms │      ~ │   63.56ms │    +4% │   63.97ms │    +4% │   63.34ms │      ~ │
+│ QQuery 39    │  206.42ms │   199.44ms │      ~ │  179.67ms │   -12% │  200.10ms │      ~ │  186.88ms │    -9% │  199.98ms │      ~ │
+│ QQuery 40    │   22.86ms │    24.80ms │    +8% │   22.84ms │      ~ │   24.46ms │    +7% │   22.31ms │      ~ │   25.41ms │   +11% │
+│ QQuery 41    │   22.30ms │    22.08ms │      ~ │   22.11ms │      ~ │   22.82ms │      ~ │   23.73ms │    +6% │   21.66ms │      ~ │
+│ QQuery 42    │   26.82ms │    29.02ms │    +8% │   27.00ms │      ~ │   28.60ms │    +6% │   28.22ms │    +5% │   27.87ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ Total Time (base)         │ 29618.65ms │
+│ Total Time (base-rerun)   │ 29447.61ms │
+│ Total Time (JOIN0)        │ 29516.82ms │
+│ Total Time (JOIN32)       │ 29584.14ms │
+│ Total Time (JOIN256)      │ 29408.31ms │
+│ Total Time (JOIN1024)     │ 29508.65ms │
+│ Average Time (base)       │   688.81ms │
+│ Average Time (base-rerun) │   684.83ms │
+│ Queries Faster            │          3 │
+│ Queries Slower            │          4 │
+│ Queries with No Change    │         36 │
+│ Average Time (JOIN0)      │   686.44ms │
+│ Queries Faster            │          6 │
+│ Queries Slower            │          5 │
+│ Queries with No Change    │         32 │
+│ Average Time (JOIN32)     │   688.00ms │
+│ Queries Faster            │          4 │
+│ Queries Slower            │          7 │
+│ Queries with No Change    │         32 │
+│ Average Time (JOIN256)    │   683.91ms │
+│ Queries Faster            │          6 │
+│ Queries Slower            │          6 │
+│ Queries with No Change    │         31 │
+│ Average Time (JOIN1024)   │   686.25ms │
+│ Queries Faster            │          5 │
+│ Queries Slower            │          6 │
+│ Queries with No Change    │         32 │
+└───────────────────────────┴────────────┘
+
+## clickbench_extended results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     JOIN0 ┃ Change ┃    JOIN32 ┃ Change ┃   JOIN256 ┃ Change ┃  JOIN1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 0     │  919.34ms │   858.85ms │    -6% │  875.15ms │    -4% │  863.69ms │    -6% │  856.23ms │    -6% │  865.53ms │    -5% │
+│ QQuery 1     │  240.76ms │   245.19ms │      ~ │  247.37ms │      ~ │  236.37ms │      ~ │  244.47ms │      ~ │  240.63ms │      ~ │
+│ QQuery 2     │  445.67ms │   459.20ms │      ~ │  453.77ms │      ~ │  475.71ms │    +6% │  465.52ms │    +4% │  522.98ms │   +17% │
+│ QQuery 3     │  253.06ms │   252.94ms │      ~ │  249.50ms │      ~ │  267.74ms │    +5% │  266.52ms │    +5% │  247.52ms │      ~ │
+│ QQuery 4     │  887.57ms │   904.68ms │      ~ │  882.18ms │      ~ │  887.82ms │      ~ │  886.91ms │      ~ │  900.17ms │      ~ │
+│ QQuery 5     │ 8249.61ms │  8189.48ms │      ~ │ 8214.35ms │      ~ │ 8214.56ms │      ~ │ 8174.34ms │      ~ │ 8220.07ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ Total Time (base)         │ 10996.01ms │
+│ Total Time (base-rerun)   │ 10910.33ms │
+│ Total Time (JOIN0)        │ 10922.32ms │
+│ Total Time (JOIN32)       │ 10945.89ms │
+│ Total Time (JOIN256)      │ 10893.99ms │
+│ Total Time (JOIN1024)     │ 10996.91ms │
+│ Average Time (base)       │  1832.67ms │
+│ Average Time (base-rerun) │  1818.39ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          0 │
+│ Queries with No Change    │          5 │
+│ Average Time (JOIN0)      │  1820.39ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          0 │
+│ Queries with No Change    │          5 │
+│ Average Time (JOIN32)     │  1824.31ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          2 │
+│ Queries with No Change    │          3 │
+│ Average Time (JOIN256)    │  1815.67ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          2 │
+│ Queries with No Change    │          3 │
+│ Average Time (JOIN1024)   │  1832.82ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          1 │
+│ Queries with No Change    │          4 │
+└───────────────────────────┴────────────┘
+
+## tpch_sf1 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃     base ┃ base-rerun ┃ Change ┃    JOIN0 ┃ Change ┃   JOIN32 ┃ Change ┃  JOIN256 ┃ Change ┃ JOIN1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  73.03ms │    78.72ms │    +7% │  75.51ms │      ~ │  76.31ms │    +4% │  75.48ms │      ~ │  75.35ms │      ~ │
+│ QQuery 2     │  22.70ms │    23.29ms │      ~ │  22.99ms │      ~ │  23.10ms │      ~ │  22.70ms │      ~ │  23.12ms │      ~ │
+│ QQuery 3     │  30.18ms │    29.33ms │      ~ │  29.06ms │      ~ │  29.02ms │      ~ │  31.20ms │      ~ │  29.47ms │      ~ │
+│ QQuery 4     │  28.50ms │    28.48ms │      ~ │  28.66ms │      ~ │  29.09ms │      ~ │  26.96ms │    -5% │  29.46ms │      ~ │
+│ QQuery 5     │  51.25ms │    51.86ms │      ~ │  49.64ms │      ~ │  52.68ms │      ~ │  51.21ms │      ~ │  50.82ms │      ~ │
+│ QQuery 6     │  14.50ms │    15.16ms │    +4% │  15.89ms │    +9% │  15.07ms │      ~ │  14.50ms │      ~ │  14.75ms │      ~ │
+│ QQuery 7     │  79.08ms │    79.31ms │      ~ │  75.62ms │    -4% │  76.41ms │      ~ │  78.00ms │      ~ │  79.52ms │      ~ │
+│ QQuery 8     │  43.12ms │    44.35ms │      ~ │  43.28ms │      ~ │  42.64ms │      ~ │  44.43ms │      ~ │  44.32ms │      ~ │
+│ QQuery 9     │  62.03ms │    64.05ms │      ~ │  63.04ms │      ~ │  63.37ms │      ~ │  62.93ms │      ~ │  62.26ms │      ~ │
+│ QQuery 10    │  49.65ms │    50.23ms │      ~ │  47.82ms │      ~ │  51.74ms │    +4% │  50.13ms │      ~ │  50.19ms │      ~ │
+│ QQuery 11    │  16.97ms │    16.49ms │      ~ │  17.43ms │      ~ │  16.96ms │      ~ │  17.36ms │      ~ │  17.21ms │      ~ │
+│ QQuery 12    │  27.86ms │    28.28ms │      ~ │  29.17ms │    +4% │  28.81ms │      ~ │  28.28ms │      ~ │  29.96ms │    +7% │
+│ QQuery 13    │  30.88ms │    31.93ms │      ~ │  31.56ms │      ~ │  32.79ms │    +6% │  32.30ms │    +4% │  31.23ms │      ~ │
+│ QQuery 14    │  23.35ms │    24.01ms │      ~ │  22.86ms │      ~ │  23.79ms │      ~ │  23.46ms │      ~ │  23.20ms │      ~ │
+│ QQuery 15    │  33.71ms │    34.11ms │      ~ │  35.87ms │    +6% │  35.22ms │    +4% │  33.81ms │      ~ │  33.29ms │      ~ │
+│ QQuery 16    │  14.99ms │    14.53ms │      ~ │  14.92ms │      ~ │  15.46ms │      ~ │  15.46ms │      ~ │  17.13ms │   +14% │
+│ QQuery 17    │  64.29ms │    62.49ms │      ~ │  64.10ms │      ~ │  62.45ms │      ~ │  64.01ms │      ~ │  68.00ms │    +5% │
+│ QQuery 18    │ 109.76ms │   110.60ms │      ~ │ 106.83ms │      ~ │ 107.55ms │      ~ │ 107.69ms │      ~ │ 111.07ms │      ~ │
+│ QQuery 19    │  43.47ms │    43.95ms │      ~ │  44.25ms │      ~ │  44.24ms │      ~ │  43.66ms │      ~ │  44.00ms │      ~ │
+│ QQuery 20    │  34.84ms │    33.56ms │      ~ │  35.86ms │      ~ │  34.22ms │      ~ │  34.90ms │      ~ │  34.29ms │      ~ │
+│ QQuery 21    │  92.47ms │    90.91ms │      ~ │  98.17ms │    +6% │  91.78ms │      ~ │  90.50ms │      ~ │  91.14ms │      ~ │
+│ QQuery 22    │  19.00ms │    18.73ms │      ~ │  19.57ms │      ~ │  19.29ms │      ~ │  19.53ms │      ~ │  19.56ms │      ~ │
+└──────────────┴──────────┴────────────┴────────┴──────────┴────────┴──────────┴────────┴──────────┴────────┴──────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Benchmark Summary         ┃          ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ Total Time (base)         │ 965.62ms │
+│ Total Time (base-rerun)   │ 974.38ms │
+│ Total Time (JOIN0)        │ 972.10ms │
+│ Total Time (JOIN32)       │ 971.99ms │
+│ Total Time (JOIN256)      │ 968.50ms │
+│ Total Time (JOIN1024)     │ 979.35ms │
+│ Average Time (base)       │  43.89ms │
+│ Average Time (base-rerun) │  44.29ms │
+│ Queries Faster            │        0 │
+│ Queries Slower            │        2 │
+│ Queries with No Change    │       20 │
+│ Average Time (JOIN0)      │  44.19ms │
+│ Queries Faster            │        1 │
+│ Queries Slower            │        4 │
+│ Queries with No Change    │       17 │
+│ Average Time (JOIN32)     │  44.18ms │
+│ Queries Faster            │        0 │
+│ Queries Slower            │        4 │
+│ Queries with No Change    │       18 │
+│ Average Time (JOIN256)    │  44.02ms │
+│ Queries Faster            │        1 │
+│ Queries Slower            │        1 │
+│ Queries with No Change    │       20 │
+│ Average Time (JOIN1024)   │  44.52ms │
+│ Queries Faster            │        0 │
+│ Queries Slower            │        3 │
+│ Queries with No Change    │       19 │
+└───────────────────────────┴──────────┘
+
+## tpch_sf10 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     JOIN0 ┃ Change ┃    JOIN32 ┃ Change ┃   JOIN256 ┃ Change ┃  JOIN1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  533.93ms │   543.70ms │      ~ │  524.29ms │      ~ │  586.80ms │    +9% │  563.25ms │    +5% │  546.51ms │      ~ │
+│ QQuery 2     │  153.11ms │   152.01ms │      ~ │  151.91ms │      ~ │  148.55ms │      ~ │  154.56ms │      ~ │  152.66ms │      ~ │
+│ QQuery 3     │  309.11ms │   311.16ms │      ~ │  308.68ms │      ~ │  308.38ms │      ~ │  309.23ms │      ~ │  316.76ms │      ~ │
+│ QQuery 4     │  236.14ms │   236.26ms │      ~ │  228.94ms │      ~ │  233.65ms │      ~ │  234.04ms │      ~ │  235.33ms │      ~ │
+│ QQuery 5     │  570.31ms │   566.66ms │      ~ │  573.42ms │      ~ │  570.57ms │      ~ │  570.14ms │      ~ │  580.69ms │      ~ │
+│ QQuery 6     │   92.47ms │    90.03ms │      ~ │   89.19ms │      ~ │   90.91ms │      ~ │   85.57ms │    -7% │   85.11ms │    -7% │
+│ QQuery 7     │  900.36ms │   914.47ms │      ~ │  858.53ms │    -4% │  860.94ms │    -4% │  864.65ms │      ~ │  894.75ms │      ~ │
+│ QQuery 8     │  528.16ms │   531.54ms │      ~ │  526.87ms │      ~ │  531.71ms │      ~ │  529.58ms │      ~ │  530.71ms │      ~ │
+│ QQuery 9     │ 1011.72ms │  1013.89ms │      ~ │  994.50ms │      ~ │  993.09ms │      ~ │  999.10ms │      ~ │ 1011.05ms │      ~ │
+│ QQuery 10    │  455.50ms │   440.61ms │      ~ │  443.77ms │      ~ │  453.82ms │      ~ │  444.87ms │      ~ │  451.30ms │      ~ │
+│ QQuery 11    │  135.66ms │   134.01ms │      ~ │  134.95ms │      ~ │  134.69ms │      ~ │  133.92ms │      ~ │  134.03ms │      ~ │
+│ QQuery 12    │  182.91ms │   183.39ms │      ~ │  186.67ms │      ~ │  179.56ms │      ~ │  181.63ms │      ~ │  182.24ms │      ~ │
+│ QQuery 13    │  388.11ms │   359.03ms │    -7% │  382.10ms │      ~ │  371.13ms │    -4% │  377.32ms │      ~ │  365.50ms │    -5% │
+│ QQuery 14    │  146.85ms │   150.79ms │      ~ │  148.66ms │      ~ │  148.10ms │      ~ │  147.00ms │      ~ │  145.85ms │      ~ │
+│ QQuery 15    │  224.77ms │   224.99ms │      ~ │  225.78ms │      ~ │  226.77ms │      ~ │  220.22ms │      ~ │  234.11ms │    +4% │
+│ QQuery 16    │   97.17ms │    98.08ms │      ~ │   97.63ms │      ~ │   96.07ms │      ~ │   99.05ms │      ~ │   99.38ms │      ~ │
+│ QQuery 17    │  808.27ms │   806.36ms │      ~ │  792.66ms │      ~ │  806.09ms │      ~ │  806.02ms │      ~ │  809.17ms │      ~ │
+│ QQuery 18    │ 1360.86ms │  1351.04ms │      ~ │ 1419.44ms │    +4% │ 1352.38ms │      ~ │ 1333.98ms │      ~ │ 1375.04ms │      ~ │
+│ QQuery 19    │  234.19ms │   246.01ms │    +5% │  246.54ms │    +5% │  248.12ms │    +5% │  238.98ms │      ~ │  234.06ms │      ~ │
+│ QQuery 20    │  277.69ms │   270.64ms │      ~ │  285.28ms │      ~ │  279.91ms │      ~ │  285.49ms │      ~ │  278.21ms │      ~ │
+│ QQuery 21    │ 1113.94ms │  1115.46ms │      ~ │ 1182.37ms │    +6% │ 1121.07ms │      ~ │ 1117.24ms │      ~ │ 1119.86ms │      ~ │
+│ QQuery 22    │   87.45ms │    85.63ms │      ~ │   86.16ms │      ~ │   89.15ms │      ~ │   88.69ms │      ~ │   86.55ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃           ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ Total Time (base)         │ 9848.66ms │
+│ Total Time (base-rerun)   │ 9825.76ms │
+│ Total Time (JOIN0)        │ 9888.34ms │
+│ Total Time (JOIN32)       │ 9831.46ms │
+│ Total Time (JOIN256)      │ 9784.53ms │
+│ Total Time (JOIN1024)     │ 9868.87ms │
+│ Average Time (base)       │  447.67ms │
+│ Average Time (base-rerun) │  446.63ms │
+│ Queries Faster            │         1 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        20 │
+│ Average Time (JOIN0)      │  449.47ms │
+│ Queries Faster            │         1 │
+│ Queries Slower            │         3 │
+│ Queries with No Change    │        18 │
+│ Average Time (JOIN32)     │  446.88ms │
+│ Queries Faster            │         2 │
+│ Queries Slower            │         2 │
+│ Queries with No Change    │        18 │
+│ Average Time (JOIN256)    │  444.75ms │
+│ Queries Faster            │         1 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        20 │
+│ Average Time (JOIN1024)   │  448.58ms │
+│ Queries Faster            │         2 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        19 │
+└───────────────────────────┴───────────┘
+
+## tpch_mem_sf1 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃     base ┃ base-rerun ┃ Change ┃    JOIN0 ┃ Change ┃   JOIN32 ┃ Change ┃  JOIN256 ┃ Change ┃ JOIN1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  56.34ms │    59.29ms │    +5% │  62.07ms │   +10% │  58.31ms │      ~ │  58.71ms │    +4% │  60.88ms │    +8% │
+│ QQuery 2     │  12.40ms │    12.50ms │      ~ │  12.81ms │      ~ │  12.35ms │      ~ │  12.29ms │      ~ │  12.45ms │      ~ │
+│ QQuery 3     │  27.76ms │    27.50ms │      ~ │  28.18ms │      ~ │  27.33ms │      ~ │  27.91ms │      ~ │  27.81ms │      ~ │
+│ QQuery 4     │   9.67ms │     9.48ms │      ~ │   9.61ms │      ~ │   9.58ms │      ~ │   9.65ms │      ~ │   9.52ms │      ~ │
+│ QQuery 5     │  35.95ms │    35.67ms │      ~ │  36.77ms │      ~ │  36.41ms │      ~ │  35.81ms │      ~ │  35.79ms │      ~ │
+│ QQuery 6     │   5.97ms │     5.68ms │    -4% │   7.38ms │   +23% │   5.98ms │      ~ │   5.81ms │      ~ │   6.05ms │      ~ │
+│ QQuery 7     │  79.05ms │    78.53ms │      ~ │  72.05ms │    -8% │  69.63ms │   -11% │  71.51ms │    -9% │  78.25ms │      ~ │
+│ QQuery 8     │  12.91ms │    12.66ms │      ~ │  14.90ms │   +15% │  12.03ms │    -6% │  12.79ms │      ~ │  12.34ms │    -4% │
+│ QQuery 9     │  34.59ms │    35.70ms │      ~ │  35.51ms │      ~ │  34.81ms │      ~ │  34.60ms │      ~ │  36.00ms │    +4% │
+│ QQuery 10    │  35.29ms │    35.90ms │      ~ │  35.11ms │      ~ │  36.10ms │      ~ │  36.55ms │      ~ │  38.09ms │    +7% │
+│ QQuery 11    │   6.10ms │     5.87ms │      ~ │   5.99ms │      ~ │   5.95ms │      ~ │   5.80ms │    -4% │   5.64ms │    -7% │
+│ QQuery 12    │  17.25ms │    22.07ms │   +27% │  17.35ms │      ~ │  16.34ms │    -5% │  16.17ms │    -6% │  16.50ms │    -4% │
+│ QQuery 13    │  12.83ms │    12.38ms │      ~ │  12.36ms │      ~ │  11.87ms │    -7% │  12.75ms │      ~ │  12.93ms │      ~ │
+│ QQuery 14    │   7.82ms │     7.61ms │      ~ │   6.08ms │   -22% │   6.45ms │   -17% │   5.91ms │   -24% │   5.70ms │   -27% │
+│ QQuery 15    │  10.85ms │    12.04ms │   +10% │  13.53ms │   +24% │  12.70ms │   +16% │  13.33ms │   +22% │  12.40ms │   +14% │
+│ QQuery 16    │  15.19ms │    12.35ms │   -18% │  13.07ms │   -13% │  13.48ms │   -11% │  14.49ms │    -4% │  13.34ms │   -12% │
+│ QQuery 17    │  45.52ms │    46.29ms │      ~ │  45.98ms │      ~ │  46.48ms │      ~ │  47.20ms │      ~ │  47.16ms │      ~ │
+│ QQuery 18    │ 148.40ms │   148.77ms │      ~ │ 129.61ms │   -12% │ 133.40ms │   -10% │ 143.18ms │      ~ │ 148.55ms │      ~ │
+│ QQuery 19    │  19.62ms │    20.89ms │    +6% │  21.62ms │   +10% │  20.15ms │      ~ │  22.51ms │   +14% │  20.63ms │    +5% │
+│ QQuery 20    │  21.97ms │    23.23ms │    +5% │  23.48ms │    +6% │  22.51ms │      ~ │  21.95ms │      ~ │  22.59ms │      ~ │
+│ QQuery 21    │ 102.54ms │   101.28ms │      ~ │  90.91ms │   -11% │  98.08ms │    -4% │  96.47ms │    -5% │ 100.52ms │      ~ │
+│ QQuery 22    │  17.19ms │    18.08ms │    +5% │  19.08ms │   +11% │  17.92ms │    +4% │  16.54ms │      ~ │  16.38ms │    -4% │
+└──────────────┴──────────┴────────────┴────────┴──────────┴────────┴──────────┴────────┴──────────┴────────┴──────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Benchmark Summary         ┃          ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ Total Time (base)         │ 735.22ms │
+│ Total Time (base-rerun)   │ 743.76ms │
+│ Total Time (JOIN0)        │ 713.43ms │
+│ Total Time (JOIN32)       │ 707.86ms │
+│ Total Time (JOIN256)      │ 721.94ms │
+│ Total Time (JOIN1024)     │ 739.51ms │
+│ Average Time (base)       │  33.42ms │
+│ Average Time (base-rerun) │  33.81ms │
+│ Queries Faster            │        2 │
+│ Queries Slower            │        6 │
+│ Queries with No Change    │       14 │
+│ Average Time (JOIN0)      │  32.43ms │
+│ Queries Faster            │        5 │
+│ Queries Slower            │        7 │
+│ Queries with No Change    │       10 │
+│ Average Time (JOIN32)     │  32.18ms │
+│ Queries Faster            │        8 │
+│ Queries Slower            │        2 │
+│ Queries with No Change    │       12 │
+│ Average Time (JOIN256)    │  32.82ms │
+│ Queries Faster            │        6 │
+│ Queries Slower            │        3 │
+│ Queries with No Change    │       13 │
+│ Average Time (JOIN1024)   │  33.61ms │
+│ Queries Faster            │        6 │
+│ Queries Slower            │        5 │
+│ Queries with No Change    │       11 │
+└───────────────────────────┴──────────┘
+
+## tpch_mem_sf10 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     JOIN0 ┃ Change ┃    JOIN32 ┃ Change ┃   JOIN256 ┃ Change ┃  JOIN1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  628.05ms │   625.82ms │      ~ │  641.41ms │      ~ │  619.99ms │      ~ │  611.43ms │      ~ │  614.58ms │      ~ │
+│ QQuery 2     │  111.67ms │   110.78ms │      ~ │  111.47ms │      ~ │  111.12ms │      ~ │  111.93ms │      ~ │  111.02ms │      ~ │
+│ QQuery 3     │  265.51ms │   266.26ms │      ~ │  266.70ms │      ~ │  267.21ms │      ~ │  268.84ms │      ~ │  268.96ms │      ~ │
+│ QQuery 4     │   78.36ms │    79.05ms │      ~ │   77.89ms │      ~ │   78.54ms │      ~ │   78.78ms │      ~ │   78.60ms │      ~ │
+│ QQuery 5     │  438.22ms │   440.66ms │      ~ │  410.06ms │    -6% │  408.32ms │    -6% │  408.68ms │    -6% │  419.97ms │    -4% │
+│ QQuery 6     │   49.25ms │    49.29ms │      ~ │   48.96ms │      ~ │   48.99ms │      ~ │   49.24ms │      ~ │   49.26ms │      ~ │
+│ QQuery 7     │  910.22ms │   909.01ms │      ~ │  813.91ms │   -10% │  820.71ms │    -9% │  817.88ms │   -10% │  894.43ms │      ~ │
+│ QQuery 8     │  344.64ms │   344.93ms │      ~ │  341.81ms │      ~ │  466.49ms │   +35% │  341.87ms │      ~ │  346.21ms │      ~ │
+│ QQuery 9     │  781.32ms │   772.21ms │      ~ │  747.75ms │    -4% │  743.65ms │    -4% │  738.24ms │    -5% │  766.12ms │      ~ │
+│ QQuery 10    │  356.04ms │   357.06ms │      ~ │  349.37ms │      ~ │  353.28ms │      ~ │  355.38ms │      ~ │  356.81ms │      ~ │
+│ QQuery 11    │  103.69ms │   103.00ms │      ~ │  104.97ms │      ~ │  105.11ms │      ~ │  103.37ms │      ~ │  101.60ms │      ~ │
+│ QQuery 12    │  161.29ms │   162.11ms │      ~ │  144.14ms │   -10% │  155.79ms │      ~ │  158.15ms │      ~ │  154.93ms │      ~ │
+│ QQuery 13    │  187.74ms │   196.69ms │    +4% │  197.27ms │    +5% │  191.48ms │      ~ │  195.37ms │    +4% │  193.68ms │      ~ │
+│ QQuery 14    │   42.26ms │    43.01ms │      ~ │   42.49ms │      ~ │   43.70ms │      ~ │   42.74ms │      ~ │   42.53ms │      ~ │
+│ QQuery 15    │   89.82ms │    89.18ms │      ~ │   90.38ms │      ~ │   90.32ms │      ~ │   89.56ms │      ~ │   89.89ms │      ~ │
+│ QQuery 16    │   84.03ms │    85.20ms │      ~ │   83.90ms │      ~ │   86.01ms │      ~ │   85.03ms │      ~ │   85.53ms │      ~ │
+│ QQuery 17    │  708.59ms │   733.30ms │      ~ │  731.06ms │      ~ │  732.88ms │      ~ │  735.55ms │      ~ │  724.34ms │      ~ │
+│ QQuery 18    │ 1821.97ms │  1806.55ms │      ~ │ 2388.66ms │   +31% │ 1688.57ms │    -7% │ 1747.55ms │    -4% │ 1812.21ms │      ~ │
+│ QQuery 19    │  107.22ms │   107.08ms │      ~ │  105.85ms │      ~ │  109.18ms │      ~ │  110.16ms │      ~ │  107.63ms │      ~ │
+│ QQuery 20    │  195.15ms │   193.83ms │      ~ │  199.74ms │      ~ │  196.86ms │      ~ │  192.09ms │      ~ │  199.00ms │      ~ │
+│ QQuery 21    │ 1080.85ms │  1069.29ms │      ~ │ 1026.93ms │    -4% │ 1014.14ms │    -6% │ 1020.56ms │    -5% │ 1065.52ms │      ~ │
+│ QQuery 22    │   69.45ms │    68.21ms │      ~ │   69.84ms │      ~ │   69.44ms │      ~ │   69.85ms │      ~ │   68.76ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃           ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ Total Time (base)         │ 8615.35ms │
+│ Total Time (base-rerun)   │ 8612.52ms │
+│ Total Time (JOIN0)        │ 8994.56ms │
+│ Total Time (JOIN32)       │ 8401.77ms │
+│ Total Time (JOIN256)      │ 8332.26ms │
+│ Total Time (JOIN1024)     │ 8551.58ms │
+│ Average Time (base)       │  391.61ms │
+│ Average Time (base-rerun) │  391.48ms │
+│ Queries Faster            │         0 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        21 │
+│ Average Time (JOIN0)      │  408.84ms │
+│ Queries Faster            │         5 │
+│ Queries Slower            │         2 │
+│ Queries with No Change    │        15 │
+│ Average Time (JOIN32)     │  381.90ms │
+│ Queries Faster            │         5 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        16 │
+│ Average Time (JOIN256)    │  378.74ms │
+│ Queries Faster            │         5 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        16 │
+│ Average Time (JOIN1024)   │  388.71ms │
+│ Queries Faster            │         1 │
+│ Queries Slower            │         0 │
+│ Queries with No Change    │        21 │
+└───────────────────────────┴───────────┘

--- a/benchmarks/sort-results.md
+++ b/benchmarks/sort-results.md
@@ -1,0 +1,446 @@
+
+## clickbench_1 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     SORT0 ┃ Change ┃    SORT32 ┃ Change ┃   SORT256 ┃ Change ┃  SORT1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 0     │    0.27ms │     0.28ms │    +6% │    0.28ms │    +4% │    0.27ms │      ~ │    0.29ms │   +10% │    0.27ms │      ~ │
+│ QQuery 1     │   31.19ms │    32.61ms │    +4% │   31.82ms │      ~ │   32.12ms │      ~ │   32.86ms │    +5% │   32.09ms │      ~ │
+│ QQuery 2     │   51.36ms │    49.41ms │      ~ │   49.61ms │      ~ │   53.83ms │    +4% │   52.75ms │      ~ │   51.23ms │      ~ │
+│ QQuery 3     │   64.74ms │    67.49ms │    +4% │   64.17ms │      ~ │   62.97ms │      ~ │   63.54ms │      ~ │   64.17ms │      ~ │
+│ QQuery 4     │  409.63ms │   407.33ms │      ~ │  411.76ms │      ~ │  423.00ms │      ~ │  398.03ms │      ~ │  433.63ms │    +5% │
+│ QQuery 5     │  461.31ms │   456.98ms │      ~ │  467.36ms │      ~ │  478.06ms │      ~ │  469.82ms │      ~ │  453.64ms │      ~ │
+│ QQuery 6     │   29.89ms │    32.07ms │    +7% │   32.63ms │    +9% │   31.68ms │    +6% │   31.95ms │    +6% │   30.32ms │      ~ │
+│ QQuery 7     │   34.04ms │    35.41ms │    +4% │   35.40ms │    +4% │   34.80ms │      ~ │   35.40ms │    +4% │   35.99ms │    +5% │
+│ QQuery 8     │  494.60ms │   493.23ms │      ~ │  489.76ms │      ~ │  508.12ms │      ~ │  499.82ms │      ~ │  484.94ms │      ~ │
+│ QQuery 9     │  508.37ms │   520.18ms │      ~ │  505.94ms │      ~ │  524.42ms │      ~ │  512.64ms │      ~ │  518.36ms │      ~ │
+│ QQuery 10    │  128.61ms │   131.21ms │      ~ │  135.41ms │    +5% │  132.06ms │      ~ │  131.24ms │      ~ │  130.19ms │      ~ │
+│ QQuery 11    │  140.51ms │   148.69ms │    +5% │  142.65ms │      ~ │  139.35ms │      ~ │  144.15ms │      ~ │  138.73ms │      ~ │
+│ QQuery 12    │  495.69ms │   482.68ms │      ~ │  507.46ms │      ~ │  486.07ms │      ~ │  503.14ms │      ~ │  501.19ms │      ~ │
+│ QQuery 13    │  767.73ms │   766.02ms │      ~ │  769.71ms │      ~ │  793.20ms │      ~ │  776.14ms │      ~ │  763.07ms │      ~ │
+│ QQuery 14    │  470.49ms │   458.54ms │      ~ │  472.87ms │      ~ │  484.20ms │      ~ │  480.01ms │      ~ │  477.76ms │      ~ │
+│ QQuery 15    │  482.71ms │   477.44ms │      ~ │  485.94ms │      ~ │  484.79ms │      ~ │  487.33ms │      ~ │  483.86ms │      ~ │
+│ QQuery 16    │  943.89ms │   936.83ms │      ~ │  964.75ms │      ~ │  960.18ms │      ~ │  959.84ms │      ~ │  953.51ms │      ~ │
+│ QQuery 17    │  907.91ms │   930.29ms │      ~ │  916.96ms │      ~ │  921.55ms │      ~ │  928.81ms │      ~ │  921.23ms │      ~ │
+│ QQuery 18    │ 1836.69ms │  1870.40ms │      ~ │ 1892.45ms │      ~ │ 1808.91ms │      ~ │ 1899.76ms │      ~ │ 1795.01ms │      ~ │
+│ QQuery 19    │   64.63ms │    58.05ms │   -10% │   58.31ms │    -9% │   62.56ms │      ~ │   57.34ms │   -11% │   57.74ms │   -10% │
+│ QQuery 20    │  549.49ms │   525.23ms │    -4% │  518.33ms │    -5% │  516.80ms │    -5% │  561.81ms │      ~ │  530.61ms │      ~ │
+│ QQuery 21    │  660.70ms │   669.35ms │      ~ │  660.84ms │      ~ │  655.59ms │      ~ │  663.20ms │      ~ │  659.69ms │      ~ │
+│ QQuery 22    │ 1715.50ms │  1730.73ms │      ~ │ 1746.29ms │      ~ │ 1771.00ms │      ~ │ 1797.28ms │    +4% │ 1774.70ms │      ~ │
+│ QQuery 23    │ 6471.15ms │  6468.85ms │      ~ │ 6465.07ms │      ~ │ 6404.03ms │      ~ │ 6548.15ms │      ~ │ 6523.08ms │      ~ │
+│ QQuery 24    │  280.70ms │   290.26ms │      ~ │  286.01ms │      ~ │  296.06ms │    +5% │  278.52ms │      ~ │  282.43ms │      ~ │
+│ QQuery 25    │  257.45ms │   248.51ms │      ~ │  230.83ms │   -10% │  269.95ms │    +4% │  240.99ms │    -6% │  246.45ms │    -4% │
+│ QQuery 26    │  306.45ms │   314.66ms │      ~ │  319.09ms │    +4% │  307.91ms │      ~ │  314.73ms │      ~ │  311.45ms │      ~ │
+│ QQuery 27    │  692.88ms │   748.21ms │    +7% │  722.49ms │    +4% │  690.83ms │      ~ │  733.01ms │    +5% │  694.19ms │      ~ │
+│ QQuery 28    │ 4826.40ms │  4866.34ms │      ~ │ 4916.32ms │      ~ │ 4852.48ms │      ~ │ 4968.18ms │      ~ │ 4861.62ms │      ~ │
+│ QQuery 29    │  215.60ms │   212.96ms │      ~ │  202.45ms │    -6% │  204.46ms │    -5% │  204.62ms │    -5% │  211.82ms │      ~ │
+│ QQuery 30    │  461.25ms │   457.22ms │      ~ │  467.98ms │      ~ │  476.94ms │      ~ │  465.01ms │      ~ │  467.70ms │      ~ │
+│ QQuery 31    │  553.02ms │   556.01ms │      ~ │  558.87ms │      ~ │  553.68ms │      ~ │  545.01ms │      ~ │  566.29ms │      ~ │
+│ QQuery 32    │ 1751.35ms │  1765.71ms │      ~ │ 1761.60ms │      ~ │ 1759.80ms │      ~ │ 1841.85ms │    +5% │ 1745.70ms │      ~ │
+│ QQuery 33    │ 1860.68ms │  1868.21ms │      ~ │ 1820.40ms │      ~ │ 1807.41ms │      ~ │ 1852.56ms │      ~ │ 1840.55ms │      ~ │
+│ QQuery 34    │ 1852.96ms │  1866.21ms │      ~ │ 1852.70ms │      ~ │ 1871.97ms │      ~ │ 1838.94ms │      ~ │ 1854.69ms │      ~ │
+│ QQuery 35    │  626.89ms │   599.60ms │    -4% │  601.48ms │    -4% │  612.45ms │      ~ │  612.77ms │      ~ │  624.62ms │      ~ │
+│ QQuery 36    │  129.51ms │   140.12ms │    +8% │  125.05ms │      ~ │  127.57ms │      ~ │  133.15ms │      ~ │  129.59ms │      ~ │
+│ QQuery 37    │   88.59ms │    87.72ms │      ~ │   87.52ms │      ~ │   89.27ms │      ~ │   87.38ms │      ~ │   91.93ms │      ~ │
+│ QQuery 38    │   89.21ms │    90.56ms │      ~ │   93.74ms │    +5% │   90.76ms │      ~ │   89.20ms │      ~ │   90.38ms │      ~ │
+│ QQuery 39    │  222.97ms │   236.90ms │    +6% │  225.24ms │      ~ │  229.46ms │      ~ │  235.31ms │    +5% │  235.96ms │    +5% │
+│ QQuery 40    │   38.28ms │    38.54ms │      ~ │   44.04ms │   +15% │   37.74ms │      ~ │   38.55ms │      ~ │   38.40ms │      ~ │
+│ QQuery 41    │   37.19ms │    36.20ms │      ~ │   35.39ms │    -4% │   36.31ms │      ~ │   35.83ms │      ~ │   37.67ms │      ~ │
+│ QQuery 42    │   42.33ms │    40.34ms │    -4% │   43.79ms │      ~ │   47.97ms │   +13% │   41.65ms │      ~ │   42.22ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ Total Time (base)         │ 32054.83ms │
+│ Total Time (base-rerun)   │ 32213.60ms │
+│ Total Time (SORT0)        │ 32220.79ms │
+│ Total Time (SORT32)       │ 32132.59ms │
+│ Total Time (SORT256)      │ 32592.57ms │
+│ Total Time (SORT1024)     │ 32188.65ms │
+│ Average Time (base)       │   745.46ms │
+│ Average Time (base-rerun) │   749.15ms │
+│ Queries Faster            │          4 │
+│ Queries Slower            │          9 │
+│ Queries with No Change    │         30 │
+│ Average Time (SORT0)      │   749.32ms │
+│ Queries Faster            │          6 │
+│ Queries Slower            │          8 │
+│ Queries with No Change    │         29 │
+│ Average Time (SORT32)     │   747.27ms │
+│ Queries Faster            │          2 │
+│ Queries Slower            │          5 │
+│ Queries with No Change    │         36 │
+│ Average Time (SORT256)    │   757.97ms │
+│ Queries Faster            │          3 │
+│ Queries Slower            │          8 │
+│ Queries with No Change    │         32 │
+│ Average Time (SORT1024)   │   748.57ms │
+│ Queries Faster            │          2 │
+│ Queries Slower            │          3 │
+│ Queries with No Change    │         38 │
+└───────────────────────────┴────────────┘
+
+## clickbench_partitioned results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     SORT0 ┃ Change ┃    SORT32 ┃ Change ┃   SORT256 ┃ Change ┃  SORT1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 0     │    1.41ms │     1.39ms │      ~ │    1.40ms │      ~ │    1.45ms │      ~ │    1.49ms │    +6% │    1.60ms │   +13% │
+│ QQuery 1     │   16.66ms │    16.27ms │      ~ │   15.75ms │    -5% │   14.85ms │   -10% │   15.98ms │    -4% │   15.48ms │    -7% │
+│ QQuery 2     │   39.83ms │    38.24ms │      ~ │   39.71ms │      ~ │   37.72ms │    -5% │   38.31ms │      ~ │   39.07ms │      ~ │
+│ QQuery 3     │   48.23ms │    48.86ms │      ~ │   47.31ms │      ~ │   46.80ms │      ~ │   49.57ms │      ~ │   46.68ms │      ~ │
+│ QQuery 4     │  389.42ms │   382.19ms │      ~ │  405.14ms │    +4% │  392.03ms │      ~ │  394.69ms │      ~ │  385.28ms │      ~ │
+│ QQuery 5     │  409.93ms │   413.22ms │      ~ │  415.90ms │      ~ │  398.13ms │      ~ │  406.63ms │      ~ │  406.58ms │      ~ │
+│ QQuery 6     │   15.53ms │    14.83ms │    -4% │   17.58ms │   +13% │   16.27ms │    +4% │   16.16ms │    +4% │   15.51ms │      ~ │
+│ QQuery 7     │   18.23ms │    18.25ms │      ~ │   19.15ms │    +5% │   18.41ms │      ~ │   17.67ms │      ~ │   18.04ms │      ~ │
+│ QQuery 8     │  464.55ms │   458.17ms │      ~ │  473.05ms │      ~ │  472.10ms │      ~ │  464.76ms │      ~ │  464.47ms │      ~ │
+│ QQuery 9     │  493.73ms │   484.49ms │      ~ │  501.78ms │      ~ │  491.50ms │      ~ │  492.50ms │      ~ │  491.37ms │      ~ │
+│ QQuery 10    │  123.75ms │   115.46ms │    -6% │  121.44ms │      ~ │  114.80ms │    -7% │  114.32ms │    -7% │  120.33ms │      ~ │
+│ QQuery 11    │  127.30ms │   132.39ms │      ~ │  128.29ms │      ~ │  132.21ms │      ~ │  132.56ms │    +4% │  124.89ms │      ~ │
+│ QQuery 12    │  447.91ms │   447.96ms │      ~ │  460.19ms │      ~ │  447.76ms │      ~ │  457.86ms │      ~ │  443.63ms │      ~ │
+│ QQuery 13    │  674.57ms │   662.34ms │      ~ │  703.85ms │    +4% │  667.16ms │      ~ │  693.41ms │      ~ │  659.09ms │      ~ │
+│ QQuery 14    │  430.16ms │   430.82ms │      ~ │  430.06ms │      ~ │  427.35ms │      ~ │  441.52ms │      ~ │  435.73ms │      ~ │
+│ QQuery 15    │  460.95ms │   475.36ms │      ~ │  472.27ms │      ~ │  467.60ms │      ~ │  466.29ms │      ~ │  469.53ms │      ~ │
+│ QQuery 16    │  919.83ms │   908.13ms │      ~ │  909.31ms │      ~ │  897.61ms │      ~ │  918.57ms │      ~ │  925.93ms │      ~ │
+│ QQuery 17    │  877.38ms │   886.52ms │      ~ │  879.04ms │      ~ │  888.89ms │      ~ │  897.45ms │      ~ │  883.01ms │      ~ │
+│ QQuery 18    │ 1778.87ms │  1768.27ms │      ~ │ 1762.13ms │      ~ │ 1774.58ms │      ~ │ 1762.29ms │      ~ │ 1892.66ms │    +6% │
+│ QQuery 19    │   41.17ms │    41.06ms │      ~ │   42.35ms │      ~ │   41.66ms │      ~ │   41.86ms │      ~ │   41.24ms │      ~ │
+│ QQuery 20    │  457.37ms │   464.49ms │      ~ │  454.81ms │      ~ │  467.60ms │      ~ │  458.63ms │      ~ │  467.77ms │      ~ │
+│ QQuery 21    │  553.79ms │   544.90ms │      ~ │  533.68ms │      ~ │  536.13ms │      ~ │  542.53ms │      ~ │  538.80ms │      ~ │
+│ QQuery 22    │ 1139.66ms │  1101.74ms │      ~ │ 1090.11ms │    -4% │ 1096.69ms │      ~ │ 1096.85ms │      ~ │ 1079.60ms │    -5% │
+│ QQuery 23    │ 6209.71ms │  6124.43ms │      ~ │ 6128.56ms │      ~ │ 6041.04ms │      ~ │ 6123.40ms │      ~ │ 6117.59ms │      ~ │
+│ QQuery 24    │  212.72ms │   215.80ms │      ~ │  213.43ms │      ~ │  213.24ms │      ~ │  213.44ms │      ~ │  206.87ms │      ~ │
+│ QQuery 25    │  174.14ms │   178.51ms │      ~ │  152.36ms │   -12% │  160.96ms │    -7% │  163.16ms │    -6% │  163.24ms │    -6% │
+│ QQuery 26    │  239.74ms │   244.47ms │      ~ │  238.76ms │      ~ │  236.29ms │      ~ │  238.61ms │      ~ │  242.23ms │      ~ │
+│ QQuery 27    │  621.53ms │   648.46ms │    +4% │  599.87ms │      ~ │  605.41ms │      ~ │  623.34ms │      ~ │  607.88ms │      ~ │
+│ QQuery 28    │ 4517.84ms │  4569.81ms │      ~ │ 4618.83ms │      ~ │ 4606.27ms │      ~ │ 4693.17ms │      ~ │ 4583.64ms │      ~ │
+│ QQuery 29    │  200.48ms │   201.42ms │      ~ │  193.75ms │      ~ │  199.21ms │      ~ │  201.84ms │      ~ │  198.59ms │      ~ │
+│ QQuery 30    │  404.06ms │   397.24ms │      ~ │  419.88ms │      ~ │  410.63ms │      ~ │  405.86ms │      ~ │  406.23ms │      ~ │
+│ QQuery 31    │  508.28ms │   515.77ms │      ~ │  505.70ms │      ~ │  503.94ms │      ~ │  504.62ms │      ~ │  508.47ms │      ~ │
+│ QQuery 32    │ 1795.68ms │  1796.02ms │      ~ │ 1764.13ms │      ~ │ 1719.55ms │    -4% │ 1742.47ms │      ~ │ 1779.84ms │      ~ │
+│ QQuery 33    │ 1812.84ms │  1797.98ms │      ~ │ 1783.74ms │      ~ │ 1814.82ms │      ~ │ 1787.86ms │      ~ │ 1788.22ms │      ~ │
+│ QQuery 34    │ 1896.58ms │  1820.08ms │    -4% │ 1791.89ms │    -5% │ 1798.69ms │    -5% │ 1807.45ms │    -4% │ 1798.13ms │    -5% │
+│ QQuery 35    │  614.27ms │   601.42ms │      ~ │  593.12ms │      ~ │  594.36ms │      ~ │  599.00ms │      ~ │  606.34ms │      ~ │
+│ QQuery 36    │   97.03ms │   101.78ms │    +4% │   94.01ms │      ~ │  111.06ms │   +14% │  112.99ms │   +16% │  101.25ms │    +4% │
+│ QQuery 37    │   44.10ms │    42.71ms │      ~ │   45.37ms │      ~ │   44.60ms │      ~ │   43.33ms │      ~ │   45.05ms │      ~ │
+│ QQuery 38    │   60.98ms │    61.00ms │      ~ │   63.88ms │    +4% │   63.22ms │      ~ │   61.09ms │      ~ │   64.64ms │    +5% │
+│ QQuery 39    │  206.42ms │   199.44ms │      ~ │  191.35ms │    -7% │  198.98ms │      ~ │  198.35ms │      ~ │  191.27ms │    -7% │
+│ QQuery 40    │   22.86ms │    24.80ms │    +8% │   23.75ms │      ~ │   22.74ms │      ~ │   23.45ms │      ~ │   24.26ms │    +6% │
+│ QQuery 41    │   22.30ms │    22.08ms │      ~ │   20.76ms │    -6% │   21.86ms │      ~ │   23.04ms │      ~ │   21.27ms │    -4% │
+│ QQuery 42    │   26.82ms │    29.02ms │    +8% │   29.12ms │    +8% │   27.65ms │      ~ │   28.46ms │    +6% │   27.50ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ Total Time (base)         │ 29618.65ms │
+│ Total Time (base-rerun)   │ 29447.61ms │
+│ Total Time (SORT0)        │ 29396.54ms │
+│ Total Time (SORT32)       │ 29243.81ms │
+│ Total Time (SORT256)      │ 29516.82ms │
+│ Total Time (SORT1024)     │ 29448.84ms │
+│ Average Time (base)       │   688.81ms │
+│ Average Time (base-rerun) │   684.83ms │
+│ Queries Faster            │          3 │
+│ Queries Slower            │          4 │
+│ Queries with No Change    │         36 │
+│ Average Time (SORT0)      │   683.64ms │
+│ Queries Faster            │          6 │
+│ Queries Slower            │          6 │
+│ Queries with No Change    │         31 │
+│ Average Time (SORT32)     │   680.09ms │
+│ Queries Faster            │          6 │
+│ Queries Slower            │          2 │
+│ Queries with No Change    │         35 │
+│ Average Time (SORT256)    │   686.44ms │
+│ Queries Faster            │          4 │
+│ Queries Slower            │          5 │
+│ Queries with No Change    │         34 │
+│ Average Time (SORT1024)   │   684.86ms │
+│ Queries Faster            │          6 │
+│ Queries Slower            │          5 │
+│ Queries with No Change    │         32 │
+└───────────────────────────┴────────────┘
+
+## clickbench_extended results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     SORT0 ┃ Change ┃    SORT32 ┃ Change ┃   SORT256 ┃ Change ┃  SORT1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 0     │  919.34ms │   858.85ms │    -6% │  863.49ms │    -6% │  869.99ms │    -5% │  863.96ms │    -6% │  843.71ms │    -8% │
+│ QQuery 1     │  240.76ms │   245.19ms │      ~ │  240.03ms │      ~ │  239.12ms │      ~ │  235.98ms │      ~ │  250.87ms │    +4% │
+│ QQuery 2     │  445.67ms │   459.20ms │      ~ │  462.52ms │      ~ │  467.68ms │    +4% │  449.76ms │      ~ │  469.74ms │    +5% │
+│ QQuery 3     │  253.06ms │   252.94ms │      ~ │  263.56ms │    +4% │  249.86ms │      ~ │  255.90ms │      ~ │  264.34ms │    +4% │
+│ QQuery 4     │  887.57ms │   904.68ms │      ~ │  892.38ms │      ~ │  887.74ms │      ~ │  880.50ms │      ~ │  877.88ms │      ~ │
+│ QQuery 5     │ 8249.61ms │  8189.48ms │      ~ │ 8263.25ms │      ~ │ 8295.07ms │      ~ │ 8153.83ms │      ~ │ 8174.00ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ Total Time (base)         │ 10996.01ms │
+│ Total Time (base-rerun)   │ 10910.33ms │
+│ Total Time (SORT0)        │ 10985.23ms │
+│ Total Time (SORT32)       │ 11009.47ms │
+│ Total Time (SORT256)      │ 10839.91ms │
+│ Total Time (SORT1024)     │ 10880.54ms │
+│ Average Time (base)       │  1832.67ms │
+│ Average Time (base-rerun) │  1818.39ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          0 │
+│ Queries with No Change    │          5 │
+│ Average Time (SORT0)      │  1830.87ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          1 │
+│ Queries with No Change    │          4 │
+│ Average Time (SORT32)     │  1834.91ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          1 │
+│ Queries with No Change    │          4 │
+│ Average Time (SORT256)    │  1806.65ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          0 │
+│ Queries with No Change    │          5 │
+│ Average Time (SORT1024)   │  1813.42ms │
+│ Queries Faster            │          1 │
+│ Queries Slower            │          3 │
+│ Queries with No Change    │          2 │
+└───────────────────────────┴────────────┘
+
+## tpch_sf1 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃     base ┃ base-rerun ┃ Change ┃    SORT0 ┃ Change ┃   SORT32 ┃ Change ┃  SORT256 ┃ Change ┃ SORT1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  73.03ms │    78.72ms │    +7% │  78.67ms │    +7% │  75.50ms │      ~ │  74.84ms │      ~ │  75.12ms │      ~ │
+│ QQuery 2     │  22.70ms │    23.29ms │      ~ │  23.22ms │      ~ │  22.77ms │      ~ │  22.36ms │      ~ │  22.34ms │      ~ │
+│ QQuery 3     │  30.18ms │    29.33ms │      ~ │  29.83ms │      ~ │  30.69ms │      ~ │  30.93ms │      ~ │  31.82ms │    +5% │
+│ QQuery 4     │  28.50ms │    28.48ms │      ~ │  28.37ms │      ~ │  28.84ms │      ~ │  28.96ms │      ~ │  29.60ms │      ~ │
+│ QQuery 5     │  51.25ms │    51.86ms │      ~ │  49.77ms │      ~ │  51.21ms │      ~ │  52.22ms │      ~ │  51.12ms │      ~ │
+│ QQuery 6     │  14.50ms │    15.16ms │    +4% │  15.26ms │    +5% │  15.19ms │    +4% │  15.33ms │    +5% │  15.01ms │      ~ │
+│ QQuery 7     │  79.08ms │    79.31ms │      ~ │  79.88ms │      ~ │  77.04ms │      ~ │  77.04ms │      ~ │  76.66ms │      ~ │
+│ QQuery 8     │  43.12ms │    44.35ms │      ~ │  42.15ms │      ~ │  43.98ms │      ~ │  43.72ms │      ~ │  43.95ms │      ~ │
+│ QQuery 9     │  62.03ms │    64.05ms │      ~ │  63.97ms │      ~ │  63.53ms │      ~ │  62.07ms │      ~ │  63.87ms │      ~ │
+│ QQuery 10    │  49.65ms │    50.23ms │      ~ │  49.22ms │      ~ │  49.51ms │      ~ │  50.63ms │      ~ │  51.17ms │      ~ │
+│ QQuery 11    │  16.97ms │    16.49ms │      ~ │  17.28ms │      ~ │  17.53ms │      ~ │  16.99ms │      ~ │  17.25ms │      ~ │
+│ QQuery 12    │  27.86ms │    28.28ms │      ~ │  27.43ms │      ~ │  28.93ms │      ~ │  28.32ms │      ~ │  28.62ms │      ~ │
+│ QQuery 13    │  30.88ms │    31.93ms │      ~ │  31.15ms │      ~ │  32.16ms │    +4% │  31.07ms │      ~ │  32.41ms │    +4% │
+│ QQuery 14    │  23.35ms │    24.01ms │      ~ │  22.96ms │      ~ │  23.91ms │      ~ │  23.08ms │      ~ │  23.33ms │      ~ │
+│ QQuery 15    │  33.71ms │    34.11ms │      ~ │  33.58ms │      ~ │  36.45ms │    +8% │  34.56ms │      ~ │  33.94ms │      ~ │
+│ QQuery 16    │  14.99ms │    14.53ms │      ~ │  14.62ms │      ~ │  15.34ms │      ~ │  16.03ms │    +6% │  15.28ms │      ~ │
+│ QQuery 17    │  64.29ms │    62.49ms │      ~ │  61.94ms │      ~ │  65.22ms │      ~ │  65.43ms │      ~ │  63.94ms │      ~ │
+│ QQuery 18    │ 109.76ms │   110.60ms │      ~ │ 110.63ms │      ~ │ 109.23ms │      ~ │ 108.67ms │      ~ │ 108.98ms │      ~ │
+│ QQuery 19    │  43.47ms │    43.95ms │      ~ │  42.64ms │      ~ │  44.07ms │      ~ │  43.20ms │      ~ │  44.37ms │      ~ │
+│ QQuery 20    │  34.84ms │    33.56ms │      ~ │  35.14ms │      ~ │  34.99ms │      ~ │  34.63ms │      ~ │  35.41ms │      ~ │
+│ QQuery 21    │  92.47ms │    90.91ms │      ~ │  89.49ms │      ~ │  98.86ms │    +6% │  91.59ms │      ~ │  91.93ms │      ~ │
+│ QQuery 22    │  19.00ms │    18.73ms │      ~ │  19.21ms │      ~ │  18.93ms │      ~ │  19.50ms │      ~ │  19.46ms │      ~ │
+└──────────────┴──────────┴────────────┴────────┴──────────┴────────┴──────────┴────────┴──────────┴────────┴──────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Benchmark Summary         ┃          ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ Total Time (base)         │ 965.62ms │
+│ Total Time (base-rerun)   │ 974.38ms │
+│ Total Time (SORT0)        │ 966.38ms │
+│ Total Time (SORT32)       │ 983.90ms │
+│ Total Time (SORT256)      │ 971.16ms │
+│ Total Time (SORT1024)     │ 975.58ms │
+│ Average Time (base)       │  43.89ms │
+│ Average Time (base-rerun) │  44.29ms │
+│ Queries Faster            │        0 │
+│ Queries Slower            │        2 │
+│ Queries with No Change    │       20 │
+│ Average Time (SORT0)      │  43.93ms │
+│ Queries Faster            │        0 │
+│ Queries Slower            │        2 │
+│ Queries with No Change    │       20 │
+│ Average Time (SORT32)     │  44.72ms │
+│ Queries Faster            │        0 │
+│ Queries Slower            │        4 │
+│ Queries with No Change    │       18 │
+│ Average Time (SORT256)    │  44.14ms │
+│ Queries Faster            │        0 │
+│ Queries Slower            │        2 │
+│ Queries with No Change    │       20 │
+│ Average Time (SORT1024)   │  44.34ms │
+│ Queries Faster            │        0 │
+│ Queries Slower            │        2 │
+│ Queries with No Change    │       20 │
+└───────────────────────────┴──────────┘
+
+## tpch_sf10 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     SORT0 ┃ Change ┃    SORT32 ┃ Change ┃   SORT256 ┃ Change ┃  SORT1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  533.93ms │   543.70ms │      ~ │  559.45ms │    +4% │  542.86ms │      ~ │  532.86ms │      ~ │  531.90ms │      ~ │
+│ QQuery 2     │  153.11ms │   152.01ms │      ~ │  151.76ms │      ~ │  152.78ms │      ~ │  154.33ms │      ~ │  150.09ms │      ~ │
+│ QQuery 3     │  309.11ms │   311.16ms │      ~ │  311.88ms │      ~ │  312.46ms │      ~ │  311.26ms │      ~ │  311.56ms │      ~ │
+│ QQuery 4     │  236.14ms │   236.26ms │      ~ │  231.87ms │      ~ │  235.74ms │      ~ │  231.39ms │      ~ │  231.74ms │      ~ │
+│ QQuery 5     │  570.31ms │   566.66ms │      ~ │  567.58ms │      ~ │  570.82ms │      ~ │  579.42ms │      ~ │  570.63ms │      ~ │
+│ QQuery 6     │   92.47ms │    90.03ms │      ~ │   94.70ms │      ~ │   91.07ms │      ~ │   89.80ms │      ~ │   90.30ms │      ~ │
+│ QQuery 7     │  900.36ms │   914.47ms │      ~ │  911.28ms │      ~ │  850.97ms │    -5% │  857.99ms │    -4% │  853.00ms │    -5% │
+│ QQuery 8     │  528.16ms │   531.54ms │      ~ │  526.70ms │      ~ │  522.88ms │      ~ │  532.98ms │      ~ │  532.80ms │      ~ │
+│ QQuery 9     │ 1011.72ms │  1013.89ms │      ~ │ 1017.22ms │      ~ │  981.60ms │      ~ │  996.73ms │      ~ │  996.07ms │      ~ │
+│ QQuery 10    │  455.50ms │   440.61ms │      ~ │  453.70ms │      ~ │  448.41ms │      ~ │  448.12ms │      ~ │  444.48ms │      ~ │
+│ QQuery 11    │  135.66ms │   134.01ms │      ~ │  135.16ms │      ~ │  134.80ms │      ~ │  134.81ms │      ~ │  134.43ms │      ~ │
+│ QQuery 12    │  182.91ms │   183.39ms │      ~ │  181.76ms │      ~ │  182.73ms │      ~ │  181.35ms │      ~ │  187.99ms │      ~ │
+│ QQuery 13    │  388.11ms │   359.03ms │    -7% │  371.05ms │    -4% │  390.64ms │      ~ │  377.59ms │      ~ │  364.10ms │    -6% │
+│ QQuery 14    │  146.85ms │   150.79ms │      ~ │  143.67ms │      ~ │  148.99ms │      ~ │  149.89ms │      ~ │  140.02ms │    -4% │
+│ QQuery 15    │  224.77ms │   224.99ms │      ~ │  221.77ms │      ~ │  235.04ms │    +4% │  234.07ms │    +4% │  233.26ms │      ~ │
+│ QQuery 16    │   97.17ms │    98.08ms │      ~ │   95.83ms │      ~ │   95.90ms │      ~ │  100.12ms │      ~ │   96.83ms │      ~ │
+│ QQuery 17    │  808.27ms │   806.36ms │      ~ │  805.32ms │      ~ │  805.10ms │      ~ │  808.21ms │      ~ │  804.71ms │      ~ │
+│ QQuery 18    │ 1360.86ms │  1351.04ms │      ~ │ 1389.14ms │      ~ │ 1432.35ms │    +5% │ 1346.35ms │      ~ │ 1358.56ms │      ~ │
+│ QQuery 19    │  234.19ms │   246.01ms │    +5% │  228.77ms │      ~ │  241.68ms │      ~ │  242.71ms │      ~ │  246.41ms │    +5% │
+│ QQuery 20    │  277.69ms │   270.64ms │      ~ │  280.99ms │      ~ │  283.83ms │      ~ │  284.14ms │      ~ │  277.40ms │      ~ │
+│ QQuery 21    │ 1113.94ms │  1115.46ms │      ~ │ 1112.08ms │      ~ │ 1178.73ms │    +5% │ 1114.02ms │      ~ │ 1123.26ms │      ~ │
+│ QQuery 22    │   87.45ms │    85.63ms │      ~ │   88.12ms │      ~ │   87.52ms │      ~ │   88.26ms │      ~ │   86.80ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃           ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ Total Time (base)         │ 9848.66ms │
+│ Total Time (base-rerun)   │ 9825.76ms │
+│ Total Time (SORT0)        │ 9879.81ms │
+│ Total Time (SORT32)       │ 9926.90ms │
+│ Total Time (SORT256)      │ 9796.38ms │
+│ Total Time (SORT1024)     │ 9766.34ms │
+│ Average Time (base)       │  447.67ms │
+│ Average Time (base-rerun) │  446.63ms │
+│ Queries Faster            │         1 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        20 │
+│ Average Time (SORT0)      │  449.08ms │
+│ Queries Faster            │         1 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        20 │
+│ Average Time (SORT32)     │  451.22ms │
+│ Queries Faster            │         1 │
+│ Queries Slower            │         3 │
+│ Queries with No Change    │        18 │
+│ Average Time (SORT256)    │  445.29ms │
+│ Queries Faster            │         1 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        20 │
+│ Average Time (SORT1024)   │  443.92ms │
+│ Queries Faster            │         3 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        18 │
+└───────────────────────────┴───────────┘
+
+## tpch_mem_sf1 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃     base ┃ base-rerun ┃ Change ┃    SORT0 ┃ Change ┃   SORT32 ┃ Change ┃  SORT256 ┃ Change ┃ SORT1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  56.34ms │    59.29ms │    +5% │  60.56ms │    +7% │  57.82ms │      ~ │  61.20ms │    +8% │  60.55ms │    +7% │
+│ QQuery 2     │  12.40ms │    12.50ms │      ~ │  12.56ms │      ~ │  11.86ms │    -4% │  12.84ms │      ~ │  12.68ms │      ~ │
+│ QQuery 3     │  27.76ms │    27.50ms │      ~ │  27.81ms │      ~ │  27.90ms │      ~ │  28.00ms │      ~ │  28.03ms │      ~ │
+│ QQuery 4     │   9.67ms │     9.48ms │      ~ │   9.85ms │      ~ │   9.86ms │      ~ │   9.87ms │      ~ │   9.72ms │      ~ │
+│ QQuery 5     │  35.95ms │    35.67ms │      ~ │  35.60ms │      ~ │  35.70ms │      ~ │  36.47ms │      ~ │  35.79ms │      ~ │
+│ QQuery 6     │   5.97ms │     5.68ms │    -4% │   6.03ms │      ~ │   5.96ms │      ~ │   5.77ms │      ~ │   5.64ms │    -5% │
+│ QQuery 7     │  79.05ms │    78.53ms │      ~ │  77.42ms │      ~ │  69.71ms │   -11% │  70.40ms │   -10% │  69.98ms │   -11% │
+│ QQuery 8     │  12.91ms │    12.66ms │      ~ │  12.98ms │      ~ │  13.75ms │    +6% │  14.93ms │   +15% │  13.10ms │      ~ │
+│ QQuery 9     │  34.59ms │    35.70ms │      ~ │  36.05ms │    +4% │  34.50ms │      ~ │  35.39ms │      ~ │  34.90ms │      ~ │
+│ QQuery 10    │  35.29ms │    35.90ms │      ~ │  34.57ms │      ~ │  35.95ms │      ~ │  35.67ms │      ~ │  35.78ms │      ~ │
+│ QQuery 11    │   6.10ms │     5.87ms │      ~ │   5.74ms │    -5% │   6.20ms │      ~ │   5.65ms │    -7% │   6.11ms │      ~ │
+│ QQuery 12    │  17.25ms │    22.07ms │   +27% │  17.03ms │      ~ │  16.63ms │      ~ │  17.99ms │    +4% │  17.91ms │      ~ │
+│ QQuery 13    │  12.83ms │    12.38ms │      ~ │  12.00ms │    -6% │  12.24ms │    -4% │  12.29ms │    -4% │  12.79ms │      ~ │
+│ QQuery 14    │   7.82ms │     7.61ms │      ~ │   6.92ms │   -11% │   8.24ms │    +5% │   6.04ms │   -22% │   5.98ms │   -23% │
+│ QQuery 15    │  10.85ms │    12.04ms │   +10% │  13.18ms │   +21% │  10.55ms │      ~ │  11.53ms │    +6% │  11.70ms │    +7% │
+│ QQuery 16    │  15.19ms │    12.35ms │   -18% │  14.18ms │    -6% │  11.56ms │   -23% │  13.91ms │    -8% │  12.70ms │   -16% │
+│ QQuery 17    │  45.52ms │    46.29ms │      ~ │  46.62ms │      ~ │  45.97ms │      ~ │  46.10ms │      ~ │  47.94ms │    +5% │
+│ QQuery 18    │ 148.40ms │   148.77ms │      ~ │ 149.37ms │      ~ │ 129.73ms │   -12% │ 132.91ms │   -10% │ 141.09ms │    -4% │
+│ QQuery 19    │  19.62ms │    20.89ms │    +6% │  20.63ms │    +5% │  20.03ms │      ~ │  20.04ms │      ~ │  20.29ms │      ~ │
+│ QQuery 20    │  21.97ms │    23.23ms │    +5% │  24.43ms │   +11% │  25.48ms │   +15% │  23.75ms │    +8% │  21.95ms │      ~ │
+│ QQuery 21    │ 102.54ms │   101.28ms │      ~ │ 102.69ms │      ~ │  90.28ms │   -11% │  96.00ms │    -6% │  96.16ms │    -6% │
+│ QQuery 22    │  17.19ms │    18.08ms │    +5% │  17.60ms │      ~ │  17.71ms │      ~ │  18.21ms │    +5% │  17.65ms │      ~ │
+└──────────────┴──────────┴────────────┴────────┴──────────┴────────┴──────────┴────────┴──────────┴────────┴──────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Benchmark Summary         ┃          ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ Total Time (base)         │ 735.22ms │
+│ Total Time (base-rerun)   │ 743.76ms │
+│ Total Time (SORT0)        │ 743.81ms │
+│ Total Time (SORT32)       │ 697.61ms │
+│ Total Time (SORT256)      │ 714.95ms │
+│ Total Time (SORT1024)     │ 718.46ms │
+│ Average Time (base)       │  33.42ms │
+│ Average Time (base-rerun) │  33.81ms │
+│ Queries Faster            │        2 │
+│ Queries Slower            │        6 │
+│ Queries with No Change    │       14 │
+│ Average Time (SORT0)      │  33.81ms │
+│ Queries Faster            │        4 │
+│ Queries Slower            │        5 │
+│ Queries with No Change    │       13 │
+│ Average Time (SORT32)     │  31.71ms │
+│ Queries Faster            │        6 │
+│ Queries Slower            │        3 │
+│ Queries with No Change    │       13 │
+│ Average Time (SORT256)    │  32.50ms │
+│ Queries Faster            │        7 │
+│ Queries Slower            │        6 │
+│ Queries with No Change    │        9 │
+│ Average Time (SORT1024)   │  32.66ms │
+│ Queries Faster            │        6 │
+│ Queries Slower            │        3 │
+│ Queries with No Change    │       13 │
+└───────────────────────────┴──────────┘
+
+## tpch_mem_sf10 results:
+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
+┃ Query        ┃      base ┃ base-rerun ┃ Change ┃     SORT0 ┃ Change ┃    SORT32 ┃ Change ┃   SORT256 ┃ Change ┃  SORT1024 ┃ Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
+│ QQuery 1     │  628.05ms │   625.82ms │      ~ │  601.74ms │    -4% │  615.73ms │      ~ │  616.89ms │      ~ │  617.67ms │      ~ │
+│ QQuery 2     │  111.67ms │   110.78ms │      ~ │  111.32ms │      ~ │  110.67ms │      ~ │  111.01ms │      ~ │  111.33ms │      ~ │
+│ QQuery 3     │  265.51ms │   266.26ms │      ~ │  266.49ms │      ~ │  267.06ms │      ~ │  268.32ms │      ~ │  266.46ms │      ~ │
+│ QQuery 4     │   78.36ms │    79.05ms │      ~ │   78.83ms │      ~ │   79.01ms │      ~ │   78.71ms │      ~ │   79.77ms │      ~ │
+│ QQuery 5     │  438.22ms │   440.66ms │      ~ │  439.83ms │      ~ │  405.50ms │    -7% │  412.63ms │    -5% │  407.50ms │    -7% │
+│ QQuery 6     │   49.25ms │    49.29ms │      ~ │   49.37ms │      ~ │   49.21ms │      ~ │   48.79ms │      ~ │   48.97ms │      ~ │
+│ QQuery 7     │  910.22ms │   909.01ms │      ~ │  897.79ms │      ~ │  815.36ms │   -10% │  827.66ms │    -9% │  814.76ms │   -10% │
+│ QQuery 8     │  344.64ms │   344.93ms │      ~ │  344.86ms │      ~ │  343.10ms │      ~ │  343.56ms │      ~ │  344.58ms │      ~ │
+│ QQuery 9     │  781.32ms │   772.21ms │      ~ │  783.30ms │      ~ │  742.76ms │    -4% │  740.18ms │    -5% │  738.22ms │    -5% │
+│ QQuery 10    │  356.04ms │   357.06ms │      ~ │  356.36ms │      ~ │  352.51ms │      ~ │  352.85ms │      ~ │  350.34ms │      ~ │
+│ QQuery 11    │  103.69ms │   103.00ms │      ~ │  103.84ms │      ~ │  102.09ms │      ~ │  103.43ms │      ~ │  104.51ms │      ~ │
+│ QQuery 12    │  161.29ms │   162.11ms │      ~ │  158.01ms │      ~ │  142.03ms │   -11% │  155.45ms │      ~ │  155.81ms │      ~ │
+│ QQuery 13    │  187.74ms │   196.69ms │    +4% │  191.34ms │      ~ │  195.70ms │    +4% │  194.93ms │      ~ │  192.61ms │      ~ │
+│ QQuery 14    │   42.26ms │    43.01ms │      ~ │   43.06ms │      ~ │   42.39ms │      ~ │   44.13ms │    +4% │   43.08ms │      ~ │
+│ QQuery 15    │   89.82ms │    89.18ms │      ~ │   90.10ms │      ~ │   90.56ms │      ~ │   89.27ms │      ~ │   90.49ms │      ~ │
+│ QQuery 16    │   84.03ms │    85.20ms │      ~ │   86.16ms │      ~ │   85.16ms │      ~ │   85.20ms │      ~ │   84.89ms │      ~ │
+│ QQuery 17    │  708.59ms │   733.30ms │      ~ │  714.45ms │      ~ │  726.39ms │      ~ │  724.68ms │      ~ │  726.23ms │      ~ │
+│ QQuery 18    │ 1821.97ms │  1806.55ms │      ~ │ 1825.26ms │      ~ │ 2416.02ms │   +32% │ 1684.97ms │    -7% │ 1739.05ms │    -4% │
+│ QQuery 19    │  107.22ms │   107.08ms │      ~ │  107.12ms │      ~ │  106.22ms │      ~ │  112.71ms │    +5% │  108.36ms │      ~ │
+│ QQuery 20    │  195.15ms │   193.83ms │      ~ │  194.65ms │      ~ │  197.02ms │      ~ │  194.22ms │      ~ │  194.73ms │      ~ │
+│ QQuery 21    │ 1080.85ms │  1069.29ms │      ~ │ 1066.08ms │      ~ │ 1025.04ms │    -5% │ 1015.88ms │    -6% │ 1012.29ms │    -6% │
+│ QQuery 22    │   69.45ms │    68.21ms │      ~ │   67.47ms │      ~ │   68.30ms │      ~ │   67.94ms │      ~ │   68.31ms │      ~ │
+└──────────────┴───────────┴────────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Benchmark Summary         ┃           ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ Total Time (base)         │ 8615.35ms │
+│ Total Time (base-rerun)   │ 8612.52ms │
+│ Total Time (SORT0)        │ 8577.45ms │
+│ Total Time (SORT32)       │ 8977.83ms │
+│ Total Time (SORT256)      │ 8273.40ms │
+│ Total Time (SORT1024)     │ 8299.95ms │
+│ Average Time (base)       │  391.61ms │
+│ Average Time (base-rerun) │  391.48ms │
+│ Queries Faster            │         0 │
+│ Queries Slower            │         1 │
+│ Queries with No Change    │        21 │
+│ Average Time (SORT0)      │  389.88ms │
+│ Queries Faster            │         1 │
+│ Queries Slower            │         0 │
+│ Queries with No Change    │        21 │
+│ Average Time (SORT32)     │  408.08ms │
+│ Queries Faster            │         5 │
+│ Queries Slower            │         2 │
+│ Queries with No Change    │        15 │
+│ Average Time (SORT256)    │  376.06ms │
+│ Queries Faster            │         5 │
+│ Queries Slower            │         2 │
+│ Queries with No Change    │        15 │
+│ Average Time (SORT1024)   │  377.27ms │
+│ Queries Faster            │         5 │
+│ Queries Slower            │         0 │
+│ Queries with No Change    │        17 │
+└───────────────────────────┴───────────┘

--- a/datafusion/physical-optimizer/src/coalesce_batches.rs
+++ b/datafusion/physical-optimizer/src/coalesce_batches.rs
@@ -26,8 +26,8 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
 use datafusion_physical_expr::Partitioning;
 use datafusion_physical_plan::{
-    coalesce_batches::CoalesceBatchesExec, filter::FilterExec, joins::HashJoinExec,
-    repartition::RepartitionExec, ExecutionPlan,
+    aggregates::AggregateExec, coalesce_batches::CoalesceBatchesExec, filter::FilterExec,
+    joins::HashJoinExec, repartition::RepartitionExec, ExecutionPlan,
 };
 
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
@@ -86,6 +86,74 @@ impl PhysicalOptimizerRule for CoalesceBatches {
 
     fn name(&self) -> &str {
         "coalesce_batches"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+/// Remove CoalesceBatchesExec that are in front of a AggregateExec
+#[derive(Default, Debug)]
+pub struct UnCoalesceBatches {}
+
+impl UnCoalesceBatches {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl PhysicalOptimizerRule for UnCoalesceBatches {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if !config.execution.coalesce_batches {
+            return Ok(plan);
+        }
+
+        plan.transform_up(|plan| {
+            if let Some(aggregate) = plan.as_any().downcast_ref::<AggregateExec>() {
+                let agg_input = aggregate.input();
+
+                if let Some(coalesce) =
+                    plan.as_any().downcast_ref::<CoalesceBatchesExec>()
+                {
+                    let coalesce_input = coalesce.input();
+
+                    return Ok(Transformed::yes(
+                        agg_input
+                            .clone()
+                            .with_new_children(vec![coalesce_input.clone()])?,
+                    ));
+                }
+            }
+
+            if let Some(hash_join) = plan.as_any().downcast_ref::<HashJoinExec>() {
+                let children = hash_join.children();
+                if let Some(coalesce) = hash_join
+                    .left()
+                    .as_any()
+                    .downcast_ref::<CoalesceBatchesExec>()
+                {
+                    let coalesce_input = coalesce.input();
+
+                    return Ok(Transformed::yes(plan.clone().with_new_children(vec![
+                        coalesce_input.clone(),
+                        children[1].clone(),
+                    ])?));
+                }
+            }
+
+            Ok(Transformed::no(plan))
+        })
+        .data()
+    }
+
+    fn name(&self) -> &str {
+        "uncoalesce_batches"
     }
 
     fn schema_check(&self) -> bool {

--- a/datafusion/physical-optimizer/src/optimizer.rs
+++ b/datafusion/physical-optimizer/src/optimizer.rs
@@ -110,7 +110,7 @@ impl PhysicalOptimizer {
             Arc::new(OptimizeAggregateOrder::new()),
             // TODO: `try_embed_to_hash_join` in the ProjectionPushdown rule would be block by the CoalesceBatches, so add it before CoalesceBatches. Maybe optimize it in the future.
             Arc::new(ProjectionPushdown::new()),
-            // The CoalesceBatches rule will not influence the distribution and ordering of the
+            // The CoalesceBatches/UnCoalesceBatches rule will not influence the distribution and ordering of the
             // whole plan tree. Therefore, to avoid influencing other rules, it should run last.
             Arc::new(CoalesceBatches::new()),
             Arc::new(UnCoalesceBatches::new()),

--- a/datafusion/physical-optimizer/src/optimizer.rs
+++ b/datafusion/physical-optimizer/src/optimizer.rs
@@ -21,7 +21,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::aggregate_statistics::AggregateStatistics;
-use crate::coalesce_batches::CoalesceBatches;
+use crate::coalesce_batches::{CoalesceBatches, UnCoalesceBatches};
 use crate::combine_partial_final_agg::CombinePartialFinalAggregate;
 use crate::enforce_distribution::EnforceDistribution;
 use crate::enforce_sorting::EnforceSorting;
@@ -113,6 +113,7 @@ impl PhysicalOptimizer {
             // The CoalesceBatches rule will not influence the distribution and ordering of the
             // whole plan tree. Therefore, to avoid influencing other rules, it should run last.
             Arc::new(CoalesceBatches::new()),
+            Arc::new(UnCoalesceBatches::new()),
             // Remove the ancillary output requirement operator since we are done with the planning
             // phase.
             Arc::new(OutputRequirements::new_remove_mode()),


### PR DESCRIPTION
Relates to Issue: #15478

## Rationale for this change

The blocking operators (HJ buid side, Aggregation) are often planned on top of a RepartitionExec with a CoalesceBatchesExec in-between. However, one of the first things these operators do is concatenate the freshly CoalescedBatches. 
This PR is to test if the overhead of the 2-step coalesce+concat outweighs the gains of fewer dispatches of the consuming operators.

## What changes are included in this PR?

This PR adds a physical optimizer rule `UncoalesceBatches`. It runs after the `CoalesceBatches` rule and removes `CoalesceBatchesExec` that are at the build side of HashJoins and in front of non-partial aggregations

## Are these changes tested?

Not yet!

## Are there any user-facing changes?

Yes.