### PR TITLE
Remove redundant license-header-check CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,14 +39,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Check license header
-  license-header-check:
-    runs-on: ubuntu-latest
-    name: Check License Header
-    steps:
-      - uses: actions/checkout@v4
-      - uses: korandoru/hawkeye@v6
-
   # Check crate compiles and base cargo check passes
   linux-build-lib:
     name: linux build test


### PR DESCRIPTION
## Which issue does this PR close?



## Rationale for this change

- While working on https://github.com/apache/datafusion/pull/16401 I noticed that the license header check ran twice:
![Screenshot 2025-06-18 at 4 05 01 PM](https://github.com/user-attachments/assets/4262b927-c212-453d-b640-85902ae13712)



## What changes are included in this PR?

Remove the redundant CI check

## Are these changes tested?
CI
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
