### PR TITLE
fix: lazy case else evaluation

### DIFF
--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -323,12 +323,14 @@ impl CaseExpr {
         }
 
         if let Some(e) = self.else_expr() {
-            // keep `else_expr`'s data type and return type consistent
-            let expr = try_cast(Arc::clone(e), &batch.schema(), return_type.clone())?;
-            let else_ = expr
-                .evaluate_selection(batch, &remainder)?
-                .into_array(batch.num_rows())?;
-            current_value = zip(&remainder, &else_, &current_value)?;
+            if remainder.true_count() > 0 {
+                // keep `else_expr`'s data type and return type consistent
+                let expr = try_cast(Arc::clone(e), &batch.schema(), return_type.clone())?;
+                let else_ = expr
+                    .evaluate_selection(batch, &remainder)?
+                    .into_array(batch.num_rows())?;
+                current_value = zip(&remainder, &else_, &current_value)?;
+            }
         }
 
         Ok(ColumnarValue::Array(current_value))

--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -482,3 +482,13 @@ SELECT v, CASE WHEN v < 0 THEN 10/0 ELSE 1 END FROM (VALUES (1), (2)) t(v)
 
 statement ok
 drop table t
+
+query I
+SELECT case when true then 1 / 1 else 1 / 0 end;
+----
+1
+
+query I
+SELECT case when false then 1 / 0 else 1 / 1 end;
+----
+1


### PR DESCRIPTION
## Which issue does this PR close?

https://github.com/apache/datafusion/pull/16946#discussion_r2296299288

- Closes #.

## Rationale for this change

for sql 
```sql
case 
when cond1 then val1
else val2
end
```

for when then expression, 

there's a short circuit. 
```rust
if when_value.true_count() == 0 {
    continue;
}
```

but there's no such short circuit for else expression.

## What changes are included in this PR?

add short-circuit for else expression

## Are these changes tested?

UT

## Are there any user-facing changes?

No