### PR TITLE
Concatenate inside hash repartition

### DIFF
--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -404,9 +404,7 @@ impl BatchPartitioner {
                         }
                     }
 
-                    for output_idx in 0..*num_partitions {
-                        let batches_to_concat =
-                            &batches_for_output_partitions[output_idx];
+                    for (output_idx, batches_to_concat) in batches_for_output_partitions.iter().enumerate() {
                         if !batches_to_concat.is_empty() {
                             // All batches for a given output partition must have the same schema
                             // as the first non-empty input batch.

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -1000,6 +1000,7 @@ impl RepartitionExec {
                 }
                 timer.done();
             }
+            batches_buffer.clear();
 
             // If the input stream is endless, we may spin forever and
             // never yield back to tokio.  See

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -404,7 +404,9 @@ impl BatchPartitioner {
                         }
                     }
 
-                    for (output_idx, batches_to_concat) in batches_for_output_partitions.iter().enumerate() {
+                    for (output_idx, batches_to_concat) in
+                        batches_for_output_partitions.iter().enumerate()
+                    {
                         if !batches_to_concat.is_empty() {
                             // All batches for a given output partition must have the same schema
                             // as the first non-empty input batch.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

Recently, I found `interleave_batches` to be faster than the existing code. 
That actually doesn't have anything to do with `interleave` being faster (in fact, it is slower), but the fact that we don't send num_partition batches *per input batch* to the output channels.
It takes individual batches and sends them to the output channels (and directly blocking progress as the batches have been sent upstream and may all be quickly "non-empty").


We can fix this by internally concatenating the input arrays inside RepartitionExec.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
