### PR TITLE
minor: remove unnecessary clippy:large_enum_variant allows

### DIFF
--- a/datafusion/expr/src/planner.rs
+++ b/datafusion/expr/src/planner.rs
@@ -313,7 +313,6 @@ pub struct RawWindowExpr {
 
 /// Result of planning a raw expr with [`ExprPlanner`]
 #[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
 pub enum PlannerResult<T> {
     /// The raw expression was successfully planned as a new [`Expr`]
     Planned(Expr),

--- a/datafusion/expr/src/simplify.rs
+++ b/datafusion/expr/src/simplify.rs
@@ -110,7 +110,6 @@ impl SimplifyInfo for SimplifyContext<'_> {
 
 /// Was the expression simplified?
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum ExprSimplifyResult {
     /// The function call was simplified to an entirely new Expr
     Simplified(Expr),

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -519,7 +519,6 @@ struct ConstEvaluator<'a> {
 
 #[allow(dead_code)]
 /// The simplify result of ConstEvaluator
-#[allow(clippy::large_enum_variant)]
 enum ConstSimplifyResult {
     // Expr was simplified and contains the new expression
     Simplified(ScalarValue, Option<FieldMetadata>),


### PR DESCRIPTION
Whilst looking at #16652 I saw some other uses of `#[allow(clippy::large_enum_variant)]`; tested removing some of these and looks fine now, clippy not complaining. Might as well clean these up in that case.