### PR TITLE
Docs: Add Tuning Guide for small data / short queries

### DIFF
--- a/dev/update_config_docs.sh
+++ b/dev/update_config_docs.sh
@@ -92,6 +92,38 @@ EOF
 echo "Running CLI and inserting runtime config docs table"
 $PRINT_RUNTIME_CONFIG_DOCS_COMMAND >> "$TARGET_FILE"
 
+cat <<'EOF' >> "$TARGET_FILE"
+
+# Tuning Guide
+
+## Short Queries
+
+By default DataFusion will attempt to maximize parallelism and use all cores --
+For example, if you have 32 cores, each plan will split the data into 32
+partitions. However, if your data is small, the overhead of splitting the data
+to enable parallelization can dominate the actual computation.
+
+You can find out how many cores are being used via the [`EXPLAIN`] command and look
+at the number of partitions in the plan.
+
+[`EXPLAIN`]: sql/explain.md
+
+The `datafusion.optimizer.repartition_file_min_size` option controls the minimum file size the
+[`ListingTable`] provider will attempt to repartition. However, this
+does not apply to user defined data sources and only works when DataFusion has accurate statistics.
+
+If you know your data is small, you can set the `datafusion.execution.target_partitions`
+option to a smaller number to reduce the overhead of repartitioning. For very small datasets (e.g. less
+than 1MB), we recommend setting `target_partitions` to 1 to avoid repartitioning altogether.
+
+```sql
+SET datafusion.execution.target_partitions = '1';
+```
+
+[`ListingTable`]: https://docs.rs/datafusion/latest/datafusion/datasource/listing/struct.ListingTable.html
+
+EOF
+
 
 echo "Running prettier"
 npx prettier@2.3.2 --write "$TARGET_FILE"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- part of #7013 

## Rationale for this change

I wrote up some guidance for running datafusion with "small" data in https://github.com/apache/datafusion/issues/17025#issuecomment-3151817573 that I felt was worth capturing in the documentation


## What changes are included in this PR?
- Add information about tuning datafusion for small data / short queries to the configuration page

<img width="869" height="664" alt="Screenshot 2025-08-04 at 3 18 26 PM" src="https://github.com/user-attachments/assets/5a3d4896-cf2a-4b2a-a62d-6821434de375" />



## Are these changes tested?
By CI (and I tested them locally)

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
