### PR TITLE
fix: sort should always output batches with `batch_size` rows

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -2139,7 +2139,7 @@ mod tests {
         // Not evenly divisible by batch size
         test_sort_output_batch_size(10, batch_size + 7, create_task_ctx).await?;
 
-        // Evenly divisible by batch size and is larger than 2 batches
+        // Evenly divisible by batch size and is larger than 2 output batches
         test_sort_output_batch_size(10, batch_size * 3, create_task_ctx).await?;
 
         Ok(())
@@ -2154,7 +2154,7 @@ mod tests {
             TaskContext::default().with_session_config(
                 SessionConfig::new()
                     .with_batch_size(batch_size)
-                    .with_sort_in_place_threshold_bytes(usize::MAX),
+                    .with_sort_in_place_threshold_bytes(usize::MAX - 1),
             )
         };
 
@@ -2182,7 +2182,7 @@ mod tests {
             );
         }
 
-        // Evenly divisible by batch size and is larger than 2 batches
+        // Evenly divisible by batch size and is larger than 2 output batches
         {
             let metrics =
                 test_sort_output_batch_size(10, batch_size * 3, create_task_ctx).await?;
@@ -2241,7 +2241,7 @@ mod tests {
             );
         }
 
-        // Evenly divisible by batch size and is larger than 2 batches
+        // Evenly divisible by batch size and is larger than 2 output batches
         {
             let metrics = test_sort_output_batch_size(
                 // Single batch


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

In `ExternalSorter` there are cases where the `batch_size` config is not respected

## What changes are included in this PR?

Wrap the stream with `BatchSplitStream` when we only have a single batch to sort and when we can sort in place (the paths that did not respect the batch size)

## Are these changes tested?

Yes

## Are there any user-facing changes?

Not an API change