### PR TITLE
Minor: Add `Accumulator::return_type` and `StateFieldsArgs::return_type` to help with upgrade to 48

### DIFF
--- a/datafusion-examples/examples/advanced_udaf.rs
+++ b/datafusion-examples/examples/advanced_udaf.rs
@@ -94,7 +94,7 @@ impl AggregateUDFImpl for GeoMeanUdaf {
     /// This is the description of the state. accumulator's state() must match the types here.
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<Field>> {
         Ok(vec![
-            Field::new("prod", args.return_field.data_type().clone(), true),
+            Field::new("prod", args.return_type().clone(), true),
             Field::new("n", DataType::UInt32, true),
         ])
     }

--- a/datafusion/functions-aggregate-common/src/accumulator.rs
+++ b/datafusion/functions-aggregate-common/src/accumulator.rs
@@ -100,3 +100,10 @@ pub struct StateFieldsArgs<'a> {
     /// Whether the aggregate function is distinct.
     pub is_distinct: bool,
 }
+
+impl StateFieldsArgs<'_> {
+    /// The return type of the aggregate function.
+    pub fn return_type(&self) -> &DataType {
+        self.return_field.data_type()
+    }
+}

--- a/datafusion/functions-aggregate/src/bit_and_or_xor.rs
+++ b/datafusion/functions-aggregate/src/bit_and_or_xor.rs
@@ -271,7 +271,7 @@ impl AggregateUDFImpl for BitwiseOperation {
                     format!("{} distinct", self.name()).as_str(),
                 ),
                 // See COMMENTS.md to understand why nullable is set to true
-                Field::new_list_field(args.return_field.data_type().clone(), true),
+                Field::new_list_field(args.return_type().clone(), true),
                 false,
             )])
         } else {

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -172,7 +172,7 @@ impl AggregateUDFImpl for FirstValue {
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<Field>> {
         let mut fields = vec![Field::new(
             format_state_name(args.name, "first_value"),
-            args.return_field.data_type().clone(),
+            args.return_type().clone(),
             true,
         )];
         fields.extend(args.ordering_fields.to_vec());

--- a/datafusion/functions-aggregate/src/sum.rs
+++ b/datafusion/functions-aggregate/src/sum.rs
@@ -206,13 +206,13 @@ impl AggregateUDFImpl for Sum {
             Ok(vec![Field::new_list(
                 format_state_name(args.name, "sum distinct"),
                 // See COMMENTS.md to understand why nullable is set to true
-                Field::new_list_field(args.return_field.data_type().clone(), true),
+                Field::new_list_field(args.return_type().clone(), true),
                 false,
             )])
         } else {
             Ok(vec![Field::new(
                 format_state_name(args.name, "sum"),
-                args.return_field.data_type().clone(),
+                args.return_type().clone(),
                 true,
             )])
         }


### PR DESCRIPTION
- Draft as it builds on https://github.com/apache/datafusion/pull/15748

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Follow up to https://github.com/apache/datafusion/pull/15911

## Rationale for this change


https://github.com/apache/datafusion/pull/15911 from @timsaucer  added `Accumulator::return_field` to make it more general, but that requires changing all call sites to refer to `return_field.data_type()`

In DataFusion 47:
```rust
args.return_type,
```

on `main`:
```
args.return_field.data_type(),
```

To help with the migration, I added a `return_type()` method to `AccumulatorArgs`

After this PR (the code looks much closer to DataFusion 47):

```rust
args.return_type(),
```


I will add similar functions to the `WindowUDFFieldArgs` and  `ScalarFunctionArgs`

## What changes are included in this PR?

1. I added a `return_type()` method to `AccumulatorArgs`
2. Update callsites to use it

## Are these changes tested?

By exsiting CI tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
