### PR TITLE
feat: Add support for glob patterns in CREATE EXTERNAL TABLE commands

### DIFF
--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -64,6 +64,7 @@ regex = { workspace = true }
 rustyline = "16.0"
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot", "signal"] }
 url = { workspace = true }
+glob = "0.3.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/datafusion-cli/src/cli_context.rs
+++ b/datafusion-cli/src/cli_context.rs
@@ -52,6 +52,9 @@ pub trait CliSessionContext {
         &self,
         plan: LogicalPlan,
     ) -> Result<DataFrame, DataFusionError>;
+
+    /// Get a reference to the underlying object as Any for downcasting
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 #[async_trait::async_trait]
@@ -94,5 +97,9 @@ impl CliSessionContext for SessionContext {
         plan: LogicalPlan,
     ) -> Result<DataFrame, DataFusionError> {
         self.execute_logical_plan(plan).await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }


### PR DESCRIPTION
Partly closes #16303

The purpose of this PR is to enable using CREATE command with glob pattern and a URL scheme - i.e., 
```
CREATE EXTERNAL TABLE ee3 
STORED AS CSV 
LOCATION 's3://tests/data/file-*-1.csv';

CREATE EXTERNAL TABLE pp 
STORED AS PARQUET 
LOCATION 's3://tests/data-p/te*';
``` 

Its currently possible to create an external table using this syntax just for local files:
```
CREATE EXTERNAL TABLE aa
STORED AS CSV 
LOCATION '/Users/aa/projects/tmdb/tmdb_*.csv';
```

Therefore, the purpose here is to enable support for glob support also for remote url scheme.

The implementation involves some sort of workaround - it intercepts `create_plan()`, and when the table involves a glob pattern and remote scheme then it creates it as a ListingTable. Part of the reason for this approach is the fact that DataFusion core modules use ListingTable::parse() method in its core modules, which only takes a glob pattern when it invovles local files. 