### PR TITLE
Ignore false positive only_used_in_recursion Clippy warning

### DIFF
--- a/datafusion/physical-optimizer/src/aggregate_statistics.rs
+++ b/datafusion/physical-optimizer/src/aggregate_statistics.rs
@@ -42,6 +42,7 @@ impl AggregateStatistics {
 
 impl PhysicalOptimizerRule for AggregateStatistics {
     #[cfg_attr(feature = "recursive_protection", recursive::recursive)]
+    #[allow(clippy::only_used_in_recursion)] // See https://github.com/rust-lang/rust-clippy/issues/14566
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,


### PR DESCRIPTION
## Which issue does this PR close?

Ignores a Clippy warning identified in https://github.com/apache/datafusion/pull/15625. Note, that this warning seems to be a false positive. I've submitted an issue with the Clippy project https://github.com/rust-lang/rust-clippy/issues/14566. Ideally we'd get this fixed upstream instead of having to add this ignore directive.

## Rationale for this change

As mentioned in https://github.com/apache/datafusion/pull/15625#pullrequestreview-2748351074, we get a Clippy warning 
```
warning: parameter is only used in recursion
  --> datafusion/physical-optimizer/src/aggregate_statistics.rs:48:9
   |
48 |         config: &ConfigOptions,
   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_config`
   |
note: parameter used here
  --> datafusion/physical-optimizer/src/aggregate_statistics.rs:86:42
   |
86 |                     self.optimize(child, config).map(Transformed::yes)
   |                                          ^^^^^^
...
91 |             plan.map_children(|child| self.optimize(child, config).map(Transformed::yes))
   |                                                            ^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#only_used_in_recursion
   = note: `#[warn(clippy::only_used_in_recursion)]` on by default
```

when linting the `datafusion-physical-optimizer` crate: `cargo clippy -p datafusion-physical-optimizer`.

## What changes are included in this PR?

No real change was possible, so I added an ignore directive.

Clippy suggests to prefix the `config` parameter with an underscore but it is still used in the function body to pass it to recursive calls. Removing the parameter was also not an option because it is defined on the `PhysicalOptimizerRule` trait and other implementations use it.

## Are these changes tested?

Running `cargo clippy -p datafusion-physical-optimizer` now reports no warnings.

## Are there any user-facing changes?

No, no actual code change.