### PR TITLE
docs: add conventional commit guide and PR title examples

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -156,6 +156,29 @@ convention but encourage its use if you want your PR to feature in the correct s
 The change log generator will also look at GitHub labels such as `bug`, `enhancement`, or `api change`, and labels
 do take priority over the conventional commit approach, allowing maintainers to re-categorize PRs after they have been merged.
 
+####  Commit Prefix Guide
+
+| Prefix     | Purpose                                 |
+|------------|-----------------------------------------|
+| `feat:`    | A new feature                           |
+| `fix:`     | A bug fix                               |
+| `docs:`    | Documentation only changes              |
+| `chore:`   | Build process or auxiliary tool changes |
+| `refactor:`| Code changes that neither fix nor add   |
+| `test:`    | Adding or updating tests                |
+
+#### Example PR Titles
+
+- `docs: update README with example usage`
+- `fix: resolve crash on null input`
+- `feat: add support for XYZ operator`
+- `chore: update Cargo dependencies`
+
+Using these formats helps:
+- Organize changelogs automatically
+- Improve review clarity
+- Maintain a clean project history
+
 [conventional commits]: https://www.conventionalcommits.org/en/v1.0.0/
 
 # Reviewing Pull Requests


### PR DESCRIPTION
### Summary

Added a new section under **Conventional Commits & Labeling PRs**  that provides:
- A table of common commit prefixes and their purposes
- Example PR titles for clarity
- A link to the official Conventional Commits specification

### Purpose
This addition is intended to assist new contributors in formatting their commit messages and PR titles effectively. It helps maintain consistency, improves changelog automation, and aligns with the contribution guidelines.

## Which issue does this PR close?

- This PR does not close any existing issue. It's a small improvement to the contributing guide.
- 
## Rationale for this change

This change enhances contributor experience by providing clear, practical examples and formatting guidance. It supports the maintainers’ existing structure and promotes better practices for contribution labeling.

## What changes are included in this PR?

1)Added a commit prefix table
2)Included example PR titles
3)Added a helpful external reference link

## Are these changes tested?
As this is a documentation update, testing is not applicable.

## Are there any user-facing changes?
Yes, this improves the documentation for all contributors, particularly newcomers. No functional changes are made to the project.
