### PR TITLE
test: add fuzz test for doing aggregation with larger than memory groups

### DIFF
--- a/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
@@ -766,31 +766,31 @@ async fn test_high_cardinality_with_limited_memory() -> Result<()> {
     let task_ctx = {
         let memory_pool = Arc::new(FairSpillPool::new(two_mb));
         TaskContext::default()
-          .with_session_config(SessionConfig::new().with_batch_size(record_batch_size))
-          .with_runtime(Arc::new(
-              RuntimeEnvBuilder::new()
-                .with_memory_pool(memory_pool)
-                .build()?,
-          ))
+            .with_session_config(SessionConfig::new().with_batch_size(record_batch_size))
+            .with_runtime(Arc::new(
+                RuntimeEnvBuilder::new()
+                    .with_memory_pool(memory_pool)
+                    .build()?,
+            ))
     };
 
     run_test_high_cardinality(task_ctx, 100, |_| (16 * KB) as usize).await
 }
 
-
 #[tokio::test]
-async fn test_high_cardinality_with_limited_memory_and_different_sizes_of_record_batch() -> Result<()> {
+async fn test_high_cardinality_with_limited_memory_and_different_sizes_of_record_batch(
+) -> Result<()> {
     let record_batch_size = 8192;
     let two_mb = 2 * MB as usize;
     let task_ctx = {
         let memory_pool = Arc::new(FairSpillPool::new(two_mb));
         TaskContext::default()
-          .with_session_config(SessionConfig::new().with_batch_size(record_batch_size))
-          .with_runtime(Arc::new(
-              RuntimeEnvBuilder::new()
-                .with_memory_pool(memory_pool)
-                .build()?,
-          ))
+            .with_session_config(SessionConfig::new().with_batch_size(record_batch_size))
+            .with_runtime(Arc::new(
+                RuntimeEnvBuilder::new()
+                    .with_memory_pool(memory_pool)
+                    .build()?,
+            ))
     };
 
     run_test_high_cardinality(task_ctx, 100, |i| {
@@ -799,22 +799,24 @@ async fn test_high_cardinality_with_limited_memory_and_different_sizes_of_record
         } else {
             (16 * KB) as usize
         }
-    }).await
+    })
+    .await
 }
 
 #[tokio::test]
