### PR TITLE
feat(small): Add `BaselineMetrics` to `generate_series()` table function

### DIFF
--- a/datafusion/physical-plan/src/metrics/baseline.rs
+++ b/datafusion/physical-plan/src/metrics/baseline.rs
@@ -117,9 +117,10 @@ impl BaselineMetrics {
         }
     }
 
-    /// Process a poll result of a stream producing output for an
-    /// operator, recording the output rows and stream done time and
-    /// returning the same poll result
+    /// Process a poll result of a stream producing output for an operator.
+    ///
+    /// Note: this method only updates `output_rows` and `end_time` metrics.
+    /// Remember to update `elapsed_compute` and other metrics manually.
     pub fn record_poll(
         &self,
         poll: Poll<Option<Result<RecordBatch>>>,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Currently `generate_series()` does not track metrics, see the result in `datafusion-cli`
```
> explain analyze select * from generate_series(1,10000);
+-------------------+-------------------------------------------------------------------------------------------------------------------+
| plan_type         | plan                                                                                                              |
+-------------------+-------------------------------------------------------------------------------------------------------------------+
| Plan with Metrics | LazyMemoryExec: partitions=1, batch_generators=[generate_series: start=1, end=10000, batch_size=8192], metrics=[] |
|                   |                                                                                                                   |
+-------------------+-------------------------------------------------------------------------------------------------------------------+
1 row(s) fetched.
Elapsed 0.003 seconds.
```

This PR includes basic metrics tracking for `generate_series()` table function:

```
> explain analyze select * from generate_series(1,10000);
+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type         | plan                                                                                                                                                         |
+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Plan with Metrics | LazyMemoryExec: partitions=1, batch_generators=[generate_series: start=1, end=10000, batch_size=8192], metrics=[output_rows=10000, elapsed_compute=69.333µs] |
|                   |                                                                                                                                                              |
+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row(s) fetched.
Elapsed 0.008 seconds.
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Update `LazyMemoryExec` for `BaselineMetrics` tracking: all executors implemented with it (like `generate_series()`) can track `BaselineMetrics` automatically.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
UT
## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
