### PR TITLE
feat: Add Window UDFs to FFI Crate

### DIFF
--- a/datafusion/ffi/src/lib.rs
+++ b/datafusion/ffi/src/lib.rs
@@ -37,6 +37,7 @@ pub mod table_source;
 pub mod udaf;
 pub mod udf;
 pub mod udtf;
+pub mod udwf;
 pub mod util;
 pub mod volatility;
 

--- a/datafusion/ffi/src/tests/mod.rs
+++ b/datafusion/ffi/src/tests/mod.rs
@@ -31,6 +31,8 @@ use crate::{catalog_provider::FFI_CatalogProvider, udtf::FFI_TableFunction};
 
 use crate::udaf::FFI_AggregateUDF;
 
+use crate::udwf::FFI_WindowUDF;
+
 use super::{table_provider::FFI_TableProvider, udf::FFI_ScalarUDF};
 use arrow::array::RecordBatch;
 use async_provider::create_async_table_provider;
@@ -40,7 +42,7 @@ use datafusion::{
 };
 use sync_provider::create_sync_table_provider;
 use udf_udaf_udwf::{
-    create_ffi_abs_func, create_ffi_random_func, create_ffi_stddev_func,
+    create_ffi_abs_func, create_ffi_random_func, create_ffi_rank_func, create_ffi_stddev_func,
     create_ffi_sum_func, create_ffi_table_func,
 };
 
@@ -75,6 +77,8 @@ pub struct ForeignLibraryModule {
 
     /// Createa  grouping UDAF using stddev
     pub create_stddev_udaf: extern "C" fn() -> FFI_AggregateUDF,
+
+    pub create_rank_udwf: extern "C" fn() -> FFI_WindowUDF,
 
     pub version: extern "C" fn() -> u64,
 }
@@ -125,6 +129,7 @@ pub fn get_foreign_library_module() -> ForeignLibraryModuleRef {
         create_table_function: create_ffi_table_func,
         create_sum_udaf: create_ffi_sum_func,
         create_stddev_udaf: create_ffi_stddev_func,
+        create_rank_udwf: create_ffi_rank_func,
         version: super::version,
     }
     .leak_into_prefix()

--- a/datafusion/ffi/src/tests/mod.rs
+++ b/datafusion/ffi/src/tests/mod.rs
@@ -42,8 +42,8 @@ use datafusion::{
 };
 use sync_provider::create_sync_table_provider;
 use udf_udaf_udwf::{
-    create_ffi_abs_func, create_ffi_random_func, create_ffi_rank_func, create_ffi_stddev_func,
-    create_ffi_sum_func, create_ffi_table_func,
+    create_ffi_abs_func, create_ffi_random_func, create_ffi_rank_func,
+    create_ffi_stddev_func, create_ffi_sum_func, create_ffi_table_func,
 };
 
 mod async_provider;

