### PR TITLE
make expr_applicable_for_cols accept &String in addition to &str

### DIFF
--- a/datafusion/catalog-listing/src/helpers.rs
+++ b/datafusion/catalog-listing/src/helpers.rs
@@ -50,11 +50,11 @@ use object_store::{ObjectMeta, ObjectStore};
 /// - the table provider can filter the table partition values with this expression
 /// - the expression can be marked as `TableProviderFilterPushDown::Exact` once this filtering
 ///   was performed
-pub fn expr_applicable_for_cols(col_names: &[&str], expr: &Expr) -> bool {
+pub fn expr_applicable_for_cols<T: AsRef<str>>(col_names: &[T], expr: &Expr) -> bool {
     let mut is_applicable = true;
     expr.apply(|expr| match expr {
         Expr::Column(Column { ref name, .. }) => {
-            is_applicable &= col_names.contains(&name.as_str());
+            is_applicable &= col_names.iter().any(|col| col.as_ref() == name.as_str());
             if is_applicable {
                 Ok(TreeNodeRecursion::Jump)
             } else {


### PR DESCRIPTION
Minor drive by, aside from compiling an extra function if used (current codebases won't) and a bit of extra compile work this should have not negative impact. Our pattern is to build a `Vec<String>` in places and it's pretty annoying to go from `Vec<String>` -> `&[&str]` since you have to build up a `Vec<&str>` and keep the reference to the `Vec<String>` as well.