### PR TITLE
docs: Fix failing documentation check in CI

### DIFF
--- a/datafusion/functions-window/src/row_number.rs
+++ b/datafusion/functions-window/src/row_number.rs
@@ -46,7 +46,7 @@ define_udwf_and_expr!(
     doc_section(label = "Ranking Functions"),
     description = "Number of the current row within its partition, counting from 1.",
     syntax_example = "row_number()",
-    sql_example = r"
+    sql_example = r#"
 ```sql
 -- Example usage of the row_number window function:
 SELECT department,
@@ -65,7 +65,7 @@ FROM employees;
 | Engineering | 80000  | 2       |
 +-------------+--------+---------+
 ```
-#"
+"#
 )]
 #[derive(Debug)]
 pub struct RowNumber {


### PR DESCRIPTION
#17014 changed the generated documentation file rather than the source used to generate the documentation, which has caused the "check configs.md and ***_functions.md is up-to-date" CI check to start failing.

This fixes the source example to remove the extra `#`