### PR TITLE
feat: add multi level merge sort that will always fit in memory

### DIFF
--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -29,7 +29,7 @@ use crate::aggregates::{
 };
 use crate::metrics::{BaselineMetrics, MetricBuilder, RecordOutput};
 use crate::sorts::sort::sort_batch;
-use crate::sorts::streaming_merge::StreamingMergeBuilder;
+use crate::sorts::streaming_merge::{SortedSpillFile, StreamingMergeBuilder};
 use crate::spill::spill_manager::SpillManager;
 use crate::stream::RecordBatchStreamAdapter;
 use crate::{aggregates, metrics, ExecutionPlan, PhysicalExpr};
@@ -39,7 +39,6 @@ use arrow::array::*;
 use arrow::compute::SortOptions;
 use arrow::datatypes::SchemaRef;
 use datafusion_common::{internal_err, DataFusionError, Result};
-use datafusion_execution::disk_manager::RefCountedTempFile;
 use datafusion_execution::memory_pool::proxy::VecAllocExt;
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion_execution::TaskContext;
@@ -100,7 +99,7 @@ struct SpillState {
     // ========================================================================
     /// If data has previously been spilled, the locations of the
     /// spill files (in Arrow IPC format)
-    spills: Vec<RefCountedTempFile>,
+    spills: Vec<SortedSpillFile>,
 
     /// true when streaming merge is in progress
     is_stream_merging: bool,
@@ -999,13 +998,21 @@ impl GroupedHashAggregateStream {
         let sorted = sort_batch(&emit, self.spill_state.spill_expr.as_ref(), None)?;
 
         // Spill sorted state to disk
-        let spillfile = self.spill_state.spill_manager.spill_record_batch_by_size(
-            &sorted,
-            "HashAggSpill",
-            self.batch_size,
-        )?;
+        let spillfile = self
+            .spill_state
+            .spill_manager
+            .spill_record_batch_by_size_and_return_max_batch_memory(
+                &sorted,
+                "HashAggSpill",
+                self.batch_size,
+            )?;
         match spillfile {
-            Some(spillfile) => self.spill_state.spills.push(spillfile),
+            Some((spillfile, max_record_batch_memory)) => {
+                self.spill_state.spills.push(SortedSpillFile {
+                    file: spillfile,
+                    max_record_batch_memory,
+                })
+            }
             None => {
                 return internal_err!(
                     "Calling spill with no intermediate batch to spill"
@@ -1066,14 +1073,13 @@ impl GroupedHashAggregateStream {
                 sort_batch(&batch, expr.as_ref(), None)
             })),
         )));
-        for spill in self.spill_state.spills.drain(..) {
-            let stream = self.spill_state.spill_manager.read_spill_as_stream(spill)?;
-            streams.push(stream);
-        }
+
         self.spill_state.is_stream_merging = true;
         self.input = StreamingMergeBuilder::new()
             .with_streams(streams)
             .with_schema(schema)
+            .with_spill_manager(self.spill_state.spill_manager.clone())
+            .with_sorted_spill_files(std::mem::take(&mut self.spill_state.spills))
             .with_expressions(self.spill_state.spill_expr.as_ref())
             .with_metrics(self.baseline_metrics.clone())
             .with_batch_size(self.batch_size)

--- a/datafusion/physical-plan/src/sorts/mod.rs
+++ b/datafusion/physical-plan/src/sorts/mod.rs
@@ -20,6 +20,7 @@
 mod builder;
 mod cursor;
 mod merge;
+mod multi_level_merge;
 pub mod partial_sort;
 pub mod sort;
 pub mod sort_preserving_merge;

