### PR TITLE
implement `AggregateExec.partition_statistics`

### DIFF
--- a/datafusion/physical-plan/src/test/exec.rs
+++ b/datafusion/physical-plan/src/test/exec.rs
@@ -614,6 +614,103 @@ impl ExecutionPlan for StatisticsExec {
     }
 }
 
+/// A mock execution plan that returns per-partition statistics
+#[derive(Debug)]
+pub struct PartitionStatisticsExec {
+    partition_stats: Vec<Statistics>,
+    schema: SchemaRef,
+    cache: PlanProperties,
+}
+
+impl PartitionStatisticsExec {
+    pub fn new(schema: SchemaRef, partition_stats: Vec<Statistics>) -> Self {
+        let cache = Self::compute_properties(Arc::clone(&schema), partition_stats.len());
+        Self {
+            partition_stats,
+            schema,
+            cache,
+        }
+    }
+
+    fn compute_properties(schema: SchemaRef, n_partitions: usize) -> PlanProperties {
+        PlanProperties::new(
+            EquivalenceProperties::new(schema),
+            Partitioning::UnknownPartitioning(n_partitions),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        )
+    }
+}
+
+impl DisplayAs for PartitionStatisticsExec {
+    fn fmt_as(
+        &self,
+        t: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "PartitionStatisticsExec: partitions={}",
+                    self.partition_stats.len()
+                )
+            }
+            DisplayFormatType::TreeRender => write!(f, ""),
+        }
+    }
+}
+
+impl ExecutionPlan for PartitionStatisticsExec {
+    fn name(&self) -> &'static str {
+        Self::static_name()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        unimplemented!("This plan only serves for testing statistics")
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        self.partition_statistics(None)
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        match partition {
+            Some(p) => {
+                if p < self.partition_stats.len() {
+                    Ok(self.partition_stats[p].clone())
+                } else {
+                    internal_err!("only have {} partitions", self.partition_stats.len())
+                }
+            }
+            None => Statistics::try_merge_iter(self.partition_stats.iter(), &self.schema),
+        }
+    }
+}
+
 /// Execution plan that emits streams that block forever.
 ///
 /// This is useful to test shutdown / cancellation behavior of certain execution plans.


### PR DESCRIPTION
## Which issue does this PR close?
part of #15873
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- `statistics_inner`:
    - Change signature to `(self, statistics: Statistics)`.
    - Preserve `min_value`/`max_value` from input statistics when grouping by a simple `Column`.
- Add `PartitionStatisticsExec`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
