### PR TITLE
perf: Introduce sort prefix computation for early TopK exit optimization on partially sorted input (10x speedup on top10 bench)

### DIFF
--- a/datafusion/core/tests/physical_optimizer/enforce_sorting.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_sorting.rs
@@ -1652,7 +1652,7 @@ async fn test_remove_unnecessary_sort7() -> Result<()> {
     ) as Arc<dyn ExecutionPlan>;
 
     let expected_input = [
-        "SortExec: TopK(fetch=2), expr=[non_nullable_col@1 ASC], preserve_partitioning=[false]",
+        "SortExec: TopK(fetch=2), expr=[non_nullable_col@1 ASC], preserve_partitioning=[false], sort_prefix=[non_nullable_col@1 ASC]",
         "  SortExec: expr=[non_nullable_col@1 ASC, nullable_col@0 ASC], preserve_partitioning=[false]",
         "    DataSourceExec: partitions=1, partition_sizes=[0]",
     ];

--- a/datafusion/physical-expr/src/equivalence/properties/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/properties/mod.rs
@@ -546,22 +546,23 @@ impl EquivalenceProperties {
         self.ordering_satisfy_requirement(&sort_requirements)
     }
 
-    /// Checks whether the given sort requirements are satisfied by any of the
-    /// existing orderings.
-    pub fn ordering_satisfy_requirement(&self, reqs: &LexRequirement) -> bool {
-        let mut eq_properties = self.clone();
-        // First, standardize the given requirement:
-        let normalized_reqs = eq_properties.normalize_sort_requirements(reqs);
-
+    /// Returns the number of consecutive requirements (starting from the left)
+    /// that are satisfied by the plan ordering.
+    fn compute_matching_prefix_length(&self, normalized_reqs: &LexRequirement) -> usize {
         // Check whether given ordering is satisfied by constraints first
-        if self.satisfied_by_constraints(&normalized_reqs) {
-            return true;
+        if self.satisfied_by_constraints(normalized_reqs) {
+            // If the constraints satisfy all requirements, return the full normalized requirements length
+            return normalized_reqs.len();
         }
 
-        for normalized_req in normalized_reqs {
+        let mut eq_properties = self.clone();
+
+        for (i, normalized_req) in normalized_reqs.iter().enumerate() {
             // Check whether given ordering is satisfied
-            if !eq_properties.ordering_satisfy_single(&normalized_req) {
-                return false;
+            if !eq_properties.ordering_satisfy_single(normalized_req) {
+                // As soon as one requirement is not satisfied, return
+                // how many we've satisfied so far
+                return i;
             }
             // Treat satisfied keys as constants in subsequent iterations. We
             // can do this because the "next" key only matters in a lexicographical
@@ -575,10 +576,35 @@ impl EquivalenceProperties {
             // From the analysis above, we know that `[a ASC]` is satisfied. Then,
             // we add column `a` as constant to the algorithm state. This enables us
             // to deduce that `(b + c) ASC` is satisfied, given `a` is constant.
-            eq_properties = eq_properties
-                .with_constants(std::iter::once(ConstExpr::from(normalized_req.expr)));
+            eq_properties = eq_properties.with_constants(std::iter::once(
+                ConstExpr::from(Arc::clone(&normalized_req.expr)),
+            ));
         }
-        true
+
+        // All requirements are satisfied.
+        normalized_reqs.len()
+    }
+
+    /// Determines the longest prefix of `reqs` that is satisfied by the existing ordering.
+    /// Returns that prefix as a new `LexRequirement`, and a boolean indicating if all the requirements are satisfied.
+    pub fn extract_matching_prefix(
+        &self,
+        reqs: &LexRequirement,
+    ) -> (LexRequirement, bool) {
+        // First, standardize the given requirement:
+        let normalized_reqs = self.normalize_sort_requirements(reqs);
+
+        let prefix_len = self.compute_matching_prefix_length(&normalized_reqs);
+        (
+            LexRequirement::new(normalized_reqs[..prefix_len].to_vec()),
+            prefix_len == normalized_reqs.len(),
+        )
+    }
+
+    /// Checks whether the given sort requirements are satisfied by any of the
+    /// existing orderings.
+    pub fn ordering_satisfy_requirement(&self, reqs: &LexRequirement) -> bool {
+        self.extract_matching_prefix(reqs).1
     }
 
     /// Checks if the sort requirements are satisfied by any of the table constraints (primary key or unique).

--- a/datafusion/physical-expr/src/equivalence/properties/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/properties/mod.rs
@@ -548,7 +548,10 @@ impl EquivalenceProperties {
 
     /// Returns the number of consecutive requirements (starting from the left)
     /// that are satisfied by the plan ordering.
-    fn compute_matching_prefix_length(&self, normalized_reqs: &LexRequirement) -> usize {
+    fn compute_common_sort_prefix_length(
+        &self,
+        normalized_reqs: &LexRequirement,
+    ) -> usize {
         // Check whether given ordering is satisfied by constraints first
         if self.satisfied_by_constraints(normalized_reqs) {
             // If the constraints satisfy all requirements, return the full normalized requirements length
@@ -587,14 +590,14 @@ impl EquivalenceProperties {
 
     /// Determines the longest prefix of `reqs` that is satisfied by the existing ordering.
     /// Returns that prefix as a new `LexRequirement`, and a boolean indicating if all the requirements are satisfied.
-    pub fn extract_matching_prefix(
+    pub fn extract_common_sort_prefix(
         &self,
         reqs: &LexRequirement,
     ) -> (LexRequirement, bool) {
         // First, standardize the given requirement:
         let normalized_reqs = self.normalize_sort_requirements(reqs);
 
-        let prefix_len = self.compute_matching_prefix_length(&normalized_reqs);
+        let prefix_len = self.compute_common_sort_prefix_length(&normalized_reqs);
         (
             LexRequirement::new(normalized_reqs[..prefix_len].to_vec()),
             prefix_len == normalized_reqs.len(),
@@ -604,7 +607,7 @@ impl EquivalenceProperties {
     /// Checks whether the given sort requirements are satisfied by any of the
     /// existing orderings.
     pub fn ordering_satisfy_requirement(&self, reqs: &LexRequirement) -> bool {
-        self.extract_matching_prefix(reqs).1
+        self.extract_common_sort_prefix(reqs).1
     }
 
     /// Checks if the sort requirements are satisfied by any of the table constraints (primary key or unique).

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -1084,7 +1084,7 @@ impl SortExec {
             .equivalence_properties()
             .extract_common_sort_prefix(&requirement);
 
-        let sort_partially_satisfied = sort_satisfied || !sort_prefix.is_empty();
+        let sort_partially_satisfied = !sort_prefix.is_empty();
 
         // The emission type depends on whether the input is already sorted:
         // - If already fully sorted, we can emit results in the same way as the input

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -1082,7 +1082,7 @@ impl SortExec {
 
         let (sort_prefix, sort_satisfied) = input
             .equivalence_properties()
-            .extract_matching_prefix(&requirement);
+            .extract_common_sort_prefix(&requirement);
 
         let sort_partially_satisfied = sort_satisfied || !sort_prefix.is_empty();
 

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -966,7 +966,7 @@ pub struct SortExec {
     preserve_partitioning: bool,
     /// Fetch highest/lowest n results
     fetch: Option<usize>,
-    /// Common sort prefix between the input and the sort expressions (only used with fetch)
+    /// Normalized common sort prefix between the input and the sort expressions (only used with fetch)
     common_sort_prefix: LexOrdering,
     /// Cache holding plan properties like equivalences, output partitioning etc.
     cache: PlanProperties,

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -966,6 +966,8 @@ pub struct SortExec {
     preserve_partitioning: bool,
     /// Fetch highest/lowest n results
     fetch: Option<usize>,
+    /// Common sort prefix between the input and the sort expressions (only used with fetch)
+    common_sort_prefix: LexOrdering,
     /// Cache holding plan properties like equivalences, output partitioning etc.
     cache: PlanProperties,
 }
@@ -975,13 +977,15 @@ impl SortExec {
     /// sorted output partition.
     pub fn new(expr: LexOrdering, input: Arc<dyn ExecutionPlan>) -> Self {
         let preserve_partitioning = false;
-        let cache = Self::compute_properties(&input, expr.clone(), preserve_partitioning);
+        let (cache, sort_prefix) =
+            Self::compute_properties(&input, expr.clone(), preserve_partitioning);
         Self {
             expr,
             input,
             metrics_set: ExecutionPlanMetricsSet::new(),
             preserve_partitioning,
             fetch: None,
+            common_sort_prefix: sort_prefix,
             cache,
         }
     }
@@ -1033,6 +1037,7 @@ impl SortExec {
             expr: self.expr.clone(),
             metrics_set: self.metrics_set.clone(),
             preserve_partitioning: self.preserve_partitioning,
+            common_sort_prefix: self.common_sort_prefix.clone(),
             fetch,
             cache,
         }
@@ -1066,22 +1071,33 @@ impl SortExec {
     }
 
     /// This function creates the cache object that stores the plan properties such as schema, equivalence properties, ordering, partitioning, etc.
+    /// It also returns the common sort prefix between the input and the sort expressions.
     fn compute_properties(
         input: &Arc<dyn ExecutionPlan>,
         sort_exprs: LexOrdering,
         preserve_partitioning: bool,
-    ) -> PlanProperties {
+    ) -> (PlanProperties, LexOrdering) {
         // Determine execution mode:
         let requirement = LexRequirement::from(sort_exprs);
-        let sort_satisfied = input
+
+        let (sort_prefix, sort_satisfied) = input
             .equivalence_properties()
-            .ordering_satisfy_requirement(&requirement);
+            .extract_matching_prefix(&requirement);
+
+        let sort_partially_satisfied = sort_satisfied || !sort_prefix.is_empty();
 
         // The emission type depends on whether the input is already sorted:
-        // - If already sorted, we can emit results in the same way as the input
+        // - If already fully sorted, we can emit results in the same way as the input
+        // - If partially sorted, we might be able to emit results incrementally, but it is not guaranteed (Both)
         // - If not sorted, we must wait until all data is processed to emit results (Final)
         let emission_type = if sort_satisfied {
             input.pipeline_behavior()
+        } else if sort_partially_satisfied {
+            if input.pipeline_behavior() == EmissionType::Incremental {
+                EmissionType::Both
+            } else {
+                input.pipeline_behavior()
+            }
         } else {
             EmissionType::Final
         };
@@ -1114,11 +1130,14 @@ impl SortExec {
         let output_partitioning =
             Self::output_partitioning_helper(input, preserve_partitioning);
 
-        PlanProperties::new(
-            eq_properties,
-            output_partitioning,
-            emission_type,
-            boundedness,
+        (
+            PlanProperties::new(
+                eq_properties,
+                output_partitioning,
+                emission_type,
+                boundedness,
+            ),
+            LexOrdering::from(sort_prefix),
         )
     }
 }
@@ -1130,7 +1149,12 @@ impl DisplayAs for SortExec {
                 let preserve_partitioning = self.preserve_partitioning;
                 match self.fetch {
                     Some(fetch) => {
-                        write!(f, "SortExec: TopK(fetch={fetch}), expr=[{}], preserve_partitioning=[{preserve_partitioning}]", self.expr)
+                        write!(f, "SortExec: TopK(fetch={fetch}), expr=[{}], preserve_partitioning=[{preserve_partitioning}]", self.expr)?;
+                        if !self.common_sort_prefix.is_empty() {
+                            write!(f, ", sort_prefix=[{}]", self.common_sort_prefix)
+                        } else {
+                            Ok(())
+                        }
                     }
                     None => write!(f, "SortExec: expr=[{}], preserve_partitioning=[{preserve_partitioning}]", self.expr),
                 }
@@ -1203,10 +1227,12 @@ impl ExecutionPlan for SortExec {
 
         trace!("End SortExec's input.execute for partition: {}", partition);
 
+        let requirement = &LexRequirement::from(self.expr.clone());
+
         let sort_satisfied = self
             .input
             .equivalence_properties()
-            .ordering_satisfy_requirement(&LexRequirement::from(self.expr.clone()));
+            .ordering_satisfy_requirement(requirement);
 
         match (sort_satisfied, self.fetch.as_ref()) {
             (true, Some(fetch)) => Ok(Box::pin(LimitStream::new(
@@ -1220,6 +1246,7 @@ impl ExecutionPlan for SortExec {
                 let mut topk = TopK::try_new(
                     partition,
                     input.schema(),
+                    self.common_sort_prefix.clone(),
                     self.expr.clone(),
                     *fetch,
                     context.session_config().batch_size(),
@@ -1232,6 +1259,9 @@ impl ExecutionPlan for SortExec {
                         while let Some(batch) = input.next().await {
                             let batch = batch?;
                             topk.insert_batch(batch)?;
+                            if topk.finished {
+                                break;
+                            }
                         }
                         topk.emit()
                     })

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -1084,20 +1084,11 @@ impl SortExec {
             .equivalence_properties()
             .extract_common_sort_prefix(&requirement);
 
-        let sort_partially_satisfied = !sort_prefix.is_empty();
-
         // The emission type depends on whether the input is already sorted:
         // - If already fully sorted, we can emit results in the same way as the input
-        // - If partially sorted, we might be able to emit results incrementally, but it is not guaranteed (Both)
         // - If not sorted, we must wait until all data is processed to emit results (Final)
         let emission_type = if sort_satisfied {
             input.pipeline_behavior()
-        } else if sort_partially_satisfied {
-            if input.pipeline_behavior() == EmissionType::Incremental {
-                EmissionType::Both
-            } else {
-                input.pipeline_behavior()
-            }
         } else {
             EmissionType::Final
         };

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -29,8 +29,8 @@ use crate::spill::get_record_batch_memory_size;
 use crate::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream};
 use arrow::array::{Array, ArrayRef, RecordBatch};
 use arrow::datatypes::SchemaRef;
-use datafusion_common::HashMap;
 use datafusion_common::Result;
+use datafusion_common::{internal_datafusion_err, HashMap};
 use datafusion_execution::{
     memory_pool::{MemoryConsumer, MemoryReservation},
     runtime_env::RuntimeEnv,
@@ -90,15 +90,41 @@ pub struct TopK {
     scratch_rows: Rows,
     /// stores the top k values and their sort key values, in order
     heap: TopKHeap,
+    /// row converter, for common keys between the sort keys and the input ordering
+    common_prefix_converter: Option<RowConverter>,
+    /// Common sort prefix between the input and the sort expressions to allow early exit optimization
+    common_sort_prefix: Arc<[PhysicalSortExpr]>,
+    /// If true, indicates that all rows of subsequent batches are guaranteed to be worse than the top K
+    pub(crate) finished: bool,
+}
+
+// Guesstimate for memory allocation: estimated number of bytes used per row in the RowConverter
+const ESTIMATED_BYTES_PER_ROW: usize = 20;
+
+fn build_sort_fields(
+    ordering: &LexOrdering,
+    schema: &SchemaRef,
+) -> Result<Vec<SortField>> {
+    ordering
+        .iter()
+        .map(|e| {
+            Ok(SortField::new_with_options(
+                e.expr.data_type(schema)?,
+                e.options,
+            ))
+        })
+        .collect::<Result<_>>()
 }
 
 impl TopK {
     /// Create a new [`TopK`] that stores the top `k` values, as
     /// defined by the sort expressions in `expr`.
     // TODO: make a builder or some other nicer API
+    #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         partition_id: usize,
         schema: SchemaRef,
+        common_sort_prefix: LexOrdering,
         expr: LexOrdering,
         k: usize,
         batch_size: usize,
@@ -108,35 +134,34 @@ impl TopK {
         let reservation = MemoryConsumer::new(format!("TopK[{partition_id}]"))
             .register(&runtime.memory_pool);
 
-        let expr: Arc<[PhysicalSortExpr]> = expr.into();
-
-        let sort_fields: Vec<_> = expr
-            .iter()
-            .map(|e| {
-                Ok(SortField::new_with_options(
-                    e.expr.data_type(&schema)?,
-                    e.options,
-                ))
-            })
-            .collect::<Result<_>>()?;
+        let sort_fields: Vec<_> = build_sort_fields(&expr, &schema)?;
 
         // TODO there is potential to add special cases for single column sort fields
         // to improve performance
         let row_converter = RowConverter::new(sort_fields)?;
-        let scratch_rows = row_converter.empty_rows(
-            batch_size,
-            20 * batch_size, // guesstimate 20 bytes per row
-        );
+        let scratch_rows =
+            row_converter.empty_rows(batch_size, ESTIMATED_BYTES_PER_ROW * batch_size);
+
+        let prefix_row_converter = if common_sort_prefix.is_empty() {
+            None
+        } else {
+            let input_sort_fields: Vec<_> =
+                build_sort_fields(&common_sort_prefix, &schema)?;
+            Some(RowConverter::new(input_sort_fields)?)
+        };
 
         Ok(Self {
             schema: Arc::clone(&schema),
             metrics: TopKMetrics::new(metrics, partition_id),
             reservation,
             batch_size,
-            expr,
+            expr: Arc::from(expr),
             row_converter,
             scratch_rows,
             heap: TopKHeap::new(k, batch_size, schema),
+            common_prefix_converter: prefix_row_converter,
+            common_sort_prefix: Arc::from(common_sort_prefix),
+            finished: false,
         })
     }
 
@@ -144,7 +169,8 @@ impl TopK {
     /// the top k seen so far.
     pub fn insert_batch(&mut self, batch: RecordBatch) -> Result<()> {
         // Updates on drop
-        let _timer = self.metrics.baseline.elapsed_compute().timer();
+        let baseline = self.metrics.baseline.clone();
+        let _timer = baseline.elapsed_compute().timer();
 
         let sort_keys: Vec<ArrayRef> = self
             .expr
@@ -163,7 +189,7 @@ impl TopK {
         // TODO make this algorithmically better?:
         // Idea: filter out rows >= self.heap.max() early (before passing to `RowConverter`)
         //       this avoids some work and also might be better vectorizable.
-        let mut batch_entry = self.heap.register_batch(batch);
+        let mut batch_entry = self.heap.register_batch(batch.clone());
         for (index, row) in rows.iter().enumerate() {
             match self.heap.max() {
                 // heap has k items, and the new row is greater than the
@@ -183,6 +209,87 @@ impl TopK {
 
         // update memory reservation
         self.reservation.try_resize(self.size())?;
+
+        // flag the topK as finished if we know that all
+        // subsequent batches are guaranteed to be worse than the
+        // current topK
+        self.attempt_early_completion(&batch)?;
+
+        Ok(())
+    }
+
+    /// If input ordering shares a common sort prefix with the TopK, and if the TopK's heap is full,
+    /// check if the computation can be finished early.
+    /// This is the case if the last row of the current batch is strictly worse than the worst row in the heap,
+    /// comparing only on the shared prefix columns.
+    fn attempt_early_completion(&mut self, batch: &RecordBatch) -> Result<()> {
+        // Early exit if the batch is empty as there is no last row to extract from it.
+        if batch.num_rows() == 0 {
+            return Ok(());
+        }
+
+        // prefix_row_converter is only `Some` if the input ordering has a common prefix with the TopK,
+        // so early exit if it is `None`.
+        let Some(prefix_converter) = &self.common_prefix_converter else {
+            return Ok(());
+        };
+
+        // Early exit if the heap is not full (`heap.max()` only returns `Some` if the heap is full).
+        let Some(worst_topk_row) = self.heap.max() else {
+            return Ok(());
+        };
+
+        // Evaluate the prefix for the last row of the current batch.
+        let last_row_idx = batch.num_rows() - 1;
+        let mut batch_prefix_scratch =
+            prefix_converter.empty_rows(1, ESTIMATED_BYTES_PER_ROW); // 1 row with capacity ESTIMATED_BYTES_PER_ROW
+
+        self.compute_common_prefix(batch, last_row_idx, &mut batch_prefix_scratch)?;
+
+        // Retrieve the "worst" row from the heap.
+        let store_entry = self
+            .heap
+            .store
+            .get(worst_topk_row.batch_id)
+            .ok_or(internal_datafusion_err!("Invalid batch id in topK heap"))?;
+        let worst_batch = &store_entry.batch;
+        let mut heap_prefix_scratch =
+            prefix_converter.empty_rows(1, ESTIMATED_BYTES_PER_ROW); // 1 row with capacity ESTIMATED_BYTES_PER_ROW
+        self.compute_common_prefix(
+            worst_batch,
+            worst_topk_row.index,
+            &mut heap_prefix_scratch,
+        )?;
+
+        // If the last row's prefix is strictly greater than the worst prefix, mark as finished.
+        if batch_prefix_scratch.row(0).as_ref() > heap_prefix_scratch.row(0).as_ref() {
+            self.finished = true;
+        }
+
+        Ok(())
+    }
+
+    // Helper function to compute the prefix for a given batch and row index, storing the result in scratch.
+    fn compute_common_prefix(
+        &self,
+        batch: &RecordBatch,
+        last_row_idx: usize,
+        scratch: &mut Rows,
+    ) -> Result<()> {
+        let last_row: Vec<ArrayRef> = self
+            .common_sort_prefix
+            .iter()
+            .map(|expr| {
+                expr.expr
+                    .evaluate(&batch.slice(last_row_idx, 1))?
+                    .into_array(1)
+            })
+            .collect::<Result<_>>()?;
+
+        self.common_prefix_converter
+            .as_ref()
+            .unwrap()
+            .append(scratch, &last_row)?;
         Ok(())
     }
 
@@ -197,6 +304,9 @@ impl TopK {
             row_converter: _,
             scratch_rows: _,
             mut heap,
+            common_prefix_converter: _,
+            common_sort_prefix: _,
+            finished: _,
         } = self;
         let _timer = metrics.baseline.elapsed_compute().timer(); // time updated on drop
 
@@ -649,6 +759,10 @@ mod tests {
     use super::*;
     use arrow::array::{Float64Array, Int32Array, RecordBatch};
     use arrow::datatypes::{DataType, Field, Schema};
+    use arrow_schema::SortOptions;
+    use datafusion_common::assert_batches_eq;
+    use datafusion_physical_expr::expressions::col;
+    use futures::TryStreamExt;
 
     /// This test ensures the size calculation is correct for RecordBatches with multiple columns.
     #[test]
@@ -680,5 +794,99 @@ mod tests {
         // when unuse record batch entry
         record_batch_store.unuse(0);
         assert_eq!(record_batch_store.batches_size, 0);
+    }
+
+    /// This test validates that the `try_finish` method marks the TopK operator as finished
+    /// when the prefix (on column "a") of the last row in the current batch is strictly greater
+    /// than the worst top‑k row.
+    /// The full sort expression is defined on both columns ("a", "b"), but the input ordering is only on "a".
+    #[tokio::test]
+    async fn test_try_finish_marks_finished_with_prefix() -> Result<()> {
+        // Create a schema with two columns.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Float64, false),
+        ]));
+
+        // Create sort expressions.
+        // Full sort: first by "a", then by "b".
+        let sort_expr_a = PhysicalSortExpr {
+            expr: col("a", schema.as_ref())?,
+            options: SortOptions::default(),
+        };
+        let sort_expr_b = PhysicalSortExpr {
+            expr: col("b", schema.as_ref())?,
+            options: SortOptions::default(),
+        };
+
+        // Input ordering uses only column "a" (a prefix of the full sort).
+        let input_ordering = LexOrdering::from(vec![sort_expr_a.clone()]);
+        let full_expr = LexOrdering::from(vec![sort_expr_a, sort_expr_b]);
+
+        // Create a dummy runtime environment and metrics.
+        let runtime = Arc::new(RuntimeEnv::default());
+        let metrics = ExecutionPlanMetricsSet::new();
+
+        // Create a TopK instance with k = 3 and batch_size = 2.
+        let mut topk = TopK::try_new(
+            0,
+            Arc::clone(&schema),
+            input_ordering,
+            full_expr,
+            3,
+            2,
+            runtime,
+            &metrics,
+        )?;
+
+        // Create the first batch with two columns:
+        // Column "a": [1, 1, 2], Column "b": [20.0, 15.0, 30.0].
+        let array_a1: ArrayRef =
+            Arc::new(Int32Array::from(vec![Some(1), Some(1), Some(2)]));
+        let array_b1: ArrayRef = Arc::new(Float64Array::from(vec![20.0, 15.0, 30.0]));
+        let batch1 = RecordBatch::try_new(Arc::clone(&schema), vec![array_a1, array_b1])?;
+
+        // Insert the first batch.
+        // At this point the heap is not yet “finished” because the prefix of the last row of the batch
+        // is not strictly greater than the prefix of the worst top‑k row (both being `2`).
+        topk.insert_batch(batch1)?;
+        assert!(
+            !topk.finished,
+            "Expected 'finished' to be false after the first batch."
+        );
+
+        // Create the second batch with two columns:
+        // Column "a": [2, 3], Column "b": [10.0, 20.0].
+        let array_a2: ArrayRef = Arc::new(Int32Array::from(vec![Some(2), Some(3)]));
+        let array_b2: ArrayRef = Arc::new(Float64Array::from(vec![10.0, 20.0]));
+        let batch2 = RecordBatch::try_new(Arc::clone(&schema), vec![array_a2, array_b2])?;
+
+        // Insert the second batch.
+        // The last row in this batch has a prefix value of `3`,
+        // which is strictly greater than the worst top‑k row (with value `2`),
+        // so try_finish should mark the TopK as finished.
+        topk.insert_batch(batch2)?;
+        assert!(
+            topk.finished,
+            "Expected 'finished' to be true after the second batch."
+        );
+
+        // Verify the TopK correctly emits the top k rows from both batches
+        // (the value 10.0 for b is from the second batch).
+        let results: Vec<_> = topk.emit()?.try_collect().await?;
+        assert_batches_eq!(
+            &[
+                "+---+------+",
+                "| a | b    |",
+                "+---+------+",
+                "| 1 | 15.0 |",
+                "| 1 | 20.0 |",
+                "| 2 | 10.0 |",
+                "+---+------+",
+            ],
+            &results
+        );
+
+        Ok(())
     }
 }

--- a/datafusion/sqllogictest/test_files/topk.slt
+++ b/datafusion/sqllogictest/test_files/topk.slt
@@ -318,6 +318,21 @@ physical_plan
 01)SortExec: TopK(fetch=3), expr=[column2@1 ASC NULLS LAST, column1@0 DESC], preserve_partitioning=[false]
 02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
 
+# Explicit NULLS ordering cases (reversing the order of the NULLS on the column1 and column2 orderings)
+query TT
+explain select column1, column2, column3 from partial_sorted order by column1 desc, column2 asc NULLS FIRST limit 3;
+----
+physical_plan
+01)SortExec: TopK(fetch=3), expr=[column1@0 DESC, column2@1 ASC], preserve_partitioning=[false], sort_prefix=[column1@0 DESC]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+
+query TT
+explain select column1, column2, column3 from partial_sorted order by column1 desc NULLS LAST, column2 asc limit 3;
+----
+physical_plan
+01)SortExec: TopK(fetch=3), expr=[column1@0 DESC NULLS LAST, column2@1 ASC NULLS LAST], preserve_partitioning=[false]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+
 
 # Verify that the sort prefix is correctly computed on the normalized ordering (removing redundant aliased columns)
 query TT

--- a/datafusion/sqllogictest/test_files/topk.slt
+++ b/datafusion/sqllogictest/test_files/topk.slt
@@ -233,3 +233,104 @@ d 1 -98 y7C453hRWd4E7ImjNDWlpexB8nUqjh y7C453hRWd4E7ImjNDWlpexB8nUqjh
 e 2 52 xipQ93429ksjNcXPX5326VSg1xJZcW xipQ93429ksjNcXPX5326VSg1xJZcW
 d 1 -72 wwXqSGKLyBQyPkonlzBNYUJTCo4LRS wwXqSGKLyBQyPkonlzBNYUJTCo4LRS
 a 1 -5 waIGbOGl1PM6gnzZ4uuZt4E2yDWRHs waIGbOGl1PM6gnzZ4uuZt4E2yDWRHs
+
+#####################################
+## Test TopK with Partially Sorted Inputs
+#####################################
+
+
+# Create an external table where data is pre-sorted by (column1 DESC, column2 ASC) only.
+statement ok
+CREATE EXTERNAL TABLE partial_sorted (
+    column1 VARCHAR,
+    column2 INT,
+    column3 INT
+)
+STORED AS parquet
+LOCATION 'test_files/scratch/topk/partial_sorted/1.parquet'
+WITH ORDER (column1 DESC, column2 ASC);
+
+# Insert test data into the external table.
+query I
+COPY (VALUES
+    ('A', 12, 100),
+    ('A', 8, 50),
+    ('B', 9, 70),
+    ('B', 10, 80),
+    ('C', 7, 60),
+    ('C', 11, 90))
+TO 'test_files/scratch/topk/partial_sorted/1.parquet';
+----
+6
+
+# Run a TopK query that orders by all columns.
+# Although the table is only guaranteed to be sorted by (column1 DESC, column2 ASC),
+# DataFusion should use the common prefix optimization
+# and return the correct top 3 rows when ordering by all columns.
+query TII
+select column1, column2, column3 from partial_sorted order by column1 desc, column2 asc, column3 desc limit 3;
+----
+C 7 60
+C 11 90
+B 9 70
+
+## explain_physical_plan_only
+statement ok
+set datafusion.explain.physical_plan_only = true
+
+# Verify that the physical plan includes the sort prefix.
+# The output should display a "sort_prefix" in the SortExec node.
+query TT
+explain select column1, column2, column3 from partial_sorted order by column1 desc, column2 asc, column3 desc limit 3;
+----
+physical_plan
+01)SortExec: TopK(fetch=3), expr=[column1@0 DESC, column2@1 ASC NULLS LAST, column3@2 DESC], preserve_partitioning=[false], sort_prefix=[column1@0 DESC, column2@1 ASC NULLS LAST]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+
+
+# Explain variations of the above query with different orderings, and different sort prefixes.
+# The "sort_prefix" in the  SortExec node should only be present if the TopK's ordering starts with either (column1 DESC, column2 ASC) or just (column1 DESC).
+query TT
+explain select column1, column2, column3 from partial_sorted order by column3 desc limit 3;
+----
+physical_plan
+01)SortExec: TopK(fetch=3), expr=[column3@2 DESC], preserve_partitioning=[false]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+
+query TT
+explain select column1, column2, column3 from partial_sorted order by column1 desc, column2 desc limit 3;
+----
+physical_plan
+01)SortExec: TopK(fetch=3), expr=[column1@0 DESC, column2@1 DESC], preserve_partitioning=[false], sort_prefix=[column1@0 DESC]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+
+query TT
+explain select column1, column2, column3 from partial_sorted order by column1 asc limit 3;
+----
+physical_plan
+01)SortExec: TopK(fetch=3), expr=[column1@0 ASC NULLS LAST], preserve_partitioning=[false]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+
+query TT
+explain select column1, column2, column3 from partial_sorted order by column2 asc, column1 desc limit 3;
+----
+physical_plan
+01)SortExec: TopK(fetch=3), expr=[column2@1 ASC NULLS LAST, column1@0 DESC], preserve_partitioning=[false]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+
+
+# Verify that the sort prefix is correctly computed on the normalized ordering (removing redundant aliased columns for example).
+query TT
+explain select column1, column2, column3, column1 as column4, column2 as column5 from partial_sorted order by column1 desc, column4 desc, column2 asc, column5 asc, column3 desc limit 3;
+----
+physical_plan
+01)SortExec: TopK(fetch=3), expr=[column1@0 DESC, column4@3 DESC, column2@1 ASC NULLS LAST, column5@4 ASC NULLS LAST, column3@2 DESC], preserve_partitioning=[false], sort_prefix=[column1@0 DESC, column2@1 ASC NULLS LAST]
+02)--ProjectionExec: expr=[column1@0 as column1, column2@1 as column2, column3@2 as column3, column1@0 as column4, column2@1 as column5]
+03)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+
+# Cleanup
+statement ok
+DROP TABLE partial_sorted;
+
+statement ok
+set datafusion.explain.physical_plan_only = false

--- a/datafusion/sqllogictest/test_files/topk.slt
+++ b/datafusion/sqllogictest/test_files/topk.slt
@@ -239,121 +239,152 @@ a 1 -5 waIGbOGl1PM6gnzZ4uuZt4E2yDWRHs waIGbOGl1PM6gnzZ4uuZt4E2yDWRHs
 #####################################
 
 
-# Create an external table where data is pre-sorted by (column1 DESC, column2 ASC) only.
+# Create an external table where data is pre-sorted by (number DESC, letter ASC) only.
 statement ok
 CREATE EXTERNAL TABLE partial_sorted (
-    column1 INT,
-    column2 VARCHAR,
-    column3 INT
+    number INT,
+    letter VARCHAR,
+    age INT
 )
 STORED AS parquet
 LOCATION 'test_files/scratch/topk/partial_sorted/1.parquet'
-WITH ORDER (column1 DESC, column2 ASC);
+WITH ORDER (number DESC, letter ASC);
 
 # Insert test data into the external table.
 query I
-COPY (VALUES
-    (1, 'F', 100),
-    (1, 'B', 50),
-    (2, 'C', 70),
-    (2, 'D', 80),
-    (3, 'A', 60),
-    (3, 'E', 90))
+COPY (
+  SELECT *
+  FROM (
+    VALUES
+      (1, 'F', 100),
+      (1, 'B', 50),
+      (2, 'C', 70),
+      (2, 'D', 80),
+      (3, 'A', 60),
+      (3, 'E', 90)
+  ) AS t(number, letter, age)
+  ORDER BY number DESC, letter ASC
+)
 TO 'test_files/scratch/topk/partial_sorted/1.parquet';
 ----
 6
 
+## explain physical_plan only
+statement ok
+set datafusion.explain.physical_plan_only = true
+
+## batch size smaller than number of rows in the table and result
+statement ok
+set datafusion.execution.batch_size = 2
+
 # Run a TopK query that orders by all columns.
-# Although the table is only guaranteed to be sorted by (column1 DESC, column2 ASC),
+# Although the table is only guaranteed to be sorted by (number DESC, letter ASC),
 # DataFusion should use the common prefix optimization
 # and return the correct top 3 rows when ordering by all columns.
 query ITI
-select column1, column2, column3 from partial_sorted order by column1 desc, column2 asc, column3 desc limit 3;
+select number, letter, age from partial_sorted order by number desc, letter asc, age desc limit 3;
 ----
 3 A 60
 3 E 90
 2 C 70
 
-## explain_physical_plan_only
-statement ok
-set datafusion.explain.physical_plan_only = true
+# A more complex example with a projection that includes an expression (see further down for the explained plan)
+query IIITI
+select
+  number + 1 as number_plus,
+  number,
+  number + 1 as other_number_plus,
+  letter,
+  age
+from partial_sorted
+order by
+  number_plus desc,
+  number desc,
+  other_number_plus desc,
+  letter asc,
+  age desc
+limit 3;
+----
+4 3 4 A 60
+4 3 4 E 90
+3 2 3 C 70
 
 # Verify that the physical plan includes the sort prefix.
 # The output should display a "sort_prefix" in the SortExec node.
 query TT
-explain select column1, column2, column3 from partial_sorted order by column1 desc, column2 asc, column3 desc limit 3;
+explain select number, letter, age from partial_sorted order by number desc, letter asc, age desc limit 3;
 ----
 physical_plan
-01)SortExec: TopK(fetch=3), expr=[column1@0 DESC, column2@1 ASC NULLS LAST, column3@2 DESC], preserve_partitioning=[false], sort_prefix=[column1@0 DESC, column2@1 ASC NULLS LAST]
-02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+01)SortExec: TopK(fetch=3), expr=[number@0 DESC, letter@1 ASC NULLS LAST, age@2 DESC], preserve_partitioning=[false], sort_prefix=[number@0 DESC, letter@1 ASC NULLS LAST]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[number, letter, age], output_ordering=[number@0 DESC, letter@1 ASC NULLS LAST], file_type=parquet
 
 
 # Explain variations of the above query with different orderings, and different sort prefixes.
-# The "sort_prefix" in the  SortExec node should only be present if the TopK's ordering starts with either (column1 DESC, column2 ASC) or just (column1 DESC).
+# The "sort_prefix" in the  SortExec node should only be present if the TopK's ordering starts with either (number DESC, letter ASC) or just (number DESC).
 query TT
-explain select column1, column2, column3 from partial_sorted order by column3 desc limit 3;
+explain select number, letter, age from partial_sorted order by age desc limit 3;
 ----
 physical_plan
-01)SortExec: TopK(fetch=3), expr=[column3@2 DESC], preserve_partitioning=[false]
-02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+01)SortExec: TopK(fetch=3), expr=[age@2 DESC], preserve_partitioning=[false]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[number, letter, age], output_ordering=[number@0 DESC, letter@1 ASC NULLS LAST], file_type=parquet
 
 query TT
-explain select column1, column2, column3 from partial_sorted order by column1 desc, column2 desc limit 3;
+explain select number, letter, age from partial_sorted order by number desc, letter desc limit 3;
 ----
 physical_plan
-01)SortExec: TopK(fetch=3), expr=[column1@0 DESC, column2@1 DESC], preserve_partitioning=[false], sort_prefix=[column1@0 DESC]
-02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+01)SortExec: TopK(fetch=3), expr=[number@0 DESC, letter@1 DESC], preserve_partitioning=[false], sort_prefix=[number@0 DESC]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[number, letter, age], output_ordering=[number@0 DESC, letter@1 ASC NULLS LAST], file_type=parquet
 
 query TT
-explain select column1, column2, column3 from partial_sorted order by column1 asc limit 3;
+explain select number, letter, age from partial_sorted order by number asc limit 3;
 ----
 physical_plan
-01)SortExec: TopK(fetch=3), expr=[column1@0 ASC NULLS LAST], preserve_partitioning=[false]
-02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+01)SortExec: TopK(fetch=3), expr=[number@0 ASC NULLS LAST], preserve_partitioning=[false]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[number, letter, age], output_ordering=[number@0 DESC, letter@1 ASC NULLS LAST], file_type=parquet
 
 query TT
-explain select column1, column2, column3 from partial_sorted order by column2 asc, column1 desc limit 3;
+explain select number, letter, age from partial_sorted order by letter asc, number desc limit 3;
 ----
 physical_plan
-01)SortExec: TopK(fetch=3), expr=[column2@1 ASC NULLS LAST, column1@0 DESC], preserve_partitioning=[false]
-02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+01)SortExec: TopK(fetch=3), expr=[letter@1 ASC NULLS LAST, number@0 DESC], preserve_partitioning=[false]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[number, letter, age], output_ordering=[number@0 DESC, letter@1 ASC NULLS LAST], file_type=parquet
 
-# Explicit NULLS ordering cases (reversing the order of the NULLS on the column1 and column2 orderings)
+# Explicit NULLS ordering cases (reversing the order of the NULLS on the number and letter orderings)
 query TT
-explain select column1, column2, column3 from partial_sorted order by column1 desc, column2 asc NULLS FIRST limit 3;
+explain select number, letter, age from partial_sorted order by number desc, letter asc NULLS FIRST limit 3;
 ----
 physical_plan
-01)SortExec: TopK(fetch=3), expr=[column1@0 DESC, column2@1 ASC], preserve_partitioning=[false], sort_prefix=[column1@0 DESC]
-02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+01)SortExec: TopK(fetch=3), expr=[number@0 DESC, letter@1 ASC], preserve_partitioning=[false], sort_prefix=[number@0 DESC]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[number, letter, age], output_ordering=[number@0 DESC, letter@1 ASC NULLS LAST], file_type=parquet
 
 query TT
-explain select column1, column2, column3 from partial_sorted order by column1 desc NULLS LAST, column2 asc limit 3;
+explain select number, letter, age from partial_sorted order by number desc NULLS LAST, letter asc limit 3;
 ----
 physical_plan
-01)SortExec: TopK(fetch=3), expr=[column1@0 DESC NULLS LAST, column2@1 ASC NULLS LAST], preserve_partitioning=[false]
-02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+01)SortExec: TopK(fetch=3), expr=[number@0 DESC NULLS LAST, letter@1 ASC NULLS LAST], preserve_partitioning=[false]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[number, letter, age], output_ordering=[number@0 DESC, letter@1 ASC NULLS LAST], file_type=parquet
 
 
 # Verify that the sort prefix is correctly computed on the normalized ordering (removing redundant aliased columns)
 query TT
-explain select column1, column2, column3, column1 as column4, column2 as column5 from partial_sorted order by column1 desc, column4 desc, column2 asc, column5 asc, column3 desc limit 3;
+explain select number, letter, age, number as column4, letter as column5 from partial_sorted order by number desc, column4 desc, letter asc, column5 asc, age desc limit 3;
 ----
 physical_plan
-01)SortExec: TopK(fetch=3), expr=[column1@0 DESC, column4@3 DESC, column2@1 ASC NULLS LAST, column5@4 ASC NULLS LAST, column3@2 DESC], preserve_partitioning=[false], sort_prefix=[column1@0 DESC, column2@1 ASC NULLS LAST]
-02)--ProjectionExec: expr=[column1@0 as column1, column2@1 as column2, column3@2 as column3, column1@0 as column4, column2@1 as column5]
-03)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+01)SortExec: TopK(fetch=3), expr=[number@0 DESC, column4@3 DESC, letter@1 ASC NULLS LAST, column5@4 ASC NULLS LAST, age@2 DESC], preserve_partitioning=[false], sort_prefix=[number@0 DESC, letter@1 ASC NULLS LAST]
+02)--ProjectionExec: expr=[number@0 as number, letter@1 as letter, age@2 as age, number@0 as column4, letter@1 as column5]
+03)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[number, letter, age], output_ordering=[number@0 DESC, letter@1 ASC NULLS LAST], file_type=parquet
 
