### PR TITLE
Remove usage of `dbg!`

### DIFF
--- a/datafusion/physical-optimizer/src/pruning.rs
+++ b/datafusion/physical-optimizer/src/pruning.rs
@@ -28,7 +28,7 @@ use arrow::{
     datatypes::{DataType, Field, Schema, SchemaRef},
     record_batch::{RecordBatch, RecordBatchOptions},
 };
-use log::trace;
+use log::{debug, trace};
 
 use datafusion_common::error::{DataFusionError, Result};
 use datafusion_common::tree_node::TransformedResult;
@@ -1557,7 +1557,7 @@ fn build_predicate_expression(
         // allow partial failure in predicate expression generation
         // this can still produce a useful predicate when multiple conditions are joined using AND
         Err(e) => {
-            dbg!(format!("Error building pruning expression: {e}"));
+            debug!("Error building pruning expression: {e}");
             return unhandled_hook.handle(expr);
         }
     };


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Follow-up for https://github.com/apache/datafusion/pull/15764/files#r2051508562 - removes unexpected stdout logging.

## What changes are included in this PR?

Changes `dbg!` to `log::debug!`

## Are these changes tested?

N/A

## Are there any user-facing changes?

No
