### PR TITLE
feat: Add decimal support for `round`

### DIFF
--- a/datafusion/functions/src/math/round.rs
+++ b/datafusion/functions/src/math/round.rs
@@ -22,11 +22,15 @@ use crate::utils::make_scalar_function;
 
 use arrow::array::{ArrayRef, AsArray, PrimitiveArray};
 use arrow::compute::{cast_with_options, CastOptions};
-use arrow::datatypes::DataType::{Float32, Float64, Int32};
-use arrow::datatypes::{DataType, Float32Type, Float64Type, Int32Type};
+use arrow::datatypes::DataType::{
+    Decimal128, Decimal256, Float32, Float64, Int32, Int64,
+};
+use arrow::datatypes::{
+    DataType, Decimal128Type, Decimal256Type, Float32Type, Float64Type, Int32Type,
+};
+use arrow_buffer::i256;
 use datafusion_common::{exec_datafusion_err, exec_err, Result, ScalarValue};
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
-use datafusion_expr::TypeSignature::Exact;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
     Volatility,
@@ -56,17 +60,8 @@ impl Default for RoundFunc {
 
 impl RoundFunc {
     pub fn new() -> Self {
-        use DataType::*;
         Self {
-            signature: Signature::one_of(
-                vec![
-                    Exact(vec![Float64, Int64]),
-                    Exact(vec![Float32, Int64]),
-                    Exact(vec![Float64]),
-                    Exact(vec![Float32]),
-                ],
-                Volatility::Immutable,
-            ),
+            signature: Signature::user_defined(Volatility::Immutable),
         }
     }
 }
@@ -84,9 +79,41 @@ impl ScalarUDFImpl for RoundFunc {
         &self.signature
     }
 
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        if arg_types.len() != 1 && arg_types.len() != 2 {
+            return exec_err!(
+                "round function requires one or two arguments, got {}",
+                arg_types.len()
+            );
+        }
+
+        if arg_types.len() == 1 {
+            match arg_types[0].clone() {
+                Decimal128(p, s) => Ok(vec![Decimal128(p, s)]),
+                Decimal256(p, s) => Ok(vec![Decimal256(p, s)]),
+                Float32 => Ok(vec![Float32]),
+                _ => Ok(vec![Float64]),
+            }
+        } else if arg_types.len() == 2 {
+            match arg_types[0].clone() {
+                Decimal128(p, s) => Ok(vec![Decimal128(p, s), Int64]),
+                Decimal256(p, s) => Ok(vec![Decimal256(p, s), Int64]),
+                Float32 => Ok(vec![Float32, Int64]),
+                _ => Ok(vec![Float64, Int64]),
+            }
+        } else {
+            exec_err!(
+                "round function requires one or two arguments, got {}",
+                arg_types.len()
+            )
+        }
+    }
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         match arg_types[0] {
             Float32 => Ok(Float32),
+            Decimal128(p, s) => Ok(Decimal128(p, s)),
+            Decimal256(p, s) => Ok(Decimal256(p, s)),
             _ => Ok(Float64),
         }
     }
@@ -215,7 +242,127 @@ pub fn round(args: &[ArrayRef]) -> Result<ArrayRef> {
             }
         },
 
