### PR TITLE
adapt filter expressions to file schema during parquet scan

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -977,7 +977,10 @@ mod tests {
             false,
         )]));
         // One row should match, 2 pruned via page index, 1 pruned via filter pushdown
-        let filter = col("c1").eq(lit(ScalarValue::TimestampMillisecond(Some(1_000), Some("UTC".into()))));
+        let filter = col("c1").eq(lit(ScalarValue::TimestampMillisecond(
+            Some(1_000),
+            Some("UTC".into()),
+        )));
         let rt = RoundTrip::new()
             .with_predicate(filter)
             .with_pushdown_predicate()
@@ -1000,7 +1003,10 @@ mod tests {
         assert_eq!(get_value(&metrics, "pushdown_rows_pruned"), 1);
         // If we filter with a value that is completely out of the range of the data
         // we prune at the row group level.
-        let filter = col("c1").eq(lit(ScalarValue::TimestampMillisecond(Some(5_000), Some("UTC".into()))));
+        let filter = col("c1").eq(lit(ScalarValue::TimestampMillisecond(
+            Some(5_000),
+            Some("UTC".into()),
+        )));
         let rt = RoundTrip::new()
             .with_predicate(filter)
             .with_pushdown_predicate()

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -39,7 +39,7 @@ mod tests {
     use crate::test::object_store::local_unpartitioned_file;
     use arrow::array::{
         ArrayRef, AsArray, Date64Array, Int32Array, Int64Array, Int8Array, StringArray,
-        StringViewArray, StructArray,
+        StringViewArray, StructArray, TimestampNanosecondArray,
     };
     use arrow::datatypes::{DataType, Field, Fields, Schema, SchemaBuilder};
     use arrow::record_batch::RecordBatch;
@@ -958,6 +958,66 @@ mod tests {
             .map(|b| b.num_rows())
             .sum::<usize>();
         assert_eq!(read, 2, "Expected 2 rows to match the predicate");
+    }
+
+    #[tokio::test]
+    async fn evolved_schema_column_type_filter_timestamp_units() {
+        // The table and filter have a common data type
+        // The table schema is in milliseconds, but the file schema is in nanoseconds
+        let c1: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![
+            Some(1_000_000_000), // 1970-01-01T00:00:01Z
+            Some(2_000_000_000), // 1970-01-01T00:00:02Z
+            Some(3_000_000_000), // 1970-01-01T00:00:03Z
+            Some(4_000_000_000), // 1970-01-01T00:00:04Z
+        ]));
+        let batch = create_batch(vec![("c1", c1.clone())]);
+        let table_schema = Arc::new(Schema::new(vec![Field::new(
+            "c1",
+            DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+            false,
+        )]));
+        // One row should match, 2 pruned via page index, 1 pruned via filter pushdown
+        let filter = col("c1").eq(lit(ScalarValue::TimestampMillisecond(Some(1_000), Some("UTC".into()))));
+        let rt = RoundTrip::new()
+            .with_predicate(filter)
+            .with_pushdown_predicate()
+            .with_page_index_predicate() // produces pages with 2 rows each (2 pages total for our data)
+            .with_table_schema(table_schema.clone())
+            .round_trip(vec![batch.clone()])
+            .await;
+        // There should be no predicate evaluation errors and we keep 1 row
+        let metrics = rt.parquet_exec.metrics().unwrap();
+        assert_eq!(get_value(&metrics, "predicate_evaluation_errors"), 0);
+        let read = rt
+            .batches
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum::<usize>();
+        assert_eq!(read, 1, "Expected 1 rows to match the predicate");
+        assert_eq!(get_value(&metrics, "row_groups_pruned_statistics"), 0);
+        assert_eq!(get_value(&metrics, "page_index_rows_pruned"), 2);
+        assert_eq!(get_value(&metrics, "pushdown_rows_pruned"), 1);
+        // If we filter with a value that is completely out of the range of the data
+        // we prune at the row group level.
+        let filter = col("c1").eq(lit(ScalarValue::TimestampMillisecond(Some(5_000), Some("UTC".into()))));
+        let rt = RoundTrip::new()
+            .with_predicate(filter)
+            .with_pushdown_predicate()
+            .with_table_schema(table_schema)
+            .round_trip(vec![batch])
+            .await;
+        // There should be no predicate evaluation errors and we keep 0 rows
+        let metrics = rt.parquet_exec.metrics().unwrap();
+        assert_eq!(get_value(&metrics, "predicate_evaluation_errors"), 0);
+        let read = rt
+            .batches
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum::<usize>();
+        assert_eq!(read, 0, "Expected 0 rows to match the predicate");
+        assert_eq!(get_value(&metrics, "row_groups_pruned_statistics"), 1);
     }
 
     #[tokio::test]

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -37,6 +37,7 @@ use datafusion_common::pruning::{
 };
 use datafusion_common::{exec_err, Result};
 use datafusion_datasource::PartitionedFile;
+use datafusion_physical_expr::utils::reassign_predicate_columns;
 use datafusion_physical_expr::PhysicalExprSchemaRewriter;
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use datafusion_physical_optimizer::pruning::PruningPredicate;
@@ -259,8 +260,11 @@ impl FileOpener for ParquetOpener {
                         file.partition_values,
                     );
 
