### PR TITLE
Fix hash/equality issues for ScalarFunctionExpr 

### DIFF
--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -39,7 +39,7 @@ use crate::PhysicalExpr;
 
 use arrow::array::{Array, RecordBatch};
 use arrow::datatypes::{DataType, FieldRef, Schema};
-use datafusion_common::config::ConfigOptions;
+use datafusion_common::config::{ConfigEntry, ConfigOptions};
 use datafusion_common::{internal_err, Result, ScalarValue};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::sort_properties::ExprProperties;
@@ -48,7 +48,6 @@ use datafusion_expr::{
     expr_vec_fmt, ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF,
 };
 use datafusion_physical_expr_common::physical_expr::{DynEq, DynHash};
-use itertools::Itertools;
 
 /// Physical expression of a scalar function
 pub struct ScalarFunctionExpr {
@@ -182,20 +181,8 @@ impl DynEq for ScalarFunctionExpr {
                 && self.name.eq(&o.name)
                 && self.args.eq(&o.args)
                 && self.return_field.eq(&o.return_field)
-                && self
-                    .config_options
-                    .entries()
-                    .iter()
-                    .sorted_by(|&l, &r| l.key.cmp(&r.key))
-                    .zip(
-                        o.config_options
-                            .entries()
-                            .iter()
-                            .sorted_by(|&l, &r| l.key.cmp(&r.key)),
-                    )
-                    .filter(|(l, r)| l.ne(r))
-                    .count()
-                    == 0
+                && sorted_config_entries(&self.config_options)
+                    == sorted_config_entries(&o.config_options)
         })
     }
 }
@@ -209,6 +196,12 @@ impl DynHash for ScalarFunctionExpr {
         self.return_field.hash(&mut state);
         self.config_options.entries().hash(&mut state);
     }
+}
+
+fn sorted_config_entries(config_options: &ConfigOptions) -> Vec<ConfigEntry> {
+    let mut entries = config_options.entries();
+    entries.sort_by(|l, r| l.key.cmp(&r.key));
+    entries
 }
 
 impl PhysicalExpr for ScalarFunctionExpr {

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -47,7 +47,6 @@ use datafusion_expr::type_coercion::functions::data_types_with_scalar_udf;
 use datafusion_expr::{
     expr_vec_fmt, ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF,
 };
-use datafusion_physical_expr_common::physical_expr::{DynEq, DynHash};
 
 /// Physical expression of a scalar function
 pub struct ScalarFunctionExpr {
@@ -174,27 +173,38 @@ impl fmt::Display for ScalarFunctionExpr {
     }
 }
 
-impl DynEq for ScalarFunctionExpr {
-    fn dyn_eq(&self, other: &dyn Any) -> bool {
-        other.downcast_ref::<Self>().is_some_and(|o| {
-            self.fun.eq(&o.fun)
-                && self.name.eq(&o.name)
-                && self.args.eq(&o.args)
-                && self.return_field.eq(&o.return_field)
-                && sorted_config_entries(&self.config_options)
-                    == sorted_config_entries(&o.config_options)
-        })
+impl PartialEq for ScalarFunctionExpr {
+    fn eq(&self, o: &Self) -> bool {
+        let Self {
+            fun,
+            name,
+            args,
+            return_field,
+            config_options,
+        } = self;
+        fun.eq(&o.fun)
+            && name.eq(&o.name)
+            && args.eq(&o.args)
+            && return_field.eq(&o.return_field)
+            && sorted_config_entries(config_options)
+                == sorted_config_entries(&o.config_options)
     }
 }
-
-impl DynHash for ScalarFunctionExpr {
-    fn dyn_hash(&self, mut state: &mut dyn Hasher) {
-        self.type_id().hash(&mut state);
-        self.fun.hash(&mut state);
-        self.name.hash(&mut state);
-        self.args.hash(&mut state);
-        self.return_field.hash(&mut state);
-        sorted_config_entries(&self.config_options).hash(&mut state);
+impl Eq for ScalarFunctionExpr {}
+impl Hash for ScalarFunctionExpr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let Self {
+            fun,
+            name,
+            args,
+            return_field,
+            config_options,
+        } = self;
+        fun.hash(state);
+        name.hash(state);
+        args.hash(state);
+        return_field.hash(state);
+        sorted_config_entries(config_options).hash(state);
     }
 }
 

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -194,7 +194,7 @@ impl DynHash for ScalarFunctionExpr {
         self.name.hash(&mut state);
         self.args.hash(&mut state);
         self.return_field.hash(&mut state);
-        self.config_options.entries().hash(&mut state);
+        sorted_config_entries(&self.config_options).hash(&mut state);
     }
 }
 


### PR DESCRIPTION
- Fix `DynEq` implementation for `ScalarFunctionExpr`; it could return `true` for non equal values
- Fox `DynHash` implementation for `ScalarFunctionExpr` to be consistent with equals