### PR TITLE
optimize `initcap` function by avoiding memory allocation

### DIFF
--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -131,10 +131,11 @@ fn initcap<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
         string_array.value_data().len(),
     );
 
+    let mut container = String::new();
     string_array.iter().for_each(|str| match str {
         Some(s) => {
-            let initcap_str = initcap_string(s);
-            builder.append_value(initcap_str);
+            initcap_string(s, &mut container);
+            builder.append_value(&container);
         }
         None => builder.append_null(),
     });
@@ -147,10 +148,11 @@ fn initcap_utf8view(args: &[ArrayRef]) -> Result<ArrayRef> {
 
     let mut builder = StringViewBuilder::with_capacity(string_view_array.len());
 
+    let mut container = String::new();
     string_view_array.iter().for_each(|str| match str {
         Some(s) => {
-            let initcap_str = initcap_string(s);
-            builder.append_value(initcap_str);
+            initcap_string(s, &mut container);
+            builder.append_value(&container);
         }
         None => builder.append_null(),
     });
@@ -158,31 +160,29 @@ fn initcap_utf8view(args: &[ArrayRef]) -> Result<ArrayRef> {
     Ok(Arc::new(builder.finish()) as ArrayRef)
 }
 
-fn initcap_string(input: &str) -> String {
-    let mut result = String::with_capacity(input.len());
+fn initcap_string(input: &str, container: &mut String) {
+    container.clear();
     let mut prev_is_alphanumeric = false;
 
     if input.is_ascii() {
         for c in input.chars() {
             if prev_is_alphanumeric {
-                result.push(c.to_ascii_lowercase());
+                container.push(c.to_ascii_lowercase());
             } else {
-                result.push(c.to_ascii_uppercase());
+                container.push(c.to_ascii_uppercase());
             };
             prev_is_alphanumeric = c.is_ascii_alphanumeric();
         }
     } else {
         for c in input.chars() {
             if prev_is_alphanumeric {
-                result.extend(c.to_lowercase());
+                container.extend(c.to_lowercase());
             } else {
-                result.extend(c.to_uppercase());
+                container.extend(c.to_uppercase());
             }
             prev_is_alphanumeric = c.is_alphanumeric();
         }
     }
-
-    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- A small change derived from https://github.com/apache/datafusion/pull/13691#discussion_r1882903037

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I'm not sure if there is a way to write into String View Builder char by char, so I keep the skeleton, but trying to reuse the allocated intermediate `String`. 


Benchmark result (not too much)
```
initcap string view shorter than 12 [size=1024]
                        time:   [14.302 µs 14.317 µs 14.330 µs]
                        change: [-15.157% -15.023% -14.900%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

initcap string view longer than 12 [size=1024]
                        time:   [25.708 µs 25.734 µs 25.761 µs]
                        change: [+0.8967% +1.0978% +1.2905%] (p = 0.00 < 0.05)
                        Change within noise threshold.

initcap string [size=1024]
                        time:   [24.750 µs 24.787 µs 24.835 µs]
                        change: [-0.9080% -0.6927% -0.4783%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

initcap string view shorter than 12 [size=4096]
                        time:   [58.671 µs 58.805 µs 58.946 µs]
                        change: [-16.380% -16.253% -16.129%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

initcap string view longer than 12 [size=4096]
                        time:   [100.75 µs 100.82 µs 100.89 µs]
                        change: [-0.0287% +0.2408% +0.4877%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

initcap string [size=4096]
                        time:   [96.766 µs 96.913 µs 97.083 µs]
                        change: [-1.0818% -0.9059% -0.7305%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Reuse intermediate `String` object in `initcap` function

## Are these changes tested?

by existing tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
