### PR TITLE
Box field to reduce DatafusionError size

### DIFF
--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -262,7 +262,7 @@ impl Column {
 
                     // If not due to USING columns then due to ambiguous column name
                     return _schema_err!(SchemaError::AmbiguousReference {
-                        field: Column::new_unqualified(&self.name),
+                        field: Box::new(Column::new_unqualified(&self.name)),
                     })
                     .map_err(|err| {
                         let mut diagnostic = Diagnostic::new_error(

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -229,7 +229,7 @@ impl DFSchema {
         for (qualifier, name) in qualified_names {
             if unqualified_names.contains(name) {
                 return _schema_err!(SchemaError::AmbiguousReference {
-                    field: Column::new(Some(qualifier.clone()), name)
+                    field: Box::new(Column::new(Some(qualifier.clone()), name))
                 });
             }
         }
@@ -489,7 +489,7 @@ impl DFSchema {
                     Ok((fields_without_qualifier[0].0, fields_without_qualifier[0].1))
                 } else {
                     _schema_err!(SchemaError::AmbiguousReference {
-                        field: Column::new_unqualified(name.to_string(),),
+                        field: Box::new(Column::new_unqualified(name.to_string(),)),
                     })
                 }
             }

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -164,7 +164,7 @@ macro_rules! context {
 #[derive(Debug)]
 pub enum SchemaError {
     /// Schema contains a (possibly) qualified and unqualified field with same unqualified name
-    AmbiguousReference { field: Column },
+    AmbiguousReference { field: Box<Column> },
     /// Schema contains duplicate qualified field name
     DuplicateQualifiedField {
         qualifier: Box<TableReference>,

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -2499,16 +2499,20 @@ mod tests {
 
         match plan {
             Err(DataFusionError::SchemaError(
-                SchemaError::AmbiguousReference {
-                    field:
-                        Column {
-                            relation: Some(TableReference::Bare { table }),
-                            name,
-                            spans: _,
-                        },
-                },
+                SchemaError::AmbiguousReference { field },
                 _,
             )) => {
+                let Column {
+                    relation: Some(TableReference::Bare { table }),
+                    name,
+                    spans: _,
+                } = *field
+                else {
+                    return plan_err!(
+                        "SchemaError::AmbiguousReference should contain relation"
+                    );
+                };
+
                 assert_eq!(*"employee_csv", *table);
                 assert_eq!("id", &name);
                 Ok(())


### PR DESCRIPTION
The `field: Column` field in SchemaError::AmbiguousReference grew the size of DatafusionError from 72 bytes to 112 bytes. Putting it on the heap fixes that.

## Are there any user-facing changes?

Yes, as SchemaError is `pub` (don't know how to apply a label)