### PR TITLE
benchmark: Add parquet h2o support

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -100,15 +100,24 @@ clickbench_pushdown:    ClickBench queries against partitioned (100 files) parqu
 clickbench_extended:    ClickBench \"inspired\" queries against a single parquet (DataFusion specific)
 
 # H2O.ai Benchmarks (Group By, Join, Window)
-h2o_small:              h2oai benchmark with small dataset (1e7 rows) for groupby,  default file format is csv
-h2o_medium:             h2oai benchmark with medium dataset (1e8 rows) for groupby, default file format is csv
-h2o_big:                h2oai benchmark with large dataset (1e9 rows) for groupby,  default file format is csv
-h2o_small_join:         h2oai benchmark with small dataset (1e7 rows) for join,  default file format is csv
-h2o_medium_join:        h2oai benchmark with medium dataset (1e8 rows) for join, default file format is csv
-h2o_big_join:           h2oai benchmark with large dataset (1e9 rows) for join,  default file format is csv
-h2o_small_window:       Extended h2oai benchmark with small dataset (1e7 rows) for window,  default file format is csv
-h2o_medium_window:      Extended h2oai benchmark with medium dataset (1e8 rows) for window, default file format is csv
-h2o_big_window:         Extended h2oai benchmark with large dataset (1e9 rows) for window,  default file format is csv
+h2o_small:                      h2oai benchmark with small dataset (1e7 rows) for groupby,  default file format is csv
+h2o_medium:                     h2oai benchmark with medium dataset (1e8 rows) for groupby, default file format is csv
+h2o_big:                        h2oai benchmark with large dataset (1e9 rows) for groupby,  default file format is csv
+h2o_small_join:                 h2oai benchmark with small dataset (1e7 rows) for join,  default file format is csv
+h2o_medium_join:                h2oai benchmark with medium dataset (1e8 rows) for join, default file format is csv
+h2o_big_join:                   h2oai benchmark with large dataset (1e9 rows) for join,  default file format is csv
+h2o_small_window:               Extended h2oai benchmark with small dataset (1e7 rows) for window,  default file format is csv
+h2o_medium_window:              Extended h2oai benchmark with medium dataset (1e8 rows) for window, default file format is csv
+h2o_big_window:                 Extended h2oai benchmark with large dataset (1e9 rows) for window,  default file format is csv
+h2o_small_parquet:              h2oai benchmark with small dataset (1e7 rows) for groupby,  file format is parquet
+h2o_medium_parquet:             h2oai benchmark with medium dataset (1e8 rows) for groupby, file format is parquet
+h2o_big_parquet:                h2oai benchmark with large dataset (1e9 rows) for groupby,  file format is parquet
+h2o_small_join_parquet:         h2oai benchmark with small dataset (1e7 rows) for join,  file format is parquet
+h2o_medium_join_parquet:        h2oai benchmark with medium dataset (1e8 rows) for join, file format is parquet
+h2o_big_join_parquet:           h2oai benchmark with large dataset (1e9 rows) for join,  file format is parquet
+h2o_small_window_parquet:       Extended h2oai benchmark with small dataset (1e7 rows) for window,  file format is parquet
+h2o_medium_window_parquet:      Extended h2oai benchmark with medium dataset (1e8 rows) for window, file format is parquet
+h2o_big_window_parquet:         Extended h2oai benchmark with large dataset (1e9 rows) for window,  file format is parquet
 
 # Join Order Benchmark (IMDB)
 imdb:                   Join Order Benchmark (JOB) using the IMDB dataset converted to parquet
@@ -245,6 +254,34 @@ main() {
                 h2o_big_window)
                     data_h2o_join "BIG" "CSV"
                     ;;
+                h2o_small_parquet)
+                    data_h2o "SMALL" "PARQUET"
+                    ;;
+                h2o_medium_parquet)
+                    data_h2o "MEDIUM" "PARQUET"
+                    ;;
+                h2o_big_parquet)
+                    data_h2o "BIG" "PARQUET"
+                    ;;
+                h2o_small_join_parquet)
+                    data_h2o_join "SMALL" "PARQUET"
+                    ;;
+                h2o_medium_join_parquet)
+                    data_h2o_join "MEDIUM" "PARQUET"
+                    ;;
+                h2o_big_join_parquet)
+                    data_h2o_join "BIG" "PARQUET"
+                    ;;
+                # h2o window benchmark uses the same data as the h2o join
+                h2o_small_window_parquet)
+                    data_h2o_join "SMALL" "PARQUET"
+                    ;;
+                h2o_medium_window_parquet)
+                    data_h2o_join "MEDIUM" "PARQUET"
+                    ;;
+                h2o_big_window_parquet)
+                    data_h2o_join "BIG" "PARQUET"
+                    ;;
                 external_aggr)
                     # same data as for tpch
                     data_tpch "1"
