### PR TITLE
Expose execution time zone to UDFs 

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -364,7 +364,7 @@ config_namespace! {
         ///
         /// Some functions, e.g. `EXTRACT(HOUR from SOME_TIME)`, shift the underlying datetime
         /// according to this time zone, and then extract the hour
-        pub time_zone: Option<String>, default = Some("+00:00".into())
+        pub time_zone: String, default = "+00:00".into()
 
         /// Parquet options
         pub parquet: ParquetOptions, default = Default::default()

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -1640,7 +1640,10 @@ impl SessionContext {
     /// [`ConfigOptions`]: crate::config::ConfigOptions
     pub fn state(&self) -> SessionState {
         let mut state = self.state.read().clone();
-        state.execution_props_mut().start_execution();
+        let execution_time_zone = state.config().options().execution.time_zone.clone();
+        state
+            .execution_props_mut()
+            .start_execution(execution_time_zone);
         state
     }
 

--- a/datafusion/core/tests/expr_api/simplification.rs
+++ b/datafusion/core/tests/expr_api/simplification.rs
@@ -133,7 +133,7 @@ fn test_evaluate_with_start_time(
     date_time: &DateTime<Utc>,
 ) {
     let execution_props =
-        ExecutionProps::new().with_query_execution_start_time(*date_time);
+        ExecutionProps::new().with_query_execution_start_time(*date_time, "UTC".into());
 
     let info: MyInfo = MyInfo {
         schema: schema(),

--- a/datafusion/core/tests/fuzz_cases/equivalence/ordering.rs
+++ b/datafusion/core/tests/fuzz_cases/equivalence/ordering.rs
@@ -110,6 +110,7 @@ fn test_ordering_satisfy_with_equivalence_complex_random() -> Result<()> {
             Arc::clone(&test_fun),
             vec![col_a],
             &test_schema,
+            "UTC".to_string(),
         )?);
         let a_plus_b = Arc::new(BinaryExpr::new(
             col("a", &test_schema)?,

--- a/datafusion/core/tests/fuzz_cases/equivalence/projection.rs
+++ b/datafusion/core/tests/fuzz_cases/equivalence/projection.rs
@@ -49,6 +49,7 @@ fn project_orderings_random() -> Result<()> {
             Arc::clone(&test_fun),
             vec![col_a],
             &test_schema,
+            "UTC".to_string(),
         )?);
         // a + b
         let a_plus_b = Arc::new(BinaryExpr::new(
@@ -122,6 +123,7 @@ fn ordering_satisfy_after_projection_random() -> Result<()> {
             Arc::clone(&test_fun),
             vec![col_a],
             &test_schema,
+            "UTC".to_string(),
         )?) as PhysicalExprRef;
         // a + b
         let a_plus_b = Arc::new(BinaryExpr::new(

--- a/datafusion/core/tests/fuzz_cases/equivalence/properties.rs
+++ b/datafusion/core/tests/fuzz_cases/equivalence/properties.rs
@@ -49,6 +49,7 @@ fn test_find_longest_permutation_random() -> Result<()> {
             Arc::clone(&test_fun),
             vec![col_a],
             &test_schema,
+            "UTC".to_string(),
         )?) as _;
 
         let a_plus_b = Arc::new(BinaryExpr::new(

--- a/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
@@ -127,6 +127,7 @@ fn test_update_matching_exprs() -> Result<()> {
                 )),
             ],
             Field::new("f", DataType::Int32, true).into(),
+            "UTC".to_string(),
         )),
         Arc::new(CaseExpr::try_new(
             Some(Arc::new(Column::new("d", 2))),
@@ -192,6 +193,7 @@ fn test_update_matching_exprs() -> Result<()> {
                 )),
             ],
             Field::new("f", DataType::Int32, true).into(),
+            "UTC".to_string(),
         )),
         Arc::new(CaseExpr::try_new(
             Some(Arc::new(Column::new("d", 3))),
@@ -260,6 +262,7 @@ fn test_update_projected_exprs() -> Result<()> {
                 )),
             ],
             Field::new("f", DataType::Int32, true).into(),
+            "UTC".to_string(),
         )),
         Arc::new(CaseExpr::try_new(
             Some(Arc::new(Column::new("d", 2))),
@@ -325,6 +328,7 @@ fn test_update_projected_exprs() -> Result<()> {
                 )),
             ],
             Field::new("f", DataType::Int32, true).into(),
