### PR TITLE
Enrich GroupedHashAggregateStream name to ease debugging Resources exhausted errors

### DIFF
--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -414,7 +414,7 @@ async fn oom_grouped_hash_aggregate() {
         .with_query("SELECT COUNT(*), SUM(request_bytes) FROM t GROUP BY host")
         .with_expected_errors(vec![
             "Failed to allocate additional",
-            "GroupedHashAggregateStream[0] (count(Int64(1)), sum(t.request_bytes))",
+            "GroupedHashAggregateStream[0] (count(1), sum(t.request_bytes))",
         ])
         .with_memory_limit(1_000)
         .run()

--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -408,6 +408,19 @@ async fn oom_with_tracked_consumer_pool() {
         .await
 }
 
+#[tokio::test]
+async fn oom_grouped_hash_aggregate() {
+    TestCase::new()
+        .with_query("SELECT COUNT(*), SUM(request_bytes) FROM t GROUP BY host")
+        .with_expected_errors(vec![
+            "Failed to allocate additional",
+            "GroupedHashAggregateStream[0] (count(Int64(1)), sum(t.request_bytes))",
+        ])
+        .with_memory_limit(1_000)
+        .run()
+        .await
+}
+
 /// For regression case: if spilled `StringViewArray`'s buffer will be referenced by
 /// other batches which are also need to be spilled, then the spill writer will
 /// repeatedly write out the same buffer, and after reading back, each batch's size

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -529,7 +529,12 @@ impl GroupedHashAggregateStream {
             })
             .collect();
 
-        let name = format!("GroupedHashAggregateStream[{partition}]");
+        let agg_fn_names = aggregate_exprs
+            .iter()
+            .map(|expr| expr.name().to_string())
+            .collect::<Vec<String>>()
+            .join(", ");
+        let name = format!("GroupedHashAggregateStream[{partition}] ({})", agg_fn_names);
         let reservation = MemoryConsumer::new(name)
             .with_can_spill(true)
             .register(context.memory_pool());

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -531,8 +531,8 @@ impl GroupedHashAggregateStream {
 
         let agg_fn_names = aggregate_exprs
             .iter()
-            .map(|expr| expr.name().to_string())
-            .collect::<Vec<String>>()
+            .map(|expr| expr.human_display())
+            .collect::<Vec<_>>()
             .join(", ");
         let name = format!("GroupedHashAggregateStream[{partition}] ({})", agg_fn_names);
         let reservation = MemoryConsumer::new(name)

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -534,7 +534,7 @@ impl GroupedHashAggregateStream {
             .map(|expr| expr.human_display())
             .collect::<Vec<_>>()
             .join(", ");
-        let name = format!("GroupedHashAggregateStream[{partition}] ({})", agg_fn_names);
+        let name = format!("GroupedHashAggregateStream[{partition}] ({agg_fn_names})");
         let reservation = MemoryConsumer::new(name)
             .with_can_spill(true)
             .register(context.memory_pool());


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/16151

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See https://github.com/apache/datafusion/issues/16151

## What changes are included in this PR?

- The `GroupedHashAggregateStream::new` function now dynamically constructs the operator name to include a comma-separated list of the aggregate functions it handles (e.g., `GroupedHashAggregateStream[0] (COUNT, SUM))`.
- A new test case, `oom_grouped_hash_aggregate`, has been added. This test verifies that the enriched `GroupedHashAggregateStream` name correctly appears in out-of-memory error messages.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Unit test

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
A change in the error message wording but it's **not** a breaking API change.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
