### PR TITLE
Redirect user defined function webpage

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,6 +16,7 @@
 # under the License.
 
 sphinx
+sphinx-reredirects
 pydata-sphinx-theme==0.8.0
 myst-parser
 maturin

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     'myst_parser',
+    'sphinx_reredirects',
 ]
 
 source_suffix = {
@@ -121,3 +122,7 @@ myst_enable_extensions = ["colon_fence", "deflist", "tasklist"]
 # issue for our documentation. So, suppress these warnings to keep our build
 # log cleaner.
 suppress_warnings = ['misc.highlighting_failure']
+
+redirects = {
+    "library-user-guide/adding-udfs": "functions/index.html",
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/16438

## Rationale for this change

@samuelcolvin noticed that when we moved some doc content in https://github.com/apache/datafusion/pull/16384  the old links are still in the search engines

We should add a redirect link

## What changes are included in this PR?

Add a redirect link to the new page

## Are these changes tested?

I tested this locally and the adding_udfs link now redirects to the new page:

* Old URL:`file:///Users/andrewlamb/Software/datafusion/docs/build/html/library-user-guide/adding-udfs.html`
* Redirects to: `file:///Users/andrewlamb/Software/datafusion/docs/build/html/library-user-guide/functions/index.html`

![Screenshot 2025-06-20 at 6 28 36 AM](https://github.com/user-attachments/assets/34bfc962-6b30-425c-986f-bf7cf74f6555)


## Are there any user-facing changes?

Docs have a redirect
