### PR TITLE
Fix `datafusion-cli` memory leak by using `snmalloc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "regex",
  "rstest",
  "rustyline",
+ "snmalloc-rs",
  "tokio",
  "url",
 ]

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -31,8 +31,10 @@ rust-version = { workspace = true }
 all-features = true
 
 [features]
-default = []
+default = ["snmalloc-global-allocator"]
 backtrace = ["datafusion/backtrace"]
+snmalloc-global-allocator = ["snmalloc-rs"]
+mimalloc-global-allocator = ["mimalloc"]
 
 [dependencies]
 arrow = { workspace = true }
@@ -55,12 +57,13 @@ datafusion = { workspace = true, features = [
 dirs = "6.0.0"
 env_logger = { workspace = true }
 futures = { workspace = true }
-mimalloc = { version = "0.1", default-features = false }
+mimalloc = { version = "0.1", default-features = false, optional = true }
 object_store = { workspace = true, features = ["aws", "gcp", "http"] }
 parking_lot = { workspace = true }
 parquet = { workspace = true, default-features = false }
 regex = { workspace = true }
 rustyline = "15.0"
+snmalloc-rs = { version = "0.3", optional = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot", "signal"] }
 url = { workspace = true }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/15939

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

To be more precise: this is not a memory leak, instead, it's memory retention by the global allocator.

The issue is in `datafusion-cli`'s REPL, the default `mimalloc` global allocator will hold memory between queries, and let the memory usage accumulate. I think it will only free the allocation lazily when hitting the physical memory limit. 
It won't cause OOM errors, but I've observed that some memory-intensive queries slow down when run after the global allocator has retained a significant amount of memory.

The direct fix is to call the purge function https://microsoft.github.io/mimalloc/group__extended.html#ga421430e2226d7d468529cec457396756, however, it's tricky to be done (has to be applied once a while on all worker threads).

I tried `snmalloc`, and the result shows:
- No more memory retention issues
- Some memory-consuming queries run faster and have a smaller memory footprint:
```
-- This query runs 50% faster and uses 30% less memory with `snmalloc`
SELECT *
FROM generate_series(1, 10000) AS t1(v1)
JOIN generate_series(1, 100000) AS t2(v2)
ON (t1.v1 + t2.v2) % 10 = 0;
```

`snmalloc` is also one of the fastest allocators like `mimalloc`. Additionally, the DataFusion benchmark already supports `snmalloc`, so I believe switching to `snmalloc` is a viable fix.


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Uses `snmalloc` by default in `datafusion-cli`, `mimalloc` is still kept as a feature.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Tested manually for the reproducer in https://github.com/apache/datafusion/issues/15939

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
