### PR TITLE
feat: Add optional extended metrics to sort_batch function

### DIFF
--- a/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregation_fuzzer/data_generator.rs
@@ -152,7 +152,7 @@ impl DatasetGenerator {
                 .map(|key| col(key, schema).map(PhysicalSortExpr::new_default))
                 .collect::<Result<Vec<_>>>()?;
             let batch = if let Some(ordering) = LexOrdering::new(sort_exprs) {
-                sort_batch(&base_batch, &ordering, None)?
+                sort_batch(&base_batch, &ordering, None, None)?
             } else {
                 base_batch.clone()
             };


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Addresses #17146 , but more PRs can follow.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It makes accurate benchmarking much easier.
I just added a new metrics struct for the lex sort done on the sort columns, which contains the column evaluation, sort time on the indices, and how long the `take` kernel itself took.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

the sort_batch itself function now takes another parameter, which is an Option, so yes any user using that function will have to either provide the metrics struct or just specify None, actual calls to this function within the crates are internal iiuc