-                    rewriter.rewrite(p).map_err(ArrowError::from)
+                    rewriter.rewrite(p)
+                    .map_err(ArrowError::from)
+                    .map(|p| reassign_predicate_columns(p, &physical_file_schema, false))
                 })
+                .transpose()?
                 .transpose()?;
 
             // Build predicates for this specific file

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -250,12 +250,16 @@ impl FileOpener for ParquetOpener {
 
             let predicate = predicate
                 .map(|p| {
-                    let rewriter =
-                        PhysicalExprSchemaRewriter::new(&physical_file_schema, &logical_file_schema)
-                            .with_partition_columns(partition_fields.to_vec(), file.partition_values);
+                    let rewriter = PhysicalExprSchemaRewriter::new(
+                        &physical_file_schema,
+                        &logical_file_schema,
+                    )
+                    .with_partition_columns(
+                        partition_fields.to_vec(),
+                        file.partition_values,
+                    );
 
-                    rewriter.rewrite(p)
-                    .map_err(ArrowError::from)
+                    rewriter.rewrite(p).map_err(ArrowError::from)
                 })
                 .transpose()?;
 

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -37,7 +37,6 @@ use datafusion_common::pruning::{
 };
 use datafusion_common::{exec_err, Result};
 use datafusion_datasource::PartitionedFile;
-use datafusion_physical_expr::utils::reassign_predicate_columns;
 use datafusion_physical_expr::PhysicalExprSchemaRewriter;
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use datafusion_physical_optimizer::pruning::PruningPredicate;
@@ -257,9 +256,7 @@ impl FileOpener for ParquetOpener {
 
                     rewriter.rewrite(p)
                     .map_err(ArrowError::from)
-                    .map(|p| reassign_predicate_columns(p, &physical_file_schema, false))
                 })
