### PR TITLE
Show LogicalType name for `INFORMATION_SCHEMA`

### DIFF
--- a/datafusion/catalog/src/information_schema.rs
+++ b/datafusion/catalog/src/information_schema.rs
@@ -30,7 +30,7 @@ use arrow::{
 use async_trait::async_trait;
 use datafusion_common::config::{ConfigEntry, ConfigOptions};
 use datafusion_common::error::Result;
-use datafusion_common::types::{NativeType, NATIVE_TYPE_PREFIX};
+use datafusion_common::types::NativeType;
 use datafusion_common::DataFusionError;
 use datafusion_execution::TaskContext;
 use datafusion_expr::{AggregateUDF, ScalarUDF, Signature, TypeSignature, WindowUDF};
@@ -478,13 +478,7 @@ fn get_udwf_args_and_return_types(
 
 #[inline]
 fn remove_native_type_prefix(native_type: NativeType) -> String {
-    // native_type.to_string() is like "NATIVE_TYPE_PREFIX + native_type"
-    // here is safe to unwrap directly
-    native_type
-        .to_string()
-        .strip_prefix(NATIVE_TYPE_PREFIX)
-        .unwrap()
-        .to_string()
+    format!("{native_type:?}")
 }
 
 #[async_trait]

--- a/datafusion/catalog/src/information_schema.rs
+++ b/datafusion/catalog/src/information_schema.rs
@@ -30,6 +30,7 @@ use arrow::{
 use async_trait::async_trait;
 use datafusion_common::config::{ConfigEntry, ConfigOptions};
 use datafusion_common::error::Result;
+use datafusion_common::types::{NativeType, NATIVE_TYPE_PREFIX};
 use datafusion_common::DataFusionError;
 use datafusion_execution::TaskContext;
 use datafusion_expr::{AggregateUDF, ScalarUDF, Signature, TypeSignature, WindowUDF};
@@ -37,7 +38,7 @@ use datafusion_expr::{TableType, Volatility};
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::streaming::PartitionStream;
 use datafusion_physical_plan::SendableRecordBatchStream;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
 use std::{any::Any, sync::Arc};
 
@@ -403,58 +404,63 @@ impl InformationSchemaConfig {
 /// returns a tuple of (arg_types, return_type)
 fn get_udf_args_and_return_types(
     udf: &Arc<ScalarUDF>,
-) -> Result<Vec<(Vec<String>, Option<String>)>> {
+) -> Result<BTreeSet<(Vec<String>, Option<String>)>> {
     let signature = udf.signature();
     let arg_types = signature.type_signature.get_example_types();
     if arg_types.is_empty() {
-        Ok(vec![(vec![], None)])
+        Ok(vec![(vec![], None)].into_iter().collect::<BTreeSet<_>>())
     } else {
         Ok(arg_types
             .into_iter()
             .map(|arg_types| {
                 // only handle the function which implemented [`ScalarUDFImpl::return_type`] method
-                let return_type = udf.return_type(&arg_types).ok().map(|t| t.to_string());
+                let return_type = udf
+                    .return_type(&arg_types)
+                    .map(|t| remove_native_type_prefix(NativeType::from(t)))
+                    .ok();
                 let arg_types = arg_types
                     .into_iter()
-                    .map(|t| t.to_string())
+                    .map(|t| remove_native_type_prefix(NativeType::from(t)))
                     .collect::<Vec<_>>();
                 (arg_types, return_type)
             })
-            .collect::<Vec<_>>())
+            .collect::<BTreeSet<_>>())
     }
 }
 
 fn get_udaf_args_and_return_types(
     udaf: &Arc<AggregateUDF>,
-) -> Result<Vec<(Vec<String>, Option<String>)>> {
+) -> Result<BTreeSet<(Vec<String>, Option<String>)>> {
     let signature = udaf.signature();
     let arg_types = signature.type_signature.get_example_types();
     if arg_types.is_empty() {
-        Ok(vec![(vec![], None)])
+        Ok(vec![(vec![], None)].into_iter().collect::<BTreeSet<_>>())
     } else {
         Ok(arg_types
             .into_iter()
             .map(|arg_types| {
                 // only handle the function which implemented [`ScalarUDFImpl::return_type`] method
-                let return_type =
-                    udaf.return_type(&arg_types).ok().map(|t| t.to_string());
+                let return_type = udaf
+                    .return_type(&arg_types)
+                    .ok()
+                    .map(|t| remove_native_type_prefix(NativeType::from(t)));
                 let arg_types = arg_types
                     .into_iter()
-                    .map(|t| t.to_string())
+                    .map(|t| remove_native_type_prefix(NativeType::from(t)))
                     .collect::<Vec<_>>();
                 (arg_types, return_type)
             })
-            .collect::<Vec<_>>())
+            .collect::<BTreeSet<_>>())
     }
 }
 
 fn get_udwf_args_and_return_types(
     udwf: &Arc<WindowUDF>,
-) -> Result<Vec<(Vec<String>, Option<String>)>> {
+) -> Result<BTreeSet<(Vec<String>, Option<String>)>> {
     let signature = udwf.signature();
     let arg_types = signature.type_signature.get_example_types();
     if arg_types.is_empty() {
-        Ok(vec![(vec![], None)])
+        Ok(vec![(vec![], None)].into_iter().collect::<BTreeSet<_>>())
     } else {
         Ok(arg_types
             .into_iter()
@@ -462,12 +468,23 @@ fn get_udwf_args_and_return_types(
                 // only handle the function which implemented [`ScalarUDFImpl::return_type`] method
                 let arg_types = arg_types
                     .into_iter()
-                    .map(|t| t.to_string())
+                    .map(|t| remove_native_type_prefix(NativeType::from(t)))
                     .collect::<Vec<_>>();
                 (arg_types, None)
             })
-            .collect::<Vec<_>>())
+            .collect::<BTreeSet<_>>())
     }
+}
+
+#[inline]
+fn remove_native_type_prefix(native_type: NativeType) -> String {
+    // native_type.to_string() is like "NATIVE_TYPE_PREFIX + native_type"
+    // here is safe to unwrap directly
+    native_type
+        .to_string()
+        .strip_prefix(NATIVE_TYPE_PREFIX)
+        .unwrap()
+        .to_string()
 }
 
 #[async_trait]

