### PR TITLE
MINOR: add unit tests for chr function

### DIFF
--- a/datafusion/functions/src/string/chr.rs
+++ b/datafusion/functions/src/string/chr.rs
@@ -49,6 +49,8 @@ pub fn chr(args: &[ArrayRef]) -> Result<ArrayRef> {
             Some(integer) => {
                 if integer == 0 {
                     return exec_err!("null character not permitted.");
+                } else if integer < 0 {
+                    return exec_err!("negative input not permitted.");
                 } else {
                     match core::char::from_u32(integer as u32) {
                         Some(c) => {
@@ -181,6 +183,15 @@ mod tests {
         assert_contains!(
             result.err().unwrap().to_string(),
             "requested character too large for encoding"
+        );
+
+        // negative input
+        let input = Arc::new(Int64Array::from(vec![i64::MIN + 2i64])); // will be 2 if cast to u32
+        let result = chr(&[input]);
+        assert!(result.is_err());
+        assert_contains!(
+            result.err().unwrap().to_string(),
+            "negative input not permitted"
         );
 
         // one error with valid values after

--- a/datafusion/functions/src/string/chr.rs
+++ b/datafusion/functions/src/string/chr.rs
@@ -157,11 +157,11 @@ mod tests {
         ]));
         let result = chr(&[input]).unwrap();
         let string_array = result.as_any().downcast_ref::<StringArray>().unwrap();
-        let expected = vec!["A", "B", "C", "🚀", "€", "α", "", " ", "\n", "\t"];
+        let expected = ["A", "B", "C", "🚀", "€", "α", "", " ", "\n", "\t"];
 
         assert_eq!(string_array.len(), 10);
-        for i in 0..string_array.len() {
-            assert_eq!(string_array.value(i), expected[i]);
+        for (i, e) in expected.iter().enumerate() {
+            assert_eq!(string_array.value(i), *e);
         }
     }
 

--- a/datafusion/functions/src/string/chr.rs
+++ b/datafusion/functions/src/string/chr.rs
@@ -207,6 +207,16 @@ mod tests {
             "requested character too large for encoding"
         );
 
+        // invalid Unicode code points (surrogate code point)
+        // link: <https://learn.microsoft.com/en-us/globalization/encoding/unicode-standard#surrogate-pairs>
+        let input = Arc::new(Int64Array::from(vec![0xD800 + 1]));
+        let result = chr(&[input]);
+        assert!(result.is_err());
+        assert_contains!(
+            result.err().unwrap().to_string(),
+            "requested character too large for encoding"
+        );
+
         // negative input
         let input = Arc::new(Int64Array::from(vec![i64::MIN + 2i64])); // will be 2 if cast to u32
         let result = chr(&[input]);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I wonder if `chr()` works for larger or negative input when reading https://github.com/apache/datafusion/pull/14700, as I read from [`encode_utf8`](https://doc.rust-lang.org/std/primitive.char.html#method.encode_utf8) would panic if the provided buffer is not large enough. So I added some unit test cases to verify. It turns out `chr()` can handle input like `i64::MAX` (gated by `core::char::from_u32`), but it does miss the negative case.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add unit tests to `chr()` function. And check if the input is negative.

My local bench result shows the extra check won't slow this function by a lot
```
chr                     time:   [5.1686 µs 5.1726 µs 5.1774 µs]
                        change: [+0.3217% +0.4109% +0.5066%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
