### PR TITLE
Derive UDWF equality from PartialEq, Hash

### DIFF
--- a/datafusion/core/tests/user_defined/user_defined_window_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_window_functions.rs
@@ -28,8 +28,10 @@ use datafusion::common::test_util::batches_to_string;
 use datafusion::common::{Result, ScalarValue};
 use datafusion::prelude::SessionContext;
 use datafusion_common::exec_datafusion_err;
+use datafusion_expr::ptr_eq::PtrEq;
 use datafusion_expr::{
-    PartitionEvaluator, Signature, TypeSignature, Volatility, WindowUDF, WindowUDFImpl,
+    udf_equals_hash, PartitionEvaluator, Signature, TypeSignature, Volatility, WindowUDF,
+    WindowUDFImpl,
 };
 use datafusion_functions_window_common::partition::PartitionEvaluatorArgs;
 use datafusion_functions_window_common::{
@@ -523,10 +525,10 @@ impl OddCounter {
     }
 
     fn register(ctx: &mut SessionContext, test_state: Arc<TestState>) {
-        #[derive(Debug, Clone)]
+        #[derive(Debug, Clone, PartialEq, Hash)]
         struct SimpleWindowUDF {
             signature: Signature,
-            test_state: Arc<TestState>,
+            test_state: PtrEq<Arc<TestState>>,
             aliases: Vec<String>,
         }
 
@@ -536,7 +538,7 @@ impl OddCounter {
                     Signature::exact(vec![DataType::Float64], Volatility::Immutable);
                 Self {
                     signature,
-                    test_state,
+                    test_state: test_state.into(),
                     aliases: vec!["odd_counter_alias".to_string()],
                 }
             }
@@ -570,32 +572,7 @@ impl OddCounter {
                 Ok(Field::new(field_args.name(), DataType::Int64, true).into())
             }
 
-            fn equals(&self, other: &dyn WindowUDFImpl) -> bool {
-                let Some(other) = other.as_any().downcast_ref::<Self>() else {
-                    return false;
-                };
-                let Self {
-                    signature,
-                    test_state,
-                    aliases,
-                } = self;
-                signature == &other.signature
-                    && Arc::ptr_eq(test_state, &other.test_state)
-                    && aliases == &other.aliases
-            }
-
-            fn hash_value(&self) -> u64 {
-                let Self {
-                    signature,
-                    test_state,
-                    aliases,
-                } = self;
-                let mut hasher = DefaultHasher::new();
-                signature.hash(&mut hasher);
-                Arc::as_ptr(test_state).hash(&mut hasher);
-                aliases.hash(&mut hasher);
-                hasher.finish()
-            }
+            udf_equals_hash!(WindowUDFImpl);
         }
 
         ctx.register_udwf(WindowUDF::from(SimpleWindowUDF::new(test_state)))

--- a/datafusion/expr/src/async_udf.rs
+++ b/datafusion/expr/src/async_udf.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::utils::{arc_ptr_eq, arc_ptr_hash};
+use crate::ptr_eq::{arc_ptr_eq, arc_ptr_hash};
 use crate::{
     udf_equals_hash, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl,
 };

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -25,8 +25,8 @@ use crate::function::{
     AccumulatorArgs, AccumulatorFactoryFunction, PartitionEvaluatorFactory,
     StateFieldsArgs,
 };
+use crate::ptr_eq::PtrEq;
 use crate::select_expr::SelectExpr;
-use crate::utils::{arc_ptr_eq, arc_ptr_hash};
 use crate::{
     conditional_expressions::CaseBuilder, expr::Sort, logical_plan::Subquery,
     udf_equals_hash, AggregateUDF, Expr, LogicalPlan, Operator, PartitionEvaluator,
@@ -403,41 +403,12 @@ pub fn create_udf(
 
 /// Implements [`ScalarUDFImpl`] for functions that have a single signature and
 /// return type.
+#[derive(PartialEq, Hash)]
 pub struct SimpleScalarUDF {
     name: String,
     signature: Signature,
     return_type: DataType,
-    fun: ScalarFunctionImplementation,
-}
-
-impl PartialEq for SimpleScalarUDF {
-    fn eq(&self, other: &Self) -> bool {
-        let Self {
-            name,
-            signature,
-            return_type,
-            fun,
-        } = self;
-        name == &other.name
-            && signature == &other.signature
-            && return_type == &other.return_type
-            && arc_ptr_eq(fun, &other.fun)
-    }
-}
-
-impl Hash for SimpleScalarUDF {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        let Self {
-            name,
-            signature,
-            return_type,
-            fun,
-        } = self;
-        name.hash(state);
-        signature.hash(state);
-        return_type.hash(state);
-        arc_ptr_hash(fun, state);
-    }
+    fun: PtrEq<ScalarFunctionImplementation>,
 }
 
 impl Debug for SimpleScalarUDF {
@@ -481,7 +452,7 @@ impl SimpleScalarUDF {
             name: name.into(),
             signature,
             return_type,
-            fun,
+            fun: fun.into(),
         }
     }
 }

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -67,6 +67,7 @@ pub mod async_udf;
 pub mod statistics {
     pub use datafusion_expr_common::statistics::*;
 }
+pub mod ptr_eq;
 pub mod test;
 pub mod tree_node;
 pub mod type_coercion;

--- a/datafusion/expr/src/ptr_eq.rs
+++ b/datafusion/expr/src/ptr_eq.rs
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::sync::Arc;
+
+pub fn arc_ptr_eq<T: ?Sized>(a: &Arc<T>, b: &Arc<T>) -> bool {
+    // Not necessarily equivalent to `Arc::ptr_eq` for fat pointers.
+    std::ptr::eq(Arc::as_ptr(a), Arc::as_ptr(b))
+}
+
+pub fn arc_ptr_hash<T: ?Sized>(a: &Arc<T>, hasher: &mut impl Hasher) {
+    std::ptr::hash(Arc::as_ptr(a), hasher)
+}
+
+/// A wrapper around a pointer that implements `PartialEq` and `Hash` comparing
+/// the underlying pointer address.
+#[derive(Clone)]
+#[allow(private_bounds)] // This is so that PtrEq can only be used with allowed pointer types (e.g. Arc), without allowing misuse.
+pub struct PtrEq<Ptr: PointerType>(Ptr);
+
+impl<T> PartialEq for PtrEq<Arc<T>>
+where
+    T: ?Sized,
+{
+    fn eq(&self, other: &Self) -> bool {
+        arc_ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl<T> Hash for PtrEq<Arc<T>>
+where
+    T: ?Sized,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        arc_ptr_hash(&self.0, state);
+    }
+}
+
+impl<Ptr> From<Ptr> for PtrEq<Ptr>
+where
+    Ptr: PointerType,
+{
+    fn from(ptr: Ptr) -> Self {
+        PtrEq(ptr)
+    }
+}
+
+impl<T> From<PtrEq<Arc<T>>> for Arc<T>
+where
+    T: ?Sized,
+{
+    fn from(wrapper: PtrEq<Arc<T>>) -> Self {
+        wrapper.0
+    }
+}
+
+impl<Ptr> Debug for PtrEq<Ptr>
+where
+    Ptr: PointerType + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<Ptr> Deref for PtrEq<Ptr>
+where
+    Ptr: PointerType,
+{
+    type Target = Ptr;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+trait PointerType {}
+impl<T> PointerType for Arc<T> where T: ?Sized {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::hash::DefaultHasher;
+
+    #[test]
+    pub fn test_ptr_eq_wrapper() {
+        let a = Arc::new("Hello".to_string());
+        let b = Arc::new(a.deref().clone());
+        let c = Arc::new("world".to_string());
+
+        let wrapper = PtrEq(Arc::clone(&a));
+        assert_eq!(wrapper, wrapper);
+
+        // same address (equal)
+        assert_eq!(PtrEq(Arc::clone(&a)), PtrEq(Arc::clone(&a)));
+        assert_eq!(hash(PtrEq(Arc::clone(&a))), hash(PtrEq(Arc::clone(&a))));
+
+        // different address, same content (not equal)
+        assert_ne!(PtrEq(Arc::clone(&a)), PtrEq(Arc::clone(&b)));
+
+        // different address, different content (not equal)
+        assert_ne!(PtrEq(Arc::clone(&a)), PtrEq(Arc::clone(&c)));
+    }
+
+    fn hash<T: Hash>(value: T) -> u64 {
+        let hasher = &mut DefaultHasher::new();
+        value.hash(hasher);
+        hasher.finish()
+    }
+}

--- a/datafusion/expr/src/ptr_eq.rs
+++ b/datafusion/expr/src/ptr_eq.rs
@@ -20,11 +20,16 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::sync::Arc;
 
+/// Compares two `Arc` pointers for equality based on their underlying pointers values.
+/// This is not equivalent to [`Arc::ptr_eq`] for fat pointers, see that method
+/// for more information.
 pub fn arc_ptr_eq<T: ?Sized>(a: &Arc<T>, b: &Arc<T>) -> bool {
-    // Not necessarily equivalent to `Arc::ptr_eq` for fat pointers.
     std::ptr::eq(Arc::as_ptr(a), Arc::as_ptr(b))
 }
 
+/// Hashes an `Arc` pointer based on its underlying pointer value.
+/// The general contract for this function is that if [`arc_ptr_eq`] returns `true`
+/// for two `Arc`s, then this function should return the same hash value for both.
 pub fn arc_ptr_hash<T: ?Sized>(a: &Arc<T>, hasher: &mut impl Hasher) {
     std::ptr::hash(Arc::as_ptr(a), hasher)
 }

--- a/datafusion/expr/src/udwf.rs
+++ b/datafusion/expr/src/udwf.rs
@@ -29,8 +29,10 @@ use std::{
 use arrow::datatypes::{DataType, FieldRef};
 
 use crate::expr::WindowFunction;
+use crate::ptr_eq::PtrEq;
 use crate::{
-    function::WindowFunctionSimplification, Expr, PartitionEvaluator, Signature,
+    function::WindowFunctionSimplification, udf_equals_hash, Expr, PartitionEvaluator,
+    Signature,
 };
 use datafusion_common::{not_impl_err, Result};
 use datafusion_doc::Documentation;
@@ -477,9 +479,9 @@ impl PartialOrd for dyn WindowUDFImpl {
 
 /// WindowUDF that adds an alias to the underlying function. It is better to
 /// implement [`WindowUDFImpl`], which supports aliases, directly if possible.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Hash)]
 struct AliasedWindowUDFImpl {
-    inner: Arc<dyn WindowUDFImpl>,
+    inner: PtrEq<Arc<dyn WindowUDFImpl>>,
     aliases: Vec<String>,
 }
 
@@ -491,7 +493,10 @@ impl AliasedWindowUDFImpl {
         let mut aliases = inner.aliases().to_vec();
         aliases.extend(new_aliases.into_iter().map(|s| s.to_string()));
 
-        Self { inner, aliases }
+        Self {
+            inner: inner.into(),
+            aliases,
+        }
     }
 }
 
@@ -530,20 +535,7 @@ impl WindowUDFImpl for AliasedWindowUDFImpl {
         self.inner.simplify()
     }
 
-    fn equals(&self, other: &dyn WindowUDFImpl) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<AliasedWindowUDFImpl>() {
-            self.inner.equals(other.inner.as_ref()) && self.aliases == other.aliases
-        } else {
-            false
-        }
-    }
-
-    fn hash_value(&self) -> u64 {
-        let hasher = &mut DefaultHasher::new();
-        self.inner.hash_value().hash(hasher);
-        self.aliases.hash(hasher);
-        hasher.finish()
-    }
+    udf_equals_hash!(WindowUDFImpl);
 
     fn field(&self, field_args: WindowUDFFieldArgs) -> Result<FieldRef> {
         self.inner.field(field_args)

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -19,7 +19,6 @@
 
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashSet};
-use std::hash::Hasher;
 use std::sync::Arc;
 
 use crate::expr::{Alias, Sort, WildcardOptions, WindowFunctionParams};
@@ -1340,15 +1339,6 @@ macro_rules! udf_equals_hash {
             Hasher::finish(hasher)
         }
     };
-}
-
-pub fn arc_ptr_eq<T: ?Sized>(a: &Arc<T>, b: &Arc<T>) -> bool {
-    // Not necessarily equivalent to `Arc::ptr_eq` for fat pointers.
-    std::ptr::eq(Arc::as_ptr(a), Arc::as_ptr(b))
-}
-
-pub fn arc_ptr_hash<T: ?Sized>(a: &Arc<T>, hasher: &mut impl Hasher) {
-    std::ptr::hash(Arc::as_ptr(a), hasher)
 }
 
 #[cfg(test)]

