### PR TITLE
Introduce DynamicFilterSource and DynamicPhysicalExpr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.8.0",
+ "insta",
  "itertools 0.14.0",
  "log",
  "paste",

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -27,6 +27,7 @@ use arrow::array::BooleanArray;
 use arrow::compute::filter_record_batch;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
+use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::{internal_err, not_impl_err, Result, ScalarValue};
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use datafusion_expr_common::interval_arithmetic::Interval;
@@ -283,6 +284,47 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + DynEq + DynHash {
     /// See the [`fmt_sql`] function for an example of printing `PhysicalExpr`s as SQL.
     ///
     fn fmt_sql(&self, f: &mut Formatter<'_>) -> fmt::Result;
+
+    /// Take a snapshot of this `PhysicalExpr` if it is dynamic.
+    /// This is used to capture the current state of `PhysicalExpr`s that may contain
+    /// dynamic references to other operators in order to serialize it over the wire
+    /// or treat it via downcast matching.
+    ///
+    /// You should not call this method directly as it does not handle recursion.
+    /// Instead use [`snapshot_physical_expr`] to handle recursion and capture the
+    /// full state of the `PhysicalExpr`.
+    ///
+    /// This is expected to return "simple" expressions that do not have mutable state
+    /// and are composed of DataFusion's built-in `PhysicalExpr` implementations.
+    /// Callers however should *not* assume anything about the returned expressions
+    /// since callers and implementers may not agree on what "simple" or "built-in"
+    /// means.
+    /// In other words, if you need to searlize a `PhysicalExpr` across the wire
+    /// you should call this method and then try to serialize the result,
+    /// but you should handle unknown or unexpected `PhysicalExpr` implementations gracefully
+    /// just as if you had not called this method at all.
+    ///
+    /// In particular, consider:
+    /// * A `PhysicalExpr` that references the current state of a `datafusion::physical_plan::TopK`
+    ///   that is involved in a query with `SELECT * FROM t1 ORDER BY a LIMIT 10`.
+    ///   This function may return something like `a >= 12`.
+    /// * A `PhysicalExpr` that references the current state of a `datafusion::physical_plan::joins::HashJoinExec`
+    ///   from a query such as `SELECT * FROM t1 JOIN t2 ON t1.a = t2.b`.
+    ///   This function may return something like `t2.b IN (1, 5, 7)`.
+    ///
+    /// A system or function that can only deal with a hardcoded set of `PhysicalExpr` implementations
+    /// or needs to serialize this state to bytes may not be able to handle these dynamic references.
+    /// In such cases, we should return a simplified version of the `PhysicalExpr` that does not
+    /// contain these dynamic references.
+    ///
+    /// Note for implementers: this method should *not* handle recursion.
+    /// Recursion is handled in [`snapshot_physical_expr`].
+    fn snapshot(&self) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+        // By default, we return None to indicate that this PhysicalExpr does not
+        // have any dynamic references or state.
+        // This is a safe default behavior.
+        Ok(None)
+    }
 }
 
 /// [`PhysicalExpr`] can't be constrained by [`Eq`] directly because it must remain object
@@ -445,4 +487,31 @@ pub fn fmt_sql(expr: &dyn PhysicalExpr) -> impl Display + '_ {
     }
 
     Wrapper { expr }
