### PR TITLE
fix: ffi aggregation

### DIFF
--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -633,7 +633,14 @@ mod tests {
             .await?
             .collect()
             .await?;
-        let expected = ["+-----+", "| cnt |", "+-----+", "| 3   |", "+-----+"];
+        #[rustfmt::skip]
+        let expected = [
+            "+-----+",
+            "| cnt |",
+            "+-----+",
+            "| 3   |",
+            "+-----+"
+        ];
         assert_batches_eq!(expected, &result);
         Ok(())
     }

--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -625,9 +625,6 @@ mod tests {
 
         ctx.register_table("t", Arc::new(foreign_table_provider))?;
 
-        let df = ctx.sql("SELECT COUNT(*) as cnt FROM t").await?;
-        let plan = df.create_physical_plan().await?;
-
         let result = ctx
             .sql("SELECT COUNT(*) as cnt FROM t")
             .await?


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #15569.

## Rationale for this change

In ffi physical plan, if projection is empty, full schema will be returned

## What changes are included in this PR?

remove this logic. But I don't know are there any other scenarios that depend on this trikcy logic.

## Are these changes tested?

UT

## Are there any user-facing changes?

No