--- a/datafusion/ffi/src/udwf/mod.rs
+++ b/datafusion/ffi/src/udwf/mod.rs
@@ -40,7 +40,7 @@ use partition_evaluator::{FFI_PartitionEvaluator, ForeignPartitionEvaluator};
 use partition_evaluator_args::{
     FFI_PartitionEvaluatorArgs, ForeignPartitionEvaluatorArgs,
 };
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::hash::{DefaultHasher, Hasher};
 use std::{ffi::c_void, sync::Arc};
 mod partition_evaluator;
 mod partition_evaluator_args;
@@ -339,31 +339,13 @@ impl WindowUDFImpl for ForeignWindowUDF {
         let Some(other) = other.as_any().downcast_ref::<Self>() else {
             return false;
         };
-        let Self {
-            name,
-            aliases,
-            udf,
-            signature,
-        } = self;
-        name == &other.name
-            && aliases == &other.aliases
-            && std::ptr::eq(udf, &other.udf)
-            && signature == &other.signature
+        // FFI_WindowUDF cannot be compared, so identity equality is the best we can do.
+        std::ptr::eq(self, other)
     }
 
     fn hash_value(&self) -> u64 {
-        let Self {
-            name,
-            aliases,
-            udf,
-            signature,
-        } = self;
         let mut hasher = DefaultHasher::new();
-        std::any::type_name::<Self>().hash(&mut hasher);
-        name.hash(&mut hasher);
-        aliases.hash(&mut hasher);
-        std::ptr::hash(udf, &mut hasher);
-        signature.hash(&mut hasher);
+        std::ptr::hash(self, &mut hasher);
         hasher.finish()
     }
 }

