### PR TITLE
Minor: add clearer link to the main website from intro paragraph.

### DIFF
--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -39,7 +39,8 @@
 //! [DataFusion] is an extensible query engine written in Rust that
 //! uses [Apache Arrow] as its in-memory format. DataFusion's target users are
 //! developers building fast and feature rich database and analytic systems,
-//! customized to particular workloads. See [use cases] for examples.
+//! customized to particular workloads. Please see the [DataFusion website] for
+//! additional documentation, [use cases] and examples.
 //!
 //! "Out of the box," DataFusion offers [SQL] and [`Dataframe`] APIs,
 //! excellent [performance], built-in support for CSV, Parquet, JSON, and Avro,
@@ -53,6 +54,7 @@
 //! See the [Architecture] section below for more details.
 //!
 //! [DataFusion]: https://datafusion.apache.org/
+//! [DataFusion website]: https://datafusion.apache.org
 //! [Apache Arrow]: https://arrow.apache.org
 //! [use cases]: https://datafusion.apache.org/user-guide/introduction.html#use-cases
 //! [SQL]: https://datafusion.apache.org/user-guide/sql/index.html


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- part of #7013 

## Rationale for this change

@crepererum  mentioned to me that it was somewhat non obvious that DataFusion has two main sources of documentation. The API docs and the website. Let's try and make that a little clearer from the api docs

## What changes are included in this PR?

Update the intro paragraph of the library docs to make the link to the website clearer

## Are these changes tested?

by CI and I rendered them locally:
![Screenshot 2025-06-25 at 4 30 25 PM](https://github.com/user-attachments/assets/36bfa0a3-9239-4796-8916-3afe38d35cc9)




## Are there any user-facing changes?
Different landing text on docs.rs page