### PR TITLE
Additional placeholder datatype inferencing

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1790,6 +1790,7 @@ impl Expr {
                             &Expr::Column(Column {
                                 relation: None,
                                 name: first_field.name().clone(),
+                                spans: Spans::new(),
                             }),
                             schema,
                         )?;
@@ -3326,6 +3327,7 @@ mod test {
                 schema: projected_schema,
             })),
             outer_ref_columns: vec![],
+            spans: Spans::new(),
         };
 
         let in_subquery = Expr::InSubquery(InSubquery {

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -3290,7 +3290,7 @@ mod test {
             Field::new("B", DataType::Int32, true),
         ]));
 
-        let source = Arc::new(LogicalTableSource::new(schema.clone()));
+        let source = Arc::new(LogicalTableSource::new(Arc::clone(&schema)));
 
         // Simulate: SELECT * FROM my_table WHERE $1 IN (SELECT A FROM my_table WHERE B > 3);
         let placeholder = Expr::Placeholder(Placeholder {
@@ -3308,7 +3308,7 @@ mod test {
         let subquery_scan = LogicalPlan::TableScan(TableScan {
             table_name: TableReference::from("my_table"),
             source,
-            projected_schema: Arc::new(DFSchema::try_from(schema.clone())?),
+            projected_schema: Arc::new(DFSchema::try_from(Arc::clone(&schema))?),
             projection: None,
             filters: vec![subquery_filter.clone()],
             fetch: None,

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1784,6 +1784,7 @@ impl Expr {
                     let fields = subquery_schema.fields();
 
                     // only supports subquery with exactly 1 field
+                    // https://github.com/apache/datafusion/blob/main/datafusion/sql/src/expr/subquery.rs#L120
                     if let [first_field] = &fields[..] {
                         rewrite_placeholder(
                             expr.as_mut(),

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -4043,7 +4043,7 @@ mod tests {
     #[test]
     fn test_resolved_placeholder_limit() -> Result<()> {
         let schema = Arc::new(Schema::new(vec![Field::new("A", DataType::Int32, true)]));
-        let source = Arc::new(LogicalTableSource::new(schema.clone()));
+        let source = Arc::new(LogicalTableSource::new(Arc::clone(&schema)));
 
         let placeholder_value = "$1";
 
@@ -4057,7 +4057,7 @@ mod tests {
             input: Arc::new(LogicalPlan::TableScan(TableScan {
                 table_name: TableReference::from("my_table"),
                 source,
-                projected_schema: Arc::new(DFSchema::try_from(schema.clone())?),
+                projected_schema: Arc::new(DFSchema::try_from(Arc::clone(&schema))?),
                 projection: None,
                 filters: vec![],
                 fetch: None,

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1494,6 +1494,14 @@ impl LogicalPlan {
         let mut param_types: HashMap<String, Option<DataType>> = HashMap::new();
 
         self.apply_with_subqueries(|plan| {
+            if let LogicalPlan::Limit(Limit { fetch: Some(e), .. }) = plan {
+                if let Expr::Placeholder(Placeholder { id, data_type }) = &**e {
+                    param_types.insert(
+                        id.clone(),
+                        Some(data_type.as_ref().cloned().unwrap_or(DataType::Int64)),
+                    );
+                }
+            }
             plan.apply_expressions(|expr| {
                 expr.apply(|expr| {
                     if let Expr::Placeholder(Placeholder { id, data_type }) = expr {
@@ -1506,6 +1514,9 @@ impl LogicalPlan {
                             }
                             (_, Some(dt)) => {
                                 param_types.insert(id.clone(), Some(dt.clone()));
+                            }
+                            (Some(Some(_)), None) => {
+                                // we have already inferred the datatype
                             }
                             _ => {
                                 param_types.insert(id.clone(), None);
@@ -4027,6 +4038,43 @@ mod tests {
             .filter(in_subquery(col("state"), Arc::new(plan1)))?
             .project(vec![col("id")])?
             .build()
+    }
+
+    #[test]
+    fn test_resolved_placeholder_limit() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("A", DataType::Int32, true)]));
+        let source = Arc::new(LogicalTableSource::new(schema.clone()));
+
+        let placeholder_value = "$1";
+
+        // SELECT * FROM my_table LIMIT $1
+        let plan = LogicalPlan::Limit(Limit {
+            skip: None,
+            fetch: Some(Box::new(Expr::Placeholder(Placeholder {
+                id: placeholder_value.to_string(),
+                data_type: None,
+            }))),
+            input: Arc::new(LogicalPlan::TableScan(TableScan {
+                table_name: TableReference::from("my_table"),
+                source,
+                projected_schema: Arc::new(DFSchema::try_from(schema.clone())?),
+                projection: None,
+                filters: vec![],
+                fetch: None,
+            })),
+        });
+
+        let params = plan.get_parameter_types().expect("to infer type");
+        assert_eq!(params.len(), 1);
+
+        let parameter_type = params
+            .clone()
+            .get(placeholder_value)
+            .expect("to get type")
+            .clone();
+        assert_eq!(parameter_type, Some(DataType::Int64));
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/15978
- Closes https://github.com/apache/datafusion/issues/15979

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Increases functionality of parameterized queries.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Placeholder datatype inference after `LIMIT` clause and `Expr::InSubquery` is now supported.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes, users can now use parameterized queries in more places.
