### PR TITLE
fix: fold cast null to substrait typed null

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -1597,7 +1597,7 @@ pub fn from_cast(
                 nullable: true,
                 type_variation_reference: DEFAULT_TYPE_VARIATION_REF,
                 literal_type: Some(LiteralType::Null(to_substrait_type(
-                    &data_type, true,
+                    data_type, true,
                 )?)),
             };
             return Ok(Expression {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #15855

## Rationale for this change
fix a error where `SELECT NULL::DOUBLE` can't be encode to substrait

## What changes are included in this PR?

replace `cast(NULL, <data type>)` to typed null in substrait

## Are these changes tested?

unit tests are added, also downstream code also have test them

## Are there any user-facing changes?

shouldn't be any, simply a constant folding shouldn't affect downstream system
