### PR TITLE
TESTING: Only update dynamic topk filters when value changes, without ArcSwap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,7 @@ name = "datafusion-physical-expr"
 version = "49.0.1"
 dependencies = [
  "ahash 0.8.12",
+ "arc-swap",
  "arrow",
  "criterion",
  "datafusion-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,7 +2449,6 @@ name = "datafusion-physical-expr"
 version = "49.0.1"
 dependencies = [
  "ahash 0.8.12",
- "arc-swap",
  "arrow",
  "criterion",
  "datafusion-common",
@@ -2464,6 +2463,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "log",
+ "parking_lot",
  "paste",
  "petgraph 0.8.2",
  "rand 0.9.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,6 +2522,7 @@ name = "datafusion-physical-plan"
 version = "49.0.1"
 dependencies = [
  "ahash 0.8.12",
+ "arc-swap",
  "arrow",
  "arrow-ord",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ ahash = { version = "0.8", default-features = false, features = [
     "runtime-rng",
 ] }
 apache-avro = { version = "0.17", default-features = false }
+arc-swap = "1.7.1"
 arrow = { version = "56.0.0", features = [
     "prettyprint",
     "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ ahash = { version = "0.8", default-features = false, features = [
     "runtime-rng",
 ] }
 apache-avro = { version = "0.17", default-features = false }
-arc-swap = "1.7.1"
 arrow = { version = "56.0.0", features = [
     "prettyprint",
     "chrono-tz",

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -409,12 +409,39 @@ impl FileOpener for ParquetOpener {
                 .with_row_groups(row_group_indexes)
                 .build()?;
 
-            let adapted = stream
-                .map_err(|e| ArrowError::ExternalError(Box::new(e)))
-                .map(move |maybe_batch| {
-                    maybe_batch
-                        .and_then(|b| schema_mapping.map_batch(b).map_err(Into::into))
-                });
+            // Create a stateful stream that can check pruning after each batch
+            let adapted = {
+                use futures::stream;
+                let schema_mapping = Some(schema_mapping);
+                let file_pruner = file_pruner;
+                let stream = stream.map_err(|e| ArrowError::ExternalError(Box::new(e)));
+                let files_ranges_pruned_statistics = file_metrics.files_ranges_pruned_statistics.clone();
+
+                stream::try_unfold(
+                    (stream, schema_mapping, file_pruner, files_ranges_pruned_statistics),
+                    move |(mut stream, schema_mapping_opt, mut file_pruner, files_ranges_pruned_statistics)| async move {
+                        match stream.try_next().await? {
+                            Some(batch) => {
+                                let schema_mapping = schema_mapping_opt.as_ref().unwrap();
+                                let mapped_batch = schema_mapping.map_batch(batch)?;
+
+                                // Check if we can prune the file now
+                                if let Some(ref mut pruner) = file_pruner {
+                                    if pruner.should_prune()? {
+                                        // File can now be pruned based on updated dynamic filters
+                                        files_ranges_pruned_statistics.add(1);
+                                        // Terminate the stream early
+                                        return Ok(None);
+                                    }
+                                }
+
+                                Ok(Some((mapped_batch, (stream, schema_mapping_opt, file_pruner, files_ranges_pruned_statistics))))
+                            }
+                            None => Ok(None),
+                        }
+                    }
+                )
+            };
 
             Ok(adapted.boxed())
         }))

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -415,11 +415,22 @@ impl FileOpener for ParquetOpener {
                 let schema_mapping = Some(schema_mapping);
                 let file_pruner = file_pruner;
                 let stream = stream.map_err(|e| ArrowError::ExternalError(Box::new(e)));
-                let files_ranges_pruned_statistics = file_metrics.files_ranges_pruned_statistics.clone();
+                let files_ranges_pruned_statistics =
+                    file_metrics.files_ranges_pruned_statistics.clone();
 
                 stream::try_unfold(
-                    (stream, schema_mapping, file_pruner, files_ranges_pruned_statistics),
-                    move |(mut stream, schema_mapping_opt, mut file_pruner, files_ranges_pruned_statistics)| async move {
+                    (
+                        stream,
+                        schema_mapping,
+                        file_pruner,
+                        files_ranges_pruned_statistics,
+                    ),
+                    move |(
+                        mut stream,
+                        schema_mapping_opt,
+                        mut file_pruner,
+                        files_ranges_pruned_statistics,
+                    )| async move {
                         match stream.try_next().await? {
                             Some(batch) => {
                                 let schema_mapping = schema_mapping_opt.as_ref().unwrap();
@@ -435,11 +446,19 @@ impl FileOpener for ParquetOpener {
                                     }
                                 }
 
-                                Ok(Some((mapped_batch, (stream, schema_mapping_opt, file_pruner, files_ranges_pruned_statistics))))
+                                Ok(Some((
+                                    mapped_batch,
+                                    (
+                                        stream,
+                                        schema_mapping_opt,
+                                        file_pruner,
+                                        files_ranges_pruned_statistics,
+                                    ),
+                                )))
                             }
                             None => Ok(None),
                         }
-                    }
+                    },
                 )
             };
 

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -39,7 +39,6 @@ name = "datafusion_physical_expr"
 
 [dependencies]
 ahash = { workspace = true }
-arc-swap = { workspace = true }
 arrow = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
@@ -50,6 +49,7 @@ half = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true, features = ["use_std"] }
+parking_lot = { workspace = true }
 log = { workspace = true }
 paste = "^1.0"
 petgraph = "0.8.2"

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -39,6 +39,7 @@ name = "datafusion_physical_expr"
 
 [dependencies]
 ahash = { workspace = true }
+arc-swap = { workspace = true }
 arrow = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -66,6 +66,7 @@ log = { workspace = true }
 parking_lot = { workspace = true }
 pin-project-lite = "^0.2.7"
 tokio = { workspace = true }
+arc-swap = "1.7.1"
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_futures"] }

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -44,6 +44,7 @@ name = "datafusion_physical_plan"
 
 [dependencies]
 ahash = { workspace = true }
+arc-swap = "1.7.1"
 arrow = { workspace = true }
 arrow-ord = { workspace = true }
 arrow-schema = { workspace = true }
@@ -66,7 +67,6 @@ log = { workspace = true }
 parking_lot = { workspace = true }
 pin-project-lite = "^0.2.7"
 tokio = { workspace = true }
-arc-swap = "1.7.1"
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_futures"] }

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -914,7 +914,10 @@ impl SortExec {
             .iter()
             .map(|sort_expr| Arc::clone(&sort_expr.expr))
             .collect::<Vec<_>>();
-        TopKDynamicFilters::new(Arc::new(DynamicFilterPhysicalExpr::new(children, lit(true))))
+        TopKDynamicFilters::new(Arc::new(DynamicFilterPhysicalExpr::new(
+            children,
+            lit(true),
+        )))
     }
 
     fn cloned(&self) -> Self {

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -51,7 +51,10 @@ use arrow::array::{Array, RecordBatch, RecordBatchOptions, StringViewArray};
 use arrow::compute::{concat_batches, lexsort_to_indices, take_arrays};
 use arrow::datatypes::SchemaRef;
 use datafusion_common::config::SpillCompression;
-use datafusion_common::{internal_datafusion_err, internal_err, DataFusionError, Result};
+use datafusion_common::{
+    internal_datafusion_err, internal_err, unwrap_or_internal_err, DataFusionError,
+    Result,
+};
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion_execution::runtime_env::RuntimeEnv;
 use datafusion_execution::TaskContext;
@@ -1192,6 +1195,7 @@ impl ExecutionPlan for SortExec {
             ))),
             (true, None) => Ok(input),
             (false, Some(fetch)) => {
+                let filter = self.filter.clone();
                 let mut topk = TopK::try_new(
                     partition,
                     input.schema(),
@@ -1201,10 +1205,7 @@ impl ExecutionPlan for SortExec {
                     context.session_config().batch_size(),
                     context.runtime_env(),
                     &self.metrics_set,
-                    self.filter
-                        .as_ref()
-                        .expect("Filter should be set when fetch is Some")
-                        .clone(),
+                    unwrap_or_internal_err!(filter),
                 )?;
                 Ok(Box::pin(RecordBatchStreamAdapter::new(
                     self.schema(),


### PR DESCRIPTION
This is built on @adriangb 's PR that 
- https://github.com/apache/datafusion/pull/16433/files?w=1

But it has a commit to avoid the use of a new arcswap dependency

I intend to use this to run some benchmarks to see if the new dependency is needed for the relevant performance