### PR TITLE
Add design process section to the docs

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -115,7 +115,7 @@ by bit and refining a solution iteratively on the `main` branch as a series of
 Pull Requests. This is different from projects which front-load the effort
 with a more comprehensive design process.
 
-By "advancing the front" we always make tangible progress, and the strategy is
+By "advancing the front" the community always makes tangible progress, and the strategy is
 especially effective in a project that relies on individual contributors who may
 not have the time or resources to invest in a large upfront design effort.
 However, this "bit by bit approach" doesn't always succeed, and sometimes we get


### PR DESCRIPTION
## Which issue does this PR close?

- part of #7013 

## Rationale for this change

While discussing a design for cancellation with @pepijnve and @zhuqi-lucas  and myself, @ozankabak wrote a great summary of how the DataFusion community handles larger projects:
- https://github.com/apache/datafusion/pull/16196#issuecomment-2956513724

> Look, I see that you are trying to help and we do want to take it. I suspect we might be facing a "culture" challenge here: Typically, DF community attacks large problems by solving them bit by bit and refining a solution iteratively. This is unlike some other projects which front-load the effort by going through a more comprehensive design process. We also do that for some tasks where this iterative approach is not applicable, but it is not very common.
> 
> This "bit by bit approach" doesn't always succeed, every now and then it happens that we get stuck or go down the wrong path for a while, and then change tacks. However, we still typically prefer to "advance the front" and make progress in tangible ways as much as we can (if we see a way). This necessarily results in imperfect solutions being the "state of the code" in some cases, and they survive in the codebase for a while, but we are good at driving things to completion in the long run.


I really liked that description and think it captures well the current state of the project, and thus would be valuable to make part of the docs


## What changes are included in this PR?

Add a description of the design process to the Datafusion docs site

## Are these changes tested?
By CI

## Are there any user-facing changes?

New docs