@@ -380,6 +417,34 @@ main() {
                     ;;
                 h2o_big_window) 
                     run_h2o_window "BIG" "CSV" "window"
+                    ;;
+                h2o_small_parquet)
+                    run_h2o "SMALL" "PARQUET"
+                    ;;
+                h2o_medium_parquet)
+                    run_h2o "MEDIUM" "PARQUET"
+                    ;;
+                h2o_big_parquet)
+                    run_h2o "BIG" "PARQUET"
+                    ;;
+                h2o_small_join_parquet)
+                    run_h2o_join "SMALL" "PARQUET"
+                    ;;
+                h2o_medium_join_parquet)
+                    run_h2o_join "MEDIUM" "PARQUET"
+                    ;;
+                h2o_big_join_parquet)
+                    run_h2o_join "BIG" "PARQUET"
+                    ;;
+                # h2o window benchmark uses the same data as the h2o join
+                h2o_small_window_parquet)
+                    run_h2o_window "SMALL" "PARQUET"
+                    ;;
+                h2o_medium_window_parquet)
+                    run_h2o_window "MEDIUM" "PARQUET"
+                    ;;
+                h2o_big_window_parquet)
+                    run_h2o_window "BIG" "PARQUET"
                     ;;
                 external_aggr)
                     run_external_aggr
