### PR TITLE
chore(devcontainer): use debian's `protobuf-compiler` package

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,9 +5,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get purge -y imagemagick imagemagick-6-common
 
 # Add protoc
-# https://datafusion.apache.org/contributor-guide/getting_started.html#protoc-installation
-RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip \
-    && unzip protoc-25.1-linux-x86_64.zip -d $HOME/.local \
-    && rm protoc-25.1-linux-x86_64.zip
-
-ENV PATH="$PATH:$HOME/.local/bin"
+# https://datafusion.apache.org/contributor-guide/development_environment.html#protoc-installation
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Which issue does this PR close?

None. It's too small of a change for an issue, in my opinion. Happy to retroactively create one, though.

## Rationale for this change

unfortunately, the current `Dockerfile` does not set the `PATH` variable correctly. the `RUN` directive is evaluated at build time. thus, the `$HOME` variable is resolved correctly to `/root/` when installing the `protoc` binary; the binary ends up in `/root/.local/bin/protoc`. in contrast, an `ENV` directive is evaluated at a container's runtime, so if `$HOME` is not correctly set at runtime, the `PATH` addition `$HOME/.local/bin` resolves to `/.local/bin`, which does not exist.


## What changes are included in this PR?

- change the way the devcontainer's Docker image installs `protoc` from "from-source" to using the base image's (debian bookworm) package repository, in line with [1].
- downgrade from protoc v3.25.1 to v3.21.12. the docs [1] say any version above v3.15 is fine.

[1] https://datafusion.apache.org/contributor-guide/development_environment.html#protoc-installation

## Are these changes tested?

Yes. I tested the container to check if the `protoc` binary is found:
```bash
$ docker build . -t datafusion-devcontainer:latest &>/dev/null && \ 
  docker run --rm -it datafusion-devcontainer:latest protoc --version
libprotoc 3.21.12
```

Additionally, I used the devcontainer to build DataFusion inside the devcontainer.

## Are there any user-facing changes?

No, none.