### PR TITLE
fix: update group by columns for merge phase after spill

### DIFF
--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -1420,8 +1420,8 @@ mod tests {
     use crate::RecordBatchStream;
 
     use arrow::array::{
-        DictionaryArray, Float32Array, Float64Array, Int32Array, StructArray,
-        UInt32Array, UInt64Array,
+        DictionaryArray, Float32Array, Float64Array, Int32Array, Int64Array, StringArray,
+        StructArray, UInt32Array, UInt64Array,
     };
     use arrow::compute::{concat_batches, SortOptions};
     use arrow::datatypes::{DataType, Int32Type};
@@ -1444,6 +1444,7 @@ mod tests {
 
     use futures::{FutureExt, Stream};
     use insta::{allow_duplicates, assert_snapshot};
+    use rand::{random, thread_rng, Rng};
 
     // Generate a schema which consists of 5 columns (a, b, c, d, e)
     fn create_test_schema() -> Result<SchemaRef> {
@@ -3016,6 +3017,114 @@ mod tests {
         run_test_with_spill_pool_if_necessary(2_000, true).await?;
         // test without spill
         run_test_with_spill_pool_if_necessary(20_000, false).await?;
+        Ok(())
+    }
+
+    // Fix for https://github.com/apache/datafusion/issues/15530
+    #[tokio::test]
+    async fn test_single_mode_aggregate_with_spill() -> Result<()> {
+        let scan_schema = Arc::new(Schema::new(vec![
+            Field::new("col_0", DataType::Int64, true),
+            Field::new("col_1", DataType::Utf8, true),
+            Field::new("col_2", DataType::Utf8, true),
+            Field::new("col_3", DataType::Utf8, true),
+            Field::new("col_4", DataType::Utf8, true),
+            Field::new("col_5", DataType::Int32, true),
+            Field::new("col_6", DataType::Utf8, true),
+            Field::new("col_7", DataType::Utf8, true),
+            Field::new("col_8", DataType::Utf8, true),
+        ]));
+
+        let group_by = PhysicalGroupBy::new_single(vec![
+            (Arc::new(Column::new("col_1", 1)), "col_1".to_string()),
+            (Arc::new(Column::new("col_7", 7)), "col_7".to_string()),
+            (Arc::new(Column::new("col_0", 0)), "col_0".to_string()),
+            (Arc::new(Column::new("col_8", 8)), "col_8".to_string()),
+        ]);
+
+        fn generate_int64_array() -> ArrayRef {
+            Arc::new(Int64Array::from_iter_values(
+                (0..1024).map(|_| random::<i64>()),
+            ))
+        }
+        fn generate_int32_array() -> ArrayRef {
+            Arc::new(Int32Array::from_iter_values(
+                (0..1024).map(|_| random::<i32>()),
+            ))
+        }
+
+        fn generate_string_array() -> ArrayRef {
+            Arc::new(StringArray::from(
+                (0..1024)
+                    .map(|_| -> String {
+                        thread_rng()
+                            .sample_iter::<char, _>(rand::distributions::Standard)
+                            .take(5)
+                            .collect()
+                    })
+                    .collect::<Vec<_>>(),
+            ))
+        }
+
+        fn generate_record_batch(schema: &SchemaRef) -> Result<RecordBatch> {
+            RecordBatch::try_new(
+                Arc::clone(schema),
+                vec![
+                    generate_int64_array(),
+                    generate_string_array(),
+                    generate_string_array(),
+                    generate_string_array(),
+                    generate_string_array(),
+                    generate_int32_array(),
+                    generate_string_array(),
+                    generate_string_array(),
+                    generate_string_array(),
+                ],
+            )
+            .map_err(|err| err.into())
+        }
+
+        let aggregate_expressions = vec![Arc::new(
+            AggregateExprBuilder::new(sum_udaf(), vec![lit(1i64)])
+                .schema(Arc::clone(&scan_schema))
+                .alias("SUM(1i64)")
+                .build()?,
+        )];
+
+        let batches = (0..5)
+            .map(|_| generate_record_batch(&scan_schema))
+            .collect::<Result<Vec<_>>>()?;
+
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(TestMemoryExec::try_new(
+            &[batches],
+            Arc::clone(&scan_schema),
+            None,
+        )?);
+
+        let single_aggregate = Arc::new(AggregateExec::try_new(
+            AggregateMode::Single,
+            group_by,
+            aggregate_expressions.clone(),
+            vec![None; aggregate_expressions.len()],
+            plan,
+            Arc::clone(&scan_schema),
+        )?);
+
+        let memory_pool = Arc::new(FairSpillPool::new(250000));
+        let task_ctx = Arc::new(
+            TaskContext::default()
+                .with_session_config(SessionConfig::new().with_batch_size(248))
+                .with_runtime(Arc::new(
+                    RuntimeEnvBuilder::new()
+                        .with_memory_pool(memory_pool)
+                        .build()?,
+                )),
+        );
+
+        collect(single_aggregate.execute(0, Arc::clone(&task_ctx))?).await?;
+
+        assert_spill_count_metric(true, single_aggregate);
+
         Ok(())
     }
 }

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -1420,8 +1420,8 @@ mod tests {
     use crate::RecordBatchStream;
 
     use arrow::array::{
-        DictionaryArray, Float32Array, Float64Array, Int32Array, Int64Array, StringArray,
-        StructArray, UInt32Array, UInt64Array,
+        DictionaryArray, Float32Array, Float64Array, Int32Array, StructArray,
+        UInt32Array, UInt64Array,
     };
     use arrow::compute::{concat_batches, SortOptions};
     use arrow::datatypes::{DataType, Int32Type};
@@ -1444,7 +1444,6 @@ mod tests {
 
     use futures::{FutureExt, Stream};
     use insta::{allow_duplicates, assert_snapshot};
-    use rand::{random, thread_rng, Rng};
 
     // Generate a schema which consists of 5 columns (a, b, c, d, e)
     fn create_test_schema() -> Result<SchemaRef> {
@@ -3017,114 +3016,6 @@ mod tests {
         run_test_with_spill_pool_if_necessary(2_000, true).await?;
         // test without spill
         run_test_with_spill_pool_if_necessary(20_000, false).await?;
-        Ok(())
-    }
-
-    // Fix for https://github.com/apache/datafusion/issues/15530
-    #[tokio::test]
-    async fn test_single_mode_aggregate_with_spill() -> Result<()> {
-        let scan_schema = Arc::new(Schema::new(vec![
-            Field::new("col_0", DataType::Int64, true),
-            Field::new("col_1", DataType::Utf8, true),
-            Field::new("col_2", DataType::Utf8, true),
-            Field::new("col_3", DataType::Utf8, true),
-            Field::new("col_4", DataType::Utf8, true),
-            Field::new("col_5", DataType::Int32, true),
-            Field::new("col_6", DataType::Utf8, true),
-            Field::new("col_7", DataType::Utf8, true),
-            Field::new("col_8", DataType::Utf8, true),
-        ]));
-
-        let group_by = PhysicalGroupBy::new_single(vec![
-            (Arc::new(Column::new("col_1", 1)), "col_1".to_string()),
-            (Arc::new(Column::new("col_7", 7)), "col_7".to_string()),
-            (Arc::new(Column::new("col_0", 0)), "col_0".to_string()),
-            (Arc::new(Column::new("col_8", 8)), "col_8".to_string()),
-        ]);
-
-        fn generate_int64_array() -> ArrayRef {
-            Arc::new(Int64Array::from_iter_values(
-                (0..1024).map(|_| random::<i64>()),
-            ))
-        }
-        fn generate_int32_array() -> ArrayRef {
-            Arc::new(Int32Array::from_iter_values(
-                (0..1024).map(|_| random::<i32>()),
-            ))
-        }
-
-        fn generate_string_array() -> ArrayRef {
-            Arc::new(StringArray::from(
-                (0..1024)
-                    .map(|_| -> String {
-                        thread_rng()
-                            .sample_iter::<char, _>(rand::distributions::Standard)
-                            .take(5)
-                            .collect()
-                    })
-                    .collect::<Vec<_>>(),
-            ))
-        }
-
-        fn generate_record_batch(schema: &SchemaRef) -> Result<RecordBatch> {
-            RecordBatch::try_new(
-                Arc::clone(schema),
-                vec![
-                    generate_int64_array(),
-                    generate_string_array(),
-                    generate_string_array(),
-                    generate_string_array(),
-                    generate_string_array(),
-                    generate_int32_array(),
-                    generate_string_array(),
-                    generate_string_array(),
-                    generate_string_array(),
-                ],
-            )
-            .map_err(|err| err.into())
-        }
-
-        let aggregate_expressions = vec![Arc::new(
-            AggregateExprBuilder::new(sum_udaf(), vec![lit(1i64)])
-                .schema(Arc::clone(&scan_schema))
-                .alias("SUM(1i64)")
-                .build()?,
-        )];
-
-        let batches = (0..5)
-            .map(|_| generate_record_batch(&scan_schema))
-            .collect::<Result<Vec<_>>>()?;
-
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(TestMemoryExec::try_new(
-            &[batches],
-            Arc::clone(&scan_schema),
-            None,
-        )?);
-
-        let single_aggregate = Arc::new(AggregateExec::try_new(
-            AggregateMode::Single,
-            group_by,
-            aggregate_expressions.clone(),
-            vec![None; aggregate_expressions.len()],
-            plan,
-            Arc::clone(&scan_schema),
-        )?);
-
-        let memory_pool = Arc::new(FairSpillPool::new(250000));
-        let task_ctx = Arc::new(
-            TaskContext::default()
-                .with_session_config(SessionConfig::new().with_batch_size(248))
-                .with_runtime(Arc::new(
-                    RuntimeEnvBuilder::new()
-                        .with_memory_pool(memory_pool)
-                        .build()?,
-                )),
-        );
-
-        collect(single_aggregate.execute(0, Arc::clone(&task_ctx))?).await?;
-
-        assert_spill_count_metric(true, single_aggregate);
-
         Ok(())
     }
 }

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -507,7 +507,7 @@ impl GroupedHashAggregateStream {
             AggregateMode::Partial,
         )?;
 
-        // Need to update the group by expressions to point to the correct column after schema change
+        // Need to update the GROUP BY expressions to point to the correct column after schema change
         let merging_group_by_expr = agg_group_by
             .expr
             .iter()


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #15530.

## Rationale for this change

I think the PR below forgot to update the group by expressions:
- #13995

## What changes are included in this PR?

Update group by columns to be based on their index for merging phase 

## Are these changes tested?

Yes

## Are there any user-facing changes?

No