### PR TITLE
fix: overcounting of memory in first/last.

### DIFF
--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -752,7 +752,7 @@ where
 
     fn size(&self) -> usize {
         self.vals.capacity() * size_of::<T::Native>()
-            + self.null_builder.capacity() / 8 // capacity is in bits, so convert to bytes 
+            + self.null_builder.capacity() / 8 // capacity is in bits, so convert to bytes
             + self.is_sets.capacity() / 8
             + self.size_of_orderings
             + self.min_of_each_group_buf.0.capacity() * size_of::<usize>()
@@ -827,9 +827,14 @@ impl FirstValueAccumulator {
     }
 
     // Updates state with the values in the given row.
-    fn update_with_new_row(&mut self, row: &[ScalarValue]) {
-        self.first = row[0].clone();
-        self.orderings = row[1..].to_vec();
+    fn update_with_new_row(&mut self, mut row: Vec<ScalarValue>) {
+        // Ensure any Array based scalars hold have a single value to reduce memory pressure
+        row.iter_mut().for_each(|s| {
+            s.compact();
+        });
+
+        self.first = row.remove(0);
+        self.orderings = row;
         self.is_set = true;
     }
 
@@ -888,7 +893,7 @@ impl Accumulator for FirstValueAccumulator {
         if !self.is_set {
             if let Some(first_idx) = self.get_first_idx(values)? {
                 let row = get_row_at_idx(values, first_idx)?;
-                self.update_with_new_row(&row);
+                self.update_with_new_row(row);
             }
         } else if !self.requirement_satisfied {
             if let Some(first_idx) = self.get_first_idx(values)? {
@@ -901,7 +906,7 @@ impl Accumulator for FirstValueAccumulator {
                 )?
                 .is_gt()
                 {
-                    self.update_with_new_row(&row);
+                    self.update_with_new_row(row);
                 }
             }
         }
@@ -925,7 +930,7 @@ impl Accumulator for FirstValueAccumulator {
         let min = (0..filtered_states[0].len()).min_by(|&a, &b| comparator.compare(a, b));
 
         if let Some(first_idx) = min {
-            let first_row = get_row_at_idx(&filtered_states, first_idx)?;
+            let mut first_row = get_row_at_idx(&filtered_states, first_idx)?;
             // When collecting orderings, we exclude the is_set flag from the state.
             let first_ordering = &first_row[1..is_set_idx];
             let sort_options = get_sort_options(self.ordering_req.as_ref());
@@ -936,7 +941,9 @@ impl Accumulator for FirstValueAccumulator {
                 // Update with first value in the state. Note that we should exclude the
                 // is_set flag from the state. Otherwise, we will end up with a state
                 // containing two is_set flags.
-                self.update_with_new_row(&first_row[0..is_set_idx]);
+                assert!(is_set_idx <= first_row.len());
+                first_row.resize(is_set_idx, ScalarValue::Null);
+                self.update_with_new_row(first_row);
             }
         }
         Ok(())
@@ -1226,9 +1233,14 @@ impl LastValueAccumulator {
     }
 
     // Updates state with the values in the given row.
-    fn update_with_new_row(&mut self, row: &[ScalarValue]) {
-        self.last = row[0].clone();
-        self.orderings = row[1..].to_vec();
+    fn update_with_new_row(&mut self, mut row: Vec<ScalarValue>) {
+        // Ensure any Array based scalars hold have a single value to reduce memory pressure
+        row.iter_mut().for_each(|s| {
+            s.compact();
+        });
+
+        self.last = row.remove(0);
+        self.orderings = row;
         self.is_set = true;
     }
 
@@ -1289,7 +1301,7 @@ impl Accumulator for LastValueAccumulator {
         if !self.is_set || self.requirement_satisfied {
             if let Some(last_idx) = self.get_last_idx(values)? {
                 let row = get_row_at_idx(values, last_idx)?;
-                self.update_with_new_row(&row);
+                self.update_with_new_row(row);
             }
         } else if let Some(last_idx) = self.get_last_idx(values)? {
             let row = get_row_at_idx(values, last_idx)?;
@@ -1302,7 +1314,7 @@ impl Accumulator for LastValueAccumulator {
             )?
             .is_lt()
             {
-                self.update_with_new_row(&row);
+                self.update_with_new_row(row);
             }
         }
 
@@ -1326,7 +1338,7 @@ impl Accumulator for LastValueAccumulator {
         let max = (0..filtered_states[0].len()).max_by(|&a, &b| comparator.compare(a, b));
 
         if let Some(last_idx) = max {
-            let last_row = get_row_at_idx(&filtered_states, last_idx)?;
+            let mut last_row = get_row_at_idx(&filtered_states, last_idx)?;
             // When collecting orderings, we exclude the is_set flag from the state.
             let last_ordering = &last_row[1..is_set_idx];
             let sort_options = get_sort_options(self.ordering_req.as_ref());
@@ -1339,7 +1351,9 @@ impl Accumulator for LastValueAccumulator {
                 // Update with last value in the state. Note that we should exclude the
                 // is_set flag from the state. Otherwise, we will end up with a state
                 // containing two is_set flags.
-                self.update_with_new_row(&last_row[0..is_set_idx]);
+                assert!(is_set_idx <= last_row.len());
+                last_row.resize(is_set_idx, ScalarValue::Null);
+                self.update_with_new_row(last_row);
             }
         }
         Ok(())
@@ -1382,7 +1396,13 @@ fn convert_to_sort_cols(arrs: &[ArrayRef], sort_exprs: &LexOrdering) -> Vec<Sort
 
 #[cfg(test)]
 mod tests {
-    use arrow::{array::Int64Array, compute::SortOptions, datatypes::Schema};
+    use std::iter::repeat_with;
+
+    use arrow::{
+        array::{Int64Array, ListArray},
+        compute::SortOptions,
+        datatypes::Schema,
+    };
     use datafusion_physical_expr::{expressions::col, PhysicalSortExpr};
 
     use super::*;
@@ -1769,6 +1789,62 @@ mod tests {
             Int64Array::from(vec![Some(1), Some(66), Some(6), None]);
 
         assert_eq!(eval_result, &expect);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_first_list_acc_size() -> Result<()> {
+        fn size_after_batch(values: &[ArrayRef]) -> Result<usize> {
+            let mut first_accumulator = FirstValueAccumulator::try_new(
+                &DataType::List(Arc::new(Field::new_list_field(DataType::Int64, false))),
+                &[],
+                LexOrdering::default(),
+                false,
+            )?;
+
+            first_accumulator.update_batch(values)?;
+
+            Ok(first_accumulator.size())
+        }
+
+        let batch1 = ListArray::from_iter_primitive::<Int32Type, _, _>(
+            repeat_with(|| Some(vec![Some(1)])).take(10000),
+        );
+        let batch2 =
+            ListArray::from_iter_primitive::<Int32Type, _, _>([Some(vec![Some(1)])]);
+
+        let size1 = size_after_batch(&[Arc::new(batch1)])?;
+        let size2 = size_after_batch(&[Arc::new(batch2)])?;
+        assert_eq!(size1, size2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_last_list_acc_size() -> Result<()> {
+        fn size_after_batch(values: &[ArrayRef]) -> Result<usize> {
+            let mut last_accumulator = LastValueAccumulator::try_new(
+                &DataType::List(Arc::new(Field::new_list_field(DataType::Int64, false))),
+                &[],
+                LexOrdering::default(),
+                false,
+            )?;
+
+            last_accumulator.update_batch(values)?;
+
+            Ok(last_accumulator.size())
+        }
+
+        let batch1 = ListArray::from_iter_primitive::<Int32Type, _, _>(
+            repeat_with(|| Some(vec![Some(1)])).take(10000),
+        );
+        let batch2 =
+            ListArray::from_iter_primitive::<Int32Type, _, _>([Some(vec![Some(1)])]);
+
+        let size1 = size_after_batch(&[Arc::new(batch1)])?;
+        let size2 = size_after_batch(&[Arc::new(batch2)])?;
+        assert_eq!(size1, size2);
 
         Ok(())
     }

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -645,19 +645,29 @@ fn min_max_batch_struct(array: &ArrayRef, ordering: Ordering) -> Result<ScalarVa
             }
         }
     }
-    // use force_clone to free array reference
-    Ok(extreme.force_clone())
+
+    Ok(extreme)
 }
 
 macro_rules! min_max_struct {
     ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
         if $VALUE.is_null() {
-            $DELTA.clone()
+            let mut delta_copy = $DELTA.clone();
+            // When the new value won we want to compact it to
+            // avoid storing the entire input
+            delta_copy.compact();
+            delta_copy
         } else if $DELTA.is_null() {
             $VALUE.clone()
         } else {
             match $VALUE.partial_cmp(&$DELTA) {
-                Some(choose_min_max!($OP)) => $DELTA.clone(),
+                Some(choose_min_max!($OP)) => {
+                    // When the new value won we want to compact it to
+                    // avoid storing the entire input
+                    let mut delta_copy = $DELTA.clone();
+                    delta_copy.compact();
+                    delta_copy
+                }
                 _ => $VALUE.clone(),
             }
         }


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #15923.

## Rationale for this change

When aggregating first/last list over a column of lists, the first/last
accumulators hold the necessary scalar value as is, which points to the
list in the original input buffer.

This results in two issues:

1) We prevent the deallocation of the input arrays which might be
significantly larger than the single value we want to hold.

2) During aggreagtion with groups, many accumulators receive slices of the
same input buffer, resulting in all held values pointing to this buffer.
Then, when calculating the size of all accumulators we count the buffer
multiple times, since each accumulator considers it to be part of its own
allocation.


## What changes are included in this PR?

The PR copies/compacts scalar values held by the first/last operators, such that they no longer hold the entire input buffer, thereby solving both 1 & 2.

## Are these changes tested?

Two tests are added.

## Are there any user-facing changes?

There's a new `compact` function, which might or might not be desired to be `pub`. I thought it might be useful somewhere else, but YMMV.