### PR TITLE
fix: reject within_group for non ordered aggregate function

### DIFF
--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -375,6 +375,10 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     return plan_err!("WITHIN GROUP clause is required when calling ordered set aggregate function({})", fm.name());
                 }
 
+                if !fm.is_ordered_set_aggregate() && !within_group.is_empty() {
+                    return plan_err!("WITHIN GROUP clause is not permitted for non-ordered set aggregate function({})", fm.name());
+                }
+
                 if null_treatment.is_some() && !fm.supports_null_handling_clause() {
                     return plan_err!(
                         "[IGNORE | RESPECT] NULLS are not permitted for {}",

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -7040,3 +7040,7 @@ VALUES
 ) GROUP BY 1 ORDER BY 1;
 ----
 x 1
+
+statement error DataFusion error:  Error during planning: WITHIN GROUP clause is not permitted for non-ordered set aggregate function(array_agg)
+SELECT array_agg(DISTINCT a_varchar) within group (order by a_varchar)
+FROM (VALUES ('a'), ('d'), ('c'), ('a')) t(a_varchar);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #16515.

## Rationale for this change

WITHIN GROUP clause gets ignored for non ordered aggregate function

## What changes are included in this PR?

reject WITHIN GROUP clause. I checked Postgres, it also doesn't support such query.

## Are these changes tested?

UT

## Are there any user-facing changes?

No