### PR TITLE
Speed up `optimize_projection`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,6 +2389,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "chrono",
+ "criterion",
  "ctor",
  "datafusion-common",
  "datafusion-expr",

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -62,3 +62,8 @@ datafusion-functions-window-common = { workspace = true }
 datafusion-sql = { workspace = true }
 env_logger = { workspace = true }
 insta = { workspace = true }
+criterion = {workspace = true}
+
+[[bench]]
+name = "projection_unnecessary"
+harness = false

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -55,6 +55,7 @@ regex-syntax = "0.8.0"
 
 [dev-dependencies]
 async-trait = { workspace = true }
+criterion = { workspace = true }
 ctor = { workspace = true }
 datafusion-functions-aggregate = { workspace = true }
 datafusion-functions-window = { workspace = true }
@@ -62,7 +63,6 @@ datafusion-functions-window-common = { workspace = true }
 datafusion-sql = { workspace = true }
 env_logger = { workspace = true }
 insta = { workspace = true }
-criterion = {workspace = true}
 
 [[bench]]
 name = "projection_unnecessary"

--- a/datafusion/optimizer/benches/projection_unnecessary.rs
+++ b/datafusion/optimizer/benches/projection_unnecessary.rs
@@ -1,0 +1,64 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datafusion_common::{Column, TableReference};
+use datafusion_expr::{logical_plan::LogicalPlan, projection_schema, Expr};
+use arrow::datatypes::{DataType, Field, Schema};
+use std::sync::Arc;
+use datafusion_optimizer::optimize_projections::is_projection_unnecessary;
+use datafusion_common::ToDFSchema;
+
+pub fn is_projection_unnecessary_old(input: &LogicalPlan, proj_exprs: &[Expr]) -> datafusion_common::Result<bool> {
+    // First check if all expressions are trivial (cheaper operation than `projection_schema`)
+    if !proj_exprs.iter().all(|expr| matches!(expr, Expr::Column(_) | Expr::Literal(_))) {
+        return Ok(false);
+    }
+    let proj_schema = projection_schema(input, proj_exprs)?;
+    Ok(&proj_schema == input.schema())
+}
+
+fn create_plan_with_many_exprs(num_exprs: usize) -> (LogicalPlan, Vec<Expr>) {
+    // Create schema with many fields
+    let fields = (0..num_exprs)
+        .map(|i| Field::new(format!("col{}", i), DataType::Int32, false))
+        .collect::<Vec<_>>();
+    let schema = Schema::new(fields);
+
+    // Create table scan
+    let table_scan = LogicalPlan::EmptyRelation(
+        datafusion_expr::EmptyRelation {
+            produce_one_row: true,
+            schema: Arc::new(schema.clone().to_dfschema().unwrap()),
+        }
+    );
+
+    // Create projection expressions (just column references)
+    let exprs = (0..num_exprs)
+        .map(|i| {
+            Expr::Column(Column::new(None::<TableReference>, format!("col{}", i)))
+        })
+        .collect();
+
+    (table_scan, exprs)
+}
+
+fn benchmark_is_projection_unnecessary(c: &mut Criterion) {
+    let (plan, exprs) = create_plan_with_many_exprs(1000);
+
+    let mut group = c.benchmark_group("projection_unnecessary_comparison");
+
+    group.bench_function("is_projection_unnecessary_new", |b| {
+        b.iter(|| {
+             black_box(is_projection_unnecessary(&plan, &exprs).unwrap())
+        })
+    });
+
+    group.bench_function("is_projection_unnecessary_old", |b| {
+        b.iter(|| {
+            black_box(is_projection_unnecessary_old(&plan, &exprs).unwrap())
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_is_projection_unnecessary);
+criterion_main!(benches);

--- a/datafusion/optimizer/benches/projection_unnecessary.rs
+++ b/datafusion/optimizer/benches/projection_unnecessary.rs
@@ -1,14 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::{DataType, Field, Schema};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datafusion_common::ToDFSchema;
 use datafusion_common::{Column, TableReference};
 use datafusion_expr::{logical_plan::LogicalPlan, projection_schema, Expr};
-use arrow::datatypes::{DataType, Field, Schema};
-use std::sync::Arc;
 use datafusion_optimizer::optimize_projections::is_projection_unnecessary;
-use datafusion_common::ToDFSchema;
+use std::sync::Arc;
 
-pub fn is_projection_unnecessary_old(input: &LogicalPlan, proj_exprs: &[Expr]) -> datafusion_common::Result<bool> {
+fn is_projection_unnecessary_old(
+    input: &LogicalPlan,
+    proj_exprs: &[Expr],
+) -> datafusion_common::Result<bool> {
     // First check if all expressions are trivial (cheaper operation than `projection_schema`)
-    if !proj_exprs.iter().all(|expr| matches!(expr, Expr::Column(_) | Expr::Literal(_))) {
+    if !proj_exprs
+        .iter()
+        .all(|expr| matches!(expr, Expr::Column(_) | Expr::Literal(_)))
+    {
         return Ok(false);
     }
     let proj_schema = projection_schema(input, proj_exprs)?;
@@ -23,18 +46,14 @@ fn create_plan_with_many_exprs(num_exprs: usize) -> (LogicalPlan, Vec<Expr>) {
     let schema = Schema::new(fields);
 
     // Create table scan
-    let table_scan = LogicalPlan::EmptyRelation(
-        datafusion_expr::EmptyRelation {
-            produce_one_row: true,
-            schema: Arc::new(schema.clone().to_dfschema().unwrap()),
-        }
-    );
+    let table_scan = LogicalPlan::EmptyRelation(datafusion_expr::EmptyRelation {
+        produce_one_row: true,
+        schema: Arc::new(schema.clone().to_dfschema().unwrap()),
+    });
 
     // Create projection expressions (just column references)
     let exprs = (0..num_exprs)
-        .map(|i| {
-            Expr::Column(Column::new(None::<TableReference>, format!("col{}", i)))
-        })
+        .map(|i| Expr::Column(Column::new(None::<TableReference>, format!("col{}", i))))
         .collect();
 
     (table_scan, exprs)
@@ -46,15 +65,11 @@ fn benchmark_is_projection_unnecessary(c: &mut Criterion) {
     let mut group = c.benchmark_group("projection_unnecessary_comparison");
 
     group.bench_function("is_projection_unnecessary_new", |b| {
-        b.iter(|| {
-             black_box(is_projection_unnecessary(&plan, &exprs).unwrap())
-        })
+        b.iter(|| black_box(is_projection_unnecessary(&plan, &exprs).unwrap()))
     });
 
     group.bench_function("is_projection_unnecessary_old", |b| {
-        b.iter(|| {
-            black_box(is_projection_unnecessary_old(&plan, &exprs).unwrap())
-        })
+        b.iter(|| black_box(is_projection_unnecessary_old(&plan, &exprs).unwrap()))
     });
 
     group.finish();

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -31,7 +31,7 @@ use datafusion_common::{
 use datafusion_expr::expr::Alias;
 use datafusion_expr::Unnest;
 use datafusion_expr::{
-    logical_plan::LogicalPlan, projection_schema, Aggregate, Distinct, Expr, Projection,
+    logical_plan::LogicalPlan, Aggregate, Distinct, Expr, Projection,
     TableScan, Window,
 };
 
@@ -785,13 +785,24 @@ fn rewrite_projection_given_requirements(
 /// Projection is unnecessary, when
 /// - input schema of the projection, output schema of the projection are same, and
 /// - all projection expressions are either Column or Literal
-fn is_projection_unnecessary(input: &LogicalPlan, proj_exprs: &[Expr]) -> Result<bool> {
-    // First check if all expressions are trivial (cheaper operation than `projection_schema`)
-    if !proj_exprs.iter().all(is_expr_trivial) {
+pub fn is_projection_unnecessary(
+    input: &LogicalPlan,
+    proj_exprs: &[Expr],
+) -> Result<bool> {
+    // First check if the number of expressions is equal to the number of fields in the input schema.
+    if proj_exprs.len() != input.schema().fields().len() {
         return Ok(false);
     }
-    let proj_schema = projection_schema(input, proj_exprs)?;
-    Ok(&proj_schema == input.schema())
+    Ok(input.schema().iter().zip(proj_exprs.iter()).all(
+        |((field_relation, field_name), expr)| {
+            // Check if the expression is a column and if it matches the field name
+            if let Expr::Column(col) = expr {
+                col.relation.as_ref() == field_relation && col.name.eq(field_name.name())
+            } else {
+                false
+            }
+        },
+    ))
 }
 
 #[cfg(test)]

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -31,8 +31,7 @@ use datafusion_common::{
 use datafusion_expr::expr::Alias;
 use datafusion_expr::Unnest;
 use datafusion_expr::{
-    logical_plan::LogicalPlan, Aggregate, Distinct, Expr, Projection,
-    TableScan, Window,
+    logical_plan::LogicalPlan, Aggregate, Distinct, Expr, Projection, TableScan, Window,
 };
 
 use crate::optimize_projections::required_indices::RequiredIndices;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We found the `is_projection_unnecessary` method is costly if there are many exprs in projection, and is a bottleneck in the `optimize_projection` rule

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Speed up the `is_projection_necessary function`
1. Add the check for the `exprs` length with the `input.schema()`
2. Optimize the way of checking if the projection can be removed.

### Benchmark result (~1000x)
```
projection_unnecessary_comparison/is_projection_unnecessary_v2
                        time:   [3.1893 µs 3.2122 µs 3.2391 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe
projection_unnecessary_comparison/is_projection_unnecessary
                        time:   [4.0953 ms 4.1299 ms 4.1644 ms]
Found 25 outliers among 100 measurements (25.00%)
  10 (10.00%) low severe
  12 (12.00%) high mild
  3 (3.00%) high severe
```

## Are these changes tested?

Yes, by existing tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
