### PR TITLE
Add SQL logic tests for compound field access in JOIN conditions

### DIFF
--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -4742,3 +4742,51 @@ drop table person;
 
 statement count 0
 drop table orders;
+
+# Create tables for testing compound field access in JOIN conditions
+statement ok
+CREATE TABLE compound_field_table_t
+AS VALUES
+({r: 'a', c: 1}),
+({r: 'b', c: 2.3});
+
+statement ok
+CREATE TABLE compound_field_table_u
+AS VALUES
+({r: 'a', c: 1}),
+({r: 'b', c: 2.3});
+
+# Test compound field access in JOIN condition with table aliases
+query ??
+SELECT * FROM compound_field_table_t tee JOIN compound_field_table_u you ON tee.column1['r'] = you.column1['r']
+----
+{r: a, c: 1.0} {r: a, c: 1.0}
+{r: b, c: 2.3} {r: b, c: 2.3}
+
+# Test compound field access in JOIN condition without table aliases
+query ??
+SELECT * FROM compound_field_table_t JOIN compound_field_table_u ON compound_field_table_t.column1['r'] = compound_field_table_u.column1['r']
+----
+{r: a, c: 1.0} {r: a, c: 1.0}
+{r: b, c: 2.3} {r: b, c: 2.3}
+
+# Test compound field access with numeric field access
+query ??
+SELECT * FROM compound_field_table_t tee JOIN compound_field_table_u you ON tee.column1['c'] = you.column1['c']
+----
+{r: a, c: 1.0} {r: a, c: 1.0}
+{r: b, c: 2.3} {r: b, c: 2.3}
+
+# Test compound field access with mixed field types
+query ??
+SELECT * FROM compound_field_table_t tee JOIN compound_field_table_u you ON tee.column1['r'] = you.column1['r'] AND tee.column1['c'] = you.column1['c']
+----
+{r: a, c: 1.0} {r: a, c: 1.0}
+{r: b, c: 2.3} {r: b, c: 2.3}
+
+# Clean up compound field tables
+statement ok
+DROP TABLE compound_field_table_t;
+
+statement ok
+DROP TABLE compound_field_table_u;


### PR DESCRIPTION
## Which issue does this PR close?

- I added some slt tests to investigate #15549

## Rationale for this change

This change adds SQL logic tests to validate support for accessing fields within compound (struct-like) columns during `JOIN` operations.

## What changes are included in this PR?

- Introduced two new tables: `compound_field_table_t` and `compound_field_table_u`, each containing a single column with a compound field (`{r: <string>, c: <number>}`).
- Added four test queries covering:
  - Field access using string keys in `JOIN` conditions with aliases
  - Same logic without using aliases
  - Joins on numeric field values within the compound field
  - Joins with combined conditions on both fields
- Added cleanup statements to drop the temporary tables after the tests

## Are these changes tested?

✅ Yes. This PR adds SQL logic tests directly into the `joins.slt` test suite. These queries act as both verification and documentation for expected behavior.

## Are there any user-facing changes?

🟢 No user-facing changes. This is strictly a test-only addition, focused on validating internal functionality.

<!-- If there are any breaking changes to public APIs, please add the `api change` label. -->
