### PR TITLE
Simplify AsyncScalarUdfImpl so it extends ScalarUdfImpl

### DIFF
--- a/datafusion-examples/examples/async_udf.rs
+++ b/datafusion-examples/examples/async_udf.rs
@@ -20,16 +20,14 @@ use arrow::compute::kernels::cmp::eq;
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use datafusion::common::error::Result;
-use datafusion::common::internal_err;
+use datafusion::common::{internal_err, not_impl_err};
 use datafusion::common::types::{logical_int64, logical_string};
 use datafusion::common::utils::take_function_args;
 use datafusion::config::ConfigOptions;
 use datafusion::logical_expr::async_udf::{
-    AsyncScalarFunctionArgs, AsyncScalarUDF, AsyncScalarUDFImpl,
+    AsyncScalarUDF, AsyncScalarUDFImpl,
 };
-use datafusion::logical_expr::{
-    ColumnarValue, Signature, TypeSignature, TypeSignatureClass, Volatility,
-};
+use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, TypeSignatureClass, Volatility};
 use datafusion::logical_expr_common::signature::Coercion;
 use datafusion::physical_expr_common::datum::apply_cmp;
 use datafusion::prelude::SessionContext;
@@ -153,7 +151,7 @@ impl AsyncUpper {
 }
 
 #[async_trait]
