### PR TITLE
Actually run wasm test in ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -403,9 +403,14 @@ jobs:
       - name: Build with wasm-pack
         working-directory: ./datafusion/wasmtest
         run: wasm-pack build --dev
-      - run: wasm-pack test --headless --chrome
-      - run: wasm-pack test --headless --firefox
-      - run: wasm-pack test --headless --safari
+      - name: Run tests with headless mode
+        working-directory: ./datafusion/wasmtest
+        env:
+          WASM_BINDGEN_TEST_TIMEOUT: 300 
+        run: |
+          wasm-pack test --headless --chrome
+          wasm-pack test --headless --firefox
+          wasm-pack test --headless --safari
 
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -394,12 +394,17 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Setup for wasm32
+        run: |
+          rustup target add wasm32-unknown-unknown
       - name: Install dependencies
         run: |
           apt-get update -qq
           apt-get install -y -qq clang jq
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Setup wasm-pack
+        run: |
+          cargo install wasm-pack
       - name: Install Chrome Environment
         run: |
           mkdir -p /tmp/chrome
@@ -414,8 +419,8 @@ jobs:
         env:
           WASM_BINDGEN_TEST_TIMEOUT: 300 
         run: |
-          export PATH=$PATH:/tmp/chrome/chrome-linux64/:/tmp/chrome/chromedriver-linux64/
-          wasm-pack test --headless --chrome
+          export PATH=$PATH:/tmp/chrome/chrome-linux64/:/tmp/chrome/chromedriver/
+          wasm-pack test --headless --chrome --chrome-driver /tmp/chrome/chromedriver/chromedriver
 
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -393,8 +393,8 @@ jobs:
           rustup target add wasm32-unknown-unknown
       - name: Install dependencies
         run: |
-          apt-get update -qq
-          apt-get install -y -qq clang jq
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq clang jq
 
       - name: Setup wasm-pack
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -397,7 +397,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -qq
-          apt-get install -y -qq clang
+          apt-get install -y -qq clang jq
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install Chrome Environment

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -386,6 +386,8 @@ jobs:
   linux-wasm-pack:
     name: build with wasm-pack
     runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -420,7 +420,7 @@ jobs:
           WASM_BINDGEN_TEST_TIMEOUT: 300 
         run: |
           export PATH=$PATH:/tmp/chrome/chrome-linux64/:/tmp/chrome/chromedriver/
-          wasm-pack test --headless --chrome --chrome-driver /tmp/chrome/chromedriver/chromedriver
+          wasm-pack test --headless --chrome --chromedriver /tmp/chrome/chromedriver/chromedriver
 
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -384,7 +384,7 @@ jobs:
         run: ci/scripts/rust_docs.sh
 
   linux-wasm-pack:
-    name: build with wasm-pack
+    name: build and run with wasm-pack
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -398,6 +398,7 @@ jobs:
         run: |
           apt-get update -qq
           apt-get install -y -qq clang
+          apt-get install -y -qq chromium-browser chromium-chromedriver
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build with wasm-pack
@@ -408,9 +409,9 @@ jobs:
         env:
           WASM_BINDGEN_TEST_TIMEOUT: 300 
         run: |
-          wasm-pack test --headless --chrome
           wasm-pack test --headless --firefox
           wasm-pack test --headless --safari
+          wasm-pack test --headless --chrome
 
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -397,14 +397,24 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -qq
-          apt-get install -y -qq clang chromium-chromedriver chromium-browser
+          apt-get install -y -qq clang
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install Chrome Environment
+        run: |
+          mkdir -p /tmp/chrome
+          wget $(curl https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq -r '.versions | sort_by(.version) | reverse | .[0] | .downloads.chrome | .[] | select(.platform == "linux64") | .url')
+          wget $(curl https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq -r '.versions | sort_by(.version) | reverse | .[0] | .downloads.chromedriver | .[] | select(.platform == "linux64") | .url')
+          unzip chromedriver-linux64.zip
+          unzip chrome-linux64.zip
+          cp -r chrome-linux64/ /tmp/chrome/
+          cp -r chromedriver-linux64 /tmp/chrome/chromedriver
       - name: Run tests with headless mode
         working-directory: ./datafusion/wasmtest
         env:
           WASM_BINDGEN_TEST_TIMEOUT: 300 
         run: |
