### PR TITLE
Remove unused feature in `physical-plan` and fix compilation error in benchmark

### DIFF
--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -36,7 +36,6 @@ workspace = true
 
 [features]
 force_hash_collisions = []
-bench = []
 
 [lib]
 name = "datafusion_physical_plan"
@@ -91,4 +90,3 @@ name = "spill_io"
 [[bench]]
 harness = false
 name = "sort_preserving_merge"
-required-features = ["bench"]

--- a/datafusion/physical-plan/benches/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/benches/sort_preserving_merge.rs
@@ -115,18 +115,13 @@ fn get_bench_data() -> Vec<BenchData> {
     let mut push_bench_data = |bench_name: &str, partitions: Vec<Vec<RecordBatch>>| {
         let schema = partitions[0][0].schema();
         // Define sort order (col1 ASC, col2 ASC, col3 ASC)
-        let sort_order = LexOrdering::new(
-            schema
-                .fields()
-                .iter()
-                .map(|field| {
-                    PhysicalSortExpr::new(
-                        col(field.name(), &schema).unwrap(),
-                        SortOptions::default(),
-                    )
-                })
-                .collect(),
-        );
+        let sort_order = LexOrdering::new(schema.fields().iter().map(|field| {
+            PhysicalSortExpr::new(
+                col(field.name(), &schema).unwrap(),
+                SortOptions::default(),
+            )
+        }))
+        .unwrap();
         ret.push(BenchData {
             bench_name: bench_name.to_string(),
             partitions,
@@ -173,7 +168,7 @@ fn bench_merge_sorted_preserving(c: &mut Criterion) {
             sort_order,
         } = data;
         c.bench_function(
-            &format!("bench_merge_sorted_preserving/{}", bench_name),
+            &format!("bench_merge_sorted_preserving/{bench_name}"),
             |b| {
                 b.iter_batched(
                     || {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #16448.

## Rationale for this change
#15913 introduced a feature to hid a test utilities module in `datafusion-physical-plan`. The module was later made public but the feature stayed behind making it non-trivial to compile/lint the sort_merge benchmark.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
