### PR TITLE
Mutable Join Unwind

### DIFF
--- a/datafusion/common-runtime/src/common.rs
+++ b/datafusion/common-runtime/src/common.rs
@@ -68,29 +68,25 @@ impl<R: 'static> SpawnedTask<R> {
     }
 
     /// Joins the task and unwinds the panic if it happens.
-    pub async fn join_unwind(self) -> Result<R, JoinError> {
-        self.await.map_err(|e| {
-            // `JoinError` can be caused either by panic or cancellation. We have to handle panics:
-            if e.is_panic() {
-                std::panic::resume_unwind(e.into_panic());
-            } else {
-                // Cancellation may be caused by two reasons:
-                // 1. Abort is called, but since we consumed `self`, it's not our case (`JoinHandle` not accessible outside).
-                // 2. The runtime is shutting down.
-                log::warn!("SpawnedTask was polled during shutdown");
-                e
-            }
-        })
+    pub async fn join_unwind(mut self) -> Result<R, JoinError> {
+        self.join_unwind_mut().await
     }
 
     /// Joins the task using a mutable reference and unwinds the panic if it happens.
     ///
     /// This method is similar to [`join_unwind`](Self::join_unwind), but takes a mutable
     /// reference instead of consuming `self`. This allows the `SpawnedTask` to remain
-    /// usable after the call, though once a task completes, subsequent calls will continue
-    /// to return the same `JoinError`.
+    /// usable after the call.
+    ///
+    /// If called multiple times on the same task:
+    /// - If the task is still running, it will continue waiting for completion
+    /// - If the task has already completed successfully, subsequent calls will
+    ///   continue to return the same `JoinError` indicating the task is finished
+    /// - If the task panicked, the first call will resume the panic, and the
+    ///   program will not reach subsequent calls
     pub async fn join_unwind_mut(&mut self) -> Result<R, JoinError> {
         self.await.map_err(|e| {
+            // `JoinError` can be caused either by panic or cancellation. We have to handle panics:
             if e.is_panic() {
                 std::panic::resume_unwind(e.into_panic());
             } else {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When implementing `Stream`s with `SpawnedTask` objects, the `poll_next` requires `&mut self `, but the existing `join_unwind` method consumes the `SpawnedTask`. The new `join_unwind_mut` method allows polling task completion status while retaining the `SpawnedTask` for subsequent polls.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Added `join_unwind_mut(&mut self)` method to `SpawnedTask` that mirrors the behavior of `join_unwind(self)`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
