### PR TITLE
Implement Helpers for ScopedTimerGuard and Time Structs

### DIFF
--- a/datafusion/physical-plan/src/metrics/value.rs
+++ b/datafusion/physical-plan/src/metrics/value.rs
@@ -907,7 +907,7 @@ mod tests {
         // Allow for small variations due to timer resolution
         let recorded = time.value();
         assert!(
-           (10_000_000..=10_100_000).contains(&recorded)
+            (10_000_000..=10_100_000).contains(&recorded),
             "Expected ~10ms, got {recorded} ns"
         );
 
@@ -941,9 +941,8 @@ mod tests {
         // Should record exactly 5ms
         let recorded = time.value();
         assert!(
-           (5_000_000..=5_100_000).contains(&recorded)
+            (5_000_000..=5_100_000).contains(&recorded),
             "Expected ~5ms, got {recorded} ns",
-
         );
 
         // Test that done_with prevents drop from recording time again
@@ -957,9 +956,8 @@ mod tests {
         // Should have added only 5ms more
         let new_recorded = time.value();
         assert!(
-            (10_000_000..=10_100_000).contains(&new_recorded)
+            (10_000_000..=10_100_000).contains(&new_recorded),
             "Expected ~10ms total, got {new_recorded} ns",
-
         );
     }
 }

--- a/datafusion/physical-plan/src/metrics/value.rs
+++ b/datafusion/physical-plan/src/metrics/value.rs
@@ -341,7 +341,7 @@ impl ScopedTimerGuard<'_> {
         self.stop()
     }
 
-    /// Stop the timer timing and record the time taken with the given endpoint.
+    /// Stop the timer timing and record the time taken since the given endpoint.
     pub fn stop_with(&mut self, end_time: Instant) {
         if let Some(start) = self.start.take() {
             let elapsed = end_time - start;

--- a/datafusion/physical-plan/src/metrics/value.rs
+++ b/datafusion/physical-plan/src/metrics/value.rs
@@ -222,6 +222,16 @@ impl Time {
     pub fn value(&self) -> usize {
         self.nanos.load(Ordering::Relaxed)
     }
+
+    /// Return a scoped guard that adds the amount of time elapsed between its
+    /// creation and its drop (or the call to `stop`) to the underlying metric
+    /// according to the given instant.
+    pub fn timer_with(&self, now: Instant) -> ScopedTimerGuard<'_> {
+        ScopedTimerGuard {
+            inner: self,
+            start: Some(now),
+        }
+    }
 }
 
 /// Stores a single timestamp, stored as the number of nanoseconds
@@ -330,6 +340,20 @@ impl ScopedTimerGuard<'_> {
     /// Stop the timer, record the time taken and consume self
     pub fn done(mut self) {
         self.stop()
+    }
+
+    /// Stop the timer timing and record the time taken with the given endpoint.
+    pub fn stop_with(&mut self, end_time: Instant) {
+        if let Some(start) = self.start.take() {
+            let elapsed = end_time - start;
+            self.inner.add_duration(elapsed)
+        }
+    }
+
+    /// Stop the timer, record the time taken with the given endpoint, and
+    /// consume self.
+    pub fn done_with(mut self, end_time: Instant) {
+        self.stop_with(end_time)
     }
 }
 
