### PR TITLE
Speed up `optimize_projection` by improving `is_projection_unnecessary`

### DIFF
--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -786,8 +786,12 @@ fn rewrite_projection_given_requirements(
 /// - input schema of the projection, output schema of the projection are same, and
 /// - all projection expressions are either Column or Literal
 fn is_projection_unnecessary(input: &LogicalPlan, proj_exprs: &[Expr]) -> Result<bool> {
+    // First check if all expressions are trivial (cheaper operation than `projection_schema`)
+    if !proj_exprs.iter().all(is_expr_trivial) {
+        return Ok(false);
+    }
     let proj_schema = projection_schema(input, proj_exprs)?;
-    Ok(&proj_schema == input.schema() && proj_exprs.iter().all(is_expr_trivial))
+    Ok(&proj_schema == input.schema())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In our prod, we found that the `optimize_projection` is slow when the number of columns is large, and `is_projection_unnecessary` is a bottleneck. After checking the method, I found we can improve it.

Here is the benchmark:

### Result
v1 is the old and v2 is the optimized version
```
Projection Optimization/v1_one_non_trivial
                        time:   [92.212 µs 93.578 µs 95.428 µs]
Found 16 outliers among 100 measurements (16.00%)
  2 (2.00%) high mild
  14 (14.00%) high severe
Projection Optimization/v2_one_non_trivial
                        time:   [242.52 ns 248.62 ns 256.51 ns]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
```

### Benchmark code
1000 exprs in Projection, and one of them is non-trival expr.
```rust
use arrow::datatypes::{DataType, Field, Schema};
use criterion::{criterion_group, criterion_main, Criterion};
use datafusion_expr::{binary_expr, col,Operator, Expr, LogicalPlan, table_scan};
use datafusion_optimizer::optimize_projections::{is_projection_unnecessary, is_projection_unnecessary_v2};

pub fn test_table_scan_fields() -> Vec<Field> {
    vec![
        Field::new("a", DataType::UInt32, false),
        Field::new("b", DataType::UInt32, false),
        Field::new("c", DataType::UInt32, false),
    ]
}

pub fn test_table_scan_with_name(name: &str) -> datafusion_common::Result<LogicalPlan> {
    let schema = Schema::new(test_table_scan_fields());
    table_scan(Some(name), &schema, None)?.build()
}

/// some tests share a common table
pub fn test_table_scan() -> datafusion_common::Result<LogicalPlan> {
    test_table_scan_with_name("test")
}
fn create_mixed_expressions(count: usize) -> Vec<Expr> {
    let mut exprs = Vec::with_capacity(count);
        for i in 0..count {
            // Most expressions are just column references
            if i != count / 2 {
                match i % 3 {
                    0 => exprs.push(col("a")),
                    1 => exprs.push(col("b")),
                    _ => exprs.push(col("c")),
                }
            } else {
                // One non-trivial expression (binary operation)
                exprs.push(binary_expr(col("a"), Operator::Plus, col("b")));
            }
        }
        exprs
}

fn benchmark_projections(c: &mut Criterion) {
    let input_plan = test_table_scan().unwrap();
    let one_non_trivial = create_mixed_expressions(1000);

    let mut group = c.benchmark_group("Projection Optimization");

    // Benchmark with one non-trivial expression
    group.bench_function("v1_one_non_trivial", |b| {
        b.iter(|| is_projection_unnecessary(&input_plan, &one_non_trivial));
    });
    group.bench_function("v2_one_non_trivial", |b| {
        b.iter(|| is_projection_unnecessary_v2(&input_plan, &one_non_trivial));
    });

    group.finish();
}

criterion_group!(benches, benchmark_projections);
criterion_main!(benches);
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
