### PR TITLE
Bump the MSRV due to transitive dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/datafusion"
 # Define Minimum Supported Rust Version (MSRV)
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 # Define DataFusion version
 version = "48.0.0"
 


### PR DESCRIPTION
datafusion-cli depends on aws-config which has some transitive dependencies which require 1.85. This was a dependabot upgrade in 8366d6e155

16:18:43  error: rustc 1.83.0 is not supported by the following packages:

16:18:43    aws-sdk-sso@1.74.0 requires rustc 1.85.0

16:18:43    aws-sdk-ssooidc@1.75.0 requires rustc 1.85.0

16:18:43    aws-sdk-sts@1.76.0 requires rustc 1.85.0

16:18:43  Either upgrade rustc or select compatible dependency versions with

```16:18:43  error: rustc 1.83.0 is not supported by the following packages:

16:18:43    aws-sdk-sso@1.74.0 requires rustc 1.85.0
16:18:43    aws-sdk-ssooidc@1.75.0 requires rustc 1.85.0
16:18:43    aws-sdk-sts@1.76.0 requires rustc 1.85.0
```


The AWS SDK for Rust team takes a pretty lenient approach with MSRV upgrades and doesn't really treat them as breaking which is why aws-config


We could probably take this or bump back down to aws-config `=1.8.0`