### PR TITLE
Extend benchmark comparison script with more detailed statistics

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -52,6 +52,7 @@ Usage:
 $0 data [benchmark] [query]
 $0 run [benchmark]
 $0 compare <branch1> <branch2>
+$0 compare_detail <branch1> <branch2>
 $0 venv
 
 **********
@@ -66,10 +67,11 @@ DATAFUSION_DIR=/source/datafusion ./bench.sh run tpch
 **********
 * Commands
 **********
-data:         Generates or downloads data needed for benchmarking
-run:          Runs the named benchmark
-compare:      Compares results from benchmark runs
-venv:         Creates new venv (unless already exists) and installs compare's requirements into it
+data:            Generates or downloads data needed for benchmarking
+run:             Runs the named benchmark
+compare:         Compares fastest results from benchmark runs
+compare_detail:  Compares minimum, average (±stddev), and maximum results from benchmark runs
+venv:            Creates new venv (unless already exists) and installs compare's requirements into it
 
 **********
 * Benchmarks
@@ -359,6 +361,9 @@ main() {
             ;;
         compare)
             compare_benchmarks "$ARG2" "$ARG3"
+            ;;
+        compare_detail)
+            compare_benchmarks "$ARG2" "$ARG3" "--detailed"
             ;;
         venv)
             setup_venv
@@ -958,6 +963,8 @@ compare_benchmarks() {
     BASE_RESULTS_DIR="${SCRIPT_DIR}/results"
     BRANCH1="$1"
     BRANCH2="$2"
+    OPTS="$3"
+
     if [ -z "$BRANCH1" ] ; then
         echo "<branch1> not specified. Available branches:"
         ls -1 "${BASE_RESULTS_DIR}"
@@ -978,7 +985,7 @@ compare_benchmarks() {
             echo "--------------------"
             echo "Benchmark ${BENCH}"
             echo "--------------------"
-            PATH=$VIRTUAL_ENV/bin:$PATH python3 "${SCRIPT_DIR}"/compare.py "${RESULTS_FILE1}" "${RESULTS_FILE2}"
+            PATH=$VIRTUAL_ENV/bin:$PATH python3 "${SCRIPT_DIR}"/compare.py $OPTS "${RESULTS_FILE1}" "${RESULTS_FILE2}"
         else
             echo "Note: Skipping ${RESULTS_FILE1} as ${RESULTS_FILE2} does not exist"
         fi


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- No issue created yet, related to PR #16196.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The current benchmark comparison script compares the fastest execution times of each query. This is already useful but only a small portion of the measure data such as maximum and average times and some metric of variability. This PR adds an extra command to the result processing Python script that calculates and shows these values.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds support for a `compare_detail` command to `bench.sg` and a `--detailed` flag to `compare.py`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Not beyond manual execution of `bench.sh` with both the existing fastest mode and the new detailed mode.

## Are there any user-facing changes?

No, this is a developer oriented change.