### PR TITLE
Remove `Filter::having` field

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -601,7 +601,7 @@ impl LogicalPlanBuilder {
     /// Apply a filter which is used for a having clause
     pub fn having(self, expr: impl Into<Expr>) -> Result<Self> {
         let expr = normalize_col(expr.into(), &self.plan)?;
-        Filter::try_new_with_having(expr, self.plan)
+        Filter::try_new(expr, self.plan)
             .map(LogicalPlan::Filter)
             .map(Self::from)
     }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -630,12 +630,9 @@ impl LogicalPlan {
                 // todo it isn't clear why the schema is not recomputed here
                 Ok(LogicalPlan::Values(Values { schema, values }))
             }
-            LogicalPlan::Filter(Filter {
-                predicate,
-                input,
-                having,
-            }) => Filter::try_new_internal(predicate, input, having)
-                .map(LogicalPlan::Filter),
+            LogicalPlan::Filter(Filter { predicate, input }) => {
+                Filter::try_new(predicate, input).map(LogicalPlan::Filter)
+            }
             LogicalPlan::Repartition(_) => Ok(self),
             LogicalPlan::Window(Window {
                 input,
@@ -2259,8 +2256,6 @@ pub struct Filter {
     pub predicate: Expr,
     /// The incoming logical plan
     pub input: Arc<LogicalPlan>,
-    /// The flag to indicate if the filter is a having clause
-    pub having: bool,
 }
 
 impl Filter {
@@ -2269,13 +2264,14 @@ impl Filter {
     /// Notes: as Aliases have no effect on the output of a filter operator,
     /// they are removed from the predicate expression.
     pub fn try_new(predicate: Expr, input: Arc<LogicalPlan>) -> Result<Self> {
-        Self::try_new_internal(predicate, input, false)
+        Self::try_new_internal(predicate, input)
     }
 
     /// Create a new filter operator for a having clause.
     /// This is similar to a filter, but its having flag is set to true.
+    #[deprecated(since = "48.0.0", note = "Use `try_new` instead")]
     pub fn try_new_with_having(predicate: Expr, input: Arc<LogicalPlan>) -> Result<Self> {
-        Self::try_new_internal(predicate, input, true)
+        Self::try_new_internal(predicate, input)
     }
 
     fn is_allowed_filter_type(data_type: &DataType) -> bool {
@@ -2289,11 +2285,7 @@ impl Filter {
         }
     }
 
-    fn try_new_internal(
-        predicate: Expr,
-        input: Arc<LogicalPlan>,
-        having: bool,
-    ) -> Result<Self> {
+    fn try_new_internal(predicate: Expr, input: Arc<LogicalPlan>) -> Result<Self> {
         // Filter predicates must return a boolean value so we try and validate that here.
         // Note that it is not always possible to resolve the predicate expression during plan
         // construction (such as with correlated subqueries) so we make a best effort here and
@@ -2309,7 +2301,6 @@ impl Filter {
         Ok(Self {
             predicate: predicate.unalias_nested().data,
             input,
-            having,
         })
     }
 

--- a/datafusion/expr/src/logical_plan/tree_node.rs
+++ b/datafusion/expr/src/logical_plan/tree_node.rs
@@ -85,17 +85,9 @@ impl TreeNode for LogicalPlan {
                     schema,
                 })
             }),
-            LogicalPlan::Filter(Filter {
-                predicate,
-                input,
-                having,
-            }) => input.map_elements(f)?.update_data(|input| {
-                LogicalPlan::Filter(Filter {
-                    predicate,
-                    input,
-                    having,
-                })
-            }),
+            LogicalPlan::Filter(Filter { predicate, input }) => input
+                .map_elements(f)?
+                .update_data(|input| LogicalPlan::Filter(Filter { predicate, input })),
             LogicalPlan::Repartition(Repartition {
                 input,
                 partitioning_scheme,
@@ -509,17 +501,10 @@ impl LogicalPlan {
             LogicalPlan::Values(Values { schema, values }) => values
                 .map_elements(f)?
                 .update_data(|values| LogicalPlan::Values(Values { schema, values })),
-            LogicalPlan::Filter(Filter {
-                predicate,
-                input,
-                having,
-            }) => f(predicate)?.update_data(|predicate| {
-                LogicalPlan::Filter(Filter {
-                    predicate,
-                    input,
-                    having,
-                })
-            }),
+            LogicalPlan::Filter(Filter { predicate, input }) => f(predicate)?
+                .update_data(|predicate| {
+                    LogicalPlan::Filter(Filter { predicate, input })
+                }),
             LogicalPlan::Repartition(Repartition {
                 input,
                 partitioning_scheme,


### PR DESCRIPTION
Both WHERE clause and HAVING clause translate to a Filter plan node. They differ in how the references and aggregates are handled. HAVING goes after aggregation and may reference aggregate expressions and therefore HAVING's filter will be placed after Aggregation plan node.

Once a plan has been built, however, there is no special additional semantics to filters created from HAVING. Remove the unnecessary field.

For reference, the field was added along with usage in a50aeefcbfc84d491495887d57fa8ebc0db57ff2 commit and the usage was later removed in eb62e2871e49c402ec7b0d25658faa6dc5219969 commit.
