### PR TITLE
fix: NaN semantics in GROUP BY

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
@@ -17,6 +17,7 @@
 
 use crate::aggregates::group_values::multi_group_by::{nulls_equal_to, GroupColumn};
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
+use arrow::array::ArrowNativeTypeOp;
 use arrow::array::{cast::AsArray, Array, ArrayRef, ArrowPrimitiveType, PrimitiveArray};
 use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::DataType;
@@ -121,7 +122,7 @@ impl<T: ArrowPrimitiveType, const NULLABLE: bool> GroupColumn
                 // Otherwise, we need to check their values
             }
 
-            *equal_to_result = self.group_values[lhs_row] == array.value(rhs_row);
+            *equal_to_result = self.group_values[lhs_row].is_eq(array.value(rhs_row));
         }
     }
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -7031,3 +7031,12 @@ VALUES
 );
 ----
 {a: 1, b: 2, c: 3} {a: 1, b: 2, c: 4}
+
+query TI
+SELECT column1, COUNT(DISTINCT column2) FROM (
+VALUES
+  ('X', arrow_cast('NAN','Float64')),
+  ('X', arrow_cast('NAN','Float64'))
+) GROUP BY 1 ORDER BY 1;
+----
+x 1

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -7035,8 +7035,8 @@ VALUES
 query TI
 SELECT column1, COUNT(DISTINCT column2) FROM (
 VALUES
-  ('X', arrow_cast('NAN','Float64')),
-  ('X', arrow_cast('NAN','Float64'))
+  ('x', arrow_cast('NAN','Float64')),
+  ('x', arrow_cast('NAN','Float64'))
 ) GROUP BY 1 ORDER BY 1;
 ----
 x 1


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #16254.

## Rationale for this change

NaN != NaN

## What changes are included in this PR?

Use arrow is_eq to test equality

## Are these changes tested?

UT

## Are there any user-facing changes?

No