### PR TITLE
Reapply "Ignore `sort_query_fuzzer_runner` (#16462)" (#16470)

### DIFF
--- a/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
@@ -48,6 +48,7 @@ use super::record_batch_generator::{get_supported_types_columns, RecordBatchGene
 ///
 /// Now memory limiting is disabled by default. See TODOs in `SortQueryFuzzer`.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "https://github.com/apache/datafusion/issues/16452"]
 async fn sort_query_fuzzer_runner() {
     let random_seed = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)


### PR DESCRIPTION
This reverts commit a0eaf5107cc4f8093378a4547b7a12c63a275171.

## Which issue does this PR close?
- related to https://github.com/apache/datafusion/issues/16452

## Rationale for this change

- We thought we fixed the test with the intermittent failures on main. so we started running the tests again https://github.com/apache/datafusion/pull/16470


However, then the test failed again when we re-enabled it: 
https://github.com/apache/datafusion/actions/runs/15780623790/job/44485106315 

Let's revert the revert


## What changes are included in this PR?

Re-disable the test on main while we sort out the root cause

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