--- a/datafusion/physical-plan/src/sorts/multi_level_merge.rs
+++ b/datafusion/physical-plan/src/sorts/multi_level_merge.rs
@@ -1,0 +1,342 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Create a stream that do a multi level merge stream
+
+use crate::metrics::BaselineMetrics;
+use crate::{EmptyRecordBatchStream, SpillManager};
+use arrow::array::RecordBatch;
+use std::fmt::{Debug, Formatter};
+use std::mem;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::datatypes::SchemaRef;
+use datafusion_common::Result;
+use datafusion_execution::memory_pool::{
+    MemoryConsumer, MemoryPool, MemoryReservation, UnboundedMemoryPool,
+};
+
+use crate::sorts::streaming_merge::{SortedSpillFile, StreamingMergeBuilder};
+use crate::stream::RecordBatchStreamAdapter;
+use datafusion_execution::{RecordBatchStream, SendableRecordBatchStream};
+use datafusion_physical_expr_common::sort_expr::LexOrdering;
+use futures::TryStreamExt;
+use futures::{Stream, StreamExt};
+
+/// Merges a stream of sorted cursors and record batches into a single sorted stream
+pub(crate) struct MultiLevelMergeBuilder {
+    spill_manager: SpillManager,
+    schema: SchemaRef,
+    sorted_spill_files: Vec<SortedSpillFile>,
+    sorted_streams: Vec<SendableRecordBatchStream>,
+    expr: LexOrdering,
+    metrics: BaselineMetrics,
+    batch_size: usize,
+    reservation: MemoryReservation,
+    fetch: Option<usize>,
+    enable_round_robin_tie_breaker: bool,
+
+    // This is for avoiding double reservation of memory from our side and the sort preserving merge stream
+    // side.
+    // and doing a lot of code changes to avoid accounting for the memory used by the streams
+    unbounded_memory_pool: Arc<dyn MemoryPool>,
+}
+
+impl Debug for MultiLevelMergeBuilder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MultiLevelMergeBuilder")
+    }
+}
+
+impl MultiLevelMergeBuilder {
+    pub(crate) fn new(
+        spill_manager: SpillManager,
+        schema: SchemaRef,
+        sorted_spill_files: Vec<SortedSpillFile>,
+        sorted_streams: Vec<SendableRecordBatchStream>,
+        expr: LexOrdering,
+        metrics: BaselineMetrics,
+        batch_size: usize,
+        reservation: MemoryReservation,
+        fetch: Option<usize>,
+        enable_round_robin_tie_breaker: bool,
+    ) -> Self {
+        Self {
+            spill_manager,
+            schema,
+            sorted_spill_files,
+            sorted_streams,
+            expr,
+            metrics,
+            batch_size,
+            reservation,
+            enable_round_robin_tie_breaker,
+            fetch,
+            unbounded_memory_pool: Arc::new(UnboundedMemoryPool::default()),
+        }
+    }
+
+    pub(crate) fn create_spillable_merge_stream(self) -> SendableRecordBatchStream {
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            futures::stream::once(self.create_stream()).try_flatten(),
+        ))
+    }
+
+    async fn create_stream(mut self) -> Result<SendableRecordBatchStream> {
+        loop {
+            // Hold this for the lifetime of the stream
+            let mut current_memory_reservation = self.reservation.new_empty();
+            let mut stream =
+                self.create_sorted_stream(&mut current_memory_reservation)?;
+
+            // TODO - add a threshold for number of files to disk even if empty and reading from disk so
+            //        we can avoid the memory reservation
+
+            // If no spill files are left, we can return the stream as this is the last sorted run
+            // TODO - We can write to disk before reading it back to avoid having multiple streams in memory
+            if self.sorted_spill_files.is_empty() {
+                // Attach the memory reservation to the stream as we are done with it
+                // but because we replaced the memory reservation of the merge stream, we must hold
+                // this to make sure we have enough memory
+                return Ok(Box::pin(StreamAttachedReservation::new(
+                    stream,
+                    current_memory_reservation,
+                )));
+            }
+
+            // Need to sort to a spill file
+            let Some((spill_file, max_record_batch_memory)) = self
+                .spill_manager
+                .spill_record_batch_stream_by_size(
+                    &mut stream,
+                    self.batch_size,
+                    "MultiLevelMergeBuilder intermediate spill",
+                )
+                .await?
+            else {
+                continue;
+            };
+
+            // Add the spill file
+            self.sorted_spill_files.push(SortedSpillFile {
+                file: spill_file,
+                max_record_batch_memory,
+            });
+        }
+    }
+
+    fn create_sorted_stream(
+        &mut self,
+        memory_reservation: &mut MemoryReservation,
+    ) -> Result<SendableRecordBatchStream> {
+        match (self.sorted_spill_files.len(), self.sorted_streams.len()) {
+            // No data so empty batch
+            (0, 0) => Ok(Box::pin(EmptyRecordBatchStream::new(Arc::clone(
+                &self.schema,
+            )))),
+
+            // Only in-memory stream, return that
+            (0, 1) => Ok(self.sorted_streams.remove(0)),
+
+            // Only single sorted spill file so return it
+            (1, 0) => {
+                let spill_file = self.sorted_spill_files.remove(0);
+
+                self.spill_manager
+                    .read_spill_as_stream(spill_file.file)
+            }
+
+            // Only in memory streams, so merge them all in a single pass
+            (0, _) => {
+                let sorted_stream = mem::take(&mut self.sorted_streams);
+                self.create_new_merge_sort(
+                    sorted_stream,
+                    // If we have no sorted spill files left, this is the last run
+                    true,
+                )
+            }
+
+            // Need to merge multiple streams
+            (_, _) => {
+                // Don't account for existing streams memory
+                // as we are not holding the memory for them
+                let mut sorted_streams = mem::take(&mut self.sorted_streams);
+
+                let (sorted_spill_files, buffer_size) = self
+                    .get_sorted_spill_files_to_merge(
+                        2,
+                        // we must have at least 2 streams to merge
+                        2_usize.saturating_sub(sorted_streams.len()),
+                        memory_reservation,
+                    )?;
+
+                for spill in sorted_spill_files {
+                    let stream = self
+                        .spill_manager
+                        .clone()
+                        .with_batch_read_buffer_capacity(buffer_size)
+                        .read_spill_as_stream(spill.file)?;
+                    sorted_streams.push(stream);
+                }
+
+                self.create_new_merge_sort(
+                    sorted_streams,
+                    // If we have no sorted spill files left, this is the last run
+                    self.sorted_spill_files.is_empty(),
+                )
+            }
+        }
+    }
+
+    fn create_new_merge_sort(
+        &mut self,
+        streams: Vec<SendableRecordBatchStream>,
+        is_output: bool,
+    ) -> Result<SendableRecordBatchStream> {
+        StreamingMergeBuilder::new()
+            .with_schema(Arc::clone(&self.schema))
+            .with_expressions(&self.expr)
+            .with_batch_size(self.batch_size)
+            .with_fetch(self.fetch)
+            .with_metrics(if is_output {
+                // Only add the metrics to the last run
+                self.metrics.clone()
+            } else {
+                self.metrics.intermediate()
+            })
+            .with_round_robin_tie_breaker(self.enable_round_robin_tie_breaker)
+            .with_streams(streams)
+            // Don't track memory used by this stream as we reserve that memory by worst case sceneries
+            // (reserving memory for the biggest batch in each stream)
+            // This is a hack
+            .with_reservation(
+                MemoryConsumer::new("merge stream mock memory")
+                    .register(&self.unbounded_memory_pool),
+            )
+            .build()
+    }
+
+    /// Return the sorted spill files to use for the next phase, and the buffer size
+    /// This will try to get as many spill files as possible to merge, and if we don't have enough streams
+    /// it will try to reduce the buffer size until we have enough streams to merge
+    /// otherwise it will return an error
+    fn get_sorted_spill_files_to_merge(
+        &mut self,
+        buffer_size: usize,
+        minimum_number_of_required_streams: usize,
+        reservation: &mut MemoryReservation,
+    ) -> Result<(Vec<SortedSpillFile>, usize)> {
+        assert_ne!(buffer_size, 0, "Buffer size must be greater than 0");
+        let mut number_of_spills_to_read_for_current_phase = 0;
+
+        for spill in &self.sorted_spill_files {
+            // For memory pools that are not shared this is good, for other this is not
+            // and there should be some upper limit to memory reservation so we won't starve the system
+            match reservation.try_grow(spill.max_record_batch_memory * buffer_size) {
+                Ok(_) => {
+                    number_of_spills_to_read_for_current_phase += 1;
+                }
+                // If we can't grow the reservation, we need to stop
+                Err(err) => {
+                    // We must have at least 2 streams to merge, so if we don't have enough memory
+                    // fail
+                    if minimum_number_of_required_streams
+                        > number_of_spills_to_read_for_current_phase
+                    {
+                        // Free the memory we reserved for this merge as we either try again or fail
+                        reservation.free();
+                        if buffer_size > 1 {
+                            // Try again with smaller buffer size, it will be slower but at least we can merge
+                            return self.get_sorted_spill_files_to_merge(
+                                buffer_size - 1,
+                                minimum_number_of_required_streams,
+                                reservation,
+                            );
+                        }
+
+                        return Err(err);
+                    }
+
+                    // We reached the maximum amount of memory we can use
+                    // for this merge
+                    break;
+                }
+            }
+        }
+
+        let spills = self
+            .sorted_spill_files
+            .drain(..number_of_spills_to_read_for_current_phase)
+            .collect::<Vec<_>>();
+
+        Ok((spills, buffer_size))
+    }
+}
+
+struct StreamAttachedReservation {
+    stream: SendableRecordBatchStream,
+    reservation: MemoryReservation,
+}
+
+impl StreamAttachedReservation {
+    fn new(stream: SendableRecordBatchStream, reservation: MemoryReservation) -> Self {
+        Self {
+            stream,
+            reservation,
+        }
+    }
+}
+
+impl Stream for StreamAttachedReservation {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let res = self.stream.poll_next_unpin(cx);
+
+        match res {
+            Poll::Ready(res) => {
+                match res {
+                    Some(Ok(batch)) => Poll::Ready(Some(Ok(batch))),
+                    Some(Err(err)) => {
+                        // Had an error so drop the data
+                        self.reservation.free();
+                        Poll::Ready(Some(Err(err)))
+                    }
+                    None => {
+                        // Stream is done so free the memory
+                        self.reservation.free();
+
+                        Poll::Ready(None)
+                    }
+                }
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl RecordBatchStream for StreamAttachedReservation {
+    fn schema(&self) -> SchemaRef {
+        self.stream.schema()
+    }
+}

--- a/datafusion/physical-plan/src/spill/get_size.rs
+++ b/datafusion/physical-plan/src/spill/get_size.rs
@@ -1,0 +1,199 @@
+use arrow::array::{
+    Array, ArrayRef, ArrowPrimitiveType, BooleanArray, FixedSizeBinaryArray,
+    FixedSizeListArray, GenericByteArray, GenericListArray, OffsetSizeTrait,
+    PrimitiveArray, RecordBatch, StructArray,
+};
+use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer};
+use arrow::datatypes::{ArrowNativeType, ByteArrayType};
+use arrow::downcast_primitive_array;
+use arrow_schema::DataType;
+
+/// TODO - NEED TO MOVE THIS TO ARROW
+///        this is needed as unlike `get_buffer_memory_size` or `get_array_memory_size`
+///        or even `get_record_batch_memory_size` calling it on a batch before writing to spill and after reading it back
+///        will return the same size (minus some optimization that IPC writer does for dictionaries)
+///
+pub trait GetActualSize {
+    fn get_actually_used_size(&self) -> usize;
+}
+
+impl GetActualSize for RecordBatch {
+    fn get_actually_used_size(&self) -> usize {
+        self.columns()
+            .iter()
+            .map(|c| c.get_actually_used_size())
+            .sum()
+    }
+}
+
+pub trait GetActualSizeArray: Array {
+    fn get_actually_used_size(&self) -> usize {
+        self.get_buffer_memory_size()
+    }
+}
+
+impl GetActualSize for dyn Array {
+    fn get_actually_used_size(&self) -> usize {
+        use arrow::array::AsArray;
+        let array = self;
+
+        // we can avoid this is we move this trait function to be in arrow
+        downcast_primitive_array!(
+            array => {
+                array.get_actually_used_size()
+            },
+            DataType::Utf8 => {
+                array.as_string::<i32>().get_actually_used_size()
+            },
+            DataType::LargeUtf8 => {
+                array.as_string::<i64>().get_actually_used_size()
+            },
+            DataType::Binary => {
+                array.as_binary::<i32>().get_actually_used_size()
+            },
+            DataType::LargeBinary => {
+                array.as_binary::<i64>().get_actually_used_size()
+            },
+            DataType::FixedSizeBinary(_) => {
+                array.as_fixed_size_binary().get_actually_used_size()
+            },
+            DataType::Struct(_) => {
+                array.as_struct().get_actually_used_size()
+            },
+            DataType::List(_) => {
+                array.as_list::<i32>().get_actually_used_size()
+            },
+            DataType::LargeList(_) => {
+                array.as_list::<i64>().get_actually_used_size()
+            },
+            DataType::FixedSizeList(_, _) => {
+                array.as_fixed_size_list().get_actually_used_size()
+            },
+            DataType::Boolean => {
+                array.as_boolean().get_actually_used_size()
+            },
+
+            _ => {
+                array.get_buffer_memory_size()
+            }
+        )
+    }
+}
+
+impl GetActualSizeArray for ArrayRef {
+    fn get_actually_used_size(&self) -> usize {
+        self.as_ref().get_actually_used_size()
+    }
+}
+
+impl GetActualSize for Option<&NullBuffer> {
+    fn get_actually_used_size(&self) -> usize {
+        self.map(|b| b.get_actually_used_size()).unwrap_or(0)
+    }
+}
+
+impl GetActualSize for NullBuffer {
+    fn get_actually_used_size(&self) -> usize {
+        // len return in bits
+        self.len() / 8
+    }
+}
+impl GetActualSize for Buffer {
+    fn get_actually_used_size(&self) -> usize {
+        self.len()
+    }
+}
+
+impl GetActualSize for BooleanBuffer {
+    fn get_actually_used_size(&self) -> usize {
+        // len return in bits
+        self.len() / 8
+    }
+}
+
+impl<O: ArrowNativeType> GetActualSize for OffsetBuffer<O> {
+    fn get_actually_used_size(&self) -> usize {
+        self.inner().inner().get_actually_used_size()
+    }
+}
+
+impl GetActualSizeArray for BooleanArray {
+    fn get_actually_used_size(&self) -> usize {
+        let null_size = self.nulls().get_actually_used_size();
+        let values_size = self.values().get_actually_used_size();
+        null_size + values_size
+    }
+}
+
+impl<T: ByteArrayType> GetActualSizeArray for GenericByteArray<T> {
+    fn get_actually_used_size(&self) -> usize {
+        let null_size = self.nulls().get_actually_used_size();
+        let offsets_size = self.offsets().get_actually_used_size();
+
+        let values_size = {
+            let first_offset = self.value_offsets()[0].as_usize();
+            let last_offset = self.value_offsets()[self.len()].as_usize();
+            last_offset - first_offset
+        };
+        null_size + offsets_size + values_size
+    }
+}
+
+impl GetActualSizeArray for FixedSizeBinaryArray {
+    fn get_actually_used_size(&self) -> usize {
+        let null_size = self.nulls().get_actually_used_size();
+        let values_size = self.value_length() as usize * self.len();
+
+        null_size + values_size
+    }
+}
+
+impl<T: ArrowPrimitiveType> GetActualSizeArray for PrimitiveArray<T> {
+    fn get_actually_used_size(&self) -> usize {
+        let null_size = self.nulls().get_actually_used_size();
+        let values_size = self.values().inner().get_actually_used_size();
+
+        null_size + values_size
+    }
+}
+
+impl<O: OffsetSizeTrait> GetActualSizeArray for GenericListArray<O> {
+    fn get_actually_used_size(&self) -> usize {
+        let null_size = self.nulls().get_actually_used_size();
+        let offsets_size = self.offsets().get_actually_used_size();
+
+        let values_size = {
+            let first_offset = self.value_offsets()[0].as_usize();
+            let last_offset = self.value_offsets()[self.len()].as_usize();
+
+            self.values()
+                .slice(first_offset, last_offset - first_offset)
+                .get_actually_used_size()
+        };
+        null_size + offsets_size + values_size
+    }
+}
+
+impl GetActualSizeArray for FixedSizeListArray {
+    fn get_actually_used_size(&self) -> usize {
+        let null_size = self.nulls().get_actually_used_size();
+        let values_size = self.values().get_actually_used_size();
+
+        null_size + values_size
+    }
+}
+
+impl GetActualSizeArray for StructArray {
+    fn get_actually_used_size(&self) -> usize {
+        let null_size = self.nulls().get_actually_used_size();
+        let values_size = self
+            .columns()
+            .iter()
+            .map(|array| array.get_actually_used_size())
+            .sum::<usize>();
+
+        null_size + values_size
+    }
+}
+
+// TODO - need to add to more arrays

--- a/datafusion/physical-plan/src/spill/mod.rs
+++ b/datafusion/physical-plan/src/spill/mod.rs
@@ -17,6 +17,7 @@
 
 //! Defines the spilling functions
 
+pub(crate) mod get_size;
 pub(crate) mod in_progress_spill_file;
 pub(crate) mod spill_manager;
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #14692.

## Rationale for this change
We need merge sort that does not fail with out of memory

## What changes are included in this PR?

Implemented multi level merge sort on top of `SortPreservingMergeStream` that spill intermediate result when not enough memory.

**How does it work:**

When using the `MultiLevelMerge` you provide in memory streams and spill files,
each spill file contain the memory size of the record batch with the largest memory consumption.

**Why is this important?**

`SortPreservingMergeStream` uses [`BatchBuilder`](https://github.com/apache/datafusion/blob/172cf8d8700dfcb62015f567e56e0bff27926812/datafusion/physical-plan/src/sorts/builder.rs) which grow and shrink memory based on the record batches that it get. however if there is not enough memory it will just fail.

this solution will reserve beforehand for each spill file the worst case scenerio for the record batch size so there will be no way that there is not enough memory mid sorting.

it will also try to reduce buffer size and number of streams to the minimum when there is not enough memory and will only fail if there is not enough memory for holding 2 record batches with no buffering in the stream 


It can also be easily adjusted to allow for predefined maximum memory to merge stream 

## Are these changes tested?

Existing tests

## Are there any user-facing changes?

not really

------

Related to #15610