### PR TITLE
feat: Use `NestedLoopJoin` instead of `HashJoin`/`SortMergeJoin` for small tables

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -705,7 +705,7 @@ config_namespace! {
         /// process to reorder the join keys
         pub top_down_join_key_reordering: bool, default = true
 
-        /// This is the maximum number of rows that either side of a table must have for Datafusion to 
+        /// This is the maximum number of rows that either side of a table must have for Datafusion to
         /// choose to use a `NestedLoopJoin` over a `SortMergeJoin` or `HashJoin` for equijoin conditions.
         pub nested_loop_equijoin_threshold: usize, default = 5
 

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -705,6 +705,10 @@ config_namespace! {
         /// process to reorder the join keys
         pub top_down_join_key_reordering: bool, default = true
 
+        /// This is the maximum number of rows that either side of a table must have for Datafusion to 
+        /// choose to use a `NestedLoopJoin` over a `SortMergeJoin` or `HashJoin` for equijoin conditions.
+        pub nested_loop_equijoin_threshold: usize, default = 5
+
         /// When set to true, the physical plan optimizer will prefer HashJoin over SortMergeJoin.
         /// HashJoin can work more efficiently than SortMergeJoin but consumes more memory
         pub prefer_hash_join: bool, default = true

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -1013,9 +1013,12 @@ impl DefaultPhysicalPlanner {
                 let right_df_schema = right.schema();
                 let execution_props = session_state.execution_props();
 
-                // We declare a threshold here of 5 rows as NestedLoopJoins tend to better when one 
-                // of the tables are small. 
-                let threshold = session_state.config_options().optimizer.nested_loop_equijoin_threshold;
+                // We declare a threshold here of 5 rows as NestedLoopJoins tend to better when one
+                // of the tables are small.
+                let threshold = session_state
+                    .config_options()
+                    .optimizer
+                    .nested_loop_equijoin_threshold;
                 let left_rows = *physical_left
                     // We set the partition to None here to draw the num_rows from the plan
                     .partition_statistics(None)?

--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -2633,23 +2633,22 @@ async fn test_count_wildcard_on_where_in() -> Result<()> {
     assert_snapshot!(
         pretty_format_batches(&sql_results).unwrap(),
         @r"
-    +---------------+------------------------------------------------------------------------------------------------------------------------+
-    | plan_type     | plan                                                                                                                   |
-    +---------------+------------------------------------------------------------------------------------------------------------------------+
-    | logical_plan  | LeftSemi Join: CAST(t1.a AS Int64) = __correlated_sq_1.count(*)                                                        |
-    |               |   TableScan: t1 projection=[a, b]                                                                                      |
-    |               |   SubqueryAlias: __correlated_sq_1                                                                                     |
-    |               |     Projection: count(Int64(1)) AS count(*)                                                                            |
-    |               |       Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]                                                                |
-    |               |         TableScan: t2 projection=[]                                                                                    |
-    | physical_plan | CoalesceBatchesExec: target_batch_size=8192                                                                            |
-    |               |   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(count(*)@0, CAST(t1.a AS Int64)@2)], projection=[a@0, b@1] |
-    |               |     ProjectionExec: expr=[4 as count(*)]                                                                               |
-    |               |       PlaceholderRowExec                                                                                               |
-    |               |     ProjectionExec: expr=[a@0 as a, b@1 as b, CAST(a@0 AS Int64) as CAST(t1.a AS Int64)]                               |
-    |               |       DataSourceExec: partitions=1, partition_sizes=[1]                                                                |
-    |               |                                                                                                                        |
-    +---------------+------------------------------------------------------------------------------------------------------------------------+
+    +---------------+-----------------------------------------------------------------------------------------------------------+
+    | plan_type     | plan                                                                                                      |
+    +---------------+-----------------------------------------------------------------------------------------------------------+
+    | logical_plan  | LeftSemi Join: CAST(t1.a AS Int64) = __correlated_sq_1.count(*)                                           |
+    |               |   TableScan: t1 projection=[a, b]                                                                         |
+    |               |   SubqueryAlias: __correlated_sq_1                                                                        |
+    |               |     Projection: count(Int64(1)) AS count(*)                                                               |
+    |               |       Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]                                                   |
+    |               |         TableScan: t2 projection=[]                                                                       |
+    | physical_plan | NestedLoopJoinExec: join_type=RightSemi, filter=CAST(t1.a AS Int64)@0 = count(*)@1, projection=[a@0, b@1] |
+    |               |   ProjectionExec: expr=[4 as count(*)]                                                                    |
+    |               |     PlaceholderRowExec                                                                                    |
+    |               |   ProjectionExec: expr=[a@0 as a, b@1 as b, CAST(a@0 AS Int64) as CAST(t1.a AS Int64)]                    |
+    |               |     DataSourceExec: partitions=1, partition_sizes=[1]                                                     |
+    |               |                                                                                                           |
+    +---------------+-----------------------------------------------------------------------------------------------------------+
     "
     );
 
@@ -2679,22 +2678,21 @@ async fn test_count_wildcard_on_where_in() -> Result<()> {
     assert_snapshot!(
         pretty_format_batches(&df_results).unwrap(),
         @r"
-    +---------------+------------------------------------------------------------------------------------------------------------------------+
-    | plan_type     | plan                                                                                                                   |
-    +---------------+------------------------------------------------------------------------------------------------------------------------+
-    | logical_plan  | LeftSemi Join: CAST(t1.a AS Int64) = __correlated_sq_1.count(*)                                                        |
-    |               |   TableScan: t1 projection=[a, b]                                                                                      |
-    |               |   SubqueryAlias: __correlated_sq_1                                                                                     |
-    |               |     Aggregate: groupBy=[[]], aggr=[[count(Int64(1)) AS count(*)]]                                                      |
-    |               |       TableScan: t2 projection=[]                                                                                      |
-    | physical_plan | CoalesceBatchesExec: target_batch_size=8192                                                                            |
-    |               |   HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(count(*)@0, CAST(t1.a AS Int64)@2)], projection=[a@0, b@1] |
-    |               |     ProjectionExec: expr=[4 as count(*)]                                                                               |
-    |               |       PlaceholderRowExec                                                                                               |
-    |               |     ProjectionExec: expr=[a@0 as a, b@1 as b, CAST(a@0 AS Int64) as CAST(t1.a AS Int64)]                               |
-    |               |       DataSourceExec: partitions=1, partition_sizes=[1]                                                                |
-    |               |                                                                                                                        |
-    +---------------+------------------------------------------------------------------------------------------------------------------------+
+    +---------------+-----------------------------------------------------------------------------------------------------------+
+    | plan_type     | plan                                                                                                      |
+    +---------------+-----------------------------------------------------------------------------------------------------------+
+    | logical_plan  | LeftSemi Join: CAST(t1.a AS Int64) = __correlated_sq_1.count(*)                                           |
+    |               |   TableScan: t1 projection=[a, b]                                                                         |
+    |               |   SubqueryAlias: __correlated_sq_1                                                                        |
+    |               |     Aggregate: groupBy=[[]], aggr=[[count(Int64(1)) AS count(*)]]                                         |
+    |               |       TableScan: t2 projection=[]                                                                         |
+    | physical_plan | NestedLoopJoinExec: join_type=RightSemi, filter=CAST(t1.a AS Int64)@0 = count(*)@1, projection=[a@0, b@1] |
+    |               |   ProjectionExec: expr=[4 as count(*)]                                                                    |
+    |               |     PlaceholderRowExec                                                                                    |
+    |               |   ProjectionExec: expr=[a@0 as a, b@1 as b, CAST(a@0 AS Int64) as CAST(t1.a AS Int64)]                    |
+    |               |     DataSourceExec: partitions=1, partition_sizes=[1]                                                     |
+    |               |                                                                                                           |
+    +---------------+-----------------------------------------------------------------------------------------------------------+
     "
     );
 
@@ -2910,32 +2908,31 @@ async fn test_count_wildcard_on_where_scalar_subquery() -> Result<()> {
     assert_snapshot!(
         pretty_format_batches(&sql_results).unwrap(),
         @r"
-    +---------------+---------------------------------------------------------------------------------------------------------------------------+
-    | plan_type     | plan                                                                                                                      |
-    +---------------+---------------------------------------------------------------------------------------------------------------------------+
-    | logical_plan  | Projection: t1.a, t1.b                                                                                                    |
-    |               |   Filter: CASE WHEN __scalar_sq_1.__always_true IS NULL THEN Int64(0) ELSE __scalar_sq_1.count(*) END > Int64(0)          |
-    |               |     Projection: t1.a, t1.b, __scalar_sq_1.count(*), __scalar_sq_1.__always_true                                           |
-    |               |       Left Join: t1.a = __scalar_sq_1.a                                                                                   |
-    |               |         TableScan: t1 projection=[a, b]                                                                                   |
-    |               |         SubqueryAlias: __scalar_sq_1                                                                                      |
-    |               |           Projection: count(Int64(1)) AS count(*), t2.a, Boolean(true) AS __always_true                                   |
-    |               |             Aggregate: groupBy=[[t2.a]], aggr=[[count(Int64(1))]]                                                         |
-    |               |               TableScan: t2 projection=[a]                                                                                |
-    | physical_plan | CoalesceBatchesExec: target_batch_size=8192                                                                               |
-    |               |   FilterExec: CASE WHEN __always_true@3 IS NULL THEN 0 ELSE count(*)@2 END > 0, projection=[a@0, b@1]                     |
-    |               |     CoalesceBatchesExec: target_batch_size=8192                                                                           |
-    |               |       HashJoinExec: mode=CollectLeft, join_type=Left, on=[(a@0, a@1)], projection=[a@0, b@1, count(*)@2, __always_true@4] |
-    |               |         DataSourceExec: partitions=1, partition_sizes=[1]                                                                 |
-    |               |         ProjectionExec: expr=[count(Int64(1))@1 as count(*), a@0 as a, true as __always_true]                             |
-    |               |           AggregateExec: mode=FinalPartitioned, gby=[a@0 as a], aggr=[count(Int64(1))]                                    |
-    |               |             CoalesceBatchesExec: target_batch_size=8192                                                                   |
-    |               |               RepartitionExec: partitioning=Hash([a@0], 4), input_partitions=4                                            |
-    |               |                 RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1                                      |
-    |               |                   AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[count(Int64(1))]                                     |
-    |               |                     DataSourceExec: partitions=1, partition_sizes=[1]                                                     |
-    |               |                                                                                                                           |
-    +---------------+---------------------------------------------------------------------------------------------------------------------------+
+    +---------------+------------------------------------------------------------------------------------------------------------------+
+    | plan_type     | plan                                                                                                             |
+    +---------------+------------------------------------------------------------------------------------------------------------------+
+    | logical_plan  | Projection: t1.a, t1.b                                                                                           |
+    |               |   Filter: CASE WHEN __scalar_sq_1.__always_true IS NULL THEN Int64(0) ELSE __scalar_sq_1.count(*) END > Int64(0) |
+    |               |     Projection: t1.a, t1.b, __scalar_sq_1.count(*), __scalar_sq_1.__always_true                                  |
+    |               |       Left Join: t1.a = __scalar_sq_1.a                                                                          |
+    |               |         TableScan: t1 projection=[a, b]                                                                          |
+    |               |         SubqueryAlias: __scalar_sq_1                                                                             |
+    |               |           Projection: count(Int64(1)) AS count(*), t2.a, Boolean(true) AS __always_true                          |
+    |               |             Aggregate: groupBy=[[t2.a]], aggr=[[count(Int64(1))]]                                                |
+    |               |               TableScan: t2 projection=[a]                                                                       |
+    | physical_plan | CoalesceBatchesExec: target_batch_size=8192                                                                      |
+    |               |   FilterExec: CASE WHEN __always_true@3 IS NULL THEN 0 ELSE count(*)@2 END > 0, projection=[a@0, b@1]            |
+    |               |     NestedLoopJoinExec: join_type=Left, filter=a@0 = a@1, projection=[a@0, b@1, count(*)@2, __always_true@4]     |
+    |               |       DataSourceExec: partitions=1, partition_sizes=[1]                                                          |
+    |               |       ProjectionExec: expr=[count(Int64(1))@1 as count(*), a@0 as a, true as __always_true]                      |
+    |               |         AggregateExec: mode=FinalPartitioned, gby=[a@0 as a], aggr=[count(Int64(1))]                             |
+    |               |           CoalesceBatchesExec: target_batch_size=8192                                                            |
+    |               |             RepartitionExec: partitioning=Hash([a@0], 4), input_partitions=4                                     |
+    |               |               RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1                               |
+    |               |                 AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[count(Int64(1))]                              |
+    |               |                   DataSourceExec: partitions=1, partition_sizes=[1]                                              |
+    |               |                                                                                                                  |
+    +---------------+------------------------------------------------------------------------------------------------------------------+
     "
     );
 
@@ -2967,32 +2964,31 @@ async fn test_count_wildcard_on_where_scalar_subquery() -> Result<()> {
     assert_snapshot!(
         pretty_format_batches(&df_results).unwrap(),
         @r"
-    +---------------+---------------------------------------------------------------------------------------------------------------------------+
-    | plan_type     | plan                                                                                                                      |
-    +---------------+---------------------------------------------------------------------------------------------------------------------------+
-    | logical_plan  | Projection: t1.a, t1.b                                                                                                    |
-    |               |   Filter: CASE WHEN __scalar_sq_1.__always_true IS NULL THEN Int64(0) ELSE __scalar_sq_1.count(*) END > Int64(0)          |
-    |               |     Projection: t1.a, t1.b, __scalar_sq_1.count(*), __scalar_sq_1.__always_true                                           |
-    |               |       Left Join: t1.a = __scalar_sq_1.a                                                                                   |
-    |               |         TableScan: t1 projection=[a, b]                                                                                   |
-    |               |         SubqueryAlias: __scalar_sq_1                                                                                      |
-    |               |           Projection: count(*), t2.a, Boolean(true) AS __always_true                                                      |
-    |               |             Aggregate: groupBy=[[t2.a]], aggr=[[count(Int64(1)) AS count(*)]]                                             |
-    |               |               TableScan: t2 projection=[a]                                                                                |
-    | physical_plan | CoalesceBatchesExec: target_batch_size=8192                                                                               |
-    |               |   FilterExec: CASE WHEN __always_true@3 IS NULL THEN 0 ELSE count(*)@2 END > 0, projection=[a@0, b@1]                     |
-    |               |     CoalesceBatchesExec: target_batch_size=8192                                                                           |
-    |               |       HashJoinExec: mode=CollectLeft, join_type=Left, on=[(a@0, a@1)], projection=[a@0, b@1, count(*)@2, __always_true@4] |
-    |               |         DataSourceExec: partitions=1, partition_sizes=[1]                                                                 |
-    |               |         ProjectionExec: expr=[count(*)@1 as count(*), a@0 as a, true as __always_true]                                    |
-    |               |           AggregateExec: mode=FinalPartitioned, gby=[a@0 as a], aggr=[count(*)]                                           |
-    |               |             CoalesceBatchesExec: target_batch_size=8192                                                                   |
-    |               |               RepartitionExec: partitioning=Hash([a@0], 4), input_partitions=4                                            |
-    |               |                 RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1                                      |
-    |               |                   AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[count(*)]                                            |
-    |               |                     DataSourceExec: partitions=1, partition_sizes=[1]                                                     |
-    |               |                                                                                                                           |
-    +---------------+---------------------------------------------------------------------------------------------------------------------------+
+    +---------------+------------------------------------------------------------------------------------------------------------------+
+    | plan_type     | plan                                                                                                             |
+    +---------------+------------------------------------------------------------------------------------------------------------------+
+    | logical_plan  | Projection: t1.a, t1.b                                                                                           |
+    |               |   Filter: CASE WHEN __scalar_sq_1.__always_true IS NULL THEN Int64(0) ELSE __scalar_sq_1.count(*) END > Int64(0) |
+    |               |     Projection: t1.a, t1.b, __scalar_sq_1.count(*), __scalar_sq_1.__always_true                                  |
+    |               |       Left Join: t1.a = __scalar_sq_1.a                                                                          |
+    |               |         TableScan: t1 projection=[a, b]                                                                          |
+    |               |         SubqueryAlias: __scalar_sq_1                                                                             |
+    |               |           Projection: count(*), t2.a, Boolean(true) AS __always_true                                             |
+    |               |             Aggregate: groupBy=[[t2.a]], aggr=[[count(Int64(1)) AS count(*)]]                                    |
+    |               |               TableScan: t2 projection=[a]                                                                       |
+    | physical_plan | CoalesceBatchesExec: target_batch_size=8192                                                                      |
+    |               |   FilterExec: CASE WHEN __always_true@3 IS NULL THEN 0 ELSE count(*)@2 END > 0, projection=[a@0, b@1]            |
+    |               |     NestedLoopJoinExec: join_type=Left, filter=a@0 = a@1, projection=[a@0, b@1, count(*)@2, __always_true@4]     |
+    |               |       DataSourceExec: partitions=1, partition_sizes=[1]                                                          |
+    |               |       ProjectionExec: expr=[count(*)@1 as count(*), a@0 as a, true as __always_true]                             |
+    |               |         AggregateExec: mode=FinalPartitioned, gby=[a@0 as a], aggr=[count(*)]                                    |
+    |               |           CoalesceBatchesExec: target_batch_size=8192                                                            |
+    |               |             RepartitionExec: partitioning=Hash([a@0], 4), input_partitions=4                                     |
+    |               |               RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1                               |
+    |               |                 AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[count(*)]                                     |
+    |               |                   DataSourceExec: partitions=1, partition_sizes=[1]                                              |
+    |               |                                                                                                                  |
+    +---------------+------------------------------------------------------------------------------------------------------------------+
     "
     );
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change
We want to support equijoins in `NestedLoopJoin` in the case where one of the tables in the join is very small. 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
I have added a `nested_loop_equijoin_threshold` to the `OptimizerOptions` which has a default value of 5 (same as DuckDB, [here](https://github.com/duckdb/duckdb/blob/b8990f49dd9b14290ca4ff405f35d3ef95acd54e/src/include/duckdb/main/client_config.hpp#L101)). This is the threshold for the number of rows that can be in either table so that the physical planner will choose  a `NestedLoopJoinExec` over `SortMergeJoin` and `HashJoin`. 

If either table has less than 5 rows then we will pass the `join_on` expressions to the `join_filter`. 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
By existing tests

