### PR TITLE
Fix incorrect `NULL IN ()` optimization

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -103,6 +103,7 @@ pub struct ExprSimplifier<S> {
     /// Should expressions be canonicalized before simplification? Defaults to
     /// true
     canonicalize: bool,
+    evaluate_constants: bool,
     /// Maximum number of simplifier cycles
     max_simplifier_cycles: u32,
 }
@@ -121,6 +122,7 @@ impl<S: SimplifyInfo> ExprSimplifier<S> {
             info,
             guarantees: vec![],
             canonicalize: true,
+            evaluate_constants: true,
             max_simplifier_cycles: DEFAULT_MAX_SIMPLIFIER_CYCLES,
         }
     }
@@ -240,10 +242,14 @@ impl<S: SimplifyInfo> ExprSimplifier<S> {
         let mut num_cycles = 0;
         let mut has_transformed = false;
         loop {
+            let constant_folded = if self.evaluate_constants {
+                expr.rewrite(&mut const_evaluator)?
+            } else {
+                Transformed::no(expr)
+            };
             let Transformed {
                 data, transformed, ..
-            } = expr
-                .rewrite(&mut const_evaluator)?
+            } = constant_folded
                 .transform_data(|expr| expr.rewrite(&mut simplifier))?
                 .transform_data(|expr| expr.rewrite(&mut guarantee_rewriter))?;
             expr = data;
@@ -3360,12 +3366,18 @@ mod tests {
     // ------------------------------
 
     fn try_simplify(expr: Expr) -> Result<Expr> {
+        with_simplifier(|simplifier| simplifier.simplify(expr))
+    }
+
+    fn with_simplifier<T>(
+        callback: impl FnOnce(&mut ExprSimplifier<SimplifyContext>) -> T,
+    ) -> T {
         let schema = expr_test_schema();
         let execution_props = ExecutionProps::new();
-        let simplifier = ExprSimplifier::new(
+        let mut simplifier = ExprSimplifier::new(
             SimplifyContext::new(&execution_props).with_schema(schema),
         );
-        simplifier.simplify(expr)
+        callback(&mut simplifier)
     }
 
     fn coerce(expr: Expr) -> Expr {
@@ -3947,6 +3959,35 @@ mod tests {
         // https://github.com/apache/datafusion/issues/8970
         // assert_eq!(simplify(expr.clone()), lit(true));
         assert_eq!(simplify(expr.clone()), expr);
+    }
+
+    #[test]
+    fn simplify_null_in_empty_inlist() {
+        for canonicalize in [false, true] {
+            for evaluate_constants in [false, true] {
+                with_simplifier(|simplifier| {
+                    simplifier.canonicalize = canonicalize;
+                    simplifier.evaluate_constants = evaluate_constants;
+
+                    // `NULL::boolean IN ()` == `NULL::boolean IN (SELECT foo FROM empty)` == false
+                    let expr = in_list(lit_bool_null(), vec![], false);
+                    assert_eq!(simplifier.simplify(expr).unwrap(), lit(false));
+
+                    // `NULL::boolean NOT IN ()` == `NULL::boolean NOT IN (SELECT foo FROM empty)` == true
+                    let expr = in_list(lit_bool_null(), vec![], true);
+                    assert_eq!(simplifier.simplify(expr).unwrap(), lit(true));
+
+                    // `NULL IN ()` == `NULL IN (SELECT foo FROM empty)` == false
+                    let null_null = || Expr::Literal(ScalarValue::Null, None);
+                    let expr = in_list(null_null(), vec![], false);
+                    assert_eq!(simplifier.simplify(expr).unwrap(), lit(false));
+
+                    // `NULL NOT IN ()` == `NULL NOT IN (SELECT foo FROM empty)` == true
+                    let expr = in_list(null_null(), vec![], true);
+                    assert_eq!(simplifier.simplify(expr).unwrap(), lit(true));
+                })
+            }
+        }
     }
 
     #[test]

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -1669,20 +1669,20 @@ impl<S: SimplifyInfo> TreeNodeRewriter for Simplifier<'_, S> {
             // expr IN () --> false
             // expr NOT IN () --> true
             Expr::InList(InList {
-                expr,
+                expr: _,
                 list,
                 negated,
-            }) if list.is_empty() && *expr != Expr::Literal(ScalarValue::Null, None) => {
-                Transformed::yes(lit(negated))
-            }
+            }) if list.is_empty() => Transformed::yes(lit(negated)),
 
             // null in (x, y, z) --> null
             // null not in (x, y, z) --> null
             Expr::InList(InList {
                 expr,
-                list: _,
+                list,
                 negated: _,
-            }) if is_null(expr.as_ref()) => Transformed::yes(lit_bool_null()),
+            }) if is_null(expr.as_ref()) && !list.is_empty() => {
+                Transformed::yes(lit_bool_null())
+            }
 
             // expr IN ((subquery)) -> expr IN (subquery), see ##5529
             Expr::InList(InList {

--- a/datafusion/sqllogictest/test_files/predicates.slt
+++ b/datafusion/sqllogictest/test_files/predicates.slt
@@ -811,5 +811,26 @@ explain select x from t where x NOT IN (1,2,3,4,5) AND x IN (1,2,3);
 logical_plan EmptyRelation
 physical_plan EmptyExec
 
+query error DataFusion error: This feature is not implemented: Physical plan does not support logical expression InSubquery\(InSubquery \{ expr: Literal\(Int64\(NULL\), None\), subquery: <subquery>, negated: false \}\)
+WITH empty AS (SELECT 10 WHERE false)
+SELECT
+    NULL IN (SELECT * FROM empty), -- should be false, as the right side is empty relation
+    NULL NOT IN (SELECT * FROM empty) -- should be true, as the right side is empty relation
+FROM (SELECT 1) t;
+
+query I
+WITH empty AS (SELECT 10 WHERE false)
+SELECT * FROM (SELECT 1) t
+WHERE NOT (NULL IN (SELECT * FROM empty)); -- all rows should be returned
+----
+1
+
+query I
+WITH empty AS (SELECT 10 WHERE false)
+SELECT * FROM (SELECT 1) t
+WHERE NULL NOT IN (SELECT * FROM empty); -- all rows should be returned
+----
+1
+
 statement ok
 drop table t;


### PR DESCRIPTION
The optimization does not manifest as a bug in typical queries, because
the `ConstantEvaluator` prevents that. However, it still needs to be
corrected (or removed), otherwise it's a bug waiting to manifest
somewhere.