### PR TITLE
Set a lower threshold for clippy to flag large error variants

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -10,3 +10,13 @@ disallowed-types = [
 # Lowering the threshold to help prevent stack overflows (default is 16384)
 # See: https://rust-lang.github.io/rust-clippy/master/index.html#/large_futures
 future-size-threshold = 10000
+
+# Be more aware of large error variants which can impact the "happy path" due
+# to large stack footprint when considering async state machines (default is 128).
+#
+# Value of 70 picked arbitrarily as something less than 100.
+#
+# See:
+# - https://github.com/apache/datafusion/issues/16652
+# - https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
+large-error-threshold = 70

--- a/datafusion/sqllogictest/src/engines/datafusion_engine/error.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/error.rs
@@ -28,7 +28,7 @@ pub type Result<T, E = DFSqlLogicTestError> = std::result::Result<T, E>;
 pub enum DFSqlLogicTestError {
     /// Error from sqllogictest-rs
     #[error("SqlLogicTest error(from sqllogictest-rs crate): {0}")]
-    SqlLogicTest(#[from] TestError),
+    SqlLogicTest(#[from] Box<TestError>),
     /// Error from datafusion
     #[error("DataFusion error: {}", .0.strip_backtrace())]
     DataFusion(#[from] DataFusionError),


### PR DESCRIPTION
- Closes #16652

Most of the work to close this issue was done by #16653 and #16672 anyway; here we just try set a lower threshold for clippy to warn us about error variants being too large (from default of 128 to 70) so hopefully we can identify any future issues quicker.