### PR TITLE
Improve performance of `last_value` by implementing special `GroupsAccumulator`

### DIFF
--- a/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/fuzzer.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/fuzzer.rs
@@ -503,7 +503,9 @@ impl QueryBuilder {
             let distinct = if *is_distinct { "DISTINCT " } else { "" };
             alias_gen += 1;
 
-            let (order_by, null_opt) = if function_name.eq("first_value") {
+            let (order_by, null_opt) = if function_name.eq("first_value")
+                || function_name.eq("last_value")
+            {
                 (
                     self.order_by(&order_by_black_list), /* Among the order by columns, at most one group by column can be included to avoid all order by column values being identical */
                     self.null_opt(),

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -166,6 +166,7 @@ impl AggregateUDFImpl for FirstValue {
     }
 
     fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {
+        // TODO: extract to function
         use DataType::*;
         matches!(
             args.return_type,
@@ -193,9 +194,9 @@ impl AggregateUDFImpl for FirstValue {
         &self,
         args: AccumulatorArgs,
     ) -> Result<Box<dyn GroupsAccumulator>> {
+        // TODO: extract to function
         fn create_accumulator<T>(
             args: AccumulatorArgs,
-            pick_first_in_group: bool,
         ) -> Result<Box<dyn GroupsAccumulator>>
         where
             T: ArrowPrimitiveType + Send,
@@ -211,74 +212,53 @@ impl AggregateUDFImpl for FirstValue {
                 args.ignore_nulls,
                 args.return_type,
                 &ordering_dtypes,
-                pick_first_in_group,
+                true,
             )?))
         }
 
-        let pick_first_in_group = true;
         match args.return_type {
-            DataType::Int8 => create_accumulator::<Int8Type>(args, pick_first_in_group),
-            DataType::Int16 => create_accumulator::<Int16Type>(args, pick_first_in_group),
-            DataType::Int32 => create_accumulator::<Int32Type>(args, pick_first_in_group),
-            DataType::Int64 => create_accumulator::<Int64Type>(args, pick_first_in_group),
-            DataType::UInt8 => create_accumulator::<UInt8Type>(args, pick_first_in_group),
-            DataType::UInt16 => {
-                create_accumulator::<UInt16Type>(args, pick_first_in_group)
-            }
-            DataType::UInt32 => {
-                create_accumulator::<UInt32Type>(args, pick_first_in_group)
-            }
-            DataType::UInt64 => {
-                create_accumulator::<UInt64Type>(args, pick_first_in_group)
-            }
-            DataType::Float16 => {
-                create_accumulator::<Float16Type>(args, pick_first_in_group)
-            }
-            DataType::Float32 => {
-                create_accumulator::<Float32Type>(args, pick_first_in_group)
-            }
-            DataType::Float64 => {
-                create_accumulator::<Float64Type>(args, pick_first_in_group)
-            }
+            DataType::Int8 => create_accumulator::<Int8Type>(args),
+            DataType::Int16 => create_accumulator::<Int16Type>(args),
+            DataType::Int32 => create_accumulator::<Int32Type>(args),
+            DataType::Int64 => create_accumulator::<Int64Type>(args),
+            DataType::UInt8 => create_accumulator::<UInt8Type>(args),
+            DataType::UInt16 => create_accumulator::<UInt16Type>(args),
+            DataType::UInt32 => create_accumulator::<UInt32Type>(args),
+            DataType::UInt64 => create_accumulator::<UInt64Type>(args),
+            DataType::Float16 => create_accumulator::<Float16Type>(args),
+            DataType::Float32 => create_accumulator::<Float32Type>(args),
+            DataType::Float64 => create_accumulator::<Float64Type>(args),
 
-            DataType::Decimal128(_, _) => {
-                create_accumulator::<Decimal128Type>(args, pick_first_in_group)
-            }
-            DataType::Decimal256(_, _) => {
-                create_accumulator::<Decimal256Type>(args, pick_first_in_group)
-            }
+            DataType::Decimal128(_, _) => create_accumulator::<Decimal128Type>(args),
+            DataType::Decimal256(_, _) => create_accumulator::<Decimal256Type>(args),
 
             DataType::Timestamp(TimeUnit::Second, _) => {
-                create_accumulator::<TimestampSecondType>(args, pick_first_in_group)
+                create_accumulator::<TimestampSecondType>(args)
             }
             DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                create_accumulator::<TimestampMillisecondType>(args, pick_first_in_group)
+                create_accumulator::<TimestampMillisecondType>(args)
             }
             DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                create_accumulator::<TimestampMicrosecondType>(args, pick_first_in_group)
+                create_accumulator::<TimestampMicrosecondType>(args)
             }
             DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                create_accumulator::<TimestampNanosecondType>(args, pick_first_in_group)
+                create_accumulator::<TimestampNanosecondType>(args)
             }
 
-            DataType::Date32 => {
-                create_accumulator::<Date32Type>(args, pick_first_in_group)
-            }
-            DataType::Date64 => {
-                create_accumulator::<Date64Type>(args, pick_first_in_group)
-            }
+            DataType::Date32 => create_accumulator::<Date32Type>(args),
+            DataType::Date64 => create_accumulator::<Date64Type>(args),
             DataType::Time32(TimeUnit::Second) => {
-                create_accumulator::<Time32SecondType>(args, pick_first_in_group)
+                create_accumulator::<Time32SecondType>(args)
             }
             DataType::Time32(TimeUnit::Millisecond) => {
-                create_accumulator::<Time32MillisecondType>(args, pick_first_in_group)
+                create_accumulator::<Time32MillisecondType>(args)
             }
 
             DataType::Time64(TimeUnit::Microsecond) => {
-                create_accumulator::<Time64MicrosecondType>(args, pick_first_in_group)
+                create_accumulator::<Time64MicrosecondType>(args)
             }
             DataType::Time64(TimeUnit::Nanosecond) => {
-                create_accumulator::<Time64NanosecondType>(args, pick_first_in_group)
+                create_accumulator::<Time64NanosecondType>(args)
             }
 
             _ => {
@@ -1124,7 +1104,6 @@ impl AggregateUDFImpl for LastValue {
     ) -> Result<Box<dyn GroupsAccumulator>> {
         fn create_accumulator<T>(
             args: AccumulatorArgs,
-            pick_first_in_group: bool,
         ) -> Result<Box<dyn GroupsAccumulator>>
         where
             T: ArrowPrimitiveType + Send,
@@ -1140,74 +1119,53 @@ impl AggregateUDFImpl for LastValue {
                 args.ignore_nulls,
                 args.return_type,
                 &ordering_dtypes,
-                pick_first_in_group,
+                false,
             )?))
         }
 
-        let pick_first_in_group = false;
         match args.return_type {
-            DataType::Int8 => create_accumulator::<Int8Type>(args, pick_first_in_group),
-            DataType::Int16 => create_accumulator::<Int16Type>(args, pick_first_in_group),
-            DataType::Int32 => create_accumulator::<Int32Type>(args, pick_first_in_group),
-            DataType::Int64 => create_accumulator::<Int64Type>(args, pick_first_in_group),
-            DataType::UInt8 => create_accumulator::<UInt8Type>(args, pick_first_in_group),
-            DataType::UInt16 => {
-                create_accumulator::<UInt16Type>(args, pick_first_in_group)
-            }
-            DataType::UInt32 => {
-                create_accumulator::<UInt32Type>(args, pick_first_in_group)
-            }
-            DataType::UInt64 => {
-                create_accumulator::<UInt64Type>(args, pick_first_in_group)
-            }
-            DataType::Float16 => {
-                create_accumulator::<Float16Type>(args, pick_first_in_group)
-            }
-            DataType::Float32 => {
-                create_accumulator::<Float32Type>(args, pick_first_in_group)
-            }
-            DataType::Float64 => {
-                create_accumulator::<Float64Type>(args, pick_first_in_group)
-            }
+            DataType::Int8 => create_accumulator::<Int8Type>(args),
+            DataType::Int16 => create_accumulator::<Int16Type>(args),
+            DataType::Int32 => create_accumulator::<Int32Type>(args),
+            DataType::Int64 => create_accumulator::<Int64Type>(args),
+            DataType::UInt8 => create_accumulator::<UInt8Type>(args),
+            DataType::UInt16 => create_accumulator::<UInt16Type>(args),
+            DataType::UInt32 => create_accumulator::<UInt32Type>(args),
+            DataType::UInt64 => create_accumulator::<UInt64Type>(args),
+            DataType::Float16 => create_accumulator::<Float16Type>(args),
+            DataType::Float32 => create_accumulator::<Float32Type>(args),
+            DataType::Float64 => create_accumulator::<Float64Type>(args),
 
-            DataType::Decimal128(_, _) => {
-                create_accumulator::<Decimal128Type>(args, pick_first_in_group)
-            }
-            DataType::Decimal256(_, _) => {
-                create_accumulator::<Decimal256Type>(args, pick_first_in_group)
-            }
+            DataType::Decimal128(_, _) => create_accumulator::<Decimal128Type>(args),
+            DataType::Decimal256(_, _) => create_accumulator::<Decimal256Type>(args),
 
             DataType::Timestamp(TimeUnit::Second, _) => {
-                create_accumulator::<TimestampSecondType>(args, pick_first_in_group)
+                create_accumulator::<TimestampSecondType>(args)
             }
             DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                create_accumulator::<TimestampMillisecondType>(args, pick_first_in_group)
+                create_accumulator::<TimestampMillisecondType>(args)
             }
             DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                create_accumulator::<TimestampMicrosecondType>(args, pick_first_in_group)
+                create_accumulator::<TimestampMicrosecondType>(args)
             }
             DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                create_accumulator::<TimestampNanosecondType>(args, pick_first_in_group)
