### PR TITLE
Report error when `SessionState::sql_to_expr_with_alias` does not consume all input

### DIFF
--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -434,7 +434,7 @@ impl SessionState {
             .with_dialect(dialect.as_ref())
             .with_recursion_limit(recursion_limit)
             .build()?
-            .parse_expr()?;
+            .parse_into_expr()?;
 
         Ok(expr)
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #16810.

## Rationale for this change

When parsing SQL strings into expressions it's preferable to get parse errors when unprocessed input is present rather than silently ignoring this.

## What changes are included in this PR?

- Add `DFParser::parse_into_expr` which expects to consume the entire input SQL string and reports an error if it did not
- Adjust `SessionState::sql_to_expr_with_alias` to use this new function.

## Are these changes tested?

Yes, extra test cases have been added to `DFParser`

## Are there any user-facing changes?

This change makes the preconditions for `SessionState::sql_to_expr` and `SessionState::sql_to_expr_with_alias` stricter which may cause errors to be reported in code that currently completes successfully.