### PR TITLE
Fix `ILIKE` expression support in SQL unparser

### DIFF
--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2425,3 +2425,48 @@ fn test_unparse_left_semi_join_with_table_scan_projection() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn test_like_filters() {
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name LIKE '%John%'"#,
+        r#"SELECT * FROM person WHERE person.first_name LIKE '%John%'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name ILIKE '%john%'"#,
+        r#"SELECT * FROM person WHERE person.first_name ILIKE '%john%'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name NOT LIKE 'A%'"#,
+        r#"SELECT * FROM person WHERE person.first_name NOT LIKE 'A%'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name NOT ILIKE 'a%'"#,
+        r#"SELECT * FROM person WHERE person.first_name NOT ILIKE 'a%'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name LIKE 'A!_%' ESCAPE '!'"#,
+        r#"SELECT * FROM person WHERE person.first_name LIKE 'A!_%' ESCAPE '!'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name NOT LIKE 'A!_%' ESCAPE '!'"#,
+        r#"SELECT * FROM person WHERE person.first_name NOT LIKE 'A!_%' ESCAPE '!'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name NOT ILIKE 'A!_%' ESCAPE '!'"#,
+        r#"SELECT * FROM person WHERE person.first_name NOT ILIKE 'A!_%' ESCAPE '!'"#,
+    );
+}

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2427,46 +2427,85 @@ fn test_unparse_left_semi_join_with_table_scan_projection() -> Result<()> {
 }
 
 #[test]
-fn test_like_filters() {
-    sql_round_trip(
+fn test_like_filter() {
+    let statement = generate_round_trip_statement(
         GenericDialect {},
-        r#"SELECT * FROM person WHERE first_name LIKE '%John%'"#,
-        r#"SELECT * FROM person WHERE person.first_name LIKE '%John%'"#,
+        r#"SELECT first_name FROM person WHERE first_name LIKE '%John%'"#,
     );
-
-    sql_round_trip(
-        GenericDialect {},
-        r#"SELECT * FROM person WHERE first_name ILIKE '%john%'"#,
-        r#"SELECT * FROM person WHERE person.first_name ILIKE '%john%'"#,
+    assert_snapshot!(
+        statement,
+        @"SELECT person.first_name FROM person WHERE person.first_name LIKE '%John%'"
     );
+}
 
-    sql_round_trip(
+#[test]
+fn test_ilike_filter() {
+    let statement = generate_round_trip_statement(
         GenericDialect {},
-        r#"SELECT * FROM person WHERE first_name NOT LIKE 'A%'"#,
-        r#"SELECT * FROM person WHERE person.first_name NOT LIKE 'A%'"#,
+        r#"SELECT first_name FROM person WHERE first_name ILIKE '%john%'"#,
     );
-
-    sql_round_trip(
-        GenericDialect {},
-        r#"SELECT * FROM person WHERE first_name NOT ILIKE 'a%'"#,
-        r#"SELECT * FROM person WHERE person.first_name NOT ILIKE 'a%'"#,
+    assert_snapshot!(
+        statement,
+        @"SELECT person.first_name FROM person WHERE person.first_name ILIKE '%john%'"
     );
+}
 
-    sql_round_trip(
+#[test]
+fn test_not_like_filter() {
+    let statement = generate_round_trip_statement(
         GenericDialect {},
-        r#"SELECT * FROM person WHERE first_name LIKE 'A!_%' ESCAPE '!'"#,
-        r#"SELECT * FROM person WHERE person.first_name LIKE 'A!_%' ESCAPE '!'"#,
+        r#"SELECT first_name FROM person WHERE first_name NOT LIKE 'A%'"#,
     );
-
-    sql_round_trip(
-        GenericDialect {},
-        r#"SELECT * FROM person WHERE first_name NOT LIKE 'A!_%' ESCAPE '!'"#,
-        r#"SELECT * FROM person WHERE person.first_name NOT LIKE 'A!_%' ESCAPE '!'"#,
+    assert_snapshot!(
+        statement,
+        @"SELECT person.first_name FROM person WHERE person.first_name NOT LIKE 'A%'"
     );
+}
 
-    sql_round_trip(
+#[test]
+fn test_not_ilike_filter() {
+    let statement = generate_round_trip_statement(
         GenericDialect {},
-        r#"SELECT * FROM person WHERE first_name NOT ILIKE 'A!_%' ESCAPE '!'"#,
-        r#"SELECT * FROM person WHERE person.first_name NOT ILIKE 'A!_%' ESCAPE '!'"#,
+        r#"SELECT first_name FROM person WHERE first_name NOT ILIKE 'a%'"#,
+    );
+    assert_snapshot!(
+        statement,
+        @"SELECT person.first_name FROM person WHERE person.first_name NOT ILIKE 'a%'"
+    );
+}
+
+#[test]
+fn test_like_filter_with_escape() {
+    let statement = generate_round_trip_statement(
+        GenericDialect {},
+        r#"SELECT first_name FROM person WHERE first_name LIKE 'A!_%' ESCAPE '!'"#,
+    );
+    assert_snapshot!(
+        statement,
+        @"SELECT person.first_name FROM person WHERE person.first_name LIKE 'A!_%' ESCAPE '!'"
+    );
+}
+
+#[test]
+fn test_not_like_filter_with_escape() {
+    let statement = generate_round_trip_statement(
+        GenericDialect {},
+        r#"SELECT first_name FROM person WHERE first_name NOT LIKE 'A!_%' ESCAPE '!'"#,
+    );
+    assert_snapshot!(
+        statement,
+        @"SELECT person.first_name FROM person WHERE person.first_name NOT LIKE 'A!_%' ESCAPE '!'"
+    );
+}
+
+#[test]
+fn test_not_ilike_filter_with_escape() {
+    let statement = generate_round_trip_statement(
+        GenericDialect {},
+        r#"SELECT first_name FROM person WHERE first_name NOT ILIKE 'A!_%' ESCAPE '!'"#,
+    );
+    assert_snapshot!(
+        statement,
+        @"SELECT person.first_name FROM person WHERE person.first_name NOT ILIKE 'A!_%' ESCAPE '!'"
     );
 }


### PR DESCRIPTION
## Which issue does this PR close?

SQL Unparser incorrectly handles `ILIKE` expressions, handling all as `LIKE`, ignoring `case_insensitive` flag.

## Rationale for this change

Case sensitivity shouldn't be ignored in `ILIKE` expressions, as it's a part of the SQL standard.

## What changes are included in this PR?

Added correct handling for `case_insensitive` flag in `ILIKE` expressions in SQL unparser

## Are these changes tested?

Yes, covered by additional SQL roundtrip test in plan_to_sql, fixed and extended expressions tests for LIKE/ILIKE.

## Are there any user-facing changes?

No
