### PR TITLE
Docs: Add Tuning Guide for larger-than-memory queries

### DIFF
--- a/dev/update_config_docs.sh
+++ b/dev/update_config_docs.sh
@@ -155,9 +155,9 @@ When executing a memory-consuming query under a tight memory limit, DataFusion
 will spill intermediate results to disk.
 
 When the [`FairSpillPool`] is used, memory is divided evenly among partitions. 
-The higher the value of `datafusion.execution.target_partitions` 
-the less memory is allocated to each partition, and the out-of-core
-execution path may trigger more frequently, slowing down execution.
+The higher the value of `datafusion.execution.target_partitions`, the less memory 
+is allocated to each partition, and the out-of-core execution path may trigger 
+more frequently, possibly slowing down execution.
 
 Additionally, while spilling, data is read back in `datafusion.execution.batch_size` size batches.
 The larger this value, the fewer spilled sorted runs can be merged. Decreasing this setting

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -224,22 +224,17 @@ SET datafusion.execution.target_partitions = '1';
 
 ## Memory-limited Queries
 
-When executing a memory-consuming query under a tight memory limit, DataFusion will
-attempt to use a separate execution path for the query, and the intermediate results
-will be spilled to disk.
+When executing a memory-consuming query under a tight memory limit, DataFusion
+will spill intermediate results to disk.
 
-If the [`FairSpillPool`] is used, partitions will attempt to divide the available
-memory evenly. If the partition count `datafusion.execution.target_partitions`
-is set too high, each partition will be allocated less memory, and the out-of-core
-execution path will trigger more spills and possibly slow down the query.
+When the [`FairSpillPool`] is used, memory is divided evenly among partitions.
+The higher the value of `datafusion.execution.target_partitions`, the less memory
+is allocated to each partition, and the out-of-core execution path may trigger
+more frequently, possibly slowing down execution.
 
-Additionally, all of the external join, aggregate, and sort operations now rely on the external
-sort implementation, which sorts the buffered data first, then spills, and in the
-final stage reads spills back incrementally and performs a sort-preserving merge. If the
-`datafusion.execution.batch_size` is set too large, in the sort-preserving merge
-phase the executor can only merge a small number of spilled sorted runs, which
-causes more re-spills to happen. As a result, setting `batch_size` to a smaller
-value can help reduce the number of spills.
+Additionally, while spilling, data is read back in `datafusion.execution.batch_size` size batches.
+The larger this value, the fewer spilled sorted runs can be merged. Decreasing this setting
+can help reduce the number of subsequent spills required.
 
 In conclusion, for queries under a very tight memory limit, it's recommended to
 set `target_partitions` and `batch_size` to smaller values.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Originally suggested by @alamb in https://github.com/apache/datafusion/pull/17040#issuecomment-3154577025

This tuning guide is more of a quick note. A more comprehensive, tutorial-style guide is still on my to-do list and I think it should be written once the feature is more mature. See https://github.com/apache/datafusion/issues/16177

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
