### PR TITLE
Support inferring new predicates to push down

### DIFF
--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -59,7 +59,7 @@ pub(crate) fn replace_qualified_name(
     let replace_map: HashMap<&Column, &Column> =
         cols.iter().zip(alias_cols.iter()).collect();
 
-    replace_col(expr, &replace_map)
+    replace_col(expr, &replace_map, |col| Expr::Column((*col).clone()))
 }
 
 /// Log the plan in debug/tracing mode after some part of the optimizer runs
@@ -136,7 +136,9 @@ fn evaluate_expr_with_null_column<'a>(
         .map(|column| (column, &null_column))
         .collect::<HashMap<_, _>>();
 
-    let replaced_predicate = replace_col(predicate, &join_cols_to_replace)?;
+    let replaced_predicate = replace_col(predicate, &join_cols_to_replace, |col| {
+        Expr::Column((*col).clone())
+    })?;
     let coerced_predicate = coerce(replaced_predicate, &input_schema)?;
     create_physical_expr(&coerced_predicate, &input_schema, &execution_props)?
         .evaluate(&input_batch)

--- a/datafusion/sqllogictest/test_files/push_down_filter.slt
+++ b/datafusion/sqllogictest/test_files/push_down_filter.slt
@@ -259,3 +259,35 @@ logical_plan TableScan: t projection=[a], full_filters=[CAST(t.a AS Utf8) = Utf8
 
 statement ok
 drop table t;
+
+statement ok
+create table t1(a int, b int) as values(1, 2), (2, 3), (3 ,4);
+
+statement ok
+create table t2(a int, b int) as values (1, 2), (2, 4), (4, 5);
+
+query TT
+explain select
+  *
+from
+  t1
+  join t2 on t1.a = t2.a
+  and t1.b between t2.b
+  and t2.b + 2
+where
+  t2.b = 3
+----
+logical_plan
+01)Inner Join: t1.a = t2.a
+02)--Projection: t1.a, t1.b
+03)----Filter: __common_expr_4 >= Int64(3) AND __common_expr_4 <= Int64(5)
+04)------Projection: CAST(t1.b AS Int64) AS __common_expr_4, t1.a, t1.b
+05)--------TableScan: t1 projection=[a, b]
+06)--Filter: t2.b = Int32(3)
+07)----TableScan: t2 projection=[a, b]
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We can infer new predicates from existing predicates to push down to reduce IO and improve performance dramatically

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Infers new predicates by substituting equalities.
For example, with predicates `t2.b = 3` and `t1.b > t2.b`,  we can infer `t1.b > 3`.

See sqllogictest for another case.


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
