### PR TITLE
Add note in upgrade guide about changes to `Expr::Scalar` in 48.0.0

### DIFF
--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -21,6 +21,41 @@
 
 ## DataFusion `48.0.0`
 
+### `Expr::Literal` has optional metadata
+
+The [`Expr::Literal`] variant now includes optional metadata, which allows for
+carrying through Arrow field metadata to support extension types and other uses.
+
+This means code such as
+
+```rust
+# /* comment to avoid running
+match expr {
+...
+  Expr::Literal(scalar) => ...
+...
+}
+#  */
+```
+
+Should be updated to:
+
+```rust
+# /* comment to avoid running
+match expr {
+...
+  Expr::Literal(scalar, _metadata) => ...
+...
+}
+#  */
+```
+
+Likewise constructing `Expr::Literal` requires metadata as well. The [`lit`] function
+has not changed and returns an `Expr::Literal` with no metadata.
+
+[`expr::literal`]: https://docs.rs/datafusion/latest/datafusion/logical_expr/enum.Expr.html#variant.Literal
+[`lit`]: https://docs.rs/datafusion/latest/datafusion/logical_expr/fn.lit.html
+
 ### `Expr::WindowFunction` is now `Box`ed
 
 `Expr::WindowFunction` is now a `Box<WindowFunction>` instead of a `WindowFunction` directly.
@@ -200,7 +235,7 @@ working but no one knows due to lack of test coverage).
 
 [api deprecation guidelines]: https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines
 
-### `PartitionedFile` added as an arguement to the `FileOpener` trait
+### `PartitionedFile` added as an argument to the `FileOpener` trait
 
 This is necessary to properly fix filter pushdown for filters that combine partition
 columns and file columns (e.g. `day = username['dob']`).


### PR DESCRIPTION
## Which issue does this PR close?
- Follow on to https://github.com/apache/datafusion/pull/16170

## Rationale for this change
I hit another required change while testing the delta-rs upgrade, which I wanted to document
- https://github.com/delta-io/delta-rs/pull/3520



## What changes are included in this PR?
1. Add a note to the upgrade guide about changes in `Expr::Scalar` in 48.0.0

<img width="658" alt="Screenshot 2025-06-10 at 8 06 43 PM" src="https://github.com/user-attachments/assets/5c6ba340-a273-48db-ba9b-5c30e061d1d5" />


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

Docs only