+          export PATH=$PATH:/tmp/chrome/chrome-linux64/:/tmp/chrome/chromedriver-linux64/
           wasm-pack test --headless --chrome
 
   # verify that the benchmark queries return the correct results

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -403,6 +403,9 @@ jobs:
       - name: Build with wasm-pack
         working-directory: ./datafusion/wasmtest
         run: wasm-pack build --dev
+      - run: wasm-pack test --headless --chrome
+      - run: wasm-pack test --headless --firefox
+      - run: wasm-pack test --headless --safari
 
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -398,7 +398,6 @@ jobs:
         run: |
           apt-get update -qq
           apt-get install -y -qq clang
-          apt-get install -y -qq chromium-browser chromium-chromedriver
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build with wasm-pack
@@ -411,7 +410,6 @@ jobs:
         run: |
           wasm-pack test --headless --firefox
           wasm-pack test --headless --safari
-          wasm-pack test --headless --chrome
 
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -386,8 +386,6 @@ jobs:
   linux-wasm-pack:
     name: build with wasm-pack
     runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
@@ -397,17 +395,15 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -qq
-          apt-get install -y -qq clang
+          apt-get install -y -qq clang chromium-chromedriver chromium-browser
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Run tests with headless mode
         working-directory: ./datafusion/wasmtest
         env:
           WASM_BINDGEN_TEST_TIMEOUT: 300 
         run: |
-          wasm-pack test --headless --firefox --chrome
+          wasm-pack test --headless --chrome
 
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -400,6 +400,8 @@ jobs:
           apt-get install -y -qq clang
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Run tests with headless mode
         working-directory: ./datafusion/wasmtest
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -385,7 +385,7 @@ jobs:
 
   linux-wasm-pack:
     name: build with wasm-pack
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup for wasm32
@@ -394,27 +394,15 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq clang jq
-
+          sudo apt-get install -y -qq clang
       - name: Setup wasm-pack
         run: |
           cargo install wasm-pack
-      - name: Install Chrome Environment
-        run: |
-          mkdir -p /tmp/chrome
-          wget $(curl https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq -r '.versions | sort_by(.version) | reverse | .[0] | .downloads.chrome | .[] | select(.platform == "linux64") | .url')
-          wget $(curl https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq -r '.versions | sort_by(.version) | reverse | .[0] | .downloads.chromedriver | .[] | select(.platform == "linux64") | .url')
-          unzip chromedriver-linux64.zip
-          unzip chrome-linux64.zip
-          cp -r chrome-linux64/ /tmp/chrome/
-          cp -r chromedriver-linux64 /tmp/chrome/chromedriver
       - name: Run tests with headless mode
         working-directory: ./datafusion/wasmtest
-        env:
-          WASM_BINDGEN_TEST_TIMEOUT: 300 
         run: |
-          export PATH=$PATH:/tmp/chrome/chrome-linux64/:/tmp/chrome/chromedriver/
-          wasm-pack test --headless --chrome --chromedriver /tmp/chrome/chromedriver/chromedriver
+          wasm-pack test --headless --firefox
+          wasm-pack test --headless --chrome --chromedriver $CHROMEWEBDRIVER/chromedriver
 
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -400,16 +400,12 @@ jobs:
           apt-get install -y -qq clang
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Build with wasm-pack
-        working-directory: ./datafusion/wasmtest
-        run: wasm-pack build --dev
       - name: Run tests with headless mode
         working-directory: ./datafusion/wasmtest
         env:
           WASM_BINDGEN_TEST_TIMEOUT: 300 
         run: |