-# Verify that the sort prefix is correctly computed over normalized, order-maintaining projections (column1 + 1, column1, column1 + 1, column3)
+# Verify that the sort prefix is correctly computed over normalized, order-maintaining projections (number + 1, number, number + 1, age)
 query TT
-explain select column1 + 1 as column1_plus, column1, column1 + 1 as other_column1_plus, column3 from partial_sorted order by column1_plus desc, column1 desc, other_column1_plus desc, column3 asc limit 3;
+explain select number + 1 as number_plus, number, number + 1 as other_number_plus, age from partial_sorted order by number_plus desc, number desc, other_number_plus desc, age asc limit 3;
 ----
 physical_plan
-01)SortPreservingMergeExec: [column1_plus@0 DESC, column1@1 DESC, other_column1_plus@2 DESC, column3@3 ASC NULLS LAST], fetch=3
-02)--SortExec: TopK(fetch=3), expr=[column1_plus@0 DESC, column1@1 DESC, other_column1_plus@2 DESC, column3@3 ASC NULLS LAST], preserve_partitioning=[true], sort_prefix=[column1_plus@0 DESC, column1@1 DESC]
-03)----ProjectionExec: expr=[__common_expr_1@0 as column1_plus, column1@1 as column1, __common_expr_1@0 as other_column1_plus, column3@2 as column3]
-04)------ProjectionExec: expr=[CAST(column1@0 AS Int64) + 1 as __common_expr_1, column1@0 as column1, column3@1 as column3]
+01)SortPreservingMergeExec: [number_plus@0 DESC, number@1 DESC, other_number_plus@2 DESC, age@3 ASC NULLS LAST], fetch=3
+02)--SortExec: TopK(fetch=3), expr=[number_plus@0 DESC, number@1 DESC, other_number_plus@2 DESC, age@3 ASC NULLS LAST], preserve_partitioning=[true], sort_prefix=[number_plus@0 DESC, number@1 DESC]
+03)----ProjectionExec: expr=[__common_expr_1@0 as number_plus, number@1 as number, __common_expr_1@0 as other_number_plus, age@2 as age]
+04)------ProjectionExec: expr=[CAST(number@0 AS Int64) + 1 as __common_expr_1, number@0 as number, age@1 as age]
 05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-06)----------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column3], output_ordering=[column1@0 DESC], file_type=parquet
