### PR TITLE
Add more context to error message for datafusion-cli config failure

### DIFF
--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::any::Any;
+use std::error::Error;
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
@@ -148,10 +149,20 @@ impl CredentialsFromConfig {
             // other errors like `CredentialsError::InvalidConfiguration`
             // should be returned to the user so they can be fixed
             Err(e) => {
+                // Pass back underlying error to the user, including underlying source
+                let source_message = if let Some(source) = e.source() {
+                    format!(": {source}")
+                } else {
+                    String::new()
+                };
+
+                let message = format!(
+                    "Error getting credentials from provider: {e}{source_message}",
+                );
+
                 return Err(DataFusionError::ObjectStore(object_store::Error::Generic {
                     store: "S3",
-                    source: format!("Error getting credentials from provider: {e}")
-                        .into(),
+                    source: message.into(),
                 }));
             }
         };


### PR DESCRIPTION
## Which issue does this PR close?

- Follow on to https://github.com/apache/datafusion/pull/16300
- Part of https://github.com/apache/datafusion/issues/16378

## Rationale for this change

CI is failing, but when I ran the same command as is failing on CI locally, it passes for me:

```shell
cargo test  --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-sqllogictest --workspace --lib --tests --features=force_hash_collisions,avro
```

Therefore I conclude something about the environment on the github builder is causing the issue

## What changes are included in this PR?

Add context from the inner error source as well to the error message, so I can debug what is the actual problem

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
