### PR TITLE
tpch: move reading of SQL queries out of timed span.

### DIFF
--- a/benchmarks/src/tpch/run.rs
+++ b/benchmarks/src/tpch/run.rs
@@ -147,10 +147,11 @@ impl RunOpt {
         let mut millis = vec![];
         // run benchmark
         let mut query_results = vec![];
+
+        let sql = &get_query_sql(query_id)?;
+
         for i in 0..self.iterations() {
             let start = Instant::now();
-
-            let sql = &get_query_sql(query_id)?;
 
             // query 15 is special, with 3 statements. the second statement is the one from which we
             // want to capture the results


### PR DESCRIPTION
## Which issue does this PR close?

None

## Rationale for this change

The TPCH benchmark currently includes the time it takes to find and read the SQL queries from disk in the measured time. This is not actually part of the benchmarked code, so it should be outside of the timed span. This change might remove some jitter from the tpch memory benchmarks.

## What changes are included in this PR?

Move reading of SQL queries outside of the timed span.

## Are these changes tested?

Manual testing

## Are there any user-facing changes?

No