@@ -775,6 +840,7 @@ data_h2o() {
 
     # Set virtual environment directory
     VIRTUAL_ENV="${PWD}/venv"
+    rm -rf "$VIRTUAL_ENV"
 
     # Create a virtual environment using the detected Python command
     $PYTHON_CMD -m venv "$VIRTUAL_ENV"

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -840,7 +840,6 @@ data_h2o() {
 
     # Set virtual environment directory
     VIRTUAL_ENV="${PWD}/venv"
-    rm -rf "$VIRTUAL_ENV"
 
     # Create a virtual environment using the detected Python command
     $PYTHON_CMD -m venv "$VIRTUAL_ENV"

--- a/benchmarks/src/h2o.rs
+++ b/benchmarks/src/h2o.rs
@@ -169,7 +169,7 @@ impl RunOpt {
                     .await
                     .map_err(|e| {
                         DataFusionError::Context(
-                            format!("Registering 'table' as {}", table_path_str).into(),
+                            format!("Registering 'table' as {table_path_str}"),
                             Box::new(e),
                         )
                     })
@@ -180,7 +180,7 @@ impl RunOpt {
                     .await
                     .map_err(|e| {
                         DataFusionError::Context(
-                            format!("Registering 'table' as {}", table_path_str).into(),
+                            format!("Registering 'table' as {table_path_str}"),
                             Box::new(e),
                         )
                     })
@@ -188,8 +188,7 @@ impl RunOpt {
             }
             _ => {
                 return Err(DataFusionError::Plan(format!(
-                    "Unsupported file extension: {}",
-                    extension
+                    "Unsupported file extension: {extension}",
                 )));
             }
         }

--- a/benchmarks/src/h2o.rs
+++ b/benchmarks/src/h2o.rs
@@ -24,7 +24,7 @@ use crate::util::{BenchmarkRun, CommonOpt};
 use datafusion::logical_expr::{ExplainFormat, ExplainOption};
 use datafusion::{error::Result, prelude::SessionContext};
 use datafusion_common::{
-    exec_datafusion_err, instant::Instant, internal_err, DataFusionError,
+    exec_datafusion_err, instant::Instant, internal_err, DataFusionError, TableReference,
 };
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
@@ -92,18 +92,18 @@ impl RunOpt {
         // Register tables depending on which h2o benchmark is being run
         // (groupby/join/window)
         if self.queries_path.to_str().unwrap().ends_with("groupby.sql") {
-            self.register_data(&ctx).await?;
+            self.register_data("x", self.path.as_os_str().to_str().unwrap(), &ctx)
+                .await?;
         } else if self.queries_path.to_str().unwrap().ends_with("join.sql") {
             let join_paths: Vec<&str> = self.join_paths.split(',').collect();
             let table_name: Vec<&str> = vec!["x", "small", "medium", "large"];
             for (i, path) in join_paths.iter().enumerate() {
-                ctx.register_csv(table_name[i], path, Default::default())
-                    .await?;
+                self.register_data(table_name[i], path, &ctx).await?;
             }
         } else if self.queries_path.to_str().unwrap().ends_with("window.sql") {
             // Only register the 'large' table in h2o-join dataset
             let h2o_join_large_path = self.join_paths.split(',').nth(3).unwrap();
-            ctx.register_csv("large", h2o_join_large_path, Default::default())
+            self.register_data("large", h2o_join_large_path, &ctx)
                 .await?;
         } else {
             return internal_err!("Invalid query file path");
@@ -147,21 +147,28 @@ impl RunOpt {
         Ok(())
     }
 
-    async fn register_data(&self, ctx: &SessionContext) -> Result<()> {
+    async fn register_data(
+        &self,
+        table_ref: impl Into<TableReference>,
+        table_path: impl AsRef<str>,
+        ctx: &SessionContext,
+    ) -> Result<()> {
         let csv_options = Default::default();
         let parquet_options = Default::default();
-        let path = self.path.as_os_str().to_str().unwrap();
+
+        let table_path_str = table_path.as_ref();
 
         if self.path.extension().map(|s| s == "csv").unwrap_or(false) {
-            ctx.register_csv("x", path, csv_options)
+            ctx.register_csv(table_ref, table_path_str, csv_options)
                 .await
                 .map_err(|e| {
                     DataFusionError::Context(
-                        format!("Registering 'table' as {path}"),
+                        format!("Registering 'table' as {}", table_path_str),
                         Box::new(e),
                     )
                 })
                 .expect("error registering csv");
+            return Ok(());
         }
 
         if self
@@ -170,11 +177,11 @@ impl RunOpt {
             .map(|s| s == "parquet")
             .unwrap_or(false)
         {
-            ctx.register_parquet("x", path, parquet_options)
+            ctx.register_parquet(table_ref, table_path_str, parquet_options)
                 .await
                 .map_err(|e| {
                     DataFusionError::Context(
-                        format!("Registering 'table' as {path}"),
+                        format!("Registering 'table' as {}", table_path_str),
                         Box::new(e),
                     )
                 })


### PR DESCRIPTION
## Which issue does this PR close?
Currently, we only support for CSV format for h2o benchmark, but from the compare with other database result, it is using parquet, so this ticket try to support parquet format benchmark in datafusion.


Details:
https://github.com/apache/datafusion/issues/16710#issuecomment-3078052376

cc @alamb @Dandandan @2010YOUY01 


## Rationale for this change

Currently, we only support for CSV format for h2o benchmark, but from the compare with other database result, it is using parquet, so this ticket try to support parquet format benchmark in datafusion.

## What changes are included in this PR?

Currently, we only support for CSV format for h2o benchmark, but from the compare with other database result, it is using parquet, so this ticket try to support parquet format benchmark in datafusion.

## Are these changes tested?

Tested group by, join, both ok now.

```rust
./bench.sh run h2o_medium_join_parquet
***************************
DataFusion Benchmark Script
COMMAND: run
BENCHMARK: h2o_medium_join_parquet
QUERY: All
DATAFUSION_DIR: /Users/zhuqi/arrow-datafusion/benchmarks/..
BRANCH_NAME: support_parquet_for_h2o
DATA_DIR: /Users/zhuqi/arrow-datafusion/benchmarks/data
RESULTS_DIR: /Users/zhuqi/arrow-datafusion/benchmarks/results/support_parquet_for_h2o
CARGO_COMMAND: cargo run --release
PREFER_HASH_JOIN: true
***************************
RESULTS_FILE: /Users/zhuqi/arrow-datafusion/benchmarks/results/support_parquet_for_h2o/h2o_join.json
Running h2o join benchmark...
+ cargo run --release --bin dfbench -- h2o --iterations 3 --join-paths /Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_NA_0.parquet,/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_1e2_0.parquet,/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_1e5_0.parquet,/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_1e8_NA.parquet --queries-path /Users/zhuqi/arrow-datafusion/benchmarks/queries/h2o/join.sql -o /Users/zhuqi/arrow-datafusion/benchmarks/results/support_parquet_for_h2o/h2o_join.json
    Finished `release` profile [optimized] target(s) in 0.34s
     Running `/Users/zhuqi/arrow-datafusion/target/aarch64-apple-darwin/release/dfbench h2o --iterations 3 --join-paths /Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_NA_0.parquet,/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_1e2_0.parquet,/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_1e5_0.parquet,/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_1e8_NA.parquet --queries-path /Users/zhuqi/arrow-datafusion/benchmarks/queries/h2o/join.sql -o /Users/zhuqi/arrow-datafusion/benchmarks/results/support_parquet_for_h2o/h2o_join.json`
Running benchmarks with the following options: RunOpt { query: None, common: CommonOpt { iterations: 3, partitions: None, batch_size: None, mem_pool_type: "fair", memory_limit: None, sort_spill_reservation_bytes: None, debug: false }, queries_path: "/Users/zhuqi/arrow-datafusion/benchmarks/queries/h2o/join.sql", path: "benchmarks/data/h2o/G1_1e7_1e7_100_0.csv", join_paths: "/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_NA_0.parquet,/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_1e2_0.parquet,/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_1e5_0.parquet,/Users/zhuqi/arrow-datafusion/benchmarks/data/h2o/J1_1e8_1e8_NA.parquet", output_path: Some("/Users/zhuqi/arrow-datafusion/benchmarks/results/support_parquet_for_h2o/h2o_join.json") }
Q1: SELECT x.id1, x.id2, x.id3, x.id4 as xid4, small.id4 as smallid4, x.id5, x.id6, x.v1, small.v2 FROM x INNER JOIN small ON x.id1 = small.id1;
Query 1 iteration 1 took 6.2 ms and returned 90 rows
Query 1 iteration 2 took 0.7 ms and returned 90 rows
Query 1 iteration 3 took 0.6 ms and returned 90 rows
Query 1 avg time: 2.51 ms
Q2: SELECT x.id1 as xid1, medium.id1 as mediumid1, x.id2, x.id3, x.id4 as xid4, medium.id4 as mediumid4, x.id5 as xid5, medium.id5 as mediumid5, x.id6, x.v1, medium.v2 FROM x INNER JOIN medium ON x.id2 = medium.id2;
Query 2 iteration 1 took 5.4 ms and returned 89 rows
Query 2 iteration 2 took 4.1 ms and returned 89 rows
Query 2 iteration 3 took 4.4 ms and returned 89 rows
Query 2 avg time: 4.64 ms
Q3: SELECT x.id1 as xid1, medium.id1 as mediumid1, x.id2, x.id3, x.id4 as xid4, medium.id4 as mediumid4, x.id5 as xid5, medium.id5 as mediumid5, x.id6, x.v1, medium.v2 FROM x LEFT JOIN medium ON x.id2 = medium.id2;
Query 3 iteration 1 took 4.1 ms and returned 100 rows
Query 3 iteration 2 took 3.8 ms and returned 100 rows
Query 3 iteration 3 took 4.2 ms and returned 100 rows
Query 3 avg time: 4.02 ms
Q4: SELECT x.id1 as xid1, medium.id1 as mediumid1, x.id2, x.id3, x.id4 as xid4, medium.id4 as mediumid4, x.id5 as xid5, medium.id5 as mediumid5, x.id6, x.v1, medium.v2 FROM x JOIN medium ON x.id5 = medium.id5;
Query 4 iteration 1 took 3.0 ms and returned 89 rows
Query 4 iteration 2 took 2.9 ms and returned 89 rows
Query 4 iteration 3 took 2.8 ms and returned 89 rows
Query 4 avg time: 2.90 ms
Q5: SELECT x.id1 as xid1, large.id1 as largeid1, x.id2 as xid2, large.id2 as largeid2, x.id3, x.id4 as xid4, large.id4 as largeid4, x.id5 as xid5, large.id5 as largeid5, x.id6 as xid6, large.id6 as largeid6, x.v1, large.v2 FROM x JOIN large ON x.id3 = large.id3;
Query 5 iteration 1 took 468.4 ms and returned 92 rows
Query 5 iteration 2 took 464.7 ms and returned 92 rows
Query 5 iteration 3 took 449.2 ms and returned 92 rows
Query 5 avg time: 460.75 ms
+ set +x
Done
```

## Are there any user-facing changes?

Yes, new format support.
