### PR TITLE
Fix: after repartitioning, the `PartitionedFile` and `FileGroup` statistics should be inexact/recomputed

### DIFF
--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1127,12 +1127,12 @@ impl ListingTable {
             get_files_with_limit(files, limit, self.options.collect_stat).await?;
 
         let file_groups = file_group.split_files(self.options.target_partitions);
-        compute_all_files_statistics(
+        Ok(compute_all_files_statistics(
             file_groups,
             self.schema(),
             self.options.collect_stat,
             inexact_stats,
-        )
+        ))
     }
 
     /// Collects statistics for a given partitioned file.

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1129,7 +1129,6 @@ impl ListingTable {
         let file_groups = file_group.split_files(self.options.target_partitions);
         compute_all_files_statistics(
             file_groups,
-            self.schema(),
             self.options.collect_stat,
             inexact_stats,
         )

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1129,6 +1129,7 @@ impl ListingTable {
         let file_groups = file_group.split_files(self.options.target_partitions);
         compute_all_files_statistics(
             file_groups,
+            self.schema(),
             self.options.collect_stat,
             inexact_stats,
         )

--- a/datafusion/datasource/src/file_groups.rs
+++ b/datafusion/datasource/src/file_groups.rs
@@ -363,12 +363,13 @@ impl FileGroupPartitioner {
                 }
                 let updated_file =
                     original_file.clone().with_range(range_start, range_end);
-                if let Some(stat) = updated_file.statistics.clone() {
-                    target_group.push(
-                        updated_file.with_statistics(Arc::new(
-                            stat.as_ref().clone().to_inexact(),
-                        )),
-                    );
+                let statistics_option = updated_file
+                    .statistics
+                    .as_ref()
+                    .map(|stat| Arc::new(stat.as_ref().clone().to_inexact()));
+
+                if let Some(statistics) = statistics_option {
+                    target_group.push(updated_file.with_statistics(statistics));
                 } else {
                     target_group.push(updated_file);
                 }

--- a/datafusion/datasource/src/file_groups.rs
+++ b/datafusion/datasource/src/file_groups.rs
@@ -206,11 +206,8 @@ impl FileGroupPartitioner {
             self.repartition_evenly_by_size(file_groups)
         };
 
-        if repartitioned_groups.is_none() {
-            return None;
-        }
+        let repartitioned_groups = repartitioned_groups?;
 
-        let repartitioned_groups = repartitioned_groups.unwrap();
         // Recompute statistics for each file group
         let mut groups = Vec::with_capacity(repartitioned_groups.len());
         for file_group in repartitioned_groups {

--- a/datafusion/datasource/src/statistics.rs
+++ b/datafusion/datasource/src/statistics.rs
@@ -498,7 +498,7 @@ pub fn compute_file_group_statistics(
     });
 
     if let Some(stats) = statistics {
-        file_group = file_group.with_statistics(stats);
+        file_group = file_group.with_statistics(Arc::new(stats));
     }
 
     file_group

--- a/datafusion/datasource/src/statistics.rs
+++ b/datafusion/datasource/src/statistics.rs
@@ -410,16 +410,14 @@ pub async fn get_statistics_with_limit(
 }
 
 /// Generic function to compute statistics across multiple items that have statistics
-fn compute_summary_statistics<T, I>(
+pub fn compute_summary_statistics<T, I>(
     items: I,
-    file_schema: &SchemaRef,
     stats_extractor: impl Fn(&T) -> Option<&Statistics>,
 ) -> Statistics
 where
     I: IntoIterator<Item = T>,
 {
-    let size = file_schema.fields().len();
-    let mut col_stats_set = vec![ColumnStatistics::default(); size];
+    let mut col_stats_set = Vec::new();
     let mut num_rows = Precision::<usize>::Absent;
     let mut total_byte_size = Precision::<usize>::Absent;
 
@@ -427,6 +425,8 @@ where
         if let Some(item_stats) = stats_extractor(&item) {
             if idx == 0 {
                 // First item, set values directly
+                col_stats_set =
+                    vec![ColumnStatistics::default(); item_stats.column_statistics.len()];
                 num_rows = item_stats.num_rows;
                 total_byte_size = item_stats.total_byte_size;
                 for (index, column_stats) in
@@ -482,17 +482,15 @@ where
 /// A new file group with summary statistics attached
 pub fn compute_file_group_statistics(
     file_group: FileGroup,
-    file_schema: SchemaRef,
     collect_stats: bool,
 ) -> Result<FileGroup> {
     if !collect_stats {
         return Ok(file_group);
     }
 
-    let statistics =
-        compute_summary_statistics(file_group.iter(), &file_schema, |file| {
-            file.statistics.as_ref().map(|stats| stats.as_ref())
-        });
+    let statistics = compute_summary_statistics(file_group.iter(), |file| {
+        file.statistics.as_ref().map(|stats| stats.as_ref())
+    });
 
     Ok(file_group.with_statistics(Arc::new(statistics)))
 }
@@ -516,7 +514,6 @@ pub fn compute_file_group_statistics(
 /// * The summary statistics across all file groups, aka all files summary statistics
 pub fn compute_all_files_statistics(
     file_groups: Vec<FileGroup>,
-    file_schema: SchemaRef,
     collect_stats: bool,
     inexact_stats: bool,
 ) -> Result<(Vec<FileGroup>, Statistics)> {
@@ -524,16 +521,13 @@ pub fn compute_all_files_statistics(
 
     // First compute statistics for each file group
     for file_group in file_groups {
-        file_groups_with_stats.push(compute_file_group_statistics(
-            file_group,
-            Arc::clone(&file_schema),
-            collect_stats,
-        )?);
+        file_groups_with_stats
+            .push(compute_file_group_statistics(file_group, collect_stats)?);
     }
 
     // Then summary statistics across all file groups
     let mut statistics =
-        compute_summary_statistics(&file_groups_with_stats, &file_schema, |file_group| {
+        compute_summary_statistics(&file_groups_with_stats, |file_group| {
             file_group.statistics()
         });
 
@@ -620,18 +614,11 @@ fn set_min_if_lesser(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::ScalarValue;
     use std::sync::Arc;
 
     #[test]
     fn test_compute_summary_statistics_basic() {
-        // Create a schema with two columns
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("col1", DataType::Int32, false),
-            Field::new("col2", DataType::Int32, false),
-        ]));
-
         // Create items with statistics
         let stats1 = Statistics {
             num_rows: Precision::Exact(10),
@@ -678,8 +665,7 @@ mod tests {
         let items = vec![Arc::new(stats1), Arc::new(stats2)];
 
         // Call compute_summary_statistics
-        let summary_stats =
-            compute_summary_statistics(items, &schema, |item| Some(item.as_ref()));
+        let summary_stats = compute_summary_statistics(items, |item| Some(item.as_ref()));
 
         // Verify the results
         assert_eq!(summary_stats.num_rows, Precision::Exact(25)); // 10 + 15
@@ -719,13 +705,6 @@ mod tests {
 
     #[test]
     fn test_compute_summary_statistics_mixed_precision() {
-        // Create a schema with one column
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "col1",
-            DataType::Int32,
-            false,
-        )]));
-
         // Create items with different precision levels
         let stats1 = Statistics {
             num_rows: Precision::Exact(10),
@@ -753,8 +732,7 @@ mod tests {
 
         let items = vec![Arc::new(stats1), Arc::new(stats2)];
 
-        let summary_stats =
-            compute_summary_statistics(items, &schema, |item| Some(item.as_ref()));
+        let summary_stats = compute_summary_statistics(items, |item| Some(item.as_ref()));
 
         assert_eq!(summary_stats.num_rows, Precision::Inexact(25));
         assert_eq!(summary_stats.total_byte_size, Precision::Inexact(250));
@@ -774,17 +752,10 @@ mod tests {
 
     #[test]
     fn test_compute_summary_statistics_empty() {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "col1",
-            DataType::Int32,
-            false,
-        )]));
-
         // Empty collection
         let items: Vec<Arc<Statistics>> = vec![];
 
-        let summary_stats =
-            compute_summary_statistics(items, &schema, |item| Some(item.as_ref()));
+        let summary_stats = compute_summary_statistics(items, |item| Some(item.as_ref()));
 
         // Verify default values for empty collection
         assert_eq!(summary_stats.num_rows, Precision::Absent);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

When I wrote tests for https://github.com/apache/datafusion/pull/15503/, I found the bug.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

After repartition, the `PartitionedFile` and `FileGroup` statistics should be inexact.

Or users may be based on inexact statistics to do some exact things. **It's dangerous!**

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, by UT, the added UT will report error in main branch

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
