### PR TITLE
Update parser recursion limit from 50 to 100

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -263,7 +263,7 @@ config_namespace! {
         pub collect_spans: bool, default = false
 
         /// Specifies the recursion depth limit when parsing complex SQL Queries
-        pub recursion_limit: usize, default = 50
+        pub recursion_limit: usize, default = 100
     }
 }
 

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -288,7 +288,7 @@ pub struct DFParser<'a> {
 }
 
 /// Same as `sqlparser`
-const DEFAULT_RECURSION_LIMIT: usize = 50;
+const DEFAULT_RECURSION_LIMIT: usize = 100;
 const DEFAULT_DIALECT: GenericDialect = GenericDialect {};
 
 /// Builder for [`DFParser`]

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -185,3 +185,17 @@ select ammp from a;
 
 statement ok
 drop table a;
+
+# Error number of nested expressions exceeds limit
+statement error DataFusion error: SQL error: RecursionLimitExceeded
+SELECT
+    c1
+FROM
+    aggregate_test_100
+WHERE
+    c1=0 OR (c2=0 OR (c3=0 OR (c4=0 OR (c5=0 OR (c6=0 OR (c7=0 OR (c8=0 OR (c9=0 OR (c10=0 OR
+    (c1=1 OR (c2=1 OR (c3=1 OR (c4=1 OR (c5=1 OR (c6=1 OR (c7=1 OR (c8=1 OR (c9=1 OR (c10=1 OR
+    (c1=2 OR (c2=2 OR (c3=2 OR (c4=2 OR (c5=2 OR (c6=2 OR (c7=2 OR (c8=2 OR (c9=2 OR (c10=2 OR
+    (c1=3 OR (c2=3 OR (c3=3 OR (c4=3 OR (c5=3 OR (c6=3 OR (c7=3 OR (c8=3 OR (c9=3 OR (c10=3 OR
+    (c1=4 OR (c2=4 OR (c3=4 OR (c4=4 OR (c5=4 OR (c6=4 OR (c7=4 OR (c8=4 OR (c9=4 OR (c10=4
+    )))))))))))))))))))))))))))))))))))))))))))))))));


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #14857

## Rationale for this change

A number of valid tests are failing because the recursion limit is fairly low. See https://github.com/apache/datafusion/issues/14091

## What changes are included in this PR?

Updated the default recursion limit from 50 to 100.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.