### PR TITLE
Add missing Substrait to DataFusion function name mappings

### DIFF
--- a/datafusion/substrait/src/extensions.rs
+++ b/datafusion/substrait/src/extensions.rs
@@ -45,9 +45,7 @@ impl Extensions {
         // Rename those to match the Substrait extensions for interoperability
         let function_name = match function_name.as_str() {
             "substr" => "substring".to_string(),
-            "signum" => "sign".to_string(),
             "isnan" => "is_nan".to_string(),
-            "log" => "logb".to_string(),
             _ => function_name,
         };
 

--- a/datafusion/substrait/src/extensions.rs
+++ b/datafusion/substrait/src/extensions.rs
@@ -45,6 +45,9 @@ impl Extensions {
         // Rename those to match the Substrait extensions for interoperability
         let function_name = match function_name.as_str() {
             "substr" => "substring".to_string(),
+            "signum" => "sign".to_string(),
+            "isnan" => "is_nan".to_string(),
+            "log" => "logb".to_string(),
             _ => function_name,
         };
 

--- a/datafusion/substrait/src/logical_plan/consumer/expr/scalar_function.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/expr/scalar_function.rs
@@ -41,12 +41,24 @@ pub async fn from_scalar_function(
             f.function_reference
         );
     };
+
     let fn_name = substrait_fun_name(fn_signature);
     let args = from_substrait_func_args(consumer, &f.arguments, input_schema).await?;
 
+    let udf_func = match consumer.get_function_registry().udf(fn_name) {
+        Ok(f) => Ok(f),
+        Err(e) => {
+            if let Some(alt_name) = substrait_to_df_name(fn_name) {
+                consumer.get_function_registry().udf(alt_name).or(Err(e))
+            } else {
+                Err(e)
+            }
+        }
+    };
+
     // try to first match the requested function into registered udfs, then built-in ops
     // and finally built-in expressions
-    if let Ok(func) = consumer.get_function_registry().udf(fn_name) {
+    if let Ok(func) = udf_func {
         Ok(Expr::ScalarFunction(expr::ScalarFunction::new_udf(
             func.to_owned(),
             args,
@@ -109,6 +121,15 @@ pub fn name_to_op(name: &str) -> Option<Operator> {
         "bitwise_xor" => Some(Operator::BitwiseXor),
         "bitwise_shift_right" => Some(Operator::BitwiseShiftRight),
         "bitwise_shift_left" => Some(Operator::BitwiseShiftLeft),
+        _ => None,
+    }
+}
+
+pub fn substrait_to_df_name(name: &str) -> Option<&str> {
+    match name {
+        "sign" => Some("signum"),
+        "is_nan" => Some("isnan"),
+        "logb" => Some("log"),
         _ => None,
     }
 }
@@ -367,6 +388,41 @@ mod tests {
         let expr =
             arg_list_to_binary_op_tree(Operator::Or, int64_literals(&[1, 2, 3, 4]))?;
         assert_snapshot!(expr.to_string(), @"Int64(1) OR Int64(2) OR Int64(3) OR Int64(4)");
+        Ok(())
+    }
+
+    //Test that DataFusion can consume scalar functions that have a different name in Substrait
+    #[tokio::test]
+    async fn test_substrait_to_df_name_mapping() -> Result<()> {
+        // Build substrait extensions (we are using only one function)
+        let mut extensions = Extensions::default();
+        //sign is one of the functions that has a different name in Substrait (mapping is in substrait_to_df_name())
+        extensions.functions.insert(0, String::from("sign:i8"));
+        // Build substrait consumer
+        let consumer = DefaultSubstraitConsumer::new(&extensions, &TEST_SESSION_STATE);
+
+        // Build arguments for the function call
+        let arg = FunctionArgument {
+            arg_type: Some(ArgType::Value(Expression {
+                rex_type: Some(RexType::Literal(Literal {
+                    nullable: false,
+                    type_variation_reference: 0,
+                    literal_type: Some(LiteralType::I8(1)),
+                })),
+            })),
+        };
+        let arguments = vec![arg; 2];
+        let func = ScalarFunction {
+            function_reference: 0,
+            arguments,
+            ..Default::default()
+        };
+        // Trivial input schema
+        let schema = Schema::new(vec![Field::new("a", DataType::Int8, false)]);
+        let df_schema = DFSchema::try_from(schema).unwrap();
+
+        // Consume the expression and ensure we don't get an error
+        let _ = consumer.consume_scalar_function(&func, &df_schema).await?;
         Ok(())
     }
 }

--- a/datafusion/substrait/src/logical_plan/consumer/expr/scalar_function.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/expr/scalar_function.rs
@@ -411,7 +411,7 @@ mod tests {
                 })),
             })),
         };