--- a/datafusion/functions-window/src/lead_lag.rs
+++ b/datafusion/functions-window/src/lead_lag.rs
@@ -25,8 +25,8 @@ use datafusion_common::arrow::datatypes::Field;
 use datafusion_common::{arrow_datafusion_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::window_doc_sections::DOC_SECTION_ANALYTICAL;
 use datafusion_expr::{
-    Documentation, Literal, PartitionEvaluator, ReversedUDWF, Signature, TypeSignature,
-    Volatility, WindowUDFImpl,
+    udf_equals_hash, Documentation, Literal, PartitionEvaluator, ReversedUDWF, Signature,
+    TypeSignature, Volatility, WindowUDFImpl,
 };
 use datafusion_functions_window_common::expr::ExpressionArgs;
 use datafusion_functions_window_common::field::WindowUDFFieldArgs;
@@ -35,7 +35,7 @@ use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use std::any::Any;
 use std::cmp::min;
 use std::collections::VecDeque;
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::hash::Hash;
 use std::ops::{Neg, Range};
 use std::sync::{Arc, LazyLock};
 
@@ -120,7 +120,7 @@ impl WindowShiftKind {
 }
 
 /// window shift expression
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Hash)]
 pub struct WindowShift {
     signature: Signature,
     kind: WindowShiftKind,
@@ -300,22 +300,7 @@ impl WindowUDFImpl for WindowShift {
         }
     }
 