-          wasm-pack test --headless --firefox
-          wasm-pack test --headless --safari
+          wasm-pack test --headless --firefox --chrome
 
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -386,14 +386,8 @@ jobs:
   linux-wasm-pack:
     name: build with wasm-pack
     runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
       - name: Setup for wasm32
         run: |
           rustup target add wasm32-unknown-unknown

--- a/datafusion/wasmtest/README.md
+++ b/datafusion/wasmtest/README.md
@@ -71,8 +71,6 @@ wasm-pack test --headless --chrome
 wasm-pack test --headless --safari
 ```
 
-**Note:** In GitHub Actions we test the compilation with `wasm-build`, but we don't currently invoke `wasm-pack test`. This is because the headless mode is not yet working. Document of adding a GitHub Action job: https://rustwasm.github.io/docs/wasm-bindgen/wasm-bindgen-test/continuous-integration.html#github-actions.
-
 To tweak timeout setting, use `WASM_BINDGEN_TEST_TIMEOUT` environment variable. E.g., `WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --firefox --headless`.
 
 ## Compatibility

--- a/datafusion/wasmtest/src/lib.rs
+++ b/datafusion/wasmtest/src/lib.rs
@@ -82,7 +82,6 @@ pub fn basic_parse() {
 #[cfg(test)]
 mod test {
     use super::*;
-    use datafusion::execution::options::ParquetReadOptions;
     use datafusion::{
         arrow::{
             array::{ArrayRef, Int32Array, RecordBatch, StringArray},
@@ -239,11 +238,12 @@ mod test {
 
         let url = Url::parse("memory://").unwrap();
         session_ctx.register_object_store(&url, Arc::new(store));
-
-        let df = session_ctx
-            .read_parquet("memory:///", ParquetReadOptions::new())
+        session_ctx
+            .register_parquet("a", "memory:///a.parquet", Default::default())
             .await
             .unwrap();
+
+        let df = session_ctx.sql("SELECT * FROM a").await.unwrap();
 
         let result = df.collect().await.unwrap();
 

--- a/datafusion/wasmtest/src/lib.rs
+++ b/datafusion/wasmtest/src/lib.rs
@@ -98,7 +98,6 @@ mod test {
     };
     use datafusion_physical_plan::collect;
     use datafusion_sql::parser::DFParser;
-    use insta::assert_snapshot;
     use object_store::{memory::InMemory, path::Path, ObjectStore};
     use url::Url;
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -248,14 +247,15 @@ mod test {
 
         let result = df.collect().await.unwrap();
 
-        assert_snapshot!(batches_to_string(&result), @r"
-        +----+-------+
-        | id | value |
-        +----+-------+
-        | 1  | a     |
-        | 2  | b     |
-        | 3  | c     |
-        +----+-------+
-        ");
+        assert_eq!(
+            batches_to_string(&result),
+            "+----+-------+\n\
+             | id | value |\n\
+             +----+-------+\n\
+             | 1  | a     |\n\
+             | 2  | b     |\n\
+             | 3  | c     |\n\
+             +----+-------+"
+        );
     }
 }

--- a/datafusion/wasmtest/webdriver.json
+++ b/datafusion/wasmtest/webdriver.json
@@ -1,0 +1,15 @@
+{
+	"moz:firefoxOptions": {
+		"prefs": {
+			"media.navigator.streams.fake": true,
+			"media.navigator.permission.disabled": true
+		},
+		"args": []
+	},
+	"goog:chromeOptions": {
+		"args": [
+			"--use-fake-device-for-media-stream",
+			"--use-fake-ui-for-media-stream"
+		]
+	}
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/datafusion/issues/13815 #15102 

## Rationale for this change

While digging into another issue, I realized the wasm test was never actually executed in CI, and thus we don't know whether our previous tests will pass (although they build successfully)

1. This PR enables running wasm test in CI. I believe headless mode is supported as of 2025.

2. The snapshot test doesn't seem to support wasm: https://github.com/mitsuhiko/insta/issues/120, so I disabled it and has to use some ugly string match


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
