### PR TITLE
fix: add missing row count limits to TPC-H queries

### DIFF
--- a/benchmarks/queries/q10.sql
+++ b/benchmarks/queries/q10.sql
@@ -28,4 +28,5 @@ group by
     c_address,
     c_comment
 order by
-    revenue desc;
+    revenue desc
+limit 20;

--- a/benchmarks/queries/q18.sql
+++ b/benchmarks/queries/q18.sql
@@ -29,4 +29,5 @@ group by
     o_totalprice
 order by
     o_totalprice desc,
-    o_orderdate;
+    o_orderdate
+limit 100;

--- a/benchmarks/queries/q2.sql
+++ b/benchmarks/queries/q2.sql
@@ -40,4 +40,5 @@ order by
     s_acctbal desc,
     n_name,
     s_name,
-    p_partkey;
+    p_partkey
+limit 100;

--- a/benchmarks/queries/q21.sql
+++ b/benchmarks/queries/q21.sql
@@ -36,4 +36,5 @@ group by
     s_name
 order by
     numwait desc,
-    s_name;
+    s_name
+limit 100;

--- a/benchmarks/queries/q3.sql
+++ b/benchmarks/queries/q3.sql
@@ -19,4 +19,5 @@ group by
     o_shippriority
 order by
     revenue desc,
-    o_orderdate;
+    o_orderdate
+limit 10;


### PR DESCRIPTION
For queries 2, 3, 10, 18 and 21 the TPC-H spec defines a row count limit.

```
2.1.2.9 Queries 2, 3, 10, 18 and 21 require that a given number of rows are to be returned (e.g., “Return the first 10 selected
rows”). If N is the number of rows to be returned, the query must return exactly the first N rows unless fewer than N
rows qualify, in which case all rows must be returned. There are three permissible ways of satisfying this
requirement. A test sponsor must select any one of them and use it consistently for all the queries that require that a
specified number of rows be returned.
```

https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v2.17.1.pdf

## Which issue does this PR close?


- Closes #16229.

## Rationale for this change

Returned row counts should match the TPC-H spec.

## What changes are included in this PR?

`limit` clause was added to TPC-H queries, 2, 3, 10, 18, 21.

## Are these changes tested?

I re-ran all of the affected queries locally to double-check their row counts.

## Are there any user-facing changes?

Users will now see the correct row counts when running TPC-H benchmarks.