### PR TITLE
fix: miss output ordering during projection

### DIFF
--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -46,7 +46,7 @@ use datafusion_physical_plan::{
     projection::{all_alias_free_columns, new_projections_for_columns, ProjectionExec},
     DisplayAs, DisplayFormatType, ExecutionPlan,
 };
-use log::{debug, warn};
+use log::warn;
 
 use crate::file_groups::FileGroup;
 use crate::{
@@ -1412,6 +1412,8 @@ fn get_projected_output_ordering(
         }
 
         // Check if any file groups are not sorted
+        // Given that currently the `output_ordering` is specified by the external mechanism,
+        // So here we only do some checks and give warnings if the file groups are not sorted from the statistics perspective.
         if base_config.file_groups.iter().any(|group| {
             if group.len() <= 1 {
                 // File groups with <= 1 files are always sorted
@@ -1434,12 +1436,11 @@ fn get_projected_output_ordering(
 
             !statistics.is_sorted()
         }) {
-            debug!(
-                "Skipping specified output ordering {:?}. \
-                Some file groups couldn't be determined to be sorted: {:?}",
-                base_config.output_ordering[0], base_config.file_groups
+            warn!(
+                "The specified output ordering is {:?}. \
+                But some file groups couldn't be determined to be sorted: {:?}",
+                output_ordering, base_config.file_groups
             );
-            continue;
         }
 
         all_orderings.push(new_ordering);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, the `base_config.output_ordering` is specified by the external mechanism; the users usually decide on the `output_ordering`. See here: https://github.com/apache/datafusion/blob/main/datafusion/core/src/datasource/listing/table.rs#L273-L277

That is, users should ensure if the output ordering is correct.

Most of user, I believe they don't enable the `collect_statistic` config, so they will miss output ordering here, even if the config is enabled, the statistic may be inaccurate, or for some file format, they don't have statistics. But if users write the output_ordering to config, I guess they think/believe their data is sorted, so if the check in `get_projected_output_ordering` will drop the output ordering for them.


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Still do the check, but only output warning.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