--- a/datafusion/common/src/types/native.rs
+++ b/datafusion/common/src/types/native.rs
@@ -183,9 +183,11 @@ pub enum NativeType {
     Map(LogicalFieldRef),
 }
 
+pub const NATIVE_TYPE_PREFIX: &str = "NativeType::";
+
 impl Display for NativeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "NativeType::{self:?}")
+        write!(f, "{NATIVE_TYPE_PREFIX}{self:?}")
     }
 }
 

--- a/datafusion/common/src/types/native.rs
+++ b/datafusion/common/src/types/native.rs
@@ -183,11 +183,9 @@ pub enum NativeType {
     Map(LogicalFieldRef),
 }
 
-pub const NATIVE_TYPE_PREFIX: &str = "NativeType::";
-
 impl Display for NativeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{NATIVE_TYPE_PREFIX}{self:?}")
+        write!(f, "NativeType::{self:?}")
     }
 }
 

--- a/datafusion/sqllogictest/test_files/information_schema.slt
+++ b/datafusion/sqllogictest/test_files/information_schema.slt
@@ -689,7 +689,7 @@ datafusion public abc CREATE EXTERNAL TABLE abc STORED AS CSV LOCATION ../../tes
 query TTT
 select routine_name, data_type, function_type from information_schema.routines where routine_name = 'string_agg';
 ----
-string_agg LargeUtf8 AGGREGATE
+string_agg String AGGREGATE
 
 # test every function type are included in the result
 query TTTTTTTBTTTT rowsort
@@ -704,7 +704,7 @@ datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestam
 datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Second, None) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
 datafusion public date_trunc datafusion public date_trunc FUNCTION true Timestamp(Second, Some("+TZ")) SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
 datafusion public rank datafusion public rank FUNCTION true NULL WINDOW Returns the rank of the current row within its partition, allowing gaps between ranks. This function provides a ranking similar to `row_number`, but skips ranks for identical values. rank()
