### PR TITLE
Improve DataFusion subcrate readme files

### DIFF
--- a/datafusion/catalog-listing/README.md
+++ b/datafusion/catalog-listing/README.md
@@ -25,6 +25,12 @@ This crate is a submodule of DataFusion with [ListingTable], an implementation
 of [TableProvider] based on files in a directory (either locally or on remote
 object storage such as S3).
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
+[df]: https://crates.io/crates/datafusion
 [df]: https://crates.io/crates/datafusion
 [listingtable]: https://docs.rs/datafusion/latest/datafusion/datasource/listing/struct.ListingTable.html
 [tableprovider]: https://docs.rs/datafusion/latest/datafusion/datasource/trait.TableProvider.html
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/catalog/README.md
+++ b/datafusion/catalog/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that provides catalog management functionality, including catalogs, schemas, and tables.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/common-runtime/README.md
+++ b/datafusion/common-runtime/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that provides common utilities.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/common/README.md
+++ b/datafusion/common/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that provides common data types and utilities.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/datasource-avro/README.md
+++ b/datafusion/datasource-avro/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that defines a Avro based file source.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/datasource-json/README.md
+++ b/datafusion/datasource-json/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that defines a JSON based file source.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/datasource-parquet/README.md
+++ b/datafusion/datasource-parquet/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that defines a Parquet based file source.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/datasource/README.md
+++ b/datafusion/datasource/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that defines common DataSource related components like FileScanConfig, FileCompression etc.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/doc/README.md
+++ b/datafusion/doc/README.md
@@ -17,11 +17,12 @@
   under the License.
 -->
 
