### PR TITLE
refactor `character_length` impl by unifying null handling logic

### DIFF
--- a/datafusion/functions/src/unicode/character_length.rs
+++ b/datafusion/functions/src/unicode/character_length.rs
@@ -151,11 +151,13 @@ where
             let values: Vec<_> = (0..array.len())
                 .map(|i| {
                     // Safety: we are iterating with array.len() so the index is always valid
-                    let value = unsafe { array.value_unchecked(i) };
-                    if value.is_empty() {
+                    if array.is_null(i) {
                         T::default_value()
                     } else {
-                        if value.is_ascii() {
+                        let value = unsafe { array.value_unchecked(i) };
+                        if value.is_empty() {
+                            T::default_value()
+                        } else if value.is_ascii() {
                             T::Native::usize_as(value.len())
                         } else {
                             T::Native::usize_as(value.chars().count())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Not a follow-up of https://github.com/apache/datafusion/pull/13696, but I came up with this change when reading #13696,

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Simplify the implementation by unifying the non-null and nullable branches. `T::default_value()` is just 0, which is the same as get `.len()` from an empty slice returned by `string_array.value()`. And in both way, the NULL in result array is marked by null buffer, not `.push_null()`.

And I also find a performance improvement by doing it this way (and I verified this is not from `value_unchecked`):
```
character_length_StringArray_ascii_str_len_8
                        time:   [1.4357 µs 1.4402 µs 1.4456 µs]
                        change: [-73.834% -73.708% -73.579%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  1 (1.00%) high mild
  20 (20.00%) high severe

character_length_StringArray_utf8_str_len_8
                        time:   [32.558 µs 32.586 µs 32.615 µs]
                        change: [-9.6460% -9.4639% -9.3101%] (p = 0.00 < 0.05)
                        Performance has improved.

character_length_StringViewArray_ascii_str_len_8
                        time:   [16.820 µs 16.846 µs 16.878 µs]
                        change: [-23.762% -23.629% -23.496%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

character_length_StringViewArray_utf8_str_len_8
                        time:   [32.588 µs 32.677 µs 32.787 µs]
                        change: [-8.1913% -8.0556% -7.8956%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

character_length_StringArray_ascii_str_len_32
                        time:   [3.9844 µs 3.9866 µs 3.9888 µs]
                        change: [-50.422% -50.382% -50.343%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

character_length_StringArray_utf8_str_len_32
                        time:   [40.577 µs 40.611 µs 40.648 µs]
                        change: [+10.569% +10.705% +10.832%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

character_length_StringViewArray_ascii_str_len_32
                        time:   [11.666 µs 11.687 µs 11.712 µs]
                        change: [-26.007% -25.861% -25.677%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

character_length_StringViewArray_utf8_str_len_32
                        time:   [42.347 µs 42.371 µs 42.401 µs]
                        change: [+10.199% +10.295% +10.390%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

character_length_StringArray_ascii_str_len_128
                        time:   [14.356 µs 14.382 µs 14.413 µs]
                        change: [-22.226% -22.152% -22.062%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

character_length_StringArray_utf8_str_len_128
                        time:   [54.869 µs 54.975 µs 55.098 µs]
                        change: [-2.7784% -2.6015% -2.4263%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

character_length_StringViewArray_ascii_str_len_128
                        time:   [20.701 µs 20.760 µs 20.822 µs]
                        change: [-17.226% -17.001% -16.771%] (p = 0.00 < 0.05)
                        Performance has improved.

character_length_StringViewArray_utf8_str_len_128
                        time:   [56.900 µs 56.946 µs 56.998 µs]
                        change: [-3.1899% -2.9799% -2.7714%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

character_length_StringArray_ascii_str_len_4096
                        time:   [499.09 µs 501.67 µs 504.62 µs]
                        change: [-2.5911% -1.9208% -1.3158%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking character_length_StringArray_utf8_str_len_4096: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.2s, enable flat sampling, or reduce sample count to 50.
character_length_StringArray_utf8_str_len_4096
                        time:   [1.4106 ms 1.4188 ms 1.4284 ms]
                        change: [-0.4802% +0.1161% +0.7536%] (p = 0.72 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

character_length_StringViewArray_ascii_str_len_4096
                        time:   [440.63 µs 443.01 µs 445.84 µs]
                        change: [-0.0900% +0.5865% +1.1823%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

Benchmarking character_length_StringViewArray_utf8_str_len_4096: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.5s, enable flat sampling, or reduce sample count to 50.
character_length_StringViewArray_utf8_str_len_4096
                        time:   [1.4722 ms 1.4775 ms 1.4836 ms]
                        change: [-2.0827% -1.3739% -0.7239%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
```

But there are two outliers `character_length_StringArray_utf8_str_len_32` and `character_length_StringViewArray_utf8_str_len_32` that become 10% slower, for some reason I don't know 😞. 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

simplify `character_length`'s implementation

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

with existing test case

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
