### PR TITLE
fix(docs): Update broken links to `TableProvider` docs

### DIFF
--- a/datafusion/catalog/src/default_table_source.rs
+++ b/datafusion/catalog/src/default_table_source.rs
@@ -33,8 +33,6 @@ use datafusion_expr::{Expr, TableProviderFilterPushDown, TableSource, TableType}
 ///
 /// It is used so logical plans in the `datafusion_expr` crate do not have a
 /// direct dependency on physical plans, such as [`TableProvider`]s.
-///
-/// [`TableProvider`]: https://docs.rs/datafusion/latest/datafusion/datasource/provider/trait.TableProvider.html
 pub struct DefaultTableSource {
     /// table provider
     pub table_provider: Arc<dyn TableProvider>,

--- a/datafusion/expr/src/table_source.rs
+++ b/datafusion/expr/src/table_source.rs
@@ -32,7 +32,7 @@ use std::{any::Any, borrow::Cow};
 /// the filter") are returned. Rows that evaluate to `false` or `NULL` are
 /// omitted.
 ///
-/// [`TableProvider::scan`]: https://docs.rs/datafusion/latest/datafusion/datasource/provider/trait.TableProvider.html#tymethod.scan
+/// [`TableProvider::scan`]: https://docs.rs/datafusion/latest/datafusion/datasource/trait.TableProvider.html#tymethod.scan
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TableProviderFilterPushDown {
     /// The filter cannot be used by the provider and will not be pushed down.
@@ -89,7 +89,7 @@ impl std::fmt::Display for TableType {
 /// plan code be dependent on the DataFusion execution engine. Some projects use
 /// DataFusion's logical plans and have their own execution engine.
 ///
-/// [`TableProvider`]: https://docs.rs/datafusion/latest/datafusion/datasource/provider/trait.TableProvider.html
+/// [`TableProvider`]: https://docs.rs/datafusion/latest/datafusion/datasource/trait.TableProvider.html
 /// [`DefaultTableSource`]: https://docs.rs/datafusion/latest/datafusion/datasource/default_table_source/struct.DefaultTableSource.html
 pub trait TableSource: Sync + Send {
     fn as_any(&self) -> &dyn Any;

--- a/docs/source/library-user-guide/building-logical-plans.md
+++ b/docs/source/library-user-guide/building-logical-plans.md
@@ -220,7 +220,7 @@ However, it is more common to use a [TableProvider]. To get a [TableSource] from
 [logicaltablesource]: https://docs.rs/datafusion-expr/latest/datafusion_expr/logical_plan/builder/struct.LogicalTableSource.html
 [defaulttablesource]: https://docs.rs/datafusion/latest/datafusion/datasource/default_table_source/struct.DefaultTableSource.html
 [provider_as_source]: https://docs.rs/datafusion/latest/datafusion/datasource/default_table_source/fn.provider_as_source.html
-[tableprovider]: https://docs.rs/datafusion/latest/datafusion/datasource/provider/trait.TableProvider.html
+[tableprovider]: https://docs.rs/datafusion/latest/datafusion/datasource/trait.TableProvider.html
 [tablesource]: https://docs.rs/datafusion-expr/latest/datafusion_expr/trait.TableSource.html
 [`executionplan`]: https://docs.rs/datafusion/latest/datafusion/physical_plan/trait.ExecutionPlan.html
 [`sessionstate::create_physical_plan`]: https://docs.rs/datafusion/latest/datafusion/execution/session_state/struct.SessionState.html#method.create_physical_plan


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #.

## Rationale for this change

Fixes broken links to the `TableProvider` trait in the Rust and website docs. I found them while manually browsing the docs.

The following links are broken:

* `https://docs.rs/datafusion/latest/datafusion/datasource/provider/trait.TableProvider.html`
* `https://docs.rs/datafusion/latest/datafusion/datasource/provider/trait.TableProvider.html#tymethod.scan`
* The `TableProvider` link on the [Building Logical Plans](https://datafusion.apache.org/library-user-guide/building-logical-plans.html#table-sources) library user guide. 

## What changes are included in this PR?

To find all instances, I grepped the codebase for the common path `datafusion/datasource/provider` and fixed the links I found.

Noter: Other broken links may still exist. I tried using [cargo deadlinks](https://github.com/deadlinks/cargo-deadlinks) to detect them automatically but the output was too verbose. I'll explore this later.

## Are these changes tested?

Verified that the updated `TableProvider` links work correctly by building the docs in local locally and manually checking the following generated pages:
- `/target/doc/datafusion/catalog/default_table_source/struct.DefaultTableSource.html`
- `/target/doc/datafusion/logical_expr/trait.TableSource.html`
- `/docs/build/html/library-user-guide/building-logical-plans.html`

## Are there any user-facing changes?

No.