### PR TITLE
minor: remove unused import in docstring of datafusion_common::record_batch

### DIFF
--- a/datafusion/common/src/test_util.rs
+++ b/datafusion/common/src/test_util.rs
@@ -359,7 +359,7 @@ macro_rules! create_array {
 ///
 /// Example:
 /// ```
-/// use datafusion_common::{record_batch, create_array};
+/// use datafusion_common::record_batch;
 /// let batch = record_batch!(
 ///     ("a", Int32, vec![1, 2, 3]),
 ///     ("b", Float64, vec![Some(4.0), None, Some(5.0)]),


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Noticed while reviewing #17102, don't need to import `create_array` as it is namespaced correctly inside the macro anyway so it's unused:

https://github.com/apache/datafusion/blob/ab794d29b3783f379a5002753cf4b369086fb1fd/datafusion/common/src/test_util.rs#L369-L389

- See line 382

## What changes are included in this PR?

Remove unused import in docstring

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
