### PR TITLE
chore: add memory catalog test to handle table removal before schema deregistration

### DIFF
--- a/datafusion/core/tests/catalog/memory.rs
+++ b/datafusion/core/tests/catalog/memory.rs
@@ -48,6 +48,20 @@ fn memory_catalog_dereg_nonempty_schema() {
 }
 
 #[test]
+fn memory_catalog_dereg_nonempty_schema_with_table_removal() {
+    let cat = Arc::new(MemoryCatalogProvider::new()) as Arc<dyn CatalogProvider>;
+
+    let schema = Arc::new(MemorySchemaProvider::new()) as Arc<dyn SchemaProvider>;
+    let test_table =
+        Arc::new(EmptyTable::new(Arc::new(Schema::empty()))) as Arc<dyn TableProvider>;
+    schema.register_table("t".into(), test_table).unwrap();
+
+    cat.register_schema("foo", schema.clone()).unwrap();
+    schema.deregister_table("t").unwrap();
+    assert!(cat.deregister_schema("foo", false).unwrap().is_some());
+}
+
+#[test]
 fn memory_catalog_dereg_empty_schema() {
     let cat = Arc::new(MemoryCatalogProvider::new()) as Arc<dyn CatalogProvider>;
 


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Contrast with the memory_catalog_dereg_nonempty_schema test

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