+                create_accumulator::<TimestampNanosecondType>(args)
             }
 
-            DataType::Date32 => {
-                create_accumulator::<Date32Type>(args, pick_first_in_group)
-            }
-            DataType::Date64 => {
-                create_accumulator::<Date64Type>(args, pick_first_in_group)
-            }
+            DataType::Date32 => create_accumulator::<Date32Type>(args),
+            DataType::Date64 => create_accumulator::<Date64Type>(args),
             DataType::Time32(TimeUnit::Second) => {
-                create_accumulator::<Time32SecondType>(args, pick_first_in_group)
+                create_accumulator::<Time32SecondType>(args)
             }
             DataType::Time32(TimeUnit::Millisecond) => {
-                create_accumulator::<Time32MillisecondType>(args, pick_first_in_group)
+                create_accumulator::<Time32MillisecondType>(args)
             }
 
             DataType::Time64(TimeUnit::Microsecond) => {
-                create_accumulator::<Time64MicrosecondType>(args, pick_first_in_group)
+                create_accumulator::<Time64MicrosecondType>(args)
             }
             DataType::Time64(TimeUnit::Nanosecond) => {
-                create_accumulator::<Time64NanosecondType>(args, pick_first_in_group)
+                create_accumulator::<Time64NanosecondType>(args)
             }
 
             _ => {

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -2232,7 +2232,7 @@ physical_plan
 03)----StreamingTableExec: partition_sizes=1, projection=[a, b, c], infinite_source=true, output_ordering=[a@0 ASC NULLS LAST, b@1 ASC NULLS LAST, c@2 ASC NULLS LAST]
 
 query III
