### PR TITLE
fix(substrait): fix regressed edge case in renaming inner struct fields

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -659,9 +659,12 @@ impl DFSchema {
     }
 
     /// Checks if two [`DataType`]s are logically equal. This is a notably weaker constraint
-    /// than datatype_is_semantically_equal in that a Dictionary<K,V> type is logically
-    /// equal to a plain V type, but not semantically equal. Dictionary<K1, V1> is also
-    /// logically equal to Dictionary<K2, V1>.
+    /// than datatype_is_semantically_equal in that different representations of same data can be
+    /// logically but not semantically equivalent. Semantically equivalent types are always also
+    /// logically equivalent. For example:
+    /// - a Dictionary<K,V> type is logically equal to a plain V type
+    /// - a Dictionary<K1, V1> is also logically equal to Dictionary<K2, V1>
+    /// - Utf8 and Utf8View are logically equal
     pub fn datatype_is_logically_equal(dt1: &DataType, dt2: &DataType) -> bool {
         // check nested fields
         match (dt1, dt2) {
@@ -714,12 +717,12 @@ impl DFSchema {
             // Utf8 and Utf8View are logically equivalent
             (DataType::Utf8, DataType::Utf8View) => true,
             (DataType::Utf8View, DataType::Utf8) => true,
-            _ => dt1 == dt2,
+            _ => Self::datatype_is_semantically_equal(dt1, dt2),
         }
     }
 
     /// Returns true of two [`DataType`]s are semantically equal (same
-    /// name and type), ignoring both metadata and nullability.
+    /// name and type), ignoring both metadata and nullability, and decimal precision/scale.
     ///
     /// request to upstream: <https://github.com/apache/arrow-rs/issues/3199>
     pub fn datatype_is_semantically_equal(dt1: &DataType, dt2: &DataType) -> bool {

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -641,7 +641,7 @@ impl DFSchema {
                         || (!DFSchema::datatype_is_semantically_equal(
                             f1.data_type(),
                             f2.data_type(),
-                        ) && !can_cast_types(f2.data_type(), f1.data_type()))
+                        ))
                     {
                         _plan_err!(
                             "Schema mismatch: Expected field '{}' with type {:?}, \
@@ -711,6 +711,9 @@ impl DFSchema {
                         .zip(iter2)
                         .all(|((t1, f1), (t2, f2))| t1 == t2 && Self::field_is_logically_equal(f1, f2))
             }
+            // Utf8 and Utf8View are logically equivalent
+            (DataType::Utf8, DataType::Utf8View) => true,
+            (DataType::Utf8View, DataType::Utf8) => true,
             _ => dt1 == dt2,
         }
     }

--- a/datafusion/expr/src/logical_plan/invariants.rs
+++ b/datafusion/expr/src/logical_plan/invariants.rs
@@ -112,11 +112,11 @@ fn assert_valid_semantic_plan(plan: &LogicalPlan) -> Result<()> {
 /// Returns an error if the plan does not have the expected schema.
 /// Ignores metadata and nullability.
 pub fn assert_expected_schema(schema: &DFSchemaRef, plan: &LogicalPlan) -> Result<()> {
-    let compatible = plan.schema().has_equivalent_names_and_types(schema);
+    let compatible = plan.schema().logically_equivalent_names_and_types(schema);
 
-    if let Err(e) = compatible {
+    if !compatible {
         internal_err!(
-            "Failed due to a difference in schemas: {e}, original schema: {:?}, new schema: {:?}",
+            "Failed due to a difference in schemas: original schema: {:?}, new schema: {:?}",
             schema,
             plan.schema()
         )

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -506,8 +506,11 @@ mod tests {
         });
         let err = opt.optimize(plan, &config, &observe).unwrap_err();
 
-        // Simplify assert to check the error message contains the expected message, which is only the schema length mismatch
-        assert_contains!(err.strip_backtrace(), "Schema mismatch: the schema length are not same Expected schema length: 3, got: 0");
+        // Simplify assert to check the error message contains the expected message
+        assert_contains!(
+            err.strip_backtrace(),
+            "Failed due to a difference in schemas: original schema: DFSchema"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

https://github.com/apache/datafusion/pull/15239 introduced a regression in Substrait consumer, where if a field was correctly named but contained struct fields which were not, those would not be renamed. See https://github.com/apache/datafusion/pull/15239#discussion_r2032824594

However, the logic used in that PR feels wrong also on a more general level. The can_cast_types is a **very** general check, so has_equivalent_names_and_types should quite certainly not use it as a criteria.

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

1. add a failing test case for https://github.com/apache/datafusion/pull/15239#discussion_r2032824594
2. switch `invariants` to use `logically_equivalent_names_and_types` instead, since that's meant to be a weaker comparison
3. mark Utf8 and Utf8View as logically the same

This does make the check in `invariants` tighter again. I'd argue that's a good thing, since the "can_cast_types" check is _very_ relaxed and certainly doesn't fulfill the criteria in https://datafusion.apache.org/contributor-guide/specification/invariants.html#logical-schema-is-invariant-under-logical-optimization. That said, I'm not sure if the Utf8->Utf8View change fulfills that criteria either, but makes sense to me to allow it?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Added a new test to catch the regression, + existing tests for the invariants.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