+            "UTC".to_string(),
         )),
         Arc::new(CaseExpr::try_new(
             Some(Arc::new(Column::new("d_new", 3))),

--- a/datafusion/expr/src/execution_props.rs
+++ b/datafusion/expr/src/execution_props.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub struct ExecutionProps {
     pub query_execution_start_time: DateTime<Utc>,
+    pub query_execution_time_zone: String,
     /// Alias generator used by subquery optimizer rules
     pub alias_generator: Arc<AliasGenerator>,
     /// Providers for scalar variables
@@ -52,6 +53,9 @@ impl ExecutionProps {
             // Set this to a fixed sentinel to make it obvious if this is
             // not being updated / propagated correctly
             query_execution_start_time: Utc.timestamp_nanos(0),
+            // Set this to a fixed sentinel to make it obvious if this is
+            // not being updated / propagated correctly
+            query_execution_time_zone: "unknown".to_string(),
             alias_generator: Arc::new(AliasGenerator::new()),
             var_providers: None,
         }
@@ -61,15 +65,18 @@ impl ExecutionProps {
     pub fn with_query_execution_start_time(
         mut self,
         query_execution_start_time: DateTime<Utc>,
+        query_execution_time_zone: String,
     ) -> Self {
         self.query_execution_start_time = query_execution_start_time;
+        self.query_execution_time_zone = query_execution_time_zone;
         self
     }
 
     /// Marks the execution of query started timestamp.
     /// This also instantiates a new alias generator.
-    pub fn start_execution(&mut self) -> &Self {
+    pub fn start_execution(&mut self, query_execution_time_zone: String) -> &Self {
         self.query_execution_start_time = Utc::now();
+        self.query_execution_time_zone = query_execution_time_zone;
         self.alias_generator = Arc::new(AliasGenerator::new());
         &*self
     }

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -311,6 +311,8 @@ pub struct ScalarFunctionArgs {
     /// or `return_field_from_args`) when creating the physical expression
     /// from the logical expression
     pub return_field: FieldRef,
+    /// The configured execution time zone (a.k.a. session time zone)
+    pub execution_time_zone: String,
 }
 
 impl ScalarFunctionArgs {

--- a/datafusion/ffi/src/udf/mod.rs
+++ b/datafusion/ffi/src/udf/mod.rs
@@ -206,6 +206,7 @@ unsafe extern "C" fn invoke_with_args_fn_wrapper(
         arg_fields,
         number_rows,
         return_field,
+        execution_time_zone: "unknown".to_string(),
     };
 
     let result = rresult_return!(udf
@@ -347,6 +348,7 @@ impl ScalarUDFImpl for ForeignScalarUDF {
             arg_fields,
             number_rows,
             return_field,
+            execution_time_zone: _,
         } = invoke_args;
 
         let args = args

--- a/datafusion/functions-nested/benches/map.rs
+++ b/datafusion/functions-nested/benches/map.rs
@@ -114,6 +114,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: 1,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("map should work on valid values"),
             );

--- a/datafusion/functions/benches/ascii.rs
+++ b/datafusion/functions/benches/ascii.rs
@@ -56,6 +56,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: N_ROWS,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -76,6 +77,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: N_ROWS,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -102,6 +104,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: N_ROWS,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -122,6 +125,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: N_ROWS,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },

--- a/datafusion/functions/benches/character_length.rs
+++ b/datafusion/functions/benches/character_length.rs
@@ -51,6 +51,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: n_rows,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -74,6 +75,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: n_rows,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -97,6 +99,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: n_rows,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -120,6 +123,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: n_rows,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },

--- a/datafusion/functions/benches/chr.rs
+++ b/datafusion/functions/benches/chr.rs
@@ -65,6 +65,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: size,
                         return_field: Field::new("f", DataType::Utf8, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .unwrap(),
             )

--- a/datafusion/functions/benches/concat.rs
+++ b/datafusion/functions/benches/concat.rs
@@ -56,6 +56,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Field::new("f", DataType::Utf8, true).into(),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )

--- a/datafusion/functions/benches/cot.rs
+++ b/datafusion/functions/benches/cot.rs
@@ -50,6 +50,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Field::new("f", DataType::Float32, true).into(),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )
@@ -75,6 +76,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )

--- a/datafusion/functions/benches/date_bin.rs
+++ b/datafusion/functions/benches/date_bin.rs
@@ -62,6 +62,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: batch_len,
                     return_field: Arc::clone(&return_field),
+                    execution_time_zone: "UTC".to_string(),
                 })
                 .expect("date_bin should work on valid values"),
             )

--- a/datafusion/functions/benches/date_trunc.rs
+++ b/datafusion/functions/benches/date_trunc.rs
@@ -67,6 +67,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: batch_len,
                     return_field: Arc::clone(&return_field),
+                    execution_time_zone: "UTC".to_string(),
                 })
                 .expect("date_trunc should work on valid values"),
             )

--- a/datafusion/functions/benches/encoding.rs
+++ b/datafusion/functions/benches/encoding.rs
@@ -40,6 +40,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     ],
                     number_rows: size,
                     return_field: Field::new("f", DataType::Utf8, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 })
                 .unwrap();
 
@@ -57,6 +58,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Field::new("f", DataType::Utf8, true).into(),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )
@@ -75,6 +77,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields,
                     number_rows: size,
                     return_field: Field::new("f", DataType::Utf8, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 })
                 .unwrap();
 
@@ -93,6 +96,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )

--- a/datafusion/functions/benches/find_in_set.rs
+++ b/datafusion/functions/benches/find_in_set.rs
@@ -165,6 +165,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: n_rows,
                     return_field: Arc::clone(&return_field),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         });
@@ -182,6 +183,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: n_rows,
                     return_field: Arc::clone(&return_field),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         });
@@ -203,6 +205,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: n_rows,
                     return_field: Arc::clone(&return_field),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         });
@@ -220,6 +223,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: n_rows,
                     return_field: Arc::clone(&return_field),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         });

--- a/datafusion/functions/benches/gcd.rs
+++ b/datafusion/functions/benches/gcd.rs
@@ -54,6 +54,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     ],
                     number_rows: 0,
                     return_field: Field::new("f", DataType::Int64, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 })
                 .expect("date_bin should work on valid values"),
             )
@@ -74,6 +75,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     ],
                     number_rows: 0,
                     return_field: Field::new("f", DataType::Int64, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 })
                 .expect("date_bin should work on valid values"),
             )
@@ -94,6 +96,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     ],
                     number_rows: 0,
                     return_field: Field::new("f", DataType::Int64, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 })
                 .expect("date_bin should work on valid values"),
             )

--- a/datafusion/functions/benches/initcap.rs
+++ b/datafusion/functions/benches/initcap.rs
@@ -66,6 +66,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: size,
                         return_field: Field::new("f", DataType::Utf8View, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -81,6 +82,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: size,
                         return_field: Field::new("f", DataType::Utf8View, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -94,6 +96,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: size,
                     return_field: Field::new("f", DataType::Utf8, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         });

--- a/datafusion/functions/benches/isnan.rs
+++ b/datafusion/functions/benches/isnan.rs
@@ -49,6 +49,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Field::new("f", DataType::Boolean, true).into(),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )
@@ -72,6 +73,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Field::new("f", DataType::Boolean, true).into(),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )

