### PR TITLE
predicate pruning: support cast and try_cast for more types

### DIFF
--- a/datafusion/physical-optimizer/src/pruning.rs
+++ b/datafusion/physical-optimizer/src/pruning.rs
@@ -1232,17 +1232,15 @@ fn verify_support_type_for_prune(from_type: &DataType, to_type: &DataType) -> Re
     if from_type == to_type {
         return Ok(());
     }
-    // TODO: support other data type for prunable cast or try cast
-    if matches!(
+    let supported_string_cast = (matches!(
         // String -> String casts are suppoted
         from_type,
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
     ) && matches!(
         to_type,
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
-    ) {
-        return Ok(());
-    } else if matches!(
+    ));
+    let supported_numeric_cast = (matches!(
         // Numeric -> Numeric casts are supported
         from_type,
         DataType::UInt8
@@ -1271,9 +1269,8 @@ fn verify_support_type_for_prune(from_type: &DataType, to_type: &DataType) -> Re
             | DataType::Float16
             | DataType::Float32
             | DataType::Float64
-    ) {
-        Ok(())
-    } else if matches!(
+    ));
+    let supported_temporal_cast = (matches!(
         // Temporal -> Temporal casts are supported
         from_type,
         DataType::Date32
@@ -1288,7 +1285,10 @@ fn verify_support_type_for_prune(from_type: &DataType, to_type: &DataType) -> Re
             | DataType::Time32(_)
             | DataType::Time64(_)
             | DataType::Timestamp(_, _)
-    ) {
+    ));
+
+    // TODO: support other data type for prunable cast or try cast
+    if supported_string_cast || supported_numeric_cast || supported_temporal_cast {
         Ok(())
     } else {
         plan_err!(

--- a/datafusion/physical-optimizer/src/pruning.rs
+++ b/datafusion/physical-optimizer/src/pruning.rs
@@ -1232,6 +1232,7 @@ fn verify_support_type_for_prune(from_type: &DataType, to_type: &DataType) -> Re
     if from_type == to_type {
         return Ok(());
     }
+    // TODO: add an `is_string()` method to DataType
     let supported_string_cast = (matches!(
         // String -> String casts are suppoted
         from_type,
@@ -1240,55 +1241,10 @@ fn verify_support_type_for_prune(from_type: &DataType, to_type: &DataType) -> Re
         to_type,
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
     ));
-    let supported_numeric_cast = (matches!(
-        // Numeric -> Numeric casts are supported
-        from_type,
-        DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Decimal128(_, _)
-            | DataType::Float16
-            | DataType::Float32
-            | DataType::Float64
-    ) && matches!(
-        to_type,
-        DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Decimal128(_, _)
-            | DataType::Float16
-            | DataType::Float32
-            | DataType::Float64
-    ));
-    let supported_temporal_cast = (matches!(
-        // Temporal -> Temporal casts are supported
-        from_type,
-        DataType::Date32
-            | DataType::Date64
-            | DataType::Time32(_)
-            | DataType::Time64(_)
-            | DataType::Timestamp(_, _)
-    ) && matches!(
-        to_type,
-        DataType::Date32
-            | DataType::Date64
-            | DataType::Time32(_)
-            | DataType::Time64(_)
-            | DataType::Timestamp(_, _)
-    ));
+    let supported_integer_cast = from_type.is_integer() && to_type.is_integer();
 
     // TODO: support other data type for prunable cast or try cast
-    if supported_string_cast || supported_numeric_cast || supported_temporal_cast {
+    if supported_string_cast || supported_integer_cast {
         Ok(())
     } else {
         plan_err!(

--- a/datafusion/physical-optimizer/src/pruning.rs
+++ b/datafusion/physical-optimizer/src/pruning.rs
@@ -3071,7 +3071,7 @@ mod tests {
     }
 
     #[test]
-    fn row_group_predicate_cast() -> Result<()> {
+    fn row_group_predicate_cast_int_int() -> Result<()> {
         let schema = Schema::new(vec![Field::new("c1", DataType::Int32, false)]);
         let expected_expr = "c1_null_count@2 != row_count@3 AND CAST(c1_min@0 AS Int64) <= 1 AND 1 <= CAST(c1_max@1 AS Int64)";
 
@@ -3101,6 +3101,79 @@ mod tests {
         // test column on the right
         let expr =
             lit(ScalarValue::Int64(Some(1))).lt(try_cast(col("c1"), DataType::Int64));
+        let predicate_expr =
+            test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
+        assert_eq!(predicate_expr.to_string(), expected_expr);
+
+        Ok(())
+    }
+
+    #[test]
+    fn row_group_predicate_cast_int_float() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("c1", DataType::Int32, false)]);
+        let expected_expr = "c1_null_count@2 != row_count@3 AND CAST(c1_min@0 AS Float64) <= 1 AND 1 <= CAST(c1_max@1 AS Float64)";
+
+        // test cast(c1 as float64) = 1
+        // test column on the left
+        let expr =
+            cast(col("c1"), DataType::Float64).eq(lit(ScalarValue::Float64(Some(1.0))));
+        let predicate_expr =
+            test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
+        assert_eq!(predicate_expr.to_string(), expected_expr);
+
+        // test column on the right
+        let expr =
+            lit(ScalarValue::Float64(Some(1.0))).eq(cast(col("c1"), DataType::Float64));
+        let predicate_expr =
+            test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
+        assert_eq!(predicate_expr.to_string(), expected_expr);
+
+        Ok(())
+    }
+
+    #[test]
+    fn row_group_predicate_cast_string_string() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("c1", DataType::Utf8View, false)]);
+        let expected_expr = "c1_null_count@2 != row_count@3 AND CAST(c1_min@0 AS Utf8) <= 1 AND 1 <= CAST(c1_max@1 AS Utf8)";
+
+        // test cast(c1 as string) = '1'
+        // test column on the left
+        let expr = cast(col("c1"), DataType::Utf8)
+            .eq(lit(ScalarValue::Utf8(Some("1".to_string()))));
+        let predicate_expr =
+            test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
+        assert_eq!(predicate_expr.to_string(), expected_expr);
+
+        // test column on the right
+        let expr = lit(ScalarValue::Utf8(Some("1".to_string())))
+            .eq(cast(col("c1"), DataType::Utf8));
+        let predicate_expr =
+            test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
+        assert_eq!(predicate_expr.to_string(), expected_expr);
+
+        Ok(())
+    }
+
+    #[test]
+    fn row_group_predicate_cast_timestamp_date() -> Result<()> {
+        let schema = Schema::new(vec![Field::new(
+            "c1",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            false,
+        )]);
+        let expected_expr = "c1_null_count@2 != row_count@3 AND CAST(c1_min@0 AS Date32) <= 1970-01-01 AND 1970-01-01 <= CAST(c1_max@1 AS Date32)";
+
+        // test cast(c1 as date) = '1970-01-01'
+        // test column on the left
+        let expr =
+            cast(col("c1"), DataType::Date32).eq(lit(ScalarValue::Date32(Some(0))));
+        let predicate_expr =
+            test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
+        assert_eq!(predicate_expr.to_string(), expected_expr);
+
+        // test column on the right
+        let expr =
+            lit(ScalarValue::Date32(Some(0))).eq(cast(col("c1"), DataType::Date32));
         let predicate_expr =
             test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
         assert_eq!(predicate_expr.to_string(), expected_expr);

--- a/datafusion/physical-optimizer/src/pruning.rs
+++ b/datafusion/physical-optimizer/src/pruning.rs
@@ -1235,10 +1235,6 @@ fn verify_support_type_for_prune(from_type: &DataType, to_type: &DataType) -> Re
         }
         _ => to_type,
     };
-    // If the types are the same (e.g. after unpacking a dictionary) they are supported
-    if from_type == to_type {
-        return Ok(());
-    }
     // If both types are strings or both are not strings (number, timestamp, etc)
     // then we can compare them.
     // PruningPredicate does not support casting of strings to numbers and such.


### PR DESCRIPTION
Adds support for dictionaries and some more primitive types to pruning predicate.
I encountered this when feeding in a stats schema with dictionary encoded columns.
I see no reason we can't support this.