### PR TITLE
Fix discrepancy in Float64 to timestamp(9) casts

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -3061,11 +3061,6 @@ impl ScalarValue {
     ) -> Result<Self> {
         let scalar_array = match (self, target_type) {
             (
-                ScalarValue::Float64(Some(float_ts)),
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
-            ) => ScalarValue::Int64(Some((float_ts * 1_000_000_000_f64).trunc() as i64))
-                .to_array()?,
-            (
                 ScalarValue::Decimal128(Some(decimal_value), _, scale),
                 DataType::Timestamp(time_unit, None),
             ) => {

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -177,6 +177,91 @@ SELECT TIMESTAMPTZ '2000-01-01T01:01:01'
 
 
 ##########
+## cast tests
+##########
+
+query PPPBB
+SELECT *, t1 = t2, t1 = t3
+FROM (SELECT
+    (SELECT CAST(CAST(1 AS double) AS timestamp(0))) AS t1,
+    (SELECT CAST(CAST(one AS double) AS timestamp(0)) FROM (SELECT 1 AS one)) AS t2,
+    (SELECT CAST(CAST(one AS double) AS timestamp(0)) FROM (VALUES (1)) t(one)) AS t3
+)
+----
+1970-01-01T00:00:01 1970-01-01T00:00:01 1970-01-01T00:00:01 true true
+
+query PPPBB
+SELECT *, t1 = t2, t1 = t3
+FROM (SELECT
+    (SELECT CAST(CAST(1 AS double) AS timestamp(3))) AS t1,
+    (SELECT CAST(CAST(one AS double) AS timestamp(3)) FROM (SELECT 1 AS one)) AS t2,
+    (SELECT CAST(CAST(one AS double) AS timestamp(3)) FROM (VALUES (1)) t(one)) AS t3
+)
+----
+1970-01-01T00:00:00.001 1970-01-01T00:00:00.001 1970-01-01T00:00:00.001 true true
+
+query PPPBB
+SELECT *, t1 = t2, t1 = t3
+FROM (SELECT
+    (SELECT CAST(CAST(1 AS double) AS timestamp(6))) AS t1,
+    (SELECT CAST(CAST(one AS double) AS timestamp(6)) FROM (SELECT 1 AS one)) AS t2,
+    (SELECT CAST(CAST(one AS double) AS timestamp(6)) FROM (VALUES (1)) t(one)) AS t3
+)
+----
+1970-01-01T00:00:00.000001 1970-01-01T00:00:00.000001 1970-01-01T00:00:00.000001 true true
+
+query PPPBB
+SELECT *, t1 = t2, t1 = t3
+FROM (SELECT
+    (SELECT CAST(CAST(1 AS double) AS timestamp(9))) AS t1,
+    (SELECT CAST(CAST(one AS double) AS timestamp(9)) FROM (SELECT 1 AS one)) AS t2,
+    (SELECT CAST(CAST(one AS double) AS timestamp(9)) FROM (VALUES (1)) t(one)) AS t3
+)
+----
+1970-01-01T00:00:00.000000001 1970-01-01T00:00:00.000000001 1970-01-01T00:00:00.000000001 true true
+
+query PPPBB
+SELECT *, t1 = t2, t1 = t3
+FROM (SELECT
+    (SELECT CAST(CAST(1.125 AS double) AS timestamp(0))) AS t1,
+    (SELECT CAST(CAST(one_and_a_bit AS double) AS timestamp(0)) FROM (SELECT 1.125 AS one_and_a_bit)) AS t2,
+    (SELECT CAST(CAST(one_and_a_bit AS double) AS timestamp(0)) FROM (VALUES (1.125)) t(one_and_a_bit)) AS t3
+)
+----
+1970-01-01T00:00:01 1970-01-01T00:00:01 1970-01-01T00:00:01 true true
+
+query PPPBB
+SELECT *, t1 = t2, t1 = t3
+FROM (SELECT
+    (SELECT CAST(CAST(1.125 AS double) AS timestamp(3))) AS t1,
+    (SELECT CAST(CAST(one_and_a_bit AS double) AS timestamp(3)) FROM (SELECT 1.125 AS one_and_a_bit)) AS t2,
+    (SELECT CAST(CAST(one_and_a_bit AS double) AS timestamp(3)) FROM (VALUES (1.125)) t(one_and_a_bit)) AS t3
+)
+----
+1970-01-01T00:00:00.001 1970-01-01T00:00:00.001 1970-01-01T00:00:00.001 true true
+
+query PPPBB
+SELECT *, t1 = t2, t1 = t3
+FROM (SELECT
+    (SELECT CAST(CAST(1.125 AS double) AS timestamp(6))) AS t1,
+    (SELECT CAST(CAST(one_and_a_bit AS double) AS timestamp(6)) FROM (SELECT 1.125 AS one_and_a_bit)) AS t2,
+    (SELECT CAST(CAST(one_and_a_bit AS double) AS timestamp(6)) FROM (VALUES (1.125)) t(one_and_a_bit)) AS t3
+)
+----
+1970-01-01T00:00:00.000001 1970-01-01T00:00:00.000001 1970-01-01T00:00:00.000001 true true
+
+query PPPBB
+SELECT *, t1 = t2, t1 = t3
+FROM (SELECT
+    (SELECT CAST(CAST(1.125 AS double) AS timestamp(9))) AS t1,
+    (SELECT CAST(CAST(one_and_a_bit AS double) AS timestamp(9)) FROM (SELECT 1.125 AS one_and_a_bit)) AS t2,
+    (SELECT CAST(CAST(one_and_a_bit AS double) AS timestamp(9)) FROM (VALUES (1.125)) t(one_and_a_bit)) AS t3
+)
+----
+1970-01-01T00:00:00.000000001 1970-01-01T00:00:00.000000001 1970-01-01T00:00:00.000000001 true true
+
+
+##########
 ## to_timestamp tests
 ##########
 
@@ -394,12 +479,12 @@ SELECT COUNT(*) FROM ts_data_secs where ts > to_timestamp_seconds('2020-09-08 12
 query PPP
 SELECT to_timestamp(1.1) as c1, cast(1.1 as timestamp) as c2, 1.1::timestamp as c3;
 ----
-1970-01-01T00:00:01.100 1970-01-01T00:00:01.100 1970-01-01T00:00:01.100
+1970-01-01T00:00:00.000000001 1970-01-01T00:00:00.000000001 1970-01-01T00:00:00.000000001
 
 query PPP
 SELECT to_timestamp(-1.1) as c1, cast(-1.1 as timestamp) as c2, (-1.1)::timestamp as c3;
 ----
-1969-12-31T23:59:58.900 1969-12-31T23:59:58.900 1969-12-31T23:59:58.900
+1969-12-31T23:59:59.999999999 1969-12-31T23:59:59.999999999 1969-12-31T23:59:59.999999999
 
 query PPP
 SELECT to_timestamp(0.0) as c1, cast(0.0 as timestamp) as c2, 0.0::timestamp as c3;
@@ -409,12 +494,12 @@ SELECT to_timestamp(0.0) as c1, cast(0.0 as timestamp) as c2, 0.0::timestamp as 
 query PPP
 SELECT to_timestamp(1.23456789) as c1, cast(1.23456789 as timestamp) as c2, 1.23456789::timestamp as c3;
 ----
-1970-01-01T00:00:01.234567890 1970-01-01T00:00:01.234567890 1970-01-01T00:00:01.234567890
+1970-01-01T00:00:00.000000001 1970-01-01T00:00:00.000000001 1970-01-01T00:00:00.000000001
 
 query PPP
 SELECT to_timestamp(123456789.123456789) as c1, cast(123456789.123456789 as timestamp) as c2, 123456789.123456789::timestamp as c3;
 ----
-1973-11-29T21:33:09.123456784 1973-11-29T21:33:09.123456784 1973-11-29T21:33:09.123456784
+1970-01-01T00:00:00.123456789 1970-01-01T00:00:00.123456789 1970-01-01T00:00:00.123456789
 
 # to_timestamp Decimal128 inputs
 


### PR DESCRIPTION
Before the change, when casting `Float64` value to `Timestamp(Nanosecond, None)`, the result would depend on whether the source value is constant-foldable scalar. This is because `ScalarValue.cast_to` had a special treatment for that source & destination type pair, producing a different result from the canonical one.

- fixes https://github.com/apache/datafusion/issues/16636
- rels https://github.com/apache/datafusion/pull/16539


