### PR TITLE
Improve performance of constant aggregate window expression

### DIFF
--- a/datafusion/physical-expr/src/window/sliding_aggregate.rs
+++ b/datafusion/physical-expr/src/window/sliding_aggregate.rs
@@ -210,4 +210,8 @@ impl AggregateWindowExpr for SlidingAggregateWindowExpr {
             accumulator.evaluate()
         }
     }
+
+    fn is_constant(&self) -> bool {
+        false
+    }
 }

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -186,6 +186,10 @@ pub trait AggregateWindowExpr: WindowExpr {
         accumulator: &mut Box<dyn Accumulator>,
     ) -> Result<ScalarValue>;
 
+    /// Indicates whether this window function always produces the same result
+    /// for all rows in the partition.
+    fn is_constant(&self) -> bool;
+
     /// Evaluates the window function against the batch.
     fn aggregate_evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef> {
         let mut accumulator = self.get_accumulator()?;
@@ -272,8 +276,13 @@ pub trait AggregateWindowExpr: WindowExpr {
         not_end: bool,
     ) -> Result<ArrayRef> {
         let values = self.evaluate_args(record_batch)?;
-        let order_bys = get_orderby_values(self.order_by_columns(record_batch)?);
 
+        if self.is_constant() {
+            accumulator.update_batch(&values)?;
+            let value = accumulator.evaluate()?;
+            return value.to_array_of_size(record_batch.num_rows());
+        }
+        let order_bys = get_orderby_values(self.order_by_columns(record_batch)?);
         let most_recent_row_order_bys = most_recent_row
             .map(|batch| self.order_by_columns(batch))
             .transpose()?


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

For unbounded aggregate window functions, the result is the same for all rows within a partition. Therefore, we can avoid repeatedly computing the window bounds and evaluating the function for each row, which can improve performance.

Related Work in DuckDB：https://github.com/duckdb/duckdb/blob/main/src/function/window/window_constant_aggregator.cpp

Benchmark results on h2o_small_window (run locally) show performance improvements for Q1 and Q3, with no noticeable changes in other queries.
### Before Optimization
```
Q1: -- Basic Window
SELECT
    id1,
    id2,
    id3,
    v2,
    sum(v2) OVER () AS window_basic
FROM large;
Query 1 iteration 1 took 1297.6 ms and returned 10000000 rows
Query 1 iteration 2 took 804.3 ms and returned 10000000 rows
Query 1 iteration 3 took 582.2 ms and returned 10000000 rows
Query 1 avg time: 894.72 ms

Q3: -- PARTITION BY
SELECT
    id1,
    id2,
    id3,
    v2,
    sum(v2) OVER (PARTITION BY id1) AS sum_by_id1,
    sum(v2) OVER (PARTITION BY id2) AS sum_by_id2,
    sum(v2) OVER (PARTITION BY id3) AS sum_by_id3
FROM large;
Query 3 iteration 1 took 1532.6 ms and returned 10000000 rows
Query 3 iteration 2 took 1755.2 ms and returned 10000000 rows
Query 3 iteration 3 took 1821.4 ms and returned 10000000 rows
Query 3 avg time: 1703.09 ms
```
### After Optimization
```
Q1: -- Basic Window
SELECT
    id1,
    id2,
    id3,
    v2,
    sum(v2) OVER () AS window_basic
FROM large;
Query 1 iteration 1 took 253.6 ms and returned 10000000 rows
Query 1 iteration 2 took 190.3 ms and returned 10000000 rows
Query 1 iteration 3 took 88.7 ms and returned 10000000 rows
Query 1 avg time: 177.54 ms

Q3: -- PARTITION BY
SELECT
    id1,
    id2,
    id3,
    v2,
    sum(v2) OVER (PARTITION BY id1) AS sum_by_id1,
    sum(v2) OVER (PARTITION BY id2) AS sum_by_id2,
    sum(v2) OVER (PARTITION BY id3) AS sum_by_id3
FROM large;
Query 3 iteration 1 took 1534.7 ms and returned 10000000 rows
Query 3 iteration 2 took 1541.5 ms and returned 10000000 rows
Query 3 iteration 3 took 1320.6 ms and returned 10000000 rows
Query 3 avg time: 1465.59 ms
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