@@ -840,5 +864,103 @@ mod tests {
                 "value {value:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_timer_with_custom_instant() {
+        let time = Time::new();
+        let start_time = Instant::now();
+
+        // Sleep a bit to ensure some time passes
+        std::thread::sleep(Duration::from_millis(1));
+
+        // Create timer with the earlier start time
+        let mut timer = time.timer_with(start_time);
+
+        // Sleep a bit more
+        std::thread::sleep(Duration::from_millis(1));
+
+        // Stop the timer
+        timer.stop();
+
+        // The recorded time should be at least 20ms (both sleeps)
+        assert!(
+            time.value() >= 2_000_000,
+            "Expected at least 2ms, got {} ns",
+            time.value()
+        );
+    }
+
+    #[test]
+    fn test_stop_with_custom_endpoint() {
+        let time = Time::new();
+        let start = Instant::now();
+        let mut timer = time.timer_with(start);
+
+        // Simulate exactly 10ms passing
+        let end = start + Duration::from_millis(10);
+
+        // Stop with custom endpoint
+        timer.stop_with(end);
+
+        // Should record exactly 10ms (10_000_000 nanoseconds)
+        // Allow for small variations due to timer resolution
+        let recorded = time.value();
+        assert!(
+            recorded >= 10_000_000 && recorded <= 10_100_000,
+            "Expected ~10ms, got {} ns",
+            recorded
+        );
+
+        // Calling stop_with again should not add more time
+        timer.stop_with(end);
+        assert_eq!(
+            recorded,
+            time.value(),
+            "Time should not change after second stop"
+        );
+    }
+
+    #[test]
+    fn test_done_with_custom_endpoint() {
+        let time = Time::new();
+        let start = Instant::now();
+
+        // Create a new scope for the timer
+        {
+            let timer = time.timer_with(start);
+
+            // Simulate 50ms passing
+            let end = start + Duration::from_millis(5);
+
+            // Call done_with to stop and consume the timer
+            timer.done_with(end);
+
+            // Timer is consumed, can't use it anymore
+        }
+
+        // Should record exactly 5ms
+        let recorded = time.value();
+        assert!(
+            recorded >= 5_000_000 && recorded <= 5_100_000,
+            "Expected ~5ms, got {} ns",
+            recorded
+        );
+
+        // Test that done_with prevents drop from recording time again
+        {
+            let timer2 = time.timer_with(start);
+            let end2 = start + Duration::from_millis(5);
+            timer2.done_with(end2);
+            // drop happens here but should not record additional time
+        }
+
+        // Should have added only 5ms more
+        let new_recorded = time.value();
+        assert!(
+            new_recorded >= 10_000_000 && new_recorded <= 10_100_000,
+            "Expected ~10ms total, got {} ns",
+            new_recorded
+        );
     }
 }

--- a/datafusion/physical-plan/src/metrics/value.rs
+++ b/datafusion/physical-plan/src/metrics/value.rs
@@ -349,7 +349,7 @@ impl ScopedTimerGuard<'_> {
         }
     }
 
-    /// Stop the timer, record the time taken with the given endpoint, and
+    /// Stop the timer, record the time taken since `end_time` endpoint, and
     /// consume self.
     pub fn done_with(mut self, end_time: Instant) {
         self.stop_with(end_time)

--- a/datafusion/physical-plan/src/metrics/value.rs
+++ b/datafusion/physical-plan/src/metrics/value.rs
@@ -907,9 +907,8 @@ mod tests {
         // Allow for small variations due to timer resolution
         let recorded = time.value();
         assert!(
-            recorded >= 10_000_000 && recorded <= 10_100_000,
-            "Expected ~10ms, got {} ns",
-            recorded
+           (10_000_000..=10_100_000).contains(&recorded)
+            "Expected ~10ms, got {recorded} ns"
         );
 
         // Calling stop_with again should not add more time
@@ -942,9 +941,9 @@ mod tests {
         // Should record exactly 5ms
         let recorded = time.value();
         assert!(
-            recorded >= 5_000_000 && recorded <= 5_100_000,
-            "Expected ~5ms, got {} ns",
-            recorded
+           (5_000_000..=5_100_000).contains(&recorded)
+            "Expected ~5ms, got {recorded} ns",
+
         );
 
         // Test that done_with prevents drop from recording time again
@@ -958,9 +957,9 @@ mod tests {
         // Should have added only 5ms more
         let new_recorded = time.value();
         assert!(
-            new_recorded >= 10_000_000 && new_recorded <= 10_100_000,
-            "Expected ~10ms total, got {} ns",
-            new_recorded
+            (10_000_000..=10_100_000).contains(&new_recorded)
+            "Expected ~10ms total, got {new_recorded} ns",
+
         );
     }
 }

--- a/datafusion/physical-plan/src/metrics/value.rs
+++ b/datafusion/physical-plan/src/metrics/value.rs
@@ -223,9 +223,8 @@ impl Time {
         self.nanos.load(Ordering::Relaxed)
     }
 
-    /// Return a scoped guard that adds the amount of time elapsed between its
-    /// creation and its drop (or the call to `stop`) to the underlying metric
-    /// according to the given instant.
+    /// Return a scoped guard that adds the amount of time elapsed between the
+    /// given instant and its drop (or the call to `stop`) to the underlying metric
     pub fn timer_with(&self, now: Instant) -> ScopedTimerGuard<'_> {
         ScopedTimerGuard {
             inner: self,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add methods to `Time` and `ScopedTimerGuard` that allow measuring elapsed time with custom start/end instants instead of relying on `Instant::now()`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Add `timer_with(now: Instant)` to `Time` - creates a timer starting from a specific instant
* Add `stop_with(end_time: Instant)` to `ScopedTimerGuard` - stops timer with a custom end time
* Add `done_with(end_time: Instant)` to `ScopedTimerGuard` - stops timer with custom end time and consumes self
* Add unit tests 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, unit tests are added

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
