### PR TITLE
fix: `ComposedPhysicalExtensionCodec` does not use the same codec as encoding when decoding

### DIFF
--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -2946,7 +2946,7 @@ fn into_physical_plan(
     registry: &dyn FunctionRegistry,
     runtime: &RuntimeEnv,
     extension_codec: &dyn PhysicalExtensionCodec,
-) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+) -> Result<Arc<dyn ExecutionPlan>> {
     if let Some(field) = node {
         field.try_into_physical_plan(registry, runtime, extension_codec)
     } else {

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -2941,10 +2941,10 @@ impl PhysicalExtensionCodec for DefaultPhysicalExtensionCodec {
     }
 }
 
-/// DataWithEncoderPositionProto captures the position of the encoder
+/// DataEncoderTuple captures the position of the encoder
 /// in the codec list that was used to encode the data and actual encoded data
 #[derive(Clone, PartialEq, prost::Message)]
-struct DataWithEncoderPositionProto {
+struct DataEncoderTuple {
     /// The position of encoder used to encode data
     /// (to be used for decoding)
     #[prost(uint32, tag = 1)]
@@ -2973,7 +2973,7 @@ impl ComposedPhysicalExtensionCodec {
         buf: &[u8],
         decode: impl FnOnce(&dyn PhysicalExtensionCodec, &[u8]) -> Result<R>,
     ) -> Result<R> {
-        let proto = DataWithEncoderPositionProto::decode(buf)
+        let proto = DataEncoderTuple::decode(buf)
             .map_err(|e| DataFusionError::Internal(e.to_string()))?;
 
         let codec = self.codecs.get(proto.encoder_position as usize).ok_or(
@@ -3014,7 +3014,7 @@ impl ComposedPhysicalExtensionCodec {
         })?;
 
         // encode with encoder position
-        let proto = DataWithEncoderPositionProto {
+        let proto = DataEncoderTuple {
             encoder_position,
             blob: data,
         };


### PR DESCRIPTION
## Which issue does this PR close?

Closes #16980 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Tested via:

```sh
cargo run --package datafusion-examples --example composed_extension_codec
```

## Are there any user-facing changes?

No.