-async fn test_high_cardinality_with_limited_memory_and_large_record_batch() -> Result<()> {
+async fn test_high_cardinality_with_limited_memory_and_large_record_batch() -> Result<()>
+{
     let record_batch_size = 8192;
     let two_mb = 2 * MB as usize;
     let task_ctx = {
         let memory_pool = Arc::new(FairSpillPool::new(two_mb));
         TaskContext::default()
-          .with_session_config(SessionConfig::new().with_batch_size(record_batch_size))
-          .with_runtime(Arc::new(
-              RuntimeEnvBuilder::new()
-                .with_memory_pool(memory_pool)
-                .build()?,
-          ))
+            .with_session_config(SessionConfig::new().with_batch_size(record_batch_size))
+            .with_runtime(Arc::new(
+                RuntimeEnvBuilder::new()
+                    .with_memory_pool(memory_pool)
+                    .build()?,
+            ))
     };
     run_test_high_cardinality(task_ctx, 100, |_| two_mb / 5).await
 }
@@ -852,10 +854,14 @@ async fn run_test_high_cardinality(
             Arc::clone(&schema),
             futures::stream::iter((0..number_of_record_batches as u64).map(
                 move |index| {
-                    let mut record_batch_memory_size = get_size_of_record_batch_to_generate(index as usize);
-                    record_batch_memory_size = record_batch_memory_size.saturating_sub(size_of::<UInt64Type::Native>() * record_batch_memory_size);
+                    let mut record_batch_memory_size =
+                        get_size_of_record_batch_to_generate(index as usize);
+                    record_batch_memory_size = record_batch_memory_size.saturating_sub(
+                        size_of::<UInt64Type::Native>() * record_batch_memory_size,
+                    );
 
-                    let string_item_size = record_batch_memory_size / record_batch_size as usize;
+                    let string_item_size =
+                        record_batch_memory_size / record_batch_size as usize;
                     let string_array = Arc::new(StringArray::from_iter_values(
                         (0..record_batch_size).map(|_| "a".repeat(string_item_size)),
                     ));

--- a/datafusion/core/tests/fuzz_cases/mod.rs
+++ b/datafusion/core/tests/fuzz_cases/mod.rs
@@ -33,3 +33,4 @@ mod window_fuzz;
 
 // Utility modules
 mod record_batch_generator;
+mod stream_exec;

--- a/datafusion/core/tests/fuzz_cases/stream_exec.rs
+++ b/datafusion/core/tests/fuzz_cases/stream_exec.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use arrow_schema::SchemaRef;
 use datafusion_common::DataFusionError;
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
@@ -10,7 +27,8 @@ use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
 
-/// Execution plan that return the stream on the call to `execute`.
+/// Execution plan that return the stream on the call to `execute`. further calls to `execute` will
+/// return an error
 pub struct StreamExec {
     /// the results to send back
     stream: Mutex<Option<SendableRecordBatchStream>>,
@@ -24,13 +42,6 @@ impl Debug for StreamExec {
 }
 
 impl StreamExec {
-    /// Create a new `MockExec` with a single partition that returns
-    /// the specified `Results`s.
-    ///
-    /// By default, the batches are not produced immediately (the
-    /// caller has to actually yield and another task must run) to
-    /// ensure any poll loops are correct. This behavior can be
-    /// changed with `with_use_task`
     pub fn new(stream: SendableRecordBatchStream) -> Self {
         let cache = Self::compute_properties(stream.schema());
         Self {

--- a/datafusion/core/tests/fuzz_cases/stream_exec.rs
+++ b/datafusion/core/tests/fuzz_cases/stream_exec.rs
@@ -1,0 +1,104 @@
+use arrow_schema::SchemaRef;
+use datafusion_common::DataFusionError;
+use datafusion_execution::{SendableRecordBatchStream, TaskContext};
+use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion_physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+};
+use std::any::Any;
+use std::fmt::{Debug, Formatter};
+use std::sync::{Arc, Mutex};
+
+/// Execution plan that return the stream on the call to `execute`.
+pub struct StreamExec {
+    /// the results to send back
+    stream: Mutex<Option<SendableRecordBatchStream>>,
+    cache: PlanProperties,
+}
+
+impl Debug for StreamExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "StreamExec")
+    }
+}
+
+impl StreamExec {
+    /// Create a new `MockExec` with a single partition that returns
+    /// the specified `Results`s.
+    ///
+    /// By default, the batches are not produced immediately (the
+    /// caller has to actually yield and another task must run) to
+    /// ensure any poll loops are correct. This behavior can be
+    /// changed with `with_use_task`
+    pub fn new(stream: SendableRecordBatchStream) -> Self {
+        let cache = Self::compute_properties(stream.schema());
+        Self {
+            stream: Mutex::new(Some(stream)),
+            cache,
+        }
+    }
+
+    /// This function creates the cache object that stores the plan properties such as schema, equivalence properties, ordering, partitioning, etc.
+    fn compute_properties(schema: SchemaRef) -> PlanProperties {
+        PlanProperties::new(
+            EquivalenceProperties::new(schema),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        )
+    }
+}
+
+impl DisplayAs for StreamExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "StreamExec:")
+            }
+            DisplayFormatType::TreeRender => {
+                write!(f, "")
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for StreamExec {
+    fn name(&self) -> &'static str {
+        Self::static_name()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        unimplemented!()
+    }
+
+    /// Returns a stream which yields data
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion_common::Result<SendableRecordBatchStream> {
+        assert_eq!(partition, 0);
+
+        let stream = self.stream.lock().unwrap().take();
+
+        stream.ok_or(DataFusionError::Internal(
+            "Stream already consumed".to_string(),
+        ))
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Adding failing tests to show the current problem with aggregation when there is a need for spilling and we can't hold all of the record batches in memory and tests to make sure that the implementation is dynamic based on the available memory

## What changes are included in this PR?

Added 3 fuzz tests

## Are these changes tested?

Yes, but they all fail currently

## Are there any user-facing changes?
No


----

Requested by @alamb in https://github.com/apache/datafusion/issues/15610#issuecomment-2807165302