### PR TITLE
WIP: Test enabling Parquet filter pushdown with parquet caching page cache reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,9 +246,8 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -265,14 +264,13 @@ dependencies = [
  "arrow-string",
  "half",
  "pyo3",
- "rand 0.8.5",
+ "rand 0.9.0",
 ]
 
 [[package]]
 name = "arrow-arith"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07e726e2b3f7816a85c6a45b6ec118eeeabf0b2a8c208122ad949437181f49a"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -284,9 +282,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2262eba4f16c78496adfd559a29fe4b24df6088efc9985a873d58e92be022d5"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -311,9 +308,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4103d88c5b441525ed4ac23153be7458494c2b0c9a11115848fdb9b81f6f886a"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -332,9 +328,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d3cb0914486a3cae19a5cad2598e44e225d53157926d0ada03c20521191a65"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -359,9 +354,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7408f2bf3b978eddda272c7699f439760ebc4ac70feca25fefa82c5b8ce808d"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -386,9 +380,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -400,9 +393,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b9340013413eb84868682ace00a1098c81a5ebc96d279f7ebf9a4cac3c0fd"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -413,16 +405,17 @@ dependencies = [
  "half",
  "indexmap 2.8.0",
  "lexical-core",
+ "memchr",
  "num",
  "serde",
  "serde_json",
+ "simdutf8",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -433,9 +426,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -455,9 +447,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2932aece2d0c869dd2125feb9bd1709ef5c445daa3838ac4112dcfa0fda52c"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -469,9 +460,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1344,9 +1334,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1354,7 +1344,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2900,11 +2890,11 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
-version = "24.12.23"
+version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.8.0",
  "rustc_version",
 ]
 
@@ -3982,7 +3972,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -4343,9 +4333,8 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88838dca3b84d41444a0341b19f347e8098a3898b0f21536654b8b799e11abd"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -4373,9 +4362,8 @@ dependencies = [
  "snap",
  "thrift",
  "tokio",
- "twox-hash",
+ "twox-hash 2.1.0",
  "zstd",
- "zstd-sys",
 ]
 
 [[package]]
@@ -4822,9 +4810,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "7f1c6c3591120564d64db2261bec5f910ae454f01def849b9c22835a84695e86"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -4840,9 +4828,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e9b6c2b34cf71427ea37c7001aefbaeb85886a074795e35f161f5aecc7620a7a"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -4850,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "5507651906a46432cdda02cd02dd0319f6064f1374c9147c45b978621d2c3a9c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -4860,9 +4848,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "b0d394b5b4fd8d97d48336bb0dd2aebabad39f1d294edd6bcd2cccf2eefe6f42"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4872,9 +4860,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "fd72da09cfa943b1080f621f024d2ef7e2773df7badd51aa30a2be1f8caa7c8e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6110,9 +6098,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
@@ -6614,6 +6602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7106,6 +7100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7498,48 +7498,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "arrow"
-version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
-
-[[patch.unused]]
-name = "arrow-array"
-version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
-
-[[patch.unused]]
-name = "arrow-cast"
-version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
-
-[[patch.unused]]
-name = "arrow-flight"
-version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
-
-[[patch.unused]]
-name = "arrow-ipc"
-version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
-
-[[patch.unused]]
-name = "arrow-ord"
-version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
-
-[[patch.unused]]
-name = "arrow-select"
-version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
-
-[[patch.unused]]
-name = "arrow-string"
-version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
-
-[[patch.unused]]
-name = "parquet"
-version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -270,7 +270,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -299,7 +299,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "bytes",
  "half",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -344,7 +344,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -355,7 +355,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -394,7 +394,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -415,7 +415,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -427,7 +427,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -439,7 +439,7 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "bitflags 2.8.0",
  "serde",
@@ -448,7 +448,7 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2905,6 +2905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -3927,6 +3928,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4334,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "54.3.1"
-source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+source = "git+https://github.com/XiangpengHao/arrow-rs.git?rev=7c10b4a93d99328928434462a044098993442a0f#7c10b4a93d99328928434462a044098993442a0f"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -7470,6 +7480,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e899dade2c3b7f5642eb8366cfd898958bcca099cde6dfea543c7e8d3ad88d4"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "bytes",
  "half",