+}
+
+/// Take a snapshot of the given `PhysicalExpr` if it is dynamic.
+///
+/// Take a snapshot of this `PhysicalExpr` if it is dynamic.
+/// This is used to capture the current state of `PhysicalExpr`s that may contain
+/// dynamic references to other operators in order to serialize it over the wire
+/// or treat it via downcast matching.
+///
+/// See the documentation of [`PhysicalExpr::snapshot`] for more details.
+///
+/// # Returns
+///
+/// Returns an `Option<Arc<dyn PhysicalExpr>>` which is the snapshot of the
+/// `PhysicalExpr` if it is dynamic. If the `PhysicalExpr` does not have
+/// any dynamic references or state, it returns `None`.
+pub fn snapshot_physical_expr(
+    expr: Arc<dyn PhysicalExpr>,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    expr.transform_up(|e| {
+        if let Some(snapshot) = e.snapshot()? {
+            Ok(Transformed::yes(snapshot))
+        } else {
+            Ok(Transformed::no(Arc::clone(&e)))
+        }
+    })
+    .data()
 }

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -316,6 +316,10 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + DynEq + DynHash {
     /// or needs to serialize this state to bytes may not be able to handle these dynamic references.
     /// In such cases, we should return a simplified version of the `PhysicalExpr` that does not
     /// contain these dynamic references.
+    /// 
+    /// Systems that implement remote execution of plans, e.g. serialize a portion of the query plan
+    /// and send it across the wire to a remote executor may want to call this method after
+    /// every batch on the source side and brodcast / update the current snaphot to the remote executor.
     ///
     /// Note for implementers: this method should *not* handle recursion.
     /// Recursion is handled in [`snapshot_physical_expr`].

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -303,7 +303,7 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + DynEq + DynHash {
     /// Callers however should *not* assume anything about the returned expressions
     /// since callers and implementers may not agree on what "simple" or "built-in"
     /// means.
-    /// In other words, if you need to searlize a `PhysicalExpr` across the wire
+    /// In other words, if you need to serialize a `PhysicalExpr` across the wire
     /// you should call this method and then try to serialize the result,
     /// but you should handle unknown or unexpected `PhysicalExpr` implementations gracefully
     /// just as if you had not called this method at all.

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -316,7 +316,7 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + DynEq + DynHash {
     /// or needs to serialize this state to bytes may not be able to handle these dynamic references.
     /// In such cases, we should return a simplified version of the `PhysicalExpr` that does not
     /// contain these dynamic references.
-    /// 
+    ///
     /// Systems that implement remote execution of plans, e.g. serialize a portion of the query plan
     /// and send it across the wire to a remote executor may want to call this method after
     /// every batch on the source side and brodcast / update the current snaphot to the remote executor.

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -285,8 +285,12 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + DynEq + DynHash {
     ///
     fn fmt_sql(&self, f: &mut Formatter<'_>) -> fmt::Result;
 
-    /// Take a snapshot of this `PhysicalExpr` if it is dynamic.
-    /// This is used to capture the current state of `PhysicalExpr`s that may contain
+    /// Take a snapshot of this `PhysicalExpr`, if it is dynamic.
+    ///
+    /// "Dynamic" in this case means containing references to structures that may change
+    /// during plan execution, such as hash tables.
+    ///
+    /// This method is used to capture the current state of `PhysicalExpr`s that may contain
     /// dynamic references to other operators in order to serialize it over the wire
     /// or treat it via downcast matching.
     ///

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -57,6 +57,7 @@ petgraph = "0.7.1"
 arrow = { workspace = true, features = ["test_utils"] }
 criterion = { workspace = true }
 datafusion-functions = { workspace = true }
+insta = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -105,7 +105,7 @@ impl Display for DynamicFilterPhysicalExpr {
 }
 
 impl DynamicFilterPhysicalExpr {
-    #[expect(dead_code)] // Only used in tests for now
+    #[allow(dead_code)] // Only used in tests for now
     pub fn new(
         children: Vec<Arc<dyn PhysicalExpr>>,
         inner: Arc<dyn DynamicFilterSource>,

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -33,8 +33,8 @@ use datafusion_physical_expr_common::physical_expr::{DynEq, DynHash};
 
 /// A source of dynamic runtime filters.
 ///
-/// During query execution, operators implementing this trait can provide
-/// filter expressions that other operators can use to dynamically prune data.
+/// Operators can create implementations of this trait that get wrapped
+/// in [`DynamicFilterPhysicalExpr`] to be pushed down into and through to scans, joins, etc.
 ///
 /// For example:
 /// - A `HashJoin` operator can use this to provide a filter expression
@@ -43,6 +43,14 @@ use datafusion_physical_expr_common::physical_expr::{DynEq, DynHash};
 /// - A `TopK` operator can use this to provide a filter expression
 ///   that filters out rows from the input based on the values from the
 ///   top K rows.
+/// 
+/// Initially this trait is intended to be only for internal use as a way to facilitate
+/// building [`DynamicFilterPhysicalExpr`]s in the various operators that will be generating
+/// dynamic filters.
+/// Because of this we've made it a public trait in a private module so that it is only
+/// accessible within the crate.
+/// If you would like to use this trait in your own code, please open an issue
+/// to discuss the use case and we can consider making it public.
 pub trait DynamicFilterSource:
     Send + Sync + std::fmt::Debug + DynEq + DynHash + Display + 'static
 {

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -36,7 +36,13 @@ use datafusion_physical_expr_common::physical_expr::{DynEq, DynHash};
 /// During query execution, operators implementing this trait can provide
 /// filter expressions that other operators can use to dynamically prune data.
 ///
-/// See `TopKDynamicFilterSource` in datafusion/physical-plan/src/topk/mod.rs for examples.
+/// For example:
+/// - A `HashJoin` operator can use this to provide a filter expression
+///   that filters out rows from the right side of the join based on the
+///   values from the left side.
+/// - A `TopK` operator can use this to provide a filter expression
+///   that filters out rows from the input based on the values from the
+///   top K rows.
 pub trait DynamicFilterSource:
     Send + Sync + std::fmt::Debug + DynEq + DynHash + Display + 'static
 {

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -1,0 +1,371 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{
+    any::Any,
+    fmt::Display,
+    hash::Hash,
+    sync::{Arc, RwLock},
+};
+
+use crate::{utils::conjunction, PhysicalExpr};
+use datafusion_common::{
+    tree_node::{Transformed, TransformedResult, TreeNode},
+    Result,
+};
+use datafusion_expr::ColumnarValue;
+use datafusion_physical_expr_common::physical_expr::{DynEq, DynHash};
+
+/// A source of dynamic runtime filters.
+///
+/// During query execution, operators implementing this trait can provide
+/// filter expressions that other operators can use to dynamically prune data.
+///
+/// See `TopKDynamicFilterSource` in datafusion/physical-plan/src/topk/mod.rs for examples.
+pub trait DynamicFilterSource:
+    Send + Sync + std::fmt::Debug + DynEq + DynHash + Display + 'static
+{
+    /// Take a snapshot of the current state of filtering, returning a non-dynamic PhysicalExpr.
+    /// This is used to e.g. serialize dynamic filters across the wire or to pass them into systems
+    /// that won't use the `PhysicalExpr` API (e.g. matching on the concrete types of the expressions like `PruningPredicate` does).
+    /// For example, it is expected that this returns a relatively simple expression such as `col1 > 5` for a TopK operator or
+    /// `col2 IN (1, 2, ... N)` for a HashJoin operator.
+    fn snapshot_current_filters(&self) -> Result<Vec<Arc<dyn PhysicalExpr>>>;
+
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl PartialEq for dyn DynamicFilterSource {
+    fn eq(&self, other: &Self) -> bool {
+        self.dyn_eq(other.as_any())
+    }
+}
+
+impl Eq for dyn DynamicFilterSource {}
+
+/// A wrapper around a [`DynamicFilterSource`] that allows it to be used as a physical expression.
+/// This will call [`DynamicFilterSource::snapshot_current_filters`] to get the current filters for each call to
+/// [`PhysicalExpr::evaluate`], [`PhysicalExpr::data_type`], and [`PhysicalExpr::nullable`].
+/// It also implements [`PhysicalExpr::snapshot`] by forwarding the call to [`DynamicFilterSource::snapshot_current_filters`].
+#[derive(Debug)]
+pub struct DynamicFilterPhysicalExpr {
+    /// The original children of this PhysicalExpr, if any.
+    /// This is necessary because the dynamic filter may be initialized with a placeholder (e.g. `lit(true)`)
+    /// and later remapped to the actual expressions that are being filtered.
+    /// But we need to know the children (e.g. columns referenced in the expression) ahead of time to evaluate the expression correctly.
+    children: Vec<Arc<dyn PhysicalExpr>>,
+    /// If any of the children were remapped / modified (e.g. to adjust for projections) we need to keep track of the new children
+    /// so that when we update `current()` in subsequent iterations we can re-apply the replacements.
+    remapped_children: Option<Vec<Arc<dyn PhysicalExpr>>>,
+    /// The source of dynamic filters.
+    inner: Arc<dyn DynamicFilterSource>,
+    /// For testing purposes track the data type and nullability to make sure they don't change.
+    /// If they do, there's a bug in the implementation.
+    /// But this can have overhead in production, so it's only included in our tests.
+    data_type: Arc<RwLock<Option<arrow::datatypes::DataType>>>,
+    nullable: Arc<RwLock<Option<bool>>>,
+}
+
+impl Hash for DynamicFilterPhysicalExpr {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.dyn_hash(state);
+        self.children.dyn_hash(state);
+        self.remapped_children.dyn_hash(state);
+    }
+}
+
+impl PartialEq for DynamicFilterPhysicalExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.dyn_eq(other.inner.as_any())
+            && self.children == other.children
+            && self.remapped_children == other.remapped_children
+    }
+}
+
+impl Eq for DynamicFilterPhysicalExpr {}
+
+impl Display for DynamicFilterPhysicalExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DynamicFilterPhysicalExpr [ {} ]", self.inner)
+    }
+}
+
+impl DynamicFilterPhysicalExpr {
+    #[expect(dead_code)] // Only used in tests for now
+    pub fn new(
+        children: Vec<Arc<dyn PhysicalExpr>>,
+        inner: Arc<dyn DynamicFilterSource>,
+    ) -> Self {
+        Self {
+            children,
+            remapped_children: None, // Initially no remapped children
+            inner,
+            data_type: Arc::new(RwLock::new(None)),
+            nullable: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    fn current(&self) -> Result<Arc<dyn PhysicalExpr>> {
+        let current = conjunction(self.inner.snapshot_current_filters()?);
+        if let Some(remapped_children) = &self.remapped_children {
+            // Remap children to the current children
+            // of the expression.
+            current
+                .transform_up(|expr| {
+                    // Check if this is any of our original children
+                    if let Some(pos) = self
+                        .children
+                        .iter()
+                        .position(|c| c.as_ref() == expr.as_ref())
+                    {
+                        // If so, remap it to the current children
+                        // of the expression.
+                        let new_child = Arc::clone(&remapped_children[pos]);
+                        Ok(Transformed::yes(new_child))
+                    } else {
+                        // Otherwise, just return the expression
+                        Ok(Transformed::no(expr))
+                    }
+                })
+                .data()
+        } else {
+            Ok(current)
+        }
+    }
+}
+
+impl PhysicalExpr for DynamicFilterPhysicalExpr {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        self.remapped_children
+            .as_ref()
+            .unwrap_or(&self.children)
+            .iter()
+            .collect()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(Arc::new(Self {
+            children: self.children.clone(),
+            remapped_children: Some(children),
+            inner: Arc::clone(&self.inner),
+            data_type: Arc::clone(&self.data_type),
+            nullable: Arc::clone(&self.nullable),
+        }))
+    }
+
+    fn data_type(
+        &self,
+        input_schema: &arrow::datatypes::Schema,
+    ) -> Result<arrow::datatypes::DataType> {
+        let res = self.current()?.data_type(input_schema)?;
+        #[cfg(test)]
+        {
+            use datafusion_common::internal_err;
+            // Check if the data type has changed.
+            let mut data_type_lock = self
+                .data_type
+                .write()
+                .expect("Failed to acquire write lock for data_type");
+            if let Some(existing) = &*data_type_lock {
+                if existing != &res {
+                    // If the data type has changed, we have a bug.
+                    return internal_err!(
+                        "DynamicFilterPhysicalExpr data type has changed unexpectedly. \
+                        Expected: {existing:?}, Actual: {res:?}"
+                    );
+                }
+            } else {
+                *data_type_lock = Some(res.clone());
+            }
+        }
+        Ok(res)
+    }
+
+    fn nullable(&self, input_schema: &arrow::datatypes::Schema) -> Result<bool> {
+        let res = self.current()?.nullable(input_schema)?;
+        #[cfg(test)]
+        {
+            use datafusion_common::internal_err;
+            // Check if the nullability has changed.
+            let mut nullable_lock = self
+                .nullable
+                .write()
+                .expect("Failed to acquire write lock for nullable");
+            if let Some(existing) = *nullable_lock {
+                if existing != res {
+                    // If the nullability has changed, we have a bug.
+                    return internal_err!(
+                        "DynamicFilterPhysicalExpr nullability has changed unexpectedly. \
+                        Expected: {existing}, Actual: {res}"
+                    );
+                }
+            } else {
+                *nullable_lock = Some(res);
+            }
+        }
+        Ok(res)
+    }
+
+    fn evaluate(
+        &self,
+        batch: &arrow::record_batch::RecordBatch,
+    ) -> Result<ColumnarValue> {
+        let current = self.current()?;
+        #[cfg(test)]
+        {
+            // Ensure that we are not evaluating after the expression has changed.
+            let schema = batch.schema();
+            self.nullable(&schema)?;
+            self.data_type(&schema)?;
+        };
+        current.evaluate(batch)
+    }
+
+    fn fmt_sql(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Ok(inner) = self.inner.snapshot_current_filters() {
+            conjunction(inner).fmt_sql(f)
+        } else {
+            write!(f, "dynamic_filter_expr()") // What do we want to do here?
+        }
+    }
+
+    fn snapshot(&self) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+        // Return the current expression as a snapshot.
+        Ok(Some(self.current()?))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::expressions::lit;
+    use arrow::array::RecordBatch;
+    use datafusion_common::ScalarValue;
+
+    use super::*;
+
+    #[test]
+    fn test_dynamic_filter_physical_expr_misbehaves_data_type_nullable() {
+        #[derive(Debug)]
+        struct MockDynamicFilterSource {
+            current_expr: Arc<RwLock<Arc<dyn PhysicalExpr>>>,
+        }
+
+        impl Hash for MockDynamicFilterSource {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                // Hash the current expression to ensure uniqueness
+                self.current_expr.read().unwrap().dyn_hash(state);
+            }
+        }
+
+        impl DynEq for MockDynamicFilterSource {
+            fn dyn_eq(&self, other: &dyn Any) -> bool {
+                if let Some(other) = other.downcast_ref::<MockDynamicFilterSource>() {
+                    self.current_expr
+                        .read()
+                        .unwrap()
+                        .eq(&other.current_expr.read().unwrap())
+                } else {
+                    false
+                }
+            }
+        }
+
+        impl DynamicFilterSource for MockDynamicFilterSource {
+            fn snapshot_current_filters(&self) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
+                let expr = self.current_expr.read().unwrap().clone();
+                Ok(vec![expr])
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        impl Display for MockDynamicFilterSource {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(
+                    f,
+                    "MockDynamicFilterSource [ current_expr: {:?} ]",
+                    self.current_expr.read().unwrap()
+                )
+            }
+        }
+
+        let source = Arc::new(MockDynamicFilterSource {
+            current_expr: Arc::new(RwLock::new(lit(42) as Arc<dyn PhysicalExpr>)),
+        });
+        let dynamic_filter = DynamicFilterPhysicalExpr::new(
+            vec![],
+            Arc::clone(&source) as Arc<dyn DynamicFilterSource>,
+        );
+
+        // First call to data_type and nullable should set the initial values.
+        let initial_data_type = dynamic_filter
+            .data_type(&arrow::datatypes::Schema::empty())
+            .unwrap();
+        let initial_nullable = dynamic_filter
+            .nullable(&arrow::datatypes::Schema::empty())
+            .unwrap();
+
+        // Call again and expect no change.
+        let second_data_type = dynamic_filter
+            .data_type(&arrow::datatypes::Schema::empty())
+            .unwrap();
+        let second_nullable = dynamic_filter
+            .nullable(&arrow::datatypes::Schema::empty())
+            .unwrap();
+        assert_eq!(
+            initial_data_type, second_data_type,
+            "Data type should not change on second call."
+        );
+        assert_eq!(
+            initial_nullable, second_nullable,
+            "Nullability should not change on second call."
+        );
+
+        // Now change the current expression to something else.
+        {
+            let mut current = source.current_expr.write().unwrap();
+            *current = lit(ScalarValue::Utf8(None)) as Arc<dyn PhysicalExpr>;
+        }
+        // Check that we error if we call data_type, nullable or evaluate after changing the expression.
+        assert!(
+            dynamic_filter
+                .data_type(&arrow::datatypes::Schema::empty())
+                .is_err(),
+            "Expected err when data_type is called after changing the expression."
+        );
+        assert!(
+            dynamic_filter
+                .nullable(&arrow::datatypes::Schema::empty())
+                .is_err(),
+            "Expected err when nullable is called after changing the expression."
+        );
+        let batch = RecordBatch::new_empty(Arc::new(arrow::datatypes::Schema::empty()));
+        assert!(
+            dynamic_filter.evaluate(&batch).is_err(),
+            "Expected err when evaluate is called after changing the expression."
+        );
+    }
+}

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -162,6 +162,7 @@ impl DynamicFilterPhysicalExpr {
     /// This should be called e.g.:
     /// - When we've computed the probe side's hash table in a HashJoinExec
     /// - After every batch is processed if we update the TopK heap in a SortExec using a TopK approach.
+    #[allow(dead_code)] // Only used in tests for now
     pub fn update(&self, new_expr: Arc<dyn PhysicalExpr>) -> Result<()> {
         let mut current = self.inner.write().map_err(|_| {
             datafusion_common::DataFusionError::Execution(

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -22,6 +22,7 @@ mod binary;
 mod case;
 mod cast;
 mod column;
+mod dynamic_filters;
 mod in_list;
 mod is_not_null;
 mod is_null;

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -68,7 +68,7 @@ pub use planner::{create_physical_expr, create_physical_exprs};
 pub use scalar_function::ScalarFunctionExpr;
 
 pub use datafusion_physical_expr_common::utils::reverse_order_bys;
-pub use utils::split_conjunction;
+pub use utils::{conjunction, conjunction_opt, split_conjunction};
 
 // For backwards compatibility
 pub mod tree_node {

--- a/datafusion/physical-expr/src/utils/mod.rs
+++ b/datafusion/physical-expr/src/utils/mod.rs
@@ -47,6 +47,31 @@ pub fn split_conjunction(
     split_impl(Operator::And, predicate, vec![])
 }
 
+/// Create a conjunction of the given predicates.
+/// If the input is empty, return a literal true.
+/// If the input contains a single predicate, return the predicate.
+/// Otherwise, return a conjunction of the predicates (e.g. `a AND b AND c`).
+pub fn conjunction(
+    predicates: impl IntoIterator<Item = Arc<dyn PhysicalExpr>>,
+) -> Arc<dyn PhysicalExpr> {
+    conjunction_opt(predicates).unwrap_or_else(|| crate::expressions::lit(true))
+}
+
+/// Create a conjunction of the given predicates.
+/// If the input is empty or the return None.
+/// If the input contains a single predicate, return Some(predicate).
+/// Otherwise, return a Some(..) of a conjunction of the predicates (e.g. `Some(a AND b AND c)`).
+pub fn conjunction_opt(
+    predicates: impl IntoIterator<Item = Arc<dyn PhysicalExpr>>,
+) -> Option<Arc<dyn PhysicalExpr>> {
+    predicates
+        .into_iter()
+        .fold(None, |acc, predicate| match acc {
+            None => Some(predicate),
+            Some(acc) => Some(Arc::new(BinaryExpr::new(acc, Operator::And, predicate))),
+        })
+}
+
 /// Assume the predicate is in the form of DNF, split the predicate to a Vec of PhysicalExprs.
 ///
 /// For example, split "a1 = a2 OR b1 <= b2 OR c1 != c2" into ["a1 = a2", "b1 <= b2", "c1 != c2"]

--- a/datafusion/physical-optimizer/src/pruning.rs
+++ b/datafusion/physical-optimizer/src/pruning.rs
@@ -41,6 +41,7 @@ use datafusion_common::{Column, DFSchema};
 use datafusion_expr_common::operator::Operator;
 use datafusion_physical_expr::utils::{collect_columns, Guarantee, LiteralGuarantee};
 use datafusion_physical_expr::{expressions as phys_expr, PhysicalExprRef};
+use datafusion_physical_expr_common::physical_expr::snapshot_physical_expr;
 use datafusion_physical_plan::{ColumnarValue, PhysicalExpr};
 
 /// A source of runtime statistical information to [`PruningPredicate`]s.
@@ -527,6 +528,9 @@ impl PruningPredicate {
     /// See the struct level documentation on [`PruningPredicate`] for more
     /// details.
     pub fn try_new(expr: Arc<dyn PhysicalExpr>, schema: SchemaRef) -> Result<Self> {
+        // Get a (simpler) snapshot of the physical expr here to use with `PruningPredicate`
+        // which does not handle dynamic exprs  in general
+        let expr = snapshot_physical_expr(expr)?;
         let unhandled_hook = Arc::new(ConstantUnhandledPredicateHook::default()) as _;
 
         // build predicate expression once

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -451,7 +451,7 @@ impl TryFrom<&PartitionedFile> for protobuf::PartitionedFile {
                 .map(|v| v.try_into())
                 .collect::<Result<Vec<_>, _>>()?,
             range: pf.range.as_ref().map(|r| r.try_into()).transpose()?,
-            statistics: pf.statistics.as_ref().map(|s| s.into()),
+            statistics: pf.statistics.as_ref().map(|s| s.as_ref().into()),
         })
     }
 }

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -211,6 +211,8 @@ pub fn serialize_physical_expr(
     value: &Arc<dyn PhysicalExpr>,
     codec: &dyn PhysicalExtensionCodec,
 ) -> Result<protobuf::PhysicalExprNode> {
+    // Snapshot the expr in case it has dynamic predicate state so
+    // it can be serialized
     let value = snapshot_physical_expr(Arc::clone(value))?;
     let expr = value.as_any();
 


### PR DESCRIPTION
- Work towards #15512

This PR introduces:
- `PhysicalExpr::snapshot` to capture the current state of dynamic PhyscalExpr's for feeding into systems that match on concrete trait impls (namely PruningPredicate and protobuf serialization)
- Internal (private) helpers DynamicFilterSource and DynamicPhysicalExpr to make it easier to build dynamic PhysicalExpr, and to test and justify the snapshotting.