+06)----------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[number, age], output_ordering=[number@0 DESC], file_type=parquet
 
 # Cleanup
 statement ok
@@ -361,3 +392,6 @@ DROP TABLE partial_sorted;
 
 statement ok
 set datafusion.explain.physical_plan_only = false
+
+statement ok
+set datafusion.execution.batch_size = 8192

--- a/datafusion/sqllogictest/test_files/topk.slt
+++ b/datafusion/sqllogictest/test_files/topk.slt
@@ -242,8 +242,8 @@ a 1 -5 waIGbOGl1PM6gnzZ4uuZt4E2yDWRHs waIGbOGl1PM6gnzZ4uuZt4E2yDWRHs
 # Create an external table where data is pre-sorted by (column1 DESC, column2 ASC) only.
 statement ok
 CREATE EXTERNAL TABLE partial_sorted (
-    column1 VARCHAR,
-    column2 INT,
+    column1 INT,
+    column2 VARCHAR,
     column3 INT
 )
 STORED AS parquet
@@ -253,12 +253,12 @@ WITH ORDER (column1 DESC, column2 ASC);
 # Insert test data into the external table.
 query I
 COPY (VALUES
-    ('A', 12, 100),
-    ('A', 8, 50),
-    ('B', 9, 70),
-    ('B', 10, 80),
-    ('C', 7, 60),
-    ('C', 11, 90))
+    (1, 'F', 100),
+    (1, 'B', 50),
+    (2, 'C', 70),
+    (2, 'D', 80),
+    (3, 'A', 60),
+    (3, 'E', 90))
 TO 'test_files/scratch/topk/partial_sorted/1.parquet';
 ----
 6
