### PR TITLE
Add test case for new casting feature from date to tz-aware timestamps

### DIFF
--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -2843,6 +2843,11 @@ select to_char(arrow_cast(TIMESTAMP '2023-08-03 14:38:50Z', 'Timestamp(Second, N
 03-08-2023 14-38-50
 
 query T
+select to_char(arrow_cast('2023-09-04'::date, 'Timestamp(Second, Some("UTC"))'), '%Y-%m-%dT%H:%M:%S%.3f');
+----
+2023-09-04T00:00:00.000
+
+query T
 select to_char(arrow_cast(123456, 'Duration(Second)'), 'pretty');
 ----
 1 days 10 hours 17 mins 36 secs


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #14638 

## Rationale for this change

https://github.com/apache/arrow-rs/pull/7141 enables casting from date to time zone-aware timestamps. (Included in [arrow 54.3.0](https://github.com/apache/arrow-rs/releases/tag/54.3.0)). 

This commit adds a SLT test case that tests against this feature. 