-                .transpose()?
                 .transpose()?;
 
             // Build predicates for this specific file

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -549,6 +549,12 @@ pub fn cast_expr_to_schema(
             let logical_field = logical_file_schema.field_with_name(column.name())?;
             let Ok(physical_field) = physical_file_schema.field_with_name(column.name())
             else {
+                if !logical_field.is_nullable() {
+                    return exec_err!(
+                        "Non-nullable column '{}' is missing from the physical schema",
+                        column.name()
+                    );
+                }
                 // If the column is missing from the physical schema fill it in with nulls as `SchemaAdapter` would do.
                 let value = ScalarValue::Null.cast_to(logical_field.data_type())?;
                 return Ok(Transformed::yes(expressions::lit(value)));

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -248,6 +248,8 @@ impl FileOpener for ParquetOpener {
                 }
             }
 
+            // Adapt the predicate to the physical file schema.
+            // This evaluates missing columns and inserts any necessary casts.
             let predicate = predicate
                 .map(|p| {
                     PhysicalExprSchemaRewriter::new(

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -1052,7 +1052,11 @@ mod test {
         let expr = col("part").eq(lit(1)).or(col("a").eq(lit(3)));
         let predicate = logical2physical(&expr, &table_schema);
         let opener = make_opener(predicate);
-        let stream = opener.open(make_meta(), file.clone()).unwrap().await.unwrap();
+        let stream = opener
+            .open(make_meta(), file.clone())
+            .unwrap()
+            .await
+            .unwrap();
         let (num_batches, num_rows) = count_batches_and_rows(stream).await;
         assert_eq!(num_batches, 1);
         assert_eq!(num_rows, 3);
@@ -1061,7 +1065,11 @@ mod test {
         let expr = col("part").eq(lit(2)).or(col("a").eq(lit(1)));
         let predicate = logical2physical(&expr, &table_schema);
         let opener = make_opener(predicate);
-        let stream = opener.open(make_meta(), file.clone()).unwrap().await.unwrap();
+        let stream = opener
+            .open(make_meta(), file.clone())
+            .unwrap()
+            .await
+            .unwrap();
         let (num_batches, num_rows) = count_batches_and_rows(stream).await;
         assert_eq!(num_batches, 1);
         assert_eq!(num_rows, 1);

--- a/datafusion/datasource-parquet/src/row_filter.rs
+++ b/datafusion/datasource-parquet/src/row_filter.rs
@@ -67,6 +67,7 @@ use arrow::array::BooleanArray;
 use arrow::datatypes::{DataType, Schema, SchemaRef};
 use arrow::error::{ArrowError, Result as ArrowResult};
 use arrow::record_batch::RecordBatch;
+use itertools::Itertools;
 use parquet::arrow::arrow_reader::{ArrowPredicate, RowFilter};
 use parquet::arrow::ProjectionMask;
 use parquet::file::metadata::ParquetMetaData;
@@ -74,9 +75,8 @@ use parquet::file::metadata::ParquetMetaData;
 use datafusion_common::cast::as_boolean_array;
 use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor};
 use datafusion_common::Result;
-use datafusion_datasource::schema_adapter::{SchemaAdapterFactory, SchemaMapper};
 use datafusion_physical_expr::expressions::Column;
-use datafusion_physical_expr::utils::reassign_predicate_columns;
+use datafusion_physical_expr::utils::{collect_columns, reassign_predicate_columns};
 use datafusion_physical_expr::{split_conjunction, PhysicalExpr};
 
 use datafusion_physical_plan::metrics;
@@ -106,8 +106,6 @@ pub(crate) struct DatafusionArrowPredicate {
     rows_matched: metrics::Count,
     /// how long was spent evaluating this predicate
     time: metrics::Time,
-    /// used to perform type coercion while filtering rows
-    schema_mapper: Arc<dyn SchemaMapper>,
 }
 
 impl DatafusionArrowPredicate {
@@ -132,7 +130,6 @@ impl DatafusionArrowPredicate {
             rows_pruned,
             rows_matched,
             time,
-            schema_mapper: candidate.schema_mapper,
         })
     }
 }
@@ -143,8 +140,6 @@ impl ArrowPredicate for DatafusionArrowPredicate {
     }
 
     fn evaluate(&mut self, batch: RecordBatch) -> ArrowResult<BooleanArray> {
-        let batch = self.schema_mapper.map_batch(batch)?;
-
         // scoped timer updates on drop
         let mut timer = self.time.timer();
 
@@ -187,9 +182,6 @@ pub(crate) struct FilterCandidate {
     /// required to pass thorugh a `SchemaMapper` to the table schema
     /// upon which we then evaluate the filter expression.
     projection: Vec<usize>,
-    ///  A `SchemaMapper` used to map batches read from the file schema to
-    /// the filter's projection of the table schema.
-    schema_mapper: Arc<dyn SchemaMapper>,
     /// The projected table schema that this filter references
     filter_schema: SchemaRef,
 }
@@ -230,25 +222,16 @@ struct FilterCandidateBuilder {
     /// columns in the file schema that are not in the table schema or columns that
     /// are in the table schema that are not in the file schema.
     file_schema: SchemaRef,
-    /// The schema of the table (merged schema) -- columns may be in different
-    /// order than in the file and have columns that are not in the file schema
-    table_schema: SchemaRef,
-    /// A `SchemaAdapterFactory` used to map the file schema to the table schema.
-    schema_adapter_factory: Arc<dyn SchemaAdapterFactory>,
 }
 
 impl FilterCandidateBuilder {
     pub fn new(
         expr: Arc<dyn PhysicalExpr>,
         file_schema: Arc<Schema>,
-        table_schema: Arc<Schema>,
-        schema_adapter_factory: Arc<dyn SchemaAdapterFactory>,
     ) -> Self {
         Self {
             expr,
             file_schema,
-            table_schema,
-            schema_adapter_factory,
         }
     }
 
@@ -261,20 +244,17 @@ impl FilterCandidateBuilder {
     /// * `Err(e)` if an error occurs while building the candidate
     pub fn build(self, metadata: &ParquetMetaData) -> Result<Option<FilterCandidate>> {
         let Some(required_indices_into_table_schema) =
-            pushdown_columns(&self.expr, &self.table_schema)?
+            pushdown_columns(&self.expr, &self.file_schema)?
         else {
             return Ok(None);
         };
 
         let projected_table_schema = Arc::new(
-            self.table_schema
+            self.file_schema
                 .project(&required_indices_into_table_schema)?,
         );
 
-        let (schema_mapper, projection_into_file_schema) = self
-            .schema_adapter_factory
-            .create(Arc::clone(&projected_table_schema), self.table_schema)
-            .map_schema(&self.file_schema)?;
+        let projection_into_file_schema = collect_columns(&self.expr).iter().map(|c| c.index()).sorted_unstable().collect_vec();
 
         let required_bytes = size_of_columns(&projection_into_file_schema, metadata)?;
         let can_use_index = columns_sorted(&projection_into_file_schema, metadata)?;
@@ -284,7 +264,6 @@ impl FilterCandidateBuilder {
             required_bytes,
             can_use_index,
             projection: projection_into_file_schema,
-            schema_mapper: Arc::clone(&schema_mapper),
             filter_schema: Arc::clone(&projected_table_schema),
         }))
     }
@@ -426,11 +405,9 @@ fn columns_sorted(_columns: &[usize], _metadata: &ParquetMetaData) -> Result<boo
 pub fn build_row_filter(
     expr: &Arc<dyn PhysicalExpr>,
     physical_file_schema: &SchemaRef,
-    logical_file_schema: &SchemaRef,
     metadata: &ParquetMetaData,
     reorder_predicates: bool,
     file_metrics: &ParquetFileMetrics,
-    schema_adapter_factory: &Arc<dyn SchemaAdapterFactory>,
 ) -> Result<Option<RowFilter>> {
     let rows_pruned = &file_metrics.pushdown_rows_pruned;
     let rows_matched = &file_metrics.pushdown_rows_matched;
@@ -447,8 +424,6 @@ pub fn build_row_filter(
             FilterCandidateBuilder::new(
                 Arc::clone(expr),
                 Arc::clone(physical_file_schema),
-                Arc::clone(logical_file_schema),
-                Arc::clone(schema_adapter_factory),
             )
             .build(metadata)
         })
@@ -492,13 +467,9 @@ mod test {
     use super::*;
     use datafusion_common::ScalarValue;
 
-    use arrow::datatypes::{Field, TimeUnit::Nanosecond};
-    use datafusion_datasource::schema_adapter::DefaultSchemaAdapterFactory;
     use datafusion_expr::{col, Expr};
     use datafusion_physical_expr::planner::logical2physical;
-    use datafusion_physical_plan::metrics::{Count, Time};
 
-    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use parquet::arrow::parquet_to_arrow_schema;
     use parquet::file::reader::{FileReader, SerializedFileReader};
 
@@ -520,109 +491,16 @@ mod test {
         let expr = col("int64_list").is_not_null();
         let expr = logical2physical(&expr, &table_schema);
 
-        let schema_adapter_factory = Arc::new(DefaultSchemaAdapterFactory);
         let table_schema = Arc::new(table_schema.clone());
 
         let candidate = FilterCandidateBuilder::new(
             expr,
             table_schema.clone(),
-            table_schema,
-            schema_adapter_factory,
         )
         .build(metadata)
         .expect("building candidate");
 
         assert!(candidate.is_none());
-    }
-
-    #[test]
-    fn test_filter_type_coercion() {
-        let testdata = datafusion_common::test_util::parquet_test_data();
-        let file = std::fs::File::open(format!("{testdata}/alltypes_plain.parquet"))
-            .expect("opening file");
-
-        let parquet_reader_builder =
-            ParquetRecordBatchReaderBuilder::try_new(file).expect("creating reader");
-        let metadata = parquet_reader_builder.metadata().clone();
-        let file_schema = parquet_reader_builder.schema().clone();
-
-        // This is the schema we would like to coerce to,
-        // which is different from the physical schema of the file.
-        let table_schema = Schema::new(vec![Field::new(
-            "timestamp_col",
-            DataType::Timestamp(Nanosecond, Some(Arc::from("UTC"))),
-            false,
-        )]);
-
-        // Test all should fail
-        let expr = col("timestamp_col").lt(Expr::Literal(
-            ScalarValue::TimestampNanosecond(Some(1), Some(Arc::from("UTC"))),
-            None,
-        ));
-        let expr = logical2physical(&expr, &table_schema);
-        let schema_adapter_factory = Arc::new(DefaultSchemaAdapterFactory);
-        let table_schema = Arc::new(table_schema.clone());
-        let candidate = FilterCandidateBuilder::new(
-            expr,
-            file_schema.clone(),
-            table_schema.clone(),
-            schema_adapter_factory,
-        )
-        .build(&metadata)
-        .expect("building candidate")
-        .expect("candidate expected");
-
-        let mut row_filter = DatafusionArrowPredicate::try_new(
-            candidate,
-            &metadata,
-            Count::new(),
-            Count::new(),
-            Time::new(),
-        )
-        .expect("creating filter predicate");
-
-        let mut parquet_reader = parquet_reader_builder
-            .with_projection(row_filter.projection().clone())
-            .build()
-            .expect("building reader");
-
-        // Parquet file is small, we only need 1 record batch
-        let first_rb = parquet_reader
-            .next()
-            .expect("expected record batch")
-            .expect("expected error free record batch");
-
-        let filtered = row_filter.evaluate(first_rb.clone());
-        assert!(matches!(filtered, Ok(a) if a == BooleanArray::from(vec![false; 8])));
-
-        // Test all should pass
-        let expr = col("timestamp_col").gt(Expr::Literal(
-            ScalarValue::TimestampNanosecond(Some(0), Some(Arc::from("UTC"))),
-            None,
-        ));
-        let expr = logical2physical(&expr, &table_schema);
-        let schema_adapter_factory = Arc::new(DefaultSchemaAdapterFactory);
-        let candidate = FilterCandidateBuilder::new(
-            expr,
-            file_schema,
-            table_schema,
-            schema_adapter_factory,
-        )
-        .build(&metadata)
-        .expect("building candidate")
-        .expect("candidate expected");
-
-        let mut row_filter = DatafusionArrowPredicate::try_new(
-            candidate,
-            &metadata,
-            Count::new(),
-            Count::new(),
-            Time::new(),
-        )
-        .expect("creating filter predicate");
-
-        let filtered = row_filter.evaluate(first_rb);
-        assert!(matches!(filtered, Ok(a) if a == BooleanArray::from(vec![true; 8])));
     }
 
     #[test]

--- a/datafusion/datasource-parquet/src/row_filter.rs
+++ b/datafusion/datasource-parquet/src/row_filter.rs
@@ -225,14 +225,8 @@ struct FilterCandidateBuilder {
 }
 
 impl FilterCandidateBuilder {
-    pub fn new(
-        expr: Arc<dyn PhysicalExpr>,
-        file_schema: Arc<Schema>,
-    ) -> Self {
-        Self {
-            expr,
-            file_schema,
-        }
+    pub fn new(expr: Arc<dyn PhysicalExpr>, file_schema: Arc<Schema>) -> Self {
+        Self { expr, file_schema }
     }
 
     /// Attempt to build a `FilterCandidate` from the expression
@@ -254,7 +248,11 @@ impl FilterCandidateBuilder {
                 .project(&required_indices_into_table_schema)?,
         );
 
-        let projection_into_file_schema = collect_columns(&self.expr).iter().map(|c| c.index()).sorted_unstable().collect_vec();
+        let projection_into_file_schema = collect_columns(&self.expr)
+            .iter()
+            .map(|c| c.index())
+            .sorted_unstable()
+            .collect_vec();
 
         let required_bytes = size_of_columns(&projection_into_file_schema, metadata)?;
         let can_use_index = columns_sorted(&projection_into_file_schema, metadata)?;
@@ -493,12 +491,9 @@ mod test {
 
         let table_schema = Arc::new(table_schema.clone());
 
-        let candidate = FilterCandidateBuilder::new(
-            expr,
-            table_schema.clone(),
-        )
-        .build(metadata)
-        .expect("building candidate");
+        let candidate = FilterCandidateBuilder::new(expr, table_schema.clone())
+            .build(metadata)
+            .expect("building candidate");
 
         assert!(candidate.is_none());
     }

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -38,6 +38,7 @@ mod partitioning;
 mod physical_expr;
 pub mod planner;
 mod scalar_function;
+pub mod schema_rewriter;
 pub mod statistics;
 pub mod utils;
 pub mod window;
@@ -68,6 +69,7 @@ pub use datafusion_physical_expr_common::sort_expr::{
 
 pub use planner::{create_physical_expr, create_physical_exprs};
 pub use scalar_function::ScalarFunctionExpr;
+pub use schema_rewriter::PhysicalExprSchemaRewriter;
 pub use utils::{conjunction, conjunction_opt, split_conjunction};
 
 // For backwards compatibility

--- a/datafusion/physical-expr/src/schema_rewriter.rs
+++ b/datafusion/physical-expr/src/schema_rewriter.rs
@@ -177,8 +177,11 @@ impl<'a> PhysicalExprSchemaRewriter<'a> {
             );
         }
 
-        let cast_expr =
-            Arc::new(CastExpr::new(expr, logical_field.data_type().clone(), None));
+        let cast_expr = Arc::new(CastExpr::new(
+            Arc::new(column),
+            logical_field.data_type().clone(),
+            None,
+        ));
 
         Ok(Transformed::yes(cast_expr))
     }
@@ -280,9 +283,9 @@ mod tests {
         let (physical_schema, logical_schema) = create_test_schema();
 
         let rewriter = PhysicalExprSchemaRewriter::new(&physical_schema, &logical_schema);
-        let column_expr = Arc::new(Column::new("b", 1));
+        let column_expr = Arc::new(Column::new("b", 1)) as Arc<dyn PhysicalExpr>;
 
-        let result = rewriter.rewrite(column_expr.clone())?;
+        let result = rewriter.rewrite(Arc::clone(&column_expr))?;
 
         // Should be the same expression (no transformation needed)
         // We compare the underlying pointer through the trait object

--- a/datafusion/physical-expr/src/schema_rewriter.rs
+++ b/datafusion/physical-expr/src/schema_rewriter.rs
@@ -258,7 +258,7 @@ mod tests {
         );
 
         let result = rewriter.rewrite(Arc::new(expr)).unwrap();
-        println!("Rewritten expression: {}", result);
+        println!("Rewritten expression: {result}");
 
         let expected = expressions::BinaryExpr::new(
             Arc::new(CastExpr::new(

--- a/datafusion/physical-expr/src/schema_rewriter.rs
+++ b/datafusion/physical-expr/src/schema_rewriter.rs
@@ -155,7 +155,7 @@ impl<'a> PhysicalExprSchemaRewriter<'a> {
             // If the indexes or data types do not match, we need to create a new column expression
             (true, _) => column.clone(),
             (false, _) => {
-                Column::new_with_schema(logical_field.name(), self.logical_file_schema)?
+                Column::new_with_schema(logical_field.name(), self.physical_file_schema)?
             }
         };
 

--- a/datafusion/physical-expr/src/schema_rewriter.rs
+++ b/datafusion/physical-expr/src/schema_rewriter.rs
@@ -413,7 +413,7 @@ mod tests {
 
         let logical_schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int64, true), // Different type
-            Field::new("b", DataType::Utf8, true),   // Missing from physical
+            Field::new("b", DataType::Utf8, true),  // Missing from physical
         ]));
 
         let projection = vec![
@@ -432,7 +432,7 @@ mod tests {
             adapted_projection
                 .iter()
                 .map(|expr| expr.return_field(&physical_schema).unwrap())
-                .collect_vec()
+                .collect_vec(),
         ));
 
         let res = batch_project(

--- a/datafusion/physical-expr/src/schema_rewriter.rs
+++ b/datafusion/physical-expr/src/schema_rewriter.rs
@@ -374,13 +374,12 @@ mod tests {
             .contains("Non-nullable column 'b' is missing"));
     }
 
-    /// Stolen from ProjectionExec
+    /// Roughly stolen from ProjectionExec
     fn batch_project(
         expr: Vec<Arc<dyn PhysicalExpr>>,
         batch: &RecordBatch,
         schema: SchemaRef,
     ) -> Result<RecordBatch> {
-        // Records time on drop
         let arrays = expr
             .iter()
             .map(|expr| {

--- a/datafusion/physical-expr/src/schema_rewriter.rs
+++ b/datafusion/physical-expr/src/schema_rewriter.rs
@@ -1,0 +1,295 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Physical expression schema rewriting utilities
+
+use std::sync::Arc;
+
+use arrow::compute::can_cast_types;
+use arrow::datatypes::{FieldRef, Schema};
+use datafusion_common::{
+    exec_err,
+    tree_node::{Transformed, TransformedResult, TreeNode},
+    Result, ScalarValue,
+};
+use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
+
+use crate::expressions::{self, CastExpr, Column};
+
+/// Builder for rewriting physical expressions to match different schemas.
+///
+/// # Example
+///
+/// ```rust
+/// use datafusion_physical_expr::schema_rewriter::PhysicalExprSchemaRewriter;
+/// use arrow::datatypes::Schema;
+///
+/// # fn example(
+/// #     predicate: std::sync::Arc<dyn datafusion_physical_expr_common::physical_expr::PhysicalExpr>,
+/// #     physical_file_schema: &Schema,
+/// #     logical_file_schema: &Schema,
+/// # ) -> datafusion_common::Result<()> {
+/// let rewriter = PhysicalExprSchemaRewriter::new(physical_file_schema, logical_file_schema);
+/// let adapted_predicate = rewriter.rewrite(predicate)?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct PhysicalExprSchemaRewriter<'a> {
+    physical_file_schema: &'a Schema,
+    logical_file_schema: &'a Schema,
+    partition_fields: Vec<FieldRef>,
+    partition_values: Vec<ScalarValue>,
+}
+
+impl<'a> PhysicalExprSchemaRewriter<'a> {
+    /// Create a new schema rewriter with the given schemas
+    pub fn new(
+        physical_file_schema: &'a Schema,
+        logical_file_schema: &'a Schema,
+    ) -> Self {
+        Self {
+            physical_file_schema,
+            logical_file_schema,
+            partition_fields: Vec::new(),
+            partition_values: Vec::new(),
+        }
+    }
+
+    /// Add partition columns and their corresponding values
+    ///
+    /// When a column reference matches a partition field, it will be replaced
+    /// with the corresponding literal value from partition_values.
+    pub fn with_partition_columns(
+        mut self,
+        partition_fields: Vec<FieldRef>,
+        partition_values: Vec<ScalarValue>,
+    ) -> Self {
+        self.partition_fields = partition_fields;
+        self.partition_values = partition_values;
+        self
+    }
+
+    /// Rewrite the given physical expression to match the target schema
+    ///
+    /// This method applies the following transformations:
+    /// 1. Replaces partition column references with literal values
+    /// 2. Handles missing columns by inserting null literals
+    /// 3. Casts columns when logical and physical schemas have different types
+    pub fn rewrite(&self, expr: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> {
+        expr.transform(|expr| self.rewrite_expr(expr)).data()
+    }
+
+    fn rewrite_expr(
+        &self,
+        expr: Arc<dyn PhysicalExpr>,
+    ) -> Result<Transformed<Arc<dyn PhysicalExpr>>> {
+        if let Some(column) = expr.as_any().downcast_ref::<Column>() {
+            return self.rewrite_column(Arc::clone(&expr), column);
+        }
+
+        Ok(Transformed::no(expr))
+    }
+
+    fn rewrite_column(
+        &self,
+        expr: Arc<dyn PhysicalExpr>,
+        column: &Column,
+    ) -> Result<Transformed<Arc<dyn PhysicalExpr>>> {
+        // Check if this is a partition column
+        if let Some(partition_value) = self.get_partition_value(column.name()) {
+            return Ok(Transformed::yes(expressions::lit(partition_value)));
+        }
+
+        // Get the logical field for this column
+        let logical_field = match self.logical_file_schema.field_with_name(column.name())
+        {
+            Ok(field) => field,
+            Err(e) => {
+                return Err(e.into());
+            }
+        };
+
+        // Check if the column exists in the physical schema
+        let physical_field =
+            match self.physical_file_schema.field_with_name(column.name()) {
+                Ok(field) => field,
+                Err(_) => {
+                    // Column is missing from physical schema
+                    if !logical_field.is_nullable() {
+                        return exec_err!(
+                        "Non-nullable column '{}' is missing from the physical schema",
+                        column.name()
+                    );
+                    }
+                    // Fill in with null value
+                    let null_value =
+                        ScalarValue::Null.cast_to(logical_field.data_type())?;
+                    return Ok(Transformed::yes(expressions::lit(null_value)));
+                }
+            };
+
+        // Check if casting is needed
+        if logical_field.data_type() == physical_field.data_type() {
+            return Ok(Transformed::no(expr));
+        }
+
+        // Perform type casting
+        if !can_cast_types(physical_field.data_type(), logical_field.data_type()) {
+            return exec_err!(
+                "Cannot cast column '{}' from '{}' (physical data type) to '{}' (logical data type)",
+                column.name(),
+                physical_field.data_type(),
+                logical_field.data_type()
+            );
+        }
+
+        let cast_expr =
+            Arc::new(CastExpr::new(expr, logical_field.data_type().clone(), None));
+
+        Ok(Transformed::yes(cast_expr))
+    }
+
+    fn get_partition_value(&self, column_name: &str) -> Option<ScalarValue> {
+        self.partition_fields
+            .iter()
+            .zip(self.partition_values.iter())
+            .find(|(field, _)| field.name() == column_name)
+            .map(|(_, value)| value.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::ScalarValue;
+    use std::sync::Arc;
+
+    fn create_test_schema() -> (Schema, Schema) {
+        let physical_schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, true),
+        ]);
+
+        let logical_schema = Schema::new(vec![
+            Field::new("a", DataType::Int64, false), // Different type
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::Float64, true), // Missing from physical
+        ]);
+
+        (physical_schema, logical_schema)
+    }
+
+    #[test]
+    fn test_rewrite_column_with_type_cast() -> Result<()> {
+        let (physical_schema, logical_schema) = create_test_schema();
+
+        let rewriter = PhysicalExprSchemaRewriter::new(&physical_schema, &logical_schema);
+        let column_expr = Arc::new(Column::new("a", 0));
+
+        let result = rewriter.rewrite(column_expr)?;
+
+        // Should be wrapped in a cast expression
+        assert!(result.as_any().downcast_ref::<CastExpr>().is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rewrite_missing_column() -> Result<()> {
+        let (physical_schema, logical_schema) = create_test_schema();
+
+        let rewriter = PhysicalExprSchemaRewriter::new(&physical_schema, &logical_schema);
+        let column_expr = Arc::new(Column::new("c", 2));
+
+        let result = rewriter.rewrite(column_expr)?;
+
+        // Should be replaced with a literal null
+        if let Some(literal) = result.as_any().downcast_ref::<expressions::Literal>() {
+            assert_eq!(*literal.value(), ScalarValue::Float64(None));
+        } else {
+            panic!("Expected literal expression");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rewrite_partition_column() -> Result<()> {
+        let (physical_schema, logical_schema) = create_test_schema();
+
+        let partition_fields =
+            vec![Arc::new(Field::new("partition_col", DataType::Utf8, false))];
+        let partition_values = vec![ScalarValue::Utf8(Some("test_value".to_string()))];
+
+        let rewriter = PhysicalExprSchemaRewriter::new(&physical_schema, &logical_schema)
+            .with_partition_columns(partition_fields, partition_values);
+
+        let column_expr = Arc::new(Column::new("partition_col", 0));
+        let result = rewriter.rewrite(column_expr)?;
+
+        // Should be replaced with the partition value
+        if let Some(literal) = result.as_any().downcast_ref::<expressions::Literal>() {
+            assert_eq!(
+                *literal.value(),
+                ScalarValue::Utf8(Some("test_value".to_string()))
+            );
+        } else {
+            panic!("Expected literal expression");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rewrite_no_change_needed() -> Result<()> {
+        let (physical_schema, logical_schema) = create_test_schema();
+
+        let rewriter = PhysicalExprSchemaRewriter::new(&physical_schema, &logical_schema);
+        let column_expr = Arc::new(Column::new("b", 1));
+
+        let result = rewriter.rewrite(column_expr.clone())?;
+
+        // Should be the same expression (no transformation needed)
+        // We compare the underlying pointer through the trait object
+        assert!(std::ptr::eq(
+            column_expr.as_ref() as *const dyn PhysicalExpr,
+            result.as_ref() as *const dyn PhysicalExpr
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_non_nullable_missing_column_error() {
+        let physical_schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let logical_schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, false), // Non-nullable missing column
+        ]);
+
+        let rewriter = PhysicalExprSchemaRewriter::new(&physical_schema, &logical_schema);
+        let column_expr = Arc::new(Column::new("b", 1));
+
+        let result = rewriter.rewrite(column_expr);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Non-nullable column 'b' is missing"));
+    }
+}

--- a/datafusion/physical-expr/src/schema_rewriter.rs
+++ b/datafusion/physical-expr/src/schema_rewriter.rs
@@ -98,7 +98,7 @@ impl<'a> PhysicalExprSchemaRewriter<'a> {
         expr: Arc<dyn PhysicalExpr>,
     ) -> Result<Transformed<Arc<dyn PhysicalExpr>>> {
         if let Some(column) = expr.as_any().downcast_ref::<Column>() {
-            return self.rewrite_column(Arc::clone(&expr), column)
+            return self.rewrite_column(Arc::clone(&expr), column);
         }
 
         Ok(Transformed::no(expr))
@@ -126,7 +126,8 @@ impl<'a> PhysicalExprSchemaRewriter<'a> {
         };
 
         // Check if the column exists in the physical schema
-        let physical_column_index = match self.physical_file_schema.index_of(column.name()) {
+        let physical_column_index =
+            match self.physical_file_schema.index_of(column.name()) {
                 Ok(index) => index,
                 Err(_) => {
                     if !logical_field.is_nullable() {
@@ -144,13 +145,18 @@ impl<'a> PhysicalExprSchemaRewriter<'a> {
                 }
             };
         let physical_field = self.physical_file_schema.field(physical_column_index);
-        
-        let column = match (column.index() == physical_column_index, logical_field.data_type() == physical_field.data_type()) {
+
+        let column = match (
+            column.index() == physical_column_index,
+            logical_field.data_type() == physical_field.data_type(),
+        ) {
             // If the column index matches and the data types match, we can use the column as is
             (true, true) => return Ok(Transformed::no(expr)),
             // If the indexes or data types do not match, we need to create a new column expression
             (true, _) => column.clone(),
-            (false, _) => Column::new_with_schema(logical_field.name(), self.logical_file_schema)?
+            (false, _) => {
+                Column::new_with_schema(logical_field.name(), self.logical_file_schema)?
+            }
         };
 
         if logical_field.data_type() == physical_field.data_type() {

--- a/datafusion/physical-expr/src/schema_rewriter.rs
+++ b/datafusion/physical-expr/src/schema_rewriter.rs
@@ -198,12 +198,16 @@ impl<'a> PhysicalExprSchemaRewriter<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::expressions::lit;
+    use crate::expressions::{col, lit};
 
     use super::*;
-    use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_common::ScalarValue;
+    use arrow::{
+        array::{RecordBatch, RecordBatchOptions},
+        datatypes::{DataType, Field, Schema, SchemaRef},
+    };
+    use datafusion_common::{record_batch, ScalarValue};
     use datafusion_expr::Operator;
+    use itertools::Itertools;
     use std::sync::Arc;
 
     fn create_test_schema() -> (Schema, Schema) {
@@ -368,5 +372,96 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Non-nullable column 'b' is missing"));
+    }
+
+    /// Stolen from ProjectionExec
+    fn batch_project(
+        expr: Vec<Arc<dyn PhysicalExpr>>,
+        batch: &RecordBatch,
+        schema: SchemaRef,
+    ) -> Result<RecordBatch> {
+        // Records time on drop
+        let arrays = expr
+            .iter()
+            .map(|expr| {
+                expr.evaluate(batch)
+                    .and_then(|v| v.into_array(batch.num_rows()))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        if arrays.is_empty() {
+            let options =
+                RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
+            RecordBatch::try_new_with_options(Arc::clone(&schema), arrays, &options)
+                .map_err(Into::into)
+        } else {
+            RecordBatch::try_new(Arc::clone(&schema), arrays).map_err(Into::into)
+        }
+    }
+
+    /// Example showing how we can use the `PhysicalExprSchemaRewriter` to adapt RecordBatches during a scan
+    /// to apply projections, type conversions and handling of missing columns all at once.
+    #[test]
+    fn test_adapt_batches() {
+        let physical_batch = record_batch!(
+            ("a", Int32, vec![Some(1), None, Some(3)]),
+            ("extra", Utf8, vec![Some("x"), Some("y"), None])
+        )
+        .unwrap();
+
+        let physical_schema = physical_batch.schema();
+
+        let logical_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true), // Different type
+            Field::new("b", DataType::Utf8, true),   // Missing from physical
+        ]));
+
+        let projection = vec![
+            col("b", &logical_schema).unwrap(),
+            col("a", &logical_schema).unwrap(),
+        ];
+
+        let rewriter = PhysicalExprSchemaRewriter::new(&physical_schema, &logical_schema);
+
+        let adapted_projection = projection
+            .into_iter()
+            .map(|expr| rewriter.rewrite(expr).unwrap())
+            .collect_vec();
+
+        let adapted_schema = Arc::new(Schema::new(
+            adapted_projection
+                .iter()
+                .map(|expr| expr.return_field(&physical_schema).unwrap())
+                .collect_vec()
+        ));
+
+        let res = batch_project(
+            adapted_projection,
+            &physical_batch,
+            Arc::clone(&adapted_schema),
+        )
+        .unwrap();
+
+        assert_eq!(res.num_columns(), 2);
+        assert_eq!(res.column(0).data_type(), &DataType::Utf8);
+        assert_eq!(res.column(1).data_type(), &DataType::Int64);
+        assert_eq!(
+            res.column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+                .unwrap()
+                .iter()
+                .collect_vec(),
+            vec![None, None, None]
+        );
+        assert_eq!(
+            res.column(1)
+                .as_any()
+                .downcast_ref::<arrow::array::Int64Array>()
+                .unwrap()
+                .iter()
+                .collect_vec(),
+            vec![Some(1), None, Some(3)]
+        );
     }
 }


### PR DESCRIPTION
The idea here is to move us one step closer to https://github.com/apache/datafusion/issues/15780 although there is still work to do (e.g. https://github.com/apache/datafusion/issues/15780#issuecomment-2824716928).

My goal is that this immediately unblocks other work (in particular https://github.com/apache/datafusion/pull/15057) while being a relatively small change that we can build upon with more optimizations, etc.