### PR TITLE
Make tree the Default EXPLAIN Format and Reorder Documentation Sections

### DIFF
--- a/docs/source/user-guide/sql/explain.md
+++ b/docs/source/user-guide/sql/explain.md
@@ -39,39 +39,7 @@ the format from the [configuration value] `datafusion.explain.format`.
 
 [configuration value]: ../configs.md
 
-### `indent` format (default)
-
-The `indent` format shows both the logical and physical plan, with one line for
-each operator in the plan. Child plans are indented to show the hierarchy.
-
-See [Reading Explain Plans](../explain-usage.md) for more information on how to interpret these plans.
-
-```sql
-> CREATE TABLE t(x int, b int) AS VALUES (1, 2), (2, 3);
-0 row(s) fetched.
-Elapsed 0.004 seconds.
-
-> EXPLAIN SELECT SUM(x) FROM t GROUP BY b;
-+---------------+-------------------------------------------------------------------------------+
-| plan_type     | plan                                                                          |
-+---------------+-------------------------------------------------------------------------------+
-| logical_plan  | Projection: sum(t.x)                                                          |
-|               |   Aggregate: groupBy=[[t.b]], aggr=[[sum(CAST(t.x AS Int64))]]                |
-|               |     TableScan: t projection=[x, b]                                            |
-| physical_plan | ProjectionExec: expr=[sum(t.x)@1 as sum(t.x)]                                 |
-|               |   AggregateExec: mode=FinalPartitioned, gby=[b@0 as b], aggr=[sum(t.x)]       |
-|               |     CoalesceBatchesExec: target_batch_size=8192                               |
-|               |       RepartitionExec: partitioning=Hash([b@0], 16), input_partitions=16      |
-|               |         RepartitionExec: partitioning=RoundRobinBatch(16), input_partitions=1 |
-|               |           AggregateExec: mode=Partial, gby=[b@1 as b], aggr=[sum(t.x)]        |
-|               |             DataSourceExec: partitions=1, partition_sizes=[1]                 |
-|               |                                                                               |
-+---------------+-------------------------------------------------------------------------------+
-2 row(s) fetched.
-Elapsed 0.004 seconds.
-```
-
-### `tree` format
+### `tree` format (default)
 
 The `tree` format is modeled after [DuckDB plans] and is designed to be easier
 to see the high level structure of the plan
@@ -136,6 +104,38 @@ to see the high level structure of the plan
 +---------------+-------------------------------+
 1 row(s) fetched.
 Elapsed 0.016 seconds.
+```
+
+### `indent` format
+
+The `indent` format shows both the logical and physical plan, with one line for
+each operator in the plan. Child plans are indented to show the hierarchy.
+
+See [Reading Explain Plans](../explain-usage.md) for more information on how to interpret these plans.
+
+```sql
+> CREATE TABLE t(x int, b int) AS VALUES (1, 2), (2, 3);
+0 row(s) fetched.
+Elapsed 0.004 seconds.
+
+> EXPLAIN SELECT SUM(x) FROM t GROUP BY b;
++---------------+-------------------------------------------------------------------------------+
+| plan_type     | plan                                                                          |
++---------------+-------------------------------------------------------------------------------+
+| logical_plan  | Projection: sum(t.x)                                                          |
+|               |   Aggregate: groupBy=[[t.b]], aggr=[[sum(CAST(t.x AS Int64))]]                |
+|               |     TableScan: t projection=[x, b]                                            |
+| physical_plan | ProjectionExec: expr=[sum(t.x)@1 as sum(t.x)]                                 |
+|               |   AggregateExec: mode=FinalPartitioned, gby=[b@0 as b], aggr=[sum(t.x)]       |
+|               |     CoalesceBatchesExec: target_batch_size=8192                               |
+|               |       RepartitionExec: partitioning=Hash([b@0], 16), input_partitions=16      |
+|               |         RepartitionExec: partitioning=RoundRobinBatch(16), input_partitions=1 |
+|               |           AggregateExec: mode=Partial, gby=[b@1 as b], aggr=[sum(t.x)]        |
+|               |             DataSourceExec: partitions=1, partition_sizes=[1]                 |
+|               |                                                                               |
++---------------+-------------------------------------------------------------------------------+
+2 row(s) fetched.
+Elapsed 0.004 seconds.
 ```
 
 ### `pgjson` format


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #15705 

## Rationale for this change

#15427 changed the default EXPLAIN format to `tree`.

This PR updates the EXPLAIN documentation to reflect that the `tree` format is now the default, instead of `indent`. This reordering ensures that users see the format that matches actual output first, improving clarity and user experience when reading or debugging EXPLAIN plans.

## What changes are included in this PR?

- Changed section heading to state that `tree` is the default format.
- Moved the `tree` format section above the `indent` format section for logical flow.
- No functional changes—documentation update only.

## Are these changes tested?

Not applicable. These are documentation-only changes and do not impact functionality.

## Are there any user-facing changes?

Yes. The documentation now:
- Reflects the `tree` format as the default EXPLAIN output.
- Presents the `tree` format example first for easier reference.
- Improves readability and accuracy of the EXPLAIN format guide.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
