### PR TITLE
Fix internal error in sort when hitting memory limit

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -679,7 +679,8 @@ impl ExternalSorter {
             let batch = concat_batches(&self.schema, &self.in_mem_batches)?;
             self.in_mem_batches.clear();
             self.reservation
-                .try_resize(get_reserved_byte_for_record_batch(&batch))?;
+                .try_resize(get_reserved_byte_for_record_batch(&batch))
+                .map_err(Self::err_with_oom_context)?;
             let reservation = self.reservation.take();
             return self.sort_batch_stream(batch, metrics, reservation);
         }

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -798,10 +798,10 @@ impl ExternalSorter {
     /// This is meant to be used with DataFusionError::ResourcesExhausted only.
     fn err_with_oom_context(e: DataFusionError) -> DataFusionError {
         match e {
-            DataFusionError::ResourcesExhausted(_) => e.context(format!(
+            DataFusionError::ResourcesExhausted(_) => e.context(
                 "Not enough memory to continue external sort. \
                     Consider increasing the memory limit, or decreasing sort_spill_reservation_bytes"
-            )),
+            ),
             // This is not an OOM error, so just return it as is.
             _ => e,
         }

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -529,6 +529,12 @@ impl ExternalSorter {
     /// Sorts the in-memory batches and merges them into a single sorted run, then writes
     /// the result to spill files.
     async fn sort_and_spill_in_mem_batches(&mut self) -> Result<()> {
+        if self.in_mem_batches.is_empty() {
+            // The spill code assumes that we have batches in memory. If we don't,
+            // we should exit early to not break that assumption.
+            return Ok(());
+        }
+
         // Release the memory reserved for merge back to the pool so
         // there is some left when `in_mem_sort_stream` requests an
         // allocation. At the end of this function, memory will be

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -760,7 +760,9 @@ impl ExternalSorter {
         if self.runtime.disk_manager.tmp_files_enabled() {
             let size = self.sort_spill_reservation_bytes;
             if self.merge_reservation.size() != size {
-                self.merge_reservation.try_resize(size)?;
+                self.merge_reservation
+                    .try_resize(size)
+                    .map_err(Self::err_with_oom_context)?;
             }
         }
 

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -524,9 +524,9 @@ impl ExternalSorter {
     /// the result to spill files.
     async fn sort_and_spill_in_mem_batches(&mut self) -> Result<()> {
         if self.in_mem_batches.is_empty() {
-            // The spill code assumes that we have batches in memory. If we don't,
-            // we should exit early to not break that assumption.
-            return Ok(());
+            return internal_err!(
+                "in_mem_batches must not be empty when attempting to sort and spill"
+            );
         }
 
         // Release the memory reserved for merge back to the pool so

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -1350,6 +1350,7 @@ impl ExecutionPlan for SortExec {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::error::Error;
     use std::pin::Pin;
     use std::task::{Context, Poll};
 
@@ -1641,7 +1642,19 @@ mod tests {
 
         let err = result.unwrap_err();
         assert!(
-            matches!(err, DataFusionError::ResourcesExhausted(_)),
+            matches!(err, DataFusionError::Context(..)),
+            "Assertion failed: expected a Context error, but got: {:?}",
+            err
+        );
+
+        // Assert that the context error is wrapping a resources exhausted error.
+        let nested_err = err
+            .source()
+            .unwrap()
+            .downcast_ref::<DataFusionError>()
+            .unwrap();
+        assert!(
+            matches!(nested_err, DataFusionError::ResourcesExhausted(_)),
             "Assertion failed: expected a ResourcesExhausted error, but got: {:?}",
             err
         );

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -323,7 +323,8 @@ impl ExternalSorter {
         }
 
         self.reserve_memory_for_merge()?;
-        self.reserve_memory_for_batch(&input).await?;
+        self.reserve_memory_for_batch_and_maybe_spill(&input)
+            .await?;
 
         self.in_mem_batches.push(input);
         Ok(())
@@ -768,7 +769,10 @@ impl ExternalSorter {
 
     /// Reserves memory to be able to accommodate the given batch.
     /// If memory is scarce, tries to spill current in-memory batches to disk first.
-    async fn reserve_memory_for_batch(&mut self, input: &RecordBatch) -> Result<()> {
+    async fn reserve_memory_for_batch_and_maybe_spill(
+        &mut self,
+        input: &RecordBatch,
+    ) -> Result<()> {
         let size = get_reserved_byte_for_record_batch(input);
 
         let result = self.reservation.try_grow(size);

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -1350,7 +1350,6 @@ impl ExecutionPlan for SortExec {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::error::Error;
     use std::pin::Pin;
     use std::task::{Context, Poll};
 
@@ -1648,13 +1647,8 @@ mod tests {
         );
 
         // Assert that the context error is wrapping a resources exhausted error.
-        let nested_err = err
-            .source()
-            .unwrap()
-            .downcast_ref::<DataFusionError>()
-            .unwrap();
         assert!(
-            matches!(nested_err, DataFusionError::ResourcesExhausted(_)),
+            matches!(err.find_root(), DataFusionError::ResourcesExhausted(_)),
             "Assertion failed: expected a ResourcesExhausted error, but got: {:?}",
             err
         );


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/15675

## Rationale for this change

I noticed an internal error in the sort implementation. This PR is exposing it as a proper user-facing error instead.

## What changes are included in this PR?

If a user hits this condition, they now receive a `DataFusionError:ResourcesExhausted` instead of `DataFusionError::Internal`.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

In away, the code now exposes a different error to the user facing API. However, since the old error was internal, this was a bug and I don't expect any documentation changes are necessary.
