### PR TITLE
feat: Add unique id for every memory consumer

### DIFF
--- a/datafusion/execution/src/memory_pool/mod.rs
+++ b/datafusion/execution/src/memory_pool/mod.rs
@@ -161,9 +161,10 @@ impl PartialEq for MemoryConsumer {
     fn eq(&self, other: &Self) -> bool {
         let is_same_id = self.id == other.id;
 
+        #[cfg(debug_assertions)]
         if is_same_id {
-            debug_assert_eq!(self.name, other.name);
-            debug_assert_eq!(self.can_spill, other.can_spill);
+            assert_eq!(self.name, other.name);
+            assert_eq!(self.can_spill, other.can_spill);
         }
 
         is_same_id

--- a/datafusion/execution/src/memory_pool/mod.rs
+++ b/datafusion/execution/src/memory_pool/mod.rs
@@ -19,6 +19,7 @@
 //! help with allocation accounting.
 
 use datafusion_common::{internal_err, Result};
+use std::hash::{Hash, Hasher};
 use std::{cmp::Ordering, sync::atomic, sync::Arc};
 
 mod pool;
@@ -171,6 +172,14 @@ impl PartialEq for MemoryConsumer {
 
 impl Eq for MemoryConsumer {}
 
+impl Hash for MemoryConsumer {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.name.hash(state);
+        self.can_spill.hash(state);
+    }
+}
+
 impl MemoryConsumer {
     fn new_unique_id() -> usize {
         static ID: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
@@ -182,6 +191,14 @@ impl MemoryConsumer {
         Self {
             name: name.into(),
             can_spill: false,
+            id: Self::new_unique_id(),
+        }
+    }
+
+    pub fn clone_with_new_id(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            can_spill: self.can_spill,
             id: Self::new_unique_id(),
         }
     }

--- a/datafusion/execution/src/memory_pool/mod.rs
+++ b/datafusion/execution/src/memory_pool/mod.rs
@@ -147,6 +147,11 @@ pub trait MemoryPool: Send + Sync + std::fmt::Debug {
 /// [`MemoryReservation`] in a [`MemoryPool`]. All allocations are registered to
 /// a particular `MemoryConsumer`;
 ///
+/// Each `MemoryConsumer` is identifiable by a process-unique id, and is therefor not cloneable,
+/// If you want a clone of a `MemoryConsumer`, you should look into [`MemoryConsumer::clone_with_new_id`],
+/// but note that this `MemoryConsumer` may be treated as a separate entity based on the used pool,
+/// and is only guaranteed to share the name and inner properties.
+///
 /// For help with allocation accounting, see the [`proxy`] module.
 ///
 /// [proxy]: datafusion_common::utils::proxy
@@ -196,6 +201,9 @@ impl MemoryConsumer {
         }
     }
 
+    /// Returns a clone of this [`MemoryConsumer`] with a new unique id,
+    /// which can be registered with a [`MemoryPool`],
+    /// This new consumer is separate from the original.
     pub fn clone_with_new_id(&self) -> Self {
         Self {
             name: self.name.clone(),
@@ -394,7 +402,7 @@ pub mod units {
     pub const KB: u64 = 1 << 10;
 }
 
-/// Present size in human readable form
+/// Present size in human-readable form
 pub fn human_readable_size(size: usize) -> String {
     use units::*;
 

--- a/datafusion/execution/src/memory_pool/mod.rs
+++ b/datafusion/execution/src/memory_pool/mod.rs
@@ -19,7 +19,7 @@
 //! help with allocation accounting.
 
 use datafusion_common::{internal_err, Result};
-use std::{cmp::Ordering, sync, sync::Arc};
+use std::{cmp::Ordering, sync::atomic, sync::Arc};
 
 mod pool;
 pub mod proxy {
@@ -158,8 +158,8 @@ pub struct MemoryConsumer {
 
 impl MemoryConsumer {
     fn new_unique_id() -> usize {
-        static ID: sync::atomic::AtomicUsize = sync::atomic::AtomicUsize::new(0);
-        ID.fetch_add(1, sync::atomic::Ordering::Relaxed)
+        static ID: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
+        ID.fetch_add(1, atomic::Ordering::Relaxed)
     }
 
     /// Create a new empty [`MemoryConsumer`] that can be grown using [`MemoryReservation`]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15126 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This makes an important change to the MemoryConsumer API, letting any memory pool identify which consumer is requesting the memory, and therefor separate consumers that might have the same name (for example, two AggregateExec operators in the same Partition)
This also modifies the TrackConsumer pool to adhere to these changes.

## What changes are included in this PR?
Nothing except the addition of  a unique identifier in the consumer, and an id() function to retrieve it.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

All of the TrackedConsumer pool tests now verify this, as they have all been updated to accomodate the fact that the pool uses the IDs to track (the inner pool is unchanged in its behaviour atm)
This ensures the validity of the logic

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes, MemoryConsumer is no longer clone-able, it is now moved into the register() function and thats it, to avoid an invalid state where a MemoryConsumer can be registered more than once.
The TrackedConsumerMemoryPool will now store Consumers based on their IDs, instead of names, so will be able to track multiple consumers with the same name, based on their ID, and the error messages are updated accordingly.