### PR TITLE
Support timestamp and date arguments for `range` and `generate_series` table functions

### DIFF
--- a/datafusion/functions-table/src/generate_series.rs
+++ b/datafusion/functions-table/src/generate_series.rs
@@ -15,8 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::Int64Array;
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::array::timezone::Tz;
+use arrow::array::types::TimestampNanosecondType;
+use arrow::array::{Int64Array, TimestampNanosecondArray};
+use arrow::datatypes::{
+    DataType, Field, IntervalMonthDayNano, Schema, SchemaRef, TimeUnit,
+};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion_catalog::Session;
@@ -28,18 +32,16 @@ use datafusion_physical_plan::memory::{LazyBatchGenerator, LazyMemoryExec};
 use datafusion_physical_plan::ExecutionPlan;
 use parking_lot::RwLock;
 use std::fmt;
+use std::str::FromStr;
 use std::sync::Arc;
 
 /// Indicates the arguments used for generating a series.
 #[derive(Debug, Clone)]
 enum GenSeriesArgs {
     /// ContainsNull signifies that at least one argument(start, end, step) was null, thus no series will be generated.
-    ContainsNull {
-        include_end: bool,
-        name: &'static str,
-    },
-    /// AllNotNullArgs holds the start, end, and step values for generating the series when all arguments are not null.
-    AllNotNullArgs {
+    ContainsNull { name: &'static str },
+    /// Int64Args holds the start, end, and step values for generating integer series when all arguments are not null.
+    Int64Args {
         start: i64,
         end: i64,
         step: i64,
@@ -47,77 +49,211 @@ enum GenSeriesArgs {
         include_end: bool,
         name: &'static str,
     },
+    /// TimestampArgs holds the start, end, and step values for generating timestamp series when all arguments are not null.
+    TimestampArgs {
+        start: i64,
+        end: i64,
+        step: IntervalMonthDayNano,
+        tz: Option<Arc<str>>,
+        /// Indicates whether the end value should be included in the series.
+        include_end: bool,
+        name: &'static str,
+    },
 }
 
-/// Table that generates a series of integers from `start`(inclusive) to `end`(inclusive), incrementing by step
+/// Table that generates a series of integers/timestamps from `start`(inclusive) to `end`, incrementing by step
 #[derive(Debug, Clone)]
 struct GenerateSeriesTable {
     schema: SchemaRef,
     args: GenSeriesArgs,
 }
 
-/// Table state that generates a series of integers from `start`(inclusive) to `end`(inclusive), incrementing by step
+/// Table state that generates a series of values from `start`(inclusive) to `end`, incrementing by step
 #[derive(Debug, Clone)]
-struct GenerateSeriesState {
-    schema: SchemaRef,
-    start: i64, // Kept for display
-    end: i64,
-    step: i64,
-    batch_size: usize,
-
-    /// Tracks current position when generating table
-    current: i64,
-    /// Indicates whether the end value should be included in the series.
-    include_end: bool,
-    name: &'static str,
-}
-
-impl GenerateSeriesState {
-    fn reach_end(&self, val: i64) -> bool {
-        if self.step > 0 {
-            if self.include_end {
-                return val > self.end;
-            } else {
-                return val >= self.end;
-            }
-        }
-
-        if self.include_end {
-            val < self.end
-        } else {
-            val <= self.end
-        }
-    }
+enum GenerateSeriesState {
+    Int64 {
+        schema: SchemaRef,
+        start: i64, // Kept for display
+        end: i64,
+        step: i64,
+        batch_size: usize,
+        /// Tracks current position when generating table
+        current: i64,
+        /// Indicates whether the end value should be included in the series.
+        include_end: bool,
+        name: &'static str,
+    },
+    Timestamp {
+        schema: SchemaRef,
+        start: i64,
+        end: i64,
+        step: IntervalMonthDayNano,
+        tz: Option<Arc<str>>,
+        parsed_tz: Tz,
+        batch_size: usize,
+        /// Tracks current position when generating table
+        current: i64,
+        /// Indicates whether the end value should be included in the series.
+        include_end: bool,
+        name: &'static str,
+    },
+    Empty {
+        batch_size: usize,
+        name: &'static str,
+    },
 }
 
 /// Detail to display for 'Explain' plan
 impl fmt::Display for GenerateSeriesState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}: start={}, end={}, batch_size={}",
-            self.name, self.start, self.end, self.batch_size
-        )
+        match self {
+            GenerateSeriesState::Int64 {
+                name,
+                start,
+                end,
+                batch_size,
+                ..
+            }
+            | GenerateSeriesState::Timestamp {
+                name,
+                start,
+                end,
+                batch_size,
+                ..
+            } => {
+                write!(
+                    f,
+                    "{name}: start={start}, end={end}, batch_size={batch_size}"
+                )
+            }
+            GenerateSeriesState::Empty {
+                name, batch_size, ..
+            } => {
+                write!(f, "{name}: empty, batch_size={batch_size}")
+            }
+        }
     }
 }
 
 impl LazyBatchGenerator for GenerateSeriesState {
     fn generate_next_batch(&mut self) -> Result<Option<RecordBatch>> {
-        let mut buf = Vec::with_capacity(self.batch_size);
-        while buf.len() < self.batch_size && !self.reach_end(self.current) {
-            buf.push(self.current);
-            self.current += self.step;
+        match self {
+            GenerateSeriesState::Int64 {
+                schema,
+                end,
+                step,
+                batch_size,
+                current,
+                include_end,
+                ..
+            } => {
+                let mut buf = Vec::with_capacity(*batch_size);
+                let end_val = *end;
+                let step_val = *step;
+                let include_end_val = *include_end;
+
+                while buf.len() < *batch_size
+                    && !reach_end_int64(*current, end_val, step_val, include_end_val)
+                {
+                    buf.push(*current);
+                    *current += step_val;
+                }
+                let array = Int64Array::from(buf);
+
+                if array.is_empty() {
+                    return Ok(None);
+                }
+
+                let batch =
+                    RecordBatch::try_new(Arc::clone(schema), vec![Arc::new(array)])?;
+                Ok(Some(batch))
+            }
+            GenerateSeriesState::Timestamp {
+                schema,
+                end,
+                step,
+                tz,
+                parsed_tz,
+                batch_size,
+                current,
+                include_end,
+                start: _,
+                name: _,
+            } => {
+                let mut buf = Vec::with_capacity(*batch_size);
+                let step_val = *step;
+                let include_end_val = *include_end;
+                let step_negative =
+                    step_val.months < 0 || step_val.days < 0 || step_val.nanoseconds < 0;
+
+                while buf.len() < *batch_size {
+                    let should_stop = if include_end_val {
+                        if step_negative {
+                            current < end
+                        } else {
+                            current > end
+                        }
+                    } else if step_negative {
+                        current <= end
+                    } else {
+                        current >= end
+                    };
+
+                    if should_stop {
+                        break;
+                    }
+
+                    // Store current value before advancing
+                    let current_value = *current;
+
+                    // Add interval using proper calendar arithmetic for next iteration
+                    let Some(next_ts) = TimestampNanosecondType::add_month_day_nano(
+                        *current, step_val, *parsed_tz,
+                    ) else {
+                        return plan_err!(
+                            "Failed to add interval {:?} to timestamp {}",
+                            step_val,
+                            current_value
+                        );
+                    };
+
+                    *current = next_ts;
+
+                    // Push the current value after successfully advancing
+                    buf.push(current_value);
+                }
+
+                let array = TimestampNanosecondArray::from(buf);
+                // Create array with proper timezone
+                let array = match tz {
+                    Some(tz_str) => array.with_timezone(Arc::clone(tz_str)),
+                    None => array,
+                };
+
+                if array.is_empty() {
+                    return Ok(None);
+                }
+
+                let batch =
+                    RecordBatch::try_new(Arc::clone(schema), vec![Arc::new(array)])?;
+                Ok(Some(batch))
+            }
+            GenerateSeriesState::Empty { .. } => Ok(None),
         }
-        let array = Int64Array::from(buf);
+    }
+}
 
-        if array.is_empty() {
-            return Ok(None);
+fn reach_end_int64(val: i64, end: i64, step: i64, include_end: bool) -> bool {
+    if step > 0 {
+        if include_end {
+            val > end
+        } else {
+            val >= end
         }
-
-        let batch =
-            RecordBatch::try_new(Arc::clone(&self.schema), vec![Arc::new(array)])?;
-
-        Ok(Some(batch))
+    } else if include_end {
+        val < end
+    } else {
+        val <= end
     }
 }
 
@@ -147,39 +283,63 @@ impl TableProvider for GenerateSeriesTable {
             Some(projection) => Arc::new(self.schema.project(projection)?),
             None => self.schema(),
         };
-        let state = match self.args {
+        let series_state = match &self.args {
             // if args have null, then return 0 row
-            GenSeriesArgs::ContainsNull { include_end, name } => GenerateSeriesState {
-                schema: self.schema(),
-                start: 0,
-                end: 0,
-                step: 1,
-                current: 1,
-                batch_size,
-                include_end,
-                name,
-            },
-            GenSeriesArgs::AllNotNullArgs {
+            GenSeriesArgs::ContainsNull { name } => {
+                GenerateSeriesState::Empty { batch_size, name }
+            }
+            GenSeriesArgs::Int64Args {
                 start,
                 end,
                 step,
                 include_end,
                 name,
-            } => GenerateSeriesState {
+            } => GenerateSeriesState::Int64 {
                 schema: self.schema(),
+                start: *start,
+                end: *end,
+                step: *step,
+                current: *start,
+                batch_size,
+                include_end: *include_end,
+                name,
+            },
+            GenSeriesArgs::TimestampArgs {
                 start,
                 end,
                 step,
-                current: start,
-                batch_size,
+                tz,
                 include_end,
                 name,
-            },
+            } => {
+                let parsed_tz = tz
+                    .as_ref()
+                    .map(|s| Tz::from_str(s.as_ref()))
+                    .transpose()
+                    .map_err(|e| {
+                        datafusion_common::DataFusionError::Internal(format!(
+                            "Failed to parse timezone: {e}"
+                        ))
+                    })?
+                    .unwrap_or_else(|| Tz::from_str("+00:00").unwrap());
+                GenerateSeriesState::Timestamp {
+                    schema: self.schema(),
+                    start: *start,
+                    end: *end,
+                    step: *step,
+                    tz: tz.clone(),
+                    parsed_tz,
+                    current: *start,
+                    batch_size,
+                    include_end: *include_end,
+                    name,
+                }
+            }
         };
 
         Ok(Arc::new(LazyMemoryExec::try_new(
             schema,
-            vec![Arc::new(RwLock::new(state))],
+            vec![Arc::new(RwLock::new(series_state))],
         )?))
     }
 }
@@ -196,6 +356,29 @@ impl TableFunctionImpl for GenerateSeriesFuncImpl {
             return plan_err!("{} function requires 1 to 3 arguments", self.name);
         }
 
+        // Determine the data type from the first argument
+        match &exprs[0] {
+            Expr::Literal(
+                // Default to int64 for null
+                ScalarValue::Null | ScalarValue::Int64(_),
+                _,
+            ) => self.call_int64(exprs),
+            Expr::Literal(s, _) if matches!(s.data_type(), DataType::Timestamp(_, _)) => {
+                self.call_timestamp(exprs)
+            }
+            Expr::Literal(scalar, _) => {
+                plan_err!(
+                    "Argument #1 must be an INTEGER, TIMESTAMP or NULL, got {:?}",
+                    scalar.data_type()
+                )
+            }
+            _ => plan_err!("Arguments must be literals"),
+        }
+    }
+}
+
+impl GenerateSeriesFuncImpl {
+    fn call_int64(&self, exprs: &[Expr]) -> Result<Arc<dyn TableProvider>> {
         let mut normalize_args = Vec::new();
         for (expr_index, expr) in exprs.iter().enumerate() {
             match expr {
@@ -221,10 +404,7 @@ impl TableFunctionImpl for GenerateSeriesFuncImpl {
             // contain null
             return Ok(Arc::new(GenerateSeriesTable {
                 schema,
-                args: GenSeriesArgs::ContainsNull {
-                    include_end: self.include_end,
-                    name: self.name,
-                },
+                args: GenSeriesArgs::ContainsNull { name: self.name },
             }));
         }
 
@@ -251,10 +431,100 @@ impl TableFunctionImpl for GenerateSeriesFuncImpl {
 
         Ok(Arc::new(GenerateSeriesTable {
             schema,
-            args: GenSeriesArgs::AllNotNullArgs {
+            args: GenSeriesArgs::Int64Args {
                 start,
                 end,
                 step,
+                include_end: self.include_end,
+                name: self.name,
+            },
+        }))
+    }
+
+    fn call_timestamp(&self, exprs: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+        if exprs.len() != 3 {
+            return plan_err!(
+                "{} function with timestamps requires exactly 3 arguments",
+                self.name
+            );
+        }
+
+        // Parse start timestamp
+        let (start_ts, tz) = match &exprs[0] {
+            Expr::Literal(ScalarValue::TimestampNanosecond(ts, tz), _) => {
+                (*ts, tz.clone())
+            }
+            other => {
+                return plan_err!(
+                    "First argument must be a timestamp or NULL, got {:?}",
+                    other
+                )
+            }
+        };
+
+        // Parse end timestamp
+        let end_ts = match &exprs[1] {
+            Expr::Literal(ScalarValue::Null, _) => None,
+            Expr::Literal(ScalarValue::TimestampNanosecond(ts, _), _) => *ts,
+            other => {
+                return plan_err!(
+                    "Second argument must be a timestamp or NULL, got {:?}",
+                    other
+                )
+            }
+        };
+
+        // Parse step interval
+        let step_interval = match &exprs[2] {
+            Expr::Literal(ScalarValue::Null, _) => None,
+            Expr::Literal(ScalarValue::IntervalMonthDayNano(interval), _) => *interval,
+            other => {
+                return plan_err!(
+                    "Third argument must be an interval or NULL, got {:?}",
+                    other
+                )
+            }
+        };
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Timestamp(TimeUnit::Nanosecond, tz.clone()),
+            false,
+        )]));
+
+        // Check if any argument is null
+        let (Some(start), Some(end), Some(step)) = (start_ts, end_ts, step_interval)
+        else {
+            return Ok(Arc::new(GenerateSeriesTable {
+                schema,
+                args: GenSeriesArgs::ContainsNull { name: self.name },
+            }));
+        };
+
+        // Basic validation
+        if step.months == 0 && step.days == 0 && step.nanoseconds == 0 {
+            return plan_err!("Step interval cannot be zero");
+        }
+
+        // Check for infinite series conditions with timestamps
+        let step_is_positive = step.months > 0 || step.days > 0 || step.nanoseconds > 0;
+        let step_is_negative = step.months < 0 || step.days < 0 || step.nanoseconds < 0;
+
+        if start > end && step_is_positive {
+            return plan_err!("Start is bigger than end, but increment is positive: Cannot generate infinite series");
+        }
+
+        if start < end && step_is_negative {
+            return plan_err!("Start is smaller than end, but increment is negative: Cannot generate infinite series");
+        }
+
+        Ok(Arc::new(GenerateSeriesTable {
+            schema,
+            args: GenSeriesArgs::TimestampArgs {
+                start,
+                end,
+                step,
+                tz,
                 include_end: self.include_end,
                 name: self.name,
             },

--- a/datafusion/sqllogictest/test_files/table_functions.slt
+++ b/datafusion/sqllogictest/test_files/table_functions.slt
@@ -177,7 +177,7 @@ statement error DataFusion error: Error during planning: generate_series functio
 SELECT * FROM generate_series(1, 2, 3, 4)
 
 
-statement error DataFusion error: Error during planning: Argument #1 must be an INTEGER or NULL, got Literal\(Utf8\("foo"\), None\)
+statement error DataFusion error: Error during planning: Argument \#1 must be an INTEGER, TIMESTAMP or NULL, got Utf8
 SELECT * FROM generate_series('foo', 'bar')
 
 # UDF and UDTF `generate_series` can be used simultaneously
@@ -300,7 +300,7 @@ statement error DataFusion error: Error during planning: range function requires
 SELECT * FROM range(1, 2, 3, 4)
 
 
-statement error DataFusion error: Error during planning: Argument #1 must be an INTEGER or NULL, got Literal\(Utf8\("foo"\), None\)
+statement error DataFusion error: Error during planning: Argument \#1 must be an INTEGER, TIMESTAMP or NULL, got Utf8
 SELECT * FROM range('foo', 'bar')
 
 statement error DataFusion error: Error during planning: Argument #2 must be an INTEGER or NULL, got Literal\(Utf8\("bar"\), None\)
@@ -312,3 +312,85 @@ SELECT range(1, t1.end) FROM range(3, 5) as t1(end)
 ----
 [1, 2, 3]
 [1, 2]
+
+#
+# Test timestamp ranges
+#
+
+# Basic timestamp range with 1 day interval
+query P rowsort
+SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-01-04T00:00:00', INTERVAL '1' DAY)
+----
+2023-01-01T00:00:00
+2023-01-02T00:00:00
+2023-01-03T00:00:00
+
+# Timestamp range with hour interval
+query P rowsort
+SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-01-01T03:00:00', INTERVAL '1' HOUR)
+----
+2023-01-01T00:00:00
+2023-01-01T01:00:00
+2023-01-01T02:00:00
+
+# Timestamp range with month interval
+query P rowsort
+SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-04-01T00:00:00', INTERVAL '1' MONTH)
+----
+2023-01-01T00:00:00
+2023-02-01T00:00:00
+2023-03-01T00:00:00
+
+# Timestamp generate_series (includes end)
+query P rowsort
+SELECT * FROM generate_series(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-01-03T00:00:00', INTERVAL '1' DAY)
+----
+2023-01-01T00:00:00
+2023-01-02T00:00:00
+2023-01-03T00:00:00
+
+# Timestamp range with timezone
+query P
+SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00+00:00', TIMESTAMP '2023-01-03T00:00:00+00:00', INTERVAL '1' DAY)
+----
+2023-01-01T00:00:00
+2023-01-02T00:00:00
+
+# Negative timestamp range (going backwards)
+query P
+SELECT * FROM range(TIMESTAMP '2023-01-03T00:00:00', TIMESTAMP '2023-01-01T00:00:00', INTERVAL '-1' DAY)
+----
+2023-01-03T00:00:00
+2023-01-02T00:00:00
+
+query error DataFusion error: Error during planning: Start is bigger than end, but increment is positive: Cannot generate infinite series
+SELECT * FROM range(TIMESTAMP '2023-01-03T00:00:00', TIMESTAMP '2023-01-01T00:00:00', INTERVAL '1' DAY)
+
+query error DataFusion error: Error during planning: Start is smaller than end, but increment is negative: Cannot generate infinite series
+SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-01-02T00:00:00', INTERVAL '-1' DAY)
+
+query error DataFusion error: Error during planning: range function with timestamps requires exactly 3 arguments
+SELECT * FROM range(TIMESTAMP '2023-01-03T00:00:00', TIMESTAMP '2023-01-01T00:00:00')
+
+# Single timestamp (start == end)
+query P
+SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-01-01T00:00:00', INTERVAL '1' DAY)  
+----
+
+# Timestamp range with NULL values
+query P
+SELECT * FROM range(NULL::TIMESTAMP, TIMESTAMP '2023-01-03T00:00:00', INTERVAL '1' DAY)
+----
+
+query P
+SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', NULL::TIMESTAMP, INTERVAL '1' DAY)
+----
+
+# No interval gives no rows
+query P
+SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-01-03T00:00:00', NULL::INTERVAL)
+----
+
+# Zero-length interval gives error
+query error DataFusion error: Error during planning: Step interval cannot be zero
+SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-01-03T00:00:00', INTERVAL '0' DAY)

--- a/datafusion/sqllogictest/test_files/table_functions.slt
+++ b/datafusion/sqllogictest/test_files/table_functions.slt
@@ -394,3 +394,9 @@ SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-01-03T00:00
 # Zero-length interval gives error
 query error DataFusion error: Error during planning: Step interval cannot be zero
 SELECT * FROM range(TIMESTAMP '2023-01-01T00:00:00', TIMESTAMP '2023-01-03T00:00:00', INTERVAL '0' DAY)
+
+# Timezone-aware
+query P
+SELECT * FROM range(TIMESTAMPTZ '2023-02-01T00:00:00-07:00', TIMESTAMPTZ '2023-02-01T09:00:00+01:00', INTERVAL '1' HOUR);
+----
+2023-02-01T07:00:00Z

--- a/datafusion/sqllogictest/test_files/table_functions.slt
+++ b/datafusion/sqllogictest/test_files/table_functions.slt
@@ -177,7 +177,7 @@ statement error DataFusion error: Error during planning: generate_series functio
 SELECT * FROM generate_series(1, 2, 3, 4)
 
 
-statement error DataFusion error: Error during planning: Argument \#1 must be an INTEGER, TIMESTAMP or NULL, got Utf8
+statement error DataFusion error: Error during planning: Argument \#1 must be an INTEGER, TIMESTAMP, DATE or NULL, got Utf8
 SELECT * FROM generate_series('foo', 'bar')
 
 # UDF and UDTF `generate_series` can be used simultaneously
@@ -300,7 +300,7 @@ statement error DataFusion error: Error during planning: range function requires
 SELECT * FROM range(1, 2, 3, 4)
 
 
-statement error DataFusion error: Error during planning: Argument \#1 must be an INTEGER, TIMESTAMP or NULL, got Utf8
+statement error DataFusion error: Error during planning: Argument \#1 must be an INTEGER, TIMESTAMP, DATE or NULL, got Utf8
 SELECT * FROM range('foo', 'bar')
 
 statement error DataFusion error: Error during planning: Argument #2 must be an INTEGER or NULL, got Literal\(Utf8\("bar"\), None\)
@@ -400,3 +400,73 @@ query P
 SELECT * FROM range(TIMESTAMPTZ '2023-02-01T00:00:00-07:00', TIMESTAMPTZ '2023-02-01T09:00:00+01:00', INTERVAL '1' HOUR);
 ----
 2023-02-01T07:00:00Z
+
+# Basic date range with hour interval
+query P
+SELECT * FROM range(DATE '1992-01-01', DATE '1992-01-03', INTERVAL '6' HOUR);
+----
+1992-01-01T00:00:00
+1992-01-01T06:00:00
+1992-01-01T12:00:00
+1992-01-01T18:00:00
+1992-01-02T00:00:00
+1992-01-02T06:00:00
+1992-01-02T12:00:00
+1992-01-02T18:00:00
+
+# Date range with day interval
+query P
+SELECT * FROM range(DATE '1992-09-01', DATE '1992-09-05', INTERVAL '1' DAY);
+----
+1992-09-01T00:00:00
+1992-09-02T00:00:00
+1992-09-03T00:00:00
+1992-09-04T00:00:00
+
+# Date range with month interval
+query P
+SELECT * FROM range(DATE '1992-09-01', DATE '1993-01-01', INTERVAL '1' MONTH);
+----
+1992-09-01T00:00:00
+1992-10-01T00:00:00
+1992-11-01T00:00:00
+1992-12-01T00:00:00
+
+# Date range generate_series includes end
+query P
+SELECT * FROM generate_series(DATE '1992-09-01', DATE '1992-09-03', INTERVAL '1' DAY);
+----
+1992-09-01T00:00:00
+1992-09-02T00:00:00
+1992-09-03T00:00:00
+
+# Backwards date range
+query P
+SELECT * FROM range(DATE '1992-09-05', DATE '1992-09-01', INTERVAL '-1' DAY);
+----
+1992-09-05T00:00:00
+1992-09-04T00:00:00
+1992-09-03T00:00:00
+1992-09-02T00:00:00
+
+# NULL handling for dates
+query P
+SELECT * FROM range(DATE '1992-09-01', NULL::DATE, INTERVAL '1' MONTH)
+----
+
+query P
+SELECT * FROM range(NULL::DATE, DATE '1992-09-01', INTERVAL '1' MONTH)
+----
+
+query P
+SELECT * FROM range(DATE '1992-09-01', DATE '1992-10-01', NULL::INTERVAL)
+----
+
+query error DataFusion error: Error during planning: Start is bigger than end, but increment is positive: Cannot generate infinite series
+SELECT * FROM range(DATE '2023-01-03', DATE '2023-01-01', INTERVAL '1' DAY)
+
+query error DataFusion error: Error during planning: Start is smaller than end, but increment is negative: Cannot generate infinite series
+SELECT * FROM range(DATE '2023-01-01', DATE '2023-01-02', INTERVAL '-1' DAY)
+
+query error DataFusion error: Error during planning: range function with dates requires exactly 3 arguments
+SELECT * FROM range(DATE '2023-01-01', DATE '2023-01-03')

--- a/datafusion/sqllogictest/test_files/table_functions.slt
+++ b/datafusion/sqllogictest/test_files/table_functions.slt
@@ -440,6 +440,12 @@ SELECT * FROM generate_series(DATE '1992-09-01', DATE '1992-09-03', INTERVAL '1'
 1992-09-02T00:00:00
 1992-09-03T00:00:00
 
+query TT
+EXPLAIN SELECT * FROM generate_series(DATE '1992-09-01', DATE '1992-09-03', INTERVAL '1' DAY);
+----
+logical_plan TableScan: generate_series() projection=[value]
+physical_plan LazyMemoryExec: partitions=1, batch_generators=[generate_series: start=715305600000000000, end=715478400000000000, batch_size=8192]
+
 # Backwards date range
 query P
 SELECT * FROM range(DATE '1992-09-05', DATE '1992-09-01', INTERVAL '-1' DAY);
@@ -453,6 +459,12 @@ SELECT * FROM range(DATE '1992-09-05', DATE '1992-09-01', INTERVAL '-1' DAY);
 query P
 SELECT * FROM range(DATE '1992-09-01', NULL::DATE, INTERVAL '1' MONTH)
 ----
+
+query TT
+EXPLAIN SELECT * FROM range(DATE '1992-09-01', NULL::DATE, INTERVAL '1' MONTH)
+----
+logical_plan TableScan: range() projection=[value]
+physical_plan LazyMemoryExec: partitions=1, batch_generators=[range: empty]
 
 query P
 SELECT * FROM range(NULL::DATE, DATE '1992-09-01', INTERVAL '1' MONTH)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/14209

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The table functions `range` and `generate_series` now matches the functionality of the scalar functions of the same name.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Introduce `SeriesValue` which abstracts how different value-types are generated
- Implement `SeriesValue` for integers and timestamps. The timestamp logic is also used for date generation

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, added more slt tests.

## Are there any user-facing changes?

Yes, `range` and `generate_series` table functions are now more powerful.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
