### PR TITLE
fix: Allow ORDER BY aggregates not present in SELECT list

### DIFF
--- a/datafusion/expr/src/expr_rewriter/order_by.rs
+++ b/datafusion/expr/src/expr_rewriter/order_by.rs
@@ -27,6 +27,7 @@ use datafusion_common::tree_node::{
 use datafusion_common::{Column, Result};
 
 /// Rewrite sort on aggregate expressions to sort on the column of aggregate output
+/// If an aggregate expression is not found in `aggregate.agg_expr`, it won't be rewritten.
 /// For example, `max(x)` is written to `col("max(x)")`
 pub fn rewrite_sort_cols_by_aggs(
     sorts: impl IntoIterator<Item = impl Into<Sort>>,

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -352,10 +352,10 @@ fn roundtrip_statement_with_dialect_2() -> Result<(), DataFusionError> {
 #[test]
 fn roundtrip_statement_with_dialect_3() -> Result<(), DataFusionError> {
     roundtrip_statement_with_dialect_helper!(
-        sql: "select min(ta.j1_id) as j1_min, max(tb.j1_max) from j1 ta, (select distinct max(ta.j1_id) as j1_max from j1 ta order by max(ta.j1_id)) tb order by min(ta.j1_id) limit 10;",
+        sql: "select min(ta.j1_id) as j1_min, max(tb.j1_max) from j1 ta, (select distinct max(ta.j1_id) as j1_max from j1 ta ) tb order by min(ta.j1_id) limit 10;",
         parser_dialect: MySqlDialect {},
         unparser_dialect: UnparserMySqlDialect {},
-        expected: @"SELECT `j1_min`, `max(tb.j1_max)` FROM (SELECT min(`ta`.`j1_id`) AS `j1_min`, max(`tb`.`j1_max`), min(`ta`.`j1_id`) FROM `j1` AS `ta` CROSS JOIN (SELECT `j1_max` FROM (SELECT DISTINCT max(`ta`.`j1_id`) AS `j1_max` FROM `j1` AS `ta`) AS `derived_distinct`) AS `tb` ORDER BY min(`ta`.`j1_id`) ASC) AS `derived_sort` LIMIT 10",
+        expected: @"SELECT `j1_min`, `max(tb.j1_max)` FROM (SELECT min(`ta`.`j1_id`) AS `j1_min`, max(`tb`.`j1_max`), min(`ta`.`j1_id`) FROM `j1` AS `ta` CROSS JOIN (SELECT DISTINCT max(`ta`.`j1_id`) AS `j1_max` FROM `j1` AS `ta`) AS `tb` ORDER BY min(`ta`.`j1_id`) ASC) AS `derived_sort` LIMIT 10",
     );
     Ok(())
 }

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -959,7 +959,7 @@ SELECT SUM(column1) FROM foo ORDER BY SUM(column1)
 16
 
 # Order by unprojected aggregate expressions is not supported
-query error DataFusion error: Error during planning: Aggregate functions are not allowed in the ORDER BY clause without a GROUP BY clause.
+query error DataFusion error: Error during planning: cannot add new aggregate func to TableScan: foo
 SELECT column2 FROM foo ORDER BY SUM(column1)
 
 statement ok

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -959,7 +959,7 @@ SELECT SUM(column1) FROM foo ORDER BY SUM(column1)
 16
 
 # Order by unprojected aggregate expressions is not supported
-query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression AggregateFunction
+query error DataFusion error: Error during planning: Aggregate functions are not allowed in the ORDER BY clause without a GROUP BY clause.
 SELECT column2 FROM foo ORDER BY SUM(column1)
 
 statement ok
@@ -1381,6 +1381,7 @@ physical_plan
 statement ok
 drop table table_with_ordered_not_null;
 
+
 # ORDER BY ALL
 statement ok
 set datafusion.sql_parser.dialect = 'DuckDB';
@@ -1419,3 +1420,35 @@ SELECT address, zip FROM addresses ORDER BY ALL;
 111 Duck Duck Goose Ln 11111
 111 Duck Duck Goose Ln 11111-0001
 123 Quack Blvd 11111
+
+# test order by agg func not selected
+statement ok
+CREATE TABLE order_by_agg_func_not_selected (
+  g INT,
+  o INT
+) AS VALUES
+(1, -1),
+(2, -2),
+(3, -3)
+
+query II
+SELECT g, max(o) + count(o)  FROM order_by_agg_func_not_selected group by g order by min(o)
+----
+3 -2
+2 -1
+1 0
+
+
+
+query II
+SELECT g, max(o) + count(o)  FROM order_by_agg_func_not_selected group by g  having  max(o) + min(o) >= -4 order by avg(o)
+----
+2 -1
+1 0
+
+query II
+SELECT g, max(o) + count(o)  FROM order_by_agg_func_not_selected group by g  having  max(o) + min(o) >= -4 order by max(o) + 1
+----
+2 -1
+1 0
+


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15875.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
If `sorts.expr` contains agg_func not selected. We first add them to LogicalPlan:Aggreate , then let `sort.children` output this columns
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