-    fn equals(&self, other: &dyn WindowUDFImpl) -> bool {
-        let Some(other) = other.as_any().downcast_ref::<Self>() else {
-            return false;
-        };
-        let Self { signature, kind } = self;
-        signature == &other.signature && kind == &other.kind
-    }
-
-    fn hash_value(&self) -> u64 {
-        let Self { signature, kind } = self;
-        let mut hasher = DefaultHasher::new();
-        std::any::type_name::<Self>().hash(&mut hasher);
-        signature.hash(&mut hasher);
-        kind.hash(&mut hasher);
-        hasher.finish()
-    }
+    udf_equals_hash!(WindowUDFImpl);
 }
 
 /// When `lead`/`lag` is evaluated on a `NULL` expression we attempt to

--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -26,8 +26,8 @@ use datafusion_common::{exec_datafusion_err, exec_err, Result, ScalarValue};
 use datafusion_expr::window_doc_sections::DOC_SECTION_ANALYTICAL;
 use datafusion_expr::window_state::WindowAggState;
 use datafusion_expr::{
-    Documentation, Literal, PartitionEvaluator, ReversedUDWF, Signature, TypeSignature,
-    Volatility, WindowUDFImpl,
+    udf_equals_hash, Documentation, Literal, PartitionEvaluator, ReversedUDWF, Signature,
+    TypeSignature, Volatility, WindowUDFImpl,
 };
 use datafusion_functions_window_common::field;
 use datafusion_functions_window_common::partition::PartitionEvaluatorArgs;
