### PR TITLE
POC: Add `ConfigOptions` to ExecutionProps when execution is started

### DIFF
--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -1640,7 +1640,7 @@ impl SessionContext {
     /// [`ConfigOptions`]: crate::config::ConfigOptions
     pub fn state(&self) -> SessionState {
         let mut state = self.state.read().clone();
-        state.execution_props_mut().start_execution();
+        state.start_execution();
         state
     }
 

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -738,6 +738,12 @@ impl SessionState {
         self.config.options()
     }
 
+    /// Mark the start of the execution
+    pub fn start_execution(&mut self) {
+        let config = self.config.options_arc();
+        self.execution_props.start_execution(config);
+    }
+
     /// Return the table options
     pub fn table_options(&self) -> &TableOptions {
         &self.table_options

--- a/datafusion/expr/src/execution_props.rs
+++ b/datafusion/expr/src/execution_props.rs
@@ -18,6 +18,7 @@
 use crate::var_provider::{VarProvider, VarType};
 use chrono::{DateTime, TimeZone, Utc};
 use datafusion_common::alias::AliasGenerator;
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::HashMap;
 use std::sync::Arc;
 
@@ -35,6 +36,8 @@ pub struct ExecutionProps {
     pub query_execution_start_time: DateTime<Utc>,
     /// Alias generator used by subquery optimizer rules
     pub alias_generator: Arc<AliasGenerator>,
+    /// Snapshot of config options
+    pub config_options: Option<Arc<ConfigOptions>>,
     /// Providers for scalar variables
     pub var_providers: Option<HashMap<VarType, Arc<dyn VarProvider + Send + Sync>>>,
 }
@@ -53,6 +56,7 @@ impl ExecutionProps {
             // not being updated / propagated correctly
             query_execution_start_time: Utc.timestamp_nanos(0),
             alias_generator: Arc::new(AliasGenerator::new()),
+            config_options: None,
             var_providers: None,
         }
     }
@@ -68,9 +72,10 @@ impl ExecutionProps {
 
     /// Marks the execution of query started timestamp.
     /// This also instantiates a new alias generator.
-    pub fn start_execution(&mut self) -> &Self {
+    pub fn start_execution(&mut self, config_options: Arc<ConfigOptions>) -> &Self {
         self.query_execution_start_time = Utc::now();
         self.alias_generator = Arc::new(AliasGenerator::new());
+        self.config_options = Some(config_options);
         &*self
     }
 
@@ -98,6 +103,12 @@ impl ExecutionProps {
         self.var_providers
             .as_ref()
             .and_then(|var_providers| var_providers.get(&var_type).cloned())
+    }
+
+    /// Returns the configuration properties for this execution
+    /// if the execution has started
+    pub fn config_options(&self) -> Option<&Arc<ConfigOptions>> {
+        self.config_options.as_ref()
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

- This is a possible alternative to https://github.com/apache/datafusion/pull/16573 from @findepi 

I think @Omega359  had other PRs as well

Relates to
- https://github.com/apache/datafusion/issues/12892
- https://github.com/apache/datafusion/issues/13519
- https://github.com/apache/datafusion/issues/13212
- https://github.com/apache/datafusion/issues/10368

## Rationale for this change

The need is to access configuration settings (such as the configured timezone) to scalar functions during planning

- https://github.com/apache/datafusion/pull/16573 proposes copying just the timezone. This PR proposes copying a reference to the entire config





## What changes are included in this PR?
Add an `Arc<ConfigOptions>` to ExecutionProps when the execution is started



Things I am still not happy about:
1. This isn't with parity with UDFs yet as the entire SessionContext is saved there (not just config options)
2. It isn't passed all the way to ScalarUDFs



## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
