### PR TITLE
CI: Fix extended test failure

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -101,7 +101,17 @@ jobs:
       - name: Run tests (excluding doctests)
         env:
           RUST_BACKTRACE: 1
-        run: cargo test --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --workspace --lib --tests --bins --features avro,json,backtrace,extended_tests,recursive_protection
+        run: |
+          cargo test \
+            --profile ci \
+            --exclude datafusion-examples \
+            --exclude datafusion-benchmarks \
+            --exclude datafusion-cli \
+            --workspace \
+            --lib \
+            --tests \
+            --bins \
+            --features avro,json,backtrace,extended_tests,recursive_protection
       - name: Verify Working Directory Clean
         run: git diff --exit-code
       - name: Cleanup


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The extended test (job `linux-test-extended`)  in CI is failing because of changes introduced in https://github.com/apache/datafusion/pull/16081. This PR added several failing snapshot tests for CLI integration. The CLI integration tests in CI run with backtrace disabled, while the extended tests run with backtrace enabled, which is causing the discrepancies.

Since the purpose of the failing CI job is only for tests guarded by the `extended_test` feature, and we don't have any for CLI tests, we can exclude CLI tests from the extended test suite.

Failed CI run: https://github.com/apache/datafusion/actions/runs/15179660797/job/42686605128
Failed CI job script: https://github.com/apache/datafusion/blob/cb45f1f9cc4f4041b8dcf9c7f0f5d51470d5f5a3/.github/workflows/extended.yml#L77

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Exclude `datafusion-cli` test from CI extended test, job `linux-test-extended`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