@@ -35,7 +35,7 @@ use field::WindowUDFFieldArgs;
 use std::any::Any;
 use std::cmp::Ordering;
 use std::fmt::Debug;
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::hash::Hash;
 use std::ops::Range;
 use std::sync::LazyLock;
 
@@ -94,7 +94,7 @@ impl NthValueKind {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Hash)]
 pub struct NthValue {
     signature: Signature,
     kind: NthValueKind,
@@ -338,22 +338,7 @@ impl WindowUDFImpl for NthValue {
         }
     }
 
-    fn equals(&self, other: &dyn WindowUDFImpl) -> bool {
-        let Some(other) = other.as_any().downcast_ref::<Self>() else {
-            return false;
-        };
-        let Self { signature, kind } = self;
-        signature == &other.signature && kind == &other.kind
-    }
-
-    fn hash_value(&self) -> u64 {
-        let Self { signature, kind } = self;
-        let mut hasher = DefaultHasher::new();
-        std::any::type_name::<Self>().hash(&mut hasher);
-        signature.hash(&mut hasher);
-        kind.hash(&mut hasher);
-        hasher.finish()
-    }
+    udf_equals_hash!(WindowUDFImpl);
 }
 
 #[derive(Debug, Clone)]

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -4443,7 +4443,7 @@ mod tests {
 
     /// A Mock UDWF which defines `simplify` to be used in tests
     /// related to UDWF simplification
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq, Hash)]
     struct SimplifyMockUdwf {
         simplify: bool,
     }
@@ -4491,21 +4491,7 @@ mod tests {
             unimplemented!("not needed for tests")
         }
 
-        fn equals(&self, other: &dyn WindowUDFImpl) -> bool {
-            let Some(other) = other.as_any().downcast_ref::<Self>() else {
-                return false;
-            };
-            let Self { simplify } = self;
-            simplify == &other.simplify
-        }
-
-        fn hash_value(&self) -> u64 {
-            let Self { simplify } = self;
-            let mut hasher = DefaultHasher::new();
-            std::any::type_name::<Self>().hash(&mut hasher);
-            simplify.hash(&mut hasher);
-            hasher.finish()
-        }
+        udf_equals_hash!(WindowUDFImpl);
     }
     #[derive(Debug)]
     struct VolatileUdf {

--- a/datafusion/proto/tests/cases/mod.rs
+++ b/datafusion/proto/tests/cases/mod.rs
@@ -151,7 +151,7 @@ pub struct MyAggregateUdfNode {
     pub result: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Hash)]
 pub(in crate::cases) struct CustomUDWF {
     signature: Signature,
     payload: String,
@@ -193,22 +193,7 @@ impl WindowUDFImpl for CustomUDWF {
         Ok(Field::new(field_args.name(), DataType::UInt64, false).into())
     }
 
-    fn equals(&self, other: &dyn WindowUDFImpl) -> bool {
-        let Some(other) = other.as_any().downcast_ref::<Self>() else {
-            return false;
-        };
-        let Self { signature, payload } = self;
-        signature == &other.signature && payload == &other.payload
-    }
-
-    fn hash_value(&self) -> u64 {
-        let Self { signature, payload } = self;
-        let mut hasher = DefaultHasher::new();
-        std::any::type_name::<Self>().hash(&mut hasher);
-        signature.hash(&mut hasher);
-        payload.hash(&mut hasher);
-        hasher.finish()
-    }
+    udf_equals_hash!(WindowUDFImpl);
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Reduce boilerplate in cases where implementation of `{ScalarUDFImpl,AggregateUDFImpl,WindowUDFImpl}::{equals,hash_value}` can be derived using standard `PartialEq` and `Hash` traits.

This is code complexity reduction. Follows https://github.com/apache/datafusion/pull/16842

While valuable on its own, this also prepares for more automatic derivation of UDF equals/hash and/or removal of default implementations (which currently are error-prone) -- https://github.com/apache/datafusion/issues/16677

- closes https://github.com/apache/datafusion/issues/16867