### PR TITLE
Make clickbench query IDs 1-based

### DIFF
--- a/benchmarks/src/clickbench.rs
+++ b/benchmarks/src/clickbench.rs
@@ -86,24 +86,23 @@ impl AllQueries {
 
     /// Returns the text of query `query_id`
     fn get_query(&self, query_id: usize) -> Result<&str> {
-        self.queries
-            .get(query_id)
-            .ok_or_else(|| {
-                let min_id = self.min_query_id();
-                let max_id = self.max_query_id();
-                exec_datafusion_err!(
-                    "Invalid query id {query_id}. Must be between {min_id} and {max_id}"
-                )
-            })
-            .map(|s| s.as_str())
+        let min_id = self.min_query_id();
+        let max_id = self.max_query_id();
+        if query_id < min_id || query_id > max_id {
+            return Err(exec_datafusion_err!(
+                "Invalid query id {query_id}. Must be in the range [{min_id}, {max_id}]"
+            ));
+        }
+
+        Ok(self.queries[query_id - 1].as_str())
     }
 
     fn min_query_id(&self) -> usize {
-        0
+        1
     }
 
     fn max_query_id(&self) -> usize {
-        self.queries.len() - 1
+        self.queries.len()
     }
 }
 impl RunOpt {


### PR DESCRIPTION
Using 1 as the basis index makes it easier to correlate benchmark runs with query files in an editor

## Which issue does this PR close?

None

## Rationale for this change

Clickbench query IDs are currently zero-based, while most (if not all) text editors are 1-based when it comes to line numbering. Using 1-based ids makes it easier to correlate benchmark output with the query files.

Additionally TPCH IDs are already 1-based, so this aligns the two.

## What changes are included in this PR?

Change clickbench runner to start counting at 1.

## Are these changes tested?

Manual testing

## Are there any user-facing changes?

Clickbench query IDs in benchmark output are all incremented by one