### PR TITLE
Improve `simplify_expressions` rule

### DIFF
--- a/datafusion/core/tests/expr_api/simplification.rs
+++ b/datafusion/core/tests/expr_api/simplification.rs
@@ -547,9 +547,9 @@ fn test_simplify_with_cycle_count(
     };
     let simplifier = ExprSimplifier::new(info);
     let (simplified_expr, count) = simplifier
-        .simplify_with_cycle_count(input_expr.clone())
+        .simplify_with_cycle_count_transformed(input_expr.clone())
         .expect("successfully evaluated");
-
+    let simplified_expr = simplified_expr.data;
     assert_eq!(
         simplified_expr, expected_expr,
         "Mismatch evaluating {input_expr}\n  Expected:{expected_expr}\n  Got:{simplified_expr}"

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -188,7 +188,7 @@ impl<S: SimplifyInfo> ExprSimplifier<S> {
     /// assert_eq!(expr, b_lt_2);
     /// ```
     pub fn simplify(&self, expr: Expr) -> Result<Expr> {
-        Ok(self.simplify_with_cycle_count(expr)?.0)
+        Ok(self.simplify_with_cycle_count_transformed(expr)?.0.data)
     }
 
     /// Like [Self::simplify], simplifies this [`Expr`] as much as possible, evaluating
@@ -198,6 +198,7 @@ impl<S: SimplifyInfo> ExprSimplifier<S> {
     ///
     /// See [Self::simplify] for details and usage examples.
     ///
+    #[deprecated(since = "48.0.0", note = "")]
     pub fn simplify_with_cycle_count(&self, mut expr: Expr) -> Result<(Expr, u32)> {
         let mut simplifier = Simplifier::new(&self.info);
         let mut const_evaluator = ConstEvaluator::try_new(self.info.execution_props())?;
@@ -228,6 +229,60 @@ impl<S: SimplifyInfo> ExprSimplifier<S> {
         // shorten inlist should be started after other inlist rules are applied
         expr = expr.rewrite(&mut shorten_in_list_simplifier).data()?;
         Ok((expr, num_cycles))
+    }
+
+    /// Like [Self::simplify], simplifies this [`Expr`] as much as possible, evaluating
+    /// constants and applying algebraic simplifications. Additionally returns a `u32`
+    /// representing the number of simplification cycles performed, which can be useful for testing
+    /// optimizations.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing:
+    /// - The simplified expression wrapped in a `Transformed<Expr>` indicating if changes were made
+    /// - The number of simplification cycles that were performed
+    ///
+    /// See [Self::simplify] for details and usage examples.
+    ///
+    pub fn simplify_with_cycle_count_transformed(
+        &self,
+        mut expr: Expr,
+    ) -> Result<(Transformed<Expr>, u32)> {
+        let mut simplifier = Simplifier::new(&self.info);
+        let mut const_evaluator = ConstEvaluator::try_new(self.info.execution_props())?;
+        let mut shorten_in_list_simplifier = ShortenInListSimplifier::new();
+        let mut guarantee_rewriter = GuaranteeRewriter::new(&self.guarantees);
+
+        if self.canonicalize {
+            expr = expr.rewrite(&mut Canonicalizer::new()).data()?
+        }
+
+        // Evaluating constants can enable new simplifications and
+        // simplifications can enable new constant evaluation
+        // see `Self::with_max_cycles`
+        let mut num_cycles = 0;
+        let mut has_transformed = false;
+        loop {
+            let Transformed {
+                data, transformed, ..
+            } = expr
+                .rewrite(&mut const_evaluator)?
+                .transform_data(|expr| expr.rewrite(&mut simplifier))?
+                .transform_data(|expr| expr.rewrite(&mut guarantee_rewriter))?;
+            expr = data;
+            num_cycles += 1;
+            // Track if any transformation occurred
+            has_transformed = has_transformed || transformed;
+            if !transformed || num_cycles >= self.max_simplifier_cycles {
+                break;
+            }
+        }
+        // shorten inlist should be started after other inlist rules are applied
+        expr = expr.rewrite(&mut shorten_in_list_simplifier).data()?;
+        Ok((
+            Transformed::new_transformed(expr, has_transformed),
+            num_cycles,
+        ))
     }
 
     /// Apply type coercion to an [`Expr`] so that it can be
@@ -392,15 +447,15 @@ impl<S: SimplifyInfo> ExprSimplifier<S> {
     /// let expr = col("a").is_not_null();
     ///
     /// // When using default maximum cycles, 2 cycles will be performed.
-    /// let (simplified_expr, count) = simplifier.simplify_with_cycle_count(expr.clone()).unwrap();
-    /// assert_eq!(simplified_expr, lit(true));
+    /// let (simplified_expr, count) = simplifier.simplify_with_cycle_count_transformed(expr.clone()).unwrap();
+    /// assert_eq!(simplified_expr.data, lit(true));
     /// // 2 cycles were executed, but only 1 was needed
     /// assert_eq!(count, 2);
     ///
     /// // Only 1 simplification pass is necessary here, so we can set the maximum cycles to 1.
-    /// let (simplified_expr, count) = simplifier.with_max_cycles(1).simplify_with_cycle_count(expr.clone()).unwrap();
+    /// let (simplified_expr, count) = simplifier.with_max_cycles(1).simplify_with_cycle_count_transformed(expr.clone()).unwrap();
     /// // Expression has been rewritten to: (c = a AND b = 1)
-    /// assert_eq!(simplified_expr, lit(true));
+    /// assert_eq!(simplified_expr.data, lit(true));
     /// // Only 1 cycle was executed
     /// assert_eq!(count, 1);
     ///
@@ -3320,7 +3375,8 @@ mod tests {
         let simplifier = ExprSimplifier::new(
             SimplifyContext::new(&execution_props).with_schema(schema),
         );
-        simplifier.simplify_with_cycle_count(expr)
+        let (expr, count) = simplifier.simplify_with_cycle_count_transformed(expr)?;
+        Ok((expr.data, count))
     }
 
     fn simplify_with_cycle_count(expr: Expr) -> (Expr, u32) {

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -123,10 +123,14 @@ impl SimplifyExpressions {
         let name_preserver = NamePreserver::new(&plan);
         let mut rewrite_expr = |expr: Expr| {
             let name = name_preserver.save(&expr);
+            let original = expr.clone();
             let expr = simplifier.simplify(expr)?;
-            // TODO it would be nice to have a way to know if the expression was simplified
-            // or not. For now conservatively return Transformed::yes
-            Ok(Transformed::yes(name.restore(expr)))
+            let transformed = if original == expr {
+                Transformed::no(original)
+            } else {
+                Transformed::yes(name.restore(expr))
+            };
+            Ok(transformed)
         };
 
         plan.map_expressions(|expr| {

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -123,14 +123,11 @@ impl SimplifyExpressions {
         let name_preserver = NamePreserver::new(&plan);
         let mut rewrite_expr = |expr: Expr| {
             let name = name_preserver.save(&expr);
-            let original = expr.clone();
-            let expr = simplifier.simplify(expr)?;
-            let transformed = if original == expr {
-                Transformed::no(original)
-            } else {
-                Transformed::yes(name.restore(expr))
-            };
-            Ok(transformed)
+            let expr = simplifier.simplify_with_cycle_count_transformed(expr)?.0;
+            Ok(Transformed::new_transformed(
+                name.restore(expr.data),
+                expr.transformed,
+            ))
         };
 
         plan.map_expressions(|expr| {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Before:
```
[2025-04-16T10:30:23Z DEBUG datafusion_optimizer::utils] Optimizer input (pass 0):
    Projection: t.a
      Filter: CAST(t.a AS Int64) BETWEEN Int64(3) AND Int64(3)
        TableScan: t
    
[2025-04-16T10:30:23Z DEBUG datafusion_optimizer::optimizer] Plan unchanged by optimizer rule 'eliminate_nested_union' (pass 0)
[2025-04-16T10:30:23Z DEBUG datafusion_optimizer::utils] simplify_expressions:
    Projection: t.a
      Filter: t.a = Int32(3)
        TableScan: t
    
...
[2025-04-16T10:30:23Z DEBUG datafusion_optimizer::utils] push_down_filter:
    Projection: t.a
      Filter: t.a = Int32(3)
        TableScan: t
    
...
[2025-04-16T10:30:23Z DEBUG datafusion_optimizer::utils] optimize_projections:
    Filter: t.a = Int32(3)
      TableScan: t projection=[a]
    
[2025-04-16T10:30:23Z DEBUG datafusion_optimizer::utils] Optimized plan (pass 0):
    Filter: t.a = Int32(3)
      TableScan: t projection=[a]
    
[2025-04-16T10:30:23Z DEBUG datafusion_optimizer::utils] Optimizer input (pass 1):
    Filter: t.a = Int32(3)
      TableScan: t projection=[a]
    
[2025-04-16T10:30:23Z DEBUG datafusion_optimizer::optimizer] Plan unchanged by optimizer rule 'eliminate_nested_union' (pass 1)
[2025-04-16T10:30:23Z DEBUG datafusion_optimizer::utils] simplify_expressions:
    Filter: t.a = Int32(3)
      TableScan: t projection=[a]
    
...
```

Now
```
[2025-04-16T10:46:09Z DEBUG datafusion_optimizer::utils] Optimizer input (pass 0):
    Projection: t.a
      Filter: CAST(t.a AS Int64) BETWEEN Int64(3) AND Int64(3)
        TableScan: t
    
[2025-04-16T10:46:09Z DEBUG datafusion_optimizer::optimizer] Plan unchanged by optimizer rule 'eliminate_nested_union' (pass 0)
[2025-04-16T10:46:09Z DEBUG datafusion_optimizer::utils] simplify_expressions:
    Projection: t.a
      Filter: t.a = Int32(3)
        TableScan: t
    
...
[2025-04-16T10:46:09Z DEBUG datafusion_optimizer::utils] push_down_filter:
    Projection: t.a
      Filter: t.a = Int32(3)
        TableScan: t
    
...
[2025-04-16T10:46:09Z DEBUG datafusion_optimizer::utils] optimize_projections:
    Filter: t.a = Int32(3)
      TableScan: t projection=[a]
    
[2025-04-16T10:46:09Z DEBUG datafusion_optimizer::utils] Optimized plan (pass 0):
    Filter: t.a = Int32(3)
      TableScan: t projection=[a]
    
[2025-04-16T10:46:09Z DEBUG datafusion_optimizer::utils] Optimizer input (pass 1):
    Filter: t.a = Int32(3)
      TableScan: t projection=[a]
    
[2025-04-16T10:46:09Z DEBUG datafusion_optimizer::optimizer] Plan unchanged by optimizer rule 'eliminate_nested_union' (pass 1)
[2025-04-16T10:46:09Z DEBUG datafusion_optimizer::optimizer] Plan unchanged by optimizer rule 'simplify_expressions' (pass 1)
```


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Check if expr is simplified, if not, return `Transformed::no`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

By existing tests.

For specific influence, it's difficult to check by test, so I put the log to check

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
