### PR TITLE
Update tpch, clickbench, sort_tpch to mark failed queries

### DIFF
--- a/benchmarks/src/bin/external_aggr.rs
+++ b/benchmarks/src/bin/external_aggr.rs
@@ -40,7 +40,7 @@ use datafusion::execution::SessionStateBuilder;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::*;
-use datafusion_benchmarks::util::{BenchmarkRun, CommonOpt};
+use datafusion_benchmarks::util::{BenchmarkRun, CommonOpt, QueryResult};
 use datafusion_common::instant::Instant;
 use datafusion_common::utils::get_available_parallelism;
 use datafusion_common::{exec_err, DEFAULT_PARQUET_EXTENSION};
@@ -75,11 +75,6 @@ struct ExternalAggrConfig {
     /// Path to JSON benchmark result to be compare using `compare.py`
     #[structopt(parse(from_os_str), short = "o", long = "output")]
     output_path: Option<PathBuf>,
-}
-
-struct QueryResult {
-    elapsed: std::time::Duration,
-    row_count: usize,
 }
 
 /// Query Memory Limits

--- a/benchmarks/src/clickbench.rs
+++ b/benchmarks/src/clickbench.rs
@@ -18,7 +18,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::util::{BenchmarkRun, CommonOpt};
+use crate::util::{BenchmarkRun, CommonOpt, QueryResult};
 use datafusion::{
     error::{DataFusionError, Result},
     prelude::SessionContext,
@@ -128,34 +128,68 @@ impl RunOpt {
         let ctx = SessionContext::new_with_config_rt(config, rt_builder.build_arc()?);
         self.register_hits(&ctx).await?;
 
-        let iterations = self.common.iterations;
         let mut benchmark_run = BenchmarkRun::new();
+        let mut failed_queries: Vec<usize> =
+            Vec::with_capacity(query_range.clone().count());
         for query_id in query_range {
-            let mut millis = Vec::with_capacity(iterations);
             benchmark_run.start_new_case(&format!("Query {query_id}"));
-            let sql = queries.get_query(query_id)?;
-            println!("Q{query_id}: {sql}");
-
-            for i in 0..iterations {
-                let start = Instant::now();
-                let results = ctx.sql(sql).await?.collect().await?;
-                let elapsed = start.elapsed();
-                let ms = elapsed.as_secs_f64() * 1000.0;
-                millis.push(ms);
-                let row_count: usize = results.iter().map(|b| b.num_rows()).sum();
-                println!(
-                    "Query {query_id} iteration {i} took {ms:.1} ms and returned {row_count} rows"
-                );
-                benchmark_run.write_iter(elapsed, row_count);
+            let query_run = self.benchmark_query(&queries, query_id, &ctx).await;
+            match query_run {
+                Ok(query_results) => {
+                    for iter in query_results {
+                        benchmark_run.write_iter(iter.elapsed, iter.row_count);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Query {query_id} failed: {e}");
+                    // TODO mark failure
+                    failed_queries.push(query_id);
+                }
             }
-            if self.common.debug {
-                ctx.sql(sql).await?.explain(false, false)?.show().await?;
-            }
-            let avg = millis.iter().sum::<f64>() / millis.len() as f64;
-            println!("Query {query_id} avg time: {avg:.2} ms");
         }
         benchmark_run.maybe_write_json(self.output_path.as_ref())?;
+        if !failed_queries.is_empty() {
+            println!(
+                "Failed Queries: {}",
+                failed_queries
+                    .iter()
+                    .map(|q| q.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
         Ok(())
+    }
+
+    async fn benchmark_query(
+        &self,
+        queries: &AllQueries,
+        query_id: usize,
+        ctx: &SessionContext,
+    ) -> Result<Vec<QueryResult>> {
+        let sql = queries.get_query(query_id)?;
+        println!("Q{query_id}: {sql}");
+
+        let mut millis = Vec::with_capacity(self.iterations());
+        let mut query_results = vec![];
+        for i in 0..self.iterations() {
+            let start = Instant::now();
+            let results = ctx.sql(sql).await?.collect().await?;
+            let elapsed = start.elapsed();
+            let ms = elapsed.as_secs_f64() * 1000.0;
+            millis.push(ms);
+            let row_count: usize = results.iter().map(|b| b.num_rows()).sum();
+            println!(
+                "Query {query_id} iteration {i} took {ms:.1} ms and returned {row_count} rows"
+            );
+            query_results.push(QueryResult { elapsed, row_count })
+        }
+        if self.common.debug {
+            ctx.sql(sql).await?.explain(false, false)?.show().await?;
+        }
+        let avg = millis.iter().sum::<f64>() / millis.len() as f64;
+        println!("Query {query_id} avg time: {avg:.2} ms");
+        Ok(query_results)
     }
 
     /// Registers the `hits.parquet` as a table named `hits`
@@ -170,5 +204,9 @@ impl RunOpt {
                     Box::new(e),
                 )
             })
+    }
+
+    fn iterations(&self) -> usize {
+        self.common.iterations
     }
 }

--- a/benchmarks/src/imdb/run.rs
+++ b/benchmarks/src/imdb/run.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::{get_imdb_table_schema, get_query_sql, IMDB_TABLES};
-use crate::util::{BenchmarkRun, CommonOpt};
+use crate::util::{BenchmarkRun, CommonOpt, QueryResult};
 
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::{self, pretty_format_batches};
@@ -473,11 +473,6 @@ impl RunOpt {
             .partitions
             .unwrap_or_else(get_available_parallelism)
     }
-}
-
-struct QueryResult {
-    elapsed: std::time::Duration,
-    row_count: usize,
 }
 
 #[cfg(test)]

--- a/benchmarks/src/sort_tpch.rs
+++ b/benchmarks/src/sort_tpch.rs
@@ -40,7 +40,7 @@ use datafusion_common::instant::Instant;
 use datafusion_common::utils::get_available_parallelism;
 use datafusion_common::DEFAULT_PARQUET_EXTENSION;
 
-use crate::util::{BenchmarkRun, CommonOpt};
+use crate::util::{BenchmarkRun, CommonOpt, QueryResult};
 
 #[derive(Debug, StructOpt)]
 pub struct RunOpt {
@@ -72,11 +72,6 @@ pub struct RunOpt {
     /// Append a `LIMIT n` clause to the query
     #[structopt(short = "l", long = "limit")]
     limit: Option<usize>,
-}
-
-struct QueryResult {
-    elapsed: std::time::Duration,
-    row_count: usize,
 }
 
 impl RunOpt {
@@ -185,18 +180,37 @@ impl RunOpt {
             Some(query_id) => query_id..=query_id,
             None => 1..=Self::SORT_QUERIES.len(),
         };
+        let mut failed_queries: Vec<usize> =
+            Vec::with_capacity(query_range.clone().count());
 
         for query_id in query_range {
             benchmark_run.start_new_case(&format!("{query_id}"));
 
-            let query_results = self.benchmark_query(query_id).await?;
-            for iter in query_results {
-                benchmark_run.write_iter(iter.elapsed, iter.row_count);
+            let query_results = self.benchmark_query(query_id).await;
+            match query_results {
+                Ok(query_results) => {
+                    for iter in query_results {
+                        benchmark_run.write_iter(iter.elapsed, iter.row_count);
+                    }
+                }
+                Err(e) => {
+                    failed_queries.push(query_id);
+                    eprintln!("Query {query_id} failed: {e}");
+                }
             }
         }
 
         benchmark_run.maybe_write_json(self.output_path.as_ref())?;
-
+        if !failed_queries.is_empty() {
+            println!(
+                "Failed Queries: {}",
+                failed_queries
+                    .iter()
+                    .map(|q| q.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
         Ok(())
     }
 

--- a/benchmarks/src/tpch/run.rs
+++ b/benchmarks/src/tpch/run.rs
@@ -118,8 +118,6 @@ impl RunOpt {
         let ctx = SessionContext::new_with_config_rt(config, rt_builder.build_arc()?);
         // register tables
         self.register_tables(&ctx).await?;
-        let mut failed_queries: Vec<usize> =
-            Vec::with_capacity(query_range.clone().count());
 
         for query_id in query_range {
             benchmark_run.start_new_case(&format!("Query {query_id}"));
@@ -131,23 +129,13 @@ impl RunOpt {
                     }
                 }
                 Err(e) => {
-                    // TODO mark
-                    failed_queries.push(query_id);
+                    benchmark_run.mark_failed();
                     eprintln!("Query {query_id} failed: {e}");
                 }
             }
         }
         benchmark_run.maybe_write_json(self.output_path.as_ref())?;
-        if !failed_queries.is_empty() {
-            println!(
-                "Failed Queries: {}",
-                failed_queries
-                    .iter()
-                    .map(|q| q.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-        }
+        benchmark_run.maybe_print_failures();
         Ok(())
     }
 

--- a/benchmarks/src/util/mod.rs
+++ b/benchmarks/src/util/mod.rs
@@ -22,4 +22,4 @@ mod run;
 
 pub use access_log::AccessLogOpt;
 pub use options::CommonOpt;
-pub use run::{BenchQuery, BenchmarkRun};
+pub use run::{BenchQuery, BenchmarkRun, QueryResult};

--- a/benchmarks/src/util/run.rs
+++ b/benchmarks/src/util/run.rs
@@ -90,6 +90,7 @@ pub struct BenchQuery {
     iterations: Vec<QueryIter>,
     #[serde(serialize_with = "serialize_start_time")]
     start_time: SystemTime,
+    success: bool,
 }
 /// Internal representation of a single benchmark query iteration result.
 pub struct QueryResult {
@@ -124,6 +125,7 @@ impl BenchmarkRun {
             query: id.to_owned(),
             iterations: vec![],
             start_time: SystemTime::now(),
+            success: true,
         });
         if let Some(c) = self.current_case.as_mut() {
             *c += 1;
@@ -139,6 +141,28 @@ impl BenchmarkRun {
                 .push(QueryIter { elapsed, row_count })
         } else {
             panic!("no cases existed yet");
+        }
+    }
+
+    /// Print the names of failed queries, if any
+    pub fn maybe_print_failures(&self) {
+        let failed_queries: Vec<&str> = self
+            .queries
+            .iter()
+            .filter_map(|q| (!q.success).then_some(q.query.as_str()))
+            .collect();
+
+        if !failed_queries.is_empty() {
+            println!("Failed Queries: {}", failed_queries.join(", "));
+        }
+    }
+
+    /// Mark current query
+    pub fn mark_failed(&mut self) {
+        if let Some(idx) = self.current_case {
+            self.queries[idx].success = false;
+        } else {
+            unreachable!("Cannot mark failure: no current case");
         }
     }
 

--- a/benchmarks/src/util/run.rs
+++ b/benchmarks/src/util/run.rs
@@ -91,7 +91,11 @@ pub struct BenchQuery {
     #[serde(serialize_with = "serialize_start_time")]
     start_time: SystemTime,
 }
-
+/// Internal representation of a single benchmark query iteration result.
+pub struct QueryResult {
+    pub elapsed: Duration,
+    pub row_count: usize,
+}
 /// collects benchmark run data and then serializes it at the end
 pub struct BenchmarkRun {
     context: RunContext,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #16160 .

## Rationale for this change
To track whether certain queries fail on limited memory, we need to continue executing benchmark queries even when previous one fails. Also, it would be better to mark & visualize the failure with `compare.py`. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- `tpch`, `clickbench`, `sort_tpch` executes next query when current query fails on any iteration. (It will not execute the next iteration of failed query) 
- In terminal, Error message is printed as [], and it will print the ids of failed queries. 
- New field `success` added to output json, updated `compare.py` to compare the elapsed time of successful results, not failed ones.  
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Since it's benchmark suite, I tested it manually. 
```
// Sample output in terminal
Query 18 failed: Resources exhausted: Additional allocation failed with top memory consumers (across reservations) as:
  HashJoinInput[1]#1239(can spill: false) consumed 9.9 MB,
  HashJoinInput[3]#1246(can spill: false) consumed 9.7 MB,
  HashJoinInput[2]#1251(can spill: false) consumed 9.6 MB,
  HashJoinInput[0]#1235(can spill: false) consumed 9.2 MB,
  HashJoinInput[0]#1266(can spill: false) consumed 2.6 MB.
Error: Failed to allocate additional 665.3 KB for HashJoinInput[0] with 9.2 MB already allocated for this reservation - 278.5 KB remain available for the total pool
Query 19 iteration 0 took 584.6 ms and returned 1 rows
Query 19 iteration 1 took 546.7 ms and returned 1 rows
Query 19 avg time: 565.66 ms
Query 20 iteration 0 took 587.3 ms and returned 186 rows
Query 20 iteration 1 took 551.7 ms and returned 186 rows
Query 20 avg time: 569.48 ms
Query 21 iteration 0 took 784.4 ms and returned 411 rows
Query 21 iteration 1 took 773.0 ms and returned 411 rows
Query 21 avg time: 778.71 ms
Query 22 iteration 0 took 295.4 ms and returned 7 rows
Query 22 iteration 1 took 299.7 ms and returned 7 rows
Query 22 avg time: 297.55 ms
Failed Queries: 4, 7, 9, 10, 13, 16, 18
```

```
// compare.py 
┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query        ┃  results ┃  results ┃        Change ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1     │ 409.33ms │ 433.54ms │  1.06x slower │
│ QQuery 2     │ 343.53ms │ 323.37ms │ +1.06x faster │
│ QQuery 3     │ 499.94ms │ 491.93ms │     no change │
│ QQuery 4     │     FAIL │ 350.74ms │  incomparable │
│ QQuery 5     │ 529.90ms │ 542.79ms │     no change │
│ QQuery 6     │ 242.10ms │ 253.38ms │     no change │
│ QQuery 7     │     FAIL │ 528.23ms │  incomparable │
│ QQuery 8     │ 634.55ms │ 638.16ms │     no change │
│ QQuery 9     │     FAIL │ 689.83ms │  incomparable │
│ QQuery 10    │     FAIL │ 601.86ms │  incomparable │
│ QQuery 11    │ 205.05ms │ 205.76ms │     no change │
│ QQuery 12    │ 421.38ms │ 418.29ms │     no change │
│ QQuery 13    │     FAIL │ 418.92ms │  incomparable │
│ QQuery 14    │ 346.10ms │ 345.50ms │     no change │
│ QQuery 15    │ 452.58ms │ 448.31ms │     no change │
│ QQuery 16    │     FAIL │ 256.87ms │  incomparable │
│ QQuery 17    │ 762.77ms │ 627.49ms │ +1.22x faster │
│ QQuery 18    │     FAIL │ 830.38ms │  incomparable │
│ QQuery 19    │ 546.70ms │ 534.35ms │     no change │
│ QQuery 20    │ 551.65ms │ 465.91ms │ +1.18x faster │
│ QQuery 21    │ 772.99ms │ 789.56ms │     no change │
│ QQuery 22    │ 295.41ms │ 301.68ms │     no change │
└──────────────┴──────────┴──────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Summary      ┃           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Total Time (results)   │ 7013.98ms │
│ Total Time (results)   │ 6820.03ms │
│ Average Time (results) │  467.60ms │
│ Average Time (results) │  454.67ms │
│ Queries Faster         │         3 │
│ Queries Slower         │         1 │
│ Queries with No Change │        11 │
│ Queries with Failure   │         7 │
└────────────────────────┴───────────┘
```
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
