### PR TITLE
Add `--substrait-round-trip` option in sqllogictests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -476,6 +476,28 @@ jobs:
           POSTGRES_HOST: postgres
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
 
+  sqllogictest-substrait:
+    name: "Run sqllogictest in Substrait round-trip mode"
+    needs: linux-build-lib
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 1
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Run sqllogictest
+        # TODO: Right now several tests are failing in Substrait round-trip mode, so this
+        #  command cannot be run for all the .slt files. Run it for just one that works (limit.slt)
+        #  until most of the tickets in https://github.com/apache/datafusion/issues/16248 are addressed
+        #  and this command can be run without filters.
+        run: cargo test --test sqllogictests -- --substrait-round-trip limit.slt
+
   #  Temporarily commenting out the Windows flow, the reason is enormously slow running build
   #  Waiting for new Windows 2025 github runner
   #  Details: https://github.com/apache/datafusion/issues/13726

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "clap 4.5.39",
  "datafusion",
  "datafusion-spark",
+ "datafusion-substrait",
  "env_logger",
  "futures",
  "half",

--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -45,6 +45,7 @@ chrono = { workspace = true, optional = true }
 clap = { version = "4.5.39", features = ["derive", "env"] }
 datafusion = { workspace = true, default-features = true, features = ["avro"] }
 datafusion-spark = { workspace = true, default-features = true }
+datafusion-substrait = { path = "../substrait" }
 futures = { workspace = true }
 half = { workspace = true, default-features = true }
 indicatif = "0.17"

--- a/datafusion/sqllogictest/README.md
+++ b/datafusion/sqllogictest/README.md
@@ -291,6 +291,27 @@ Tests that need to write temporary files should write (only) to this
 directory to ensure they do not interfere with others concurrently
 running tests.
 
+## Running tests: Substrait round-trip mode
+
+This mode will run all the .slt test files in validation mode, adding a Substrait conversion round-trip for each
+generated DataFusion logical plan (SQL statement → DF logical → Substrait → DF logical → DF physical → execute).
+
+Not all statements will be round-tripped, some statements like CREATE, INSERT, SET or EXPLAIN statements will be
+issued as is, but any other statement will be round-tripped to/from Substrait.
+
+_WARNING_: as there are still a lot of failures in this mode, it is not enforced in the CI, instead, it needs
+to be run manually with the following command:
+
+```shell
+cargo test --test sqllogictests -- --substrait-round-trip
+```
+
+For focusing on one specific failing test, a file:line filter can be used:
+
+```shell
+cargo test --test sqllogictests -- --substrait-round-trip binary.slt:23
+```
+
 ## `.slt` file format
 
 [`sqllogictest`] was originally written for SQLite to verify the

--- a/datafusion/sqllogictest/README.md
+++ b/datafusion/sqllogictest/README.md
@@ -19,19 +19,16 @@
 
 # DataFusion sqllogictest
 
