### PR TITLE
Update `spilled_bytes` metric to reflect actual disk usage

### DIFF
--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -366,6 +366,10 @@ impl RefCountedTempFile {
 
         Ok(())
     }
+
+    pub fn current_disk_usage(&self) -> u64 {
+        self.current_file_disk_usage
+    }
 }
 
 /// When the temporary file is dropped, subtract its disk usage from the disk manager's total

--- a/datafusion/physical-plan/src/metrics/baseline.rs
+++ b/datafusion/physical-plan/src/metrics/baseline.rs
@@ -151,7 +151,7 @@ pub struct SpillMetrics {
     /// count of spills during the execution of the operator
     pub spill_file_count: Count,
 
-    /// total spilled bytes during the execution of the operator
+    /// total bytes actually written to disk during the execution of the operator
     pub spilled_bytes: Count,
 
     /// total spilled rows during the execution of the operator

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -1514,7 +1514,7 @@ mod tests {
         // bytes. We leave a little wiggle room for the actual numbers.
         assert!((3..=10).contains(&spill_count));
         assert!((9000..=10000).contains(&spilled_rows));
-        assert!((38000..=42000).contains(&spilled_bytes));
+        assert!((38000..=44000).contains(&spilled_bytes));
 
         let columns = result[0].columns();
 

--- a/datafusion/physical-plan/src/spill/mod.rs
+++ b/datafusion/physical-plan/src/spill/mod.rs
@@ -809,12 +809,13 @@ mod tests {
                 Arc::new(StringArray::from(vec!["d", "e", "f"])),
             ],
         )?;
-
+        // After appending each batch, spilled_rows should increase, while spill_file_count and
+        // spilled_bytes remain the same (spilled_bytes is updated only after finish() is called)
         in_progress_file.append_batch(&batch1)?;
-        verify_metrics(&in_progress_file, 1, 356, 3)?;
+        verify_metrics(&in_progress_file, 1, 0, 3)?;
 
         in_progress_file.append_batch(&batch2)?;
-        verify_metrics(&in_progress_file, 1, 712, 6)?;
+        verify_metrics(&in_progress_file, 1, 0, 6)?;
 
         let completed_file = in_progress_file.finish()?;
         assert!(completed_file.is_some());


### PR DESCRIPTION
## Which issue does this PR close?
- Related to #16367 

## Rationale for this change
Previously, the `spilled_bytes` metric reported the estimated in-memory size of spilled `RecordBatches`, based on their array sizes. However, with the introduction of spill file compression in the `SpillManager`, the in-memory size no longer reflects the actual bytes written to disk.

This PR updates the `spilled_bytes` metric to instead report the total number of bytes physically **written to disk** during spilling.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Whenever `in_progress_file.finish()` is called, it updates the spill file metric based on `current_disk_usage` for this spill file. Since spill files are append-only, we only update this value once. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes. We manually compare the spill file size and reported metric.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
After this PR, running certain spilling aggregate queries may show significantly lower `spilled_bytes` values compared to previous runs—even when using the uncompressed spill option.

This is because the previous metric was based on an inaccurate estimate of in-memory size. In particular, when a large `RecordBatch` was sliced into smaller batches during `spill_record_batch_by_size`, the underlying buffers were not resized due to zero-copy semantics, resulting in inflated memory accounting.

The updated `spilled_bytes` metric now reflects the actual number of bytes written to disk, and therefore provides a more accurate representation of spill size.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