--- a/datafusion/functions/benches/iszero.rs
+++ b/datafusion/functions/benches/iszero.rs
@@ -51,6 +51,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: batch_len,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )
@@ -77,6 +78,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: batch_len,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )

--- a/datafusion/functions/benches/lower.rs
+++ b/datafusion/functions/benches/lower.rs
@@ -140,6 +140,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: size,
                     return_field: Field::new("f", DataType::Utf8, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         });
@@ -161,6 +162,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: size,
                     return_field: Field::new("f", DataType::Utf8, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         });
@@ -184,6 +186,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: size,
                         return_field: Field::new("f", DataType::Utf8, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -217,6 +220,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                                 arg_fields: arg_fields.clone(),
                                 number_rows: size,
                                 return_field: Field::new("f", DataType::Utf8, true).into(),
+                                execution_time_zone: "UTC".to_string(),
                             }))
                         }),
                     );
@@ -231,6 +235,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                                 arg_fields: arg_fields.clone(),
                                 number_rows: size,
                                 return_field: Field::new("f", DataType::Utf8, true).into(),
+                                execution_time_zone: "UTC".to_string(),
                             }))
                         }),
                     );
@@ -246,6 +251,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                                 arg_fields: arg_fields.clone(),
                                 number_rows: size,
                                 return_field: Field::new("f", DataType::Utf8, true).into(),
+                                execution_time_zone: "UTC".to_string(),
                             }))
                         }),
                     );

--- a/datafusion/functions/benches/ltrim.rs
+++ b/datafusion/functions/benches/ltrim.rs
@@ -149,6 +149,7 @@ fn run_with_string_type<M: Measurement>(
                     arg_fields: arg_fields.clone(),
                     number_rows: size,
                     return_field: Field::new("f", DataType::Utf8, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         },

--- a/datafusion/functions/benches/make_date.rs
+++ b/datafusion/functions/benches/make_date.rs
@@ -78,6 +78,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("make_date should work on valid values"),
             )
@@ -105,6 +106,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("make_date should work on valid values"),
             )
@@ -132,6 +134,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("make_date should work on valid values"),
             )
@@ -157,6 +160,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: 1,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("make_date should work on valid values"),
             )

--- a/datafusion/functions/benches/nullif.rs
+++ b/datafusion/functions/benches/nullif.rs
@@ -50,6 +50,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Field::new("f", DataType::Utf8, true).into(),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )

--- a/datafusion/functions/benches/pad.rs
+++ b/datafusion/functions/benches/pad.rs
@@ -112,6 +112,7 @@ fn invoke_pad_with_args(
         arg_fields,
         number_rows,
         return_field: Field::new("f", DataType::Utf8, true).into(),
+        execution_time_zone: "UTC".to_string(),
     };
 
     if left_pad {

--- a/datafusion/functions/benches/random.rs
+++ b/datafusion/functions/benches/random.rs
@@ -39,6 +39,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: vec![],
                             number_rows: 8192,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 );
@@ -59,6 +60,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: vec![],
                             number_rows: 128,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 );

--- a/datafusion/functions/benches/repeat.rs
+++ b/datafusion/functions/benches/repeat.rs
@@ -72,6 +72,7 @@ fn invoke_repeat_with_args(
         arg_fields,
         number_rows: repeat_times as usize,
         return_field: Field::new("f", DataType::Utf8, true).into(),
+        execution_time_zone: "UTC".to_string(),
     })
 }
 

--- a/datafusion/functions/benches/reverse.rs
+++ b/datafusion/functions/benches/reverse.rs
@@ -53,6 +53,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         ).into()],
                         number_rows: N_ROWS,
                         return_field: Field::new("f", DataType::Utf8, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -74,6 +75,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         ],
                         number_rows: N_ROWS,
                         return_field: Field::new("f", DataType::Utf8, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -100,6 +102,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         ).into()],
                         number_rows: N_ROWS,
                         return_field: Field::new("f", DataType::Utf8, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -122,7 +125,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             true,
                         ).into()],
                         number_rows: N_ROWS,
-                        return_field: Field::new("f", DataType::Utf8, true).into(),
+                        return_field: Field::new("f", DataType::Utf8, true).into(),execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },

--- a/datafusion/functions/benches/signum.rs
+++ b/datafusion/functions/benches/signum.rs
@@ -51,6 +51,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: batch_len,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )
@@ -78,6 +79,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: batch_len,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )

--- a/datafusion/functions/benches/strpos.rs
+++ b/datafusion/functions/benches/strpos.rs
@@ -123,6 +123,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: n_rows,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -140,6 +141,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: arg_fields.clone(),
                     number_rows: n_rows,
                     return_field: Arc::clone(&return_field),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         });
@@ -158,6 +160,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: n_rows,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },
@@ -177,6 +180,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: n_rows,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     }))
                 })
             },

--- a/datafusion/functions/benches/substr.rs
+++ b/datafusion/functions/benches/substr.rs
@@ -112,6 +112,7 @@ fn invoke_substr_with_args(
         arg_fields,
         number_rows,
         return_field: Field::new("f", DataType::Utf8View, true).into(),
+        execution_time_zone: "UTC".to_string(),
     })
 }
 

--- a/datafusion/functions/benches/substr_index.rs
+++ b/datafusion/functions/benches/substr_index.rs
@@ -107,6 +107,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Field::new("f", DataType::Utf8, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("substr_index should work on valid values"),
             )

--- a/datafusion/functions/benches/to_char.rs
+++ b/datafusion/functions/benches/to_char.rs
@@ -99,6 +99,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         ],
                         number_rows: batch_len,
                         return_field: Field::new("f", DataType::Utf8, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("to_char should work on valid values"),
             )
