### PR TITLE
benchmark: Support sort_tpch10 for benchmark

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -89,6 +89,7 @@ tpch_mem10:             TPCH inspired benchmark on Scale Factor (SF) 10 (~10GB),
 
 # Extended TPC-H Benchmarks
 sort_tpch:              Benchmark of sorting speed for end-to-end sort queries on TPC-H dataset (SF=1)
+sort_tpch10:            Benchmark of sorting speed for end-to-end sort queries on TPC-H dataset (SF=10)
 topk_tpch:              Benchmark of top-k (sorting with limit) queries on TPC-H dataset (SF=1)
 external_aggr:          External aggregation benchmark on TPC-H dataset (SF=1)
 
@@ -250,6 +251,10 @@ main() {
                     # same data as for tpch
                     data_tpch "1"
                     ;;
+                sort_tpch10)
+                    # same data as for tpch10
+                    data_tpch "10"
+                    ;;
                 topk_tpch)
                     # same data as for tpch
                     data_tpch "1"
@@ -382,7 +387,10 @@ main() {
                     run_external_aggr
                     ;;
                 sort_tpch)
-                    run_sort_tpch
+                    run_sort_tpch "1"
+                    ;;
+                sort_tpch10)
+                    run_sort_tpch "10"
                     ;;
                 topk_tpch)
                     run_topk_tpch
@@ -997,8 +1005,13 @@ run_external_aggr() {
 
 # Runs the sort integration benchmark
 run_sort_tpch() {
-    TPCH_DIR="${DATA_DIR}/tpch_sf1"
-    RESULTS_FILE="${RESULTS_DIR}/sort_tpch.json"
+    SCALE_FACTOR=$1
+    if [ -z "$SCALE_FACTOR" ] ; then
+        echo "Internal error: Scale factor not specified"
+        exit 1
+    fi
+    TPCH_DIR="${DATA_DIR}/tpch_sf${SCALE_FACTOR}"
+    RESULTS_FILE="${RESULTS_DIR}/sort_tpch${SCALE_FACTOR}.json"
     echo "RESULTS_FILE: ${RESULTS_FILE}"
     echo "Running sort tpch benchmark..."
 


### PR DESCRIPTION
## Which issue does this PR close?

Currently we only have sort_tpch for benchmark, recently when optimizing sort, i found sort_tpch10 will show more stable result sometimes, so i added this to benchmark script also.

- Closes #.

## Rationale for this change

Currently we only have sort_tpch for benchmark, recently when optimizing sort, i found sort_tpch10 will show more stable result sometimes, so i added this to benchmark script also.

## What changes are included in this PR?

Currently we only have sort_tpch for benchmark, recently when optimizing sort, i found sort_tpch10 will show more stable result sometimes, so i added this to benchmark script also.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No