@@ -267,12 +267,12 @@ TO 'test_files/scratch/topk/partial_sorted/1.parquet';
 # Although the table is only guaranteed to be sorted by (column1 DESC, column2 ASC),
 # DataFusion should use the common prefix optimization
 # and return the correct top 3 rows when ordering by all columns.
-query TII
+query ITI
 select column1, column2, column3 from partial_sorted order by column1 desc, column2 asc, column3 desc limit 3;
 ----
-C 7 60
-C 11 90
-B 9 70
+3 A 60
+3 E 90
+2 C 70
 
 ## explain_physical_plan_only
 statement ok
@@ -319,7 +319,7 @@ physical_plan
 02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
 
 
-# Verify that the sort prefix is correctly computed on the normalized ordering (removing redundant aliased columns for example).
+# Verify that the sort prefix is correctly computed on the normalized ordering (removing redundant aliased columns)
 query TT
 explain select column1, column2, column3, column1 as column4, column2 as column5 from partial_sorted order by column1 desc, column4 desc, column2 asc, column5 asc, column3 desc limit 3;
 ----
@@ -327,6 +327,18 @@ physical_plan
 01)SortExec: TopK(fetch=3), expr=[column1@0 DESC, column4@3 DESC, column2@1 ASC NULLS LAST, column5@4 ASC NULLS LAST, column3@2 DESC], preserve_partitioning=[false], sort_prefix=[column1@0 DESC, column2@1 ASC NULLS LAST]
 02)--ProjectionExec: expr=[column1@0 as column1, column2@1 as column2, column3@2 as column3, column1@0 as column4, column2@1 as column5]
 03)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column2, column3], output_ordering=[column1@0 DESC, column2@1 ASC NULLS LAST], file_type=parquet
