### PR TITLE
Segfault in ByteGroupValueBuilder

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
@@ -50,6 +50,8 @@ where
     offsets: Vec<O>,
     /// Nulls
     nulls: MaybeNullBufferBuilder,
+    /// The maximum size of the buffer for `0`
+    max_buffer_size: usize,
 }
 
 impl<O> ByteGroupValueBuilder<O>
@@ -62,6 +64,11 @@ where
             buffer: BufferBuilder::new(INITIAL_BUFFER_CAPACITY),
             offsets: vec![O::default()],
             nulls: MaybeNullBufferBuilder::new(),
+            max_buffer_size: if O::IS_LARGE {
+                i64::MAX as usize
+            } else {
+                i32::MAX as usize
+            },
         }
     }
 
@@ -187,6 +194,13 @@ where
     {
         let value: &[u8] = array.value(row).as_ref();
         self.buffer.append_slice(value);
+
+        assert!(
+            self.buffer.len() <= self.max_buffer_size,
+            "offset overflow, buffer size > {}",
+            self.max_buffer_size
+        );
+
         self.offsets.push(O::usize_as(self.buffer.len()));
     }
 
@@ -318,6 +332,7 @@ where
             mut buffer,
             offsets,
             nulls,
+            ..
         } = *self;
 
         let null_buffer = nulls.build();
@@ -409,16 +424,18 @@ mod tests {
     use datafusion_physical_expr::binary_map::OutputType;
 
     use super::GroupColumn;
-    
+
     #[test]
+    #[should_panic]
     fn test_byte_group_value_builder_overflow() {
         let mut builder = ByteGroupValueBuilder::<i32>::new(OutputType::Utf8);
-        
+
         let large_string = std::iter::repeat('a').take(1024 * 1024).collect::<String>();
-        
-        let array = Arc::new(StringArray::from(vec![Some(large_string.as_str())])) as ArrayRef;
-        
-        // Append items until our buffer length is 1 + i32::MAX as usize 
+
+        let array =
+            Arc::new(StringArray::from(vec![Some(large_string.as_str())])) as ArrayRef;
+
+        // Append items until our buffer length is 1 + i32::MAX as usize
         for _ in 0..2048 {
             builder.append_val(&array, 0);
         }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
@@ -430,7 +430,7 @@ mod tests {
     fn test_byte_group_value_builder_overflow() {
         let mut builder = ByteGroupValueBuilder::<i32>::new(OutputType::Utf8);
 
-        let large_string = std::iter::repeat('a').take(1024 * 1024).collect::<String>();
+        let large_string = "a".repeat(1024 * 1024);
 
         let array =
             Arc::new(StringArray::from(vec![Some(large_string.as_str())])) as ArrayRef;

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
@@ -409,6 +409,22 @@ mod tests {
     use datafusion_physical_expr::binary_map::OutputType;
 
     use super::GroupColumn;
+    
+    #[test]
+    fn test_byte_group_value_builder_overflow() {
+        let mut builder = ByteGroupValueBuilder::<i32>::new(OutputType::Utf8);
+        
+        let large_string = std::iter::repeat('a').take(1024 * 1024).collect::<String>();
+        
+        let array = Arc::new(StringArray::from(vec![Some(large_string.as_str())])) as ArrayRef;
+        
+        // Append items until our buffer length is 1 + i32::MAX as usize 
+        for _ in 0..2048 {
+            builder.append_val(&array, 0);
+        }
+
+        assert_eq!(builder.value(2047), large_string.as_bytes());
+    }
 
     #[test]
     fn test_byte_take_n() {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15967.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See issue description

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

When appending values in `ByteGroupValueBuilder` we check for overflows of the underlying `OffsetSizeTrait` type

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

There is a test which reproduces the segfault without this fix

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
