### PR TITLE
Make `Diagnostic` easy/convinient to attach by using macro and avoiding `map_err`

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -759,7 +759,7 @@ macro_rules! make_error {
             /// Macro wraps `$ERR` to add backtrace feature
             #[macro_export]
             macro_rules! $NAME_DF_ERR {
-                ($d($d args:expr),* $d(; diag = $d DIAG:expr)?) => {{
+                ($d($d args:expr),* $d(; diagnostic=$d DIAG:expr)?) => {{
                     let err =$crate::DataFusionError::$ERR(
                         ::std::format!(
                             "{}{}",
@@ -778,7 +778,7 @@ macro_rules! make_error {
             /// Macro wraps Err(`$ERR`) to add backtrace feature
             #[macro_export]
             macro_rules! $NAME_ERR {
-                ($d($d args:expr),* $d(; diag = $d DIAG:expr)?) => {{
+                ($d($d args:expr),* $d(; diagnostic = $d DIAG:expr)?) => {{
                     let err = $crate::[<_ $NAME_DF_ERR>]!($d($d args),*);
                     $d (
                         let err = err.with_diagnostic($d DIAG);

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -826,7 +826,7 @@ make_error!(resources_err, resources_datafusion_err, ResourcesExhausted);
 // Exposes a macro to create `DataFusionError::SQL` with optional backtrace
 #[macro_export]
 macro_rules! sql_datafusion_err {
-    ($ERR:expr $(, $DIAG:expr)?) => {{
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
         let err = DataFusionError::SQL($ERR, Some(DataFusionError::get_back_trace()));
         $(
             let err = err.with_diagnostic($DIAG);
@@ -838,7 +838,7 @@ macro_rules! sql_datafusion_err {
 // Exposes a macro to create `Err(DataFusionError::SQL)` with optional backtrace
 #[macro_export]
 macro_rules! sql_err {
-    ($ERR:expr $(, $DIAG:expr)?) => {{
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
         let err = datafusion_common::sql_datafusion_err!($ERR);
         $(
             let err = err.with_diagnostic($DIAG);
@@ -850,38 +850,56 @@ macro_rules! sql_err {
 // Exposes a macro to create `DataFusionError::ArrowError` with optional backtrace
 #[macro_export]
 macro_rules! arrow_datafusion_err {
-    ($ERR:expr) => {
-        DataFusionError::ArrowError($ERR, Some(DataFusionError::get_back_trace()))
-    };
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
+        let err = DataFusionError::ArrowError($ERR, Some(DataFusionError::get_back_trace()));
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        err
+    }};
 }
 
 // Exposes a macro to create `Err(DataFusionError::ArrowError)` with optional backtrace
 #[macro_export]
 macro_rules! arrow_err {
-    ($ERR:expr) => {
-        Err(datafusion_common::arrow_datafusion_err!($ERR))
-    };
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {
+    {
+        let err = datafusion_common::arrow_datafusion_err!($ERR);
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        Err(err)
+    }};
 }
 
 // Exposes a macro to create `DataFusionError::SchemaError` with optional backtrace
 #[macro_export]
 macro_rules! schema_datafusion_err {
-    ($ERR:expr) => {
-        $crate::error::DataFusionError::SchemaError(
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
+        let err = $crate::error::DataFusionError::SchemaError(
             $ERR,
             Box::new(Some($crate::error::DataFusionError::get_back_trace())),
-        )
-    };
+        );
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        err
+    }};
 }
 
 // Exposes a macro to create `Err(DataFusionError::SchemaError)` with optional backtrace
 #[macro_export]
 macro_rules! schema_err {
-    ($ERR:expr) => {
-        Err($crate::error::DataFusionError::SchemaError(
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
+        let err = $crate::error::DataFusionError::SchemaError(
             $ERR,
             Box::new(Some($crate::error::DataFusionError::get_back_trace())),
-        ))
+        );
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        Err(err)
+    }
     };
 }
 

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -759,23 +759,33 @@ macro_rules! make_error {
             /// Macro wraps `$ERR` to add backtrace feature
             #[macro_export]
             macro_rules! $NAME_DF_ERR {
-                ($d($d args:expr),*) => {
-                    $crate::DataFusionError::$ERR(
+                ($d($d args:expr),* $d(; diag = $d DIAG:expr)?) => {{
+                    let err =$crate::DataFusionError::$ERR(
                         ::std::format!(
                             "{}{}",
                             ::std::format!($d($d args),*),
                             $crate::DataFusionError::get_back_trace(),
                         ).into()
-                    )
+                    );
+                    $d (
+                        let err = err.with_diagnostic($d DIAG);
+                    )?
+                    err
                 }
             }
+        }
 
             /// Macro wraps Err(`$ERR`) to add backtrace feature
             #[macro_export]
             macro_rules! $NAME_ERR {
-                ($d($d args:expr),*) => {
-                    Err($crate::[<_ $NAME_DF_ERR>]!($d($d args),*))
-                }
+                ($d($d args:expr),* $d(; diag = $d DIAG:expr)?) => {{
+                    let err = $crate::[<_ $NAME_DF_ERR>]!($d($d args),*);
+                    $d (
+                        let err = err.with_diagnostic($d DIAG);
+                    )?
+                    Err(err)
+
+                }}
             }
 
 
@@ -816,17 +826,25 @@ make_error!(resources_err, resources_datafusion_err, ResourcesExhausted);
 // Exposes a macro to create `DataFusionError::SQL` with optional backtrace
 #[macro_export]
 macro_rules! sql_datafusion_err {
-    ($ERR:expr) => {
-        DataFusionError::SQL($ERR, Some(DataFusionError::get_back_trace()))
-    };
+    ($ERR:expr $(, $DIAG:expr)?) => {{
+        let err = DataFusionError::SQL($ERR, Some(DataFusionError::get_back_trace()));
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        err
+    }};
 }
 
 // Exposes a macro to create `Err(DataFusionError::SQL)` with optional backtrace
 #[macro_export]
 macro_rules! sql_err {
-    ($ERR:expr) => {
-        Err(datafusion_common::sql_datafusion_err!($ERR))
-    };
+    ($ERR:expr $(, $DIAG:expr)?) => {{
+        let err = datafusion_common::sql_datafusion_err!($ERR);
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        Err(err)
+    }};
 }
 
 // Exposes a macro to create `DataFusionError::ArrowError` with optional backtrace

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -413,7 +413,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 Diagnostic::new_error(format!("Invalid function '{name}'"), span);
             diagnostic
                 .add_note(format!("Possible function '{}'", suggested_func_name), None);
-            plan_err!("Invalid function '{name}'.\nDid you mean '{suggested_func_name}'?"; diag=diagnostic)
+            plan_err!("Invalid function '{name}'.\nDid you mean '{suggested_func_name}'?"; diagnostic=diagnostic)
         } else {
             internal_err!("No functions registered with this context.")
         }

--- a/datafusion/sql/src/expr/subquery.rs
+++ b/datafusion/sql/src/expr/subquery.rs
@@ -138,15 +138,9 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         if sub_plan.schema().fields().len() > 1 {
             let sub_schema = sub_plan.schema();
             let field_names = sub_schema.field_names();
-
-            plan_err!("{}: {}", error_message, field_names.join(", ")).map_err(|err| {
-                let diagnostic = self.build_multi_column_diagnostic(
-                    spans,
-                    error_message,
-                    help_message,
-                );
-                err.with_diagnostic(diagnostic)
-            })
+            let diagnostic =
+                self.build_multi_column_diagnostic(spans, error_message, help_message);
+            plan_err!("{}: {}", error_message, field_names.join(", "); diagnostic=diagnostic)
         } else {
             Ok(())
         }

--- a/datafusion/sql/src/expr/unary_op.rs
+++ b/datafusion/sql/src/expr/unary_op.rs
@@ -45,16 +45,18 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 {
                     Ok(operand)
                 } else {
-                    plan_err!("Unary operator '+' only supports numeric, interval and timestamp types").map_err(|e| {
-                        let span = operand.spans().and_then(|s| s.first());
-                        let mut diagnostic = Diagnostic::new_error(
-                            format!("+ cannot be used with {data_type}"), 
-                            span
-                        );
-                        diagnostic.add_note("+ can only be used with numbers, intervals, and timestamps", None);
-                        diagnostic.add_help(format!("perhaps you need to cast {operand}"), None);
-                        e.with_diagnostic(diagnostic)
-                    })
+                    let span = operand.spans().and_then(|s| s.first());
+                    let mut diagnostic = Diagnostic::new_error(
+                        format!("+ cannot be used with {data_type}"),
+                        span,
+                    );
+                    diagnostic.add_note(
+                        "+ can only be used with numbers, intervals, and timestamps",
+                        None,
+                    );
+                    diagnostic
+                        .add_help(format!("perhaps you need to cast {operand}"), None);
+                    plan_err!("Unary operator '+' only supports numeric, interval and timestamp types"; diagnostic=diagnostic)
                 }
             }
             UnaryOperator::Minus => {

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -39,9 +39,14 @@ use std::fmt;
 
 // Use `Parser::expected` instead, if possible
 macro_rules! parser_err {
-    ($MSG:expr) => {
-        Err(ParserError::ParserError($MSG.to_string()))
-    };
+    ($MSG:expr $(, $DIAG:expr)?) => {{
+
+        let err = DataFusionError::from(ParserError::ParserError($MSG.to_string()));
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        Err(err)
+    }};
 }
 
 fn parse_file_type(s: &str) -> Result<String, DataFusionError> {
@@ -448,20 +453,15 @@ impl<'a> DFParser<'a> {
         found: TokenWithSpan,
     ) -> Result<T, DataFusionError> {
         let sql_parser_span = found.span;
-        parser_err!(format!(
-            "Expected: {expected}, found: {found}{}",
-            found.span.start
-        ))
-        .map_err(|e| {
-            let e = DataFusionError::from(e);
-            let span = Span::try_from_sqlparser_span(sql_parser_span);
-            let diagnostic = Diagnostic::new_error(
-                format!("Expected: {expected}, found: {found}{}", found.span.start),
-                span,
-            );
-
-            e.with_diagnostic(diagnostic)
-        })
+        let span = Span::try_from_sqlparser_span(sql_parser_span);
+        let diagnostic = Diagnostic::new_error(
+            format!("Expected: {expected}, found: {found}{}", found.span.start),
+            span,
+        );
+        parser_err!(
+            format!("Expected: {expected}, found: {found}{}", found.span.start),
+            diagnostic
+        )
     }
 
     /// Parse a new expression

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -39,7 +39,7 @@ use std::fmt;
 
 // Use `Parser::expected` instead, if possible
 macro_rules! parser_err {
-    ($MSG:expr $(, $DIAG:expr)?) => {{
+    ($MSG:expr $(; diagnostic = $DIAG:expr)?) => {{
 
         let err = DataFusionError::from(ParserError::ParserError($MSG.to_string()));
         $(
@@ -459,7 +459,8 @@ impl<'a> DFParser<'a> {
             span,
         );
         parser_err!(
-            format!("Expected: {expected}, found: {found}{}", found.span.start),
+            format!("Expected: {expected}, found: {found}{}", found.span.start);
+            diagnostic=
             diagnostic
         )
     }

--- a/datafusion/sql/src/set_expr.rs
+++ b/datafusion/sql/src/set_expr.rs
@@ -95,26 +95,22 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         if left_plan.schema().fields().len() == right_plan.schema().fields().len() {
             return Ok(());
         }
-
-        plan_err!("{} queries have different number of columns", op).map_err(|err| {
-            err.with_diagnostic(
-                Diagnostic::new_error(
-                    format!("{} queries have different number of columns", op),
-                    set_expr_span,
-                )
-                .with_note(
-                    format!("this side has {} fields", left_plan.schema().fields().len()),
-                    left_span,
-                )
-                .with_note(
-                    format!(
-                        "this side has {} fields",
-                        right_plan.schema().fields().len()
-                    ),
-                    right_span,
-                ),
-            )
-        })
+        let diagnostic = Diagnostic::new_error(
+            format!("{} queries have different number of columns", op),
+            set_expr_span,
+        )
+        .with_note(
+            format!("this side has {} fields", left_plan.schema().fields().len()),
+            left_span,
+        )
+        .with_note(
+            format!(
+                "this side has {} fields",
+                right_plan.schema().fields().len()
+            ),
+            right_span,
+        );
+        plan_err!("{} queries have different number of columns", op; diagnostic =diagnostic)
     }
 
     pub(super) fn set_operation_to_plan(

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -158,20 +158,19 @@ fn check_column_satisfies_expr(
     purpose: CheckColumnsSatisfyExprsPurpose,
 ) -> Result<()> {
     if !columns.contains(expr) {
+        let diagnostic = Diagnostic::new_error(
+            purpose.diagnostic_message(expr),
+            expr.spans().and_then(|spans| spans.first()),
+        )
+        .with_help(format!("Either add '{expr}' to GROUP BY clause, or use an aggregare function like ANY_VALUE({expr})"), None);
+
         return plan_err!(
             "{}: While expanding wildcard, column \"{}\" must appear in the GROUP BY clause or must be part of an aggregate function, currently only \"{}\" appears in the SELECT clause satisfies this requirement",
             purpose.message_prefix(),
             expr,
-            expr_vec_fmt!(columns)
-        )
-        .map_err(|err| {
-            let diagnostic = Diagnostic::new_error(
-                purpose.diagnostic_message(expr),
-                expr.spans().and_then(|spans| spans.first()),
-            )
-            .with_help(format!("Either add '{expr}' to GROUP BY clause, or use an aggregare function like ANY_VALUE({expr})"), None);
-            err.with_diagnostic(diagnostic)
-        });
+            expr_vec_fmt!(columns);
+            diagnostic=diagnostic
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
```
this actually gives me an idea that `err!` should support diagnostics as optional param, so we can remove extra `map_err`
```

_Originally posted by @comphead in https://github.com/apache/datafusion/pull/15680#discussion_r2047736900_
            
- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
