### PR TITLE
[branch-49] Final Changelog Tweaks

### DIFF
--- a/dev/changelog/49.0.0.md
+++ b/dev/changelog/49.0.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # Apache DataFusion 49.0.0 Changelog
 
-This release consists of 251 commits from 71 contributors. See credits at the end of this changelog for more information.
+This release consists of 253 commits from 71 contributors. See credits at the end of this changelog for more information.
 
 See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgrading.html) for information on how to upgrade from previous versions.
 
@@ -35,6 +35,7 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - Reuse Rows allocation in RowCursorStream [#16647](https://github.com/apache/datafusion/pull/16647) (Dandandan)
 - refactor: shrink `SchemaError` [#16653](https://github.com/apache/datafusion/pull/16653) (crepererum)
 - Remove unused AggregateUDF struct [#16683](https://github.com/apache/datafusion/pull/16683) (ViggoC)
+- Bump the MSRV to `1.85.1` due to transitive dependencies (`aws-sdk`) [#16728](https://github.com/apache/datafusion/pull/16728) (rtyler)
 
 **Performance related:**
 
@@ -89,6 +90,9 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - fix: return NULL if any of the param to make_date is NULL [#16759](https://github.com/apache/datafusion/pull/16759) (feniljain)
 - fix: add `order_requirement` & `dist_requirement` to `OutputRequirementExec` display [#16726](https://github.com/apache/datafusion/pull/16726) (Loaki07)
 - fix: support nullable columns in pre-sorted data sources [#16783](https://github.com/apache/datafusion/pull/16783) (crepererum)
+- fix: The inconsistency between scalar and array on the cast decimal to timestamp [#16539](https://github.com/apache/datafusion/pull/16539) (chenkovsky)
+- fix: unit test for object_storage [#16824](https://github.com/apache/datafusion/pull/16824) (chenkovsky)
+- fix(docs): Update broken links to `TableProvider` docs [#16830](https://github.com/apache/datafusion/pull/16830) (jcsherin)
 
 **Documentation updates:**
 
@@ -129,6 +133,8 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - Restore custom SchemaAdapter functionality for Parquet [#16791](https://github.com/apache/datafusion/pull/16791) (adriangb)
 - Update `upgrading.md` for new unified config for sql string mapping to utf8view [#16809](https://github.com/apache/datafusion/pull/16809) (zhuqi-lucas)
 - docs: Remove reference to forthcoming example (#16817) [#16818](https://github.com/apache/datafusion/pull/16818) (m09526)
+- docs: Fix broken links [#16839](https://github.com/apache/datafusion/pull/16839) (2010YOUY01)
+- Add note to upgrade guide about MSRV update [#16845](https://github.com/apache/datafusion/pull/16845) (alamb)
 
 **Other:**
 
@@ -259,7 +265,6 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - chore(devcontainer): use debian's `protobuf-compiler` package [#16687](https://github.com/apache/datafusion/pull/16687) (fvj)
 - Add link to upgrade guide in changelog script [#16680](https://github.com/apache/datafusion/pull/16680) (alamb)
 - Improve display format of BoundedWindowAggExec [#16645](https://github.com/apache/datafusion/pull/16645) (geetanshjuneja)
-- Bump the MSRV due to transitive dependencies [#16728](https://github.com/apache/datafusion/pull/16728) (rtyler)
 - Fix: optimize projections for unnest logical plan. [#16632](https://github.com/apache/datafusion/pull/16632) (bert-beyondloops)
 - Use the `test-threads` option in sqllogictests [#16722](https://github.com/apache/datafusion/pull/16722) (mjgarton)
 - chore(deps): bump clap from 4.5.40 to 4.5.41 [#16735](https://github.com/apache/datafusion/pull/16735) (dependabot[bot])
@@ -291,13 +296,22 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - chore(deps): bump object_store from 0.12.2 to 0.12.3 [#16807](https://github.com/apache/datafusion/pull/16807) (dependabot[bot])
 - Implement equals for stateful functions [#16781](https://github.com/apache/datafusion/pull/16781) (findepi)
 - benchmark: Add parquet h2o support [#16804](https://github.com/apache/datafusion/pull/16804) (zhuqi-lucas)
+- chore: use `equals_datatype` for `BinaryExpr` [#16813](https://github.com/apache/datafusion/pull/16813) (comphead)
+- chore: add tests for out of bounds for NullArray [#16802](https://github.com/apache/datafusion/pull/16802) (comphead)
+- Refactor binary.rs tests into modular submodules under `binary/tests` [#16782](https://github.com/apache/datafusion/pull/16782) (kosiew)
+- cache generation of dictionary keys and null arrays for ScalarValue [#16789](https://github.com/apache/datafusion/pull/16789) (adriangb)
+- refactor(examples): remove redundant call to create directory in `parquet_embedded_index.rs` [#16825](https://github.com/apache/datafusion/pull/16825) (jcsherin)
+- Add benchmark for ByteViewGroupValueBuilder [#16826](https://github.com/apache/datafusion/pull/16826) (zhuqi-lucas)
+- Simplify try cast expr evaluation [#16834](https://github.com/apache/datafusion/pull/16834) (lewiszlw)
+- Fix flaky test case in joins.slt [#16849](https://github.com/apache/datafusion/pull/16849) (findepi)
+- chore(deps): bump sysinfo from 0.35.2 to 0.36.1 [#16850](https://github.com/apache/datafusion/pull/16850) (dependabot[bot])
 
 ## Credits
 
 Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
 
 ```
-    32	Andrew Lamb
+    33	Andrew Lamb
     26	dependabot[bot]
     19	Adrian Garcia Badaracco
     14	kosiew
@@ -306,9 +320,9 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
      7	Jonathan Chen
      6	Chen Chongchen
      6	Marco Neumann
+     6	Oleks V
      6	Pepijn Van Eeckhoudt
      6	xudong.w
-     5	Oleks V
      5	Yongting You
      5	ding-young
      4	Simon Vandel Sillesen


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- part of https://github.com/apache/datafusion/issues/16235
- related to https://github.com/apache/datafusion/pull/16847
## Rationale for this change

OCD include https://github.com/apache/datafusion/pull/16847 in the changelog for 0.49.0 release

As another PR I plan to bring all the 49 changes from the 49 branch to main after that.



## What changes are included in this PR?

Run this and check in the result:

```shell
./dev/release/generate-changelog.py 48.0.0 HEAD 49.0.0 > dev/changelog/49.0.0.md
npx prettier@2.7.1 --write             '{datafusion,datafusion-cli,datafusion-examples,dev,docs}/**/*.md'             '!datafusion/CHANGELOG.md'             README.md             CONTRIBUTING.md
```

## Are these changes tested?

By CI
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
