### PR TITLE
[branch-49] Update version to 49.0.1 and add changelog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-benchmarks"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "datafusion",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-cli"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "assert_cmd",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "ahash 0.8.12",
  "apache-avro",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "futures",
  "log",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-avro"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2166,11 +2166,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "49.0.0"
+version = "49.0.1"
 
 [[package]]
 name = "datafusion-examples"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2201,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ffi"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "abi_stable",
  "arrow",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto-common"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-spark"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "criterion",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sqllogictest"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-substrait"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-wasmtest"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ repository = "https://github.com/apache/datafusion"
 # Define Minimum Supported Rust Version (MSRV)
 rust-version = "1.85.1"
 # Define DataFusion version
-version = "49.0.0"
+version = "49.0.1"
 
 [workspace.dependencies]
 # We turn off default-features for some dependencies here so the workspaces which inherit them can

--- a/dev/changelog/49.0.1.md
+++ b/dev/changelog/49.0.1.md
@@ -1,0 +1,46 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Apache DataFusion 49.0.1 Changelog
+
+This release consists of 5 commits from 5 contributors. See credits at the end of this changelog for more information.
+
+See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgrading.html) for information on how to upgrade from previous versions.
+
+**Other:**
+
+- [branch-49] Final Changelog Tweaks [#16852](https://github.com/apache/datafusion/pull/16852) (alamb)
+- [branch-49] remove warning from every file open [#17059](https://github.com/apache/datafusion/pull/17059) (mbutrovich)
+- [branch-49] Backport PR #16995 to branch-49 [#17068](https://github.com/apache/datafusion/pull/17068) (pepijnve)
+- [branch-49] Backport "Add ExecutionPlan::reset_state (apache#17028)" to v49 [#17096](https://github.com/apache/datafusion/pull/17096) (adriangb)
+- [branch-49] Backport #17129 to branch 49 [#17143](https://github.com/apache/datafusion/pull/17143) (AdamGS)
+
+## Credits
+
+Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
+
+```
+     1	Adam Gutglick
+     1	Adrian Garcia Badaracco
+     1	Andrew Lamb
+     1	Matt Butrovich
+     1	Pepijn Van Eeckhoudt
+```
+
+Thank you also to everyone who contributed in other ways such as filing issues, reviewing PRs, and providing feedback on this release.


### PR DESCRIPTION
Note this targets `branch-49`, not main

I plan to regenerate the changelog one more time once the final PRs have been merged

## Which issue does this PR close?

- part of https://github.com/apache/datafusion/issues/17036

## Rationale for this change

Prepare for the release

## What changes are included in this PR?

1. Update version to `49.0.1`
2. Generate changelog. See rendered version

I generated the changelog like this

```shell
./dev/release/generate-changelog.py 49.0.0 branch-49 49.0.1 > dev/changelog/49.0.1.md
npx prettier -w dev/changelog/49.0.1.md
```


## Are these changes tested?
By CI

## Are there any user-facing changes?
New version/changelog


Note once this PR merges I will forward port it to main