### PR TITLE
fix(ci): update `datafusion-physical-expr-adapter` version to 49.0.1in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "49.0.0"
+version = "49.0.1"
 dependencies = [
  "arrow",
  "datafusion-common",


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #17208.

## Rationale for this change
https://github.com/apache/datafusion/blob/0a024a2f0e64194042c2965804dce20669047113/Cargo.lock#L1816-L1818
https://github.com/apache/datafusion/blob/0a024a2f0e64194042c2965804dce20669047113/Cargo.lock#L2466-L2468
 the version of `datafusion-physical-expr-adapter` does not match with `datafusion` in Cargo.lock
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
update `datafusion-physical-expr-adapter` version to 49.0.1 in `Cargo.lock`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
ci test
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
