### PR TITLE
Disable `datafusion-cli tests for hash_collision tets

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run tests
         run: |
           cd datafusion
-          cargo test  --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-sqllogictest --workspace --lib --tests --features=force_hash_collisions,avro
+          cargo test  --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-sqllogictest --exclude datafusion-cli --workspace --lib --tests --features=force_hash_collisions,avro
           cargo clean
 
   sqllogictest-sqlite:


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/16378

## Rationale for this change

As described on https://github.com/apache/datafusion/issues/16378, the `datafusion-cli` tests started failing after https://github.com/apache/datafusion/pull/16300 because now it tries to fetch credentials when creating a table (rather than just accessing it)

It turns out that there is something in the github ci runner builder environment that triggers trying to fetch credentials from the AWS metastore which causes an error

Since the point of the hash collisions test is to verify that the core hash operators (hash join, merge join) don't get the wrong answers when there are hash collisions, there is no need to run the `datafusion-cli` tests 

## What changes are included in this PR?

Disable `datafusion-cli` tests as part of the extended suite (they are already run on normal CI jobs) 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