-# DataFusion datasource
+# DataFusion Execution
 
 [DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate is a submodule of DataFusion that defines a CSV based file source.
+This crate is a submodule of DataFusion that provides structures and macros
+for documenting user defined functions.
 
 Most projects should use the [`datafusion`] crate directly, which re-exports
 this module. If you are already using the [`datafusion`] crate, there is no

--- a/datafusion/execution/README.md
+++ b/datafusion/execution/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that provides execution runtime such as the memory pools and disk manager.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/expr-common/README.md
+++ b/datafusion/expr-common/README.md
@@ -17,11 +17,11 @@
   under the License.
 -->
 
-# DataFusion datasource
+# DataFusion Logical Plan and Expressions
 
 [DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate is a submodule of DataFusion that defines a CSV based file source.
+This crate is a submodule of DataFusion that provides common logical expressions
 
 Most projects should use the [`datafusion`] crate directly, which re-exports
 this module. If you are already using the [`datafusion`] crate, there is no

--- a/datafusion/expr/README.md
+++ b/datafusion/expr/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that provides data types and utilities for logical plans and expressions.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/functions-aggregate-common/README.md
+++ b/datafusion/functions-aggregate-common/README.md
@@ -17,11 +17,11 @@
   under the License.
 -->
 
-# DataFusion datasource
+# DataFusion Aggregate Function Library
 
 [DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate is a submodule of DataFusion that defines a CSV based file source.
+This crate contains common functionality for implementation aggregate and window functions.
 
 Most projects should use the [`datafusion`] crate directly, which re-exports
 this module. If you are already using the [`datafusion`] crate, there is no

--- a/datafusion/functions-aggregate/README.md
+++ b/datafusion/functions-aggregate/README.md
@@ -21,7 +21,11 @@
 
 [DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate contains packages of function that can be used to customize the
-functionality of DataFusion.
+This crate contains implementations of aggregate functions.
+
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
 
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/functions-nested/README.md
+++ b/datafusion/functions-nested/README.md
@@ -24,4 +24,9 @@
 This crate contains functions for working with arrays, maps and structs, such as `array_append` that work with
 `ListArray`, `LargeListArray` and `FixedListArray` types from the `arrow` crate.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/functions-table/README.md
+++ b/datafusion/functions-table/README.md
@@ -23,4 +23,9 @@
 
 This crate contains table functions that can be used in DataFusion queries.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/functions-window-common/README.md
+++ b/datafusion/functions-window-common/README.md
@@ -21,6 +21,11 @@
 
 [DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate contains common functions for implementing user-defined window functions.
+This crate contains common functions for implementing window functions.
+
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
 
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/functions-window/README.md
+++ b/datafusion/functions-window/README.md
@@ -21,6 +21,11 @@
 
 [DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate contains user-defined window functions.
+This crate contains window function definitions.
+
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
 
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/functions/README.md
+++ b/datafusion/functions/README.md
@@ -24,4 +24,9 @@
 This crate contains packages of function that can be used to customize the
 functionality of DataFusion.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/macros/README.md
+++ b/datafusion/macros/README.md
@@ -17,11 +17,11 @@
   under the License.
 -->
 
-# DataFusion datasource
+# DataFusion Window Function Common Library
 
 [DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
-This crate is a submodule of DataFusion that defines a CSV based file source.
+This crate contains common macros used in DataFusion
 
 Most projects should use the [`datafusion`] crate directly, which re-exports
 this module. If you are already using the [`datafusion`] crate, there is no

--- a/datafusion/optimizer/README.md
+++ b/datafusion/optimizer/README.md
@@ -17,6 +17,15 @@
   under the License.
 -->
 
-Please see [Query Optimizer] in the Library User Guide
+[DataFusion][df] is an extensible query execution framework, written in Rust, that uses Apache Arrow as its in-memory format.
 
+This crate contains the DataFusion logical optimizer.
+Please see [Query Optimizer] in the Library User Guide for more information.
+
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
+[df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion
 [query optimizer]: https://datafusion.apache.org/library-user-guide/query-optimizer.html

--- a/datafusion/physical-expr-common/README.md
+++ b/datafusion/physical-expr-common/README.md
@@ -24,4 +24,9 @@
 This crate is a submodule of DataFusion that provides shared APIs for implementing
 physical expressions such as `PhysicalExpr` and `PhysicalSortExpr`.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/physical-expr/README.md
+++ b/datafusion/physical-expr/README.md
@@ -23,4 +23,9 @@
 
 This crate is a submodule of DataFusion that provides data types and utilities for physical expressions.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/physical-optimizer/README.md
+++ b/datafusion/physical-optimizer/README.md
@@ -23,3 +23,10 @@ DataFusion is an extensible query execution framework, written in Rust,
 that uses Apache Arrow as its in-memory format.
 
 This crate contains the physical optimizer for DataFusion.
+
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
+[df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/physical-plan/README.md
+++ b/datafusion/physical-plan/README.md
@@ -24,4 +24,9 @@
 This crate is a submodule of DataFusion that contains the `ExecutionPlan` trait and the various implementations of that
 trait for built in operators such as filters, projections, joins, aggregations, etc.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/proto-common/README.md
+++ b/datafusion/proto-common/README.md
@@ -24,5 +24,10 @@ bytes, which can be useful for sending data over the network.
 
 See [API Docs] for details and examples.
 
+Most projects should use the [`datafusion-proto`] crate directly, which re-exports
+this module. If you are already using the [`datafusion-protp`] crate, there is no
+reason to use this crate directly in your project as well.
+
+[`datafusion-proto`]: https://crates.io/crates/datafusion-proto
 [datafusion]: https://datafusion.apache.org
 [api docs]: http://docs.rs/datafusion-proto/latest

--- a/datafusion/session/README.md
+++ b/datafusion/session/README.md
@@ -23,4 +23,9 @@
 
 This crate provides **session-related abstractions** used in the DataFusion query engine. A _session_ represents the runtime context for query execution, including configuration, runtime environment, function registry, and planning.
 
+Most projects should use the [`datafusion`] crate directly, which re-exports
+this module. If you are already using the [`datafusion`] crate, there is no
+reason to use this crate directly in your project as well.
+
 [df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion

--- a/datafusion/sql/README.md
+++ b/datafusion/sql/README.md
@@ -25,6 +25,13 @@ project that requires a SQL query planner and does not make any assumptions abou
 will be translated to a physical plan. For example, there is no concept of row-based versus columnar execution in the
 logical plan.
 
+Note that the [`datafusion`] crate re-exports this module. If you are already
+using the [`datafusion`] crate in your project, there is no reason to use this
+crate directly in your project as well.
+
+[df]: https://crates.io/crates/datafusion
+[`datafusion`]: https://crates.io/crates/datafusion
+
 ## Example Usage
 
 See the [examples](examples) directory for fully working examples.


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/delta-io/delta-rs/pull/3521

## Rationale for this change

While testing a DataFusion upgrade in delta.rs I found that that project used many of the subcrates in DataFusion directly. I made a PR to clean this up (https://github.com/delta-io/delta-rs/pull/3521) but I wanted to make it easier to understand which `datafusion-*` crate is designed to be used directly and which is not

## What changes are included in this PR?

1. Add a note to subcrates README.md files that are not intended to be used directly
2. Add a few missing READMEs I found while doing this

## Are these changes tested?

By CI
## Are there any user-facing changes?
(Hopefully) better documentation