+
+# Verify that the sort prefix is correctly computed over normalized, order-maintaining projections (column1 + 1, column1, column1 + 1, column3)
+query TT
+explain select column1 + 1 as column1_plus, column1, column1 + 1 as other_column1_plus, column3 from partial_sorted order by column1_plus desc, column1 desc, other_column1_plus desc, column3 asc limit 3;
+----
+physical_plan
+01)SortPreservingMergeExec: [column1_plus@0 DESC, column1@1 DESC, other_column1_plus@2 DESC, column3@3 ASC NULLS LAST], fetch=3
+02)--SortExec: TopK(fetch=3), expr=[column1_plus@0 DESC, column1@1 DESC, other_column1_plus@2 DESC, column3@3 ASC NULLS LAST], preserve_partitioning=[true], sort_prefix=[column1_plus@0 DESC, column1@1 DESC]
+03)----ProjectionExec: expr=[__common_expr_1@0 as column1_plus, column1@1 as column1, __common_expr_1@0 as other_column1_plus, column3@2 as column3]
+04)------ProjectionExec: expr=[CAST(column1@0 AS Int64) + 1 as __common_expr_1, column1@0 as column1, column3@1 as column3]
+05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/topk/partial_sorted/1.parquet]]}, projection=[column1, column3], output_ordering=[column1@0 DESC], file_type=parquet
 
 # Cleanup
 statement ok

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -2356,7 +2356,7 @@ logical_plan
 03)----WindowAggr: windowExpr=[[row_number() ORDER BY [aggregate_test_100.c9 DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
 04)------TableScan: aggregate_test_100 projection=[c9]
 physical_plan
-01)SortExec: TopK(fetch=5), expr=[rn1@1 ASC NULLS LAST, c9@0 ASC NULLS LAST], preserve_partitioning=[false]
+01)SortExec: TopK(fetch=5), expr=[rn1@1 ASC NULLS LAST, c9@0 ASC NULLS LAST], preserve_partitioning=[false], sort_prefix=[rn1@1 ASC NULLS LAST]
 02)--ProjectionExec: expr=[c9@0 as c9, row_number() ORDER BY [aggregate_test_100.c9 DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@1 as rn1]
 03)----BoundedWindowAggExec: wdw=[row_number() ORDER BY [aggregate_test_100.c9 DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Ok(Field { name: "row_number() ORDER BY [aggregate_test_100.c9 DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", data_type: UInt64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }), frame: WindowFrame { units: Range, start_bound: Preceding(UInt64(NULL)), end_bound: CurrentRow, is_causal: false }], mode=[Sorted]
 04)------SortExec: expr=[c9@0 DESC], preserve_partitioning=[false]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #15529.

