### PR TITLE
feat: add macros for DataFusionError variants

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -38,7 +38,7 @@ use datafusion_cli::{
 };
 
 use clap::Parser;
-use datafusion::common::config_err;
+use datafusion::common::{config_err, external_datafusion_err};
 use datafusion::config::ConfigOptions;
 use datafusion::execution::disk_manager::DiskManagerConfig;
 use mimalloc::MiMalloc;
@@ -233,7 +233,7 @@ async fn main_inner() -> Result<()> {
         // TODO maybe we can have thiserror for cli but for now let's keep it simple
         return exec::exec_from_repl(&ctx, &mut print_options)
             .await
-            .map_err(|e| DataFusionError::External(Box::new(e)));
+            .map_err(|e| external_datafusion_err!(e));
     }
 
     if !files.is_empty() {

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use std::process::ExitCode;
 use std::sync::{Arc, LazyLock};
 
-use datafusion::error::{DataFusionError, Result};
+use datafusion::error::Result;
 use datafusion::execution::context::SessionConfig;
 use datafusion::execution::memory_pool::{FairSpillPool, GreedyMemoryPool, MemoryPool};
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
@@ -381,6 +381,7 @@ pub fn extract_disk_limit(size: &str) -> Result<usize, String> {
 mod tests {
     use super::*;
     use datafusion::common::test_util::batches_to_string;
+    use datafusion::common::DataFusionError;
     use insta::assert_snapshot;
 
     fn assert_conversion(input: &str, expected: Result<usize, String>) {

--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -25,7 +25,7 @@ use crate::print_format::PrintFormat;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use datafusion::common::instant::Instant;
-use datafusion::common::DataFusionError;
+use datafusion::common::{external_err, DataFusionError};
 use datafusion::error::Result;
 use datafusion::physical_plan::RecordBatchStream;
 
@@ -143,9 +143,9 @@ impl PrintOptions {
         format_options: &FormatOptions,
     ) -> Result<()> {
         if self.format == PrintFormat::Table {
-            return Err(DataFusionError::External(
-                "PrintFormat::Table is not implemented".to_string().into(),
-            ));
+            return external_err!("PrintFormat::Table is not implemented"
+                .to_string()
+                .into());
         };
 
         let stdout = std::io::stdout();

--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -24,8 +24,8 @@ use crate::print_format::PrintFormat;
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
+use datafusion::common::external_err;
 use datafusion::common::instant::Instant;
-use datafusion::common::{external_err, DataFusionError};
 use datafusion::error::Result;
 use datafusion::physical_plan::RecordBatchStream;
 
@@ -143,9 +143,11 @@ impl PrintOptions {
         format_options: &FormatOptions,
     ) -> Result<()> {
         if self.format == PrintFormat::Table {
-            return external_err!("PrintFormat::Table is not implemented"
-                .to_string()
-                .into());
+            let err = std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "PrintFormat::Table is not implemented",
+            );
+            return external_err!(err);
         };
 
         let stdout = std::io::stdout();

--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -143,11 +143,7 @@ impl PrintOptions {
         format_options: &FormatOptions,
     ) -> Result<()> {
         if self.format == PrintFormat::Table {
-            let err = std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "PrintFormat::Table is not implemented",
-            );
-            return external_err!(err);
+            return external_err!("PrintFormat::Table is not implemented");
         };
 
         let stdout = std::io::stdout();

--- a/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/src/main.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use datafusion::{
+    common::external_datafusion_err,
     error::{DataFusionError, Result},
     prelude::SessionContext,
 };
@@ -32,12 +33,12 @@ async fn main() -> Result<()> {
     // so you will need to change the approach here based on your use case.
     let target: &std::path::Path = "../../../../target/".as_ref();
     let library_path = compute_library_path::<TableProviderModuleRef>(target)
-        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        .map_err(|e| external_datafusion_err!(e))?;
 
     // Load the module
     let table_provider_module =
         TableProviderModuleRef::load_from_directory(&library_path)
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            .map_err(|e| external_datafusion_err!(e))?;
 
     // By calling the code below, the table provided will be created within
     // the module's code.

--- a/datafusion-examples/examples/sql_query.rs
+++ b/datafusion-examples/examples/sql_query.rs
@@ -18,7 +18,9 @@
 use datafusion::arrow::array::{UInt64Array, UInt8Array};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::{assert_batches_eq, exec_datafusion_err};
+use datafusion::common::{
+    assert_batches_eq, exec_datafusion_err, external_datafusion_err,
+};
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::ListingOptions;
 use datafusion::datasource::MemTable;
@@ -168,8 +170,7 @@ async fn query_parquet() -> Result<()> {
 
     let local_fs = Arc::new(LocalFileSystem::default());
 
-    let u = url::Url::parse("file://./")
-        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+    let u = url::Url::parse("file://./").map_err(|e| external_datafusion_err!(e))?;
     ctx.register_object_store(&u, local_fs);
 
     // Register a listing table - this will use all files in the directory as data sources

--- a/datafusion-examples/examples/sql_query.rs
+++ b/datafusion-examples/examples/sql_query.rs
@@ -24,7 +24,7 @@ use datafusion::common::{
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::ListingOptions;
 use datafusion::datasource::MemTable;
-use datafusion::error::{DataFusionError, Result};
+use datafusion::error::Result;
 use datafusion::prelude::*;
 use object_store::local::LocalFileSystem;
 use std::path::Path;

--- a/datafusion/catalog/src/stream.rs
+++ b/datafusion/catalog/src/stream.rs
@@ -28,7 +28,10 @@ use std::sync::Arc;
 use crate::{Session, TableProvider, TableProviderFactory};
 use arrow::array::{RecordBatch, RecordBatchReader, RecordBatchWriter};
 use arrow::datatypes::SchemaRef;
-use datafusion_common::{config_err, plan_err, Constraints, DataFusionError, Result};
+use datafusion_common::{
+    config_err, execution_join_datafusion_err, plan_err, Constraints, DataFusionError,
+    Result,
+};
 use datafusion_common_runtime::SpawnedTask;
 use datafusion_datasource::sink::{DataSink, DataSinkExec};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
@@ -440,6 +443,6 @@ impl DataSink for StreamWrite {
         write_task
             .join_unwind()
             .await
-            .map_err(DataFusionError::ExecutionJoin)?
+            .map_err(|e| execution_join_datafusion_err!(e))?
     }
 }

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -20,7 +20,7 @@
 use crate::error::_config_err;
 use crate::parsers::CompressionTypeVariant;
 use crate::utils::get_available_parallelism;
-use crate::{DataFusionError, Result};
+use crate::{external_datafusion_err, DataFusionError, Result};
 use std::any::Any;
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
@@ -1186,7 +1186,7 @@ where
                 input,
                 std::any::type_name::<T>()
             ),
-            Box::new(DataFusionError::External(Box::new(e))),
+            Box::new(external_datafusion_err!(e)),
         )
     })
 }

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -809,11 +809,17 @@ make_error!(plan_err, plan_datafusion_err, Plan);
 // Exposes a macro to create `DataFusionError::Internal` with optional backtrace
 make_error!(internal_err, internal_datafusion_err, Internal);
 
+// Exposes a macro to create `DataFusionError::IoError` with optional backtrace
+make_error!(external_err, external_datafusion_err, External);
+
 // Exposes a macro to create `DataFusionError::NotImplemented` with optional backtrace
 make_error!(not_impl_err, not_impl_datafusion_err, NotImplemented);
 
 // Exposes a macro to create `DataFusionError::Execution` with optional backtrace
 make_error!(exec_err, exec_datafusion_err, Execution);
+
+// Exposes a macro to create `DataFusionError::ExecutionJoin` with optional backtrace
+make_error!(exec_join_err, exec_join_datafusion_err, ExecutionJoin);
 
 // Exposes a macro to create `DataFusionError::Configuration` with optional backtrace
 make_error!(config_err, config_datafusion_err, Configuration);

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -671,6 +671,20 @@ impl DataFusionError {
         queue.push_back(self);
         ErrorIterator { queue }
     }
+
+    /// Converts input to a [`GenericError`],
+    /// handling both regular values and pre-boxed errors to avoid double-boxing.
+    ///
+    /// The input must implement [`Into<GenericError>`], which includes:
+    /// [`Error`] types (implementing `std::error::Error + Send + Sync + 'static`)
+    /// [`String`] and &str (automatically converted to errors)
+    /// [`Box<dyn Error + Send + Sync>`] (passed through without additional boxing)
+    pub fn box_error_if_needed<E>(err: E) -> GenericError
+    where
+        E: Into<GenericError>,
+    {
+        err.into()
+    }
 }
 
 /// A builder for [`DataFusionError`]
@@ -922,9 +936,10 @@ macro_rules! schema_err {
 // Exposes a macro to create `DataFusionError::External` with optional backtrace
 #[macro_export]
 macro_rules! external_datafusion_err {
-    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
+    ($CONVERTIBLE_TO_ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
+        let boxed_err = $crate::DataFusionError::box_error_if_needed($CONVERTIBLE_TO_ERR);
         let err = $crate::error::DataFusionError::External(
-            Box::new($ERR),
+            boxed_err,
             Some($crate::error::DataFusionError::get_back_trace())
         );
         $(

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -923,7 +923,7 @@ macro_rules! schema_err {
 #[macro_export]
 macro_rules! external_datafusion_err {
     ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
-        let err = DataFusionError::External(Box::new($ERR));
+        let err = DataFusionError::External(Box::new($ERR), Some(DataFusionError::get_back_trace()));
         $(
             let err = err.with_diagnostic($DIAG);
         )?
@@ -935,7 +935,7 @@ macro_rules! external_datafusion_err {
 #[macro_export]
 macro_rules! external_err {
     ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
-        let err = DataFusionError::(Box::new($ERR));
+        let err = let err = datafusion_common::external_datafusion_err!($ERR);
         $(
             let err = err.with_diagnostic($DIAG);
         )?
@@ -947,7 +947,7 @@ macro_rules! external_err {
 #[macro_export]
 macro_rules! execution_join_datafusion_err {
     ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
-        let err = DataFusionError::ExecutionJoin($ERR);
+        let err = DataFusionError::ExecutionJoin($ERR, Some(DataFusionError::get_back_trace()));
         $(
             let err = err.with_diagnostic($DIAG);
         )?
@@ -959,7 +959,7 @@ macro_rules! execution_join_datafusion_err {
 #[macro_export]
 macro_rules! execution_join_err {
     ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
-        let err = DataFusionError::ExecutionJoin($ERR);
+        let err = datafusion_common::execution_join_datafusion_err!($ERR);
         $(
             let err = err.with_diagnostic($DIAG);
         )?

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -935,7 +935,7 @@ macro_rules! external_datafusion_err {
 #[macro_export]
 macro_rules! external_err {
     ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
-        let err = let err = datafusion_common::external_datafusion_err!($ERR);
+        let err = datafusion_common::external_datafusion_err!($ERR);
         $(
             let err = err.with_diagnostic($DIAG);
         )?

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -923,7 +923,10 @@ macro_rules! schema_err {
 #[macro_export]
 macro_rules! external_datafusion_err {
     ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
-        let err = DataFusionError::External(Box::new($ERR), Some(DataFusionError::get_back_trace()));
+        let err = $crate::error::DataFusionError::External(
+            Box::new($ERR),
+            Some($crate::error::DataFusionError::get_back_trace())
+        );
         $(
             let err = err.with_diagnostic($DIAG);
         )?
@@ -935,7 +938,7 @@ macro_rules! external_datafusion_err {
 #[macro_export]
 macro_rules! external_err {
     ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
-        let err = datafusion_common::external_datafusion_err!($ERR);
+        let err = $crate::external_datafusion_err!($ERR);
         $(
             let err = err.with_diagnostic($DIAG);
         )?
@@ -947,7 +950,10 @@ macro_rules! external_err {
 #[macro_export]
 macro_rules! execution_join_datafusion_err {
     ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
-        let err = DataFusionError::ExecutionJoin($ERR, Some(DataFusionError::get_back_trace()));
+        let err = $crate::error::DataFusionError::ExecutionJoin(
+            $ERR,
+            Some($crate::error::DataFusionError::get_back_trace())
+        );
         $(
             let err = err.with_diagnostic($DIAG);
         )?
@@ -959,7 +965,7 @@ macro_rules! execution_join_datafusion_err {
 #[macro_export]
 macro_rules! execution_join_err {
     ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
-        let err = datafusion_common::execution_join_datafusion_err!($ERR);
+        let err = $crate::execution_join_datafusion_err!($ERR);
         $(
             let err = err.with_diagnostic($DIAG);
         )?

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -809,17 +809,11 @@ make_error!(plan_err, plan_datafusion_err, Plan);
 // Exposes a macro to create `DataFusionError::Internal` with optional backtrace
 make_error!(internal_err, internal_datafusion_err, Internal);
 
-// Exposes a macro to create `DataFusionError::IoError` with optional backtrace
-make_error!(external_err, external_datafusion_err, External);
-
 // Exposes a macro to create `DataFusionError::NotImplemented` with optional backtrace
 make_error!(not_impl_err, not_impl_datafusion_err, NotImplemented);
 
 // Exposes a macro to create `DataFusionError::Execution` with optional backtrace
 make_error!(exec_err, exec_datafusion_err, Execution);
-
-// Exposes a macro to create `DataFusionError::ExecutionJoin` with optional backtrace
-make_error!(exec_join_err, exec_join_datafusion_err, ExecutionJoin);
 
 // Exposes a macro to create `DataFusionError::Configuration` with optional backtrace
 make_error!(config_err, config_datafusion_err, Configuration);
@@ -906,8 +900,55 @@ macro_rules! schema_err {
             let err = err.with_diagnostic($DIAG);
         )?
         Err(err)
-    }
-    };
+    }};
+}
+
+// Exposes a macro to create `DataFusionError::External` with optional backtrace
+#[macro_export]
+macro_rules! external_datafusion_err {
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
+        let err = DataFusionError::External(Box::new($ERR));
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        err
+    }};
+}
+
+// Exposes a macro to create `Err(DataFusionError::External)` with optional backtrace
+#[macro_export]
+macro_rules! external_err {
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
+        let err = DataFusionError::(Box::new($ERR));
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        Err(err)
+    }};
+}
+
+// Exposes a macro to create `DataFusionError::ExecutionJoin` with optional backtrace
+#[macro_export]
+macro_rules! execution_join_datafusion_err {
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
+        let err = DataFusionError::ExecutionJoin($ERR);
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        err
+    }};
+}
+
+// Exposes a macro to create `Err(DataFusionError::ExecutionJoin)` with optional backtrace
+#[macro_export]
+macro_rules! execution_join_err {
+    ($ERR:expr $(; diagnostic = $DIAG:expr)?) => {{
+        let err = DataFusionError::ExecutionJoin($ERR);
+        $(
+            let err = err.with_diagnostic($DIAG);
+        )?
+        Err(err)
+    }};
 }
 
 // To avoid compiler error when using macro in the same crate:

--- a/datafusion/core/src/datasource/file_format/arrow.rs
+++ b/datafusion/core/src/datasource/file_format/arrow.rs
@@ -44,7 +44,8 @@ use arrow::ipc::{root_as_message, CompressionType};
 use datafusion_catalog::Session;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{
-    not_impl_err, DataFusionError, GetExt, Statistics, DEFAULT_ARROW_EXTENSION,
+    execution_join_datafusion_err, not_impl_err, DataFusionError, GetExt, Statistics,
+    DEFAULT_ARROW_EXTENSION,
 };
 use datafusion_common_runtime::{JoinSet, SpawnedTask};
 use datafusion_datasource::display::FileGroupDisplay;
@@ -294,7 +295,7 @@ impl FileSink for ArrowFileSink {
         demux_task
             .join_unwind()
             .await
-            .map_err(DataFusionError::ExecutionJoin)??;
+            .map_err(|e| execution_join_datafusion_err!(e))??;
         Ok(row_count as u64)
     }
 }

--- a/datafusion/core/src/test/mod.rs
+++ b/datafusion/core/src/test/mod.rs
@@ -38,7 +38,7 @@ use crate::test_util::{aggr_test_schema, arrow_test_data};
 use arrow::array::{self, Array, ArrayRef, Decimal128Builder, Int32Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use datafusion_common::DataFusionError;
+use datafusion_common::{external_datafusion_err, DataFusionError};
 use datafusion_datasource::source::DataSourceExec;
 
 #[cfg(feature = "compression")]
@@ -135,7 +135,7 @@ pub fn partitioned_file_groups(
             #[cfg(feature = "compression")]
             FileCompressionType::ZSTD => {
                 let encoder = ZstdEncoder::new(file, 0)
-                    .map_err(|e| DataFusionError::External(Box::new(e)))?
+                    .map_err(|e| external_datafusion_err!(e))?
                     .auto_finish();
                 Box::new(encoder)
             }

--- a/datafusion/core/src/test/mod.rs
+++ b/datafusion/core/src/test/mod.rs
@@ -38,7 +38,7 @@ use crate::test_util::{aggr_test_schema, arrow_test_data};
 use arrow::array::{self, Array, ArrayRef, Decimal128Builder, Int32Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use datafusion_common::{external_datafusion_err, DataFusionError};
+use datafusion_common::external_datafusion_err;
 use datafusion_datasource::source::DataSourceExec;
 
 #[cfg(feature = "compression")]

--- a/datafusion/datasource/src/file_compression_type.rs
+++ b/datafusion/datasource/src/file_compression_type.rs
@@ -19,7 +19,7 @@
 
 use std::str::FromStr;
 
-use datafusion_common::error::{DataFusionError, Result};
+use datafusion_common::{external_datafusion_err, DataFusionError, Result};
 
 use datafusion_common::parsers::CompressionTypeVariant::{self, *};
 use datafusion_common::GetExt;
@@ -231,7 +231,7 @@ impl FileCompressionType {
             #[cfg(feature = "compression")]
             ZSTD => match ZstdDecoder::new(r) {
                 Ok(decoder) => Box::new(decoder),
-                Err(e) => return Err(DataFusionError::External(Box::new(e))),
+                Err(e) => return Err(external_datafusion_err!(e)),
             },
             #[cfg(not(feature = "compression"))]
             GZIP | BZIP2 | XZ | ZSTD => {

--- a/datafusion/datasource/src/url.rs
+++ b/datafusion/datasource/src/url.rs
@@ -128,11 +128,7 @@ impl ListingTableUrl {
         };
 
         let url = url_from_filesystem_path(path).ok_or_else(|| {
-            let err = std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Failed to convert path to URL: {path}"),
-            );
-            external_datafusion_err!(err)
+            external_datafusion_err!(format!("Failed to convert path to URL: {path}"))
         })?;
 
         Self::try_new(url, glob)

--- a/datafusion/datasource/src/url.rs
+++ b/datafusion/datasource/src/url.rs
@@ -128,9 +128,11 @@ impl ListingTableUrl {
         };
 
         let url = url_from_filesystem_path(path).ok_or_else(|| {
-            external_datafusion_err!(
-                format!("Failed to convert path to URL: {path}").into()
-            )
+            let err = std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to convert path to URL: {path}"),
+            );
+            external_datafusion_err!(err)
         })?;
 
         Self::try_new(url, glob)

--- a/datafusion/datasource/src/write/orchestration.rs
+++ b/datafusion/datasource/src/write/orchestration.rs
@@ -27,7 +27,9 @@ use crate::file_compression_type::FileCompressionType;
 use datafusion_common::error::Result;
 
 use arrow::array::RecordBatch;
-use datafusion_common::{internal_datafusion_err, internal_err, DataFusionError};
+use datafusion_common::{
+    execution_join_datafusion_err, internal_datafusion_err, internal_err, DataFusionError,
+};
 use datafusion_common_runtime::{JoinSet, SpawnedTask};
 use datafusion_execution::TaskContext;
 
@@ -285,8 +287,8 @@ pub async fn spawn_writer_tasks_and_join(
         write_coordinator_task.join_unwind(),
         demux_task.join_unwind()
     );
-    r1.map_err(DataFusionError::ExecutionJoin)??;
-    r2.map_err(DataFusionError::ExecutionJoin)??;
+    r1.map_err(|e| execution_join_datafusion_err!(e))??;
+    r2.map_err(|e| execution_join_datafusion_err!(e))??;
 
     // Return total row count:
     rx_row_cnt.await.map_err(|_| {

--- a/datafusion/execution/src/object_store.rs
+++ b/datafusion/execution/src/object_store.rs
@@ -20,7 +20,7 @@
 //! and query data inside these systems.
 
 use dashmap::DashMap;
-use datafusion_common::{exec_err, DataFusionError, Result};
+use datafusion_common::{exec_err, external_datafusion_err, DataFusionError, Result};
 #[cfg(not(target_arch = "wasm32"))]
 use object_store::local::LocalFileSystem;
 use object_store::ObjectStore;
@@ -55,7 +55,7 @@ impl ObjectStoreUrl {
     /// ```
     pub fn parse(s: impl AsRef<str>) -> Result<Self> {
         let mut parsed =
-            Url::parse(s.as_ref()).map_err(|e| DataFusionError::External(Box::new(e)))?;
+            Url::parse(s.as_ref()).map_err(|e| external_datafusion_err!(e))?;
 
         let remaining = &parsed[url::Position::BeforePath..];
         if !remaining.is_empty() && remaining != "/" {

--- a/datafusion/expr/src/logical_plan/display.rs
+++ b/datafusion/expr/src/logical_plan/display.rs
@@ -31,7 +31,7 @@ use crate::dml::CopyTo;
 use arrow::datatypes::Schema;
 use datafusion_common::display::GraphvizBuilder;
 use datafusion_common::tree_node::{TreeNodeRecursion, TreeNodeVisitor};
-use datafusion_common::{Column, DataFusionError};
+use datafusion_common::{external_datafusion_err, Column, DataFusionError};
 use serde_json::json;
 
 /// Formats plans with a single line per node. For example:
@@ -711,7 +711,7 @@ impl<'n> TreeNodeVisitor<'n> for PgJsonVisitor<'_, '_> {
                 self.f,
                 "{}",
                 serde_json::to_string_pretty(&plan)
-                    .map_err(|e| DataFusionError::External(Box::new(e)))?
+                    .map_err(|e| external_datafusion_err!(e))?
             )?;
         }
 

--- a/datafusion/ffi/src/plan_properties.rs
+++ b/datafusion/ffi/src/plan_properties.rs
@@ -26,6 +26,7 @@ use abi_stable::{
 };
 use arrow::datatypes::SchemaRef;
 use datafusion::{
+    common::external_datafusion_err,
     error::{DataFusionError, Result},
     physical_expr::EquivalenceProperties,
     physical_plan::{
@@ -187,7 +188,7 @@ impl TryFrom<FFI_PlanProperties> for PlanProperties {
 
         let proto_output_ordering =
             PhysicalSortExprNodeCollection::decode(df_result!(ffi_orderings)?.as_ref())
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                .map_err(|e| external_datafusion_err!(e))?;
         let orderings = Some(parse_physical_sort_exprs(
             &proto_output_ordering.physical_sort_expr_nodes,
             &default_ctx,
@@ -197,9 +198,8 @@ impl TryFrom<FFI_PlanProperties> for PlanProperties {
 
         let partitioning_vec =
             unsafe { df_result!((ffi_props.output_partitioning)(&ffi_props))? };
-        let proto_output_partitioning =
-            Partitioning::decode(partitioning_vec.as_ref())
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let proto_output_partitioning = Partitioning::decode(partitioning_vec.as_ref())
+            .map_err(|e| external_datafusion_err!(e))?;
         let partitioning = parse_protobuf_partitioning(
             Some(&proto_output_partitioning),
             &default_ctx,

--- a/datafusion/ffi/src/tests/utils.rs
+++ b/datafusion/ffi/src/tests/utils.rs
@@ -17,7 +17,7 @@
 
 use crate::tests::ForeignLibraryModuleRef;
 use abi_stable::library::RootModule;
-use datafusion::error::{DataFusionError, Result};
+use datafusion::common::{external_datafusion_err, DataFusionError, Result};
 use std::path::Path;
 
 /// Compute the path to the library. It would be preferable to simply use
@@ -69,12 +69,12 @@ pub fn get_module() -> Result<ForeignLibraryModuleRef> {
     // let target: &std::path::Path = "../../../../target/".as_ref();
     let library_path =
         compute_library_path::<ForeignLibraryModuleRef>(target_dir.as_path())
-            .map_err(|e| DataFusionError::External(Box::new(e)))?
+            .map_err(|e| external_datafusion_err!(e))?
             .join("deps");
 
     // Load the module
     let module = ForeignLibraryModuleRef::load_from_directory(&library_path)
-        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        .map_err(|e| external_datafusion_err!(e))?;
 
     assert_eq!(
         module

--- a/datafusion/ffi/src/tests/utils.rs
+++ b/datafusion/ffi/src/tests/utils.rs
@@ -17,7 +17,7 @@
 
 use crate::tests::ForeignLibraryModuleRef;
 use abi_stable::library::RootModule;
-use datafusion::common::{external_datafusion_err, DataFusionError, Result};
+use datafusion::common::{external_datafusion_err, Result};
 use std::path::Path;
 
 /// Compute the path to the library. It would be preferable to simply use

--- a/datafusion/functions/src/regex/regexpreplace.rs
+++ b/datafusion/functions/src/regex/regexpreplace.rs
@@ -26,6 +26,8 @@ use arrow::array::{ArrayAccessor, StringViewArray};
 use arrow::datatypes::DataType;
 use datafusion_common::cast::as_string_view_array;
 use datafusion_common::exec_err;
+use datafusion_common::external_datafusion_err;
+use datafusion_common::external_err;
 use datafusion_common::plan_err;
 use datafusion_common::ScalarValue;
 use datafusion_common::{
@@ -278,7 +280,7 @@ where
                                         Ok(patterns.get(pattern).unwrap())
                                     }
                                     Err(err) => {
-                                        Err(DataFusionError::External(Box::new(err)))
+                                        external_err!(err)
                                     }
                                 },
                             };
@@ -344,7 +346,7 @@ where
                                         Ok(patterns.get(&pattern).unwrap())
                                     }
                                     Err(err) => {
-                                        Err(DataFusionError::External(Box::new(err)))
+                                        external_err!(err)
                                     }
                                 },
                             };
@@ -453,8 +455,7 @@ fn _regexp_replace_static_pattern_replace<T: OffsetSizeTrait>(
         None => (pattern.to_string(), 1),
     };
 
-    let re =
-        Regex::new(&pattern).map_err(|err| DataFusionError::External(Box::new(err)))?;
+    let re = Regex::new(&pattern).map_err(|err| external_datafusion_err!(err))?;
 
     // Replaces the posix groups in the replacement string
     // with rust ones.

--- a/datafusion/functions/src/regex/regexpreplace.rs
+++ b/datafusion/functions/src/regex/regexpreplace.rs
@@ -30,9 +30,7 @@ use datafusion_common::external_datafusion_err;
 use datafusion_common::external_err;
 use datafusion_common::plan_err;
 use datafusion_common::ScalarValue;
-use datafusion_common::{
-    cast::as_generic_string_array, internal_err, DataFusionError, Result,
-};
+use datafusion_common::{cast::as_generic_string_array, internal_err, Result};
 use datafusion_expr::function::Hint;
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::TypeSignature;

--- a/datafusion/optimizer/src/simplify_expressions/regex.rs
+++ b/datafusion/optimizer/src/simplify_expressions/regex.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion_common::{DataFusionError, Result, ScalarValue};
+use datafusion_common::{external_datafusion_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::{lit, BinaryExpr, Expr, Like, Operator};
 use regex_syntax::hir::{Capture, Hir, HirKind, Literal, Look};
 
@@ -79,10 +79,7 @@ pub fn simplify_regex_expr(
             }
             Err(e) => {
                 // error out early since the execution may fail anyways
-                return Err(DataFusionError::Context(
-                    "Invalid regex".to_owned(),
-                    Box::new(DataFusionError::External(Box::new(e))),
-                ));
+                return Err(external_datafusion_err!(e).context("Invalid regex"));
             }
         }
     }

--- a/datafusion/optimizer/src/simplify_expressions/regex.rs
+++ b/datafusion/optimizer/src/simplify_expressions/regex.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion_common::{external_datafusion_err, DataFusionError, Result, ScalarValue};
+use datafusion_common::{external_datafusion_err, Result, ScalarValue};
 use datafusion_expr::{lit, BinaryExpr, Expr, Like, Operator};
 use regex_syntax::hir::{Capture, Hir, HirKind, Literal, Look};
 

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -45,7 +45,7 @@ use arrow::compute::take_arrays;
 use arrow::datatypes::{SchemaRef, UInt32Type};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::utils::transpose;
-use datafusion_common::HashMap;
+use datafusion_common::{external_datafusion_err, HashMap};
 use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_common_runtime::SpawnedTask;
 use datafusion_execution::memory_pool::MemoryConsumer;
@@ -948,10 +948,8 @@ impl RepartitionExec {
                 let e = Arc::new(e);
 
                 for (_, tx) in txs {
-                    let err = Err(DataFusionError::Context(
-                        "Join Error".to_string(),
-                        Box::new(DataFusionError::External(Box::new(Arc::clone(&e)))),
-                    ));
+                    let err = Err(external_datafusion_err!(Arc::clone(&e))
+                        .context("Join Error".to_string()));
                     tx.send(Some(err)).await.ok();
                 }
             }

--- a/datafusion/physical-plan/src/spill/mod.rs
+++ b/datafusion/physical-plan/src/spill/mod.rs
@@ -33,7 +33,9 @@ use arrow::datatypes::{Schema, SchemaRef};
 use arrow::ipc::{reader::StreamReader, writer::StreamWriter};
 use arrow::record_batch::RecordBatch;
 
-use datafusion_common::{exec_datafusion_err, DataFusionError, HashSet, Result};
+use datafusion_common::{
+    exec_datafusion_err, external_err, DataFusionError, HashSet, Result,
+};
 use datafusion_common_runtime::SpawnedTask;
 use datafusion_execution::disk_manager::RefCountedTempFile;
 use datafusion_execution::RecordBatchStream;
@@ -114,7 +116,7 @@ impl SpillReaderStream {
 
             SpillReaderStreamState::ReadInProgress(task) => {
                 let result = futures::ready!(task.poll_unpin(cx))
-                    .unwrap_or_else(|err| Err(DataFusionError::External(Box::new(err))));
+                    .unwrap_or_else(|err| external_err!(err));
 
                 match result {
                     Ok((reader, batch)) => {

--- a/datafusion/physical-plan/src/spill/mod.rs
+++ b/datafusion/physical-plan/src/spill/mod.rs
@@ -33,9 +33,7 @@ use arrow::datatypes::{Schema, SchemaRef};
 use arrow::ipc::{reader::StreamReader, writer::StreamWriter};
 use arrow::record_batch::RecordBatch;
 
-use datafusion_common::{
-    exec_datafusion_err, external_err, DataFusionError, HashSet, Result,
-};
+use datafusion_common::{exec_datafusion_err, external_err, HashSet, Result};
 use datafusion_common_runtime::SpawnedTask;
 use datafusion_execution::disk_manager::RefCountedTempFile;
 use datafusion_execution::RecordBatchStream;

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -97,7 +97,8 @@ use datafusion_common::file_options::json_writer::JsonWriterOptions;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::stats::Precision;
 use datafusion_common::{
-    internal_err, not_impl_err, DataFusionError, Result, UnnestOptions,
+    external_datafusion_err, internal_err, not_impl_err, DataFusionError, Result,
+    UnnestOptions,
 };
 use datafusion_expr::{
     Accumulator, AccumulatorFactoryFunction, AggregateUDF, ColumnarValue, ScalarUDF,
@@ -1597,7 +1598,7 @@ async fn roundtrip_coalesce() -> Result<()> {
         &DefaultPhysicalExtensionCodec {},
     )?;
     let node = PhysicalPlanNode::decode(node.encode_to_vec().as_slice())
-        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        .map_err(|e| external_datafusion_err!(e))?;
     let restored = node.try_into_physical_plan(
         &ctx,
         ctx.runtime_env().as_ref(),

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -39,7 +39,7 @@ use crate::unparser::extension_unparser::{
 use crate::unparser::utils::{find_unnest_node_until_relation, unproject_agg_exprs};
 use crate::utils::UNNEST_PLACEHOLDER;
 use datafusion_common::{
-    internal_err, not_impl_err,
+    external_datafusion_err, internal_err, not_impl_err,
     tree_node::{TransformedResult, TreeNode},
     Column, DataFusionError, Result, ScalarValue, TableReference,
 };
@@ -1382,7 +1382,7 @@ impl Unparser<'_> {
 
 impl From<BuilderError> for DataFusionError {
     fn from(e: BuilderError) -> Self {
-        DataFusionError::External(Box::new(e))
+        external_datafusion_err!(e)
     }
 }
 

--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -271,7 +271,8 @@ async fn run_file_in_runner<D: AsyncDB, M: MakeConnection<Conn = D>>(
             }
             msg.push_str(&format!("{}. {err}\n\n", i + 1));
         }
-        return external_err!(msg.into());
+        let err = std::io::Error::new(std::io::ErrorKind::Other, msg);
+        return external_err!(err);
     }
 
     Ok(())

--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -271,8 +271,7 @@ async fn run_file_in_runner<D: AsyncDB, M: MakeConnection<Conn = D>>(
             }
             msg.push_str(&format!("{}. {err}\n\n", i + 1));
         }
-        let err = std::io::Error::new(std::io::ErrorKind::Other, msg);
-        return external_err!(err);
+        return external_err!(msg);
     }
 
     Ok(())


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15491.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
As #15491 says, add two macros for 
* External
* ExecutionJoin

Moreover, the macro for `ResourcesExhausted` already existed, so we don't need to add it in the PR

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