-datafusion public string_agg datafusion public string_agg FUNCTION true LargeUtf8 AGGREGATE Concatenates the values of string expressions and places separator values between them. If ordering is required, strings are concatenated in the specified order. This aggregation function can only mix DISTINCT and ORDER BY if the ordering expression is exactly the same as the first argument expression. string_agg([DISTINCT] expression, delimiter [ORDER BY expression])
+datafusion public string_agg datafusion public string_agg FUNCTION true String AGGREGATE Concatenates the values of string expressions and places separator values between them. If ordering is required, strings are concatenated in the specified order. This aggregation function can only mix DISTINCT and ORDER BY if the ordering expression is exactly the same as the first argument expression. string_agg([DISTINCT] expression, delimiter [ORDER BY expression])
 
 query B
 select is_deterministic from information_schema.routines where routine_name = 'now';
@@ -713,119 +713,65 @@ false
 
 # test every function type are included in the result
 query TTTITTTTBI
-select * from information_schema.parameters where specific_name = 'date_trunc' OR specific_name = 'string_agg' OR specific_name = 'rank' ORDER BY specific_name, rid;
+select * from information_schema.parameters where specific_name = 'date_trunc' OR specific_name = 'string_agg' OR specific_name = 'rank' ORDER BY specific_name, rid, data_type;
 ----
