### PR TITLE
make can_expr_be_pushed_down_with_schemas public again

### DIFF
--- a/datafusion/datasource-parquet/src/row_filter.rs
+++ b/datafusion/datasource-parquet/src/row_filter.rs
@@ -372,7 +372,7 @@ fn pushdown_columns(
 /// Otherwise, true.
 /// Note that the schema passed in here is *not* the physical file schema (as it is not available at that point in time);
 /// it is the schema of the table that this expression is being evaluated against minus any projected columns and partition columns.
-pub(crate) fn can_expr_be_pushed_down_with_schemas(
+pub fn can_expr_be_pushed_down_with_schemas(
     expr: &Arc<dyn PhysicalExpr>,
     file_schema: &Schema,
 ) -> bool {


### PR DESCRIPTION
I changed this from `pub fn` to pub(crate) fn` in https://github.com/apache/datafusion/pull/15769 because it was no longer being used outside of the crate.

However then I went to update our system and realized we use it as well for a custom `FileSource` implementation. I imagine others may use it as well / may want to use it.

And since it would be a breaking change to make it private... I propose we revert this before the next release and keep it public.