### PR TITLE
Fix: Show backtrace for ArrowError

### DIFF
--- a/datafusion-cli/tests/cli_integration.rs
+++ b/datafusion-cli/tests/cli_integration.rs
@@ -332,3 +332,31 @@ SELECT COUNT(*) FROM hits;
         .env_remove("AWS_ENDPOINT")
         .pass_stdin(input));
 }
+
+/// Ensure backtrace will be printed, if executing `datafusion-cli` with a query
+/// that triggers error.
+/// Example:
+///     RUST_BACKTRACE=1 cargo run --features backtrace -- -c 'select pow(1,'foo');'
+#[rstest]
+#[case("SELECT pow(1,'foo')")]
+#[case("SELECT CAST('not_a_number' AS INTEGER);")]
+fn test_backtrace_output(#[case] query: &str) {
+    let mut cmd = cli();
+    // Use a command that will cause an error and trigger backtrace
+    cmd.args(["--command", query, "-q"])
+        .env("RUST_BACKTRACE", "1"); // Enable backtrace
+
+    let output = cmd.output().expect("Failed to execute command");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined_output = format!("{}{}", stdout, stderr);
+
+    // Assert that the output includes literal 'backtrace'
+    // Note: The user mentioned backtrace isn't working yet, but we test for the literal string
+    assert!(
+        combined_output.to_lowercase().contains("backtrace"),
+        "Expected output to contain 'backtrace', but got stdout: '{}' stderr: '{}'",
+        stdout,
+        stderr
+    );
+}

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -276,7 +276,7 @@ impl From<io::Error> for DataFusionError {
 
 impl From<ArrowError> for DataFusionError {
     fn from(e: ArrowError) -> Self {
-        DataFusionError::ArrowError(Box::new(e), None)
+        DataFusionError::ArrowError(Box::new(e), Some(DataFusionError::get_back_trace()))
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
When an error is encountered inside DataFusion, the `backtrace` feature can be enabled to print the stack trace for the error, for easier debugging.
When I was working on a bug fix: I found the backtrace for `ArrowError` might not be able to display, while most other errors backtrace display is working.

See reproducer in `datafusion-cli`:

Backtrace is displayed for `SchemaError`
```sh
yongting@Yongtings-MacBook-Pro-2 ~/C/d/datafusion-cli (main=)> RUST_BACKTRACE=1 cargo run --features backtrace --profile release-nonlto -- -c 'select pow(1,'foo');'
    Finished `release-nonlto` profile [optimized] target(s) in 0.15s
     Running `/Users/yongting/Code/datafusion/target/release-nonlto/datafusion-cli -c 'select pow(1,foo);'`
DataFusion CLI v49.0.0
Error: Schema error: No field named foo.

backtrace:    0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2: std::backtrace::Backtrace::create
             at /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/std/src/backtrace.rs:331:13
   3: datafusion_common::error::field_not_found
```

Backtrace is not displayed for `ArrowError`
```sh
yongting@Yongtings-MacBook-Pro-2 ~/C/d/datafusion-cli (main=) [1]> RUST_BACKTRACE=1 cargo run --features backtrace --profile release-nonlto -- -c 'SELECT CAST(\'not_a_number\' AS INTEGER);'
    Finished `release-nonlto` profile [optimized] target(s) in 0.14s
     Running `/Users/yongting/Code/datafusion/target/release-nonlto/datafusion-cli -c 'SELECT CAST('\''not_a_number'\'' AS INTEGER);'`
DataFusion CLI v49.0.0
Error: Arrow error: Cast error: Cannot cast string 'not_a_number' to value of Int32 type
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Show backtrace for `ArrowError`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Added integration test in datafusion-cli

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