-datafusion public date_trunc 1 IN precision Utf8 NULL false 0
-datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, None) NULL false 0
-datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, None) NULL false 0
-datafusion public date_trunc 1 IN precision Utf8View NULL false 1
-datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, None) NULL false 1
-datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, None) NULL false 1
-datafusion public date_trunc 1 IN precision Utf8 NULL false 2
-datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, Some("+TZ")) NULL false 2
-datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, Some("+TZ")) NULL false 2
-datafusion public date_trunc 1 IN precision Utf8View NULL false 3
-datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, Some("+TZ")) NULL false 3
-datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, Some("+TZ")) NULL false 3
-datafusion public date_trunc 1 IN precision Utf8 NULL false 4
-datafusion public date_trunc 2 IN expression Timestamp(Microsecond, None) NULL false 4
-datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, None) NULL false 4
-datafusion public date_trunc 1 IN precision Utf8View NULL false 5
-datafusion public date_trunc 2 IN expression Timestamp(Microsecond, None) NULL false 5
-datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, None) NULL false 5
-datafusion public date_trunc 1 IN precision Utf8 NULL false 6
-datafusion public date_trunc 2 IN expression Timestamp(Microsecond, Some("+TZ")) NULL false 6
-datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, Some("+TZ")) NULL false 6
-datafusion public date_trunc 1 IN precision Utf8View NULL false 7
-datafusion public date_trunc 2 IN expression Timestamp(Microsecond, Some("+TZ")) NULL false 7
-datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, Some("+TZ")) NULL false 7
-datafusion public date_trunc 1 IN precision Utf8 NULL false 8
-datafusion public date_trunc 2 IN expression Timestamp(Millisecond, None) NULL false 8
-datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, None) NULL false 8
-datafusion public date_trunc 1 IN precision Utf8View NULL false 9
-datafusion public date_trunc 2 IN expression Timestamp(Millisecond, None) NULL false 9
-datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, None) NULL false 9
-datafusion public date_trunc 1 IN precision Utf8 NULL false 10
-datafusion public date_trunc 2 IN expression Timestamp(Millisecond, Some("+TZ")) NULL false 10
-datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, Some("+TZ")) NULL false 10
-datafusion public date_trunc 1 IN precision Utf8View NULL false 11
-datafusion public date_trunc 2 IN expression Timestamp(Millisecond, Some("+TZ")) NULL false 11
-datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, Some("+TZ")) NULL false 11
-datafusion public date_trunc 1 IN precision Utf8 NULL false 12
-datafusion public date_trunc 2 IN expression Timestamp(Second, None) NULL false 12
-datafusion public date_trunc 1 OUT NULL Timestamp(Second, None) NULL false 12
-datafusion public date_trunc 1 IN precision Utf8View NULL false 13
-datafusion public date_trunc 2 IN expression Timestamp(Second, None) NULL false 13
-datafusion public date_trunc 1 OUT NULL Timestamp(Second, None) NULL false 13
-datafusion public date_trunc 1 IN precision Utf8 NULL false 14
-datafusion public date_trunc 2 IN expression Timestamp(Second, Some("+TZ")) NULL false 14
-datafusion public date_trunc 1 OUT NULL Timestamp(Second, Some("+TZ")) NULL false 14
-datafusion public date_trunc 1 IN precision Utf8View NULL false 15
-datafusion public date_trunc 2 IN expression Timestamp(Second, Some("+TZ")) NULL false 15
-datafusion public date_trunc 1 OUT NULL Timestamp(Second, Some("+TZ")) NULL false 15
-datafusion public string_agg 1 IN expression LargeUtf8 NULL false 0
-datafusion public string_agg 2 IN delimiter Utf8 NULL false 0
-datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 0
-datafusion public string_agg 1 IN expression LargeUtf8 NULL false 1
-datafusion public string_agg 2 IN delimiter LargeUtf8 NULL false 1
-datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 1
-datafusion public string_agg 1 IN expression LargeUtf8 NULL false 2
-datafusion public string_agg 2 IN delimiter Null NULL false 2
-datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 2
-datafusion public string_agg 1 IN expression Utf8 NULL false 3
-datafusion public string_agg 2 IN delimiter Utf8 NULL false 3
-datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 3
-datafusion public string_agg 1 IN expression Utf8 NULL false 4
-datafusion public string_agg 2 IN delimiter LargeUtf8 NULL false 4
-datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 4
-datafusion public string_agg 1 IN expression Utf8 NULL false 5
-datafusion public string_agg 2 IN delimiter Null NULL false 5
-datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 5
+datafusion public date_trunc 1 IN precision String NULL false 0
+datafusion public date_trunc 2 IN expression Timestamp(Microsecond, None) NULL false 0
+datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, None) NULL false 0
+datafusion public date_trunc 1 IN precision String NULL false 1
+datafusion public date_trunc 2 IN expression Timestamp(Microsecond, Some("+TZ")) NULL false 1
+datafusion public date_trunc 1 OUT NULL Timestamp(Microsecond, Some("+TZ")) NULL false 1
+datafusion public date_trunc 1 IN precision String NULL false 2
+datafusion public date_trunc 2 IN expression Timestamp(Millisecond, None) NULL false 2
+datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, None) NULL false 2
+datafusion public date_trunc 1 IN precision String NULL false 3
+datafusion public date_trunc 2 IN expression Timestamp(Millisecond, Some("+TZ")) NULL false 3
+datafusion public date_trunc 1 OUT NULL Timestamp(Millisecond, Some("+TZ")) NULL false 3
+datafusion public date_trunc 1 IN precision String NULL false 4
+datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, None) NULL false 4
+datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, None) NULL false 4
+datafusion public date_trunc 1 IN precision String NULL false 5
+datafusion public date_trunc 2 IN expression Timestamp(Nanosecond, Some("+TZ")) NULL false 5
+datafusion public date_trunc 1 OUT NULL Timestamp(Nanosecond, Some("+TZ")) NULL false 5
+datafusion public date_trunc 1 IN precision String NULL false 6
+datafusion public date_trunc 2 IN expression Timestamp(Second, None) NULL false 6
+datafusion public date_trunc 1 OUT NULL Timestamp(Second, None) NULL false 6
+datafusion public date_trunc 1 IN precision String NULL false 7
+datafusion public date_trunc 2 IN expression Timestamp(Second, Some("+TZ")) NULL false 7
+datafusion public date_trunc 1 OUT NULL Timestamp(Second, Some("+TZ")) NULL false 7
+datafusion public string_agg 2 IN delimiter Null NULL false 0
+datafusion public string_agg 1 IN expression String NULL false 0
+datafusion public string_agg 1 OUT NULL String NULL false 0
+datafusion public string_agg 1 IN expression String NULL false 1
+datafusion public string_agg 2 IN delimiter String NULL false 1
+datafusion public string_agg 1 OUT NULL String NULL false 1
 
 # test variable length arguments
 query TTTBI rowsort
 select specific_name, data_type, parameter_mode, is_variadic, rid from information_schema.parameters where specific_name = 'concat';
 ----
-concat LargeUtf8 IN true 2
-concat LargeUtf8 OUT false 2
-concat Utf8 IN true 1
-concat Utf8 OUT false 1
-concat Utf8View IN true 0
-concat Utf8View OUT false 0
+concat String IN true 0
+concat String OUT false 0
 
 # test ceorcion signature
 query TTITI rowsort
 select specific_name, data_type, ordinal_position, parameter_mode, rid from information_schema.parameters where specific_name = 'repeat';
 ----
 repeat Int64 2 IN 0
