### PR TITLE
Update Upgrade Guide for 48.0.1

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -126,6 +126,7 @@ To get started, see
    :caption: Library User Guide
    
    library-user-guide/index
+   library-user-guide/upgrading
    library-user-guide/extensions
    library-user-guide/using-the-sql-api
    library-user-guide/working-with-exprs
@@ -138,7 +139,6 @@ To get started, see
    library-user-guide/extending-operators
    library-user-guide/profiling
    library-user-guide/query-optimizer
-   library-user-guide/upgrading
 
 .. .. _toc.contributor-guide:
 

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -62,24 +62,7 @@ DataFusionError::SchemaError(
 
 [#16652]: https://github.com/apache/datafusion/issues/16652
 
-### `datafusion.execution.collect_statistics` now defaults to `true`
-
-The default value of the `datafusion.execution.collect_statistics` configuration
-setting is now true. This change impacts users that use that value directly and relied
-on its default value being `false`.
-
-This change also restores the default behavior of `ListingTable` to its previous. If you use it directly
-you can maintain the current behavior by overriding the default value in your code.
-
-```rust
-# /* comment to avoid running
-ListingOptions::new(Arc::new(ParquetFormat::default()))
-    .with_collect_stat(false)
-    // other options
-# */
-```
-
-### Metadata is now represented by `FieldMetadata`
+### Metadata on Arrow Types is now represented by `FieldMetadata`
 
 Metadata from the Arrow `Field` is now stored using the `FieldMetadata`
 structure. In prior versions it was stored as both a `HashMap<String, String>`
@@ -136,6 +119,25 @@ SET datafusion.execution.spill_compression = 'zstd';
 ```
 
 For more details about this configuration option, including performance trade-offs between different compression codecs, see the [Configuration Settings](../user-guide/configs.md) documentation.
+
+## DataFusion `48.0.1`
+
+### `datafusion.execution.collect_statistics` now defaults to `true`
+
+The default value of the `datafusion.execution.collect_statistics` configuration
+setting is now true. This change impacts users that use that value directly and relied
+on its default value being `false`.
+
+This change also restores the default behavior of `ListingTable` to its previous. If you use it directly
+you can maintain the current behavior by overriding the default value in your code.
+
+```rust
+# /* comment to avoid running
+ListingOptions::new(Arc::new(ParquetFormat::default()))
+    .with_collect_stat(false)
+    // other options
+# */
+```
 
 ## DataFusion `48.0.0`
 


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #16486 

## Rationale for this change

We back ported the default setting for statistics `datafusion.execution.collect_statistics` to 48.0.1 so we should update the upgrade guide to reflect that

## What changes are included in this PR?

1. Move the description to 48.0.1 release heading
2. Move the upgrade guide higher in the index to make it easier to find

## Are these changes tested?

by CI

## Are there any user-facing changes?

Upgrade guide