-        let arguments = vec![arg; 2];
+        let arguments = vec![arg];
         let func = ScalarFunction {
             function_reference: 0,
             arguments,

--- a/datafusion/substrait/src/logical_plan/consumer/expr/scalar_function.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/expr/scalar_function.rs
@@ -124,9 +124,7 @@ pub fn name_to_op(name: &str) -> Option<Operator> {
 
 pub fn substrait_to_df_name(name: &str) -> Option<&str> {
     match name {
-        "sign" => Some("signum"),
         "is_nan" => Some("isnan"),
-        "logb" => Some("log"),
         _ => None,
     }
 }
@@ -393,8 +391,8 @@ mod tests {
     async fn test_substrait_to_df_name_mapping() -> Result<()> {
         // Build substrait extensions (we are using only one function)
         let mut extensions = Extensions::default();
-        //sign is one of the functions that has a different name in Substrait (mapping is in substrait_to_df_name())
-        extensions.functions.insert(0, String::from("sign:i8"));
+        //is_nan is one of the functions that has a different name in Substrait (mapping is in substrait_to_df_name())
+        extensions.functions.insert(0, String::from("is_nan:fp32"));
         // Build substrait consumer
         let consumer = DefaultSubstraitConsumer::new(&extensions, &TEST_SESSION_STATE);
 
@@ -404,7 +402,7 @@ mod tests {
                 rex_type: Some(RexType::Literal(Literal {
                     nullable: false,
                     type_variation_reference: 0,
-                    literal_type: Some(LiteralType::I8(1)),
+                    literal_type: Some(LiteralType::Fp32(1.0)),
                 })),
             })),
         };
@@ -415,7 +413,7 @@ mod tests {
             ..Default::default()
         };
         // Trivial input schema
-        let schema = Schema::new(vec![Field::new("a", DataType::Int8, false)]);
+        let schema = Schema::new(vec![Field::new("a", DataType::Float32, false)]);
         let df_schema = DFSchema::try_from(schema).unwrap();
 
         // Consume the expression and ensure we don't get an error

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -430,10 +430,10 @@ async fn simple_scalar_function_substr() -> Result<()> {
 // Follows the same structure as existing roundtrip tests, but more explicitly tests for name mappings
 async fn test_substrait_to_df_name_mapping(
     substrait_name: &str,
-    df_name: &str,
+    sql: &str,
 ) -> Result<()> {
     let ctx = create_context().await?;
-    let df = ctx.sql(&format!("SELECT {df_name}(a) FROM data")).await?;
+    let df = ctx.sql(sql).await?;
     let plan = df.into_optimized_plan()?;
     let proto = to_substrait_plan(&plan, &ctx.state())?;
 
@@ -458,17 +458,17 @@ async fn test_substrait_to_df_name_mapping(
 
 #[tokio::test]
 async fn scalar_function_is_nan_mapping() -> Result<()> {
-    test_substrait_to_df_name_mapping("is_nan", "ISNAN").await
+    test_substrait_to_df_name_mapping("is_nan", "SELECT ISNAN(a) FROM data").await
 }
 
 #[tokio::test]
 async fn scalar_function_sign_mapping() -> Result<()> {
-    test_substrait_to_df_name_mapping("sign", "SIGNUM").await
+    test_substrait_to_df_name_mapping("sign", "SELECT SIGNUM(a) FROM data").await
 }
 
 #[tokio::test]
 async fn scalar_function_logb_mapping() -> Result<()> {
-    test_substrait_to_df_name_mapping("logb", "LOG").await
+    test_substrait_to_df_name_mapping("logb", "SELECT LOG(a, b) FROM data").await
 }
 
 #[tokio::test]

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -462,16 +462,6 @@ async fn scalar_function_is_nan_mapping() -> Result<()> {
 }
 
 #[tokio::test]
-async fn scalar_function_sign_mapping() -> Result<()> {
-    test_substrait_to_df_name_mapping("sign", "SELECT SIGNUM(a) FROM data").await
-}
-
-#[tokio::test]
-async fn scalar_function_logb_mapping() -> Result<()> {
-    test_substrait_to_df_name_mapping("logb", "SELECT LOG(a, b) FROM data").await
-}
-
-#[tokio::test]
 async fn simple_scalar_function_is_null() -> Result<()> {
     roundtrip("SELECT * FROM data WHERE a IS NULL").await
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #16949.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
We've identified Substrait functions that have implementations in DataFusion, but are not mapped to those functions because their names are slightly different. For example, DataFusion does not understand the Substrait is_nan function, because DataFusion's name for the same function is isnan, and the Substrait consumer and producer work off of direct name mappings.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- New mapping created in the consumer to map Substrait names to DataFusion names
- Added new name mappings to the existing mapping of DataFusion names to Substrait names; in the producer, the register_function() calls the implementation of register_function() in Extensions, and this registers function names with function anchors (so this is where mappings are added).

This PR adds mappings for the Substrait functions sign, is_nan, and logb, but the same process can be done to add mappings for more functions.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
- Test added on the consumer side that consumes a scalar function and checks if an error occurs
- Roundtrip test added that follows the structure of existing roundtrip tests (testing both the producer and consumer) but includes a check that the producer produced Substrait with the appropriate Substrait name. 
  - There's an [existing test](https://github.com/apache/datafusion/blob/2a7f64a85e3d98c51c106607a425d73d2b839e82/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs#L415) that would test this roundtrip. Without the changes introduced with this PR, this test would create an intermediate Substrait plan with the wrong function name (when it calls to_substrait_plan()) but the test would still pass because it would convert back to the right DataFusion name. This test makes testing this change more explicit, but feel free to let me know if this test is unnecessary / should be removed / any other suggestion!

The roundtrip test tests is_nan function mappings, and the test on the consumer side tests sign function mappings. It seems repetitive to run the same test for all the newly added mappings, but I'm open to feedback on whether this should be added!

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
The Substrait consumer will be able to consume functions that previously resulted in an unsupported function error, and the producer will produce Substrait plans with the correct function names.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
