### PR TITLE
Fix: mark "Spilling (to disk) Joins" as supported in features

### DIFF
--- a/docs/source/user-guide/features.md
+++ b/docs/source/user-guide/features.md
@@ -93,7 +93,7 @@
 - [x] Memory limits enforced
 - [x] Spilling (to disk) Sort
 - [x] Spilling (to disk) Grouping
-- [ ] Spilling (to disk) Joins
+- [x] Spilling (to disk) Joins
 
 ## Data Sources
 

--- a/docs/source/user-guide/features.md
+++ b/docs/source/user-guide/features.md
@@ -93,7 +93,8 @@
 - [x] Memory limits enforced
 - [x] Spilling (to disk) Sort
 - [x] Spilling (to disk) Grouping
-- [x] Spilling (to disk) Joins
+- [x] Spilling (to disk) Sort Merge Join
+- [ ] Spilling (to disk) Hash Join
 
 ## Data Sources
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #16341.

## Rationale for this change

The feature matrix in the user guide was missing an updated status for join spilling support. This PR ensures that the documentation reflects the current capabilities of the system, improving clarity for users and maintainers.

## What changes are included in this PR?

- Updates the feature matrix to mark "Spilling (to disk) Joins" as supported (`[x]`).

## Are these changes tested?

- No tests are required for this documentation-only change.
- The underlying functionality is assumed to be covered by existing tests related to join spilling.

## Are there any user-facing changes?

- Yes, this is a documentation update that clarifies existing functionality.
- No behavioral or API changes are included.