--- a/datafusion/ffi/src/tests/udf_udaf_udwf.rs
+++ b/datafusion/ffi/src/tests/udf_udaf_udwf.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{udaf::FFI_AggregateUDF, udf::FFI_ScalarUDF, udtf::FFI_TableFunction, udwf::FFI_WindowUDF};
+use crate::{
+    udaf::FFI_AggregateUDF, udf::FFI_ScalarUDF, udtf::FFI_TableFunction,
+    udwf::FFI_WindowUDF,
+};
 use datafusion::{
     catalog::TableFunctionImpl,
     functions::math::{abs::AbsFunc, random::RandomFunc},
@@ -58,7 +61,13 @@ pub(crate) extern "C" fn create_ffi_stddev_func() -> FFI_AggregateUDF {
 }
 
 pub(crate) extern "C" fn create_ffi_rank_func() -> FFI_WindowUDF {
-    let udwf: Arc<WindowUDF> = Arc::new(Rank::new("rank_demo".to_string(), datafusion::functions_window::rank::RankType::Basic).into());
+    let udwf: Arc<WindowUDF> = Arc::new(
+        Rank::new(
+            "rank_demo".to_string(),
+            datafusion::functions_window::rank::RankType::Basic,
+        )
+        .into(),
+    );
 
     udwf.into()
 }

--- a/datafusion/ffi/src/tests/udf_udaf_udwf.rs
+++ b/datafusion/ffi/src/tests/udf_udaf_udwf.rs
@@ -15,13 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{udaf::FFI_AggregateUDF, udf::FFI_ScalarUDF, udtf::FFI_TableFunction};
+use crate::{udaf::FFI_AggregateUDF, udf::FFI_ScalarUDF, udtf::FFI_TableFunction, udwf::FFI_WindowUDF};
 use datafusion::{
     catalog::TableFunctionImpl,
     functions::math::{abs::AbsFunc, random::RandomFunc},
     functions_aggregate::{stddev::Stddev, sum::Sum},
     functions_table::generate_series::RangeFunc,
-    logical_expr::{AggregateUDF, ScalarUDF},
+    functions_window::rank::Rank,
+    logical_expr::{AggregateUDF, ScalarUDF, WindowUDF},
 };
 
 use std::sync::Arc;
@@ -54,4 +55,10 @@ pub(crate) extern "C" fn create_ffi_stddev_func() -> FFI_AggregateUDF {
     let udaf: Arc<AggregateUDF> = Arc::new(Stddev::new().into());
 
     udaf.into()
+}
+
+pub(crate) extern "C" fn create_ffi_rank_func() -> FFI_WindowUDF {
+    let udwf: Arc<WindowUDF> = Arc::new(Rank::new("rank_demo".to_string(), datafusion::functions_window::rank::RankType::Basic).into());
+
+    udwf.into()
 }

--- a/datafusion/ffi/src/udwf/mod.rs
+++ b/datafusion/ffi/src/udwf/mod.rs
@@ -1,0 +1,373 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{ffi::c_void, sync::Arc};
+
+use abi_stable::{
+    std_types::{ROption, RResult, RString, RVec},
+    StableAbi,
+};
+use arrow::datatypes::Schema;
+use arrow::{
+    compute::SortOptions,
+    datatypes::{DataType, SchemaRef},
+};
+use datafusion::{
+    error::DataFusionError,
+    logical_expr::{
+        function::WindowUDFFieldArgs,
+        type_coercion::functions::data_types_with_window_udf, PartitionEvaluator,
+    },
+};
+use datafusion::{
+    error::Result,
+    logical_expr::{Signature, WindowUDF, WindowUDFImpl},
+};
+use partition_evaluator::{FFI_PartitionEvaluator, ForeignPartitionEvaluator};
+use partition_evaluator_args::{
+    FFI_PartitionEvaluatorArgs, ForeignPartitionEvaluatorArgs,
+};
+mod partition_evaluator;
+mod partition_evaluator_args;
+mod range;
+
+use crate::{
+    arrow_wrappers::WrappedSchema,
+    df_result, rresult, rresult_return,
+    util::{rvec_wrapped_to_vec_datatype, vec_datatype_to_rvec_wrapped},
+    volatility::FFI_Volatility,
+};
+
+/// A stable struct for sharing a [`WindowUDF`] across FFI boundaries.
+#[repr(C)]
+#[derive(Debug, StableAbi)]
+#[allow(non_camel_case_types)]
+pub struct FFI_WindowUDF {
+    /// FFI equivalent to the `name` of a [`WindowUDF`]
+    pub name: RString,
+
+    /// FFI equivalent to the `aliases` of a [`WindowUDF`]
+    pub aliases: RVec<RString>,
+
+    /// FFI equivalent to the `volatility` of a [`WindowUDF`]
+    pub volatility: FFI_Volatility,
+
+    pub partition_evaluator:
+        unsafe extern "C" fn(
+            udwf: &Self,
+            args: FFI_PartitionEvaluatorArgs,
+        ) -> RResult<FFI_PartitionEvaluator, RString>,
+
+    pub field: unsafe extern "C" fn(
+        udwf: &Self,
+        input_types: RVec<WrappedSchema>,
+        display_name: RString,
+    ) -> RResult<WrappedSchema, RString>,
+
+    /// Performs type coersion. To simply this interface, all UDFs are treated as having
+    /// user defined signatures, which will in turn call coerce_types to be called. This
+    /// call should be transparent to most users as the internal function performs the
+    /// appropriate calls on the underlying [`WindowUDF`]
+    pub coerce_types: unsafe extern "C" fn(
+        udf: &Self,
+        arg_types: RVec<WrappedSchema>,
+    ) -> RResult<RVec<WrappedSchema>, RString>,
+
+    pub schema: unsafe extern "C" fn(udwf: &Self) -> WrappedSchema,
+
+    pub sort_options: ROption<FFI_SortOptions>,
+
+    /// Used to create a clone on the provider of the udf. This should
+    /// only need to be called by the receiver of the udf.
+    pub clone: unsafe extern "C" fn(udf: &Self) -> Self,
+
+    /// Release the memory of the private data when it is no longer being used.
+    pub release: unsafe extern "C" fn(udf: &mut Self),
+
+    /// Internal data. This is only to be accessed by the provider of the udf.
+    /// A [`ForeignWindowUDF`] should never attempt to access this data.
+    pub private_data: *mut c_void,
+}
+
+unsafe impl Send for FFI_WindowUDF {}
+unsafe impl Sync for FFI_WindowUDF {}
+
+pub struct WindowUDFPrivateData {
+    pub udf: Arc<WindowUDF>,
+    pub schema: SchemaRef,
+}
+
+impl FFI_WindowUDF {
+    unsafe fn inner(&self) -> &Arc<WindowUDF> {
+        let private_data = self.private_data as *const WindowUDFPrivateData;
+        &(*private_data).udf
+    }
+
+    unsafe fn inner_schema(&self) -> SchemaRef {
+        let private_data = self.private_data as *const WindowUDFPrivateData;
+        Arc::clone(&(*private_data).schema)
+    }
+}
+
+unsafe extern "C" fn partition_evaluator_fn_wrapper(
+    udwf: &FFI_WindowUDF,
+    args: FFI_PartitionEvaluatorArgs,
+) -> RResult<FFI_PartitionEvaluator, RString> {
+    let inner = udwf.inner();
+
+    let args = rresult_return!(ForeignPartitionEvaluatorArgs::try_from(args));
+
+    let evaluator = rresult_return!(inner.partition_evaluator_factory((&args).into()));
+
+    RResult::ROk(evaluator.into())
+}
+
+unsafe extern "C" fn field_fn_wrapper(
+    udwf: &FFI_WindowUDF,
+    input_types: RVec<WrappedSchema>,
+    display_name: RString,
+) -> RResult<WrappedSchema, RString> {
+    let inner = udwf.inner();
+
+    let input_types = rresult_return!(rvec_wrapped_to_vec_datatype(&input_types));
+
+    let field = rresult_return!(
+        inner.field(WindowUDFFieldArgs::new(&input_types, display_name.as_str()))
+    );
+
+    let schema = Arc::new(Schema::new(vec![field]));
+
+    RResult::ROk(WrappedSchema::from(schema))
+}
+
+unsafe extern "C" fn coerce_types_fn_wrapper(
+    udwf: &FFI_WindowUDF,
+    arg_types: RVec<WrappedSchema>,
+) -> RResult<RVec<WrappedSchema>, RString> {
+    let inner = udwf.inner();
+
+    let arg_types = rresult_return!(rvec_wrapped_to_vec_datatype(&arg_types));
+
+    let return_types = rresult_return!(data_types_with_window_udf(&arg_types, inner));
+
+    rresult!(vec_datatype_to_rvec_wrapped(&return_types))
+}
+
+unsafe extern "C" fn schema_fn_wrapper(udwf: &FFI_WindowUDF) -> WrappedSchema {
+    let schema = udwf.inner_schema();
+
+    schema.into()
+}
+
+unsafe extern "C" fn release_fn_wrapper(udwf: &mut FFI_WindowUDF) {
+    let private_data = Box::from_raw(udwf.private_data as *mut WindowUDFPrivateData);
+    drop(private_data);
+}
+
+unsafe extern "C" fn clone_fn_wrapper(udwf: &FFI_WindowUDF) -> FFI_WindowUDF {
+    // let private_data = udf.private_data as *const WindowUDFPrivateData;
+    // let udf_data = &(*private_data);
+
+    // let private_data = Box::new(WindowUDFPrivateData {
+    //     udf: Arc::clone(&udf_data.udf),
+    // });
+    let private_data = Box::new(WindowUDFPrivateData {
+        udf: Arc::clone(udwf.inner()),
+        schema: udwf.inner_schema(),
+    });
+
+    FFI_WindowUDF {
+        name: udwf.name.clone(),
+        aliases: udwf.aliases.clone(),
+        volatility: udwf.volatility.clone(),
+        partition_evaluator: partition_evaluator_fn_wrapper,
+        sort_options: udwf.sort_options.clone(),
+        schema: schema_fn_wrapper,
+        coerce_types: coerce_types_fn_wrapper,
+        field: field_fn_wrapper,
+        clone: clone_fn_wrapper,
+        release: release_fn_wrapper,
+        private_data: Box::into_raw(private_data) as *mut c_void,
+    }
+}
+
+impl Clone for FFI_WindowUDF {
+    fn clone(&self) -> Self {
+        unsafe { (self.clone)(self) }
+    }
+}
+
+impl FFI_WindowUDF {
+    pub fn new(udf: Arc<WindowUDF>, schema: SchemaRef) -> Self {
+        let name = udf.name().into();
+        let aliases = udf.aliases().iter().map(|a| a.to_owned().into()).collect();
+        let volatility = udf.signature().volatility.into();
+        let sort_options = udf.sort_options().map(|v| (&v).into()).into();
+
+        let private_data = Box::new(WindowUDFPrivateData { udf, schema });
+
+        Self {
+            name,
+            aliases,
+            volatility,
+            partition_evaluator: partition_evaluator_fn_wrapper,
+            sort_options,
+            schema: schema_fn_wrapper,
+            coerce_types: coerce_types_fn_wrapper,
+            field: field_fn_wrapper,
+            clone: clone_fn_wrapper,
+            release: release_fn_wrapper,
+            private_data: Box::into_raw(private_data) as *mut c_void,
+        }
+    }
+}
+
+impl Drop for FFI_WindowUDF {
+    fn drop(&mut self) {
+        unsafe { (self.release)(self) }
+    }
+}
+
+/// This struct is used to access an UDF provided by a foreign
+/// library across a FFI boundary.
+///
+/// The ForeignWindowUDF is to be used by the caller of the UDF, so it has
+/// no knowledge or access to the private data. All interaction with the UDF
+/// must occur through the functions defined in FFI_WindowUDF.
+#[derive(Debug)]
+pub struct ForeignWindowUDF {
+    name: String,
+    aliases: Vec<String>,
+    udf: FFI_WindowUDF,
+    signature: Signature,
+}
+
+unsafe impl Send for ForeignWindowUDF {}
+unsafe impl Sync for ForeignWindowUDF {}
+
+impl TryFrom<&FFI_WindowUDF> for ForeignWindowUDF {
+    type Error = DataFusionError;
+
+    fn try_from(udf: &FFI_WindowUDF) -> Result<Self, Self::Error> {
+        let name = udf.name.to_owned().into();
+        let signature = Signature::user_defined((&udf.volatility).into());
+
+        let aliases = udf.aliases.iter().map(|s| s.to_string()).collect();
+
+        Ok(Self {
+            name,
+            udf: udf.clone(),
+            aliases,
+            signature,
+        })
+    }
+}
+
+impl WindowUDFImpl for ForeignWindowUDF {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        unsafe {
+            let arg_types = vec_datatype_to_rvec_wrapped(arg_types)?;
+            let result_types = df_result!((self.udf.coerce_types)(&self.udf, arg_types))?;
+            Ok(rvec_wrapped_to_vec_datatype(&result_types)?)
+        }
+    }
+
+    fn partition_evaluator(
+        &self,
+        args: datafusion::logical_expr::function::PartitionEvaluatorArgs,
+    ) -> Result<Box<dyn PartitionEvaluator>> {
+        let evaluator = unsafe {
+            let schema = (self.udf.schema)(&self.udf);
+            let args = FFI_PartitionEvaluatorArgs::new(args, schema.into())?;
+            (self.udf.partition_evaluator)(&self.udf, args)
+        };
+
+        df_result!(evaluator).map(|evaluator| {
+            Box::new(ForeignPartitionEvaluator::from(evaluator))
+                as Box<dyn PartitionEvaluator>
+        })
+    }
+
+    fn field(&self, field_args: WindowUDFFieldArgs) -> Result<arrow::datatypes::Field> {
+        unsafe {
+            let input_types = vec_datatype_to_rvec_wrapped(field_args.input_types())?;
+            let schema = df_result!((self.udf.field)(
+                &self.udf,
+                input_types,
+                field_args.name().into()
+            ))?;
+            let schema: SchemaRef = schema.into();
+
+            match schema.fields().is_empty() {
+                true => Err(DataFusionError::Execution(
+                    "Unable to retrieve field in WindowUDF via FFI".to_string(),
+                )),
+                false => Ok(schema.field(0).to_owned()),
+            }
+        }
+    }
+
+    fn sort_options(&self) -> Option<SortOptions> {
+        let options: Option<&FFI_SortOptions> = self.udf.sort_options.as_ref().into();
+        options.map(|s| s.into())
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, StableAbi, Clone)]
+#[allow(non_camel_case_types)]
+pub struct FFI_SortOptions {
+    pub descending: bool,
+    pub nulls_first: bool,
+}
+
+impl From<&SortOptions> for FFI_SortOptions {
+    fn from(value: &SortOptions) -> Self {
+        Self {
+            descending: value.descending,
+            nulls_first: value.nulls_first,
+        }
+    }
+}
+
+impl From<&FFI_SortOptions> for SortOptions {
+    fn from(value: &FFI_SortOptions) -> Self {
+        Self {
+            descending: value.descending,
+            nulls_first: value.nulls_first,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/datafusion/ffi/src/udwf/partition_evaluator.rs
+++ b/datafusion/ffi/src/udwf/partition_evaluator.rs
@@ -1,0 +1,316 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{ffi::c_void, ops::Range};
+
+use abi_stable::{
+    std_types::{RResult, RString, RVec},
+    StableAbi,
+};
+use arrow::{array::ArrayRef, error::ArrowError};
+use datafusion::{
+    error::{DataFusionError, Result},
+    logical_expr::{window_state::WindowAggState, PartitionEvaluator},
+    scalar::ScalarValue,
+};
+use prost::Message;
+
+use crate::{arrow_wrappers::WrappedArray, df_result, rresult, rresult_return};
+
+use super::range::FFI_Range;
+
+#[repr(C)]
+#[derive(Debug, StableAbi)]
+#[allow(non_camel_case_types)]
+pub struct FFI_PartitionEvaluator {
+    pub evaluate_all: unsafe extern "C" fn(
+        evaluator: &mut Self,
+        values: RVec<WrappedArray>,
+        num_rows: usize,
+    ) -> RResult<WrappedArray, RString>,
+
+    pub evaluate: unsafe extern "C" fn(
+        evaluator: &mut Self,
+        values: RVec<WrappedArray>,
+        range: FFI_Range,
+    ) -> RResult<RVec<u8>, RString>,
+
+    pub evaluate_all_with_rank: unsafe extern "C" fn(
+        evaluator: &Self,
+        num_rows: usize,
+        ranks_in_partition: RVec<FFI_Range>,
+    )
+        -> RResult<WrappedArray, RString>,
+
+    pub get_range: unsafe extern "C" fn(
+        evaluator: &Self,
+        idx: usize,
+        n_rows: usize,
+    ) -> RResult<FFI_Range, RString>,
+
+    pub is_causal: bool,
+
+    pub supports_bounded_execution: bool,
+    pub uses_window_frame: bool,
+    pub include_rank: bool,
+
+    /// Release the memory of the private data when it is no longer being used.
+    pub release: unsafe extern "C" fn(evaluator: &mut Self),
+
+    /// Internal data. This is only to be accessed by the provider of the evaluator.
+    /// A [`ForeignPartitionEvaluator`] should never attempt to access this data.
+    pub private_data: *mut c_void,
+}
+
+unsafe impl Send for FFI_PartitionEvaluator {}
+unsafe impl Sync for FFI_PartitionEvaluator {}
+
+pub struct PartitionEvaluatorPrivateData {
+    pub evaluator: Box<dyn PartitionEvaluator>,
+}
+
+impl FFI_PartitionEvaluator {
+    unsafe fn inner_mut(&mut self) -> &mut Box<(dyn PartitionEvaluator + 'static)> {
+        let private_data = self.private_data as *mut PartitionEvaluatorPrivateData;
+        &mut (*private_data).evaluator
+    }
+
+    unsafe fn inner(&self) -> &(dyn PartitionEvaluator + 'static) {
+        let private_data = self.private_data as *mut PartitionEvaluatorPrivateData;
+        (*private_data).evaluator.as_ref()
+    }
+}
+
+unsafe extern "C" fn evaluate_all_fn_wrapper(
+    evaluator: &mut FFI_PartitionEvaluator,
+    values: RVec<WrappedArray>,
+    num_rows: usize,
+) -> RResult<WrappedArray, RString> {
+    let inner = evaluator.inner_mut();
+
+    let values_arrays = values
+        .into_iter()
+        .map(|v| v.try_into().map_err(DataFusionError::from))
+        .collect::<Result<Vec<ArrayRef>>>();
+    let values_arrays = rresult_return!(values_arrays);
+
+    let return_array = (inner.evaluate_all(&values_arrays, num_rows))
+        .and_then(|array| WrappedArray::try_from(&array).map_err(DataFusionError::from));
+
+    rresult!(return_array)
+}
+
+unsafe extern "C" fn evaluate_fn_wrapper(
+    evaluator: &mut FFI_PartitionEvaluator,
+    values: RVec<WrappedArray>,
+    range: FFI_Range,
+) -> RResult<RVec<u8>, RString> {
+    let inner = evaluator.inner_mut();
+
+    let values_arrays = values
+        .into_iter()
+        .map(|v| v.try_into().map_err(DataFusionError::from))
+        .collect::<Result<Vec<ArrayRef>>>();
+    let values_arrays = rresult_return!(values_arrays);
+
+    // let return_array = (inner.evaluate(&values_arrays, &range.into()));
+    // .and_then(|array| WrappedArray::try_from(&array).map_err(DataFusionError::from));
+    let scalar_result = rresult_return!(inner.evaluate(&values_arrays, &range.into()));
+    let proto_result: datafusion_proto::protobuf::ScalarValue =
+        rresult_return!((&scalar_result).try_into());
+
+    RResult::ROk(proto_result.encode_to_vec().into())
+}
+
+unsafe extern "C" fn evaluate_all_with_rank_fn_wrapper(
+    evaluator: &FFI_PartitionEvaluator,
+    num_rows: usize,
+    ranks_in_partition: RVec<FFI_Range>,
+) -> RResult<WrappedArray, RString> {
+    let inner = evaluator.inner();
+
+    let ranks_in_partition = ranks_in_partition
+        .into_iter()
+        .map(Range::from)
+        .collect::<Vec<_>>();
+
+    let return_array = (inner.evaluate_all_with_rank(num_rows, &ranks_in_partition))
+        .and_then(|array| WrappedArray::try_from(&array).map_err(DataFusionError::from));
+
+    rresult!(return_array)
+}
+
+unsafe extern "C" fn get_range_fn_wrapper(
+    evaluator: &FFI_PartitionEvaluator,
+    idx: usize,
+    n_rows: usize,
+) -> RResult<FFI_Range, RString> {
+    let inner = evaluator.inner();
+    let range = inner.get_range(idx, n_rows).map(FFI_Range::from);
+
+    rresult!(range)
+}
+
+unsafe extern "C" fn release_fn_wrapper(evaluator: &mut FFI_PartitionEvaluator) {
+    let private_data =
+        Box::from_raw(evaluator.private_data as *mut PartitionEvaluatorPrivateData);
+    drop(private_data);
+}
+
+impl From<Box<dyn PartitionEvaluator>> for FFI_PartitionEvaluator {
+    fn from(evaluator: Box<dyn PartitionEvaluator>) -> Self {
+        let is_causal = evaluator.is_causal();
+        let supports_bounded_execution = evaluator.supports_bounded_execution();
+        let include_rank = evaluator.include_rank();
+        let uses_window_frame = evaluator.uses_window_frame();
+
+        let private_data = PartitionEvaluatorPrivateData { evaluator };
+
+        Self {
+            evaluate: evaluate_fn_wrapper,
+            evaluate_all: evaluate_all_fn_wrapper,
+            evaluate_all_with_rank: evaluate_all_with_rank_fn_wrapper,
+            get_range: get_range_fn_wrapper,
+            is_causal,
+            supports_bounded_execution,
+            include_rank,
+            uses_window_frame,
+            release: release_fn_wrapper,
+            private_data: Box::into_raw(Box::new(private_data)) as *mut c_void,
+        }
+    }
+}
+
+impl Drop for FFI_PartitionEvaluator {
+    fn drop(&mut self) {
+        unsafe { (self.release)(self) }
+    }
+}
+
+/// This struct is used to access an UDF provided by a foreign
+/// library across a FFI boundary.
+///
+/// The ForeignPartitionEvaluator is to be used by the caller of the UDF, so it has
+/// no knowledge or access to the private data. All interaction with the UDF
+/// must occur through the functions defined in FFI_PartitionEvaluator.
+#[derive(Debug)]
+pub struct ForeignPartitionEvaluator {
+    evaluator: FFI_PartitionEvaluator,
+}
+
+unsafe impl Send for ForeignPartitionEvaluator {}
+unsafe impl Sync for ForeignPartitionEvaluator {}
+
+impl From<FFI_PartitionEvaluator> for ForeignPartitionEvaluator {
+    fn from(evaluator: FFI_PartitionEvaluator) -> Self {
+        Self { evaluator }
+    }
+}
+
+impl PartitionEvaluator for ForeignPartitionEvaluator {
+    fn memoize(&mut self, _state: &mut WindowAggState) -> Result<()> {
+        // Exposing `memoize` increases the surface are of the FFI work
+        // so for now we dot support it.
+        Ok(())
+    }
+
+    fn get_range(&self, idx: usize, n_rows: usize) -> Result<Range<usize>> {
+        let range = unsafe { (self.evaluator.get_range)(&self.evaluator, idx, n_rows) };
+        df_result!(range).map(Range::from)
+    }
+
+    /// Get whether evaluator needs future data for its result (if so returns `false`) or not
+    fn is_causal(&self) -> bool {
+        self.evaluator.is_causal
+    }
+
+    fn evaluate_all(&mut self, values: &[ArrayRef], num_rows: usize) -> Result<ArrayRef> {
+        let result = unsafe {
+            let values = values
+                .iter()
+                .map(WrappedArray::try_from)
+                .collect::<std::result::Result<RVec<_>, ArrowError>>()?;
+            (self.evaluator.evaluate_all)(&mut self.evaluator, values, num_rows)
+        };
+
+        let array = df_result!(result)?;
+
+        Ok(array.try_into()?)
+    }
+
+    fn evaluate(
+        &mut self,
+        values: &[ArrayRef],
+        range: &Range<usize>,
+    ) -> Result<ScalarValue> {
+        unsafe {
+            let values = values
+                .iter()
+                .map(WrappedArray::try_from)
+                .collect::<std::result::Result<RVec<_>, ArrowError>>()?;
+
+            let scalar_bytes = df_result!((self.evaluator.evaluate)(
+                &mut self.evaluator,
+                values,
+                range.to_owned().into()
+            ))?;
+
+            let proto_scalar =
+                datafusion_proto::protobuf::ScalarValue::decode(scalar_bytes.as_ref())
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+            ScalarValue::try_from(&proto_scalar).map_err(DataFusionError::from)
+        }
+    }
+
+    fn evaluate_all_with_rank(
+        &self,
+        num_rows: usize,
+        ranks_in_partition: &[Range<usize>],
+    ) -> Result<ArrayRef> {
+        let result = unsafe {
+            let ranks_in_partition = ranks_in_partition
+                .iter()
+                .map(|rank| FFI_Range::from(rank.to_owned()))
+                .collect();
+            (self.evaluator.evaluate_all_with_rank)(
+                &self.evaluator,
+                num_rows,
+                ranks_in_partition,
+            )
+        };
+
+        let array = df_result!(result)?;
+
+        Ok(array.try_into()?)
+    }
+
+    fn supports_bounded_execution(&self) -> bool {
+        self.evaluator.supports_bounded_execution
+    }
+
+    fn uses_window_frame(&self) -> bool {
+        self.evaluator.uses_window_frame
+    }
+
+    fn include_rank(&self) -> bool {
+        self.evaluator.include_rank
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/datafusion/ffi/src/udwf/range.rs
+++ b/datafusion/ffi/src/udwf/range.rs
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::ops::Range;
+
+use abi_stable::StableAbi;
+
+#[repr(C)]
+#[derive(Debug, StableAbi)]
+#[allow(non_camel_case_types)]
+pub struct FFI_Range {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl From<Range<usize>> for FFI_Range {
+    fn from(value: Range<usize>) -> Self {
+        Self {
+            start: value.start,
+            end: value.end,
+        }
+    }
+}
+
+impl From<FFI_Range> for Range<usize> {
+    fn from(value: FFI_Range) -> Self {
+        Self {
+            start: value.start,
+            end: value.end,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_round_trip_ffi_range() {
+        let original = Range { start: 10, end: 30 };
+
+        let ffi_range: FFI_Range = original.clone().into();
+        let round_trip: Range<usize> = ffi_range.into();
+
+        assert_eq!(original, round_trip);
+    }
+}

--- a/datafusion/ffi/src/udwf/range.rs
+++ b/datafusion/ffi/src/udwf/range.rs
@@ -19,6 +19,9 @@ use std::ops::Range;
 
 use abi_stable::StableAbi;
 
+/// A stable struct for sharing [`Range`] across FFI boundaries.
+/// For an explanation of each field, see the corresponding function
+/// defined in [`Range`].
 #[repr(C)]
 #[derive(Debug, StableAbi)]
 #[allow(non_camel_case_types)]

--- a/datafusion/ffi/src/volatility.rs
+++ b/datafusion/ffi/src/volatility.rs
@@ -19,7 +19,7 @@ use abi_stable::StableAbi;
 use datafusion::logical_expr::Volatility;
 
 #[repr(C)]
-#[derive(Debug, StableAbi)]
+#[derive(Debug, StableAbi, Clone)]
 #[allow(non_camel_case_types)]
 pub enum FFI_Volatility {
     Immutable,

--- a/datafusion/ffi/tests/ffi_integration.rs
+++ b/datafusion/ffi/tests/ffi_integration.rs
@@ -20,15 +20,11 @@
 #[cfg(feature = "integration-tests")]
 mod tests {
     use datafusion::error::{DataFusionError, Result};
-    use datafusion::prelude::{col, SessionContext};
+    use datafusion::prelude::SessionContext;
     use datafusion_ffi::catalog_provider::ForeignCatalogProvider;
     use datafusion_ffi::table_provider::ForeignTableProvider;
     use datafusion_ffi::tests::create_record_batch;
     use datafusion_ffi::tests::utils::get_module;
-    use datafusion::logical_expr::{ScalarUDF, WindowUDF};
-    use datafusion_ffi::udf::ForeignScalarUDF;
-    use datafusion_ffi::udwf::ForeignWindowUDF;
-    use std::path::Path;
     use std::sync::Arc;
 
     /// It is important that this test is in the `tests` directory and not in the
@@ -98,42 +94,5 @@ mod tests {
         assert!(results[0].num_rows() != 0);
 
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_rank_udwf() -> Result<()> {
-        let module = get_module()?;
-
-        let ffi_rank_func =
-            module
-                .create_rank_udwf()
-                .ok_or(DataFusionError::NotImplemented(
-                    "External table provider failed to implement create_scalar_udf"
-                        .to_string(),
-                ))?();
-        let foreign_rank_func: ForeignWindowUDF = (&ffi_rank_func).try_into()?;
-
-        let udwf: WindowUDF = foreign_rank_func.into();
-
-        let ctx = SessionContext::default();
-        let df = ctx.read_batch(create_record_batch(-5, 5))?;
-
-        let df = df
-            .with_column("rank_a", udwf.call(vec![]))?;
-
-        let result = df.collect().await?;
-
-        let expected = record_batch!(
-            ("a", Int32, vec![-5, -4, -3, -2, -1]),
-            ("b", Float64, vec![-5., -4., -3., -2., -1.]),
-            ("abs_a", Int32, vec![5, 4, 3, 2, 1]),
-            ("abs_b", Float64, vec![5., 4., 3., 2., 1.])
-        )?;
-
-        assert!(result.len() == 1);
-        assert!(result[0] == expected);
-
-        Ok(())
-
     }
 }

--- a/datafusion/ffi/tests/ffi_udwf.rs
+++ b/datafusion/ffi/tests/ffi_udwf.rs
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// Add an additional module here for convenience to scope this to only
+/// when the feature integtation-tests is built
+#[cfg(feature = "integration-tests")]
+mod tests {
+    use arrow::array::{create_array, ArrayRef};
+    use datafusion::error::{DataFusionError, Result};
+    use datafusion::logical_expr::expr::Sort;
+    use datafusion::logical_expr::{col, ExprFunctionExt, WindowUDF};
+    use datafusion::prelude::SessionContext;
+    use datafusion_ffi::tests::create_record_batch;
+    use datafusion_ffi::tests::utils::get_module;
+    use datafusion_ffi::udwf::ForeignWindowUDF;
+
+    #[tokio::test]
+    async fn test_rank_udwf() -> Result<()> {
+        let module = get_module()?;
+
+        let ffi_rank_func =
+            module
+                .create_rank_udwf()
+                .ok_or(DataFusionError::NotImplemented(
+                    "External table provider failed to implement create_scalar_udf"
+                        .to_string(),
+                ))?();
+        let foreign_rank_func: ForeignWindowUDF = (&ffi_rank_func).try_into()?;
+
+        let udwf: WindowUDF = foreign_rank_func.into();
+
+        let ctx = SessionContext::default();
+        let df = ctx.read_batch(create_record_batch(-5, 5))?;
+
+        let df = df.select(vec![
+            col("a"),
+            udwf.call(vec![])
+                .order_by(vec![Sort::new(col("a"), true, true)])
+                .build()
+                .unwrap()
+                .alias("rank_a"),
+        ])?;
+
+        df.clone().show().await?;
+
+        let result = df.collect().await?;
+        let expected = create_array!(UInt64, [1, 2, 3, 4, 5]) as ArrayRef;
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].column(1), &expected);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #14562

## Rationale for this change

This is the last part of the FFI UDFs that remain. It builds on top of https://github.com/apache/datafusion/pull/14775 so this PR looks larger than it really is.

## What changes are included in this PR?

- Exposes window UDFs via FFI
- Adds unit test and integration test

## Are these changes tested?

Yes, including an end-to-end integration test.

## Are there any user-facing changes?

None.
