### PR TITLE
Fix `contains` function expression

### DIFF
--- a/datafusion/functions/src/string/contains.rs
+++ b/datafusion/functions/src/string/contains.rs
@@ -150,10 +150,11 @@ fn contains(args: &[ArrayRef]) -> Result<ArrayRef, DataFusionError> {
 #[cfg(test)]
 mod test {
     use super::ContainsFunc;
+    use crate::expr_fn::contains;
     use arrow::array::{BooleanArray, StringArray};
     use arrow::datatypes::{DataType, Field};
     use datafusion_common::ScalarValue;
-    use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl};
+    use datafusion_expr::{ColumnarValue, Expr, ScalarFunctionArgs, ScalarUDFImpl};
     use std::sync::Arc;
 
     #[test]
@@ -184,6 +185,18 @@ mod test {
         assert_eq!(
             *actual.into_array(2).unwrap(),
             *expect.into_array(2).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_contains_api() {
+        let expr = contains(
+            Expr::Literal(ScalarValue::Utf8(Some("the quick brown fox".to_string()))),
+            Expr::Literal(ScalarValue::Utf8(Some("row".to_string()))),
+        );
+        assert_eq!(
+            expr.to_string(),
+            "contains(Utf8(\"the quick brown fox\"), Utf8(\"row\"))"
         );
     }
 }

--- a/datafusion/functions/src/string/mod.rs
+++ b/datafusion/functions/src/string/mod.rs
@@ -140,7 +140,8 @@ pub mod expr_fn {
         "returns uuid v4 as a string value",
     ), (
         contains,
-        "Return true if search_string is found within string.",
+        "Return true if `search_string` is found within `string`.",
+        string search_string
     ));
 
     #[doc = "Removes all characters, spaces by default, from both sides of a string"]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #15866.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, I think this can be simply tested by importing the `contains` function and making sure it compiles with 2 args.

## Are there any user-facing changes?

User can use `contains` function as expected