@@ -349,9 +348,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a329fb064477c9ec5f0870d2f5130966f91055c7c5bce2b3a084f116bc28c3b"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -448,9 +446,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85934a9d0261e0fa5d4e2a5295107d743b543a6e0484a835d4b8db2da15306f9"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
 dependencies = [
  "bitflags 2.8.0",
  "serde",
@@ -3897,7 +3894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7046,7 +7043,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7501,3 +7498,48 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "arrow"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+
+[[patch.unused]]
+name = "arrow-array"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+
+[[patch.unused]]
+name = "arrow-cast"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+
+[[patch.unused]]
+name = "arrow-flight"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+
+[[patch.unused]]
+name = "arrow-ipc"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+
+[[patch.unused]]
+name = "arrow-ord"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+
+[[patch.unused]]
+name = "arrow-select"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+
+[[patch.unused]]
+name = "arrow-string"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"
+
+[[patch.unused]]
+name = "parquet"
+version = "54.3.1"
+source = "git+https://github.com/apache/arrow-rs.git?rev=b30336da8c1318f3f45e22f0a377ca21830fddac#b30336da8c1318f3f45e22f0a377ca21830fddac"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,18 +208,19 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
 unused_qualifications = "deny"
 
 
-## Temporary arrow-rs patch until 55
+## Temporary arrow-rs patch
+## https://github.com/apache/arrow-rs/pull/6921cli
 
 [patch.crates-io]
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
-parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-array = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-buffer = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-cast = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-data = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-ipc = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-schema = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-select = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-string = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-ord = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+arrow-flight = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }
+parquet = { git = "https://github.com/XiangpengHao/arrow-rs.git", rev = "7c10b4a93d99328928434462a044098993442a0f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,3 +206,20 @@ used_underscore_binding = "warn"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
 unused_qualifications = "deny"
+
+
+## Temporary arrow-rs patch until 55
+
+[patch.crates-io]
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "b30336da8c1318f3f45e22f0a377ca21830fddac" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,19 +87,19 @@ ahash = { version = "0.8", default-features = false, features = [
     "runtime-rng",
 ] }
 apache-avro = { version = "0.17", default-features = false }
-arrow = { version = "54.2.1", features = [
+arrow = { version = "54.3.1", features = [
     "prettyprint",
     "chrono-tz",
 ] }
-arrow-buffer = { version = "54.1.0", default-features = false }
-arrow-flight = { version = "54.2.1", features = [
+arrow-buffer = { version = "54.3.1", default-features = false }
+arrow-flight = { version = "54.3.1", features = [
     "flight-sql-experimental",
 ] }
-arrow-ipc = { version = "54.2.0", default-features = false, features = [
+arrow-ipc = { version = "54.3.1", default-features = false, features = [
     "lz4",
 ] }
-arrow-ord = { version = "54.1.0", default-features = false }
-arrow-schema = { version = "54.1.0", default-features = false }
+arrow-ord = { version = "54.3.1", default-features = false }
+arrow-schema = { version = "54.3.1", default-features = false }
 async-trait = "0.1.88"
 bigdecimal = "0.4.7"
 bytes = "1.10"
@@ -149,7 +149,7 @@ itertools = "0.14"
 log = "^0.4"
 object_store = { version = "0.11.0", default-features = false }
 parking_lot = "0.12"
-parquet = { version = "54.2.1", default-features = false, features = [
+parquet = { version = "54.3.1", default-features = false, features = [
     "arrow",
     "async",
     "object_store",

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -63,7 +63,7 @@ log = { workspace = true }
 object_store = { workspace = true, optional = true }
 parquet = { workspace = true, optional = true, default-features = true }
 paste = "1.0.15"
-pyo3 = { version = "0.23.5", optional = true }
+pyo3 = { version = "0.24.0", optional = true }
 recursive = { workspace = true, optional = true }
 sqlparser = { workspace = true }
 tokio = { workspace = true }

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -432,12 +432,12 @@ config_namespace! {
 
         /// (reading) If true, filter expressions are be applied during the parquet decoding operation to
         /// reduce the number of rows decoded. This optimization is sometimes called "late materialization".
-        pub pushdown_filters: bool, default = false
+        pub pushdown_filters: bool, default = true
 
         /// (reading) If true, filter expressions evaluated during the parquet decoding operation
         /// will be reordered heuristically to minimize the cost of evaluation. If false,
         /// the filters are applied in the same order as written in the query
-        pub reorder_filters: bool, default = false
+        pub reorder_filters: bool, default = true
 
         /// (reading) If true, parquet reader will read columns of `Utf8/Utf8Large` with `Utf8View`,
         /// and `Binary/BinaryLarge` with `BinaryView`.

--- a/datafusion/functions/benches/chr.rs
+++ b/datafusion/functions/benches/chr.rs
@@ -17,14 +17,20 @@
 
 extern crate criterion;
 
-use arrow::{array::PrimitiveArray, datatypes::Int64Type, util::test_util::seedable_rng};
+use arrow::{array::PrimitiveArray, datatypes::Int64Type};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs};
 use datafusion_functions::string::chr;
-use rand::Rng;
+use rand::{Rng, SeedableRng};
 
 use arrow::datatypes::DataType;
+use rand::rngs::StdRng;
 use std::sync::Arc;
+
+/// Returns fixed seedable RNG
+pub fn seedable_rng() -> StdRng {
+    StdRng::seed_from_u64(42)
+}
 
 fn criterion_benchmark(c: &mut Criterion) {
     let cot_fn = chr();

--- a/datafusion/sqllogictest/test_files/dates.slt
+++ b/datafusion/sqllogictest/test_files/dates.slt
@@ -183,7 +183,7 @@ query error input contains invalid characters
 SELECT to_date('2020-09-08 12/00/00+00:00', '%c', '%+')
 
 # to_date with broken formatting
-query error bad or unsupported format string
+query error DataFusion error: Execution error: Error parsing timestamp from '2020\-09\-08 12/00/00\+00:00' using format '%q': trailing input
 SELECT to_date('2020-09-08 12/00/00+00:00', '%q')
 
 statement ok

--- a/datafusion/sqllogictest/test_files/expr/date_part.slt
+++ b/datafusion/sqllogictest/test_files/expr/date_part.slt
@@ -884,7 +884,7 @@ SELECT extract(day from arrow_cast('14400 minutes', 'Interval(DayTime)'))
 query I
 SELECT extract(minute from arrow_cast('14400 minutes', 'Interval(DayTime)'))
 ----
-14400
+0
 
 query I
 SELECT extract(second from arrow_cast('5.1 seconds', 'Interval(DayTime)'))
@@ -894,7 +894,7 @@ SELECT extract(second from arrow_cast('5.1 seconds', 'Interval(DayTime)'))
 query I
 SELECT extract(second from arrow_cast('14400 minutes', 'Interval(DayTime)'))
 ----
-864000
+0
 
 query I
 SELECT extract(second from arrow_cast('2 months', 'Interval(MonthDayNano)'))
@@ -954,7 +954,7 @@ from t
 order by id;
 ----
 0 0 5
-1 0 15
+1 0 3
 2 0 0
 3 2 0
 4 0 8

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -2241,23 +2241,23 @@ query error input contains invalid characters
 SELECT to_timestamp_seconds('2020-09-08 12/00/00+00:00', '%c', '%+')
 
 # to_timestamp with broken formatting
-query error bad or unsupported format string
+query error DataFusion error: Execution error: Error parsing timestamp from '2020\-09\-08 12/00/00\+00:00' using format '%q': trailing input
 SELECT to_timestamp('2020-09-08 12/00/00+00:00', '%q')
 
 # to_timestamp_nanos with broken formatting
-query error bad or unsupported format string
+query error DataFusion error: Execution error: Error parsing timestamp from '2020\-09\-08 12/00/00\+00:00' using format '%q': trailing input
 SELECT to_timestamp_nanos('2020-09-08 12/00/00+00:00', '%q')
 
 # to_timestamp_millis with broken formatting
-query error bad or unsupported format string
+query error DataFusion error: Execution error: Error parsing timestamp from '2020\-09\-08 12/00/00\+00:00' using format '%q': trailing input
 SELECT to_timestamp_millis('2020-09-08 12/00/00+00:00', '%q')
 
 # to_timestamp_micros with broken formatting
-query error bad or unsupported format string
+query error DataFusion error: Execution error: Error parsing timestamp from '2020\-09\-08 12/00/00\+00:00' using format '%q': trailing input
 SELECT to_timestamp_micros('2020-09-08 12/00/00+00:00', '%q')
 
 # to_timestamp_seconds with broken formatting
-query error bad or unsupported format string
+query error DataFusion error: Execution error: Error parsing timestamp from '2020\-09\-08 12/00/00\+00:00' using format '%q': trailing input
 SELECT to_timestamp_seconds('2020-09-08 12/00/00+00:00', '%q')
 
 # Create string timestamp table with different formats


### PR DESCRIPTION
This is still a draft as the branch appears to hang on certain queries:

```shell
(venv) andrewlamb@Andrews-MacBook-Pro-2:~/Software/datafusion2$ cargo test --test sqllogictests -- parquet_filter_pushdown
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running bin/sqllogictests.rs (target/debug/deps/sqllogictests-ae4ca2e4c85de797)
[00:00:00] ##########################--------------      11/17      "parquet_filter_pushdown.slt"
.. hangs indefinitely ..
```

## Which issue does this PR close?
- builds on https://github.com/apache/datafusion/pull/15466
- part of https://github.com/apache/arrow-rs/issues/7363
- related to https://github.com/apache/datafusion/issues/3463

## Rationale for this change

This PR is designed to verify the changes from @XiangpengHao 's pushdown encoder"
- https://github.com/apache/arrow-rs/pull/6921

## What changes are included in this PR?

1. Pin to https://github.com/apache/arrow-rs/pull/6921
2. Enable filter pushdown by default 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

## Benchmarks

Not too shabby!

I need to look at some of these queries that report being slower to see if there is somethig we cna do to make the speed back up

```

--------------------
Benchmark clickbench_1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃  main_base ┃ alamb_filter_pushdown ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 0     │     0.57ms │                0.58ms │     no change │
│ QQuery 1     │    68.16ms │               70.64ms │     no change │
│ QQuery 2     │   116.52ms │              118.28ms │     no change │
│ QQuery 3     │   123.86ms │              123.76ms │     no change │
│ QQuery 4     │   776.15ms │              797.72ms │     no change │
│ QQuery 5     │   848.82ms │              880.01ms │     no change │
│ QQuery 6     │    64.80ms │               67.14ms │     no change │
│ QQuery 7     │    77.36ms │               93.04ms │  1.20x slower │
│ QQuery 8     │   957.21ms │              983.79ms │     no change │
│ QQuery 9     │  1239.49ms │             1275.73ms │     no change │
│ QQuery 10    │   299.68ms │              318.01ms │  1.06x slower │
│ QQuery 11    │   344.19ms │              360.58ms │     no change │
│ QQuery 12    │   945.45ms │             1058.68ms │  1.12x slower │
│ QQuery 13    │  1323.58ms │             1548.38ms │  1.17x slower │
│ QQuery 14    │   885.86ms │             1063.57ms │  1.20x slower │
│ QQuery 15    │  1110.56ms │             1134.68ms │     no change │
│ QQuery 16    │  1834.24ms │             1789.95ms │     no change │
│ QQuery 17    │  1662.90ms │             1650.05ms │     no change │
│ QQuery 18    │  3176.45ms │             3164.17ms │     no change │
│ QQuery 19    │   116.43ms │              123.84ms │  1.06x slower │
│ QQuery 20    │  1206.01ms │             1204.47ms │     no change │
│ QQuery 21    │  1445.16ms │             1351.41ms │ +1.07x faster │
│ QQuery 22    │  2708.56ms │             2401.18ms │ +1.13x faster │
│ QQuery 23    │  8690.72ms │             5234.73ms │ +1.66x faster │
│ QQuery 24    │   509.28ms │              684.55ms │  1.34x slower │
│ QQuery 25    │   426.36ms │              553.26ms │  1.30x slower │
│ QQuery 26    │   581.56ms │              802.46ms │  1.38x slower │
│ QQuery 27    │  1797.38ms │             2464.11ms │  1.37x slower │
│ QQuery 28    │ 13274.54ms │            14650.91ms │  1.10x slower │
│ QQuery 29    │   629.26ms │              598.10ms │     no change │
│ QQuery 30    │   970.56ms │             1286.68ms │  1.33x slower │
│ QQuery 31    │  1008.49ms │             1398.40ms │  1.39x slower │
│ QQuery 32    │  3220.54ms │             3249.25ms │     no change │
│ QQuery 33    │  3948.22ms │             3595.57ms │ +1.10x faster │
│ QQuery 34    │  3968.56ms │             3536.51ms │ +1.12x faster │
│ QQuery 35    │  1477.42ms │             1317.28ms │ +1.12x faster │
│ QQuery 36    │   310.58ms │              277.12ms │ +1.12x faster │
│ QQuery 37    │   144.55ms │              136.09ms │ +1.06x faster │
│ QQuery 38    │   188.40ms │              167.13ms │ +1.13x faster │
│ QQuery 39    │   537.25ms │              419.03ms │ +1.28x faster │
│ QQuery 40    │    73.01ms │              110.69ms │  1.52x slower │
│ QQuery 41    │    83.59ms │              105.50ms │  1.26x slower │
│ QQuery 42    │    91.66ms │               96.24ms │     no change │
└──────────────┴────────────┴───────────────────────┴───────────────┘

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Benchmark Summary                    ┃            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Total Time (main_base)               │ 63263.96ms │
│ Total Time (alamb_filter_pushdown)   │ 62263.28ms │
│ Average Time (main_base)             │  1471.25ms │
│ Average Time (alamb_filter_pushdown) │  1447.98ms │
│ Queries Faster                       │         10 │
│ Queries Slower                       │         15 │
│ Queries with No Change               │         18 │
└──────────────────────────────────────┴────────────┘
```

```
--------------------
Benchmark clickbench_extended.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃  main_base ┃ alamb_filter_pushdown ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 0     │  2255.92ms │             1949.07ms │ +1.16x faster │
│ QQuery 1     │   750.84ms │              716.29ms │     no change │
│ QQuery 2     │  1618.66ms │             1410.83ms │ +1.15x faster │
│ QQuery 3     │   739.24ms │              703.75ms │     no change │
│ QQuery 4     │  1659.53ms │             1715.83ms │     no change │
│ QQuery 5     │ 18684.93ms │            17202.28ms │ +1.09x faster │
└──────────────┴────────────┴───────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Benchmark Summary                    ┃            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Total Time (main_base)               │ 25709.12ms │
│ Total Time (alamb_filter_pushdown)   │ 23698.05ms │
│ Average Time (main_base)             │  4284.85ms │
│ Average Time (alamb_filter_pushdown) │  3949.67ms │
│ Queries Faster                       │          3 │
│ Queries Slower                       │          0 │
│ Queries with No Change               │          3 │
└──────────────────────────────────────┴────────────┘
```

```
--------------------
Benchmark clickbench_partitioned.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃  main_base ┃ alamb_filter_pushdown ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 0     │     3.56ms │                2.75ms │ +1.30x faster │
│ QQuery 1     │    40.80ms │               44.22ms │  1.08x slower │
│ QQuery 2     │   101.20ms │               95.75ms │ +1.06x faster │
│ QQuery 3     │   104.30ms │              100.38ms │     no change │
│ QQuery 4     │   837.17ms │              760.17ms │ +1.10x faster │
│ QQuery 5     │   980.95ms │              872.30ms │ +1.12x faster │
│ QQuery 6     │    40.34ms │               37.64ms │ +1.07x faster │
│ QQuery 7     │    44.91ms │               63.34ms │  1.41x slower │
│ QQuery 8     │  1069.04ms │              953.13ms │ +1.12x faster │
│ QQuery 9     │  1450.28ms │             1225.24ms │ +1.18x faster │
│ QQuery 10    │   310.34ms │              301.07ms │     no change │
│ QQuery 11    │   349.23ms │              351.62ms │     no change │
│ QQuery 12    │  1095.13ms │             1081.91ms │     no change │
│ QQuery 13    │  1635.08ms │             1496.78ms │ +1.09x faster │
│ QQuery 14    │   988.22ms │             1101.26ms │  1.11x slower │
│ QQuery 15    │  1185.88ms │             1116.01ms │ +1.06x faster │
│ QQuery 16    │  2003.29ms │             1804.50ms │ +1.11x faster │
│ QQuery 17    │  1822.90ms │             1638.95ms │ +1.11x faster │
│ QQuery 18    │  3521.78ms │             3125.60ms │ +1.13x faster │
│ QQuery 19    │    93.58ms │              100.39ms │  1.07x slower │
│ QQuery 20    │  1260.89ms │             1150.78ms │ +1.10x faster │
│ QQuery 21    │  1528.21ms │             1303.30ms │ +1.17x faster │
│ QQuery 22    │  2742.69ms │             2316.73ms │ +1.18x faster │
│ QQuery 23    │  9454.13ms │             4883.92ms │ +1.94x faster │
│ QQuery 24    │   520.27ms │              703.58ms │  1.35x slower │
│ QQuery 25    │   435.35ms │              490.67ms │  1.13x slower │
│ QQuery 26    │   606.38ms │              765.75ms │  1.26x slower │
│ QQuery 27    │  1837.71ms │             2154.70ms │  1.17x slower │
│ QQuery 28    │ 13463.85ms │            13430.95ms │     no change │
│ QQuery 29    │   558.16ms │              536.66ms │     no change │
│ QQuery 30    │   934.19ms │             1342.03ms │  1.44x slower │
│ QQuery 31    │   985.71ms │             1388.86ms │  1.41x slower │
│ QQuery 32    │  3225.41ms │             2742.11ms │ +1.18x faster │
│ QQuery 33    │  3887.36ms │             3454.26ms │ +1.13x faster │
│ QQuery 34    │  3852.77ms │             3411.24ms │ +1.13x faster │
│ QQuery 35    │  1530.92ms │             1322.73ms │ +1.16x faster │
│ QQuery 36    │   265.16ms │              237.61ms │ +1.12x faster │
│ QQuery 37    │   105.59ms │              100.96ms │     no change │
│ QQuery 38    │   142.28ms │              142.17ms │     no change │
│ QQuery 39    │   522.51ms │              425.74ms │ +1.23x faster │
│ QQuery 40    │    60.05ms │               89.14ms │  1.48x slower │
│ QQuery 41    │    50.38ms │               78.62ms │  1.56x slower │
│ QQuery 42    │    62.24ms │               70.20ms │  1.13x slower │
└──────────────┴────────────┴───────────────────────┴───────────────┘


--------------------
Benchmark tpch_mem_sf1.json
--------------------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ Query        ┃ main_base ┃ alamb_filter_pushdown ┃       Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ QQuery 1     │  125.02ms │              125.37ms │    no change │
│ QQuery 2     │   24.36ms │               24.40ms │    no change │
│ QQuery 3     │   36.76ms │               35.86ms │    no change │
│ QQuery 4     │   20.87ms │               20.76ms │    no change │
│ QQuery 5     │   57.47ms │               56.27ms │    no change │
│ QQuery 6     │    8.11ms │                8.39ms │    no change │
│ QQuery 7     │  102.83ms │              103.92ms │    no change │
│ QQuery 8     │   26.51ms │               26.58ms │    no change │
│ QQuery 9     │   62.19ms │               63.73ms │    no change │
│ QQuery 10    │   60.77ms │               60.92ms │    no change │
│ QQuery 11    │   13.11ms │               13.00ms │    no change │
│ QQuery 12    │   37.41ms │               38.59ms │    no change │
│ QQuery 13    │   30.73ms │               29.83ms │    no change │
│ QQuery 14    │    9.86ms │               10.15ms │    no change │
│ QQuery 15    │   25.03ms │               26.15ms │    no change │
│ QQuery 16    │   25.89ms │               24.94ms │    no change │
│ QQuery 17    │   95.52ms │               98.14ms │    no change │
│ QQuery 18    │  253.23ms │              252.32ms │    no change │
│ QQuery 19    │   28.84ms │               30.05ms │    no change │
│ QQuery 20    │   40.94ms │               41.14ms │    no change │
│ QQuery 21    │  172.30ms │              181.19ms │ 1.05x slower │
│ QQuery 22    │   18.05ms │               17.22ms │    no change │
└──────────────┴───────────┴───────────────────────┴──────────────┘


```