+        Decimal128(precision, scale) => match decimal_places {
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(decimal_places))) => {
+                let decimal_places: i32 = decimal_places.try_into().map_err(|e| {
+                    exec_datafusion_err!(
+                        "Invalid value for decimal places: {decimal_places}: {e}"
+                    )
+                })?;
+
+                let values = args[0].as_primitive::<Decimal128Type>();
+                let result = values.unary::<_, Decimal128Type>(|value| {
+                    round_decimal128(value, *scale, decimal_places)
+                });
+
+                Ok(Arc::new(result.with_precision_and_scale(*precision, *scale)?) as _)
+            }
+            ColumnarValue::Array(decimal_places) => {
+                let options = CastOptions {
+                    safe: false, // raise error if the cast is not possible
+                    ..Default::default()
+                };
+                let decimal_places = cast_with_options(&decimal_places, &Int32, &options)
+                    .map_err(|e| {
+                        exec_datafusion_err!("Invalid values for decimal places: {e}")
+                    })?;
+
+                let values = args[0].as_primitive::<Decimal128Type>();
+                let decimal_places = decimal_places.as_primitive::<Int32Type>();
+                let result = arrow::compute::binary::<_, _, _, Decimal128Type>(
+                    values,
+                    decimal_places,
+                    |value, decimal_places| {
+                        round_decimal128(value, *scale, decimal_places)
+                    },
+                )?;
+
+                Ok(Arc::new(result.with_precision_and_scale(*precision, *scale)?) as _)
+            }
+            _ => {
+                exec_err!("round function requires a scalar or array for decimal_places")
+            }
+        },
+
+        Decimal256(precision, scale) => match decimal_places {
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(decimal_places))) => {
+                let decimal_places: i32 = decimal_places.try_into().map_err(|e| {
+                    exec_datafusion_err!(
+                        "Invalid value for decimal places: {decimal_places}: {e}"
+                    )
+                })?;
+
+                let values = args[0].as_primitive::<Decimal256Type>();
+                let result = values.unary::<_, Decimal256Type>(|value| {
+                    round_decimal256(value, *scale, decimal_places)
+                });
+
+                Ok(Arc::new(result.with_precision_and_scale(*precision, *scale)?) as _)
+            }
+            ColumnarValue::Array(decimal_places) => {
+                let options = CastOptions {
+                    safe: false,
+                    ..Default::default()
+                };
+                let decimal_places = cast_with_options(&decimal_places, &Int32, &options)
+                    .map_err(|e| {
+                        exec_datafusion_err!("Invalid values for decimal places: {e}")
+                    })?;
+
+                let values = args[0].as_primitive::<Decimal256Type>();
+                let decimal_places = decimal_places.as_primitive::<Int32Type>();
+                let result = arrow::compute::binary::<_, _, _, Decimal256Type>(
+                    values,
+                    decimal_places,
+                    |value, decimal_places| {
+                        round_decimal256(value, *scale, decimal_places)
+                    },
+                )?;
+
+                Ok(Arc::new(result.with_precision_and_scale(*precision, *scale)?) as _)
+            }
+            _ => {
+                exec_err!("round function requires a scalar or array for decimal_places")
+            }
+        },
+
         other => exec_err!("Unsupported data type {other:?} for function round"),
+    }
+}
+
+#[inline]
+fn round_decimal128(value: i128, current_scale: i8, decimal_places: i32) -> i128 {
+    let scale_adjustment = current_scale as i32 - decimal_places;
+
+    if scale_adjustment > 0 {
+        let remove_factor = 10_i128.pow(scale_adjustment as u32);
+        let half = remove_factor / 2;
+
+        if value >= 0 {
+            ((value + half) / remove_factor) * remove_factor
+        } else {
+            ((value - half) / remove_factor) * remove_factor
+        }
+    } else {
+        value
+    }
+}
+
+#[inline]
+fn round_decimal256(value: i256, current_scale: i8, decimal_places: i32) -> i256 {
+    let scale_adjustment = current_scale as i32 - decimal_places;
+
+    if scale_adjustment > 0 {
+        let remove_factor = i256::from_i128(10_i128.pow(scale_adjustment as u32));
+        let half = remove_factor / i256::from_i128(2);
+
+        if value >= i256::from_i128(0) {
+            ((value + half) / remove_factor) * remove_factor
+        } else {
+            ((value - half) / remove_factor) * remove_factor
+        }
+    } else {
+        value
     }
 }
 
