### PR TITLE
fix: make `with_new_state` a trait method for `ExecutionPlan`

### DIFF
--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -23,6 +23,7 @@ use crate::filter_pushdown::{
 pub use crate::metrics::Metric;
 pub use crate::ordering::InputOrderMode;
 pub use crate::stream::EmptyRecordBatchStream;
+pub use crate::work_table::WorkTable;
 
 pub use datafusion_common::hash_utils;
 pub use datafusion_common::utils::project_schema;
@@ -569,6 +570,24 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
         Ok(FilterPushdownPropagation::transparent(
             child_pushdown_result,
         ))
+    }
+
+    /// Returns a new execution plan that uses the provided work table, if supported.
+    /// This enables recursive query execution by allowing work table injection.
+    ///
+    /// Primarily implemented by [`WorkTableExec`], but custom execution nodes that wrap
+    /// or contain `WorkTableExec` instances should also implement this to propagate
+    /// work table injection to their inner components.
+    ///
+    /// See [`WorkTableExec::with_work_table`] for the reference implementation.
+    ///
+    /// [`WorkTableExec`]: crate::work_table::WorkTableExec
+    /// [`WorkTableExec::with_work_table`]: crate::work_table::WorkTableExec::with_work_table
+    fn with_work_table(
+        &self,
+        _work_table: Arc<WorkTable>,
+    ) -> Option<Arc<dyn ExecutionPlan>> {
+        None
     }
 }
 

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -50,6 +50,7 @@ pub use crate::ordering::InputOrderMode;
 pub use crate::stream::EmptyRecordBatchStream;
 pub use crate::topk::TopK;
 pub use crate::visitor::{accept, visit_execution_plan, ExecutionPlanVisitor};
+pub use crate::work_table::WorkTable;
 pub use spill::spill_manager::SpillManager;
 
 mod ordering;