## Rationale for this change

DataFusion currently implements an early termination optimization (TopK) for fully sorted data. However, many real-world datasets are only partially sorted (for example, a time-series dataset sorted by day but not within each day). This PR extends the TopK early termination optimization to recognize and leverage a common prefix between the input ordering and the query’s requested ordering. With this enhancement, once the top‑K buffer is full and subsequent rows are guaranteed to be worse based on the shared sort prefix, DataFusion can safely terminate scanning early. This change is expected to reduce unnecessary data scans and sorts, thereby significantly improving query performance and reducing resource consumption.

## What changes are included in this PR?

- **Sort Prefix Computation:**  
  - Enhanced the computation of equivalence properties to calculate the matching prefix length between the input ordering and the query’s sort requirements.  
  - Introduced a new method to extract the common sort prefix.

- **Modifications in `SortExec`:**  
  - Added a new field (`common_sort_prefix`) to track the common prefix between the input and sort expressions.  
  - Updated the property computation to return both the plan properties and the computed sort prefix.  
  - Modified the display implementation to include the sort prefix when available.

- **Updates in TopK Execution:**  
  - Added a `common_prefix_converter` to handle the conversion for common prefix columns.  
  - Integrated early termination logic in the TopK operator that checks if the last row of a batch (on the prefix columns) is strictly worse than the worst row in the current top‑K.  
  - Updated the TopK insertion logic to flag early completion when applicable.

