### PR TITLE
Add support for glob string in datafusion-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "futures",
+ "glob",
  "insta",
  "insta-cmd",
  "mimalloc",

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -55,6 +55,7 @@ datafusion = { workspace = true, features = [
 dirs = "6.0.0"
 env_logger = { workspace = true }
 futures = { workspace = true }
+glob = "0.3.0"
 mimalloc = { version = "0.1", default-features = false }
 object_store = { workspace = true, features = ["aws", "gcp", "http"] }
 parking_lot = { workspace = true }

--- a/datafusion-cli/src/functions.rs
+++ b/datafusion-cli/src/functions.rs
@@ -531,7 +531,6 @@ impl TableFunctionImpl for GlobFunc {
             let glob = Pattern::new(glob_part).map_err(|e| {
                 DataFusionError::Plan(format!("Invalid glob pattern: {}", e))
             })?;
-            println!("base_url: [{:?}] glob: [{:?}]", base_url, glob);
             ListingTableUrl::try_new(base_url, Some(glob))?
         } else {
             // Local path or URL without globs - parse() handles this correctly

--- a/datafusion-cli/src/functions.rs
+++ b/datafusion-cli/src/functions.rs
@@ -537,7 +537,7 @@ impl TableFunctionImpl for GlobFunc {
             ListingTableUrl::parse(pattern)?
         };
 
-        // 3. Determine file format
+        // Determine file format for the table configuration
         let file_extension = format
             .or_else(|| {
                 // Extract extension from original pattern (before any URL manipulation)
@@ -552,7 +552,7 @@ impl TableFunctionImpl for GlobFunc {
             other => return plan_err!("glob(): unsupported format '{other}'"),
         };
 
-        // 4. Build and return table
+        // Create the listing table - block is needed in order to infer schema which is an async io operation within a sync function.
         let listing_opts =
             ListingOptions::new(file_format).with_file_extension(file_extension);
         let schema = block_on(listing_opts.infer_schema(&self.ctx.state(), &url))?;

--- a/datafusion-cli/tests/snapshots/cli@glob_test.sql.snap
+++ b/datafusion-cli/tests/snapshots/cli@glob_test.sql.snap
@@ -1,0 +1,57 @@
+---
+source: datafusion-cli/tests/cli_integration.rs
+assertion_line: 173
+info:
+  program: datafusion-cli
+  args: []
+  stdin: "-- Test glob function with files available in CI\n-- Test 1: Single CSV file - verify basic functionality\nSELECT COUNT(*) AS cars_count FROM glob('../datafusion/core/tests/data/cars.csv');\n\n-- Test 2: Data aggregation from CSV file - verify actual data reading\nSELECT car, COUNT(*) as count FROM glob('../datafusion/core/tests/data/cars.csv') GROUP BY car ORDER BY car;\n\n-- Test 3: JSON file with explicit format parameter - verify format specification\nSELECT COUNT(*) AS json_count FROM glob('../datafusion/core/tests/data/1.json', 'json');\n\n-- Test 4: Single specific CSV file - verify another CSV works\nSELECT COUNT(*) AS example_count FROM glob('../datafusion/core/tests/data/example.csv');\n\n-- Test 5: Glob pattern with wildcard - test actual glob functionality\nSELECT COUNT(*) AS glob_pattern_count FROM glob('../datafusion/core/tests/data/exa*.csv'); "
+input_file: datafusion-cli/tests/sql/integration/glob_test.sql
+---
+success: true
+exit_code: 0
+----- stdout -----
+[CLI_VERSION]
++------------+
+| cars_count |
++------------+
+| 25         |
++------------+
+1 row(s) fetched. 
+[ELAPSED]
+
++-------+-------+
+| car   | count |
++-------+-------+
+| green | 12    |
+| red   | 13    |
++-------+-------+
+2 row(s) fetched. 
+[ELAPSED]
+
++------------+
+| json_count |
++------------+
+| 4          |
++------------+
+1 row(s) fetched. 
+[ELAPSED]
+
++---------------+
+| example_count |
++---------------+
+| 1             |
++---------------+
+1 row(s) fetched. 
+[ELAPSED]
+
++--------------------+
+| glob_pattern_count |
++--------------------+
+| 4                  |
++--------------------+
+1 row(s) fetched. 
+[ELAPSED]
+
+\q
+
+----- stderr -----

--- a/datafusion-cli/tests/sql/integration/glob_test.sql
+++ b/datafusion-cli/tests/sql/integration/glob_test.sql
@@ -1,0 +1,15 @@
+-- Test glob function with files available in CI
+-- Test 1: Single CSV file - verify basic functionality
+SELECT COUNT(*) AS cars_count FROM glob('../datafusion/core/tests/data/cars.csv');
+
+-- Test 2: Data aggregation from CSV file - verify actual data reading
+SELECT car, COUNT(*) as count FROM glob('../datafusion/core/tests/data/cars.csv') GROUP BY car ORDER BY car;
+
+-- Test 3: JSON file with explicit format parameter - verify format specification
+SELECT COUNT(*) AS json_count FROM glob('../datafusion/core/tests/data/1.json', 'json');
+
+-- Test 4: Single specific CSV file - verify another CSV works
+SELECT COUNT(*) AS example_count FROM glob('../datafusion/core/tests/data/example.csv');
+
+-- Test 5: Glob pattern with wildcard - test actual glob functionality
+SELECT COUNT(*) AS glob_pattern_count FROM glob('../datafusion/core/tests/data/exa*.csv'); 


### PR DESCRIPTION
Partly closes #16303 

Introduces glob() table function that allows running queries on multiple files, like:
```
 SELECT id FROM glob('s3://tests/data/file-a*.csv');
 SELECT id FROM glob('s3://tests/*/*.csv');

```
note that the latter statement include 2 glob layers (2 wildcards) that work on only if you enable 
```
SET datafusion.execution.listing_table_ignore_subdirectory = false;
```

Integration tests were added to test
