### PR TITLE
re-export can_expr_be_pushed_down_with_schemas to be public

### DIFF
--- a/datafusion/datasource-parquet/src/mod.rs
+++ b/datafusion/datasource-parquet/src/mod.rs
@@ -59,6 +59,7 @@ pub use metrics::ParquetFileMetrics;
 pub use page_filter::PagePruningAccessPlanFilter;
 pub use reader::{DefaultParquetFileReaderFactory, ParquetFileReaderFactory};
 pub use row_filter::build_row_filter;
+pub use row_filter::can_expr_be_pushed_down_with_schemas;
 pub use row_group_filter::RowGroupAccessPlanFilter;
 use source::ParquetSource;
 pub use writer::plan_to_parquet;


### PR DESCRIPTION
Followup to #15971. I forgot to re-export it 🤦🏻 and there's obviously no test to make sure the function is public...