### PR TITLE
[Update] : Removal of duplicate CI jobs

### DIFF
--- a/.github/workflows/docs_pr.yaml
+++ b/.github/workflows/docs_pr.yaml
@@ -34,26 +34,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Run doc tests
-  linux-test-doc:
-    name: cargo doctest (amd64)
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 1
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-      - name: Run doctests (embedded rust examples)
-        run: cargo test --doc --features avro,json
-      - name: Verify Working Directory Clean
-        run: git diff --exit-code
-
+  
   # Test doc build
   linux-test-doc-build:
     name: Test doc build


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15951 

## Rationale for this change
@alamb  noticed that some CI jobs are doing the same task with the different names and thus adding an extra 15 minutes in the CI jobs .thus , this two same jobs are unnecessary and need to be handle 

## What changes are included in this PR?
Updates the `docs_pr.yaml`

