### PR TITLE
Simplify `GetFieldFunc`'s `display_name`, `schema_name`

### DIFF
--- a/datafusion/functions/src/core/getfield.rs
+++ b/datafusion/functions/src/core/getfield.rs
@@ -108,8 +108,8 @@ impl ScalarUDFImpl for GetFieldFunc {
         let [base, field_name] = take_function_args(self.name(), args)?;
 
         let name = match field_name {
-            Expr::Literal(name, _) => name,
-            other => &ScalarValue::Utf8(Some(other.schema_name().to_string())),
+            Expr::Literal(name, _) => name.to_string(),
+            other => other.schema_name().to_string(),
         };
 
         Ok(format!("{base}[{name}]"))
@@ -118,8 +118,8 @@ impl ScalarUDFImpl for GetFieldFunc {
     fn schema_name(&self, args: &[Expr]) -> Result<String> {
         let [base, field_name] = take_function_args(self.name(), args)?;
         let name = match field_name {
-            Expr::Literal(name, _) => name,
-            other => &ScalarValue::Utf8(Some(other.schema_name().to_string())),
+            Expr::Literal(name, _) => name.to_string(),
+            other => other.schema_name().to_string(),
         };
 
         Ok(format!("{}[{}]", base.schema_name(), name))


### PR DESCRIPTION
There is no need to create intermediate `ScalarValue::Utf8` if all we want is the inner value.
