### PR TITLE
Minor: Add `ScalarFunctionArgs::return_type` method

### DIFF
--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -306,6 +306,14 @@ pub struct ScalarFunctionArgs<'a, 'b> {
     pub return_field: &'b Field,
 }
 
+impl<'a, 'b> ScalarFunctionArgs<'a, 'b> {
+    /// The return type of the function. See [`Self::return_field`] for more
+    /// details.
+    pub fn return_type(&self) -> &DataType {
+        self.return_field.data_type()
+    }
+}
+
 /// Information about arguments passed to the function
 ///
 /// This structure contains metadata about how the function was called

--- a/datafusion/functions/src/core/named_struct.rs
+++ b/datafusion/functions/src/core/named_struct.rs
@@ -150,7 +150,7 @@ impl ScalarUDFImpl for NamedStructFunc {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let DataType::Struct(fields) = args.return_field.data_type() else {
+        let DataType::Struct(fields) = args.return_type() else {
             return internal_err!("incorrect named_struct return type");
         };
 

--- a/datafusion/functions/src/core/struct.rs
+++ b/datafusion/functions/src/core/struct.rs
@@ -117,7 +117,7 @@ impl ScalarUDFImpl for StructFunc {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let DataType::Struct(fields) = args.return_field.data_type() else {
+        let DataType::Struct(fields) = args.return_type() else {
             return internal_err!("incorrect struct return type");
         };
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

- Similarly to https://github.com/apache/datafusion/pull/16112

I think it would be helpful to have a method that mimic'd the old field rather than having to always access `return_field.data_type`

## What changes are included in this PR?

 Add `ScalarFunctionArgs::return_type` method and change some callsites

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
A new API method. No changes to existing APIs
