### PR TITLE
Minor: Optimize byte view benchmark to add more groups and more testing cases.

### DIFF
--- a/datafusion/physical-plan/benches/aggregate_vectorized.rs
+++ b/datafusion/physical-plan/benches/aggregate_vectorized.rs
@@ -29,10 +29,9 @@ const SIZES: [usize; 3] = [1_000, 10_000, 100_000];
 const NULL_DENSITIES: [f32; 4] = [0.0, 0.1, 0.5, 1.0];
 
 fn bench_byte_view_group_operation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ByteViewGroupValueBuilder_inlined");
     // test all inlined scenarios random from 0 ~ 12
     for &size in &SIZES {
-        let mut group = c.benchmark_group("ByteViewGroupValueBuilder_inlined");
-
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {
@@ -80,12 +79,13 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 });
             });
         }
-        group.finish();
     }
+    group.finish();
 
+    group = c.benchmark_group("ByteViewGroupValueBuilder_mixed");
     // test mixed length from 0 ~ 64
     for &size in &SIZES {
-        let mut group = c.benchmark_group("ByteViewGroupValueBuilder_mixed");
+
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {
@@ -134,12 +134,13 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 });
             });
         }
-        group.finish();
     }
+    group.finish();
 
+    group = c.benchmark_group("ByteViewGroupValueBuilder_fixed");
     // test fixed length 64
     for &size in &SIZES {
-        let mut group = c.benchmark_group("ByteViewGroupValueBuilder_fixed");
+
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {
@@ -188,12 +189,12 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 });
             });
         }
-        group.finish();
     }
+    group.finish();
 
+    group = c.benchmark_group("ByteViewGroupValueBuilder_random");
     // test random length from 0 ~ 400
     for &size in &SIZES {
-        let mut group = c.benchmark_group("ByteViewGroupValueBuilder_random");
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {
@@ -242,8 +243,8 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 });
             });
         }
-        group.finish();
     }
+    group.finish();
 }
 
 criterion_group!(benches, bench_byte_view_group_operation);

--- a/datafusion/physical-plan/benches/aggregate_vectorized.rs
+++ b/datafusion/physical-plan/benches/aggregate_vectorized.rs
@@ -85,7 +85,6 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
     group = c.benchmark_group("ByteViewGroupValueBuilder_mixed");
     // test mixed length from 0 ~ 64
     for &size in &SIZES {
-
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {
@@ -140,7 +139,6 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
     group = c.benchmark_group("ByteViewGroupValueBuilder_fixed");
     // test fixed length 64
     for &size in &SIZES {
-
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {

--- a/datafusion/physical-plan/benches/aggregate_vectorized.rs
+++ b/datafusion/physical-plan/benches/aggregate_vectorized.rs
@@ -29,9 +29,10 @@ const SIZES: [usize; 3] = [1_000, 10_000, 100_000];
 const NULL_DENSITIES: [f32; 4] = [0.0, 0.1, 0.5, 1.0];
 
 fn bench_byte_view_group_operation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("ByteViewGroupValueBuilder_inlined");
     // test all inlined scenarios random from 0 ~ 12
     for &size in &SIZES {
+        let mut group = c.benchmark_group("ByteViewGroupValueBuilder_inlined");
+
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {
@@ -43,9 +44,9 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 format!("inlined_null_{null_density:.1}_size_{size}"),
                 "vectorized_append",
             );
+            let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
             group.bench_function(id, |b| {
                 b.iter(|| {
-                    let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
                     builder.vectorized_append(&input, &rows).unwrap();
                 });
             });
@@ -55,9 +56,9 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 format!("inlined_null_{null_density:.1}_size_{size}"),
                 "append_val",
             );
+            let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
             group.bench_function(id, |b| {
                 b.iter(|| {
-                    let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
                     for &i in &rows {
                         builder.append_val(&input, i).unwrap();
                     }
@@ -79,12 +80,12 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 });
             });
         }
+        group.finish();
     }
-    group.finish();
 
-    group = c.benchmark_group("ByteViewGroupValueBuilder_mixed");
     // test mixed length from 0 ~ 64
     for &size in &SIZES {
+        let mut group = c.benchmark_group("ByteViewGroupValueBuilder_mixed");
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {
@@ -97,9 +98,10 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 format!("{scenario}_null_{null_density:.1}_size_{size}"),
                 "vectorized_append",
             );
+
+            let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
             group.bench_function(id, |b| {
                 b.iter(|| {
-                    let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
                     builder.vectorized_append(&input, &rows).unwrap();
                 });
             });
@@ -109,9 +111,10 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 format!("{scenario}_null_{null_density:.1}_size_{size}"),
                 "append_val",
             );
+
+            let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
             group.bench_function(id, |b| {
                 b.iter(|| {
-                    let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
                     for &i in &rows {
                         builder.append_val(&input, i).unwrap();
                     }
@@ -133,12 +136,12 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 });
             });
         }
+        group.finish();
     }
-    group.finish();
 
-    group = c.benchmark_group("ByteViewGroupValueBuilder_fixed");
     // test fixed length 64
     for &size in &SIZES {
+        let mut group = c.benchmark_group("ByteViewGroupValueBuilder_fixed");
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {
@@ -151,9 +154,9 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 format!("{scenario}_null_{null_density:.1}_size_{size}"),
                 "vectorized_append",
             );
+            let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
             group.bench_function(id, |b| {
                 b.iter(|| {
-                    let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
                     builder.vectorized_append(&input, &rows).unwrap();
                 });
             });
@@ -163,9 +166,9 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 format!("{scenario}_null_{null_density:.1}_size_{size}"),
                 "append_val",
             );
+            let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
             group.bench_function(id, |b| {
                 b.iter(|| {
-                    let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
                     for &i in &rows {
                         builder.append_val(&input, i).unwrap();
                     }
@@ -187,12 +190,12 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 });
             });
         }
+        group.finish();
     }
-    group.finish();
 
-    group = c.benchmark_group("ByteViewGroupValueBuilder_random");
     // test random length from 0 ~ 400
     for &size in &SIZES {
+        let mut group = c.benchmark_group("ByteViewGroupValueBuilder_random");
         let rows: Vec<usize> = (0..size).collect();
 
         for &null_density in &NULL_DENSITIES {
@@ -205,9 +208,10 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 format!("{scenario}_null_{null_density:.1}_size_{size}"),
                 "vectorized_append",
             );
+
+            let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
             group.bench_function(id, |b| {
                 b.iter(|| {
-                    let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
                     builder.vectorized_append(&input, &rows).unwrap();
                 });
             });
@@ -217,9 +221,10 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 format!("{scenario}_null_{null_density:.1}_size_{size}"),
                 "append_val",
             );
+
+            let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
             group.bench_function(id, |b| {
                 b.iter(|| {
-                    let mut builder = ByteViewGroupValueBuilder::<StringViewType>::new();
                     for &i in &rows {
                         builder.append_val(&input, i).unwrap();
                     }
@@ -241,8 +246,8 @@ fn bench_byte_view_group_operation(c: &mut Criterion) {
                 });
             });
         }
+        group.finish();
     }
-    group.finish();
 }
 
 criterion_group!(benches, bench_byte_view_group_operation);


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up https://github.com/apache/datafusion/pull/16826

1. I found single group will have some cache will affect this benchmark, so i added more groups in this PR.
2. I also add more cases to include fixed 64 str
3. I also make equal case not to include append operation for benchmark time
4. I also add all null cases in this PR

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
