### PR TITLE
Update user guide to note decimal is not experimental anymore

### DIFF
--- a/docs/source/user-guide/sql/data_types.md
+++ b/docs/source/user-guide/sql/data_types.md
@@ -60,20 +60,20 @@ select arrow_cast(now(), 'Timestamp(Second, None)');
 
 ## Numeric Types
 
-| SQL DataType                         | Arrow DataType                 | Notes                                                                                                 |
-| ------------------------------------ | :----------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `TINYINT`                            | `Int8`                         |                                                                                                       |
-| `SMALLINT`                           | `Int16`                        |                                                                                                       |
-| `INT` or `INTEGER`                   | `Int32`                        |                                                                                                       |
-| `BIGINT`                             | `Int64`                        |                                                                                                       |
-| `TINYINT UNSIGNED`                   | `UInt8`                        |                                                                                                       |
-| `SMALLINT UNSIGNED`                  | `UInt16`                       |                                                                                                       |
-| `INT UNSIGNED` or `INTEGER UNSIGNED` | `UInt32`                       |                                                                                                       |
-| `BIGINT UNSIGNED`                    | `UInt64`                       |                                                                                                       |
-| `FLOAT`                              | `Float32`                      |                                                                                                       |
-| `REAL`                               | `Float32`                      |                                                                                                       |
-| `DOUBLE`                             | `Float64`                      |                                                                                                       |
-| `DECIMAL(precision, scale)`          | `Decimal128(precision, scale)` | Decimal support has been fully implemented ([#3523](https://github.com/apache/datafusion/issues/3523)) |
+| SQL DataType                         | Arrow DataType                 | Notes                                                                                                     |
+| ------------------------------------ | :----------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `TINYINT`                            | `Int8`                         |                                                                                                           |
+| `SMALLINT`                           | `Int16`                        |                                                                                                           |
+| `INT` or `INTEGER`                   | `Int32`                        |                                                                                                           |
+| `BIGINT`                             | `Int64`                        |                                                                                                           |
+| `TINYINT UNSIGNED`                   | `UInt8`                        |                                                                                                           |
+| `SMALLINT UNSIGNED`                  | `UInt16`                       |                                                                                                           |
+| `INT UNSIGNED` or `INTEGER UNSIGNED` | `UInt32`                       |                                                                                                           |
+| `BIGINT UNSIGNED`                    | `UInt64`                       |                                                                                                           |
+| `FLOAT`                              | `Float32`                      |                                                                                                           |
+| `REAL`                               | `Float32`                      |                                                                                                           |
+| `DOUBLE`                             | `Float64`                      |                                                                                                           |
+| `DECIMAL(precision, scale)`          | `Decimal128(precision, scale)` | Decimal support has been fully implemented in ([#3523](https://github.com/apache/datafusion/issues/3523)) |
 
 ## Date/Time Types
 

--- a/docs/source/user-guide/sql/data_types.md
+++ b/docs/source/user-guide/sql/data_types.md
@@ -73,7 +73,7 @@ select arrow_cast(now(), 'Timestamp(Second, None)');
 | `FLOAT`                              | `Float32`                      |                                                                                                       |
 | `REAL`                               | `Float32`                      |                                                                                                       |
 | `DOUBLE`                             | `Float64`                      |                                                                                                       |
-| `DECIMAL(precision, scale)`          | `Decimal128(precision, scale)` | Decimal support is currently experimental ([#3523](https://github.com/apache/datafusion/issues/3523)) |
+| `DECIMAL(precision, scale)`          | `Decimal128(precision, scale)` |  |
 
 ## Date/Time Types
 

--- a/docs/source/user-guide/sql/data_types.md
+++ b/docs/source/user-guide/sql/data_types.md
@@ -73,7 +73,7 @@ select arrow_cast(now(), 'Timestamp(Second, None)');
 | `FLOAT`                              | `Float32`                      |                                                                                                       |
 | `REAL`                               | `Float32`                      |                                                                                                       |
 | `DOUBLE`                             | `Float64`                      |                                                                                                       |
-| `DECIMAL(precision, scale)`          | `Decimal128(precision, scale)` |  |
+| `DECIMAL(precision, scale)`          | `Decimal128(precision, scale)` | Decimal support has been fully implemented ([#3523](https://github.com/apache/datafusion/issues/3523)) |
 
 ## Date/Time Types
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- [Closes #15464](https://github.com/apache/datafusion/issues/15464).

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The Decimal support in DataFusion was marked as complete in [Issue #3523](https://github.com/apache/datafusion/issues/3523) on November 21, 2024. However, the user guide documentation (`docs/source/user-guide/sql/data_types.md`) still labels it as "experimental," which is outdated and misleading. This PR updates the documentation to reflect the current status, improving user understanding and trust in the Decimal functionality.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Updated the `Numeric Types` section in `docs/source/user-guide/sql/data_types.md` to remove the "experimental" label for `DECIMAL(precision, scale)`.
- Replaced the note with: "Decimal support has been fully implemented“
- Retained the link to #3523 for historical context.

## Are these changes tested?
No tests are included in this PR because it only modifies documentation

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Yes, this PR updates the user-facing documentation at `https://datafusion.apache.org/user-guide/sql/data_types.html`. It clarifies that Decimal support is fully implemented, removing the outdated "experimental" label. No code or API changes are involved.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
