### PR TITLE
Fix CI tests by disabling AWS metadata

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -100,7 +100,10 @@ jobs:
           df -h
       - name: Run tests (excluding doctests)
         env:
-          RUST_BACKTRACE: 1
+          # Disable AWS EC2 metadata service which does not work in
+          # GitHub Actions container environment.
+          # See https://github.com/apache/datafusion/issues/16378
+          AWS_EC2_METADATA_DISABLED: 1
         run: |
           cargo test \
             --profile ci \
@@ -134,6 +137,8 @@ jobs:
         with:
           rust-version: stable
       - name: Run tests
+        env:
+          RUST_BACKTRACE: 1
         run: |
           cd datafusion
           cargo test  --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-sqllogictest --workspace --lib --tests --features=force_hash_collisions,avro
@@ -195,7 +200,6 @@ jobs:
               },
               details_url: workflowRunUrl
             });
-
 
 
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/16378

## Rationale for this change
The way credentials are resolved on AWS builders has changed and now the tests seem to try to get access to credentials which are not available

## What changes are included in this PR?
Disable test name resolution

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

I am testing manually on an EC2 instance

## Are there any user-facing changes?

no