### PR TITLE
[branch-48] Make `SessionContext::register_parquet` obey `collect_statistics` con…

### DIFF
--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -21,7 +21,7 @@
 
 ## DataFusion `48.0.0`
 
-### The `VARCHAR` SQL type is now represented as `Utf8View` in Arrow.
+\### The `VARCHAR` SQL type is now represented as `Utf8View` in Arrow.
 
 The mapping of the SQL `VARCHAR` type has been changed from `Utf8` to `Utf8View`
 which improves performance for many string operations. You can read more about
@@ -86,6 +86,9 @@ ListingOptions::new(Arc::new(ParquetFormat::default()))
 ```
 
 ### Processing `FieldRef` instead of `DataType` for user defined functions
+=======
+### Processing `Field` instead of `DataType` for user defined functions
+>>>>>>> 6cf74d64e (Make `SessionContext::register_parquet` obey `collect_statistics` config (#16080))
 
 In order to support metadata handling and extension types, user defined functions are
 now switching to traits which use `FieldRef` rather than a `DataType` and nullability.


### PR DESCRIPTION
(note this targets branch-48, NOT `main`)

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of https://github.com/apache/datafusion/issues/16486


## Rationale for this change

- Fixes https://github.com/apache/datafusion/issues/15908 on 48.0.1

## What changes are included in this PR?

- Backport of https://github.com/apache/datafusion/pull/16080
