### PR TITLE
Fix: make datafusion-cli running inconsistent with clickbench benchma…

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -171,7 +171,13 @@ async fn main_inner() -> Result<()> {
         env::set_current_dir(p).unwrap();
     };
 
-    let session_config = get_session_config(&args)?;
+    let mut session_config = get_session_config(&args)?;
+
+    let parquet_options = &mut session_config.options_mut().execution.parquet;
+    // Consistent with the clickbench benchmark:
+    // The hits_partitioned dataset specifies string columns
+    // as binary due to how it was written. Force it to strings
+    parquet_options.binary_as_string = true;
 
     let mut rt_builder = RuntimeEnvBuilder::new();
     // set memory pool size


### PR DESCRIPTION
…rk for parquet format

## Which issue does this PR close?

The clickbench benchmark data hits.parquet, hits_partitioned dataset specifies string columns
 as binary due to how it was written, it was an older parquet written data. 
 
But datafusion-cli is inconsistent with it, this PR try to make the datafusion-cli and clickbench benchmark consistent.

- Closes [#16591](https://github.com/apache/datafusion/issues/16591)

## Rationale for this change

The clickbench benchmark data hits.parquet, hits_partitioned dataset specifies string columns
 as binary due to how it was written, it was an older parquet written data. 
 
But datafusion-cli is inconsistent with it, this PR try to make the datafusion-cli and clickbench benchmark consistent.


## What changes are included in this PR?

The clickbench benchmark data hits.parquet, hits_partitioned dataset specifies string columns
 as binary due to how it was written, it was an older parquet written data. 
 
But datafusion-cli is inconsistent with it, this PR try to make the datafusion-cli and clickbench benchmark consistent.


## Are these changes tested?

Testing now, it will not have cast.

```rust
./datafusion-cli -c "EXPLAIN SELECT \"SearchPhrase\", MIN(\"URL\"), COUNT(*) AS c FROM 'data/hits_partitioned' WHERE \"URL\" LIKE '%google%' AND \"SearchPhrase\" <> '' GROUP BY \"SearchPhrase\" ORDER BY c DESC LIMIT 10;"
DataFusion CLI v48.0.0
+---------------+-------------------------------+
| plan_type     | plan                          |
+---------------+-------------------------------+
| physical_plan | ┌───────────────────────────┐ |
|               | │  SortPreservingMergeExec  │ |
|               | │    --------------------   │ |
|               | │      c DESClimit: 10      │ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │       SortExec(TopK)      │ |
|               | │    --------------------   │ |
|               | │          c@2 DESC         │ |
|               | │                           │ |
|               | │         limit: 10         │ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │       ProjectionExec      │ |
|               | │    --------------------   │ |
|               | │       SearchPhrase:       │ |
|               | │        SearchPhrase       │ |
|               | │                           │ |
|               | │     c: count(Int64(1))    │ |
|               | │                           │ |
|               | │ min(data/hits_partitioned │ |
|               | │           .URL):          │ |
|               | │ min(data/hits_partitioned │ |
|               | │           .URL)           │ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │       AggregateExec       │ |
|               | │    --------------------   │ |
|               | │           aggr:           │ |
|               | │ min(data/hits_partitioned │ |
|               | │      .URL), count(1)      │ |
|               | │                           │ |
|               | │         group_by:         │ |
|               | │        SearchPhrase       │ |
|               | │                           │ |
|               | │           mode:           │ |
|               | │      FinalPartitioned     │ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │    CoalesceBatchesExec    │ |
|               | │    --------------------   │ |
|               | │     target_batch_size:    │ |
|               | │            8192           │ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │      RepartitionExec      │ |
|               | │    --------------------   │ |
|               | │ partition_count(in->out): │ |
|               | │          14 -> 14         │ |
|               | │                           │ |
|               | │    partitioning_scheme:   │ |
|               | │ Hash([SearchPhrase@0], 14)│ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │       AggregateExec       │ |
|               | │    --------------------   │ |
|               | │           aggr:           │ |
|               | │ min(data/hits_partitioned │ |
|               | │      .URL), count(1)      │ |
|               | │                           │ |
|               | │         group_by:         │ |
|               | │        SearchPhrase       │ |
|               | │                           │ |
|               | │       mode: Partial       │ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │    CoalesceBatchesExec    │ |
|               | │    --------------------   │ |
|               | │     target_batch_size:    │ |
|               | │            8192           │ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │         FilterExec        │ |
|               | │    --------------------   │ |
|               | │         predicate:        │ |
|               | │   URL LIKE %google% AND   │ |
|               | │       SearchPhrase !=     │ |
|               | └─────────────┬─────────────┘ |
|               | ┌─────────────┴─────────────┐ |
|               | │       DataSourceExec      │ |
|               | │    --------------------   │ |
|               | │         files: 113        │ |
|               | │      format: parquet      │ |
|               | │                           │ |
|               | │         predicate:        │ |
|               | │   URL LIKE %google% AND   │ |
|               | │       SearchPhrase !=     │ |
|               | └───────────────────────────┘ |
|               |                               |
+---------------+-------------------------------+
1 row(s) fetched.
Elapsed 0.058 seconds.
```

## Are there any user-facing changes?

Now, the datafusion-cli will not take extra time to cast to Utf8View.
