### PR TITLE
Support from-first SQL syntax

### DIFF
--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -664,6 +664,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
     ) -> Result<Vec<SelectExpr>> {
         let mut prepared_select_exprs = vec![];
         let mut error_builder = DataFusionErrorBuilder::new();
+
+        // Handle the case where no projection is specified but we have a valid FROM clause
+        // In this case, implicitly add a wildcard projection (SELECT *)
+        let projection = if projection.is_empty() && !empty_from {
+            vec![SelectItem::Wildcard(WildcardAdditionalOptions::default())]
+        } else {
+            projection
+        };
+
         for expr in projection {
             match self.sql_select_to_rex(expr, plan, empty_from, planner_context) {
                 Ok(expr) => prepared_select_exprs.push(expr),

--- a/datafusion/sqllogictest/test_files/from-first.slt
+++ b/datafusion/sqllogictest/test_files/from-first.slt
@@ -39,3 +39,17 @@ FROM (FROM range(2))
 ----
 0
 1
+
+query I
+FROM range(2)
+SELECT 1
+----
+1
+1
+
+query I
+FROM range(2) as r
+SELECT r.value
+----
+0
+1

--- a/datafusion/sqllogictest/test_files/from-first.slt
+++ b/datafusion/sqllogictest/test_files/from-first.slt
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+query I
+FROM range(2)
+----
+0
+1
+
+query I
+FROM range(2)
+SELECT *
+----
+0
+1
+
+query I
+FROM (SELECT * FROM range(2))
+----
+0
+1
+
+query I
+FROM (FROM range(2))
+----
+0
+1

--- a/docs/source/user-guide/sql/select.md
+++ b/docs/source/user-guide/sql/select.md
@@ -75,6 +75,20 @@ Example:
 SELECT t.a FROM table AS t
 ```
 
+The `FROM` clause can also come before the `SELECT` clause.
+Example:
+
+```sql
+FROM table AS t
+SELECT t.a
+```
+
+If the `SELECT` clause is omitted, the `FROM` clause will return all columns from the table.
+
+```sql
+FROM table
+```
+
 ## WHERE clause
 
 Example:


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I noticed in https://github.com/apache/datafusion/pull/17278 that `from` without an explicit projection did not work.
This should fix it.

The from-first syntax is also available in duckdb. See https://duckdb.org/docs/stable/sql/query_syntax/from.html#examples

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, added SLT test

## Are there any user-facing changes?

FROM-first syntax without projection is now supported.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