-[DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory
-format.
+[DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate is a submodule of DataFusion that contains an implementation
-of [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki).
+This crate is a submodule of DataFusion that contains an implementation of [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki).
 
 [df]: https://crates.io/crates/datafusion
 
 ## Overview
 
 This crate uses [sqllogictest-rs](https://github.com/risinglightdb/sqllogictest-rs) to parse and run `.slt` files in the
-[`test_files`](test_files) directory of this crate or the [
-`data/sqlite`](https://github.com/apache/datafusion-testing/tree/main/data/sqlite)
+[`test_files`](test_files) directory of this crate or the [`data/sqlite`](https://github.com/apache/datafusion-testing/tree/main/data/sqlite)
 directory of the [datafusion-testing](https://github.com/apache/datafusion-testing) crate.
 
 ## Testing setup
@@ -229,8 +226,7 @@ INCLUDE_TPCH=true cargo test --test sqllogictests
 ## Running Tests: `sqlite`
 
 Test files in `data/sqlite` directory of the datafusion-testing crate were
-sourced from the [sqlite test suite](https://www.sqlite.org/sqllogictest/dir?ci=tip) and have been cleansed and updated
-to
+sourced from the [sqlite test suite](https://www.sqlite.org/sqllogictest/dir?ci=tip) and have been cleansed and updated to
 run within DataFusion's sqllogictest runner.
 
 To run the sqlite tests you need to increase the rust stack size and add
@@ -337,8 +333,7 @@ location such as `/tmp/`)
 Query records follow the format:
 
 ```sql
-#
-<test_name>
+# <test_name>
 query <type_string> <sort_mode>
 <sql_query>
 ----
@@ -348,20 +343,20 @@ query <type_string> <sort_mode>
 - `test_name`: Uniquely identify the test name (DataFusion only)
 - `type_string`: A short string that specifies the number of result columns and the expected datatype of each result
   column. There is one character in the <type_string> for each result column. The characters codes are:
-    - 'B' - **B**oolean,
-    - 'D' - **D**atetime,
-    - 'I' - **I**nteger,
-    - 'P' - timestam**P**,
-    - 'R' - floating-point results,
-    - 'T' - **T**ext,
-    - "?" - any other types
+  - 'B' - **B**oolean,
+  - 'D' - **D**atetime,
+  - 'I' - **I**nteger,
+  - 'P' - timestam**P**,
+  - 'R' - floating-point results,
+  - 'T' - **T**ext,
+  - "?" - any other types
 - `expected_result`: In the results section, some values are converted according to some rules:
-    - floating point values are rounded to the scale of "12",
-    - NULL values are rendered as `NULL`,
-    - empty strings are rendered as `(empty)`,
-    - boolean values are rendered as `true`/`false`,
-    - this list can be not exhaustive, check the `datafusion/sqllogictest/src/engines/conversion.rs` for
-      details.
+  - floating point values are rounded to the scale of "12",
+  - NULL values are rendered as `NULL`,
+  - empty strings are rendered as `(empty)`,
+  - boolean values are rendered as `true`/`false`,
+  - this list can be not exhaustive, check the `datafusion/sqllogictest/src/engines/conversion.rs` for
+    details.
 - `sort_mode`: If included, it must be one of `nosort` (**default**), `rowsort`, or `valuesort`. In `nosort` mode, the
   results appear in exactly the order in which they were received from the database engine. The `nosort` mode should
   only be used on queries that have an `ORDER BY` clause or which only have a single row of result, since otherwise the
@@ -377,15 +372,11 @@ query <type_string> <sort_mode>
 ### Example
 
 ```sql
-#
-group_by_distinct
+# group_by_distinct
 query TTI
-SELECT a, b, COUNT(DISTINCT c)
-FROM my_table
-GROUP BY a, b
-ORDER BY a, b
+SELECT a, b, COUNT(DISTINCT c) FROM my_table GROUP BY a, b ORDER BY a, b
 ----
-    foo bar 10
+foo bar 10
 foo baz 5
 foo     4
         3

--- a/datafusion/sqllogictest/README.md
+++ b/datafusion/sqllogictest/README.md
@@ -19,16 +19,19 @@
 
 # DataFusion sqllogictest
 
-[DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
+[DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory
+format.
 
-This crate is a submodule of DataFusion that contains an implementation of [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki).
+This crate is a submodule of DataFusion that contains an implementation
+of [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki).
 
 [df]: https://crates.io/crates/datafusion
 
 ## Overview
 
 This crate uses [sqllogictest-rs](https://github.com/risinglightdb/sqllogictest-rs) to parse and run `.slt` files in the
-[`test_files`](test_files) directory of this crate or the [`data/sqlite`](https://github.com/apache/datafusion-testing/tree/main/data/sqlite)
+[`test_files`](test_files) directory of this crate or the [
+`data/sqlite`](https://github.com/apache/datafusion-testing/tree/main/data/sqlite)
 directory of the [datafusion-testing](https://github.com/apache/datafusion-testing) crate.
 
 ## Testing setup
@@ -226,7 +229,8 @@ INCLUDE_TPCH=true cargo test --test sqllogictests
 ## Running Tests: `sqlite`
 
 Test files in `data/sqlite` directory of the datafusion-testing crate were
-sourced from the [sqlite test suite](https://www.sqlite.org/sqllogictest/dir?ci=tip) and have been cleansed and updated to
+sourced from the [sqlite test suite](https://www.sqlite.org/sqllogictest/dir?ci=tip) and have been cleansed and updated
+to
 run within DataFusion's sqllogictest runner.
 
 To run the sqlite tests you need to increase the rust stack size and add
@@ -299,8 +303,8 @@ generated DataFusion logical plan (SQL statement → DF logical → Substrait �
 Not all statements will be round-tripped, some statements like CREATE, INSERT, SET or EXPLAIN statements will be
 issued as is, but any other statement will be round-tripped to/from Substrait.
 
-_WARNING_: as there are still a lot of failures in this mode, it is not enforced in the CI, instead, it needs
-to be run manually with the following command:
+_WARNING_: as there are still a lot of failures in this mode (https://github.com/apache/datafusion/issues/16248),
+it is not enforced in the CI, instead, it needs to be run manually with the following command:
 
 ```shell
 cargo test --test sqllogictests -- --substrait-round-trip
@@ -333,7 +337,8 @@ location such as `/tmp/`)
 Query records follow the format:
 
 ```sql
-# <test_name>
+#
+<test_name>
 query <type_string> <sort_mode>
 <sql_query>
 ----
@@ -343,20 +348,20 @@ query <type_string> <sort_mode>
 - `test_name`: Uniquely identify the test name (DataFusion only)
 - `type_string`: A short string that specifies the number of result columns and the expected datatype of each result
   column. There is one character in the <type_string> for each result column. The characters codes are:
-  - 'B' - **B**oolean,
-  - 'D' - **D**atetime,
-  - 'I' - **I**nteger,
-  - 'P' - timestam**P**,
-  - 'R' - floating-point results,
-  - 'T' - **T**ext,
-  - "?" - any other types
+    - 'B' - **B**oolean,
+    - 'D' - **D**atetime,
+    - 'I' - **I**nteger,
+    - 'P' - timestam**P**,
+    - 'R' - floating-point results,
+    - 'T' - **T**ext,
+    - "?" - any other types
 - `expected_result`: In the results section, some values are converted according to some rules:
-  - floating point values are rounded to the scale of "12",
-  - NULL values are rendered as `NULL`,
-  - empty strings are rendered as `(empty)`,
-  - boolean values are rendered as `true`/`false`,
-  - this list can be not exhaustive, check the `datafusion/sqllogictest/src/engines/conversion.rs` for
-    details.
+    - floating point values are rounded to the scale of "12",
+    - NULL values are rendered as `NULL`,
+    - empty strings are rendered as `(empty)`,
+    - boolean values are rendered as `true`/`false`,
+    - this list can be not exhaustive, check the `datafusion/sqllogictest/src/engines/conversion.rs` for
+      details.
 - `sort_mode`: If included, it must be one of `nosort` (**default**), `rowsort`, or `valuesort`. In `nosort` mode, the
   results appear in exactly the order in which they were received from the database engine. The `nosort` mode should
   only be used on queries that have an `ORDER BY` clause or which only have a single row of result, since otherwise the
@@ -372,11 +377,15 @@ query <type_string> <sort_mode>
 ### Example
 
 ```sql
-# group_by_distinct
+#
+group_by_distinct
 query TTI
-SELECT a, b, COUNT(DISTINCT c) FROM my_table GROUP BY a, b ORDER BY a, b
+SELECT a, b, COUNT(DISTINCT c)
+FROM my_table
+GROUP BY a, b
+ORDER BY a, b
 ----
-foo bar 10
+    foo bar 10
 foo baz 5
 foo     4
         3

--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -21,7 +21,8 @@ use datafusion::common::utils::get_available_parallelism;
 use datafusion::common::{exec_err, DataFusionError, Result};
 use datafusion_sqllogictest::{
     df_value_validator, read_dir_recursive, setup_scratch_dir, should_skip_file,
-    should_skip_record, value_normalizer, DataFusion, Filter, TestContext,
+    should_skip_record, value_normalizer, DataFusion, DataFusionSubstraitRoundTrip,
+    Filter, TestContext,
 };
 use futures::stream::StreamExt;
 use indicatif::{
@@ -102,6 +103,11 @@ async fn run_tests() -> Result<()> {
         // to stdout and return OK so they can continue listing other tests.
         return Ok(());
     }
+    if options.substrait_round_trip && (options.postgres_runner || options.complete) {
+        let msg = "--substrait-round-trip option is not supported with --postgres-runner or --complete";
+        return Err(DataFusionError::External(msg.into()));
+    }
+
     options.warn_on_ignored();
 
     #[cfg(feature = "postgres")]
@@ -138,8 +144,22 @@ async fn run_tests() -> Result<()> {
             let filters = options.filters.clone();
 
             SpawnedTask::spawn(async move {
-                match (options.postgres_runner, options.complete) {
-                    (false, false) => {
+                match (
+                    options.postgres_runner,
+                    options.complete,
+                    options.substrait_round_trip,
+                ) {
+                    (_, _, true) => {
+                        run_test_file_substrait_round_trip(
+                            test_file,
+                            validator,
+                            m_clone,
+                            m_style_clone,
+                            filters.as_ref(),
+                        )
+                        .await?
+                    }
+                    (false, false, _) => {
                         run_test_file(
                             test_file,
                             validator,
@@ -149,11 +169,11 @@ async fn run_tests() -> Result<()> {
                         )
                         .await?
                     }
-                    (false, true) => {
+                    (false, true, _) => {
                         run_complete_file(test_file, validator, m_clone, m_style_clone)
                             .await?
                     }
-                    (true, false) => {
+                    (true, false, _) => {
                         run_test_file_with_postgres(
                             test_file,
                             validator,
@@ -163,7 +183,7 @@ async fn run_tests() -> Result<()> {
                         )
                         .await?
                     }
-                    (true, true) => {
+                    (true, true, _) => {
                         run_complete_file_with_postgres(
                             test_file,
                             validator,
@@ -208,6 +228,45 @@ async fn run_tests() -> Result<()> {
     } else {
         Ok(())
     }
+}
+
+async fn run_test_file_substrait_round_trip(
+    test_file: TestFile,
+    validator: Validator,
+    mp: MultiProgress,
+    mp_style: ProgressStyle,
+    filters: &[Filter],
+) -> Result<()> {
+    let TestFile {
+        path,
+        relative_path,
+    } = test_file;
+    let Some(test_ctx) = TestContext::try_new_for_test_file(&relative_path).await else {
+        info!("Skipping: {}", path.display());
+        return Ok(());
+    };
+    setup_scratch_dir(&relative_path)?;
+
+    let count: u64 = get_record_count(&path, "DatafusionSubstraitRoundTrip".to_string());
+    let pb = mp.add(ProgressBar::new(count));
+
+    pb.set_style(mp_style);
+    pb.set_message(format!("{:?}", &relative_path));
+
+    let mut runner = sqllogictest::Runner::new(|| async {
+        Ok(DataFusionSubstraitRoundTrip::new(
+            test_ctx.session_ctx().clone(),
+            relative_path.clone(),
+            pb.clone(),
+        ))
+    });
+    runner.add_label("DatafusionSubstraitRoundTrip");
+    runner.with_column_validator(strict_column_validator);
+    runner.with_normalizer(value_normalizer);
+    runner.with_validator(validator);
+    let res = run_file_in_runner(path, runner, filters).await;
+    pb.finish_and_clear();
+    res
 }
 
 async fn run_test_file(
@@ -577,6 +636,12 @@ struct Options {
         help = "Run Postgres compatibility tests with Postgres runner"
     )]
     postgres_runner: bool,
+
+    #[clap(
+        long,
+        help = "Before executing each query, convert its logical plan to Substrait and from Substrait back to its logical plan"
+    )]
+    substrait_round_trip: bool,
 
     #[clap(long, env = "INCLUDE_SQLITE", help = "Include sqlite files")]
     include_sqlite: bool,

--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -103,10 +103,6 @@ async fn run_tests() -> Result<()> {
         // to stdout and return OK so they can continue listing other tests.
         return Ok(());
     }
-    if options.substrait_round_trip && (options.postgres_runner || options.complete) {
-        let msg = "--substrait-round-trip option is not supported with --postgres-runner or --complete";
-        return Err(DataFusionError::External(msg.into()));
-    }
 
     options.warn_on_ignored();
 
@@ -639,6 +635,8 @@ struct Options {
 
     #[clap(
         long,
+        conflicts_with = "complete",
+        conflicts_with = "postgres_runner",
         help = "Before executing each query, convert its logical plan to Substrait and from Substrait back to its logical plan"
     )]
     substrait_round_trip: bool,

--- a/datafusion/sqllogictest/src/engines/datafusion_substrait_roundtrip_engine/mod.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_substrait_roundtrip_engine/mod.rs
@@ -1,0 +1,3 @@
+mod runner;
+
+pub use runner::*;

--- a/datafusion/sqllogictest/src/engines/datafusion_substrait_roundtrip_engine/mod.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_substrait_roundtrip_engine/mod.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 mod runner;
 
 pub use runner::*;

--- a/datafusion/sqllogictest/src/engines/datafusion_substrait_roundtrip_engine/runner.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_substrait_roundtrip_engine/runner.rs
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+use std::{path::PathBuf, time::Duration};
+
+use crate::engines::datafusion_engine::Result;
+use crate::engines::output::{DFColumnType, DFOutput};
+use crate::{convert_batches, convert_schema_to_types, DFSqlLogicTestError};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::common::collect;
+use datafusion::physical_plan::execute_stream;
+use datafusion::prelude::SessionContext;
+use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
+use datafusion_substrait::logical_plan::producer::to_substrait_plan;
+use indicatif::ProgressBar;
+use log::Level::{Debug, Info};
+use log::{debug, log_enabled, warn};
+use sqllogictest::DBOutput;
+use tokio::time::Instant;
+
+pub struct DataFusionSubstraitRoundTrip {
+    ctx: SessionContext,
+    relative_path: PathBuf,
+    pb: ProgressBar,
+}
+
+impl DataFusionSubstraitRoundTrip {
+    pub fn new(ctx: SessionContext, relative_path: PathBuf, pb: ProgressBar) -> Self {
+        Self {
+            ctx,
+            relative_path,
+            pb,
+        }
+    }
+
+    fn update_slow_count(&self) {
+        let msg = self.pb.message();
+        let split: Vec<&str> = msg.split(" ").collect();
+        let mut current_count = 0;
+
+        if split.len() > 2 {
+            // third match will be current slow count
+            current_count = split[2].parse::<i32>().unwrap();
+        }
+
+        current_count += 1;
+
+        self.pb
+            .set_message(format!("{} - {} took > 500 ms", split[0], current_count));
+    }
+}
+
+#[async_trait]
+impl sqllogictest::AsyncDB for DataFusionSubstraitRoundTrip {
+    type Error = DFSqlLogicTestError;
+    type ColumnType = DFColumnType;
+
+    async fn run(&mut self, sql: &str) -> Result<DFOutput> {
+        if log_enabled!(Debug) {
+            debug!(
+                "[{}] Running query: \"{}\"",
+                self.relative_path.display(),
+                sql
+            );
+        }
+
+        let start = Instant::now();
+        let result = run_query_substrait_round_trip(&self.ctx, sql).await;
+        let duration = start.elapsed();
+
+        if duration.gt(&Duration::from_millis(500)) {
+            self.update_slow_count();
+        }
+
+        self.pb.inc(1);
+
+        if log_enabled!(Info) && duration.gt(&Duration::from_secs(2)) {
+            warn!(
+                "[{}] Running query took more than 2 sec ({duration:?}): \"{sql}\"",
+                self.relative_path.display()
+            );
+        }
+
+        result
+    }
+
+    /// Engine name of current database.
+    fn engine_name(&self) -> &str {
+        "DataFusionSubstraitRoundTrip"
+    }
+
+    /// [`DataFusion`] calls this function to perform sleep.
+    ///
+    /// The default implementation is `std::thread::sleep`, which is universal to any async runtime
+    /// but would block the current thread. If you are running in tokio runtime, you should override
+    /// this by `tokio::time::sleep`.
+    async fn sleep(dur: Duration) {
+        tokio::time::sleep(dur).await;
+    }
+
+    async fn shutdown(&mut self) {}
+}
+
+async fn run_query_substrait_round_trip(
+    ctx: &SessionContext,
+    sql: impl Into<String>,
+) -> Result<DFOutput> {
+    let df = ctx.sql(sql.into().as_str()).await?;
+    let task_ctx = Arc::new(df.task_ctx());
+
+    let state = ctx.state();
+    let round_tripped_plan = match df.logical_plan() {
+        // Substrait does not handle these plans
+        LogicalPlan::Ddl(_)
+        | LogicalPlan::Explain(_)
+        | LogicalPlan::Dml(_)
+        | LogicalPlan::Copy(_)
+        | LogicalPlan::Statement(_) => df.logical_plan().clone(),
+        // For any other plan, convert to Substrait
+        logical_plan => {
+            let plan = to_substrait_plan(logical_plan, &state)?;
+            from_substrait_plan(&state, &plan).await?
+        }
+    };
+
+    let physical_plan = state.create_physical_plan(&round_tripped_plan).await?;
+    let stream = execute_stream(physical_plan, task_ctx)?;
+    let types = convert_schema_to_types(stream.schema().fields());
+    let results: Vec<RecordBatch> = collect(stream).await?;
+    let rows = convert_batches(results, false)?;
+
+    if rows.is_empty() && types.is_empty() {
+        Ok(DBOutput::StatementComplete(0))
+    } else {
+        Ok(DBOutput::Rows { types, rows })
+    }
+}

--- a/datafusion/sqllogictest/src/engines/datafusion_substrait_roundtrip_engine/runner.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_substrait_roundtrip_engine/runner.rs
@@ -106,7 +106,7 @@ impl sqllogictest::AsyncDB for DataFusionSubstraitRoundTrip {
         "DataFusionSubstraitRoundTrip"
     }
 
-    /// [`DataFusion`] calls this function to perform sleep.
+    /// `DataFusion` calls this function to perform sleep.
     ///
     /// The default implementation is `std::thread::sleep`, which is universal to any async runtime
     /// but would block the current thread. If you are running in tokio runtime, you should override

--- a/datafusion/sqllogictest/src/engines/mod.rs
+++ b/datafusion/sqllogictest/src/engines/mod.rs
@@ -18,12 +18,14 @@
 /// Implementation of sqllogictest for datafusion.
 mod conversion;
 mod datafusion_engine;
+mod datafusion_substrait_roundtrip_engine;
 mod output;
 
 pub use datafusion_engine::convert_batches;
 pub use datafusion_engine::convert_schema_to_types;
 pub use datafusion_engine::DFSqlLogicTestError;
 pub use datafusion_engine::DataFusion;
+pub use datafusion_substrait_roundtrip_engine::DataFusionSubstraitRoundTrip;
 pub use output::DFColumnType;
 pub use output::DFOutput;
 

--- a/datafusion/sqllogictest/src/lib.rs
+++ b/datafusion/sqllogictest/src/lib.rs
@@ -34,6 +34,7 @@ pub use engines::DFColumnType;
 pub use engines::DFOutput;
 pub use engines::DFSqlLogicTestError;
 pub use engines::DataFusion;
+pub use engines::DataFusionSubstraitRoundTrip;
 
 #[cfg(feature = "postgres")]
 pub use engines::Postgres;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

It probably does not fully closes it but it partially addresses:
- https://github.com/apache/datafusion/issues/15069

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Being able to execute the full sqllogictest suite adding a Substrait roundtrip. This means:
- Parsing the test statement
- Building a logical plan out of it
- Converting the logical plan to Substrait
- Converting the Substrait plan back to logical
- Execute it

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds a new `DataFusionSubstraitRoundTrip` sqllogictest runner implementation that will do a Substrait roundtrip where it makes sense, and a new `--substrait-round-trip` option to the sqllogictest CLI.

Example:

Runs the full aggregate.slt file doing a Substrait roundtrip on each individual statement
```shell
cargo test --test sqllogictests -- --substrait-round-trip aggregate 
```

Runs an individual failing test reproducing one specific issue with the current Substrait conversions
```shell
cargo test --test sqllogictests -- --substrait-round-trip aggregate:1522
```

This is still not enforced in the CI, and I would say the expectations are that it's just another tool to catch existing bugs in the current Substrait conversion code and better communicate them so that contributors have a clear path forward for contributing fixes.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

N/A

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
