### PR TITLE
Minor: Fix compiler warning when compiling `datafusion-cli`

### DIFF
--- a/datafusion/datasource-parquet/src/reader.rs
+++ b/datafusion/datasource-parquet/src/reader.rs
@@ -244,7 +244,7 @@ impl AsyncFileReader for CachedParquetFileReader {
 
     fn get_metadata<'a>(
         &'a mut self,
-        options: Option<&'a ArrowReaderOptions>,
+        _options: Option<&'a ArrowReaderOptions>,
     ) -> BoxFuture<'a, parquet::errors::Result<Arc<ParquetMetaData>>> {
         let file_meta = self.file_meta.clone();
         let metadata_cache = Arc::clone(&self.metadata_cache);
@@ -252,7 +252,7 @@ impl AsyncFileReader for CachedParquetFileReader {
         async move {
             #[cfg(feature = "parquet_encryption")]
             let file_decryption_properties =
-                options.and_then(|o| o.file_decryption_properties());
+                _options.and_then(|o| o.file_decryption_properties());
 
             #[cfg(not(feature = "parquet_encryption"))]
             let file_decryption_properties = None;

--- a/datafusion/datasource-parquet/src/reader.rs
+++ b/datafusion/datasource-parquet/src/reader.rs
@@ -244,7 +244,7 @@ impl AsyncFileReader for CachedParquetFileReader {
 
     fn get_metadata<'a>(
         &'a mut self,
-        _options: Option<&'a ArrowReaderOptions>,
+        #[allow(unused_variables)] options: Option<&'a ArrowReaderOptions>,
     ) -> BoxFuture<'a, parquet::errors::Result<Arc<ParquetMetaData>>> {
         let file_meta = self.file_meta.clone();
         let metadata_cache = Arc::clone(&self.metadata_cache);
@@ -252,7 +252,7 @@ impl AsyncFileReader for CachedParquetFileReader {
         async move {
             #[cfg(feature = "parquet_encryption")]
             let file_decryption_properties =
-                _options.and_then(|o| o.file_decryption_properties());
+                options.and_then(|o| o.file_decryption_properties());
 
             #[cfg(not(feature = "parquet_encryption"))]
             let file_decryption_properties = None;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
When compiling `datafusion-cli` with `cargo run`, there is a compiler warning:
```sh
warning: unused variable: `options`
   --> datafusion/datasource-parquet/src/reader.rs:247:9
    |
247 |         options: Option<&'a ArrowReaderOptions>,
    |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_options`
    |
    = note: `#[warn(unused_variables)]` on by default
```
This PR uses `#[allow(unused_variables)]` to suppress the warning.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
