### PR TITLE
Bump MSRV to 1.86.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/datafusion"
 # Define Minimum Supported Rust Version (MSRV)
-rust-version = "1.86.1"
+rust-version = "1.86.0"
 # Define DataFusion version
 version = "49.0.1"
 


### PR DESCRIPTION
According to our MSRV policy we are able to do this because the last 4 minor versions are 1.86, 1.87, 1.88 and 1.89. 1.85 was released > 4 months ago. So it is fair game to do this bump. I would like to do the bump for https://github.com/apache/datafusion/pull/17201/

Prior art: https://github.com/apache/datafusion/pull/16728