### PR TITLE
Support Type Coercion for NULL in Binary Arithmetic Expressions

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -250,6 +250,18 @@ impl<'a> BinaryTypeCoercer<'a> {
             } else if let Some(numeric) = mathematics_numerical_coercion(self.lhs, self.rhs) {
                 // Numeric arithmetic, e.g. Int32 + Int32
                 Ok(Signature::uniform(numeric))
+            } else if let Some(coerced) = null_coercion(self.lhs, self.rhs) {
+                // One side is NULL, cast it to the other's type
+                let ret = get_result(&coerced, &coerced).map_err(|e| {
+                    plan_datafusion_err!(
+                        "Cannot get result type for null arithmetic {coerced} {} {coerced}: {e}", self.op
+                    )
+                })?;
+                Ok(Signature {
+                    lhs: coerced.clone(),
+                    rhs: coerced,
+                    ret,
+                })
             } else {
                 plan_err!(
                     "Cannot coerce arithmetic expression {} {} {} to valid types", self.lhs, self.op, self.rhs

--- a/datafusion/sqllogictest/test_files/dates.slt
+++ b/datafusion/sqllogictest/test_files/dates.slt
@@ -108,6 +108,12 @@ SELECT '2023-01-01T00:00:00'::timestamp - DATE '2021-01-01';
 ----
 730 days 0 hours 0 mins 0.000000000 secs
 
+# NULL with DATE arithmetic should yield NULL
+query ?
+SELECT NULL - DATE '1984-02-28';
+----
+NULL
+
 # to_date_test
 statement ok
 create table to_date_t1(ts bigint) as VALUES

--- a/datafusion/sqllogictest/test_files/dates.slt
+++ b/datafusion/sqllogictest/test_files/dates.slt
@@ -114,6 +114,11 @@ SELECT NULL - DATE '1984-02-28';
 ----
 NULL
 
+query ?
+SELECT DATE '1984-02-28' - NULL
+----
+NULL
+
 # to_date_test
 statement ok
 create table to_date_t1(ts bigint) as VALUES


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #16760

## Rationale for this change

Currently, binary arithmetic expressions involving `NULL` (e.g., `NULL - DATE '1984-02-28'`) fail coercion because they do not account for `NULL` types explicitly. This patch adds support for type coercion when one operand is `NULL`, aligning behavior with SQL semantics where operations involving `NULL` should return `NULL`.

## What changes are included in this PR?

- Added logic in `BinaryTypeCoercer` to handle `NULL` in binary arithmetic expressions by coercing it to the non-null side's type.
- Updated signature resolution to include this new coercion case.
- Added SQL logic tests verifying expected behavior for `NULL` arithmetic with `DATE` values.

## Are these changes tested?

Yes. New test cases are added in `dates.slt` to validate arithmetic involving `NULL`, ensuring that:
- `NULL - DATE` returns `NULL`
- `DATE - NULL` returns `NULL`

## Are there any user-facing changes?

Yes. Users can now perform arithmetic operations with `NULL` operands in SQL queries without encountering coercion errors. This improves compatibility and correctness with standard SQL behavior.

