### PR TITLE
Add `prettier` to the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,5 +7,5 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # Add protoc
 # https://datafusion.apache.org/contributor-guide/development_environment.html#protoc-installation
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev \
+    && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev npm nodejs\
     && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,8 +4,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common
 
-# Add protoc
+# Add protoc, npm, prettier
 # https://datafusion.apache.org/contributor-guide/development_environment.html#protoc-installation
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev npm nodejs\
+    && npm install -y prettier@2.7.1
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

I suggested using dev containers on this PR
https://github.com/apache/datafusion/pull/17018#issuecomment-3146420097

<img width="1343" height="717" alt="Screenshot 2025-08-02 at 6 22 00 AM" src="https://github.com/user-attachments/assets/2c0ba5e2-651e-47cd-a12c-4f8b07c76932" />


However, when I actually tried to use it, I got an error about npm not being installed (see screenshot):

<img width="1701" height="1041" alt="Screenshot 2025-08-02 at 6 41 21 AM" src="https://github.com/user-attachments/assets/882bacc4-7159-4ab5-ac50-deec78a08ffa" />

```shell
root@codespaces-09a5ab:/workspaces/datafusion# ./dev/update_function_docs.sh
/workspaces/datafusion
Inserting header
Running CLI and inserting aggregate function docs table
    Updating crates.io index
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    ...

   Compiling datafusion v49.0.0 (/workspaces/datafusion/datafusion/core)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9m 59s
     Running `target/debug/print_functions_docs aggregate`
Running prettier
./dev/update_function_docs.sh: line 68: npx: command not found
root@codespaces-09a5ab:/workspaces/datafusion# apt-get install npm
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package npm
```


## What changes are included in this PR?

1. Add nodejs, npm to the dev container
2. Pre-install prettier

## Are these changes tested?

I am testing them manually

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
