### PR TITLE
tests: only refresh the minimum sysinfo in mem limit tests.

### DIFF
--- a/datafusion/core/tests/memory_limit/memory_limit_validation/utils.rs
+++ b/datafusion/core/tests/memory_limit/memory_limit_validation/utils.rs
@@ -18,7 +18,7 @@
 use datafusion_common_runtime::SpawnedTask;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use sysinfo::System;
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
 use tokio::time::{interval, Duration};
 
 use datafusion::prelude::{SessionConfig, SessionContext};
@@ -62,7 +62,11 @@ where
 
         loop {
             interval.tick().await;
-            sys.refresh_all();
+            sys.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[pid]),
+                true,
+                ProcessRefreshKind::nothing().with_memory(),
+            );
             if let Some(process) = sys.process(pid) {
                 let rss_bytes = process.memory();
                 max_rss_clone
@@ -116,8 +120,8 @@ where
 /// # Example
 ///
 ///     utils::validate_query_with_memory_limits(
-///         40_000_000 * 2,                   
-///         Some(40_000_000),              
+///         40_000_000 * 2,
+///         Some(40_000_000),
 ///         "SELECT * FROM generate_series(1, 100000000) AS t(i) ORDER BY i",
 ///         "SELECT * FROM generate_series(1, 10000000) AS t(i) ORDER BY i"
 ///     );


### PR DESCRIPTION
## Rationale for this change

Currently the memory limit tests hang due to lock contention and the overhead from frequently calling `sysinfo::System::refresh_all()` in the memory monitoring task. 

In fact, we don't really need to refresh all info, it's enough to just get the memory data about the current process, which significantly reduces the refresh time and the tests finish quickly.

## What changes are included in this PR?

In the memory limit utils, the memory monitoring spawned task now refreshes system info only for what's actually necessary.

## Are these changes tested?

It's part of the tests, and they seem to not hang anymore :)

## Are there any user-facing changes?

No