### PR TITLE
Unify Metadata Handing: use `FieldMetadata` in `Expr::Alias` and `ExprSchemable`

### DIFF
--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -70,7 +70,7 @@ use datafusion_common::{
 use datafusion_common_runtime::SpawnedTask;
 use datafusion_execution::config::SessionConfig;
 use datafusion_execution::runtime_env::RuntimeEnv;
-use datafusion_expr::expr::{GroupingSet, Sort, WindowFunction};
+use datafusion_expr::expr::{FieldMetadata, GroupingSet, Sort, WindowFunction};
 use datafusion_expr::var_provider::{VarProvider, VarType};
 use datafusion_expr::{
     cast, col, create_udf, exists, in_subquery, lit, out_ref_col, placeholder,
@@ -5674,6 +5674,7 @@ async fn test_alias() -> Result<()> {
 async fn test_alias_with_metadata() -> Result<()> {
     let mut metadata = HashMap::new();
     metadata.insert(String::from("k"), String::from("v"));
+    let metadata = FieldMetadata::from(metadata);
     let df = create_test_table("test")
         .await?
         .select(vec![col("a").alias_with_metadata("b", Some(metadata))])?

--- a/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
@@ -40,6 +40,7 @@ use datafusion_common::{
     assert_batches_eq, assert_batches_sorted_eq, assert_contains, exec_err, not_impl_err,
     plan_err, DFSchema, DataFusionError, Result, ScalarValue,
 };
+use datafusion_expr::expr::FieldMetadata;
 use datafusion_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion_expr::{
     lit_with_metadata, Accumulator, ColumnarValue, CreateFunction, CreateFunctionBody,
@@ -1535,7 +1536,7 @@ async fn test_metadata_based_udf_with_literal() -> Result<()> {
     let df = ctx.sql("select 0;").await?.select(vec![
         lit(5u64).alias_with_metadata("lit_with_doubling", Some(input_metadata.clone())),
         lit(5u64).alias("lit_no_doubling"),
-        lit_with_metadata(5u64, Some(input_metadata))
+        lit_with_metadata(5u64, Some(FieldMetadata::from(input_metadata)))
             .alias("lit_with_double_no_alias_metadata"),
     ])?;
 

--- a/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
@@ -1533,10 +1533,11 @@ async fn test_metadata_based_udf_with_literal() -> Result<()> {
         [("modify_values".to_string(), "double_output".to_string())]
             .into_iter()
             .collect();
+    let input_metadata = FieldMetadata::from(input_metadata);
     let df = ctx.sql("select 0;").await?.select(vec![
         lit(5u64).alias_with_metadata("lit_with_doubling", Some(input_metadata.clone())),
         lit(5u64).alias("lit_no_doubling"),
-        lit_with_metadata(5u64, Some(FieldMetadata::from(input_metadata)))
+        lit_with_metadata(5u64, Some(input_metadata))
             .alias("lit_with_double_no_alias_metadata"),
     ])?;
 

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -462,6 +462,24 @@ impl FieldMetadata {
         }
     }
 
+    /// Merges two optional `FieldMetadata` instances, overwriting any existing
+    /// keys in `m` with keys from `n` if present
+    pub fn merge_options(
+        m: Option<&FieldMetadata>,
+        n: Option<&FieldMetadata>,
+    ) -> Option<FieldMetadata> {
+        match (m, n) {
+            (Some(m), Some(n)) => {
+                let mut merged = m.clone();
+                merged.extend(n.clone());
+                Some(merged)
+            }
+            (Some(m), None) => Some(m.clone()),
+            (None, Some(n)) => Some(n.clone()),
+            (None, None) => None,
+        }
+    }
+
     /// Create a new metadata instance from a `Field`'s metadata.
     pub fn new_from_field(field: &Field) -> Self {
         let inner = field
@@ -507,7 +525,7 @@ impl FieldMetadata {
         self.inner.len()
     }
 
-    /// Updates the metadata on the Field with this metadata
+    /// Updates the metadata on the Field with this metadata, if it is not empty.
     pub fn add_to_field(&self, field: Field) -> Field {
         if self.inner.is_empty() {
             return field;

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -528,18 +528,21 @@ impl FieldMetadata {
         self.inner.len()
     }
 
+    /// Convert this `FieldMetadata` into a `HashMap<String, String>`
+    pub fn to_hashmap(&self) -> std::collections::HashMap<String, String> {
+        self.inner
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
     /// Updates the metadata on the Field with this metadata, if it is not empty.
     pub fn add_to_field(&self, field: Field) -> Field {
         if self.inner.is_empty() {
             return field;
         }
 
-        field.with_metadata(
-            self.inner
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect(),
-        )
+        field.with_metadata(self.to_hashmap())
     }
 }
 

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -511,6 +511,9 @@ impl FieldMetadata {
 
     /// Adds metadata from `other` into `self`, overwriting any existing keys.
     pub fn extend(&mut self, other: Self) {
+        if other.is_empty() {
+            return;
+        }
         let other = Arc::unwrap_or_clone(other.into_inner());
         Arc::make_mut(&mut self.inner).extend(other);
     }
@@ -569,6 +572,24 @@ impl From<&std::collections::HashMap<String, String>> for FieldMetadata {
     }
 }
 
+/// From hashbrown map
+impl From<HashMap<String, String>> for FieldMetadata {
+    fn from(map: HashMap<String, String>) -> Self {
+        let inner = map.into_iter().collect();
+        Self::new(inner)
+    }
+}
+
+impl From<&HashMap<String, String>> for FieldMetadata {
+    fn from(map: &HashMap<String, String>) -> Self {
+        let inner = map
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Self::new(inner)
+    }
+}
+
 /// UNNEST expression.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
 pub struct Unnest {
@@ -595,7 +616,7 @@ pub struct Alias {
     pub expr: Box<Expr>,
     pub relation: Option<TableReference>,
     pub name: String,
-    pub metadata: Option<std::collections::HashMap<String, String>>,
+    pub metadata: Option<FieldMetadata>,
 }
 
 impl Hash for Alias {
@@ -635,10 +656,7 @@ impl Alias {
         }
     }
 
-    pub fn with_metadata(
-        mut self,
-        metadata: Option<std::collections::HashMap<String, String>>,
-    ) -> Self {
+    pub fn with_metadata(mut self, metadata: Option<FieldMetadata>) -> Self {
         self.metadata = metadata;
         self
     }
@@ -1593,7 +1611,7 @@ impl Expr {
     pub fn alias_with_metadata(
         self,
         name: impl Into<String>,
-        metadata: Option<std::collections::HashMap<String, String>>,
+        metadata: Option<FieldMetadata>,
     ) -> Expr {
         Expr::Alias(Alias::new(self, None::<&str>, name.into()).with_metadata(metadata))
     }
@@ -1624,7 +1642,7 @@ impl Expr {
         self,
         relation: Option<impl Into<TableReference>>,
         name: impl Into<String>,
-        metadata: Option<std::collections::HashMap<String, String>>,
+        metadata: Option<FieldMetadata>,
     ) -> Expr {
         Expr::Alias(Alias::new(self, relation, name.into()).with_metadata(metadata))
     }

--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -390,11 +390,7 @@ mod test {
                     } else {
                         utf8_val
                     };
-                    Ok(Transformed::yes(lit_with_metadata(
-                        utf8_val,
-                        metadata
-                            .map(|m| m.into_iter().collect::<HashMap<String, String>>()),
-                    )))
+                    Ok(Transformed::yes(lit_with_metadata(utf8_val, metadata)))
                 }
                 // otherwise, return None
                 _ => Ok(Transformed::no(expr)),

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -423,12 +423,7 @@ impl ExprSchemable for Expr {
             Expr::Literal(l, metadata) => {
                 let mut field = Field::new(&schema_name, l.data_type(), l.is_null());
                 if let Some(metadata) = metadata {
-                    field = field.with_metadata(
-                        metadata
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect(),
-                    );
+                    field = metadata.add_to_field(field);
                 }
                 Ok(Arc::new(field))
             }

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -17,8 +17,8 @@
 
 use super::{Between, Expr, Like};
 use crate::expr::{
-    AggregateFunction, AggregateFunctionParams, Alias, BinaryExpr, Cast, InList,
-    InSubquery, Placeholder, ScalarFunction, TryCast, Unnest, WindowFunction,
+    AggregateFunction, AggregateFunctionParams, Alias, BinaryExpr, Cast, FieldMetadata,
+    InList, InSubquery, Placeholder, ScalarFunction, TryCast, Unnest, WindowFunction,
     WindowFunctionParams,
 };
 use crate::type_coercion::functions::{
@@ -34,7 +34,6 @@ use datafusion_common::{
 };
 use datafusion_expr_common::type_coercion::binary::BinaryTypeCoercer;
 use datafusion_functions_window_common::field::WindowUDFFieldArgs;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Trait to allow expr to typable with respect to a schema
@@ -46,7 +45,7 @@ pub trait ExprSchemable {
     fn nullable(&self, input_schema: &dyn ExprSchema) -> Result<bool>;
 
     /// Given a schema, return the expr's optional metadata
-    fn metadata(&self, schema: &dyn ExprSchema) -> Result<HashMap<String, String>>;
+    fn metadata(&self, schema: &dyn ExprSchema) -> Result<FieldMetadata>;
 
     /// Convert to a field with respect to a schema
     fn to_field(
@@ -346,9 +345,9 @@ impl ExprSchemable for Expr {
         }
     }
 
-    fn metadata(&self, schema: &dyn ExprSchema) -> Result<HashMap<String, String>> {
+    fn metadata(&self, schema: &dyn ExprSchema) -> Result<FieldMetadata> {
         self.to_field(schema)
-            .map(|(_, field)| field.metadata().clone())
+            .map(|(_, field)| FieldMetadata::from(field.metadata()))
     }
 
     /// Returns the datatype and nullability of the expression based on [ExprSchema].
@@ -405,12 +404,10 @@ impl ExprSchemable for Expr {
 
                 let mut combined_metadata = expr.metadata(schema)?;
                 if let Some(metadata) = metadata {
-                    if !metadata.is_empty() {
-                        combined_metadata.extend(metadata.clone());
-                    }
+                    combined_metadata.extend(metadata.clone());
                 }
 
-                Ok(Arc::new(field.with_metadata(combined_metadata)))
+                Ok(Arc::new(combined_metadata.add_to_field(field)))
             }
             Expr::Negative(expr) => expr.to_field(schema).map(|(_, f)| f),
             Expr::Column(c) => schema.field_from_column(c).map(|f| Arc::new(f.clone())),
@@ -736,7 +733,7 @@ mod tests {
     use super::*;
     use crate::{col, lit};
 
-    use datafusion_common::{internal_err, DFSchema, ScalarValue};
+    use datafusion_common::{internal_err, DFSchema, HashMap, ScalarValue};
 
     macro_rules! test_is_expr_nullable {
         ($EXPR_TYPE:ident) => {{
@@ -842,6 +839,7 @@ mod tests {
     fn test_expr_metadata() {
         let mut meta = HashMap::new();
         meta.insert("bar".to_string(), "buzz".to_string());
+        let meta = FieldMetadata::from(meta);
         let expr = col("foo");
         let schema = MockExprSchema::new()
             .with_data_type(DataType::Int32)
@@ -860,14 +858,13 @@ mod tests {
         );
 
         let schema = DFSchema::from_unqualified_fields(
-            vec![Field::new("foo", DataType::Int32, true).with_metadata(meta.clone())]
-                .into(),
-            HashMap::new(),
+            vec![meta.add_to_field(Field::new("foo", DataType::Int32, true))].into(),
+            std::collections::HashMap::new(),
         )
         .unwrap();
 
         // verify to_field method populates metadata
-        assert_eq!(&meta, expr.to_field(&schema).unwrap().1.metadata());
+        assert_eq!(meta, expr.metadata(&schema).unwrap());
     }
 
     #[derive(Debug)]
@@ -899,8 +896,8 @@ mod tests {
             self
         }
 
-        fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
-            self.field = self.field.with_metadata(metadata);
+        fn with_metadata(mut self, metadata: FieldMetadata) -> Self {
+            self.field = metadata.add_to_field(self.field);
             self
         }
     }

--- a/datafusion/expr/src/literal.rs
+++ b/datafusion/expr/src/literal.rs
@@ -17,20 +17,16 @@
 
 //! Literal module contains foundational types that are used to represent literals in DataFusion.
 
+use crate::expr::FieldMetadata;
 use crate::Expr;
 use datafusion_common::ScalarValue;
-use std::collections::HashMap;
 
 /// Create a literal expression
 pub fn lit<T: Literal>(n: T) -> Expr {
     n.lit()
 }
 
-pub fn lit_with_metadata<T: Literal>(
-    n: T,
-    metadata: impl Into<Option<HashMap<String, String>>>,
-) -> Expr {
-    let metadata = metadata.into();
+pub fn lit_with_metadata<T: Literal>(n: T, metadata: Option<FieldMetadata>) -> Expr {
     let Some(metadata) = metadata else {
         return n.lit();
     };
@@ -38,13 +34,12 @@ pub fn lit_with_metadata<T: Literal>(
     let Expr::Literal(sv, prior_metadata) = n.lit() else {
         unreachable!();
     };
-
     let new_metadata = match prior_metadata {
         Some(mut prior) => {
             prior.extend(metadata);
             prior
         }
-        None => metadata.into_iter().collect(),
+        None => metadata,
     };
 
     Expr::Literal(sv, Some(new_metadata))

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -18,7 +18,6 @@
 //! Literal expressions for physical operations
 
 use std::any::Any;
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -30,6 +29,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use datafusion_common::{Result, ScalarValue};
+use datafusion_expr::expr::FieldMetadata;
 use datafusion_expr::Expr;
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use datafusion_expr_common::interval_arithmetic::Interval;
@@ -64,14 +64,13 @@ impl Literal {
     /// Create a literal value expression
     pub fn new_with_metadata(
         value: ScalarValue,
-        metadata: impl Into<Option<HashMap<String, String>>>,
+        metadata: Option<FieldMetadata>,
     ) -> Self {
-        let metadata = metadata.into();
         let mut field =
             Field::new(format!("{value}"), value.data_type(), value.is_null());
 
         if let Some(metadata) = metadata {
-            field = field.with_metadata(metadata);
+            field = metadata.add_to_field(field);
         }
 
         Self {

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::ScalarFunctionExpr;
@@ -29,7 +28,9 @@ use datafusion_common::{
     exec_err, not_impl_err, plan_err, DFSchema, Result, ScalarValue, ToDFSchema,
 };
 use datafusion_expr::execution_props::ExecutionProps;
-use datafusion_expr::expr::{Alias, Cast, InList, Placeholder, ScalarFunction};
+use datafusion_expr::expr::{
+    Alias, Cast, FieldMetadata, InList, Placeholder, ScalarFunction,
+};
 use datafusion_expr::var_provider::is_system_variables;
 use datafusion_expr::var_provider::VarType;
 use datafusion_expr::{
@@ -114,21 +115,25 @@ pub fn create_physical_expr(
     match e {
         Expr::Alias(Alias { expr, metadata, .. }) => {
             if let Expr::Literal(v, prior_metadata) = expr.as_ref() {
-                let mut new_metadata = prior_metadata
-                    .as_ref()
-                    .map(|m| {
-                        m.iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect::<HashMap<String, String>>()
-                    })
-                    .unwrap_or_default();
-                if let Some(metadata) = metadata {
-                    new_metadata.extend(metadata.clone());
-                }
-                let new_metadata = match new_metadata.is_empty() {
-                    true => None,
-                    false => Some(new_metadata),
+                let metadata = metadata.as_ref().map(|m| FieldMetadata::from(m.clone()));
+                let new_metadata = match (prior_metadata.as_ref(), metadata) {
+                    (Some(m), Some(n)) => {
+                        let mut m = m.clone();
+                        m.extend(n);
+                        Some(m)
+                    }
+                    (Some(m), None) => Some(m.clone()),
+                    (None, Some(n)) => Some(n),
+                    (None, None) => None,
                 };
+
+                let new_metadata = new_metadata.and_then(|new_metadata| {
+                    if new_metadata.is_empty() {
+                        None
+                    } else {
+                        Some(new_metadata)
+                    }
+                });
 
                 Ok(Arc::new(Literal::new_with_metadata(
                     v.clone(),
@@ -144,9 +149,7 @@ pub fn create_physical_expr(
         }
         Expr::Literal(value, metadata) => Ok(Arc::new(Literal::new_with_metadata(
             value.clone(),
-            metadata
-                .as_ref()
-                .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()),
+            metadata.clone(),
         ))),
         Expr::ScalarVariable(_, variable_names) => {
             if is_system_variables(variable_names) {

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -116,25 +116,10 @@ pub fn create_physical_expr(
         Expr::Alias(Alias { expr, metadata, .. }) => {
             if let Expr::Literal(v, prior_metadata) = expr.as_ref() {
                 let metadata = metadata.as_ref().map(|m| FieldMetadata::from(m.clone()));
-                let new_metadata = match (prior_metadata.as_ref(), metadata) {
-                    (Some(m), Some(n)) => {
-                        let mut m = m.clone();
-                        m.extend(n);
-                        Some(m)
-                    }
-                    (Some(m), None) => Some(m.clone()),
-                    (None, Some(n)) => Some(n),
-                    (None, None) => None,
-                };
-
-                let new_metadata = new_metadata.and_then(|new_metadata| {
-                    if new_metadata.is_empty() {
-                        None
-                    } else {
-                        Some(new_metadata)
-                    }
-                });
-
+                let new_metadata = FieldMetadata::merge_options(
+                    prior_metadata.as_ref(),
+                    metadata.as_ref(),
+                );
                 Ok(Arc::new(Literal::new_with_metadata(
                     v.clone(),
                     new_metadata,

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -115,7 +115,6 @@ pub fn create_physical_expr(
     match e {
         Expr::Alias(Alias { expr, metadata, .. }) => {
             if let Expr::Literal(v, prior_metadata) = expr.as_ref() {
-                let metadata = metadata.as_ref().map(|m| FieldMetadata::from(m.clone()));
                 let new_metadata = FieldMetadata::merge_options(
                     prior_metadata.as_ref(),
                     metadata.as_ref(),

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -211,7 +211,10 @@ pub fn serialize_expr(
                     .map(|r| vec![r.into()])
                     .unwrap_or(vec![]),
                 alias: name.to_owned(),
-                metadata: metadata.to_owned().unwrap_or(HashMap::new()),
+                metadata: metadata
+                    .as_ref()
+                    .map(|m| m.to_hashmap())
+                    .unwrap_or(HashMap::new()),
             });
             protobuf::LogicalExprNode {
                 expr_type: Some(ExprType::Alias(alias)),


### PR DESCRIPTION
- Draft until https://github.com/apache/datafusion/pull/16317 is merged

## Which issue does this PR close?

- Follow on to https://github.com/apache/datafusion/pull/16317

## Rationale for this change
We are working metadata through DataFusion as part of supporting extension types
so having a single unified representation to work on will make the code easier
to do. I added `FieldMetadata` to avoid the use of `BTreeMap` direcectly, but found
there were still places that used `HashMap` to pass metadata around directly




## What changes are included in this PR?

Let's use FieldMetadata everywhere


## Are these changes tested?

By CI
## Are there any user-facing changes?

This is an API change, but I think it sets us up for unified and efficient metadata handling in DataFusion
