### PR TITLE
Add a fast path for `optimize_projection`

### DIFF
--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -455,6 +455,17 @@ fn merge_consecutive_projections(proj: Projection) -> Result<Transformed<Project
         return Projection::try_new_with_schema(expr, input, schema).map(Transformed::no);
     };
 
+    // A fast path: if the previous projection is same as the current projection
+    // we can directly remove the current projection and return child projection.
+    if prev_projection.expr == expr {
+        return Projection::try_new_with_schema(
+            expr,
+            Arc::clone(&prev_projection.input),
+            schema,
+        )
+        .map(Transformed::yes);
+    }
+
     // Count usages (referrals) of each projection expression in its input fields:
     let mut column_referral_map = HashMap::<&Column, usize>::new();
     expr.iter()


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

If the two projections have same exprs (my real case). We can directly remove the current projection and return the child projection. Avoid really running the `merge_consecutive_projections` method. This would improve performance if the projections have many exprs

### Benchmark
```rust
use criterion::{criterion_group, criterion_main, Criterion};
use datafusion_common::{DFSchema, ScalarValue, Result};
use datafusion_expr::{col, lit, Expr, LogicalPlan, Projection};
use std::sync::Arc;
use datafusion_optimizer::optimize_projections::{merge_consecutive_projections, merge_consecutive_projections_v2};

/// Creates a projection with another projection as input, both with n expressions
fn create_nested_projection(n_exprs: usize) -> Result<Projection> {
    // Create a simple empty relation as the base
    let schema = Arc::new(DFSchema::empty());
    let base_plan = LogicalPlan::EmptyRelation(
        datafusion_expr::EmptyRelation {
            produce_one_row: true,
            schema: schema.clone(),
        }
    );

    // Create inner projection with n expressions (i AS col_i)
    let inner_exprs: Vec<Expr> = (0..n_exprs)
        .map(|i| lit(ScalarValue::Int32(Some(i as i32))).alias(format!("col_{}", i)))
        .collect();

    let inner_projection = Projection::try_new(
        inner_exprs.clone(),
        Arc::new(base_plan)
    )?;

    Projection::try_new(
        inner_exprs,
        Arc::new(LogicalPlan::Projection(inner_projection))
    )
}

fn bench_merge_consecutive_projections(c: &mut Criterion) {
    let n_exprs = 1000;
    let projection = create_nested_projection(n_exprs).unwrap();

    let mut group = c.benchmark_group("projection_merge");

    group.bench_function("merge_consecutive_projections", |b| {
        b.iter(|| {
            let proj_clone = projection.clone();
            merge_consecutive_projections(proj_clone).unwrap()
        });
    });

    group.bench_function("merge_consecutive_projections_v2", |b| {
        b.iter(|| {
            let proj_clone = projection.clone();
            merge_consecutive_projections_v2(proj_clone).unwrap()
        });
    });

    group.finish();
}

criterion_group!(benches, bench_merge_consecutive_projections);
criterion_main!(benches);
```

### Benchmark result
```
    Finished `bench` profile [optimized] target(s) in 36.80s
     Running benches/projection_merge.rs (arrow-datafusion/target/release/deps/projection_merge-968d896acadbdb0b)
projection_merge/merge_consecutive_projections
                        time:   [219.66 µs 220.36 µs 221.21 µs]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
projection_merge/merge_consecutive_projections_v2
                        time:   [66.409 µs 66.974 µs 67.756 µs]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add a fast path

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
By existing tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
