### PR TITLE
replace reassign_predicate_columns helper with PhysicalExpr::with_schema

### DIFF
--- a/datafusion/datasource-parquet/src/row_filter.rs
+++ b/datafusion/datasource-parquet/src/row_filter.rs
@@ -67,6 +67,7 @@ use arrow::array::BooleanArray;
 use arrow::datatypes::{DataType, Schema, SchemaRef};
 use arrow::error::{ArrowError, Result as ArrowResult};
 use arrow::record_batch::RecordBatch;
+use datafusion_physical_expr_common::physical_expr::transform_physical_expr_with_schema;
 use parquet::arrow::arrow_reader::{ArrowPredicate, RowFilter};
 use parquet::arrow::ProjectionMask;
 use parquet::file::metadata::ParquetMetaData;
@@ -76,7 +77,6 @@ use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor}
 use datafusion_common::Result;
 use datafusion_datasource::schema_adapter::{SchemaAdapterFactory, SchemaMapper};
 use datafusion_physical_expr::expressions::Column;
-use datafusion_physical_expr::utils::reassign_predicate_columns;
 use datafusion_physical_expr::{split_conjunction, PhysicalExpr};
 
 use datafusion_physical_plan::metrics;
@@ -120,8 +120,7 @@ impl DatafusionArrowPredicate {
         time: metrics::Time,
     ) -> Result<Self> {
         let projected_schema = Arc::clone(&candidate.filter_schema);
-        let physical_expr =
-            reassign_predicate_columns(candidate.expr, &projected_schema, true)?;
+        let physical_expr = transform_physical_expr_with_schema(candidate.expr, &projected_schema)?;
 
         Ok(Self {
             physical_expr,

--- a/datafusion/datasource-parquet/src/row_filter.rs
+++ b/datafusion/datasource-parquet/src/row_filter.rs
@@ -120,7 +120,8 @@ impl DatafusionArrowPredicate {
         time: metrics::Time,
     ) -> Result<Self> {
         let projected_schema = Arc::clone(&candidate.filter_schema);
-        let physical_expr = transform_physical_expr_with_schema(candidate.expr, &projected_schema)?;
+        let physical_expr =
+            transform_physical_expr_with_schema(candidate.expr, &projected_schema)?;
 
         Ok(Self {
             physical_expr,

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -337,10 +337,7 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + DynEq + DynHash {
     /// Adapt this [`PhysicalExpr`] to a new schema.
     /// For example, `Column("b", 1)` can be adapted to `Column("b", 0)`
     /// given the schema `Schema::new(vec![("b", DataType::Int32)])`.
-    fn with_schema(
-        &self,
-        _schema: &Schema,
-    ) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+    fn with_schema(&self, _schema: &Schema) -> Result<Option<Arc<dyn PhysicalExpr>>> {
         // By default, we return the same expression.
         // This is a safe default behavior.
         Ok(None)

--- a/datafusion/physical-expr/src/expressions/column.rs
+++ b/datafusion/physical-expr/src/expressions/column.rs
@@ -142,10 +142,7 @@ impl PhysicalExpr for Column {
         write!(f, "{}", self.name)
     }
 
-    fn with_schema(
-            &self,
-            schema: &Schema,
-        ) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+    fn with_schema(&self, schema: &Schema) -> Result<Option<Arc<dyn PhysicalExpr>>> {
         // Find our index in the new schema
         let new_index = schema.index_of(&self.name)?;
         // If the index is the same return None to indicate no change

--- a/datafusion/physical-expr/src/expressions/column.rs
+++ b/datafusion/physical-expr/src/expressions/column.rs
@@ -141,6 +141,21 @@ impl PhysicalExpr for Column {
     fn fmt_sql(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)
     }
+
+    fn with_schema(
+            &self,
+            schema: &Schema,
+        ) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+        // Find our index in the new schema
+        let new_index = schema.index_of(&self.name)?;
+        // If the index is the same return None to indicate no change
+        if new_index == self.index {
+            Ok(None)
+        } else {
+            // Otherwise, create a new column expression with the new index
+            Ok(Some(Arc::new(Column::new(&self.name, new_index))))
+        }
+    }
 }
 
 impl Column {

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -295,15 +295,13 @@ impl PhysicalExpr for DynamicFilterPhysicalExpr {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        expressions::{col, lit, BinaryExpr},
-        utils::reassign_predicate_columns,
-    };
+    use crate::expressions::{col, lit, BinaryExpr};
     use arrow::{
         array::RecordBatch,
         datatypes::{DataType, Field, Schema},
     };
     use datafusion_common::ScalarValue;
+    use datafusion_physical_expr_common::physical_expr::transform_physical_expr_with_schema;
 
     use super::*;
 
@@ -335,20 +333,12 @@ mod test {
         ]));
         // Each ParquetExec calls `with_new_children` on the DynamicFilterPhysicalExpr
         // and remaps the children to the file schema.
-        let dynamic_filter_1 = reassign_predicate_columns(
-            Arc::clone(&dynamic_filter) as Arc<dyn PhysicalExpr>,
-            &filter_schema_1,
-            false,
-        )
-        .unwrap();
+        let filter = Arc::clone(&dynamic_filter);
+        let dynamic_filter_1 = transform_physical_expr_with_schema(filter, &filter_schema_1).unwrap();
         let snap = dynamic_filter_1.snapshot().unwrap().unwrap();
         insta::assert_snapshot!(format!("{snap:?}"), @r#"BinaryExpr { left: Column { name: "a", index: 0 }, op: Eq, right: Literal { value: Int32(42) }, fail_on_overflow: false }"#);
-        let dynamic_filter_2 = reassign_predicate_columns(
-            Arc::clone(&dynamic_filter) as Arc<dyn PhysicalExpr>,
-            &filter_schema_2,
-            false,
-        )
-        .unwrap();
+        let filter = Arc::clone(&dynamic_filter);
+        let dynamic_filter_2 = transform_physical_expr_with_schema(filter, &filter_schema_2).unwrap();
         let snap = dynamic_filter_2.snapshot().unwrap().unwrap();
         insta::assert_snapshot!(format!("{snap:?}"), @r#"BinaryExpr { left: Column { name: "a", index: 1 }, op: Eq, right: Literal { value: Int32(42) }, fail_on_overflow: false }"#);
         // Both filters allow evaluating the same expression

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -334,11 +334,13 @@ mod test {
         // Each ParquetExec calls `with_new_children` on the DynamicFilterPhysicalExpr
         // and remaps the children to the file schema.
         let filter = Arc::clone(&dynamic_filter);
-        let dynamic_filter_1 = transform_physical_expr_with_schema(filter, &filter_schema_1).unwrap();
+        let dynamic_filter_1 =
+            transform_physical_expr_with_schema(filter, &filter_schema_1).unwrap();
         let snap = dynamic_filter_1.snapshot().unwrap().unwrap();
         insta::assert_snapshot!(format!("{snap:?}"), @r#"BinaryExpr { left: Column { name: "a", index: 0 }, op: Eq, right: Literal { value: Int32(42) }, fail_on_overflow: false }"#);
         let filter = Arc::clone(&dynamic_filter);
-        let dynamic_filter_2 = transform_physical_expr_with_schema(filter, &filter_schema_2).unwrap();
+        let dynamic_filter_2 =
+            transform_physical_expr_with_schema(filter, &filter_schema_2).unwrap();
         let snap = dynamic_filter_2.snapshot().unwrap().unwrap();
         insta::assert_snapshot!(format!("{snap:?}"), @r#"BinaryExpr { left: Column { name: "a", index: 1 }, op: Eq, right: Literal { value: Int32(42) }, fail_on_overflow: false }"#);
         // Both filters allow evaluating the same expression


### PR DESCRIPTION
I think this is simpler and avoids the need for specialized code as in #6114.

I also think this *could* pave the way to one day achieve #15057 in a dynamic way, i.e. let a `PhysicalExpr` how it can be evaluated against a file.

This could mean e.g. that variant / json is implemented completely as an external crate.
In the short term this would not be possible because we'd have to add methods to pass the new schema along to functions so they can match their children... etc., it gets a bit complicated but the fact that it's theoretically possible is interesting.