### PR TITLE
Support min/max aggregates for FixedSizeBinary type

### DIFF
--- a/datafusion/datasource/src/file_compression_type.rs
+++ b/datafusion/datasource/src/file_compression_type.rs
@@ -244,6 +244,12 @@ impl FileCompressionType {
     }
 }
 
+/// Trait for extending the functionality of the `FileType` enum.
+pub trait FileTypeExt {
+    /// Given a `FileCompressionType`, return the `FileType`'s extension with compression suffix
+    fn get_ext_with_compression(&self, c: FileCompressionType) -> Result<String>;
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/datafusion/datasource/src/file_compression_type.rs
+++ b/datafusion/datasource/src/file_compression_type.rs
@@ -244,12 +244,6 @@ impl FileCompressionType {
     }
 }
 
-/// Trait for extending the functionality of the `FileType` enum.
-pub trait FileTypeExt {
-    /// Given a `FileCompressionType`, return the `FileType`'s extension with compression suffix
-    fn get_ext_with_compression(&self, c: FileCompressionType) -> Result<String>;
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -257,7 +257,7 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::FixedSizeBinary(size) => {
             let array = downcast_value!(&values, FixedSizeBinaryArray);
             let value = compute::min_fixed_size_binary(array);
-            let value = value.and_then(|e| Some(e.to_vec()));
+            let value = value.map(|e| e.to_vec());
             ScalarValue::FixedSizeBinary(*size, value)
         }
         DataType::BinaryView => {
@@ -348,7 +348,7 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::FixedSizeBinary(size) => {
             let array = downcast_value!(&values, FixedSizeBinaryArray);
             let value = compute::max_fixed_size_binary(array);
-            let value = value.and_then(|e| Some(e.to_vec()));
+            let value = value.map(|e| e.to_vec());
             ScalarValue::FixedSizeBinary(*size, value)
         }
         DataType::Struct(_) => min_max_batch_generic(values, Ordering::Less)?,

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -20,11 +20,11 @@
 use arrow::array::{
     ArrayRef, AsArray as _, BinaryArray, BinaryViewArray, BooleanArray, Date32Array,
     Date64Array, Decimal128Array, Decimal256Array, DurationMicrosecondArray,
-    DurationMillisecondArray, DurationNanosecondArray, DurationSecondArray, Float16Array,
-    Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
-    IntervalDayTimeArray, IntervalMonthDayNanoArray, IntervalYearMonthArray,
-    LargeBinaryArray, LargeStringArray, StringArray, StringViewArray,
-    Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
+    DurationMillisecondArray, DurationNanosecondArray, DurationSecondArray,
+    FixedSizeBinaryArray, Float16Array, Float32Array, Float64Array, Int16Array,
+    Int32Array, Int64Array, Int8Array, IntervalDayTimeArray, IntervalMonthDayNanoArray,
+    IntervalYearMonthArray, LargeBinaryArray, LargeStringArray, StringArray,
+    StringViewArray, Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
     Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
     TimestampNanosecondArray, TimestampSecondArray, UInt16Array, UInt32Array,
     UInt64Array, UInt8Array,
@@ -254,6 +254,12 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
                 min_binary
             )
         }
+        DataType::FixedSizeBinary(size) => {
+            let array = downcast_value!(&values, FixedSizeBinaryArray);
+            let value = compute::min_fixed_size_binary(array);
+            let value = value.and_then(|e| Some(e.to_vec()));
+            ScalarValue::FixedSizeBinary(*size, value)
+        }
         DataType::BinaryView => {
             typed_min_max_batch_binary!(
                 &values,
@@ -338,6 +344,12 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
                 LargeBinary,
                 max_binary
             )
+        }
+        DataType::FixedSizeBinary(size) => {
+            let array = downcast_value!(&values, FixedSizeBinaryArray);
+            let value = compute::max_fixed_size_binary(array);
+            let value = value.and_then(|e| Some(e.to_vec()));
+            ScalarValue::FixedSizeBinary(*size, value)
         }
         DataType::Struct(_) => min_max_batch_generic(values, Ordering::Less)?,
         DataType::List(_) => min_max_batch_generic(values, Ordering::Less)?,

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -4351,6 +4351,50 @@ DROP VIEW binary_views
 statement ok
 DROP TABLE strings;
 
+############ FixedSizeBinary ############
+
+statement ok
+CREATE TABLE binaries
+AS VALUES
+ (X'000103', 1),
+ (X'000104', 1),
+ (X'000101', 3),
+ (X'000103', 1),
+ (X'000102', 1),
+ (NULL, 1),
+ (NULL, 4),
+ (X'000104', 1),
+ (X'000109', 2),
+ (X'000103', 1),
+ (X'000101', 2);
+
+statement ok
+CREATE VIEW fixed_size_binary_views
+AS SELECT arrow_cast(column1, 'FixedSizeBinary(3)') as value, column2 as id FROM binaries;
+
+query I?
+SELECT id, MIN(value) FROM fixed_size_binary_views GROUP BY id ORDER BY id;
+----
+1 000102
+2 000101
+3 000101
+4 NULL
+
+query I?
+SELECT id, MAX(value) FROM fixed_size_binary_views GROUP BY id ORDER BY id;
+----
+1 000104
+2 000109
+3 000101
+4 NULL
+
+statement ok
+DROP VIEW fixed_size_binary_views;
+
+statement ok
+DROP TABLE binaries;
+
+
 #################
 # End min_max on strings/binary with null values and groups
 #################


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #16513

## Rationale for this change

This
```sql
CREATE TABLE binaries AS VALUES (X'000103', 1);

CREATE VIEW fixed_size_binary_views
AS SELECT arrow_cast(column1, 'FixedSizeBinary(3)') as value, column2 as id FROM binaries;

SELECT id, MIN(value) FROM fixed_size_binary_views GROUP BY id ORDER BY id;
```
led to `Min/Max accumulator not implemented for type FixedSizeBinary`

## What changes are included in this PR?

Extended function-aggregate implementation to support FixedSizeBinary using [new arrow-rs](https://github.com/apache/arrow-rs/issues/7674) `min_fixed_size_binary` function.

Also, removed a leftover `FileTypeExt` after a previous refactoring

## Are these changes tested?

- slt integration tests
- manual tests

## Are there any user-facing changes?

No
