### PR TITLE
fix: reserved keywords in qualified column names

### DIFF
--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -21,8 +21,9 @@ use datafusion_expr::planner::{
 };
 use sqlparser::ast::{
     AccessExpr, BinaryOperator, CastFormat, CastKind, DataType as SQLDataType,
-    DictionaryField, Expr as SQLExpr, ExprWithAlias as SQLExprWithAlias, MapEntry,
-    StructField, Subscript, TrimWhereField, Value, ValueWithSpan,
+    DictionaryField, Expr as SQLExpr, ExprWithAlias as SQLExprWithAlias,
+    FunctionArguments, MapEntry, StructField, Subscript, TrimWhereField, Value,
+    ValueWithSpan,
 };
 
 use datafusion_common::{
@@ -476,7 +477,21 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             ),
 
             SQLExpr::Function(function) => {
-                self.sql_function_to_expr(function, schema, planner_context)
+                // workaround for https://github.com/apache/datafusion-sqlparser-rs/issues/1909
+                if matches!(function.args, FunctionArguments::None)
+                    && function.name.0.len() > 1
+                    && function.name.0.iter().all(|part| part.as_ident().is_some())
+                {
+                    let ids = function
+                        .name
+                        .0
+                        .iter()
+                        .map(|part| part.as_ident().expect("just checked").clone())
+                        .collect();
+                    self.sql_compound_identifier_to_expr(ids, schema, planner_context)
+                } else {
+                    self.sql_function_to_expr(function, schema, planner_context)
+                }
             }
 
             SQLExpr::Rollup(exprs) => {

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -408,7 +408,7 @@ VALUES (1,2,3,4,5,6,7,8,9,10,11,12,13,NULL,'F',3.5)
 
 # Test non-literal expressions in VALUES
 query II
-VALUES (1, CASE WHEN RANDOM() > 0.5 THEN 1 ELSE 1 END), 
+VALUES (1, CASE WHEN RANDOM() > 0.5 THEN 1 ELSE 1 END),
        (2, CASE WHEN RANDOM() > 0.5 THEN 2 ELSE 2 END);
 ----
 1 1
@@ -558,7 +558,7 @@ EXPLAIN SELECT * FROM ((SELECT column1 FROM foo) "T1" CROSS JOIN (SELECT column2
 ----
 logical_plan
 01)SubqueryAlias: F
-02)--Cross Join: 
+02)--Cross Join:
 03)----SubqueryAlias: T1
 04)------TableScan: foo projection=[column1]
 05)----SubqueryAlias: T2
@@ -1641,7 +1641,7 @@ query II
 SELECT
 CASE WHEN B.x > 0 THEN A.x / B.x ELSE 0 END AS value1,
 CASE WHEN B.x > 0 AND B.y > 0 THEN A.x / B.x ELSE 0 END AS value3
-FROM t AS A, (SELECT * FROM t WHERE x = 0) AS B; 
+FROM t AS A, (SELECT * FROM t WHERE x = 0) AS B;
 ----
 0 0
 0 0
@@ -1871,3 +1871,14 @@ select *, count(*) over() as ta from t;
 
 statement count 0
 drop table t;
+
+# test "user" column
+# See https://github.com/apache/datafusion/issues/14141
+statement count 0
+create table t_with_user(a int, user text) as values (1,'test'), (2,null);
+
+query T
+select t_with_user.user from t_with_user;
+----
+test
+NULL


### PR DESCRIPTION
## Which issue does this PR close?
It doesn't close it, but it at least partly addresses #14141.

## Rationale for this change
`SELECT t.user` cannot be a function, that makes no sense.

## What changes are included in this PR?
Workaround for https://github.com/apache/datafusion-sqlparser-rs/issues/1909 . We could fix it upstream too, it depends what people prefer.

## Are these changes tested?
`SELECT t.user FROM t` now works, see test.

## Are there any user-facing changes?
More queries work.