@@ -225,7 +372,11 @@ mod test {
 
     use crate::math::round::round;
 
-    use arrow::array::{ArrayRef, Float32Array, Float64Array, Int64Array};
+    use arrow::array::{
+        ArrayRef, Decimal128Array, Decimal256Array, Float32Array, Float64Array,
+        Int64Array,
+    };
+    use arrow_buffer::i256;
     use datafusion_common::cast::{as_float32_array, as_float64_array};
     use datafusion_common::DataFusionError;
 
@@ -306,5 +457,116 @@ mod test {
 
         assert!(result.is_err());
         assert!(matches!(result, Err(DataFusionError::Execution { .. })));
+    }
+
+    #[test]
+    fn test_round_decimal128() {
+        let args: Vec<ArrayRef> = vec![
+            Arc::new(
+                Decimal128Array::from(vec![1252345_i128; 10])
+                    .with_precision_and_scale(10, 4)
+                    .unwrap(),
+            ),
+            Arc::new(Int64Array::from(vec![0, 1, 2, 3, 4, 5, -1, -2, -3, -4])),
+        ];
+
+        let result = round(&args).expect("failed to initialize function round");
+        let decimals = result.as_any().downcast_ref::<Decimal128Array>().unwrap();
+
+        let expected = Decimal128Array::from(vec![
+            1250000_i128,
+            1252000_i128,
+            1252300_i128,
+            1252350_i128,
+            1252345_i128,
+            1252345_i128,
+            1300000_i128,
+            1000000_i128,
+            0_i128,
+            0_i128,
+        ])
+        .with_precision_and_scale(10, 4)
+        .unwrap();
+
+        assert_eq!(decimals, &expected);
+    }
+
+    #[test]
+    fn test_round_decimal128_one_input() {
+        let args: Vec<ArrayRef> = vec![Arc::new(
+            Decimal128Array::from(vec![1252345_i128, 123450_i128, 12340_i128, 1234_i128])
+                .with_precision_and_scale(10, 4)
+                .unwrap(),
+        )];
+
+        let result = round(&args).expect("failed to initialize function round");
+        let decimals = result.as_any().downcast_ref::<Decimal128Array>().unwrap();
+
+        let expected =
+            Decimal128Array::from(vec![1250000_i128, 120000_i128, 10000_i128, 0_i128])
+                .with_precision_and_scale(10, 4)
+                .unwrap();
+
+        assert_eq!(decimals, &expected);
+    }
+
+    #[test]
+    fn test_round_decimal256() {
+        let args: Vec<ArrayRef> = vec![
+            Arc::new(
+                Decimal256Array::from(vec![i256::from_i128(1252345_i128); 10])
+                    .with_precision_and_scale(20, 4)
+                    .unwrap(),
+            ),
+            Arc::new(Int64Array::from(vec![0, 1, 2, 3, 4, 5, -1, -2, -3, -4])),
+        ];
+
+        let result = round(&args).expect("failed to initialize function round");
+        let decimals = result.as_any().downcast_ref::<Decimal256Array>().unwrap();
+
+        let expected = Decimal256Array::from(vec![
+            i256::from_i128(1250000_i128),
+            i256::from_i128(1252000_i128),
+            i256::from_i128(1252300_i128),
+            i256::from_i128(1252350_i128),
+            i256::from_i128(1252345_i128),
+            i256::from_i128(1252345_i128),
+            i256::from_i128(1300000_i128),
+            i256::from_i128(1000000_i128),
+            i256::from_i128(0_i128),
+            i256::from_i128(0_i128),
+        ])
+        .with_precision_and_scale(20, 4)
+        .unwrap();
+
+        assert_eq!(decimals, &expected);
+    }
+
+    #[test]
+    fn test_round_decimal256_one_input() {
+        let args: Vec<ArrayRef> = vec![Arc::new(
+            Decimal256Array::from(vec![
+                i256::from_i128(1252345_i128),
+                i256::from_i128(123450_i128),
+                i256::from_i128(12340_i128),
+                i256::from_i128(1234_i128),
+            ])
+            .with_precision_and_scale(20, 4)
+            .unwrap(),
+        )];
+
+        let result = round(&args).expect("failed to initialize function round");
+        let decimals = result.as_any().downcast_ref::<Decimal256Array>().unwrap();
+
+        let expected = Decimal256Array::from(vec![
+            i256::from_i128(1250000_i128),
+            i256::from_i128(120000_i128),
+            i256::from_i128(10000_i128),
+            i256::from_i128(0_i128),
+        ])
+        .with_precision_and_scale(20, 4)
+        .unwrap();
+
+        assert_eq!(decimals, &expected);
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #17054 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Added Decimal as an Input type in Datafusion round 
- Created rounddecimal functions
- Added respective units tests

## Are these changes tested?
yes , respective unit tests added
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
