### PR TITLE
Perf: Port arrow-rs optimization for get_buffer_memory_size and add fast path for no buffer for gc string view

### DIFF
--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -240,7 +240,8 @@ fn gc_string_view_batch(batch: &RecordBatch) -> RecordBatch {
                     }
                 })
                 .sum();
-            let actual_buffer_size = s.get_buffer_memory_size();
+            let actual_buffer_size =
+                s.data_buffers().iter().map(|b| b.capacity()).sum::<usize>();
 
             // Re-creating the array copies data and can be time consuming.
             // We only do it if the array is sparse


### PR DESCRIPTION
## Which issue does this PR close?


- Closes [#17007](https://github.com/apache/datafusion/issues/17007)

## Rationale for this change
1. Port arrow-rs optimization for get_buffer_memory_size for gc string view
2. Add fast path for no buffer case, so we don't need to do any calculation further.

## What changes are included in this PR?

1. Port arrow-rs optimization for get_buffer_memory_size for gc string view
2. Add fast path for no buffer case, so we don't need to do any calculation further.


## Are these changes tested?

Yes

## Are there any user-facing changes?

No