### PR TITLE
Configure cli test that requires backtrace to be optional

### DIFF
--- a/datafusion-cli/tests/cli_integration.rs
+++ b/datafusion-cli/tests/cli_integration.rs
@@ -340,7 +340,7 @@ SELECT COUNT(*) FROM hits;
 #[rstest]
 #[case("SELECT pow(1,'foo')")]
 #[case("SELECT CAST('not_a_number' AS INTEGER);")]
-#[cfg(backtrace)]
+#[cfg(feature = "backtrace")]
 fn test_backtrace_output(#[case] query: &str) {
     let mut cmd = cli();
     // Use a command that will cause an error and trigger backtrace


### PR DESCRIPTION
Running pure `cargo test` off main (no env vars or features set) results in error in test suite:

```
test test_backtrace_output::case_1 ... FAILED
test test_backtrace_output::case_2 ... FAILED

failures:

---- test_backtrace_output::case_1 stdout ----

thread 'test_backtrace_output::case_1' panicked at datafusion-cli/tests/cli_integration.rs:355:5:
Expected output to contain 'backtrace', but got stdout: 'Error: Error during planning: Failed to coerce arguments to satisfy a call to 'power' function: coercion from [Int64, Utf8] to the signature OneOf([Exact([Int64, Int64]), Exact([Float64, Float64])]) failed No function matches the given name and argument types 'power(Int64, Utf8)'. You might need to add explicit type casts.
        Candidate functions:
        power(Int64, Int64)
        power(Float64, Float64)
' stderr: ''
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- test_backtrace_output::case_2 stdout ----

thread 'test_backtrace_output::case_2' panicked at datafusion-cli/tests/cli_integration.rs:355:5:
Expected output to contain 'backtrace', but got stdout: 'Error: Arrow error: Cast error: Cannot cast string 'not_a_number' to value of Int32 type
' stderr: ''


failures:
    test_backtrace_output::case_1
    test_backtrace_output::case_2

test result: FAILED. 20 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.55s

error: test failed, to rerun pass `-p datafusion-cli --test cli_integration`
```

Looks to be due to test introduced by #17204 which requires the backtrace feature. Place a `cfg` directive on that test so it won't run unless backtrace feature is enabled, so `cargo test` can succeed again.