### PR TITLE
restore topk pre-filtering of batches and make sort query fuzzer less sensitive to expected non determinism 

### DIFF
--- a/datafusion/core/tests/fuzz_cases/record_batch_generator.rs
+++ b/datafusion/core/tests/fuzz_cases/record_batch_generator.rs
@@ -34,7 +34,6 @@ use arrow_schema::{
     DECIMAL256_MAX_SCALE,
 };
 use datafusion_common::{arrow_datafusion_err, DataFusionError, Result};
-use itertools::Itertools;
 use rand::{rng, rngs::StdRng, Rng, SeedableRng};
 use test_utils::array_gen::{
     BinaryArrayGenerator, BooleanArrayGenerator, DecimalArrayGenerator,
@@ -284,13 +283,7 @@ impl RecordBatchGenerator {
     }
 
     pub fn generate(&mut self) -> Result<RecordBatch> {
-        let range = self.min_rows_num..=self.max_rows_num;
-        let num_rows = if range.try_len().unwrap() > 0 {
-            self.rng.random_range(range)
-        } else {
-            // If the range is empty, we return self.min_rows_num
-            self.min_rows_num
-        };
+        let num_rows = self.rng.random_range(self.min_rows_num..=self.max_rows_num);
         let array_gen_rng = StdRng::from_seed(self.rng.random());
         let mut batch_gen_rng = StdRng::from_seed(self.rng.random());
         let columns = self.columns.clone();

--- a/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
@@ -464,7 +464,8 @@ impl SortFuzzerTestGenerator {
 
         let query = format!(
             "SELECT {} FROM {} ORDER BY {}{}",
-            selected_columns.iter()
+            selected_columns
+                .iter()
                 .map(|col| col.name.clone())
                 .collect::<Vec<_>>()
                 .join(", "),

--- a/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
@@ -576,7 +576,7 @@ impl SortFuzzerTestGenerator {
 
         let config = SessionConfig::new()
             .with_target_partitions(num_partitions)
-            .with_batch_size(std::cmp::max(init_state.approx_batch_num_rows / 2, 1))
+            .with_batch_size(init_state.approx_batch_num_rows / 2)
             .with_sort_spill_reservation_bytes(sort_spill_reservation_bytes)
             .with_sort_in_place_threshold_bytes(sort_in_place_threshold_bytes);
 

--- a/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
@@ -21,7 +21,7 @@ use std::cmp::min;
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
-use arrow_schema::SchemaRef;
+use arrow_schema::{DataType, IntervalUnit, SchemaRef};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_common::{instant::Instant, Result};
@@ -80,7 +80,7 @@ async fn test_reproduce_sort_query_issue_16452() {
     // Seeds from the failing test case
     let init_seed = 10313160656544581998u64;
     let query_seed = 15004039071976572201u64;
-    let config_seed_1 = 11807432710583113300u64;
+    let config_seed_1 = 1;
 
     let random_seed = 1u64; // Use a fixed seed to ensure consistent behavior
 
@@ -88,7 +88,13 @@ async fn test_reproduce_sort_query_issue_16452() {
         2000,
         128,
         "sort_fuzz_table".to_string(),
-        get_supported_types_columns(random_seed),
+        vec![
+            ColumnDescr::new("u64", DataType::UInt64),
+            ColumnDescr::new(
+                "interval_month_day_nano",
+                DataType::Interval(IntervalUnit::MonthDayNano),
+            ),
+        ],
         false,
         random_seed,
     );

--- a/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
@@ -31,6 +31,7 @@ use datafusion_execution::memory_pool::{
 };
 use datafusion_expr::display_schema;
 use datafusion_physical_plan::spill::get_record_batch_memory_size;
+use itertools::Itertools;
 use std::time::Duration;
 
 use datafusion_execution::{memory_pool::FairSpillPool, runtime_env::RuntimeEnvBuilder};
@@ -70,6 +71,43 @@ async fn sort_query_fuzzer_runner() {
         .with_test_generator(test_generator);
 
     fuzzer.run().await.unwrap();
+}
+
+/// Reproduce the bug with specific seeds from the
+/// [failing test case](https://github.com/apache/datafusion/issues/16452).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reproduce_sort_query_issue_16452() {
+    // Seeds from the failing test case
+    let init_seed = 10313160656544581998u64;
+    let query_seed = 15004039071976572201u64;
+    let config_seed_1 = 11807432710583113300u64;
+    let config_seed_2 = 759937414670321802u64;
+
+    let random_seed = 1u64; // Use a fixed seed to ensure consistent behavior
+
+    let mut test_generator = SortFuzzerTestGenerator::new(
+        2000,
+        3,
+        "sort_fuzz_table".to_string(),
+        get_supported_types_columns(random_seed),
+        false,
+        random_seed,
+    );
+
+    let mut results = vec![];
+
+    for config_seed in [config_seed_1, config_seed_2] {
+        let r = test_generator
+            .fuzzer_run(init_seed, query_seed, config_seed)
+            .await
+            .unwrap();
+
+        results.push(r);
+    }
+
+    for (lhs, rhs) in results.iter().tuple_windows() {
+        check_equality_of_batches(lhs, rhs).unwrap();
+    }
 }
 
 /// SortQueryFuzzer holds the runner configuration for executing sort query fuzz tests. The fuzzing details are managed inside `SortFuzzerTestGenerator`.

--- a/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
@@ -31,7 +31,6 @@ use datafusion_execution::memory_pool::{
 };
 use datafusion_expr::display_schema;
 use datafusion_physical_plan::spill::get_record_batch_memory_size;
-use itertools::Itertools;
 use std::time::Duration;
 
 use datafusion_execution::{memory_pool::FairSpillPool, runtime_env::RuntimeEnvBuilder};
@@ -71,43 +70,6 @@ async fn sort_query_fuzzer_runner() {
         .with_test_generator(test_generator);
 
     fuzzer.run().await.unwrap();
-}
-
-/// Reproduce the bug with specific seeds from the
-/// [failing test case](https://github.com/apache/datafusion/issues/16452).
-#[tokio::test(flavor = "multi_thread")]
-async fn test_reproduce_sort_query_issue_16452() {
-    // Seeds from the failing test case
-    let init_seed = 10313160656544581998u64;
-    let query_seed = 15004039071976572201u64;
-    let config_seed_1 = 11807432710583113300u64;
-    let config_seed_2 = 759937414670321802u64;
-
-    let random_seed = 1u64; // Use a fixed seed to ensure consistent behavior
-
-    let mut test_generator = SortFuzzerTestGenerator::new(
-        2000,
-        3,
-        "sort_fuzz_table".to_string(),
-        get_supported_types_columns(random_seed),
-        false,
-        random_seed,
-    );
-
-    let mut results = vec![];
-
-    for config_seed in [config_seed_1, config_seed_2] {
-        let r = test_generator
-            .fuzzer_run(init_seed, query_seed, config_seed)
-            .await
-            .unwrap();
-
-        results.push(r);
-    }
-
-    for (lhs, rhs) in results.iter().tuple_windows() {
-        check_equality_of_batches(lhs, rhs).unwrap();
-    }
 }
 
 /// SortQueryFuzzer holds the runner configuration for executing sort query fuzz tests. The fuzzing details are managed inside `SortFuzzerTestGenerator`.

--- a/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
@@ -86,10 +86,7 @@ async fn test_reproduce_sort_query_issue_16452() {
         "sort_fuzz_table".to_string(),
         vec![
             ColumnDescr::new("u64", DataType::UInt64),
-            ColumnDescr::new(
-                "u32",
-                DataType::UInt32,
-            ),
+            ColumnDescr::new("u32", DataType::UInt32),
         ],
         false,
         random_seed,

--- a/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/sort_query_fuzz.rs
@@ -87,7 +87,7 @@ async fn test_reproduce_sort_query_issue_16452() {
         vec![record_batch!(("u64", UInt64, [2]), ("u32", UInt32, [2])).unwrap()],
     ];
 
-    let query = "SELECT * FROM sort_fuzz_table ORDER BY u32 NULLS FIRST LIMIT 1";
+    let query = "SELECT * FROM sort_fuzz_table ORDER BY u32 LIMIT 1";
     let config = SessionConfig::new()
         .with_target_partitions(2)
         .with_batch_size(1);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/16452

## Rationale for this change

- @AdamGS  removed some of the code here https://github.com/apache/datafusion/pull/16465
- However, the test kept failing
- @adriangb fixed what we think is the real issue here: https://github.com/apache/datafusion/pull/16491

## What changes are included in this PR?

- Let's restore the removed code in https://github.com/apache/datafusion/pull/16465

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
