### PR TITLE
Use the `test-threads` option in sqllogictests

### DIFF
--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -194,7 +194,7 @@ async fn run_tests() -> Result<()> {
             .join()
         })
         // run up to num_cpus streams in parallel
-        .buffer_unordered(get_available_parallelism())
+        .buffer_unordered(options.test_threads)
         .flat_map(|result| {
             // Filter out any Ok() leaving only the DataFusionErrors
             futures::stream::iter(match result {
@@ -692,9 +692,10 @@ struct Options {
 
     #[clap(
         long,
-        help = "IGNORED (for compatibility with built-in rust test runner)"
+        help = "Number of threads used for running tests in parallel",
+        default_value_t = get_available_parallelism()
     )]
-    test_threads: Option<usize>,
+    test_threads: usize,
 }
 
 impl Options {


### PR DESCRIPTION
Use the `test-threads` option in sqllogictests if it is passed in, instead of ignoring it.  Default to using get_available_parallelism as before otherwise.

Previously, this option was only added for compatability with the standard test runner, but was ignored.

( This change was suggested by @alamb :
https://github.com/apache/datafusion/pull/16694#discussion_r2190398395 )

Closes #16721 