### PR TITLE
fix: return NULL if any of the param to make_date is NULL

### DIFF
--- a/datafusion/functions/src/datetime/make_date.rs
+++ b/datafusion/functions/src/datetime/make_date.rs
@@ -122,6 +122,12 @@ impl ScalarUDFImpl for MakeDateFunc {
 
         let [years, months, days] = take_function_args(self.name(), args)?;
 
+        if matches!(years, ColumnarValue::Scalar(ScalarValue::Null)) 
+            || matches!(months, ColumnarValue::Scalar(ScalarValue::Null))
+            || matches!(days, ColumnarValue::Scalar(ScalarValue::Null)) {
+            return Ok(ColumnarValue::Scalar(ScalarValue::Null));
+        }
+
         let years = years.cast_to(&Int32, None)?;
         let months = months.cast_to(&Int32, None)?;
         let days = days.cast_to(&Int32, None)?;
@@ -376,5 +382,20 @@ mod tests {
             res.err().unwrap().strip_backtrace(),
             "Arrow error: Cast error: Can't cast value 4294967295 to type Int32"
         );
+    }
+
+    #[test]
+    fn test_make_date_null_param() {
+        let res = invoke_make_date_with_args(
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Null),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1))),
+                ColumnarValue::Scalar(ScalarValue::UInt32(Some(14))),
+            ],
+            1,
+        )
+        .expect("that make_date parsed values without error");
+
+        assert!(matches!(res, ColumnarValue::Scalar(ScalarValue::Null)));
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #16746

## Rationale for this change

Consistent make_date behavior with duck_db and postgres

## What changes are included in this PR?

Check each param for NULLs and early exit if any is

## Are these changes tested?

Have included a simple test

## Are there any user-facing changes?

Not sure about this part, do we want to change documentation around this?