### PR TITLE
minor: improve display output for FFI execution plans

### DIFF
--- a/datafusion/ffi/src/execution_plan.rs
+++ b/datafusion/ffi/src/execution_plan.rs
@@ -205,7 +205,8 @@ impl DisplayAs for ForeignExecutionPlan {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
                 write!(
                     f,
-                    "FFI_ExecutionPlan(number_of_children={})",
+                    "FFI_ExecutionPlan: {}, number_of_children={}",
+                    self.name,
                     self.children.len(),
                 )
             }
@@ -390,7 +391,10 @@ mod tests {
         );
 
         let buf = display.one_line().to_string();
-        assert_eq!(buf.trim(), "FFI_ExecutionPlan(number_of_children=0)");
+        assert_eq!(
+            buf.trim(),
+            "FFI_ExecutionPlan: empty-exec, number_of_children=0"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

None

## Rationale for this change

This change makes it easier to debug execution plans. Currently when using FFI you get a printout that looks like `FFI_ExecutionPlan(number_of_children=0)` and with this change it tells the underlying execution plan name as well: `FFI_ExecutionPlan: MyCustomExec, number_of_children=0`

## What changes are included in this PR?

Changes the display.

## Are these changes tested?

Tested with datafusion-python.
Unit test updated.

## Are there any user-facing changes?

No