@@ -124,6 +125,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         ],
                         number_rows: batch_len,
                         return_field: Field::new("f", DataType::Utf8, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("to_char should work on valid values"),
             )
@@ -155,6 +157,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         ],
                         number_rows: 1,
                         return_field: Field::new("f", DataType::Utf8, true).into(),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("to_char should work on valid values"),
             )

--- a/datafusion/functions/benches/to_hex.rs
+++ b/datafusion/functions/benches/to_hex.rs
@@ -39,6 +39,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: vec![Field::new("a", DataType::Int32, false).into()],
                     number_rows: batch_len,
                     return_field: Field::new("f", DataType::Utf8, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 })
                 .unwrap(),
             )
@@ -56,6 +57,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: vec![Field::new("a", DataType::Int64, false).into()],
                     number_rows: batch_len,
                     return_field: Field::new("f", DataType::Utf8, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 })
                 .unwrap(),
             )

--- a/datafusion/functions/benches/to_timestamp.rs
+++ b/datafusion/functions/benches/to_timestamp.rs
@@ -126,6 +126,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("to_timestamp should work on valid values"),
             )
@@ -145,6 +146,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("to_timestamp should work on valid values"),
             )
@@ -164,6 +166,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("to_timestamp should work on valid values"),
             )
@@ -196,6 +199,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("to_timestamp should work on valid values"),
             )
@@ -236,6 +240,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("to_timestamp should work on valid values"),
             )
@@ -277,6 +282,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         arg_fields: arg_fields.clone(),
                         number_rows: batch_len,
                         return_field: Arc::clone(&return_field),
+                        execution_time_zone: "UTC".to_string(),
                     })
                     .expect("to_timestamp should work on valid values"),
             )

--- a/datafusion/functions/benches/trunc.rs
+++ b/datafusion/functions/benches/trunc.rs
@@ -44,6 +44,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )
@@ -62,6 +63,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             arg_fields: arg_fields.clone(),
                             number_rows: size,
                             return_field: Arc::clone(&return_field),
+                            execution_time_zone: "UTC".to_string(),
                         })
                         .unwrap(),
                 )

--- a/datafusion/functions/benches/upper.rs
+++ b/datafusion/functions/benches/upper.rs
@@ -45,6 +45,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     arg_fields: vec![Field::new("a", DataType::Utf8, true).into()],
                     number_rows: size,
                     return_field: Field::new("f", DataType::Utf8, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 }))
             })
         });

--- a/datafusion/functions/benches/uuid.rs
+++ b/datafusion/functions/benches/uuid.rs
@@ -31,6 +31,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 arg_fields: vec![],
                 number_rows: 1024,
                 return_field: Field::new("f", DataType::Utf8, true).into(),
+                execution_time_zone: "UTC".to_string(),
             }))
         })
     });

--- a/datafusion/functions/src/core/union_extract.rs
+++ b/datafusion/functions/src/core/union_extract.rs
@@ -207,6 +207,7 @@ mod tests {
             arg_fields,
             number_rows: 1,
             return_field: Field::new("f", DataType::Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         })?;
 
         assert_scalar(result, ScalarValue::Utf8(None));
@@ -229,6 +230,7 @@ mod tests {
             arg_fields,
             number_rows: 1,
             return_field: Field::new("f", DataType::Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         })?;
 
         assert_scalar(result, ScalarValue::Utf8(None));
@@ -250,6 +252,7 @@ mod tests {
             arg_fields,
             number_rows: 1,
             return_field: Field::new("f", DataType::Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         })?;
 
         assert_scalar(result, ScalarValue::new_utf8("42"));

--- a/datafusion/functions/src/core/union_tag.rs
+++ b/datafusion/functions/src/core/union_tag.rs
@@ -180,8 +180,9 @@ mod tests {
             .invoke_with_args(ScalarFunctionArgs {
                 args: vec![ColumnarValue::Scalar(scalar)],
                 number_rows: 1,
-                return_field: Field::new("res", return_type, true).into(),
                 arg_fields: vec![],
+                return_field: Field::new("res", return_type, true).into(),
+                execution_time_zone: "UTC".to_string(),
             })
             .unwrap();
 
@@ -202,8 +203,9 @@ mod tests {
             .invoke_with_args(ScalarFunctionArgs {
                 args: vec![ColumnarValue::Scalar(scalar)],
                 number_rows: 1,
-                return_field: Field::new("res", return_type, true).into(),
                 arg_fields: vec![],
+                return_field: Field::new("res", return_type, true).into(),
+                execution_time_zone: "UTC".to_string(),
             })
             .unwrap();
 

--- a/datafusion/functions/src/core/version.rs
+++ b/datafusion/functions/src/core/version.rs
@@ -109,6 +109,7 @@ mod test {
                 arg_fields: vec![],
                 number_rows: 0,
                 return_field: Field::new("f", DataType::Utf8, true).into(),
+                execution_time_zone: "UTC".to_string(),
             })
             .unwrap();
 

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -528,6 +528,7 @@ mod tests {
             arg_fields,
             number_rows,
             return_field: Arc::clone(return_field),
+            execution_time_zone: "UTC".to_string(),
         };
         DateBinFunc::new().invoke_with_args(args)
     }

--- a/datafusion/functions/src/datetime/date_trunc.rs
+++ b/datafusion/functions/src/datetime/date_trunc.rs
@@ -743,6 +743,7 @@ mod tests {
                     true,
                 )
                 .into(),
