### PR TITLE
ci: fix workflow triggering extended tests from pr comments.

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -47,7 +47,7 @@ on:
 permissions:
   contents: read
   checks: write
-      
+
 jobs:
 
   # Check crate compiles and base cargo check passes
@@ -58,6 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.pr_head_sha }} # will be empty if triggered by push
           submodules: true
           fetch-depth: 1
       - name: Install Rust
@@ -81,6 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.pr_head_sha }} # will be empty if triggered by push
           submodules: true
           fetch-depth: 1
       - name: Free Disk Space (Ubuntu)
@@ -114,6 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.pr_head_sha }} # will be empty if triggered by push
           submodules: true
           fetch-depth: 1
       - name: Setup Rust toolchain
@@ -134,6 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.pr_head_sha }} # will be empty if triggered by push
           submodules: true
           fetch-depth: 1
       - name: Setup Rust toolchain
@@ -161,14 +165,14 @@ jobs:
             echo "workflow_status=completed" >> $GITHUB_OUTPUT
             echo "conclusion=success" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: Update check run
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            
+
             await github.rest.checks.update({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr_comment_commands.yml
+++ b/.github/workflows/pr_comment_commands.yml
@@ -44,12 +44,12 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: context.payload.issue.number
             });
-            
+
             // Extract the branch name
             const branchName = pullRequest.head.ref;
             const headSha = pullRequest.head.sha;
             const workflowRunsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions?query=workflow%3A%22Datafusion+extended+tests%22+branch%3A${branchName}`;
-            
+
             // Create a check run that links to the Actions tab so the run will be visible in GitHub UI
             const check = await github.rest.checks.create({
               owner: context.repo.owner,
@@ -69,7 +69,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'extended.yml',
-              ref: branchName,
+              ref: 'main',
               inputs: {
                 pr_number: context.payload.issue.number.toString(),
                 check_run_id: check.data.id.toString(),
@@ -77,7 +77,7 @@ jobs:
               }
             });
 
-      - name: Add reaction to comment 
+      - name: Add reaction to comment
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Rationale for this change

Triggering extended tests failed here: https://github.com/apache/datafusion/actions/runs/14439917392

For creating a workflow with workflow_dispatch, you can't specify a branch name in another repo as the ref.
Instead you need a local branch name and to send which PR to checkout as a parameter.

It sucks a bit that in the Actions list it looks like a test on `main`, but I'm not sure there's a better alternative.

## Are these changes tested?

Here's the trigger working in https://github.com/ashdnazg/datafusion/pull/1 with the correct hash being used: https://github.com/ashdnazg/datafusion/actions/runs/14443854280/job/40499839662#step:2:3
Here's the test working as usual on push to main: https://github.com/ashdnazg/datafusion/actions/runs/14443836470/job/40499776589#step:2:2

## Are there any user-facing changes?

No