### PR TITLE
fix: TrivialValueAccumulators to ignore nulls for `ignore nulls`

### DIFF
--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -833,8 +833,11 @@ impl Accumulator for TrivialFirstValueAccumulator {
                 filter_states_according_to_is_set(&states[0..1], flags)?;
             if let Some(first) = filtered_states.first() {
                 if !first.is_empty() {
-                    self.first = ScalarValue::try_from_array(first, 0)?;
-                    self.is_set = true;
+                    let first = ScalarValue::try_from_array(first, 0)?;
+                    if !self.ignore_nulls || !first.is_null() {
+                        self.first = first;
+                        self.is_set = true;
+                    }
                 }
             }
         }
@@ -1326,8 +1329,11 @@ impl Accumulator for TrivialLastValueAccumulator {
         let filtered_states = filter_states_according_to_is_set(&states[0..1], flags)?;
         if let Some(last) = filtered_states.last() {
             if !last.is_empty() {
-                self.last = ScalarValue::try_from_array(last, 0)?;
-                self.is_set = true;
+                let last = ScalarValue::try_from_array(last, 0)?;
+                if !self.ignore_nulls || !last.is_null() {
+                    self.last = last;
+                    self.is_set = true;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.
Related to https://github.com/apache/datafusion/issues/16235 and https://github.com/apache/datafusion-comet/pull/2040

## Rationale for this change

After introducing TrivialValueAccumulators in https://github.com/apache/datafusion/pull/16217 we found a `ignore nulls` test failed in Comet. I cannot reproduce the same in DataFusion, although I created the similar environment in DF.

If the key is spread across 2 files and batch_size = 1

file1
|a  |  b|
|---|---|
|2  |  1|

file2
|a  |  b|
|---|---|
|2  |  2 |

And run query 
```
 SELECT a, last_value(case when b==1 then null else b end) IGNORE NULLS FROM t1 GROUP BY a order by a;
```
or 
```
 SELECT a, first_value(case when b==1 then null else b end) IGNORE NULLS FROM t1 GROUP BY a order by a;
```

The query actually returns

|a  |  b|
|---|---|
|2  |  null |

While debugging a `merge_batch` I found Comet sends sometimes a state `null, true` whereas DF never does that and send s `nulls, false` instead. Probably it is explained that Comet calls physical operations directly, without optimizations.

So this fix is more guess but it works for Comet and Datafusion and unblocks the Comet migration.
Appreciate @ozankabak @alamb @berkaysynnada @mbutrovich for ideas for better fix (if any)

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
