### PR TITLE
Allow comparison between boolean and int values

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -2539,7 +2539,7 @@ mod tests {
         for int_type in int_types {
             test_coercion_binary_rule!(
                 DataType::Boolean,
-                DataType::Int8,
+                int_type,
                 Operator::Eq,
                 DataType::Boolean
             );

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1823,11 +1823,25 @@ mod test {
         "
         )?;
 
-        let empty = empty_with_type(DataType::Int64);
+        let empty = empty_with_type(DataType::Float64);
         let plan = LogicalPlan::Projection(Projection::try_new(vec![expr], empty)?);
         assert_type_coercion_error(
             plan,
-            "Cannot infer common argument type for comparison operation Int64 IS DISTINCT FROM Boolean"
+            "Cannot infer common argument type for comparison operation Float64 IS DISTINCT FROM Boolean"
+        )?;
+
+        // cast to integer
+        let expr = col("a").is_true();
+        let empty = empty_with_type(DataType::Int64);
+        let plan =
+            LogicalPlan::Projection(Projection::try_new(vec![expr.clone()], empty)?);
+
+        assert_analyzed_plan_eq!(
+            plan,
+            @r"
+        Projection: CAST(a AS Boolean) IS TRUE
+          EmptyRelation
+        "
         )?;
 
         // is not true

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -1085,19 +1085,19 @@ mod tests {
 
     #[test]
     fn case_test_incompatible() -> Result<()> {
-        // 1 then is int64
+        // 1 then is float64
         // 2 then is boolean
         let batch = case_test_batch()?;
         let schema = batch.schema();
 
-        // CASE WHEN a = 'foo' THEN 123 WHEN a = 'bar' THEN true END
+        // CASE WHEN a = 'foo' THEN 1.23 WHEN a = 'bar' THEN true END
         let when1 = binary(
             col("a", &schema)?,
             Operator::Eq,
             lit("foo"),
             &batch.schema(),
         )?;
-        let then1 = lit(123i32);
+        let then1 = lit(1.23f64);
         let when2 = binary(
             col("a", &schema)?,
             Operator::Eq,

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1536,8 +1536,10 @@ SELECT not(true), not(false)
 ----
 false true
 
-query error type_coercion\ncaused by\nError during planning: Cannot infer common argument type for comparison operation Int64 IS DISTINCT FROM Boolean
+query BB
 SELECT not(1), not(0)
+----
+false true
 
 query ?B
 SELECT null, not(null)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #16797 

## Rationale for this change

This PR enables comparison between boolean and interger types which already supported by [arrow cast](https://github.com/apache/arrow-rs/blob/main/arrow-cast/src/cast/mod.rs#L583-L595)


## What changes are included in this PR?

Added boolean_coercion

## Are these changes tested?
Added tests

## Are there any user-facing changes?
No
