### PR TITLE
Support compound identifier when parsing tuples

### DIFF
--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -644,7 +644,9 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         values: Vec<SQLExpr>,
     ) -> Result<Expr> {
         match values.first() {
-            Some(SQLExpr::Identifier(_)) | Some(SQLExpr::Value(_)) => {
+            Some(SQLExpr::Identifier(_))
+            | Some(SQLExpr::Value(_))
+            | Some(SQLExpr::CompoundIdentifier(_)) => {
                 self.parse_struct(schema, planner_context, values, vec![])
             }
             None => not_impl_err!("Empty tuple not supported yet"),

--- a/datafusion/sqllogictest/test_files/struct.slt
+++ b/datafusion/sqllogictest/test_files/struct.slt
@@ -272,7 +272,28 @@ select a from values where (a, c) = (1, 'a');
 1
 
 query I
+select a from values as v where (v.a, v.c) = (1, 'a');
+----
+1
+
+query I
+select a from values as v where (v.a, v.c) != (1, 'a');
+----
+2
+3
+
+query I
+select a from values as v where (v.a, v.c) = (1, 'b');
+----
+
+query I
 select a from values where (a, c) IN ((1, 'a'), (2, 'b'));
+----
+1
+2
+
+query I
+select a from values as v where (v.a, v.c) IN ((1, 'a'), (2, 'b'));
 ----
 1
 2


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #16224

## Rationale for this change

We would like to support adding table name qualifiers to columns inside tuples. Currently, this query:

```sql
SELECT a FROM values AS v WHERE (v.a, v.c) = (1, 'a');
```

throws the error: "This feature is not implemented: Only identifiers and literals are supported in tuples."

## What changes are included in this PR?

- Add support for compound identifiers when parsing tuples

## Are these changes tested?

Yes

## Are there any user-facing changes?

No