### PR TITLE
Add note to upgrade guide about MSRV update

### DIFF
--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -26,7 +26,7 @@ You can see the current [status of the `49.0.0 `release here](https://github.com
 
 ### `MSRV` updated to 1.85.1
 
-The Minimum Supported Rust Version (MSRV) for `DataFusionError` has been updated to [`1.85.1`]. See
+The Minimum Supported Rust Version (MSRV) has been updated to [`1.85.1`]. See
 [#16728] for details.
 
 [`1.85.1`]: https://releases.rs/docs/1.85.1/

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -24,6 +24,14 @@
 **Note:** DataFusion `49.0.0` has not been released yet. The information provided in this section pertains to features and changes that have already been merged to the main branch and are awaiting release in this version.
 You can see the current [status of the `49.0.0 `release here](https://github.com/apache/datafusion/issues/16235)
 
+### `MSRV` updated to 1.85.1
+
+The Minimum Supported Rust Version (MSRV) for `DataFusionError` has been updated to [`1.85.1`]. See
+[#16728] for details.
+
+[`1.85.1`]: https://releases.rs/docs/1.85.1/
+[#16728]: https://github.com/apache/datafusion/pull/16728
+
 ### `DataFusionError` variants are now `Box`ed
 
 To reduce the size of `DataFusionError`, several variants that were previously stored inline are now `Box`ed. This reduces the size of `Result<T, DataFusionError>` and thus stack usage and async state machine size. Please see [#16652] for more details.


### PR DESCRIPTION
## Which issue does this PR close?


- Part of https://github.com/apache/datafusion/issues/16235





## Rationale for this change
- While working on the upgrade to delta.rs https://github.com/delta-io/delta-rs/pull/3603 I found that the MSRV has been updated but was not called out in the upgrade guide.

## What changes are included in this PR?
This PR adds a note to the upgrade guide to call out the MSRV update that happened in 
- https://github.com/apache/datafusion/pull/16728


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
