### PR TITLE
Add DESC alias for DESCRIBE command. Closes #16311

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -215,7 +215,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
     ) -> Result<LogicalPlan> {
         match statement {
             Statement::ExplainTable {
-                describe_alias: DescribeAlias::Describe, // only parse 'DESCRIBE table_name' and not 'EXPLAIN table_name'
+                describe_alias: DescribeAlias::Describe | DescribeAlias::Desc, // only parse 'DESCRIBE table_name' or 'DESC table_name' and not 'EXPLAIN table_name'
                 table_name,
                 ..
             } => self.describe_table_to_plan(table_name),

--- a/datafusion/sqllogictest/test_files/describe.slt
+++ b/datafusion/sqllogictest/test_files/describe.slt
@@ -86,3 +86,33 @@ string_col Utf8View YES
 timestamp_col Timestamp(Nanosecond, None) YES
 year Int32 YES
 month Int32 YES
+
+# Test DESC alias functionality
+statement ok
+CREATE TABLE test_desc_table (id INT, name VARCHAR);
+
+# Test DESC works the same as DESCRIBE
+query TTT
+DESC test_desc_table;
+----
+id Int32 YES
+name Utf8View YES
+
+query TTT
+DESCRIBE test_desc_table;
+----
+id Int32 YES
+name Utf8View YES
+
+# Test with qualified table names
+statement ok
+CREATE TABLE public.test_qualified (col1 INT);
+
+query TTT
+DESC public.test_qualified;
+----
+col1 Int32 YES
+
+# Test error cases
+statement error
+DESC nonexistent_table;


### PR DESCRIPTION
- Allow DESC as shorthand for DESCRIBE in SQL parser
- Maintains backward compatibility with existing DESCRIBE syntax
- Adds test coverage for new DESC alias functionality

## Which issue does this PR close?

- Closes #16311

## What changes are proposed in this pull request?

Add support for `DESC` as an alias for the `DESCRIBE` command in SQL parsing.

## How are these changes tested?

- Added test cases in `describe.slt` 
- Verified backward compatibility with existing `DESCRIBE` syntax
- All existing tests continue to pass

## Are there any user-facing changes?

Yes - users can now use `DESC table_name` as shorthand for `DESCRIBE table_name`