### PR TITLE
chore: avoid erroneuous warning for FFI table operation (only not default value)

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -149,9 +149,17 @@ macro_rules! config_namespace {
                             // $(#[allow(deprecated)])?
                             {
                                 $(let value = $transform(value);)? // Apply transformation if specified
-                                $(log::warn!($warn);)? // Log warning if specified
                                 #[allow(deprecated)]
-                                self.$field_name.set(rem, value.as_ref())
+                                let ret = self.$field_name.set(rem, value.as_ref());
+
+                                $(if !$warn.is_empty() {
+                                    let default: $field_type = $default;
+                                    #[allow(deprecated)]
+                                    if default != self.$field_name {
+                                        log::warn!($warn);
+                                    }
+                                })? // Log warning if specified, and the value is not the default
+                                ret
                             }
                         },
                     )*
@@ -1999,8 +2007,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::config::{
-        ConfigEntry, ConfigExtension, ConfigFileType, ExtensionOptions, Extensions,
-        TableOptions,
+        ConfigEntry, ConfigExtension, ConfigField, ConfigFileType, ExtensionOptions, Extensions, TableOptions
     };
 
     #[derive(Default, Debug, Clone)]
@@ -2083,6 +2090,33 @@ mod tests {
         assert_eq!(table_config.csv.escape.unwrap() as char, '"');
         table_config.set("format.escape", "\'").unwrap();
         assert_eq!(table_config.csv.escape.unwrap() as char, '\'');
+    }
+
+    #[test]
+    fn warning_only_not_default() {
+        use std::sync::atomic::AtomicUsize;
+        static COUNT: AtomicUsize = AtomicUsize::new(0);
+        use log::{Level, LevelFilter, Metadata, Record};
+        struct SimpleLogger;
+        impl log::Log for SimpleLogger {
+            fn enabled(&self, metadata: &Metadata) -> bool {
+                metadata.level() <= Level::Info
+            }
+
+            fn log(&self, record: &Record) {
+                if self.enabled(record.metadata()) {
+                    COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+            }
+            fn flush(&self) {}
+        }
+        log::set_logger(&SimpleLogger).unwrap();
+        log::set_max_level(LevelFilter::Info);
+        let mut sql_parser_options = crate::config::SqlParserOptions::default();
+        sql_parser_options.set("enable_options_value_normalization", "false").unwrap();
+        assert_eq!(COUNT.load(std::sync::atomic::Ordering::Relaxed), 0);
+        sql_parser_options.set("enable_options_value_normalization", "true").unwrap();
+        assert_eq!(COUNT.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
 
     #[cfg(feature = "parquet")]

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -2007,7 +2007,8 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::config::{
-        ConfigEntry, ConfigExtension, ConfigField, ConfigFileType, ExtensionOptions, Extensions, TableOptions
+        ConfigEntry, ConfigExtension, ConfigField, ConfigFileType, ExtensionOptions,
+        Extensions, TableOptions,
     };
 
     #[derive(Default, Debug, Clone)]
@@ -2113,9 +2114,13 @@ mod tests {
         log::set_logger(&SimpleLogger).unwrap();
         log::set_max_level(LevelFilter::Info);
         let mut sql_parser_options = crate::config::SqlParserOptions::default();
-        sql_parser_options.set("enable_options_value_normalization", "false").unwrap();
+        sql_parser_options
+            .set("enable_options_value_normalization", "false")
+            .unwrap();
         assert_eq!(COUNT.load(std::sync::atomic::Ordering::Relaxed), 0);
-        sql_parser_options.set("enable_options_value_normalization", "true").unwrap();
+        sql_parser_options
+            .set("enable_options_value_normalization", "true")
+            .unwrap();
         assert_eq!(COUNT.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
 


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #15565.

## Rationale for this change

warning is erroneous and confusing to the user.

## What changes are included in this PR?

only log warning if value != default

## Are these changes tested?

UT

## Are there any user-facing changes?

No