+                execution_time_zone: "UTC".to_string(),
             };
             let result = DateTruncFunc::new().invoke_with_args(args).unwrap();
             if let ColumnarValue::Array(result) = result {
@@ -915,6 +916,7 @@ mod tests {
                     true,
                 )
                 .into(),
+                execution_time_zone: "UTC".to_string(),
             };
             let result = DateTruncFunc::new().invoke_with_args(args).unwrap();
             if let ColumnarValue::Array(result) = result {

--- a/datafusion/functions/src/datetime/from_unixtime.rs
+++ b/datafusion/functions/src/datetime/from_unixtime.rs
@@ -177,6 +177,7 @@ mod test {
             arg_fields: vec![arg_field],
             number_rows: 1,
             return_field: Field::new("f", DataType::Timestamp(Second, None), true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = FromUnixtimeFunc::new().invoke_with_args(args).unwrap();
 
@@ -209,6 +210,7 @@ mod test {
                 true,
             )
             .into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = FromUnixtimeFunc::new().invoke_with_args(args).unwrap();
 

--- a/datafusion/functions/src/datetime/make_date.rs
+++ b/datafusion/functions/src/datetime/make_date.rs
@@ -241,6 +241,7 @@ mod tests {
             arg_fields,
             number_rows,
             return_field: Field::new("f", DataType::Date32, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         MakeDateFunc::new().invoke_with_args(args)
     }

--- a/datafusion/functions/src/datetime/to_char.rs
+++ b/datafusion/functions/src/datetime/to_char.rs
@@ -395,6 +395,7 @@ mod tests {
                 arg_fields,
                 number_rows: 1,
                 return_field: Field::new("f", DataType::Utf8, true).into(),
+                execution_time_zone: "UTC".to_string(),
             };
             let result = ToCharFunc::new()
                 .invoke_with_args(args)
@@ -483,6 +484,7 @@ mod tests {
                 arg_fields,
                 number_rows: batch_len,
                 return_field: Field::new("f", DataType::Utf8, true).into(),
+                execution_time_zone: "UTC".to_string(),
             };
             let result = ToCharFunc::new()
                 .invoke_with_args(args)
@@ -619,6 +621,7 @@ mod tests {
                 arg_fields,
                 number_rows: batch_len,
                 return_field: Field::new("f", DataType::Utf8, true).into(),
+                execution_time_zone: "UTC".to_string(),
             };
             let result = ToCharFunc::new()
                 .invoke_with_args(args)
@@ -646,6 +649,7 @@ mod tests {
                 arg_fields,
                 number_rows: batch_len,
                 return_field: Field::new("f", DataType::Utf8, true).into(),
+                execution_time_zone: "UTC".to_string(),
             };
             let result = ToCharFunc::new()
                 .invoke_with_args(args)
@@ -670,6 +674,7 @@ mod tests {
             arg_fields: vec![arg_field],
             number_rows: 1,
             return_field: Field::new("f", DataType::Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = ToCharFunc::new().invoke_with_args(args);
         assert_eq!(
@@ -690,6 +695,7 @@ mod tests {
             arg_fields,
             number_rows: 1,
             return_field: Field::new("f", DataType::Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = ToCharFunc::new().invoke_with_args(args);
         assert_eq!(

--- a/datafusion/functions/src/datetime/to_date.rs
+++ b/datafusion/functions/src/datetime/to_date.rs
@@ -185,6 +185,7 @@ mod tests {
             arg_fields,
             number_rows,
             return_field: Field::new("f", DataType::Date32, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         ToDateFunc::new().invoke_with_args(args)
     }

--- a/datafusion/functions/src/datetime/to_local_time.rs
+++ b/datafusion/functions/src/datetime/to_local_time.rs
@@ -545,6 +545,7 @@ mod tests {
                 arg_fields: vec![arg_field],
                 number_rows: 1,
                 return_field: Field::new("f", expected.data_type(), true).into(),
+                execution_time_zone: "UTC".to_string(),
             })
             .unwrap();
         match res {
@@ -615,6 +616,7 @@ mod tests {
                     true,
                 )
                 .into(),
+                execution_time_zone: "UTC".to_string(),
             };
             let result = ToLocalTimeFunc::new().invoke_with_args(args).unwrap();
             if let ColumnarValue::Array(result) = result {

--- a/datafusion/functions/src/datetime/to_timestamp.rs
+++ b/datafusion/functions/src/datetime/to_timestamp.rs
@@ -1019,6 +1019,7 @@ mod tests {
                     arg_fields: vec![arg_field],
                     number_rows: 4,
                     return_field: Field::new("f", rt, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 };
                 let res = udf
                     .invoke_with_args(args)
@@ -1068,6 +1069,7 @@ mod tests {
                     arg_fields: vec![arg_field],
                     number_rows: 5,
                     return_field: Field::new("f", rt, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 };
                 let res = udf
                     .invoke_with_args(args)

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -281,6 +281,7 @@ mod tests {
             arg_fields,
             number_rows: 4,
             return_field: Field::new("f", DataType::Float64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let _ = LogFunc::new().invoke_with_args(args);
     }
@@ -295,6 +296,7 @@ mod tests {
             arg_fields: vec![arg_field],
             number_rows: 1,
             return_field: Field::new("f", DataType::Float64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
 
         let result = LogFunc::new().invoke_with_args(args);
@@ -311,6 +313,7 @@ mod tests {
             arg_fields: vec![arg_field],
             number_rows: 1,
             return_field: Field::new("f", DataType::Float32, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = LogFunc::new()
             .invoke_with_args(args)
@@ -340,6 +343,7 @@ mod tests {
             arg_fields: vec![arg_field],
             number_rows: 1,
             return_field: Field::new("f", DataType::Float64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = LogFunc::new()
             .invoke_with_args(args)
@@ -373,6 +377,7 @@ mod tests {
             arg_fields,
             number_rows: 1,
             return_field: Field::new("f", DataType::Float32, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = LogFunc::new()
             .invoke_with_args(args)
@@ -406,6 +411,7 @@ mod tests {
             arg_fields,
             number_rows: 1,
             return_field: Field::new("f", DataType::Float64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = LogFunc::new()
             .invoke_with_args(args)
@@ -437,6 +443,7 @@ mod tests {
             arg_fields: vec![arg_field],
             number_rows: 4,
             return_field: Field::new("f", DataType::Float64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = LogFunc::new()
             .invoke_with_args(args)
@@ -471,6 +478,7 @@ mod tests {
             arg_fields: vec![arg_field],
             number_rows: 4,
             return_field: Field::new("f", DataType::Float32, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = LogFunc::new()
             .invoke_with_args(args)
@@ -511,6 +519,7 @@ mod tests {
             arg_fields,
             number_rows: 4,
             return_field: Field::new("f", DataType::Float64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = LogFunc::new()
             .invoke_with_args(args)
@@ -551,6 +560,7 @@ mod tests {
             arg_fields,
             number_rows: 4,
             return_field: Field::new("f", DataType::Float32, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = LogFunc::new()
             .invoke_with_args(args)

--- a/datafusion/functions/src/math/power.rs
+++ b/datafusion/functions/src/math/power.rs
@@ -213,6 +213,7 @@ mod tests {
             arg_fields,
             number_rows: 4,
             return_field: Field::new("f", DataType::Float64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = PowerFunc::new()
             .invoke_with_args(args)
@@ -248,6 +249,7 @@ mod tests {
             arg_fields,
             number_rows: 4,
             return_field: Field::new("f", DataType::Int64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = PowerFunc::new()
             .invoke_with_args(args)

--- a/datafusion/functions/src/math/signum.rs
+++ b/datafusion/functions/src/math/signum.rs
@@ -163,6 +163,7 @@ mod test {
             arg_fields,
             number_rows: array.len(),
             return_field: Field::new("f", DataType::Float32, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = SignumFunc::new()
             .invoke_with_args(args)
@@ -209,6 +210,7 @@ mod test {
             arg_fields,
             number_rows: array.len(),
             return_field: Field::new("f", DataType::Float64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
         let result = SignumFunc::new()
             .invoke_with_args(args)

--- a/datafusion/functions/src/regex/regexpcount.rs
+++ b/datafusion/functions/src/regex/regexpcount.rs
@@ -662,6 +662,7 @@ mod tests {
             arg_fields,
             number_rows: args.len(),
             return_field: Field::new("f", Int64, true).into(),
+            execution_time_zone: "UTC".to_string(),
         })
     }
 

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -485,6 +485,7 @@ mod tests {
             arg_fields,
             number_rows: 3,
             return_field: Field::new("f", Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
 
         let result = ConcatFunc::new().invoke_with_args(args)?;

--- a/datafusion/functions/src/string/concat_ws.rs
+++ b/datafusion/functions/src/string/concat_ws.rs
@@ -493,6 +493,7 @@ mod tests {
             arg_fields,
             number_rows: 3,
             return_field: Field::new("f", Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
 
         let result = ConcatWsFunc::new().invoke_with_args(args)?;
@@ -529,6 +530,7 @@ mod tests {
             arg_fields,
             number_rows: 3,
             return_field: Field::new("f", Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
 
         let result = ConcatWsFunc::new().invoke_with_args(args)?;

--- a/datafusion/functions/src/string/contains.rs
+++ b/datafusion/functions/src/string/contains.rs
@@ -175,6 +175,7 @@ mod test {
             arg_fields,
             number_rows: 2,
             return_field: Field::new("f", DataType::Boolean, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
 
         let actual = udf.invoke_with_args(args).unwrap();

--- a/datafusion/functions/src/string/lower.rs
+++ b/datafusion/functions/src/string/lower.rs
@@ -111,6 +111,7 @@ mod tests {
             args: vec![ColumnarValue::Array(input)],
             arg_fields,
             return_field: Field::new("f", Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
 
         let result = match func.invoke_with_args(args)? {

--- a/datafusion/functions/src/string/upper.rs
+++ b/datafusion/functions/src/string/upper.rs
@@ -110,6 +110,7 @@ mod tests {
             args: vec![ColumnarValue::Array(input)],
             arg_fields: vec![arg_field],
             return_field: Field::new("f", Utf8, true).into(),
+            execution_time_zone: "UTC".to_string(),
         };
 
         let result = match func.invoke_with_args(args)? {

--- a/datafusion/functions/src/unicode/find_in_set.rs
+++ b/datafusion/functions/src/unicode/find_in_set.rs
@@ -483,6 +483,7 @@ mod tests {
                     arg_fields,
                     number_rows: cardinality,
                     return_field: Field::new("f", return_type, true).into(),
+                    execution_time_zone: "UTC".to_string(),
                 });
                 assert!(result.is_ok());
 

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -174,7 +174,13 @@ pub mod test {
                     let return_type = return_field.data_type();
                     assert_eq!(return_type, &$EXPECTED_DATA_TYPE);
 
-                    let result = func.invoke_with_args(datafusion_expr::ScalarFunctionArgs{args: $ARGS, arg_fields, number_rows: cardinality, return_field});
+                    let result = func.invoke_with_args(datafusion_expr::ScalarFunctionArgs {
+                        args: $ARGS,
+                        arg_fields,
+                        number_rows: cardinality,
+                        return_field,
+                        execution_time_zone: "UTC".to_string(),
+                    });
                     assert_eq!(result.is_ok(), true, "function returned an error: {}", result.unwrap_err());
 
                     let result = result.unwrap().to_array(cardinality).expect("Failed to convert to array");
@@ -198,7 +204,14 @@ pub mod test {
                         let return_field = return_field.unwrap();
 
                         // invoke is expected error - cannot use .expect_err() due to Debug not being implemented
-                        match func.invoke_with_args(datafusion_expr::ScalarFunctionArgs{args: $ARGS, arg_fields, number_rows: cardinality, return_field}) {
+                        let result = func.invoke_with_args(datafusion_expr::ScalarFunctionArgs {
+                            args: $ARGS,
+                            arg_fields,
+                            number_rows: cardinality,
+                            return_field,
+                            execution_time_zone: "UTC".to_string(),
+                        });
+                        match result {
                             Ok(_) => assert!(false, "expected error"),
                             Err(error) => {
                                 assert!(expected_error.strip_backtrace().starts_with(&error.strip_backtrace()));

--- a/datafusion/physical-expr/src/async_scalar_function.rs
+++ b/datafusion/physical-expr/src/async_scalar_function.rs
@@ -39,6 +39,7 @@ pub struct AsyncFuncExpr {
     pub func: Arc<dyn PhysicalExpr>,
     /// The field that this function will return
     return_field: FieldRef,
+    execution_time_zone: String,
 }
 
 impl Display for AsyncFuncExpr {
@@ -66,6 +67,7 @@ impl AsyncFuncExpr {
         name: impl Into<String>,
         func: Arc<dyn PhysicalExpr>,
         schema: &Schema,
+        execution_time_zone: String,
     ) -> Result<Self> {
         let Some(_) = func.as_any().downcast_ref::<ScalarFunctionExpr>() else {
             return internal_err!(
@@ -79,6 +81,7 @@ impl AsyncFuncExpr {
             name: name.into(),
             func,
             return_field,
+            execution_time_zone,
         })
     }
 
@@ -168,6 +171,7 @@ impl AsyncFuncExpr {
                                 arg_fields: arg_fields.clone(),
                                 number_rows: current_batch.num_rows(),
                                 return_field: Arc::clone(&self.return_field),
+                                execution_time_zone: self.execution_time_zone.clone(),
                             },
                             option,
                         )
@@ -189,6 +193,7 @@ impl AsyncFuncExpr {
                             arg_fields,
                             number_rows: batch.num_rows(),
                             return_field: Arc::clone(&self.return_field),
+                            execution_time_zone: self.execution_time_zone.clone(),
                         },
                         option,
                     )
@@ -241,6 +246,7 @@ impl PhysicalExpr for AsyncFuncExpr {
             name: self.name.clone(),
             func: new_func,
             return_field: Arc::clone(&self.return_field),
+            execution_time_zone: self.execution_time_zone.clone(),
         }))
     }
 

--- a/datafusion/physical-expr/src/equivalence/ordering.rs
+++ b/datafusion/physical-expr/src/equivalence/ordering.rs
@@ -390,16 +390,19 @@ mod tests {
             Arc::clone(&test_fun),
             vec![Arc::clone(col_a)],
             &test_schema,
+            "UTC".to_string(),
         )?) as PhysicalExprRef;
         let floor_f = Arc::new(ScalarFunctionExpr::try_new(
             Arc::clone(&test_fun),
             vec![Arc::clone(col_f)],
             &test_schema,
+            "UTC".to_string(),
         )?) as PhysicalExprRef;
         let exp_a = Arc::new(ScalarFunctionExpr::try_new(
             Arc::clone(&test_fun),
             vec![Arc::clone(col_a)],
             &test_schema,
+            "UTC".to_string(),
         )?) as PhysicalExprRef;
 
         let a_plus_b = Arc::new(BinaryExpr::new(

--- a/datafusion/physical-expr/src/equivalence/projection.rs
+++ b/datafusion/physical-expr/src/equivalence/projection.rs
@@ -689,6 +689,7 @@ mod tests {
             test_fun,
             vec![Arc::clone(col_c)],
             &schema,
+            "UTC".to_string(),
         )?) as PhysicalExprRef;
 
         let option_asc = SortOptions {

--- a/datafusion/physical-expr/src/equivalence/properties/dependency.rs
+++ b/datafusion/physical-expr/src/equivalence/properties/dependency.rs
@@ -1035,6 +1035,7 @@ mod tests {
             concat(),
             vec![Arc::clone(&col_a), Arc::clone(&col_b)],
             Field::new("f", DataType::Utf8, true).into(),
+            "UTC".to_string(),
         ));
 
         // Assume existing ordering is [c ASC, a ASC, b ASC]
@@ -1125,6 +1126,7 @@ mod tests {
             concat(),
             vec![Arc::clone(&col_a), Arc::clone(&col_b)],
             Field::new("f", DataType::Utf8, true).into(),
+            "UTC".to_string(),
         )) as _;
 
         // Assume existing ordering is [concat(a, b) ASC, a ASC, b ASC]

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -322,6 +322,7 @@ pub fn create_physical_expr(
                 Arc::clone(func),
                 physical_args,
                 input_schema,
+                execution_props.query_execution_time_zone.clone(),
             )?))
         }
         Expr::Between(Between {

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -54,6 +54,7 @@ pub struct ScalarFunctionExpr {
     name: String,
     args: Vec<Arc<dyn PhysicalExpr>>,
     return_field: FieldRef,
+    execution_time_zone: String,
 }
 
 impl Debug for ScalarFunctionExpr {
@@ -74,12 +75,14 @@ impl ScalarFunctionExpr {
         fun: Arc<ScalarUDF>,
         args: Vec<Arc<dyn PhysicalExpr>>,
         return_field: FieldRef,
+        execution_time_zone: String,
     ) -> Self {
         Self {
             fun,
             name: name.to_owned(),
             args,
             return_field,
+            execution_time_zone,
         }
     }
 
@@ -88,6 +91,7 @@ impl ScalarFunctionExpr {
         fun: Arc<ScalarUDF>,
         args: Vec<Arc<dyn PhysicalExpr>>,
         schema: &Schema,
+        execution_time_zone: String,
     ) -> Result<Self> {
         let name = fun.name().to_string();
         let arg_fields = args
@@ -120,6 +124,7 @@ impl ScalarFunctionExpr {
             name,
             args,
             return_field,
+            execution_time_zone,
         })
     }
 
@@ -202,6 +207,7 @@ impl PhysicalExpr for ScalarFunctionExpr {
             arg_fields,
             number_rows: batch.num_rows(),
             return_field: Arc::clone(&self.return_field),
+            execution_time_zone: self.execution_time_zone.clone(),
         })?;
 
         if let ColumnarValue::Array(array) = &output {
@@ -238,6 +244,7 @@ impl PhysicalExpr for ScalarFunctionExpr {
             Arc::clone(&self.fun),
             children,
             Arc::clone(&self.return_field),
+            self.execution_time_zone.clone(),
         )))
     }
 

--- a/datafusion/physical-plan/src/async_func.rs
+++ b/datafusion/physical-plan/src/async_func.rs
@@ -25,6 +25,7 @@ use arrow_schema::{Fields, Schema, SchemaRef};
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion_common::{internal_err, Result};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
+use datafusion_expr::execution_props::ExecutionProps;
 use datafusion_physical_expr::async_scalar_function::AsyncFuncExpr;
 use datafusion_physical_expr::equivalence::ProjectionMapping;
 use datafusion_physical_expr::expressions::Column;
@@ -246,6 +247,7 @@ impl AsyncMapper {
         &mut self,
         physical_expr: &Arc<dyn PhysicalExpr>,
         schema: &Schema,
+        execution_props: &ExecutionProps,
     ) -> Result<()> {
         // recursively look for references to async functions
         physical_expr.apply(|expr| {
@@ -258,6 +260,7 @@ impl AsyncMapper {
                         next_name,
                         Arc::clone(expr),
                         schema,
+                        execution_props.query_execution_time_zone.clone(),
                     )?));
                 }
             }

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -369,6 +369,7 @@ pub fn parse_physical_expr(
                     scalar_fun_def,
                     args,
                     Field::new("f", convert_required!(e.return_type)?, true).into(),
+                    "UTC".to_string(), // TODO should this come from configuration?
                 )
                 .with_nullable(e.nullable),
             )

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -984,6 +984,7 @@ fn roundtrip_scalar_udf() -> Result<()> {
         fun_def,
         vec![col("a", &schema)?],
         Field::new("f", DataType::Int64, true).into(),
+        "UTC".to_string(),
     );
 
     let project =
@@ -1112,6 +1113,7 @@ fn roundtrip_scalar_udf_extension_codec() -> Result<()> {
         Arc::new(ScalarUDF::from(MyRegexUdf::new(".*".to_string()))),
         vec![col("text", &schema)?],
         Field::new("f", DataType::Int64, true).into(),
+        "UTC".to_string(),
     ));
 
     let filter = Arc::new(FilterExec::try_new(
@@ -1214,6 +1216,7 @@ fn roundtrip_aggregate_udf_extension_codec() -> Result<()> {
         Arc::new(ScalarUDF::from(MyRegexUdf::new(".*".to_string()))),
         vec![col("text", &schema)?],
         Field::new("f", DataType::Int64, true).into(),
+        "UTC".to_string(),
     ));
 
     let udaf = Arc::new(AggregateUDF::from(MyAggregateUDF::new(

--- a/datafusion/spark/src/function/utils.rs
+++ b/datafusion/spark/src/function/utils.rs
@@ -67,11 +67,12 @@ pub mod test {
                     let return_field = return_field.unwrap();
                     assert_eq!(return_field.data_type(), &$EXPECTED_DATA_TYPE);
 
-                    let result = func.invoke_with_args(datafusion_expr::ScalarFunctionArgs{
+                    let result = func.invoke_with_args(datafusion_expr::ScalarFunctionArgs {
                         args: $ARGS,
                         number_rows: cardinality,
-                        return_field,
                         arg_fields: arg_fields.clone(),
+                        return_field,
+                        execution_time_zone: "UTC".to_string(),
                     });
                     assert_eq!(result.is_ok(), true, "function returned an error: {}", result.unwrap_err());
 
@@ -96,11 +97,12 @@ pub mod test {
                         let return_field = return_field.unwrap();
 
                         // invoke is expected error - cannot use .expect_err() due to Debug not being implemented
-                        match func.invoke_with_args(datafusion_expr::ScalarFunctionArgs{
+                        match func.invoke_with_args(datafusion_expr::ScalarFunctionArgs {
                             args: $ARGS,
                             number_rows: cardinality,
-                            return_field,
                             arg_fields,
+                            return_field,
+                            execution_time_zone: "UTC".to_string(),
                         }) {
                             Ok(_) => assert!(false, "expected error"),
                             Err(error) => {

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -616,7 +616,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     // Timestamp With Time Zone
                     // INPUT : [SQLDataType]   TimestampTz + [Config] Time Zone
                     // OUTPUT: [ArrowDataType] Timestamp<TimeUnit, Some(Time Zone)>
-                    self.context_provider.options().execution.time_zone.clone()
+                    Some(self.context_provider.options().execution.time_zone.clone())
                 } else {
                     // Timestamp Without Time zone
                     None


### PR DESCRIPTION
The execution time zone serves as the session zone from SQL semantics
perspective. In particular, it influences how a CAST form `timestamp` to
`timestamp with time zone` is performed. This is, however, applied at
query parser stage. The execution/session time zone should be also
available to functions in both invoke and simplify APIs.

relates to
- https://github.com/apache/datafusion/issues/12892
- https://github.com/apache/datafusion/issues/13519
- https://github.com/apache/datafusion/issues/13212
- https://github.com/apache/datafusion/issues/10368

