### PR TITLE
fix: align `array_has` null buffer for scalar

### DIFF
--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -8072,6 +8072,18 @@ select [named_struct('a', 1, 'b', null)][-2];
 ----
 NULL
 
+statement ok
+COPY (select [[true, false], [false, true]] a, [false, true] b union select [[null, null]], null) to 'test_files/scratch/array/array_has/single_file.parquet' stored as parquet;
+
+statement ok
+CREATE EXTERNAL TABLE array_has STORED AS PARQUET location 'test_files/scratch/array/array_has/single_file.parquet';
+
+query B
+select array_contains(a, b) from array_has;
+----
+true
+NULL
+
 ### Delete tables
 
 statement ok
@@ -8250,3 +8262,6 @@ drop table values_all_empty;
 
 statement ok
 drop table fixed_size_col_table;
+
+statement ok
+drop table array_has;

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -8079,7 +8079,7 @@ statement ok
 CREATE EXTERNAL TABLE array_has STORED AS PARQUET location 'test_files/scratch/array/array_has/single_file.parquet';
 
 query B
-select array_contains(a, b) from array_has;
+select array_contains(a, b) from array_has order by 1 nulls last;
 ----
 true
 NULL


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #17263 .

## Rationale for this change

- Error occurred in BooleanArray::new() when comparing nested arrays (arrays of arrays)
- Root cause: Null buffer length mismatch in scalar-to-array comparisons

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Fixed Length Mismatch: Null buffers now correctly match result array length
- Proper Null Propagation: Null scalars correctly propagate to entire result
- Combined Cases: (false, false) | (true, true) use same logic
- Clear Intent: filter(|nulls| !nulls.is_valid(0)) clearly shows null scalar check

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
