### PR TITLE
refactor(optimizer): Add support for dynamically adding test tables

### DIFF
--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -492,46 +492,10 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
         .with_expr_planners(vec![
             Arc::new(AggregateFunctionPlanner),
             Arc::new(WindowFunctionPlanner),
-        ]);
-
-    let sql_to_rel = SqlToRel::new(&context_provider);
-    let plan = sql_to_rel.sql_statement_to_plan(statement.clone())?;
-
-    let config = OptimizerContext::new().with_skip_failing_rules(false);
-    let analyzer = Analyzer::new();
-    let optimizer = Optimizer::new();
-    // analyze and optimize the logical plan
-    let plan = analyzer.execute_and_check(plan, config.options(), |_, _| {})?;
-    optimizer.optimize(plan, &config, observe)
-}
-
-fn observe(_plan: &LogicalPlan, _rule: &dyn OptimizerRule) {}
-
-#[derive(Default)]
-struct MyContextProvider {
-    options: ConfigOptions,
-    udafs: HashMap<String, Arc<AggregateUDF>>,
-    expr_planners: Vec<Arc<dyn ExprPlanner>>,
-}
-
-impl MyContextProvider {
-    fn with_udaf(mut self, udaf: Arc<AggregateUDF>) -> Self {
-        // TODO: change to to_string() if all the function name is converted to lowercase
-        self.udafs.insert(udaf.name().to_lowercase(), udaf);
-        self
-    }
-
-    fn with_expr_planners(mut self, expr_planners: Vec<Arc<dyn ExprPlanner>>) -> Self {
-        self.expr_planners = expr_planners;
-        self
-    }
-}
-
-impl ContextProvider for MyContextProvider {
-    fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
-        let table_name = name.table();
-        if table_name.starts_with("test") {
-            let schema = Schema::new_with_metadata(
+        ])
+        .with_schema(
+            "test",
+            Schema::new_with_metadata(
                 vec![
                     Field::new("col_int32", DataType::Int32, true),
                     Field::new("col_uint32", DataType::UInt32, true),
@@ -552,11 +516,58 @@ impl ContextProvider for MyContextProvider {
                     ),
                 ],
                 HashMap::new(),
-            );
+            ),
+        );
 
-            Ok(Arc::new(MyTableSource {
+    let sql_to_rel = SqlToRel::new(&context_provider);
+    let plan = sql_to_rel.sql_statement_to_plan(statement.clone())?;
+
+    let config = OptimizerContext::new().with_skip_failing_rules(false);
+    let analyzer = Analyzer::new();
+    let optimizer = Optimizer::new();
+    // analyze and optimize the logical plan
+    let plan = analyzer.execute_and_check(plan, config.options(), |_, _| {})?;
+    optimizer.optimize(plan, &config, observe)
+}
+
+fn observe(_plan: &LogicalPlan, _rule: &dyn OptimizerRule) {}
+
+#[derive(Default)]
+struct MyContextProvider {
+    options: ConfigOptions,
+    tables: HashMap<String, Arc<dyn TableSource>>,
+    udafs: HashMap<String, Arc<AggregateUDF>>,
+    expr_planners: Vec<Arc<dyn ExprPlanner>>,
+}
+
+impl MyContextProvider {
+    fn with_udaf(mut self, udaf: Arc<AggregateUDF>) -> Self {
+        // TODO: change to to_string() if all the function name is converted to lowercase
+        self.udafs.insert(udaf.name().to_lowercase(), udaf);
+        self
+    }
+
+    fn with_expr_planners(mut self, expr_planners: Vec<Arc<dyn ExprPlanner>>) -> Self {
+        self.expr_planners = expr_planners;
+        self
+    }
+
+    fn with_schema(mut self, name: impl Into<String>, schema: Schema) -> Self {
+        self.tables.insert(
+            name.into(),
+            Arc::new(MyTableSource {
                 schema: Arc::new(schema),
-            }))
+            }),
+        );
+        self
+    }
+}
+
+impl ContextProvider for MyContextProvider {
+    fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
+        let table_name = name.table();
+        if let Some(table) = self.tables.get(table_name) {
+            Ok(table.clone())
         } else {
             plan_err!("table does not exist")
         }


### PR DESCRIPTION
Added `tables: HashMap<String, Arc<dyn TableSource>>` and `MyContextProvider::with_schema` method for dynamically defining tables for optimizer integration tests.

## Which issue does this PR close?

--

## Rationale for this change

Current mock context uses hardcoded tables, this change allows adding multiple tables without modify the mock implementation. This change will make testing #16023 easier.

## What changes are included in this PR?

--

## Are these changes tested?

Yes, all of the integration tests are passing.

## Are there any user-facing changes?

No, this is purely for integration tests in `datafusion/optimizer`

