### PR TITLE
Make dynamic filter creation in HashJoinExec deterministic against partition evaluation order

### DIFF
--- a/datafusion/core/tests/physical_optimizer/filter_pushdown/mod.rs
+++ b/datafusion/core/tests/physical_optimizer/filter_pushdown/mod.rs
@@ -950,7 +950,7 @@ async fn test_hashjoin_dynamic_filter_pushdown_partitioned() {
     use datafusion_common::JoinType;
     use datafusion_physical_plan::joins::{HashJoinExec, PartitionMode};
 
-    // Rouugh plan we're trying to recreate:
+    // Rough sketch of the MRE we're trying to recreate:
     // COPY (select i as k from generate_series(1, 10000000) as t(i))
     // TO 'test_files/scratch/push_down_filter/t1.parquet'
     // STORED AS PARQUET;


### PR DESCRIPTION
Fixes https://github.com/apache/datafusion/actions/runs/17135806873/job/48611550480#step:6:1257