-repeat Int64 2 IN 1
-repeat Int64 2 IN 2
-repeat LargeUtf8 1 IN 1
-repeat LargeUtf8 1 OUT 1
-repeat Utf8 1 IN 0
-repeat Utf8 1 OUT 0
-repeat Utf8 1 OUT 2
-repeat Utf8View 1 IN 2
+repeat String 1 IN 0
+repeat String 1 OUT 0
 
 query TT??TTT rowsort
 show functions like 'date_trunc';
 ----
-date_trunc Timestamp(Microsecond, None) [precision, expression] [Utf8, Timestamp(Microsecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Microsecond, None) [precision, expression] [Utf8View, Timestamp(Microsecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Microsecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Microsecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Microsecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Microsecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Millisecond, None) [precision, expression] [Utf8, Timestamp(Millisecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Millisecond, None) [precision, expression] [Utf8View, Timestamp(Millisecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Millisecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Millisecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Millisecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Millisecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Nanosecond, None) [precision, expression] [Utf8, Timestamp(Nanosecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Nanosecond, None) [precision, expression] [Utf8View, Timestamp(Nanosecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Nanosecond, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Nanosecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Nanosecond, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Nanosecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Second, None) [precision, expression] [Utf8, Timestamp(Second, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Second, None) [precision, expression] [Utf8View, Timestamp(Second, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Second, Some("+TZ")) [precision, expression] [Utf8, Timestamp(Second, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
-date_trunc Timestamp(Second, Some("+TZ")) [precision, expression] [Utf8View, Timestamp(Second, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Microsecond, None) [precision, expression] [String, Timestamp(Microsecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Microsecond, Some("+TZ")) [precision, expression] [String, Timestamp(Microsecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, None) [precision, expression] [String, Timestamp(Millisecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Millisecond, Some("+TZ")) [precision, expression] [String, Timestamp(Millisecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, None) [precision, expression] [String, Timestamp(Nanosecond, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Nanosecond, Some("+TZ")) [precision, expression] [String, Timestamp(Nanosecond, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, None) [precision, expression] [String, Timestamp(Second, None)] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
+date_trunc Timestamp(Second, Some("+TZ")) [precision, expression] [String, Timestamp(Second, Some("+TZ"))] SCALAR Truncates a timestamp value to a specified precision. date_trunc(precision, expression)
 
 statement ok
 show functions


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related to https://github.com/apache/datafusion/issues/13371

## Rationale for this change
Previously, we showed the physical type name for the function parameter type. However, it produces too many similar records for a function. For example, if we try to get the parameters of `string_agg`, we will get the result:
```
datafusion public string_agg 1 IN expression LargeUtf8 NULL false 0
datafusion public string_agg 2 IN delimiter Utf8 NULL false 0
datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 0
datafusion public string_agg 1 IN expression LargeUtf8 NULL false 1
datafusion public string_agg 2 IN delimiter LargeUtf8 NULL false 1
datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 1
datafusion public string_agg 1 IN expression LargeUtf8 NULL false 2
datafusion public string_agg 2 IN delimiter Null NULL false 2
datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 2
datafusion public string_agg 1 IN expression Utf8 NULL false 3
datafusion public string_agg 2 IN delimiter Utf8 NULL false 3
datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 3
datafusion public string_agg 1 IN expression Utf8 NULL false 4
datafusion public string_agg 2 IN delimiter LargeUtf8 NULL false 4
datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 4
datafusion public string_agg 1 IN expression Utf8 NULL false 5
datafusion public string_agg 2 IN delimiter Null NULL false 5
datafusion public string_agg 1 OUT NULL LargeUtf8 NULL false 5
```
`LargeUtf8` and `Utf8` can be represented by `NativeType::String`. So, after we change to the logical type name, we can get
```
datafusion public string_agg 2 IN delimiter Null NULL false 0
datafusion public string_agg 1 IN expression String NULL false 0
datafusion public string_agg 1 OUT NULL String NULL false 0
datafusion public string_agg 1 IN expression String NULL false 1
datafusion public string_agg 2 IN delimiter String NULL false 1
datafusion public string_agg 1 OUT NULL String NULL false 1
```
The number of combinations can be decreased significantly.
I think that it's enough to make the user know how to use the function through the logical type name.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Show native type for the column of `INFORMATION_SCHEMA.parameters` and `routines`.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
sqllogictests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Now, users get the logical type name instead of the physical type name.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
