### PR TITLE
Apply pre-selection and computation skipping to short-circuit optimization

### DIFF
--- a/datafusion/physical-expr/benches/binary_op.rs
+++ b/datafusion/physical-expr/benches/binary_op.rs
@@ -141,9 +141,10 @@ fn generate_boolean_cases<const TEST_ALL_FALSE: bool>(
 
 /// Benchmarks AND/OR operator short-circuiting by evaluating complex regex conditions.
 ///
-/// Creates 6 test scenarios per operator:
+/// Creates 7 test scenarios per operator:
 /// 1. All values enable short-circuit (all_true/all_false)
 /// 2. 2-6 Single true/false value at different positions to measure early exit
+/// 3. Test all true or all false in AND/OR
 ///
 /// You can run this benchmark with:
 /// ```sh

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -822,6 +822,23 @@ enum ShortCircuitStrategy {
     ReturnRight,
     None,
 }
+/// Helper function to count the number of true and false values in a BooleanArray.
+/// Assumes the array does not contain nulls.
+#[inline(always)]
+fn count_boolean_values(array: &BooleanArray) -> (usize, usize) {
+    let mut true_count = 0;
+    let mut false_count = 0;
+    for i in 0..array.len() {
+        // Since we assume there are no nulls (null_count() == 0), we can directly call value(i)
+        if array.value(i) {
+            true_count += 1;
+        } else {
+            false_count += 1;
+        }
+    }
+    (true_count, false_count)
+}
+
 /// Checks if a logical operator (`AND`/`OR`) can short-circuit evaluation based on the left-hand side (lhs) result.
 ///
 /// Short-circuiting occurs under these circumstances:
@@ -831,6 +848,7 @@ enum ShortCircuitStrategy {
 /// - For `OR`:
 ///    - if LHS is all true  => short-circuit → return LHS
 ///    - if LHS is all false => short-circuit → return RHS
+///
 /// # Arguments
 /// * `lhs` - The left-hand side (lhs) columnar value (array or scalar)
 /// * `lhs` - The left-hand side (lhs) columnar value (array or scalar)
@@ -839,7 +857,7 @@ enum ShortCircuitStrategy {
 /// # Implementation Notes
 /// 1. Only works with Boolean-typed arguments (other types automatically return `None`)
 /// 2. Handles both scalar values and array values
-/// 3. For arrays, uses optimized bit counting techniques for boolean arrays
+/// 3. For arrays, uses a single-pass count to acquire both true and false counts
 fn check_short_circuit(lhs: &ColumnarValue, op: &Operator) -> ShortCircuitStrategy {
     // Only apply short-circuiting for logical operators And/Or.
     if !matches!(op, Operator::And | Operator::Or) {
@@ -855,37 +873,32 @@ fn check_short_circuit(lhs: &ColumnarValue, op: &Operator) -> ShortCircuitStrate
 
     match lhs {
         ColumnarValue::Array(array) => {
-            if let Ok(array) = as_boolean_array(&array) {
-                // For both operations, check if we have nulls
-                if array.null_count() > 0 {
+            if let Ok(bool_array) = as_boolean_array(&array) {
+                // If there are any nulls, we cannot safely short-circuit.
+                if bool_array.null_count() > 0 {
                     return ShortCircuitStrategy::None;
                 }
 
-                let len = array.len();
+                let len = bool_array.len();
+                // Use the helper to count true and false in one pass.
+                let (true_count, false_count) = count_boolean_values(bool_array);
 
-                // Optimize evaluation order based on operator type
-                // This avoids redundant counting operations
                 if is_and {
-                    // For AND, check for all false values first (most common short-circuit case)
-                    let false_count = array.false_count();
+                    // For AND, if every value is false, we can return LHS.
                     if false_count == len {
                         return ShortCircuitStrategy::ReturnLeft; // All false for AND
                     }
-
-                    if false_count == 0 {
-                        // This means all true
+                    // If every value is true, we must evaluate the RHS.
+                    if true_count == len {
                         return ShortCircuitStrategy::ReturnRight; // All true for AND
                     }
                 } else {
-                    // is OR
-                    // For OR, check for all true values first (most common short-circuit case)
-                    let true_count = array.true_count();
+                    // For OR, if every value is true, we can return LHS.
                     if true_count == len {
                         return ShortCircuitStrategy::ReturnLeft; // All true for OR
                     }
-
-                    if true_count == 0 {
-                        // This means all false
+                    // If every value is false, we must evaluate the RHS.
+                    if false_count == len {
                         return ShortCircuitStrategy::ReturnRight; // All false for OR
                     }
                 }
@@ -894,7 +907,8 @@ fn check_short_circuit(lhs: &ColumnarValue, op: &Operator) -> ShortCircuitStrate
         ColumnarValue::Scalar(scalar) => {
             if let ScalarValue::Boolean(Some(value)) = scalar {
                 let is_true = *value;
-
+                // For AND, a false scalar immediately determines the result,
+                // and for OR, a true scalar immediately determines the result.
                 if (is_and && !is_true) || (!is_and && is_true) {
                     return ShortCircuitStrategy::ReturnLeft;
                 } else {

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -840,7 +840,7 @@ const PRE_SELECTION_THRESHOLD: f32 = 0.2;
 /// - For `AND`:
 ///    - if LHS is all false => short-circuit → return LHS
 ///    - if LHS is all true  => short-circuit → return RHS
-///    - if LHS is mixed and true_count/sum_count <= [`PRE_SELECTIO_THRESHOLD`] -> pre-selection
+///    - if LHS is mixed and true_count/sum_count <= [`PRE_SELECTION_THRESHOLD`] -> pre-selection
 /// - For `OR`:
 ///    - if LHS is all true  => short-circuit → return LHS
 ///    - if LHS is all false => short-circuit → return RHS

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -370,14 +370,17 @@ impl PhysicalExpr for BinaryExpr {
             return Ok(result);
         }
 
-        // Check for short-circuit evaluation based on LHS alone
-        if let Some(result) = get_short_circuit_result(&lhs, &self.op, Some(rhs_lazy()?))
+        // Only evaluate RHS if short-circuit evaluation doesn't apply
+        let rhs = rhs_lazy()?;
+
+        // Check for short-circuit cases that need RHS value
+        if let Some(result) = get_short_circuit_result(&lhs, &self.op, Some(rhs.clone()))
         {
             return Ok(result);
         }
 
-        // Only evaluate RHS if short-circuit evaluation doesn't apply
-        let rhs = rhs_lazy()?;
+        let left_data_type = lhs.data_type();
+        let right_data_type = rhs.data_type();
 
         // Check for short-circuit cases that need RHS value
         if let Some(result) = get_short_circuit_result(&lhs, &self.op, Some(rhs.clone()))

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -29,7 +29,7 @@ use arrow::compute::kernels::boolean::{and_kleene, not, or_kleene};
 use arrow::compute::kernels::cmp::*;
 use arrow::compute::kernels::comparison::{regexp_is_match, regexp_is_match_scalar};
 use arrow::compute::kernels::concat_elements::concat_elements_utf8;
-use arrow::compute::{bool_or, cast, ilike, like, nilike, nlike};
+use arrow::compute::{cast, ilike, like, nilike, nlike};
 use arrow::datatypes::*;
 use arrow::error::ArrowError;
 use datafusion_common::cast::as_boolean_array;

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -848,6 +848,7 @@ fn get_short_circuit_result(
 ) -> Option<ColumnarValue> {
     // Only apply short-circuiting for logical operators And/Or.
     if !matches!(op, Operator::And | Operator::Or) {
+        println!("==> No short-circuit applies");
         return None;
     }
 
@@ -1135,6 +1136,8 @@ mod tests {
             // verify that the result itself is correct
             for (i, x) in $VEC.iter().enumerate() {
                 let v = result.value(i);
+                println!("==> Evaluating binary op: +, result = {:?}", v);
+                println!("==> Evaluating binary op: +, expected = {:?}", x);
                 assert_eq!(
                     v,
                     *x,

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -963,7 +963,7 @@ fn check_short_circuit<'a>(
 ///   Right Evaluation
 ///     (Condition: Even numbers)
 ///          ↓
-///  Right Data: [2]
+///  Right Data: [ 2 ]
 ///    Right Bitmap: [1, 0]
 ///          ↓
 ///   Combine Results

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -1739,10 +1739,15 @@ mod tests {
             0,
         ));
 
+        // Add debug prints to show dictionary values
+        println!("==> Dictionary values: {:?}", decimal_array);
+
         let keys = Int8Array::from(vec![Some(0), Some(2), None, Some(3), Some(0)]);
+        println!("==> A keys: {:?}", keys);
         let a = DictionaryArray::try_new(keys, decimal_array)?;
 
         let keys = Int8Array::from(vec![Some(0), None, Some(3), Some(2), Some(2)]);
+        println!("==> B keys: {:?}", keys);
         let decimal_array = Arc::new(create_decimal_array(
             &[
                 Some(value + 1),

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -376,12 +376,6 @@ impl PhysicalExpr for BinaryExpr {
         // Check for short-circuit cases that need RHS value
         if let Some(result) = get_short_circuit_result(&lhs, &self.op, Some(rhs.clone()))
         {
-            return Ok(result);
-        }
-
-        // Check for short-circuit cases that need RHS value
-        if let Some(result) = get_short_circuit_result(&lhs, &self.op, Some(rhs.clone()))
-        {
             println!("==> Short-circuit with RHS: op={:?}", self.op);
             return Ok(result);
         }
@@ -838,6 +832,16 @@ impl BinaryExpr {
 /// - For `OR`:
 ///    - if LHS is all true  => short-circuit → return LHS
 ///    - if LHS is all false => short-circuit → return RHS
+/// -/// # Arguments
+/// * `arg` - The left-hand side (lhs) columnar value (array or scalar)
+/// * `op` - The logical operator (`AND` or `OR`)
+/// * `rhs` - The right-hand side (rhs) columnar value (array or scalar)
+///
+/// # Implementation Notes
+/// 1. Only works with Boolean-typed arguments (other types automatically return `false`)
+/// 2. Handles both scalar values and array values
+/// 3. For arrays, uses optimized `true_count()`/`false_count()` methods from arrow-rs.
+///    `bool_or`/`bool_and` maybe a better choice too，for detailed discussion,see:[link](https://github.com/apache/datafusion/pull/15462#discussion_r2020558418)
 fn get_short_circuit_result(
     lhs: &ColumnarValue,
     op: &Operator,

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -839,8 +839,7 @@ enum ShortCircuitStrategy {
 /// # Implementation Notes
 /// 1. Only works with Boolean-typed arguments (other types automatically return `None`)
 /// 2. Handles both scalar values and array values
-/// 3. For arrays, uses optimized `true_count()`/`false_count()` methods from arrow-rs.
-///    `bool_or`/`bool_and` maybe a better choice too，for detailed discussion,see:[link](https://github.com/apache/datafusion/pull/15462#discussion_r2020558418)
+/// 3. For arrays, uses optimized bit counting techniques for boolean arrays
 fn check_short_circuit(lhs: &ColumnarValue, op: &Operator) -> ShortCircuitStrategy {
     // Only apply short-circuiting for logical operators And/Or.
     if !matches!(op, Operator::And | Operator::Or) {
@@ -862,36 +861,38 @@ fn check_short_circuit(lhs: &ColumnarValue, op: &Operator) -> ShortCircuitStrate
                     return ShortCircuitStrategy::None;
                 }
 
-                // For AND: return left if all false, return right if all true
-                // For OR: return left if all true, return right if all false
-                let true_count = array.true_count();
                 let len = array.len();
 
-                // Check for all true values
-                if true_count == len {
-                    return if is_and {
-                        ShortCircuitStrategy::ReturnRight
-                    } else {
-                        ShortCircuitStrategy::ReturnLeft
-                    };
-                }
+                // Optimize evaluation order based on operator type
+                // This avoids redundant counting operations
+                if is_and {
+                    // For AND, check for all false values first (most common short-circuit case)
+                    let false_count = array.false_count();
+                    if false_count == len {
+                        return ShortCircuitStrategy::ReturnLeft; // All false for AND
+                    }
 
-                // Check for all false values
-                let false_count = array.false_count();
-                if false_count == len {
-                    return if is_and {
-                        ShortCircuitStrategy::ReturnLeft
-                    } else {
-                        ShortCircuitStrategy::ReturnRight
-                    };
+                    if false_count == 0 {
+                        // This means all true
+                        return ShortCircuitStrategy::ReturnRight; // All true for AND
+                    }
+                } else {
+                    // is OR
+                    // For OR, check for all true values first (most common short-circuit case)
+                    let true_count = array.true_count();
+                    if true_count == len {
+                        return ShortCircuitStrategy::ReturnLeft; // All true for OR
+                    }
+
+                    if true_count == 0 {
+                        // This means all false
+                        return ShortCircuitStrategy::ReturnRight; // All false for OR
+                    }
                 }
             }
         }
         ColumnarValue::Scalar(scalar) => {
             if let ScalarValue::Boolean(Some(value)) = scalar {
-                // For AND: return left if false, return right if true
-                // For OR: return left if true, return right if false
-
                 let is_true = *value;
 
                 if (is_and && !is_true) || (!is_and && is_true) {

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -379,9 +379,6 @@ impl PhysicalExpr for BinaryExpr {
             return Ok(result);
         }
 
-        let left_data_type = lhs.data_type();
-        let right_data_type = rhs.data_type();
-
         // Check for short-circuit cases that need RHS value
         if let Some(result) = get_short_circuit_result(&lhs, &self.op, Some(rhs.clone()))
         {

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -846,10 +846,12 @@ fn get_short_circuit_result(
             match lhs {
                 ColumnarValue::Array(array) => {
                     if let Ok(array) = as_boolean_array(&array) {
-                        if array.false_count() == array.len() {
+                        // For AND, only short-circuit if ALL values are false and there are NO nulls
+                        if array.false_count() == array.len() && array.null_count() == 0 {
                             return Some(lhs.clone()); // all false → result is false
                         }
-                        if array.true_count() == array.len() {
+                        // Only short-circuit to RHS if ALL values are true and there are NO nulls
+                        if array.true_count() == array.len() && array.null_count() == 0 {
                             return rhs; // all true → just return RHS
                         }
                     }
@@ -870,10 +872,12 @@ fn get_short_circuit_result(
             match lhs {
                 ColumnarValue::Array(array) => {
                     if let Ok(array) = as_boolean_array(&array) {
-                        if array.true_count() == array.len() {
+                        // For OR, only short-circuit if ALL values are true and there are NO nulls
+                        if array.true_count() == array.len() && array.null_count() == 0 {
                             return Some(lhs.clone()); // all true → result is true
                         }
-                        if array.false_count() == array.len() {
+                        // Only short-circuit to RHS if ALL values are false and there are NO nulls
+                        if array.false_count() == array.len() && array.null_count() == 0 {
                             return rhs; // all false → just return RHS
                         }
                     }
@@ -2025,7 +2029,7 @@ mod tests {
                 Some(value),
                 Some(value - 1),
             ],
-            11,
+            10,
             0,
         ));
 

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -953,21 +953,21 @@ fn check_short_circuit<'a>(
 /// A combined ColumnarValue with values from right_result where left_result is true
 ///
 /// # Example
-///  Initial Data: [1, 2, 3, 4, 5]
+///  Initial Data: { 1, 2, 3, 4, 5 }
 ///  Left Evaluation
 ///     (Condition: Equal to 2 or 3)
 ///          ↓
-///  Filtered Data: [2, 3]
-///    Left Bitmap: [0, 1, 1, 0, 0]
+///  Filtered Data: {2, 3}
+///    Left Bitmap: { 0, 1, 1, 0, 0 }
 ///          ↓
 ///   Right Evaluation
 ///     (Condition: Even numbers)
 ///          ↓
-///  Right Data: [ 2 ]
-///    Right Bitmap: [1, 0]
+///  Right Data: { 2 }
+///    Right Bitmap: { 1, 0 }
 ///          ↓
 ///   Combine Results
-///  Final Bitmap: [0, 1, 0, 0, 0]
+///  Final Bitmap: { 0, 1, 0, 0, 0 }
 ///
 /// # Note
 /// Perhaps it would be better to modify `left_result` directly without creating a copy?

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -360,13 +360,23 @@ impl PhysicalExpr for BinaryExpr {
 
         let lhs = self.left.evaluate(batch)?;
 
+        // Optimize for short-circuiting `Operator::And` or `Operator::Or` operations and return early.
+        let strategy = get_short_circuit_strategy(&lhs, &self.op);
+        match strategy {
+            ShortCircuitStrategy::ReturnLeft => return Ok(lhs),
+            ShortCircuitStrategy::ReturnRight(value) => return Ok(value),
+            // Currently, we can't utilize the PreSelection strategy without changing the API
+            // but in the future we could add evaluate_selection to PhysicalExpr
+            ShortCircuitStrategy::PreSelection(_) | ShortCircuitStrategy::None => {
+                // Continue with existing logic
+                if let Some(result) = get_short_circuit_result(&lhs, &self.op, None) {
+                    return Ok(result);
+                }
+            }
+        }
+
         // Delay evaluating RHS unless we really need it
         let rhs_lazy = || self.right.evaluate(batch);
-
-        // Optimize for short-circuiting `Operator::And` or `Operator::Or` operations and return early.
-        if let Some(result) = get_short_circuit_result(&lhs, &self.op, None) {
-            return Ok(result);
-        }
 
         // Only evaluate RHS if short-circuit evaluation doesn't apply
         let rhs = rhs_lazy()?;

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -365,7 +365,8 @@ impl PhysicalExpr for BinaryExpr {
         match check_short_circuit(&lhs, &self.op) {
             ShortCircuitStrategy::ReturnLeft => return Ok(lhs),
             ShortCircuitStrategy::ReturnRight => {
-                return Ok(self.right.evaluate(batch)?)
+                let rhs = self.right.evaluate(batch)?;
+                return Ok(rhs);
             }
             ShortCircuitStrategy::None => {} // Continue if no short-circuit applies.
         }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -899,7 +899,7 @@ fn check_short_circuit<'a>(
                     }
 
                     // determine if we can pre-selection
-                    if (true_count / len) as f32 <= PRE_SELECTIO_THRESHOLD {
+                    if true_count as f32 / len as f32 <= PRE_SELECTIO_THRESHOLD {
                         return ShortCircuitStrategy::PreSelection(bool_array);
                     }
                 } else {

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -846,6 +846,11 @@ fn get_short_circuit_result(
     op: &Operator,
     rhs: Option<ColumnarValue>, // we pass RHS only if needed
 ) -> Option<ColumnarValue> {
+    // Only apply short-circuiting for logical operators And/Or.
+    if !matches!(op, Operator::And | Operator::Or) {
+        return None;
+    }
+
     println!(
         "==> Checking short-circuit: op={:?}, lhs_type={:?}, has_rhs={}",
         op,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15636

You can learn the reason behind this PR by reviewing the discussion in this issue: https://github.com/apache/datafusion/issues/15631#issuecomment-2798871646

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Many thanks to @kosiew for doing a tremendous amount of work. Based on his PR https://github.com/apache/datafusion/pull/15648, I have made the following changes:
1. Performance test cases have been added for "all false" in AND operations and "all true" in OR operations.
2. Reduce some unnecessary function calls: for instance, `false_count` and `true_count` can be unified as `values().count_set_bits()` in non-null cases, which would eliminate two calls to `nulls_count` and one call to `true_count`.
3. Add heuristic pre-selection under the `and` operation. For more details on the principle, you can refer to: https://github.com/apache/datafusion/issues/15631#issuecomment-2788923437.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->



Wonderful work done by kosiew: https://github.com/apache/datafusion/pull/15648

Discussion of the related issue for this PR: https://github.com/apache/datafusion/issues/15631#issuecomment-2798871646


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
