### PR TITLE
Validate the memory consumption in SPM created by multi level merge

### DIFF
--- a/datafusion/core/tests/sql/runtime_config.rs
+++ b/datafusion/core/tests/sql/runtime_config.rs
@@ -193,7 +193,7 @@ async fn test_max_temp_directory_size_enforcement() {
         .unwrap();
 
     let result = ctx.sql(query).await.unwrap().collect().await;
-    println!("result is {result:?}");
+
     assert!(
         result.is_ok(),
         "Should not fail due to max temp directory size limit"

--- a/datafusion/execution/src/memory_pool/pool.rs
+++ b/datafusion/execution/src/memory_pool/pool.rs
@@ -44,7 +44,6 @@ impl MemoryPool for UnboundedMemoryPool {
 
     fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> Result<()> {
         self.grow(reservation, additional);
-        println!("[mem pool] {} used", self.reserved());
         Ok(())
     }
 
@@ -71,8 +70,7 @@ pub struct GreedyMemoryPool {
 impl GreedyMemoryPool {
     /// Create a new pool that can allocate up to `pool_size` bytes
     pub fn new(pool_size: usize) -> Self {
-        // debug!("Created new GreedyMemoryPool(pool_size={pool_size})");
-        println!("Created new GreedyMemoryPool(pool_size={pool_size})");
+        debug!("Created new GreedyMemoryPool(pool_size={pool_size})");
         Self {
             pool_size,
             used: AtomicUsize::new(0),

--- a/datafusion/physical-plan/src/sorts/streaming_merge.rs
+++ b/datafusion/physical-plan/src/sorts/streaming_merge.rs
@@ -29,9 +29,8 @@ use arrow::array::*;
 use arrow::datatypes::{DataType, SchemaRef};
 use datafusion_common::{internal_err, Result};
 use datafusion_execution::disk_manager::RefCountedTempFile;
-#[allow(unused_imports)]
 use datafusion_execution::memory_pool::{
-    human_readable_size, GreedyMemoryPool, MemoryConsumer, MemoryPool, MemoryReservation,
+    human_readable_size, MemoryConsumer, MemoryPool, MemoryReservation,
     UnboundedMemoryPool,
 };
 use datafusion_physical_expr_common::sort_expr::LexOrdering;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #16909 .

## Rationale for this change
In multi-level merge, we reserve estimated memory need for merging sorted spill files first, and bypass global memory pool when creating `SortPreservingMergeStream`(shortly SPM). The purpose of it is to ensure that we can finish `SPM` step without lacking memory by keeping worst case memory reservation til SPM ends. 

<details>

- grow merge_reservation based on max batch memory per spill file
https://github.com/apache/datafusion/blob/66d6995b8f626f28f811489bd2cb552b6c64a85f/datafusion/physical-plan/src/sorts/multi_level_merge.rs#L256-L268

- bypass global buffer pool (use unbounded memory pool)
https://github.com/apache/datafusion/blob/66d6995b8f626f28f811489bd2cb552b6c64a85f/datafusion/physical-plan/src/sorts/multi_level_merge.rs#L326-L336

</details>


Since we use `UnboundedMemoryPool` as a trick, we don't validate whether this `memory_reservation` is the actual upper limit when `SPM` step for multi level merge. Therefore, we need to validate the memory consumption in SPM does not exceed the size of memory_reservation. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
This PR add check to `SpillReadStream` so that whenever a spill stream is polled, the memory size of the batch being read does not exceed `max_record_batch_memory` + margin. This allows us to detect cases where we made an incorrect (underestimated) memory reservation — for example, when the batch consumes more memory after the write-read cycle than originally expected.

~~This PR creates a separate `GreedyMemoryPool` size of `memory_reservation` instead of using `UnboundedMemoryPool` when merging spill files (and in-memory streams) on multi-level merge.~~ 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
**Yes, and following tests related to spilling fail** :cry: 
Maybe our previous worst-case memory estimation was wrong, but don't understand why at this point. We need more investigation here. I'll put more details in comments. 

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
