### PR TITLE
Optimize hash partitioning for cache friendliness

### DIFF
--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -315,8 +315,6 @@ impl BatchPartitioner {
                         }
                     }
 
-                    // Finished building index-arrays for output partitions
-                    timer.done();
 
                     let mut output_batch_columns = (0..partition_indices.len())
                         .map(|_| Vec::with_capacity(batch.num_columns()))
@@ -329,6 +327,8 @@ impl BatchPartitioner {
                                 .push(compute::take(column, indices, None)?);
                         }
                     }
+
+                    timer.done();
 
                     let it = output_batch_columns
                         .into_iter()

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -289,9 +289,17 @@ impl BatchPartitioner {
 
                     let mut cum_histogram = vec![0; *partitions];
 
-                    for hash in hash_buffer.iter_mut() {
-                        *hash %= *partitions as u64;
-                        cum_histogram[*hash as usize] += 1;
+                    if partitions.is_power_of_two() {
+                        for hash in hash_buffer.iter_mut() {
+                            // modulo bit trick: a % (2^k) == a & (2^k - 1)
+                            *hash &= *partitions as u64 - 1;
+                            cum_histogram[*hash as usize] += 1;
+                        }
+                    } else {
+                        for hash in hash_buffer.iter_mut() {
+                            *hash %= *partitions as u64;
+                            cum_histogram[*hash as usize] += 1;
+                        }
                     }
 
                     for idx in 1..cum_histogram.len() {


### PR DESCRIPTION
## Which issue does this PR close?

Helps https://github.com/apache/datafusion/issues/6822 a bit.

## Rationale for this change

Before this PR, hash partitioning worked roughly like this:

```
for each partition {
  for each column {
     take(column, indices of partition)
  }
}
```

This PR changes it to

```
for each column {
  for each partition {
     take(column, indices of partition)
  }
}
```

Reasoning being, that it might play nicer with the CPU's cache. Especially when the number of columns is large, the old approach would need to load each column `number_of_partition` times into cache.

## What changes are included in this PR?

Layered on the change above are a bunch of micro-optimizations:

- Pack the indices for each partition into a single vector (hopefully nice prefetching behaviour)
- Reuse the allocation for the indices
- Avoid modulo if the number of partitions is a power of 2 (quite common).

Mostly throwing out ideas and seeing what sticks.

## Are these changes tested?

Covered by existing tests - I hope.

## Are there any user-facing changes?

No.

cc: @Dandandan @goldmedal 
