### PR TITLE
Fix sqllogictests test running compatibility (ignore `--test-threads`)

### DIFF
--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -694,7 +694,7 @@ struct Options {
         long,
         help = "IGNORED (for compatibility with built-in rust test runner)"
     )]
-    test_threads: usize,
+    test_threads: Option<usize>,
 }
 
 impl Options {


### PR DESCRIPTION
sqllogictests.rs already has various parts of it's Options struct that provide compatibility with the standard test running options.

Extend this to include the standard `--test-threads` option, so that running for example `cargo test -- --test-threads 1` in the project root will succeed.  Previously it complained about the unknown option.

This can be useful on a machine with a large number of cores which causes many tests to build & run in parallel, which in my case caused a crash due to exhausing the system RAM.

Fixes #16693 