--- a/datafusion/physical-plan/src/recursive_query.rs
+++ b/datafusion/physical-plan/src/recursive_query.rs
@@ -351,7 +351,9 @@ fn assign_work_table(
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut work_table_refs = 0;
     plan.transform_down(|plan| {
-        if let Some(new_plan) = plan.with_work_table(Arc::clone(&work_table)) {
+        if let Some(new_plan) =
+            plan.with_new_state(Arc::clone(&work_table) as Arc<dyn Any + Send + Sync>)
+        {
             if work_table_refs > 0 {
                 not_impl_err!(
                     "Multiple recursive references to the same CTE are not supported"

--- a/datafusion/physical-plan/src/recursive_query.rs
+++ b/datafusion/physical-plan/src/recursive_query.rs
@@ -351,16 +351,14 @@ fn assign_work_table(
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut work_table_refs = 0;
     plan.transform_down(|plan| {
-        if let Some(exec) = plan.as_any().downcast_ref::<WorkTableExec>() {
+        if let Some(new_plan) = plan.with_work_table(Arc::clone(&work_table)) {
             if work_table_refs > 0 {
                 not_impl_err!(
                     "Multiple recursive references to the same CTE are not supported"
                 )
             } else {
                 work_table_refs += 1;
-                Ok(Transformed::yes(Arc::new(
-                    exec.with_work_table(Arc::clone(&work_table)),
-                )))
+                Ok(Transformed::yes(new_plan))
             }
         } else if plan.as_any().is::<RecursiveQueryExec>() {
             not_impl_err!("Recursive queries cannot be nested")

--- a/datafusion/physical-plan/src/work_table.rs
+++ b/datafusion/physical-plan/src/work_table.rs
@@ -57,7 +57,7 @@ impl ReservedBatches {
 /// See <https://wiki.postgresql.org/wiki/CTEReadme#How_Recursion_Works>
 /// This table serves as a mirror or buffer between each iteration of a recursive query.
 #[derive(Debug)]
-pub(super) struct WorkTable {
+pub struct WorkTable {
     batches: Mutex<Option<ReservedBatches>>,
 }
 
@@ -132,16 +132,6 @@ impl WorkTableExec {
         Arc::clone(&self.schema)
     }
 
-    pub(super) fn with_work_table(&self, work_table: Arc<WorkTable>) -> Self {
-        Self {
-            name: self.name.clone(),
-            schema: Arc::clone(&self.schema),
-            metrics: ExecutionPlanMetricsSet::new(),
-            work_table,
-            cache: self.cache.clone(),
-        }
-    }
-
     /// This function creates the cache object that stores the plan properties such as schema, equivalence properties, ordering, partitioning, etc.
     fn compute_properties(schema: SchemaRef) -> PlanProperties {
         PlanProperties::new(
@@ -184,16 +174,16 @@ impl ExecutionPlan for WorkTableExec {
         &self.cache
     }
 
-    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![]
-    }
-
     fn maintains_input_order(&self) -> Vec<bool> {
         vec![false]
     }
 
     fn benefits_from_input_partitioning(&self) -> Vec<bool> {
         vec![false]
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
     }
 
     fn with_new_children(
@@ -233,6 +223,22 @@ impl ExecutionPlan for WorkTableExec {
 
     fn partition_statistics(&self, _partition: Option<usize>) -> Result<Statistics> {
         Ok(Statistics::new_unknown(&self.schema()))
+    }
+
+    /// Creates a new `WorkTableExec` with the provided work table for recursive query execution.
+    /// During query planning, `WorkTableExec` nodes are created as placeholders; this method
+    /// "wires up" the actual work table that coordinates data between recursive iterations.
+    fn with_work_table(
+        &self,
+        work_table: Arc<WorkTable>,
+    ) -> Option<Arc<dyn ExecutionPlan>> {
+        Some(Arc::new(Self {
+            name: self.name.clone(),
+            schema: Arc::clone(&self.schema),
+            metrics: ExecutionPlanMetricsSet::new(),
+            work_table,
+            cache: self.cache.clone(),
+        }))
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR addresses the extensibility limitation that causes recursive queries to fail when used with the `datafusion-tracing` crate, as reported in [datafusion-contrib/datafusion-tracing#5](https://github.com/datafusion-contrib/datafusion-tracing/issues/5).

While there isn't a specific DataFusion issue filed, this change enables external crates like `datafusion-tracing` to properly support recursive queries by implementing work table injection in their wrapper nodes.

## Rationale for this change

Currently, recursive query execution in `RecursiveQueryExec` uses downcasting to find `WorkTableExec` nodes and inject work tables. This approach fails when execution plans are wrapped by custom execution nodes, as is done by the `datafusion-tracing` crate, causing recursive queries to fail with "Unexpected empty work table" errors.

The fundamental issue is that `RecursiveQueryExec` assumes direct access to concrete `WorkTableExec` types, but wrapper nodes (like those used for tracing) break this assumption. This limits DataFusion's extensibility for recursive queries and prevents external crates from properly supporting this feature.

## What changes are included in this PR?

### Commit 1
- **Add `with_work_table` as a public trait method** on `ExecutionPlan` with a default implementation returning `None`.
- **Update `WorkTableExec`** to implement the trait method, creating a new instance with the provided work table.
- **Modify `assign_work_table` logic** in `RecursiveQueryExec` to use the trait method instead of down-casting, enabling support for wrapper nodes.
- **Publicly re-export `WorkTable`** so external implementers can access it without knowing internal module structure.
- **Add comprehensive documentation** explaining the purpose and usage of `with_work_table`.

### Commit 2 _(follow-up/generalisation)_
- **Replace the specialised `with_work_table` API with a generic `with_new_state(&self, state: Arc<dyn Any + Send + Sync>)`** on `ExecutionPlan`.  
  The default implementation still returns `None`.
- **Implement `with_new_state` in `WorkTableExec`** by down-casting the supplied state to an `Arc<WorkTable>`.
- **Refactor `RecursiveQueryExec::assign_work_table`** to use the new generic API.
- **Update documentation** throughout to reflect the generic nature of state injection and keep `WorkTableExec` as an illustrative example.
- **Maintain the public re-export of `WorkTable`** from the root of `physical-plan` so custom external nodes can downcast `Arc<dyn Any + Send + Sync>` into `Arc<WorkTable>`

## Are these changes tested?

The changes are covered by existing tests:
- All existing recursive query tests continue to pass, ensuring backward compatibility
- The `WorkTableExec` implementation is tested through existing recursive query execution paths
- The trait method follows the same logic as the previous direct implementation

This change enables functionality that was previously broken (recursive queries with instrumentation), so it fixes existing test scenarios in external crates rather than requiring new DataFusion-specific tests.

Compiling the `datafusion-tracing` crate against this branch locally enables full instrumentation of recursive queries, with one "span group" per recursion, as demonstrated by the Jaeger screenshot below for the following basic recursive SQL:
```sql
WITH RECURSIVE numbers(n) AS (
    SELECT 1 AS n
    UNION ALL
    SELECT n + 1 FROM numbers WHERE n < 3
) SELECT n FROM numbers
```
![image](https://github.com/user-attachments/assets/b91d3d7d-4606-4a48-9050-5be0facabc61)

## Are there any user-facing changes?

**API Addition (Non-breaking):**
- Adds `with_new_state` method to the `ExecutionPlan` trait with a default `None`-returning implementation
- External crates can down-cast any late-bound state they need (e.g. `WorkTable`) inside their own `ExecutionPlan` implementations.

**Benefits for Users:**
- External crates can now implement `with_new_state` in their custom execution plans to support recursive queries
- Instrumentation and wrapper nodes can properly participate in recursive query execution
- Enables recursive queries to work with tracing, monitoring, and other execution plan decorators

**No Breaking Changes:**
- All existing code continues to work unchanged
- The new trait method has a default implementation, so existing `ExecutionPlan` implementations don't need updates
- Internal behavior for `WorkTableExec` remains identical

This change primarily enables extensibility that was previously impossible, resolving compatibility issues between recursive queries and external crates.
