### PR TITLE
chore: fix clippy::large_enum_variant for DataFusionError

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -59,7 +59,7 @@ pub enum DataFusionError {
     ParquetError(ParquetError),
     /// Error when reading Avro data.
     #[cfg(feature = "avro")]
-    AvroError(AvroError),
+    AvroError(Box<AvroError>),
     /// Error when reading / writing to / from an object_store (e.g. S3 or LocalFile)
     #[cfg(feature = "object_store")]
     ObjectStore(object_store::Error),
@@ -311,7 +311,7 @@ impl From<ParquetError> for DataFusionError {
 #[cfg(feature = "avro")]
 impl From<AvroError> for DataFusionError {
     fn from(e: AvroError) -> Self {
-        DataFusionError::AvroError(e)
+        DataFusionError::AvroError(Box::new(e))
     }
 }
 

--- a/datafusion/datasource-avro/src/avro_to_arrow/schema.rs
+++ b/datafusion/datasource-avro/src/avro_to_arrow/schema.rs
@@ -22,7 +22,7 @@ use apache_avro::types::Value;
 use apache_avro::Schema as AvroSchema;
 use arrow::datatypes::{DataType, IntervalUnit, Schema, TimeUnit, UnionMode};
 use arrow::datatypes::{Field, UnionFields};
-use datafusion_common::error::{DataFusionError, Result};
+use datafusion_common::error::Result;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -107,9 +107,7 @@ fn schema_to_field_with_props(
                         .data_type()
                         .clone()
                 } else {
-                    return Err(DataFusionError::AvroError(
-                        apache_avro::Error::GetUnionDuplicate,
-                    ));
+                    return Err(apache_avro::Error::GetUnionDuplicate.into());
                 }
             } else {
                 let fields = sub_schemas


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15860.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fixes `clippy::large_enum_variant` which has been enabled by default on nightly.  Not only does it flag a problem when compiling with `features = ["avro"]`, it also propagates a lot of lint to downstream projects which use `Result<T, DataFusionError>` as a return type.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The `DataFusionError::AvroError(AvroError)` variant is changed to `DataFusionError::AvroError(Box<AvroError>)`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Regression testing will validate that error messages from Avro are preserved.

I have tested using the reproducer from #15860 to verify that this change removes the lint.  To add a regression test to verify this would require changes to project configuration or CI. I will implement this if requested but didn't see the point in putting in up-front effort.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Users invoking the `DataFusionError::AvroError` constructor directly must update their code to either `DataFusionError::AvroError(Box::new(my_avro_error))` or `DataFusionError::from(my_avro_error)`.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
