### PR TITLE
feat: Emit warning with Diagnostic when doing = Null

### DIFF
--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -94,14 +94,12 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 }) = *right
                                 {
                                     let left_span = match &*left {
-                                        SQLExpr::Identifier(Ident { span, .. }) => {
-                                            span.clone()
-                                        }
+                                        SQLExpr::Identifier(Ident { span, .. }) => *span,
                                         // In this case, we expect left to be
                                         // Indentifier. Just to make the code
                                         // more robust, we'll make left_span
                                         // equals to null_span otherwise.
-                                        _ => null_span.clone(),
+                                        _ => null_span,
                                     };
                                     let combined_span = Span {
                                         start: Into::into(left_span.start),

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 //! [`SqlToRel`]: SQL Query Planner (produces [`LogicalPlan`] from SQL AST)
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::vec;
@@ -337,6 +338,7 @@ pub struct SqlToRel<'a, S: ContextProvider> {
     pub(crate) context_provider: &'a S,
     pub(crate) options: ParserOptions,
     pub(crate) ident_normalizer: IdentNormalizer,
+    pub(crate) warnings: RefCell<Vec<Diagnostic>>,
 }
 
 impl<'a, S: ContextProvider> SqlToRel<'a, S> {
@@ -359,6 +361,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             context_provider,
             options,
             ident_normalizer: IdentNormalizer::new(ident_normalize),
+            warnings: RefCell::new(Vec::new()),
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #14434

## Rationale for this change

This PR addresses a common SQL anti-pattern where users accidentally use `= NULL` instead of `IS NULL`. While syntactically valid, this comparison always returns NULL in SQL and often indicates a developer mistake. The changes help users identify this pitfall through rich warnings while maintaining full query execution capabilities.

## What changes are included in this PR?

1. Added warning detection for `= NULL` comparisons in predicate contexts
2. Implemented span-based diagnostics highlighting the problematic expression
3. Enhanced SQL parser integration with upgraded sqlparser dependency (0.55+)
4. Warning collection plumbing using non-intrusive RefCell storage
5. Added help messages suggesting `IS NULL` alternative
6. Test coverage for single and multiple occurrences


## Are these changes tested?

Yes, this PR includes:

- Unit tests for single `= NULL` detection
- Validation of multiple warnings in complex expressions
- Span position verification
- Help message content checks

## Are there any user-facing changes?

Yes, but non-breaking. No API changes or behavior modifications - existing queries will still execute normally but may produce additional warnings.