### PR TITLE
bug: remove busy-wait while sort is ongoing

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -1386,7 +1386,7 @@ mod tests {
             match self.partition {
                 0 => {
                     if self.none_polled_once {
-                        panic!("Exhausted stream is polled more than one")
+                        panic!("Exhausted stream is polled more than once")
                     } else {
                         self.none_polled_once = true;
                         Poll::Ready(None)


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #16321.

## Rationale for this change

`SortPreservingMergeStream` works in two phases. It first waits for each input stream to be ready to emit. Once everybody's ready it proceeds to an emit phase.

During the waiting phase, it will poll each stream in a round-robin fashion. If any stream returns `Pending` the code self-wakes the current task and immediately returns `Pending`. This results in busy-waiting when waiting for, for instance, a `SortExec` that's sorting its data or any other pipeline breaker.

While this works, it wastes CPU cycles.

## What changes are included in this PR?

Rather than returning immediately when one stream is pending, poll each stream once. Only return pending when there are still streams left that have not started emitting. This assumes that the pending streams are well behaved and will wake the task when they need to be polled again as required by the `Stream` contract. Note that this may surface bugs in other streams.

Rotation of `uninitiated_partitions` has been removed since that's no longer useful. There was a comment in the code about 'upstream buffer size increase', but I'm not sure what that was referring to.

## Are these changes tested?

Only by existing test and manual testing

## Are there any user-facing changes?

No