### PR TITLE
Fix array_concat with NULL arrays

### DIFF
--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -3082,6 +3082,18 @@ select array_concat(NULL::integer[], NULL::integer[]);
 ----
 NULL
 
+# test with NULL LargeList
+query ?
+select array_concat(arrow_cast(NULL::string[], 'LargeList(Utf8)'));
+----
+NULL
+
+# test with NULL FixedSizeList
+query ?
+select array_concat(arrow_cast(NULL::string[], 'FixedSizeList(2, Utf8)'));
+----
+NULL
+
 # test with mix of NULL and empty arrays
 query ?
 select array_concat(NULL::integer[], []);

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -3070,6 +3070,30 @@ select array_concat([]);
 ----
 []
 
+# test with NULL array
+query ?
+select array_concat(NULL::integer[]);
+----
+NULL
+
+# test with multiple NULL arrays
+query ?
+select array_concat(NULL::integer[], NULL::integer[]);
+----
+NULL
+
+# test with mix of NULL and empty arrays
+query ?
+select array_concat(NULL::integer[], []);
+----
+[]
+
+# test with mix of NULL and non-empty arrays
+query ?
+select array_concat(NULL::integer[], [1, 2, 3]);
+----
+[1, 2, 3]
+
 # Concatenating strings arrays
 query ?
 select array_concat(


### PR DESCRIPTION
Fixes issue where 'select array_concat(NULL::integer[])' would throw 'Arrow error: Compute error: concat requires input of at least one array'

## Which issue does this PR close?

- Closes #16349 

## What changes are included in this PR?

- Fix array_concat_inner to properly handle NULL list arrays by checking null_count
- Add logic to create properly typed empty arrays for all-null inputs
- Support NULL handling for List, LargeList, and FixedSizeList types
- Add comprehensive test coverage for NULL array scenarios