- **Test Enhancements:**  
  - Updated existing tests (e.g., in the physical optimizer and sqllogictest files) to validate the new sort prefix display and behavior.
  - Introduced new tests to specifically verify that early termination is triggered when the input ordering partially satisfies the full sort expression.

## Are these changes tested?

Yes, the changes include comprehensive tests:
- Existing "topK" tests in the SQL logic tests have been enhanced with partially sorted inputs.
- New unit tests have been added to verify that the TopK operator correctly marks itself as finished when the common prefix condition is met, ensuring that the early termination logic behaves as expected.

I've also ran the newly introduced [TopK benchmarks](https://github.com/apache/datafusion/pull/15560) with the following code, which validate performance improvements on partially sorted input.

**Benchmark:**
```bash
cd benchmarks
git checkout perf/topk_benchmarks
cargo run --release --bin tpch -- convert --input ./data/tpch_sf1 --output ./data/tpch_sf1_sorted --format parquet --sort
cargo run --release --bin dfbench -- sort-tpch --sorted --limit 10 --iterations 5 --path ./data/tpch_sf1_sorted -o ./results/main/top10_sorted_tpch.json
git cherry-pick perf/partitioned_topk
cargo run --release --bin dfbench -- sort-tpch --sorted --limit 10 --iterations 5 --path ./data/tpch_sf1_sorted -o ./results/partitioned_topk/top10_sorted_tpch.json
```

