### PR TITLE
Deprecate ScalarUDF::is_nullable

### DIFF
--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -198,8 +198,9 @@ impl ScalarUDF {
         self.inner.simplify(args, info)
     }
 
-    #[allow(deprecated)]
+    #[deprecated(since = "50.0.0", note = "Use `return_field_from_args` instead.")]
     pub fn is_nullable(&self, args: &[Expr], schema: &dyn ExprSchema) -> bool {
+        #[allow(deprecated)]
         self.inner.is_nullable(args, schema)
     }
 


### PR DESCRIPTION
`ScalarUDFImpl::is_nullable` is deprecated since d3f1c9ad026e181e8cc6d1121f3223be5c26c3ae. The `ScalarUDF`'s wrapper also needs deprecation to allow eventually removing the deprecated `ScalarUDFImpl::is_nullable`.

cc @Blizzara 