### PR TITLE
Minor: fix upgrade papercut `pub use PruningStatistics`

### DIFF
--- a/datafusion/physical-optimizer/src/pruning.rs
+++ b/datafusion/physical-optimizer/src/pruning.rs
@@ -28,7 +28,8 @@ use arrow::{
     datatypes::{DataType, Field, Schema, SchemaRef},
     record_batch::{RecordBatch, RecordBatchOptions},
 };
-use datafusion_common::pruning::PruningStatistics;
+// pub use for backwards compatibility
+pub use datafusion_common::pruning::PruningStatistics;
 use log::{debug, trace};
 
 use datafusion_common::error::{DataFusionError, Result};


### PR DESCRIPTION
## Which issue does this PR close?

- Found while testing https://github.com/delta-io/delta-rs/pull/3520
- Related to #15771 

## Rationale for this change

While testing the DataFuion upgrade in delta.rs I found that `PruningStatistics` is no longer exported from `datafusion::physical_optimizer::pruning` after #16069

The fix downstream is easy (use the new import location) but I think leaving a backwards compatible `pub use` would mean no changes needed

## What changes are included in this PR?

1. change `use` to `pub use` so downstream users can upgrade without change

## Are these changes tested?
By CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
