### PR TITLE
Run config_docs CI check on PRs to change auto generated docs

### DIFF
--- a/.github/workflows/docs_generated.yaml
+++ b/.github/workflows/docs_generated.yaml
@@ -1,0 +1,78 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Generated Docs Check
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths:
+      - ".github/**"
+      - "datafusion/**"
+      - "dev/update_config_docs.sh"
+      - "dev/update_function_docs.sh"
+      - "docs/source/user-guide/configs.md"
+      - "docs/source/user-guide/sql/aggregate_functions.md"
+      - "docs/source/user-guide/sql/scalar_functions.md"
+      - "docs/source/user-guide/sql/window_functions.md"
+  pull_request:
+    paths:
+      - ".github/**"
+      - "datafusion/**"
+      - "dev/update_config_docs.sh"
+      - "dev/update_function_docs.sh"
+      - "docs/source/user-guide/configs.md"
+      - "docs/source/user-guide/sql/aggregate_functions.md"
+      - "docs/source/user-guide/sql/scalar_functions.md"
+      - "docs/source/user-guide/sql/window_functions.md"
+  # manual trigger
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+
+generated-docs-check:
+  name: check configs.md and ***_functions.md is up-to-date
+  needs: linux-build-lib
+  runs-on: ubuntu-latest
+  container:
+    image: amd64/rust
+  steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        submodules: true
+        fetch-depth: 1
+    - name: Setup Rust toolchain
+      uses: ./.github/actions/setup-builder
+      with:
+        rust-version: stable
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+      with:
+        node-version: "20"
+    - name: Check if configs.md has been modified
+      run: |
+        # If you encounter an error, run './dev/update_config_docs.sh' and commit
+        ./dev/update_config_docs.sh
+        git diff --exit-code
+    - name: Check if any of the ***_functions.md has been modified
+      run: |
+        # If you encounter an error, run './dev/update_function_docs.sh' and commit
+        ./dev/update_function_docs.sh
+        git diff --exit-code

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -702,34 +702,6 @@ jobs:
       - name: Check Cargo.toml formatting
         run: taplo format --check
 
-  config-docs-check:
-    name: check configs.md and ***_functions.md is up-to-date
-    needs: linux-build-lib
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          submodules: true
-          fetch-depth: 1
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
-        with:
-          node-version: "20"
-      - name: Check if configs.md has been modified
-        run: |
-          # If you encounter an error, run './dev/update_config_docs.sh' and commit
-          ./dev/update_config_docs.sh
-          git diff --exit-code
-      - name: Check if any of the ***_functions.md has been modified
-        run: |
-          # If you encounter an error, run './dev/update_function_docs.sh' and commit
-          ./dev/update_function_docs.sh
-          git diff --exit-code
 
   # Verify MSRV for the crates which are directly used by other projects:
   # - datafusion


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

We now broke CI twice in the last day with docs changes that did not run the config_docs check.

Here are two PRs that fixed it:
- https://github.com/apache/datafusion/pull/17026
- https://github.com/apache/datafusion/pull/17041

(Thanks to @liamzwbao and @adamreeve for pointing them out)

let's fix the docs check to automatically run on PRs that change the auto generated files


## What changes are included in this PR?

1. Move CI check to a new file

## Are these changes tested?

I am testing them manually

## Are there any user-facing changes?

No, this is a CI process change only