-impl AsyncScalarUDFImpl for AsyncUpper {
+impl ScalarUDFImpl for AsyncUpper {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -170,13 +168,24 @@ impl AsyncScalarUDFImpl for AsyncUpper {
         Ok(DataType::Utf8)
     }
 
-    fn ideal_batch_size(&self) -> Option<usize> {
+    fn invoke_with_args(
+        &self,
+        _args: ScalarFunctionArgs,
+    ) -> Result<ColumnarValue> {
+        not_impl_err!("AsyncUpper can only be called from async contexts")
+    }
+}
+
+#[async_trait]
+impl AsyncScalarUDFImpl for AsyncUpper {
+
+fn ideal_batch_size(&self) -> Option<usize> {
         Some(10)
     }
 
     async fn invoke_async_with_args(
         &self,
-        args: AsyncScalarFunctionArgs,
+        args: ScalarFunctionArgs,
         _option: &ConfigOptions,
     ) -> Result<ArrayRef> {
         trace!("Invoking async_upper with args: {:?}", args);
@@ -226,7 +235,7 @@ impl AsyncEqual {
 }
 
 #[async_trait]
-impl AsyncScalarUDFImpl for AsyncEqual {
+impl ScalarUDFImpl for AsyncEqual {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -243,9 +252,20 @@ impl AsyncScalarUDFImpl for AsyncEqual {
         Ok(DataType::Boolean)
     }
 
+    fn invoke_with_args(
+        &self,
+        _args: ScalarFunctionArgs,
+    ) -> Result<ColumnarValue> {
+        not_impl_err!("AsyncEqual can only be called from async contexts")
+    }
+}
+
+#[async_trait]
+ impl AsyncScalarUDFImpl for AsyncEqual {
+
     async fn invoke_async_with_args(
         &self,
-        args: AsyncScalarFunctionArgs,
+        args: ScalarFunctionArgs,
         _option: &ConfigOptions,
     ) -> Result<ArrayRef> {
         let [arg1, arg2] = take_function_args(self.name(), &args.args)?;

--- a/datafusion/expr/src/async_udf.rs
+++ b/datafusion/expr/src/async_udf.rs
@@ -17,7 +17,7 @@
 
 use crate::{ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl};
 use arrow::array::ArrayRef;
-use arrow::datatypes::{DataType, Field, FieldRef, SchemaRef};
+use arrow::datatypes::{DataType,  FieldRef};
 use async_trait::async_trait;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
@@ -35,34 +35,7 @@ use std::sync::Arc;
 ///
 /// The name is chosen to mirror ScalarUDFImpl
 #[async_trait]
-pub trait AsyncScalarUDFImpl: Debug + Send + Sync {
-    /// the function cast as any
-    fn as_any(&self) -> &dyn Any;
-
-    /// The name of the function
-    fn name(&self) -> &str;
-
-    /// The signature of the function
-    fn signature(&self) -> &Signature;
-
-    /// The return type of the function
-    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType>;
-
-    /// What type will be returned by this function, given the arguments?
-    ///
-    /// By default, this function calls [`Self::return_type`] with the
-    /// types of each argument.
-    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
-        let data_types = args
-            .arg_fields
-            .iter()
-            .map(|f| f.data_type())
-            .cloned()
-            .collect::<Vec<_>>();
-        let return_type = self.return_type(&data_types)?;
-        Ok(Arc::new(Field::new(self.name(), return_type, true)))
-    }
-
+pub trait AsyncScalarUDFImpl: ScalarUDFImpl {
     /// The ideal batch size for this function.
     ///
     /// This is used to determine what size of data to be evaluated at once.
@@ -74,7 +47,7 @@ pub trait AsyncScalarUDFImpl: Debug + Send + Sync {
     /// Invoke the function asynchronously with the async arguments
     async fn invoke_async_with_args(
         &self,
-        args: AsyncScalarFunctionArgs,
+        args: ScalarFunctionArgs,
         option: &ConfigOptions,
     ) -> Result<ArrayRef>;
 }
@@ -107,7 +80,7 @@ impl AsyncScalarUDF {
     /// Invoke the function asynchronously with the async arguments
     pub async fn invoke_async_with_args(
         &self,
-        args: AsyncScalarFunctionArgs,
+        args: ScalarFunctionArgs,
         option: &ConfigOptions,
     ) -> Result<ArrayRef> {
         self.inner.invoke_async_with_args(args, option).await
@@ -144,11 +117,4 @@ impl Display for AsyncScalarUDF {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "AsyncScalarUDF: {}", self.inner.name())
     }
-}
-
-#[derive(Debug)]
-pub struct AsyncScalarFunctionArgs {
-    pub args: Vec<ColumnarValue>,
-    pub number_rows: usize,
-    pub schema: SchemaRef,
 }

--- a/datafusion/physical-expr/src/async_scalar_function.rs
+++ b/datafusion/physical-expr/src/async_scalar_function.rs
@@ -17,17 +17,18 @@
 
 use crate::ScalarFunctionExpr;
 use arrow::array::{make_array, MutableArrayData, RecordBatch};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Field, FieldRef, Schema};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::Result;
 use datafusion_common::{internal_err, not_impl_err};
-use datafusion_expr::async_udf::{AsyncScalarFunctionArgs, AsyncScalarUDF};
+use datafusion_expr::async_udf::{AsyncScalarUDF};
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use std::any::Any;
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use datafusion_expr::ScalarFunctionArgs;
 
 /// Wrapper around a scalar function that can be evaluated asynchronously
 #[derive(Debug, Clone, Eq)]
@@ -36,6 +37,8 @@ pub struct AsyncFuncExpr {
     pub name: String,
     /// The actual function (always `ScalarFunctionExpr`)
     pub func: Arc<dyn PhysicalExpr>,
+    /// The field that this function will return
+    return_field: FieldRef,
 }
 
 impl Display for AsyncFuncExpr {
@@ -59,7 +62,8 @@ impl Hash for AsyncFuncExpr {
 
 impl AsyncFuncExpr {
     /// create a new AsyncFuncExpr
-    pub fn try_new(name: impl Into<String>, func: Arc<dyn PhysicalExpr>) -> Result<Self> {
+    pub fn try_new(name: impl Into<String>, func: Arc<dyn PhysicalExpr>,         schema: &Schema,
+    ) -> Result<Self> {
         let Some(_) = func.as_any().downcast_ref::<ScalarFunctionExpr>() else {
             return internal_err!(
                 "unexpected function type, expected ScalarFunctionExpr, got: {:?}",
@@ -67,9 +71,11 @@ impl AsyncFuncExpr {
             );
         };
 
+        let return_field =  func.return_field(schema)?;
         Ok(Self {
             name: name.into(),
             func,
+            return_field,
         })
     }
 
@@ -128,6 +134,12 @@ impl AsyncFuncExpr {
             );
         };
 
+        let arg_fields =  scalar_function_expr
+            .args()
+            .iter()
+            .map(|e| e.return_field(batch.schema_ref()))
+            .collect::<Result<Vec<_>>>()?;
+
         let mut result_batches = vec![];
         if let Some(ideal_batch_size) = self.ideal_batch_size()? {
             let mut remainder = batch.clone();
@@ -148,10 +160,11 @@ impl AsyncFuncExpr {
                 result_batches.push(
                     async_udf
                         .invoke_async_with_args(
-                            AsyncScalarFunctionArgs {
-                                args: args.to_vec(),
+                            ScalarFunctionArgs {
+                                args,
+                                arg_fields: arg_fields.clone(),
                                 number_rows: current_batch.num_rows(),
-                                schema: current_batch.schema(),
+                                return_field: Arc::clone(&self.return_field),
                             },
                             option,
                         )
@@ -168,10 +181,11 @@ impl AsyncFuncExpr {
             result_batches.push(
                 async_udf
                     .invoke_async_with_args(
-                        AsyncScalarFunctionArgs {
+                        ScalarFunctionArgs {
                             args: args.to_vec(),
+                            arg_fields,
                             number_rows: batch.num_rows(),
-                            schema: batch.schema(),
+                            return_field: Arc::clone(&self.return_field),
                         },
                         option,
                     )
@@ -223,6 +237,7 @@ impl PhysicalExpr for AsyncFuncExpr {
         Ok(Arc::new(AsyncFuncExpr {
             name: self.name.clone(),
             func: new_func,
+            return_field: Arc::clone(&self.return_field),
         }))
     }
 

--- a/datafusion/physical-plan/src/async_func.rs
+++ b/datafusion/physical-plan/src/async_func.rs
@@ -245,6 +245,7 @@ impl AsyncMapper {
     pub fn find_references(
         &mut self,
         physical_expr: &Arc<dyn PhysicalExpr>,
+        schema: &Schema,
     ) -> Result<()> {
         // recursively look for references to async functions
         physical_expr.apply(|expr| {
@@ -256,6 +257,7 @@ impl AsyncMapper {
                     self.async_exprs.push(Arc::new(AsyncFuncExpr::try_new(
                         next_name,
                         Arc::clone(expr),
+                        schema,
                     )?));
                 }
             }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/16522

## Rationale for this change

Following @berkaysynnada 's suggestion in https://github.com/apache/datafusion/pull/14837 having parallel implementations of functions allows sync and async UDFs to drift apart. 

Let's try and make the differences as small as possible

## What changes are included in this PR?

1. Make Avoid duplication of AsyncUDFImpl  and instead use the same structures for `ScalarUdfImpl`
2. Update examples to match

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

API is changed, but it has not been released uet
