### PR TITLE
feat: add `isodow` (ISO day-of-week) support to date_part (Monday = 0)

### DIFF
--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -68,9 +68,10 @@ use datafusion_macros::user_doc;
     - millisecond
     - microsecond
     - nanosecond
-    - dow (day of the week)
+    - dow (day of the week where Sunday is 0)
     - doy (day of the year)
     - epoch (seconds since Unix epoch)
+    - isodow (day of the week where Monday is 0)
 "#
     ),
     argument(

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -217,6 +217,7 @@ impl ScalarUDFImpl for DatePartFunc {
                 "qtr" | "quarter" => date_part(array.as_ref(), DatePart::Quarter)?,
                 "doy" => date_part(array.as_ref(), DatePart::DayOfYear)?,
                 "dow" => date_part(array.as_ref(), DatePart::DayOfWeekSunday0)?,
+                "isodow" => date_part(array.as_ref(), DatePart::DayOfWeekMonday0)?,
                 "epoch" => epoch(array.as_ref())?,
                 _ => return exec_err!("Date part '{part}' not supported"),
             }

--- a/datafusion/sqllogictest/test_files/expr/date_part.slt
+++ b/datafusion/sqllogictest/test_files/expr/date_part.slt
@@ -1070,3 +1070,23 @@ true
 
 query error DataFusion error: This feature is not implemented: Date part Nanosecond not supported
 SELECT (date_part('nanosecond', now()) = EXTRACT(nanosecond FROM now()))
+
+query I
+SELECT date_part('ISODOW', CAST('2000-01-01' AS DATE))
+----
+5
+
+query I
+SELECT EXTRACT(isodow FROM to_timestamp('2020-09-08T12:00:00+00:00'))
+----
+1
+
+query I
+SELECT EXTRACT("isodow" FROM to_timestamp('2020-09-08T12:00:00+00:00'))
+----
+1
+
+query I
+SELECT EXTRACT('isodow' FROM to_timestamp('2020-09-08T12:00:00+00:00'))
+----
+1

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -2114,9 +2114,10 @@ date_part(part, expression)
   - millisecond
   - microsecond
   - nanosecond
-  - dow (day of the week)
+  - dow (day of the week where Sunday is 0)
   - doy (day of the year)
   - epoch (seconds since Unix epoch)
+  - isodow (day of the week where Monday is 0)
 
 - **expression**: Time expression to operate on. Can be a constant, column, or function.
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #17111.

## Are these changes tested?

Yes, SLT tests added.

## Are there any user-facing changes?

`isoweek` support added to `date_part`
