### PR TITLE
test: Fix flaky join tests

### DIFF
--- a/datafusion/sqllogictest/test_files/join.slt.part
+++ b/datafusion/sqllogictest/test_files/join.slt.part
@@ -853,47 +853,47 @@ physical_plan
 03)----DataSourceExec: partitions=1, partition_sizes=[1]
 04)----DataSourceExec: partitions=1, partition_sizes=[1]
 
-query ITT
+query ITT rowsort
 SELECT e.emp_id, e.name, d.dept_name
 FROM employees AS e
 LEFT JOIN department AS d
 ON (e.name = 'Alice' OR e.name = 'Bob');
 ----
-1 Alice HR
 1 Alice Engineering
+1 Alice HR
 1 Alice Sales
-2 Bob HR
 2 Bob Engineering
+2 Bob HR
 2 Bob Sales
 3 Carol NULL
 
 # neither RIGHT OUTER JOIN
-query ITT
+query ITT rowsort
 SELECT e.emp_id, e.name, d.dept_name
 FROM department AS d
 RIGHT JOIN employees AS e
 ON (e.name = 'Alice' OR e.name = 'Bob');
 ----
-1 Alice HR
 1 Alice Engineering
+1 Alice HR
 1 Alice Sales
-2 Bob HR
 2 Bob Engineering
+2 Bob HR
 2 Bob Sales
 3 Carol NULL
 
 # neither FULL OUTER JOIN
-query ITT
+query ITT rowsort
 SELECT e.emp_id, e.name, d.dept_name
 FROM department AS d
 FULL JOIN employees AS e
 ON (e.name = 'Alice' OR e.name = 'Bob');
 ----
-1 Alice HR
 1 Alice Engineering
+1 Alice HR
 1 Alice Sales
-2 Bob HR
 2 Bob Engineering
+2 Bob HR
 2 Bob Sales
 3 Carol NULL
 

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -4164,23 +4164,40 @@ AS VALUES
 (3, 3, true),
 (3, 3, false);
 
-query IIIIB
-SELECT * FROM t0 FULL JOIN t1 ON t0.c1 = t1.c1 LIMIT 2;
+query IIIIB rowsort
+SELECT * FROM t0 FULL JOIN t1 ON t0.c1 = t1.c1 LIMIT 20;
 ----
-2 2 2 2 true
+1 1 NULL NULL NULL
 2 2 2 2 false
-
-query IIIIB
-SELECT * FROM t0 FULL JOIN t1 ON t0.c2 >= t1.c2 LIMIT 2;
-----
 2 2 2 2 true
+3 3 3 3 false
+3 3 3 3 true
+4 4 NULL NULL NULL
+
+query IIIIB rowsort
+SELECT * FROM t0 FULL JOIN t1 ON t0.c2 >= t1.c2 LIMIT 20;
+----
+1 1 NULL NULL NULL
+2 2 2 2 false
+2 2 2 2 true
+3 3 2 2 false
 3 3 2 2 true
+3 3 3 3 false
+3 3 3 3 true
+4 4 2 2 false
+4 4 2 2 true
+4 4 3 3 false
+4 4 3 3 true
 
-query IIIIB
-SELECT * FROM t0 FULL JOIN t1 ON t0.c1 = t1.c1 AND t0.c2 >= t1.c2 LIMIT 2;
+query IIIIB rowsort
+SELECT * FROM t0 FULL JOIN t1 ON t0.c1 = t1.c1 AND t0.c2 >= t1.c2 LIMIT 20;
 ----
-2 2 2 2 true
+1 1 NULL NULL NULL
 2 2 2 2 false
+2 2 2 2 true
+3 3 3 3 false
+3 3 3 3 true
+4 4 NULL NULL NULL
 
 ## Test !join.on.is_empty() && join.filter.is_none()
 query TT

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -4192,6 +4192,7 @@ SELECT * FROM t0 FULL JOIN t1 ON t0.c2 >= t1.c2 LIMIT 20;
 4 4 3 3 true
 
 query IIIIB rowsort
+-- Note: using LIMIT value higher than cardinality before LIMIT to avoid query non-determinism
 SELECT * FROM t0 FULL JOIN t1 ON t0.c1 = t1.c1 AND t0.c2 >= t1.c2 LIMIT 20;
 ----
 1 1 NULL NULL NULL

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -4165,6 +4165,7 @@ AS VALUES
 (3, 3, false);
 
 query IIIIB rowsort
+-- Note: using LIMIT value higher than cardinality before LIMIT to avoid query non-determinism
 SELECT * FROM t0 FULL JOIN t1 ON t0.c1 = t1.c1 LIMIT 20;
 ----
 1 1 NULL NULL NULL

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -4176,6 +4176,7 @@ SELECT * FROM t0 FULL JOIN t1 ON t0.c1 = t1.c1 LIMIT 20;
 4 4 NULL NULL NULL
 
 query IIIIB rowsort
+-- Note: using LIMIT value higher than cardinality before LIMIT to avoid query non-determinism
 SELECT * FROM t0 FULL JOIN t1 ON t0.c2 >= t1.c2 LIMIT 20;
 ----
 1 1 NULL NULL NULL


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

When I was working on a join related task, I found some sqlogictests failing due to different result sort orders.
However, those queries should not assume the returned order, so this PR enforce static order for them using `rowsort` option in sqllogictest framework.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
