### PR TITLE
Feat/better compaction

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -355,6 +355,14 @@ config_namespace! {
         /// target batch size is determined by the configuration setting
         pub coalesce_batches: bool, default = true
 
+        /// When set to true, record batches will be examined between operators and their backing
+        /// data buffers compacted if found to be too large. This helps reduce memory usage when processing
+        /// large string data.
+        pub compact_batches: bool, default = true
+
+        /// How empty may the data buffers be for compaction to trigger?
+        pub compact_threshold: f64, default = 0.3
+
         /// Should DataFusion collect statistics when first creating a table.
         /// Has no effect after the table is created. Applies to the default
         /// `ListingTableProvider` in DataFusion. Defaults to true.

--- a/datafusion/physical-optimizer/src/compact.rs
+++ b/datafusion/physical-optimizer/src/compact.rs
@@ -1,0 +1,107 @@
+use datafusion_common::{
+    config::ConfigOptions,
+    tree_node::{Transformed, TransformedResult, TreeNode},
+    Result,
+};
+use datafusion_physical_plan::{
+    aggregates::AggregateExec, coalesce_batches::CoalesceBatchesExec,
+    compact::CompactExec, execution_plan::CardinalityEffect, joins::HashJoinExec,
+    repartition::RepartitionExec, ExecutionPlan,
+};
+
+use crate::PhysicalOptimizerRule;
+
+use std::sync::Arc;
+
+/// Optimizer rule that introduces CoalesceBatchesExec to avoid overhead with small batches that
+/// are produced by highly selective filters
+#[derive(Default, Debug)]
+pub struct CompactBatches {}
+
+impl CompactBatches {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+impl PhysicalOptimizerRule for CompactBatches {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if !config.execution.compact_batches {
+            return Ok(plan);
+        }
+
+        fn passthrough(root: &dyn ExecutionPlan) -> bool {
+            let root_any = root.as_any();
+
+            return root_any.downcast_ref::<RepartitionExec>().is_some()
+                || root_any.downcast_ref::<CoalesceBatchesExec>().is_some()
+                || matches!(root.cardinality_effect(), CardinalityEffect::Equal)
+                || root.children().len() == 0;
+        }
+
+        fn rec(
+            root: Arc<dyn ExecutionPlan>,
+            compact_needed: bool,
+            compact_threshold: f64,
+        ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
+            // todo: Move compaction into hash join: Different compaction strategy for build / probe side
+            if let Some(hj) = root.as_any().downcast_ref::<HashJoinExec>() {
+                let left = rec(Arc::clone(&hj.left()), true, compact_threshold)?;
+                let right = rec(Arc::clone(&hj.right()), false, compact_threshold)?;
+
+                return if left.transformed || right.transformed {
+                    Ok(Transformed::yes(Arc::new(CompactExec::new(
+                        compact_threshold,
+                        root.with_new_children(vec![left.data, right.data])?,
+                    ))))
+                } else {
+                    Ok(Transformed::yes(Arc::new(CompactExec::new(
+                        compact_threshold,
+                        root,
+                    ))))
+                };
+            }
+
+            if let Some(agg) = root.as_any().downcast_ref::<AggregateExec>() {
+                let input = rec(Arc::clone(&agg.input()), true, compact_threshold)?;
+
+                return if input.transformed {
+                    Ok(Transformed::yes(root.with_new_children(vec![input.data])?))
+                } else {
+                    Ok(Transformed::no(root))
+                };
+            }
+
+            if passthrough(root.as_ref()) {
+                return root
+                    .map_children(|child| rec(child, compact_needed, compact_threshold));
+            }
+
+            if root.as_any().downcast_ref::<CompactExec>().is_some() {
+                return root.map_children(|child| rec(child, false, compact_threshold));
+            }
+
+            let new_root =
+                root.map_children(|child| rec(child, false, compact_threshold));
+
+            Ok(Transformed::yes(Arc::new(CompactExec::new(
+                compact_threshold,
+                new_root.data()?,
+            ))))
+        }
+
+        rec(plan, false, config.execution.compact_threshold).data()
+    }
+
+    fn name(&self) -> &str {
+        "compact"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}

--- a/datafusion/physical-optimizer/src/lib.rs
+++ b/datafusion/physical-optimizer/src/lib.rs
@@ -28,6 +28,7 @@ pub mod aggregate_statistics;
 pub mod coalesce_async_exec_input;
 pub mod coalesce_batches;
 pub mod combine_partial_final_agg;
+pub mod compact;
 pub mod enforce_distribution;
 pub mod enforce_sorting;
 pub mod ensure_coop;

--- a/datafusion/physical-optimizer/src/optimizer.rs
+++ b/datafusion/physical-optimizer/src/optimizer.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use crate::aggregate_statistics::AggregateStatistics;
 use crate::coalesce_batches::CoalesceBatches;
 use crate::combine_partial_final_agg::CombinePartialFinalAggregate;
+use crate::compact::CompactBatches;
 use crate::enforce_distribution::EnforceDistribution;
 use crate::enforce_sorting::EnforceSorting;
 use crate::ensure_coop::EnsureCooperative;
@@ -123,6 +124,7 @@ impl PhysicalOptimizer {
             // whole plan tree. Therefore, to avoid influencing other rules, it should run last.
             Arc::new(CoalesceBatches::new()),
             Arc::new(CoalesceAsyncExecInput::new()),
+            Arc::new(CompactBatches::new()),
             // Remove the ancillary output requirement operator since we are done with the planning
             // phase.
             Arc::new(OutputRequirements::new_remove_mode()),

--- a/datafusion/physical-optimizer/src/optimizer.rs
+++ b/datafusion/physical-optimizer/src/optimizer.rs
@@ -120,11 +120,13 @@ impl PhysicalOptimizer {
             Arc::new(OptimizeAggregateOrder::new()),
             // TODO: `try_embed_to_hash_join` in the ProjectionPushdown rule would be block by the CoalesceBatches, so add it before CoalesceBatches. Maybe optimize it in the future.
             Arc::new(ProjectionPushdown::new()),
+            // We introduce the compact batches rule ahead of CoalesceBatches. We want CompactBatches to occur before repartitions,
+            // but to occur after CoalesceBatches in other contexts (... after filters).
+            Arc::new(CompactBatches::new()),
             // The CoalesceBatches rule will not influence the distribution and ordering of the
             // whole plan tree. Therefore, to avoid influencing other rules, it should run last.
             Arc::new(CoalesceBatches::new()),
             Arc::new(CoalesceAsyncExecInput::new()),
-            Arc::new(CompactBatches::new()),
             // Remove the ancillary output requirement operator since we are done with the planning
             // phase.
             Arc::new(OutputRequirements::new_remove_mode()),

--- a/datafusion/physical-plan/src/compact.rs
+++ b/datafusion/physical-plan/src/compact.rs
@@ -1,0 +1,276 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{ready, Context, Poll},
+};
+
+use arrow::{
+    array::{
+        Array, ArrayRef, AsArray, ByteView, GenericByteViewArray, GenericByteViewBuilder,
+        RecordBatch,
+    },
+    datatypes::ByteViewType,
+};
+use arrow_schema::SchemaRef;
+use datafusion_common::{config::ConfigOptions, internal_err, Result, Statistics};
+use datafusion_execution::{RecordBatchStream, SendableRecordBatchStream};
+use datafusion_physical_expr::PhysicalExpr;
+use futures::{Stream, StreamExt};
+
+use crate::{
+    execution_plan::CardinalityEffect,
+    filter_pushdown::{
+        ChildPushdownResult, FilterDescription, FilterPushdownPhase,
+        FilterPushdownPropagation,
+    },
+    metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet, RecordOutput},
+    DisplayAs, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+};
+
+#[derive(Clone, Debug)]
+struct CompactExec {
+    compact_threshold: f64,
+    metrics: ExecutionPlanMetricsSet,
+    cache: PlanProperties,
+    input: Arc<dyn ExecutionPlan>,
+}
+
+impl DisplayAs for CompactExec {
+    fn fmt_as(
+        &self,
+        t: crate::DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        use crate::DisplayFormatType::*;
+
+        match t {
+            Default | Verbose => {
+                write!(
+                    f,
+                    "CompactExec: compact_threshold={}",
+                    self.compact_threshold,
+                )?;
+            }
+            TreeRender => {
+                write!(f, "compact_threshold={}", self.compact_threshold)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl CompactExec {
+    fn new(compact_threshold: f64, input: Arc<dyn ExecutionPlan>) -> Self {
+        let cache = Self::compute_properties(&input);
+
+        Self {
+            compact_threshold,
+            metrics: ExecutionPlanMetricsSet::new(),
+            cache,
+            input,
+        }
+    }
+
+    /// This function creates the cache object that stores the plan properties such as
+    /// schema, equivalence properties, ordering, partitioning, etc.
+    fn compute_properties(input: &Arc<dyn ExecutionPlan>) -> PlanProperties {
+        // The compact operator does not make any changes to the
+        // partitioning of its input.
+        PlanProperties::new(
+            input.equivalence_properties().clone(), // Equivalence Properties
+            input.output_partitioning().clone(),    // Output Partitioning
+            input.pipeline_behavior(),
+            input.boundedness(),
+        )
+    }
+}
+
+impl ExecutionPlan for CompactExec {
+    fn name(&self) -> &str {
+        "CompactExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let Some(input) = children.pop() else {
+            return internal_err!("CompactExec needs a single child");
+        };
+        Ok(Arc::new(Self::new(self.compact_threshold, input)))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion_execution::TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        return Ok(Box::pin(CompactStream {
+            schema: self.schema(),
+            input: self.input.execute(partition, context)?,
+            compact_threshold: self.compact_threshold,
+            metrics: BaselineMetrics::new(&self.metrics, partition),
+        }));
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        self.partition_statistics(None)
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        self.input.partition_statistics(partition)
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+    }
+}
+
+struct CompactStream {
+    schema: SchemaRef,
+    input: SendableRecordBatchStream,
+    compact_threshold: f64,
+    metrics: BaselineMetrics,
+}
+
+impl RecordBatchStream for CompactStream {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}
+
+impl Stream for CompactStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match ready!(self.input.poll_next_unpin(cx)) {
+            Some(Ok(batch)) => {
+                let _timer = self.metrics.elapsed_compute().timer();
+                let output = compact(self.compact_threshold, batch);
+                Poll::Ready(Some(Ok(output.record_output(&self.metrics))))
+            }
+            Some(Err(e)) => Poll::Ready(Some(Err(e))),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+fn compact_view_column<T: ByteViewType>(
+    threshold: f64,
+    array: &GenericByteViewArray<T>,
+) -> Option<ArrayRef> {
+    const INLINE_THRESHOLD: u32 = 12;
+
+    if array.data_buffers().is_empty() {
+        return None;
+    }
+
+    let ideal_buffer_size: usize = array
+        .views()
+        .iter()
+        .map(|view| {
+            let byte_view = ByteView::from(*view);
+            if byte_view.length > INLINE_THRESHOLD {
+                byte_view.length as usize
+            } else {
+                0
+            }
+        })
+        .sum();
+
+    let actual_buffer_size: usize =
+        array.data_buffers().iter().map(|buf| buf.capacity()).sum();
+
+    if actual_buffer_size as f64 > ideal_buffer_size as f64 * threshold {
+        // todo: request APIs from arrow-rs to obtain a mutable downcasted array
+        // ... so we can reuse the data buffers of the column here.
+        // until then: out of place :(
+
+        // No data buffers are needed => Drop them all
+        if ideal_buffer_size == 0 {
+            return Some(Arc::new(unsafe {
+                GenericByteViewArray::<T>::new_unchecked(
+                    array.views().clone(),
+                    vec![],
+                    array.nulls().cloned(),
+                )
+            }));
+        }
+
+        let mut builder = GenericByteViewBuilder::<T>::with_capacity(array.len())
+            .with_fixed_block_size(ideal_buffer_size as u32);
+
+        for view in array.iter() {
+            builder.append_option(view);
+        }
+
+        Some(Arc::new(builder.finish()))
+    } else {
+        None
+    }
+}
+
+fn compact(threshold: f64, batch: RecordBatch) -> RecordBatch {
+    let compact_column = |column: ArrayRef| -> ArrayRef {
+        if let Some(string_view_array) = column.as_string_view_opt() {
+            return compact_view_column(threshold, string_view_array).unwrap_or(column);
+        }
+
+        if let Some(bin_view_array) = column.as_binary_view_opt() {
+            return compact_view_column(threshold, bin_view_array).unwrap_or(column);
+        }
+
+        column
+    };
+
+    let (schema, columns, row_count) = batch.into_parts();
+    let columns = columns.into_iter().map(compact_column).collect();
+
+    unsafe { RecordBatch::new_unchecked(schema, columns, row_count) }
+}

--- a/datafusion/physical-plan/src/compact.rs
+++ b/datafusion/physical-plan/src/compact.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-struct CompactExec {
+pub struct CompactExec {
     compact_threshold: f64,
     metrics: ExecutionPlanMetricsSet,
     cache: PlanProperties,
@@ -61,7 +61,7 @@ impl DisplayAs for CompactExec {
 }
 
 impl CompactExec {
-    fn new(compact_threshold: f64, input: Arc<dyn ExecutionPlan>) -> Self {
+    pub fn new(compact_threshold: f64, input: Arc<dyn ExecutionPlan>) -> Self {
         let cache = Self::compute_properties(&input);
 
         Self {

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -65,6 +65,7 @@ pub mod coalesce;
 pub mod coalesce_batches;
 pub mod coalesce_partitions;
 pub mod common;
+pub mod compact;
 pub mod coop;
 pub mod display;
 pub mod empty;


### PR DESCRIPTION
Goal: decouple the compaction of string view / binary view buffers from the coalescing of batches.
Why: Avoid compacting string views after hash partitioning
How: Add CompactExec ExecutionPlan that compacts StringView columns as they pass through the operator. Remove compaction from CoalesceBatchesExec