### PR TITLE
fix: describe escaped quoted identifiers

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -33,8 +33,8 @@ use crate::execution::context::{SessionState, TaskContext};
 use crate::execution::FunctionRegistry;
 use crate::logical_expr::utils::find_window_exprs;
 use crate::logical_expr::{
-    col, Expr, JoinType, LogicalPlan, LogicalPlanBuilder, LogicalPlanBuilderOptions,
-    Partitioning, TableType,
+    col, ident, Expr, JoinType, LogicalPlan, LogicalPlanBuilder,
+    LogicalPlanBuilderOptions, Partitioning, TableType,
 };
 use crate::physical_plan::{
     collect, collect_partitioned, execute_stream, execute_stream_partitioned,
@@ -934,7 +934,7 @@ impl DataFrame {
                 vec![],
                 original_schema_fields
                     .clone()
-                    .map(|f| count(col(format!("\"{}\"", f.name()))).alias(f.name()))
+                    .map(|f| count(ident(f.name())).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // null_count aggregation
@@ -943,7 +943,7 @@ impl DataFrame {
                 original_schema_fields
                     .clone()
                     .map(|f| {
-                        sum(case(is_null(col(format!("\"{}\"", f.name()))))
+                        sum(case(is_null(ident(f.name())))
                             .when(lit(true), lit(1))
                             .otherwise(lit(0))
                             .unwrap())
@@ -957,7 +957,7 @@ impl DataFrame {
                 original_schema_fields
                     .clone()
                     .filter(|f| f.data_type().is_numeric())
-                    .map(|f| avg(col(format!("\"{}\"", f.name()))).alias(f.name()))
+                    .map(|f| avg(ident(f.name())).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // std aggregation
@@ -966,7 +966,7 @@ impl DataFrame {
                 original_schema_fields
                     .clone()
                     .filter(|f| f.data_type().is_numeric())
-                    .map(|f| stddev(col(format!("\"{}\"", f.name()))).alias(f.name()))
+                    .map(|f| stddev(ident(f.name())).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // min aggregation
@@ -977,7 +977,7 @@ impl DataFrame {
                     .filter(|f| {
                         !matches!(f.data_type(), DataType::Binary | DataType::Boolean)
                     })
-                    .map(|f| min(col(format!("\"{}\"", f.name()))).alias(f.name()))
+                    .map(|f| min(ident(f.name())).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // max aggregation
@@ -988,7 +988,7 @@ impl DataFrame {
                     .filter(|f| {
                         !matches!(f.data_type(), DataType::Binary | DataType::Boolean)
                     })
-                    .map(|f| max(col(format!("\"{}\"", f.name()))).alias(f.name()))
+                    .map(|f| max(ident(f.name())).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // median aggregation
@@ -997,7 +997,7 @@ impl DataFrame {
                 original_schema_fields
                     .clone()
                     .filter(|f| f.data_type().is_numeric())
-                    .map(|f| median(col(format!("\"{}\"", f.name()))).alias(f.name()))
+                    .map(|f| median(ident(f.name())).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
         ];

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -934,7 +934,7 @@ impl DataFrame {
                 vec![],
                 original_schema_fields
                     .clone()
-                    .map(|f| count(col(f.name())).alias(f.name()))
+                    .map(|f| count(col(format!("\"{}\"", f.name()))).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // null_count aggregation
@@ -943,7 +943,7 @@ impl DataFrame {
                 original_schema_fields
                     .clone()
                     .map(|f| {
-                        sum(case(is_null(col(f.name())))
+                        sum(case(is_null(col(format!("\"{}\"", f.name()))))
                             .when(lit(true), lit(1))
                             .otherwise(lit(0))
                             .unwrap())
@@ -957,7 +957,7 @@ impl DataFrame {
                 original_schema_fields
                     .clone()
                     .filter(|f| f.data_type().is_numeric())
-                    .map(|f| avg(col(f.name())).alias(f.name()))
+                    .map(|f| avg(col(format!("\"{}\"", f.name()))).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // std aggregation
@@ -966,7 +966,7 @@ impl DataFrame {
                 original_schema_fields
                     .clone()
                     .filter(|f| f.data_type().is_numeric())
-                    .map(|f| stddev(col(f.name())).alias(f.name()))
+                    .map(|f| stddev(col(format!("\"{}\"", f.name()))).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // min aggregation
@@ -977,7 +977,7 @@ impl DataFrame {
                     .filter(|f| {
                         !matches!(f.data_type(), DataType::Binary | DataType::Boolean)
                     })
-                    .map(|f| min(col(f.name())).alias(f.name()))
+                    .map(|f| min(col(format!("\"{}\"", f.name()))).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // max aggregation
@@ -988,7 +988,7 @@ impl DataFrame {
                     .filter(|f| {
                         !matches!(f.data_type(), DataType::Binary | DataType::Boolean)
                     })
-                    .map(|f| max(col(f.name())).alias(f.name()))
+                    .map(|f| max(col(format!("\"{}\"", f.name()))).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
             // median aggregation
@@ -997,7 +997,7 @@ impl DataFrame {
                 original_schema_fields
                     .clone()
                     .filter(|f| f.data_type().is_numeric())
-                    .map(|f| median(col(f.name())).alias(f.name()))
+                    .map(|f| median(col(format!("\"{}\"", f.name()))).alias(f.name()))
                     .collect::<Vec<_>>(),
             ),
         ];

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -1871,31 +1871,31 @@ async fn describe_lookup_via_quoted_identifier() -> Result<()> {
         ])?
         .select_columns(&["c1"])?;
 
-    let df_renamed = df.clone().with_column_renamed("c1", "CoLu.Mn1")?;
+    let df_renamed = df.clone().with_column_renamed("c1", "CoLu.Mn[\"1\"]")?;
 
     let describe_result = df_renamed.describe().await?;
     describe_result
         .clone()
         .sort(vec![
             col("describe").sort(true, true),
-            col("\"CoLu.Mn1\"").sort(true, true),
+            col("CoLu.Mn[\"1\"]").sort(true, true),
         ])?
         .show()
         .await?;
     assert_snapshot!(
         batches_to_sort_string(&describe_result.clone().collect().await?),
         @r###"
-        +------------+----------+
-        | describe   | CoLu.Mn1 |
-        +------------+----------+
-        | count      | 1        |
-        | max        | a        |
-        | mean       | null     |
-        | median     | null     |
-        | min        | a        |
-        | null_count | 0        |
-        | std        | null     |
-        +------------+----------+
+        +------------+--------------+
+        | describe   | CoLu.Mn["1"] |
+        +------------+--------------+
+        | count      | 1            |
+        | max        | a            |
+        | mean       | null         |
+        | median     | null         |
+        | min        | a            |
+        | null_count | 0            |
+        | std        | null         |
+        +------------+--------------+
     "###
     );
 

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -1853,6 +1853,56 @@ async fn with_column_renamed_case_sensitive() -> Result<()> {
 }
 
 #[tokio::test]
+async fn describe_lookup_via_quoted_identifier() -> Result<()> {
+    let ctx = SessionContext::new();
+    let name = "aggregate_test_100";
+    register_aggregate_csv(&ctx, name).await?;
+    let df = ctx.table(name);
+
+    let df = df
+        .await?
+        .filter(col("c2").eq(lit(3)).and(col("c1").eq(lit("a"))))?
+        .limit(0, Some(1))?
+        .sort(vec![
+            // make the test deterministic
+            col("c1").sort(true, true),
+            col("c2").sort(true, true),
+            col("c3").sort(true, true),
+        ])?
+        .select_columns(&["c1"])?;
+
+    let df_renamed = df.clone().with_column_renamed("c1", "CoLu.Mn1")?;
+
+    let describe_result = df_renamed.describe().await?;
+    describe_result
+        .clone()
+        .sort(vec![
+            col("describe").sort(true, true),
+            col("\"CoLu.Mn1\"").sort(true, true),
+        ])?
+        .show()
+        .await?;
+    assert_snapshot!(
+        batches_to_sort_string(&describe_result.clone().collect().await?),
+        @r###"
+        +------------+----------+
+        | describe   | CoLu.Mn1 |
+        +------------+----------+
+        | count      | 1        |
+        | max        | a        |
+        | mean       | null     |
+        | median     | null     |
+        | min        | a        |
+        | null_count | 0        |
+        | std        | null     |
+        +------------+----------+
+    "###
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn cast_expr_test() -> Result<()> {
     let df = test_table()
         .await?


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #16017 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The dataframe `describe` method serves as a tidier way to produce standard summary statistics about a dataset via the dataframe API. The abstraction hides an implicit normalization of column names performed by calls made to `col` from within the method's definition. @johnkerl flagged that use of datasets with non-normal column names (i.e. using uppercase or periods in the name) causes unexpected failures. The method is leaking its implementation and the fix provided properly seals it by escaping identifiers passed to `col`.

### Regarding Other Kinds Of Non-Alphanumeric Characters In Identifiers

@findepi asks:

> what if f.name() contains " itself?
>
> should we use some format ident function?

The question raises a nuanced edge case. The following is a diagram of the call chain from passing a string to `col` followed by an explanation of each call.

![col_call_chain_diagram](https://github.com/user-attachments/assets/c47fe310-a072-46f3-910b-a1b77463548b)

1. The `col` method ([source here](https://github.com/apache/datafusion/blob/main/datafusion/expr/src/expr_fn.rs#L65)) is passed the string literal "\"Colu.MN1\"".
2. The string literal passed is implicitly cast on instantiation of the enum variant Expr::Column via an implementation of the std::convert::Into trait's `into()` method.
3. `Expr::Column` ([source here](https://github.com/apache/datafusion/blob/main/datafusion/expr/src/expr.rs#L282)) is an enum variant holding a `datafusion_common::Column` ([source here](https://github.com/apache/datafusion/blob/main/datafusion/common/src/column.rs#L31)). `datafusion_common::Column` is the type to which the string literal is cast.
4. The type constraint `impl Into<Column>` requires that the string literal implement a mechanism to cast to a string. `std::convert` provides generic implementation of the `From` and `Into` trait such that only one or the other need be defined (i.e. the `From<&str>` trait implemented for `Column` implies the `Into<Column>` trait on `&str`) ([source here](https://doc.rust-lang.org/std/convert/index.html#generic-implementations)).
5. There are several string types for which `Column` implements the `From<...>` trait thereby implicitly implementing the `Into<Column>` trait for those types. These include: `From<&str>`, `From<&String>`, and `From<String>` ([source here](https://github.com/apache/datafusion/blob/main/datafusion/common/src/column.rs#L325))
6. Regardless of the particular `from` method, the string literal is passed to one of them which produces a `Column` instance.
7. All of the `from` methods for string to `Column` conversion call `from_qualified_name` ([source here](https://github.com/apache/datafusion/blob/main/datafusion/common/src/column.rs#L131)) which parses the string to produce a column.
8. `from_qualified_name` expects an argument which implements the `Into<String>` conversion trait. `Into<...>` and `From<...>` traits are reflexive so `String` implements `Into<String>` by default. The string literal is "converted" to a `String` which largely amounts to a no-op in this example's call to `from_qualified_name`.
9. `from_qualified_name` calls `parse_identifiers_normalized` ([source here](https://github.com/apache/datafusion/blob/main/datafusion/common/src/utils/mod.rs#L293)) which parses the string.
10. `parse_identifiers_normalized` calls `parse_identifiers` ([source here](https://github.com/apache/datafusion/blob/main/datafusion/common/src/utils/mod.rs#L286)) which produces a `Result` holding a vector of `sqlparser::ast::Ident` structs ([source here](https://github.com/apache/datafusion-sqlparser-rs/blob/main/src/ast/mod.rs#L178).
11. To produce the `Ident` structs, `parse_identifiers` defines a `sqlparser::parser::Parser` ([source here](https://github.com/apache/datafusion-sqlparser-rs/blob/main/src/parser/mod.rs#L347)) with a sql dialect of `sqlparser::dialect::GenericDialect` ([source here](https://github.com/apache/datafusion-sqlparser-rs/blob/main/src/dialect/generic.rs#L23)). The `Parser` calls `try_with_sql` ([source here](https://github.com/apache/datafusion-sqlparser-rs/blob/main/src/parser/mod.rs#L347) which uses a tokenizer to produce locations in the string for the identifier tokens. The parser then has the `parse_multipart_identifier` method called ([source here](https://github.com/apache/datafusion-sqlparser-rs/blob/main/src/parser/mod.rs#L10294)) which is meant to extract the `Ident` structs from the tokens.
12. The resulting vector of `Ident` structs is mapped with alias `id` for each element to a match statement.
13. The match statement is checking each `Ident` struct's "quote style" which per the doc strings are:
>    /// The starting quote if any. Valid quote characters are the single quote,
>    /// double quote, backtick, and opening square bracket.
14. The quote style is matched against via `id.quote_style` which is getting the `quote_style` attribute for each `Ident` in the result from `parse_identifiers`.
15. When the identifier is quoted, the quote style matches `Some(_)` and the string is returned as from the `Ident` structs `value` attribute.
16. When the identifier is not quoted, the quote style is `None` and the additional condition is checked that `parse_identifiers_normalized` was called with the `ignore_case` boolean flag set to `true` or `false`. `from_qualified_name` always calls `parse_identifiers_normalized` with `ignore_case` set to `false` so this branch is never entered.
17. When the identifier is not quoted and `parse_identifiers_normalized` was called with `ignore_case` set to `false`, the default branch is entered which converts the `Ident` structs value attribute to lower case only ascii. This branch is not entered in this example because `"\"Colu.MN1\""` is quoted.
18. `collect()` is called on the mapping to produce a new vector of `String` values.
19. `from_idents` ([source here](https://github.com/apache/datafusion/blob/main/datafusion/common/src/column.rs#L91) is called on the vector of `Strings` from `parse_identifiers_normalized` which produces a column by processing all but the last tokens into a relation on the `Column` struct, the last token as the column's name, and initializes a new `Span` instance.
20. A column struct is returned from `col` with the quoted name.

I wrote all of that up to document what I understand about `col` and compare that with `ident` ([source here](https://github.com/apache/datafusion/blob/main/datafusion/expr/src/expr_fn.rs#L93)) which just calls `from_name` on `Column` ([source here](https://github.com/apache/datafusion/blob/main/datafusion/common/src/column.rs#L79)) which is essentially a special constructor that creates a `Column` with no `relation` attribute and the string as-is for a `name` (bypassing using the `sqlparser` crate entirely). ~My concern in using `ident` to potentially more readily handle messier column names is that by doing no parsing it may break describe on something like a Postgres table.~ That appears to be moot as the identifier just has to be valid for the resulting dataframe/relation and not the source. `ident` appears to work well in this context. Thanks to @findepi for the suggestion.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Calls to `col` in the `describe` method of dataframes to calculate summary statistics are passed the escape-quoted identifier via a `format!` macro.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
14. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, a test was added to the file: `datafusion/core/dataframe/tests/mod.rs`

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, the change ensures the dataframe API behaves as expected when using `describe` with non-normal identifiers.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
