### PR TITLE
Fix: ListingTableFactory hive column detection

### DIFF
--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -802,6 +802,8 @@ impl ListingOptions {
                     .rev()
                     .skip(1) // get parents only; skip the file itself
                     .rev()
+                    // Partitions are expected to follow the format "column_name=value", so we
+                    // should ignore any path part that cannot be parsed into the expected format
                     .filter(|s| s.contains('='))
                     .map(|s| s.split('=').take(1).collect())
                     .collect_vec()

--- a/datafusion/core/src/datasource/listing_table_factory.rs
+++ b/datafusion/core/src/datasource/listing_table_factory.rs
@@ -65,6 +65,10 @@ impl TableProviderFactory for ListingTableFactory {
 
         let mut table_path = ListingTableUrl::parse(&cmd.location)?;
         let file_extension = match table_path.is_collection() {
+            // Setting the extension to be empty instead of allowing the default extension seems
+            // odd, but was done to ensure existing behavior isn't modified. It seems like this
+            // could be refactored to either use the default extension or set the fully expected
+            // extension when compression is included (e.g. ".csv.gz")
             true => "",
             false => &get_extension(cmd.location.as_str()),
         };
@@ -444,7 +448,7 @@ mod tests {
 
         let cmd = CreateExternalTable {
             name,
-            location: dir.path().to_str().unwrap().to_string(),
+            location: String::from(path.to_str().unwrap()),
             file_type: "parquet".to_string(),
             schema: Arc::new(DFSchema::empty()),
             table_partition_cols: vec![],


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #17049

## What changes are included in this PR?

 - Fixes an issue in the ListingTableFactory where hive columns are not detected and incorporated into the table schema when an explicit schema has not been set by the user
 - Fixes an issue where NO files are detected when a path that represents a collection has a . in the final element of the prefix because the contents following the . was interpreted as a file extension (i.e. s3://bucket/prefix/version.v1/ would only attempt to list files with ending with '.v1' instead of the expected extension such as .csv or .parquet)
 - Fixes an issue where subdirectories that do not follow Hive formatting (e.g. key=value) could be erroneously interpreted as contributing to the table schema

## Are these changes tested?

~~I'm initially submitting this as a draft PR without tests to provide a solid basis for discussion on whether or not this is the desired solution to the linked issue. If/when the solution to the PR is ready to merge I will make additional commits to address feedback as well as implement tests for the solution. At present, the changes have been tested functionally using `datafusion-cli` and the public dataset noted in the issue, and all existing unit tests pass.~~

Yes, unit tests have been pushed. Example functional test using the dataset from the linked issue is shown below:
```sql
DataFusion CLI v49.0.0
> CREATE EXTERNAL TABLE overture_maps
STORED AS PARQUET LOCATION 's3://overturemaps-us-west-2/release/2025-07-23.0/';
0 row(s) fetched.
Elapsed 10.165 seconds.

> select column_name, is_nullable from information_schema.columns where table_name='overture_maps' and column_name in ('theme', 'type');
+-------------+-------------+
| column_name | is_nullable |
+-------------+-------------+
| theme       | NO          |
| type        | NO          |
+-------------+-------------+
2 row(s) fetched.
Elapsed 0.003 seconds.

> select count(*) from overture_maps where type='address';
+-----------+
| count(*)  |
+-----------+
| 446544475 |
+-----------+
1 row(s) fetched.
Elapsed 0.693 seconds.
```

## Are there any user-facing changes?

Part of the reason I've left this in draft is because I think there's a possibility for the changes to impact users of the `ListingTableFactory`. In my mind the behavior represented here is what I would think the "expected" behavior should be, but there's a good possibility users are relying on the previous behavior and could get unexpected results if this PR is merged.

