### PR TITLE
feat: make error handling in indent explain consistent with that in tree

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2734,7 +2734,7 @@ mod tests {
         // Verify that the execution fails due to indentation error
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.to_string(), "Execution error: Test Err");
+        assert!(err.to_string().starts_with("Execution error: Test Err"));
     }
 
     #[tokio::test]

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -1714,6 +1714,14 @@ impl DefaultPhysicalPlanner {
         let config = &session_state.config_options().explain;
         let explain_format = &e.explain_format;
 
+        if !e.logical_optimization_succeeded {
+            return Ok(Arc::new(ExplainExec::new(
+                Arc::clone(e.schema.inner()),
+                e.stringified_plans.clone(),
+                e.verbose,
+            )));
+        }
+
         match explain_format {
             ExplainFormat::Indent => { /* fall through */ }
             ExplainFormat::Tree => {
@@ -1755,12 +1763,6 @@ impl DefaultPhysicalPlanner {
                 stringified_plans,
                 e.verbose,
             )));
-        }
-
-        if !e.logical_optimization_succeeded {
-            if let Some(plan) = e.stringified_plans.last() {
-                return exec_err!("{}", plan.plan);
-            }
         }
 
         // The indent mode is quite sophisticated, and handles quite a few


### PR DESCRIPTION
## Which issue does this PR close?


## Rationale for this change

when logical optimization failed, explain format indent will return

```
+-----------+------+
| plan_type | plan |
+-----------+------+
+-----------+------+
```

error message is swallowed.

but for tree format, error will be thrown out.

## What changes are included in this PR?

throw error if optimization failed for indent format.

## Are these changes tested?

UT

## Are there any user-facing changes?

No
