### PR TITLE
fix: serialize listing table without partition column

### DIFF
--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -90,7 +90,7 @@ message ListingTableScanNode {
   ProjectionColumns projection = 4;
   datafusion_common.Schema schema = 5;
   repeated LogicalExprNode filters = 6;
-  repeated string table_partition_cols = 7;
+  repeated PartitionColumn table_partition_cols = 7;
   bool collect_stat = 8;
   uint32 target_partitions = 9;
   oneof FileFormatType {

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -115,8 +115,8 @@ pub struct ListingTableScanNode {
     pub schema: ::core::option::Option<super::datafusion_common::Schema>,
     #[prost(message, repeated, tag = "6")]
     pub filters: ::prost::alloc::vec::Vec<LogicalExprNode>,
-    #[prost(string, repeated, tag = "7")]
-    pub table_partition_cols: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag = "7")]
+    pub table_partition_cols: ::prost::alloc::vec::Vec<PartitionColumn>,
     #[prost(bool, tag = "8")]
     pub collect_stat: bool,
     #[prost(uint32, tag = "9")]

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -463,9 +463,9 @@ impl AsLogicalPlan for LogicalPlanNode {
                     .iter()
                     .map(|col| {
                         let Some(arrow_type) = col.arrow_type.as_ref() else {
-                            return Err(proto_error(format!(
-                                "Missing Arrow type in partition columns"
-                            )));
+                            return Err(proto_error(
+                                "Missing Arrow type in partition columns".to_string(),
+                            ));
                         };
                         let arrow_type = DataType::try_from(arrow_type).map_err(|e| {
                             proto_error(format!("Received an unknown ArrowType: {}", e))

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -467,7 +467,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                                 "Missing Arrow type in partition columns"
                             )));
                         };
-                       let arrow_type = DataType::try_from(arrow_type).map_err(|e| {
+                        let arrow_type = DataType::try_from(arrow_type).map_err(|e| {
                             proto_error(format!("Received an unknown ArrowType: {}", e))
                         })?;
                         Ok((col.name.clone(), arrow_type))

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 use crate::protobuf::{proto_error, ToProtoError};
-use arrow::datatypes::{DataType, Schema, SchemaRef};
+use arrow::datatypes::{DataType, Schema, SchemaBuilder, SchemaRef};
 use datafusion::datasource::cte_worktable::CteWorkTable;
 #[cfg(feature = "avro")]
 use datafusion::datasource::file_format::avro::AvroFormat;
@@ -458,23 +458,24 @@ impl AsLogicalPlan for LogicalPlanNode {
                     .map(ListingTableUrl::parse)
                     .collect::<Result<Vec<_>, _>>()?;
 
+                let partition_columns = scan
+                    .table_partition_cols
+                    .iter()
+                    .map(|col| {
+                        let arrow_type =
+                            col.arrow_type.as_ref().unwrap().try_into().map_err(|e| {
+                                proto_error(format!(
+                                    "Received an unknown ArrowType: {}",
+                                    e
+                                ))
+                            })?;
+                        Ok((col.name.clone(), arrow_type))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
                 let options = ListingOptions::new(file_format)
                     .with_file_extension(&scan.file_extension)
-                    .with_table_partition_cols(
-                        scan.table_partition_cols
-                            .iter()
-                            .map(|col| {
-                                (
-                                    col.clone(),
-                                    schema
-                                        .field_with_name(col)
-                                        .unwrap()
-                                        .data_type()
-                                        .clone(),
-                                )
-                            })
-                            .collect(),
-                    )
+                    .with_table_partition_cols(partition_columns)
                     .with_collect_stat(scan.collect_stat)
                     .with_target_partitions(scan.target_partitions as usize)
                     .with_file_sort_order(all_sort_orders);
@@ -1046,7 +1047,6 @@ impl AsLogicalPlan for LogicalPlanNode {
                         })
                     }
                 };
-                let schema: protobuf::Schema = schema.as_ref().try_into()?;
 
                 let filters: Vec<protobuf::LogicalExprNode> =
                     serialize_exprs(filters, extension_codec)?;
@@ -1099,6 +1099,21 @@ impl AsLogicalPlan for LogicalPlanNode {
 
                     let options = listing_table.options();
 
+                    let mut builder = SchemaBuilder::from(schema.as_ref());
+                    for (idx, field) in schema.fields().iter().enumerate().rev() {
+                        if options
+                            .table_partition_cols
+                            .iter()
+                            .any(|(name, _)| name == field.name())
+                        {
+                            builder.remove(idx);
+                        }
+                    }
+
+                    let schema = builder.finish();
+
+                    let schema: protobuf::Schema = (&schema).try_into()?;
+
                     let mut exprs_vec: Vec<SortExprNodeCollection> = vec![];
                     for order in &options.file_sort_order {
                         let expr_vec = SortExprNodeCollection {
@@ -1107,6 +1122,24 @@ impl AsLogicalPlan for LogicalPlanNode {
                         exprs_vec.push(expr_vec);
                     }
 
+                    let partition_columns = options
+                        .table_partition_cols
+                        .iter()
+                        .map(|(name, arrow_type)| {
+                            let arrow_type = protobuf::ArrowType::try_from(arrow_type)
+                                .map_err(|e| {
+                                    proto_error(format!(
+                                        "Received an unknown ArrowType: {}",
+                                        e
+                                    ))
+                                })?;
+                            Ok(protobuf::PartitionColumn {
+                                name: name.clone(),
+                                arrow_type: Some(arrow_type),
+                            })
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+
                     Ok(LogicalPlanNode {
                         logical_plan_type: Some(LogicalPlanType::ListingScan(
                             protobuf::ListingTableScanNode {
@@ -1114,11 +1147,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                                 table_name: Some(table_name.clone().into()),
                                 collect_stat: options.collect_stat,
                                 file_extension: options.file_extension.clone(),
-                                table_partition_cols: options
-                                    .table_partition_cols
-                                    .iter()
-                                    .map(|x| x.0.clone())
-                                    .collect::<Vec<_>>(),
+                                table_partition_cols: partition_columns,
                                 paths: listing_table
                                     .table_paths()
                                     .iter()
@@ -1133,6 +1162,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                         )),
                     })
                 } else if let Some(view_table) = source.downcast_ref::<ViewTable>() {
+                    let schema: protobuf::Schema = schema.as_ref().try_into()?;
                     Ok(LogicalPlanNode {
                         logical_plan_type: Some(LogicalPlanType::ViewScan(Box::new(
                             protobuf::ViewTableScanNode {
@@ -1167,6 +1197,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                         )),
                     })
                 } else {
+                    let schema: protobuf::Schema = schema.as_ref().try_into()?;
                     let mut bytes = vec![];
                     extension_codec
                         .try_encode_table_provider(table_name, provider, &mut bytes)


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #15718.

## Rationale for this change

partition columns should exclude file schema in listing table

## What changes are included in this PR?

1. update partition column type in proto
2. remove partition columns from ListingTableScanNode schema.

## Are these changes tested?

UT

## Are there any user-facing changes?

No