**Results:**
```
> ./bench.sh compare main partitioned_topk
Comparing main and partitioned_topk
--------------------                                                                          
Benchmark top10_sorted_tpch.json                                                              
--------------------                                                                          
┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Query        ┃     main ┃ partitioned_topk ┃         Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ Q1           │  24.73ms │          24.86ms │      no change │
│ Q2           │   5.42ms │           5.27ms │      no change │
│ Q3           │  77.20ms │          76.83ms │      no change │
│ Q4           │  28.43ms │           5.41ms │  +5.26x faster │
│ Q5           │  18.44ms │          18.34ms │      no change │
│ Q6           │  32.91ms │          32.52ms │      no change │
│ Q7           │  74.63ms │          75.11ms │      no change │
│ Q8           │  77.22ms │           6.78ms │ +11.39x faster │
│ Q9           │  90.10ms │          10.04ms │  +8.97x faster │
│ Q10          │ 135.39ms │          14.04ms │  +9.64x faster │
│ Q11          │  72.33ms │          71.06ms │      no change │
└──────────────┴──────────┴──────────────────┴────────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓ 
┃ Benchmark Summary               ┃          ┃ 
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩ 
│ Total Time (main)               │ 636.81ms │
│ Total Time (partitioned_topk)   │ 340.26ms │
│ Average Time (main)             │  57.89ms │
│ Average Time (partitioned_topk) │  30.93ms │                                                
│ Queries Faster                  │        4 │                                                
│ Queries Slower                  │        0 │                                                
│ Queries with No Change          │        7 │                                                
└─────────────────────────────────┴──────────┘
```

## Are there any user-facing changes?

There are no breaking user-facing changes to the external API. The changes improve internal performance optimizations for queries using `ORDER BY` with `LIMIT` on partially sorted datasets. Users may see significant performance improvements for relevant queries, but the output and overall query semantics remain unchanged.

---