-SELECT a, b, LAST_VALUE(c) as last_c
+SELECT a, b, LAST_VALUE(c order by c) as last_c
   FROM annotated_data_infinite2
   GROUP BY a, b
 ----
@@ -2701,6 +2701,29 @@ select k, first_value(val order by o) IGNORE NULLS from first_null group by k;
 
 query II rowsort
 select k, first_value(val order by o) respect NULLS from first_null group by k;
+----
+0 NULL
+1 1
+
+
+statement ok
+CREATE TABLE last_null (
+          k INT,
+          val INT,
+          o int
+        ) as VALUES
+          (0, NULL, 9),
+          (0, 1, 1),
+          (1, 1, 1);
+
+query II rowsort
+select k, last_value(val order by o) IGNORE NULLS from last_null group by k;
+----
+0 1
+1 1
+
+query II rowsort
+select k, last_value(val order by o) respect NULLS from last_null group by k;
 ----
 0 NULL
 1 1
@@ -3775,7 +3798,7 @@ ORDER BY x;
 2 2
 
 query II
-SELECT y, LAST_VALUE(x)
+SELECT y, LAST_VALUE(x order by x desc)
 FROM FOO
 GROUP BY y
 ORDER BY y;


### PR DESCRIPTION
## Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #13998.

## Rationale for this change
Achieved significant performance improvement when cardinality is high.
| benchmark sql                                                                                                                                                            | main    | thisPR |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------ |
| `select id2, id4, last_value(v1 order by id2, id4) as r2 from '~/h2o_100m.parquet' group by id2, id4;`                                                                   | 36.546s | 7.276s |
| `select l_shipmode, last_value(l_partkey order by l_orderkey, l_linenumber, l_comment, l_suppkey, l_tax) from 'benchmarks/data/tpch_sf10/lineitem' group by l_shipmode;` | 0.962s  | 0.801s |



<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
+ Add fields `pick_first_in_group: bool` to `PrimitiveGroupsAccumulator`. If ture take first element in an aggregation group according to the requested ordering, otherwisetake last element
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Additional context
https://github.com/apache/datafusion/pull/15266


## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
