### PR TITLE
fix: Support aggregate expressions in `QUALIFY`

### DIFF
--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -84,6 +84,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         // Handle named windows before processing the projection expression
         check_conflicting_windows(&select.named_window)?;
         self.match_window_definitions(&mut select.projection, &select.named_window)?;
+
         // Process the SELECT expressions
         let select_exprs = self.prepare_select_exprs(
             &base_plan,
@@ -146,39 +147,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             })
             .transpose()?;
 
-        // Optionally the QUALIFY expression.
-        let qualify_expr_opt = select
-            .qualify
-            .map::<Result<Expr>, _>(|qualify_expr| {
-                let qualify_expr = self.sql_expr_to_logical_expr(
-                    qualify_expr,
-                    &combined_schema,
-                    planner_context,
-                )?;
-                // This step "dereferences" any aliases in the QUALIFY clause.
-                //
-                // This is how we support queries with QUALIFY expressions that
-                // refer to aliased columns.
-                //
-                // For example:
-                //
-                //   select row_number() over (PARTITION BY id) as rk from users qualify rk > 1;
-                //
-                // are rewritten as, respectively:
-                //
-                //   select row_number() over (PARTITION BY id) as rk from users qualify row_number() over (PARTITION BY id) > 1;
-                //
-                let qualify_expr = resolve_aliases_to_exprs(qualify_expr, &alias_map)?;
-                normalize_col(qualify_expr, &projected_plan)
-            })
-            .transpose()?;
-
-        // The outer expressions we will search through for aggregates.
-        // Aggregates may be sourced from the SELECT list or from the HAVING expression.
-        let aggr_expr_haystack = select_exprs.iter().chain(having_expr_opt.iter());
-        // All of the aggregate expressions (deduplicated).
-        let aggr_exprs = find_aggregate_exprs(aggr_expr_haystack);
-
         // All of the group by expressions
         let group_by_exprs = if let GroupByExpr::Expressions(exprs, _) = select.group_by {
             exprs
@@ -223,22 +191,61 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 .collect()
         };
 
+        // Optionally the QUALIFY expression.
+        let qualify_expr_opt = select
+            .qualify
+            .map::<Result<Expr>, _>(|qualify_expr| {
+                let qualify_expr = self.sql_expr_to_logical_expr(
+                    qualify_expr,
+                    &combined_schema,
+                    planner_context,
+                )?;
+                // This step "dereferences" any aliases in the QUALIFY clause.
+                //
+                // This is how we support queries with QUALIFY expressions that
+                // refer to aliased columns.
+                //
+                // For example:
+                //
+                //   select row_number() over (PARTITION BY id) as rk from users qualify rk > 1;
+                //
+                // are rewritten as, respectively:
+                //
+                //   select row_number() over (PARTITION BY id) as rk from users qualify row_number() over (PARTITION BY id) > 1;
+                //
+                let qualify_expr = resolve_aliases_to_exprs(qualify_expr, &alias_map)?;
+                normalize_col(qualify_expr, &projected_plan)
+            })
+            .transpose()?;
+
+        // The outer expressions we will search through for aggregates.
+        // Aggregates may be sourced from the SELECT list or from the HAVING expression.
+        let aggr_expr_haystack = select_exprs
+            .iter()
+            .chain(having_expr_opt.iter())
+            .chain(qualify_expr_opt.iter());
+        // All of the aggregate expressions (deduplicated).
+        let aggr_exprs = find_aggregate_exprs(aggr_expr_haystack);
+
         // Process group by, aggregation or having
-        let (plan, mut select_exprs_post_aggr, having_expr_post_aggr) = if !group_by_exprs
-            .is_empty()
-            || !aggr_exprs.is_empty()
-        {
+        let (
+            plan,
+            mut select_exprs_post_aggr,
+            having_expr_post_aggr,
+            qualify_expr_post_aggr,
+        ) = if !group_by_exprs.is_empty() || !aggr_exprs.is_empty() {
             self.aggregate(
                 &base_plan,
                 &select_exprs,
                 having_expr_opt.as_ref(),
+                qualify_expr_opt.as_ref(),
                 &group_by_exprs,
                 &aggr_exprs,
             )?
         } else {
             match having_expr_opt {
                 Some(having_expr) => return plan_err!("HAVING clause references: {having_expr} must appear in the GROUP BY clause or be used in an aggregate function"),
-                None => (base_plan.clone(), select_exprs.clone(), having_expr_opt)
+                None => (base_plan.clone(), select_exprs.clone(), having_expr_opt, qualify_expr_opt)
             }
         };
 
@@ -252,11 +259,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
 
         // The outer expressions we will search through for window functions.
         // Window functions may be sourced from the SELECT list or from the QUALIFY expression.
-        let windows_expr_haystack =
-            select_exprs_post_aggr.iter().chain(qualify_expr_opt.iter());
-        // All of the window expressions (deduplicated).
+        let windows_expr_haystack = select_exprs_post_aggr
+            .iter()
+            .chain(qualify_expr_post_aggr.iter());
+        // All of the window expressions (deduplicated and rewritten to reference aggregates as
+        // columns from input).
         let window_func_exprs = find_window_exprs(windows_expr_haystack);
 
+        // Process window functions after aggregation as they can reference
+        // aggregate functions in their body
         let plan = if window_func_exprs.is_empty() {
             plan
         } else {
@@ -273,7 +284,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
 
         // Process QUALIFY clause after window functions
         // QUALIFY filters the results of window functions, similar to how HAVING filters aggregates
-        let plan = if let Some(qualify_expr) = qualify_expr_opt {
+        let plan = if let Some(qualify_expr) = qualify_expr_post_aggr {
             // Validate that QUALIFY is used with window functions
             if window_func_exprs.is_empty() {
                 return plan_err!(
@@ -848,6 +859,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
     ///   "having" expressions must all be resolvable from this plan.
     /// * `select_exprs`    - The projection expressions from the SELECT clause.
     /// * `having_expr_opt` - Optional HAVING clause.
+    /// * `qualify_expr_opt` - Optional QUALIFY clause.
     /// * `group_by_exprs`  - Grouping expressions from the GROUP BY clause. These can be column
     ///   references or more complex expressions.
     /// * `aggr_exprs`      - Aggregate expressions, such as `SUM(a)` or `COUNT(1)`.
@@ -861,14 +873,17 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
     ///   the aggregate
     /// * `having_expr_post_aggr`  - The "having" expression rewritten to reference a column from
     ///   the aggregate
+    /// * `qualify_expr_post_aggr`  - The "qualify" expression rewritten to reference a column from
+    ///   the aggregate
     fn aggregate(
         &self,
         input: &LogicalPlan,
         select_exprs: &[Expr],
         having_expr_opt: Option<&Expr>,
+        qualify_expr_opt: Option<&Expr>,
         group_by_exprs: &[Expr],
         aggr_exprs: &[Expr],
-    ) -> Result<(LogicalPlan, Vec<Expr>, Option<Expr>)> {
+    ) -> Result<(LogicalPlan, Vec<Expr>, Option<Expr>, Option<Expr>)> {
         // create the aggregate plan
         let options =
             LogicalPlanBuilderOptions::new().with_add_implicit_group_by_exprs(true);
@@ -952,7 +967,29 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             None
         };
 
-        Ok((plan, select_exprs_post_aggr, having_expr_post_aggr))
+        // Rewrite the QUALIFY expression to use the columns produced by the
+        // aggregation.
+        let qualify_expr_post_aggr = if let Some(qualify_expr) = qualify_expr_opt {
+            let qualify_expr_post_aggr =
+                rebase_expr(qualify_expr, &aggr_projection_exprs, input)?;
+
+            check_columns_satisfy_exprs(
+                &column_exprs_post_aggr,
+                std::slice::from_ref(&qualify_expr_post_aggr),
+                CheckColumnsSatisfyExprsPurpose::QualifyMustReferenceAggregate,
+            )?;
+
+            Some(qualify_expr_post_aggr)
+        } else {
+            None
+        };
+
+        Ok((
+            plan,
+            select_exprs_post_aggr,
+            having_expr_post_aggr,
+            qualify_expr_post_aggr,
+        ))
     }
 
     // If the projection is done over a named window, that window

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -96,6 +96,7 @@ pub(crate) fn rebase_expr(
 pub(crate) enum CheckColumnsSatisfyExprsPurpose {
     ProjectionMustReferenceAggregate,
     HavingMustReferenceAggregate,
+    QualifyMustReferenceAggregate,
 }
 
 impl CheckColumnsSatisfyExprsPurpose {
@@ -106,6 +107,9 @@ impl CheckColumnsSatisfyExprsPurpose {
             }
             CheckColumnsSatisfyExprsPurpose::HavingMustReferenceAggregate => {
                 "Column in HAVING must be in GROUP BY or an aggregate function"
+            }
+            CheckColumnsSatisfyExprsPurpose::QualifyMustReferenceAggregate => {
+                "Column in QUALIFY must be in GROUP BY or an aggregate function"
             }
         }
     }

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -4203,6 +4203,67 @@ Projection: person.id, row_number() PARTITION BY [person.age] ORDER BY [person.i
 }
 
 #[test]
+fn test_select_qualify_aggregate_reference() {
+    let sql = "
+        SELECT
+            person.id,
+            ROW_NUMBER() OVER (PARTITION BY person.id ORDER BY person.id) as rn
+        FROM person
+        GROUP BY
+            person.id
+        QUALIFY rn = 1 AND SUM(person.age) > 0";
+    let plan = logical_plan(sql).unwrap();
+    assert_snapshot!(
+        plan,
+        @r"
+    Projection: person.id, row_number() PARTITION BY [person.id] ORDER BY [person.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW AS rn
+      Filter: row_number() PARTITION BY [person.id] ORDER BY [person.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW = Int64(1) AND sum(person.age) > Int64(0)
+        WindowAggr: windowExpr=[[row_number() PARTITION BY [person.id] ORDER BY [person.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
+          Aggregate: groupBy=[[person.id]], aggr=[[sum(person.age)]]
+            TableScan: person
+    "
+    );
+}
+
+#[test]
+fn test_select_qualify_aggregate_reference_within_window_function() {
+    let sql = "
+        SELECT
+            person.id
+        FROM person
+        GROUP BY
+            person.id
+        QUALIFY ROW_NUMBER() OVER (PARTITION BY person.id ORDER BY SUM(person.age) DESC) = 1";
+    let plan = logical_plan(sql).unwrap();
+    assert_snapshot!(
+        plan,
+        @r"
+    Projection: person.id
+      Filter: row_number() PARTITION BY [person.id] ORDER BY [sum(person.age) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW = Int64(1)
+        WindowAggr: windowExpr=[[row_number() PARTITION BY [person.id] ORDER BY [sum(person.age) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
+          Aggregate: groupBy=[[person.id]], aggr=[[sum(person.age)]]
+            TableScan: person
+    "
+    );
+}
+
+#[test]
+fn test_select_qualify_aggregate_invalid_column_reference() {
+    let sql = "
+        SELECT
+            person.id
+        FROM person
+        GROUP BY
+            person.id
+        QUALIFY ROW_NUMBER() OVER (PARTITION BY person.id ORDER BY person.age DESC) = 1";
+    let err = logical_plan(sql).unwrap_err();
+    assert_snapshot!(
+        err.strip_backtrace(),
+        @r#"Error during planning: Column in QUALIFY must be in GROUP BY or an aggregate function: While expanding wildcard, column "person.age" must appear in the GROUP BY clause or must be part of an aggregate function, currently only "person.id" appears in the SELECT clause satisfies this requirement"#
+    );
+}
+
+#[test]
 fn test_select_qualify_without_window_function() {
     let sql = "SELECT person.id FROM person QUALIFY person.id > 1";
     let err = logical_plan(sql).unwrap_err();

--- a/datafusion/sqllogictest/test_files/qualify.slt
+++ b/datafusion/sqllogictest/test_files/qualify.slt
@@ -204,6 +204,46 @@ Marketing 70000
 Marketing 70000
 Marketing 70000
 
+# QUALIFY with aggregate function reference from projection
+query TR
+SELECT dept, SUM(salary) AS s
+FROM users
+GROUP BY dept
+QUALIFY RANK() OVER (ORDER BY dept DESC) = 1 AND s > 1000
+ORDER BY dept;
+----
+Marketing 210000
+
+# QUALIFY with aggregate function
+query T
+SELECT dept
+FROM users
+GROUP BY dept
+QUALIFY RANK() OVER (ORDER BY dept DESC) = 1 AND SUM(salary) > 1000
+ORDER BY dept;
+----
+Marketing
+
+# QUALIFY with aggregate function within window function
+query TR
+SELECT dept, SUM(salary) AS s
+FROM users
+GROUP BY dept
+QUALIFY RANK() OVER (ORDER BY SUM(salary) DESC) = 1
+ORDER BY dept;
+----
+Engineering 279000
+
+# QUALIFY with aggregate function reference from projection within window function
+query TR
+SELECT dept, SUM(salary) AS s
+FROM users
+GROUP BY dept
+QUALIFY RANK() OVER (ORDER BY s DESC) = 1
+ORDER BY dept;
+----
+Engineering 279000
+
 # Error: QUALIFY without window functions
 query error
 SELECT id, name FROM users QUALIFY id > 1;
@@ -295,6 +335,38 @@ physical_plan
 16)------------------------------CoalesceBatchesExec: target_batch_size=8192
 17)--------------------------------FilterExec: salary@0 > Some(500000),10,2
 18)----------------------------------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# plan with aggregate function
+query TT
+EXPLAIN SELECT dept, SUM(salary) AS s
+FROM users
+GROUP BY dept
+QUALIFY RANK() OVER (ORDER BY s DESC) = 1
+ORDER BY dept;
+----
+logical_plan
+01)Sort: users.dept ASC NULLS LAST
+02)--Projection: users.dept, sum(users.salary) AS s
+03)----Filter: rank() ORDER BY [sum(users.salary) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW = UInt64(1)
+04)------WindowAggr: windowExpr=[[rank() ORDER BY [sum(users.salary) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
+05)--------Aggregate: groupBy=[[users.dept]], aggr=[[sum(users.salary)]]
+06)----------TableScan: users projection=[salary, dept]
+physical_plan
+01)SortPreservingMergeExec: [dept@0 ASC NULLS LAST]
+02)--SortExec: expr=[dept@0 ASC NULLS LAST], preserve_partitioning=[true]
+03)----ProjectionExec: expr=[dept@0 as dept, sum(users.salary)@1 as s]
+04)------CoalesceBatchesExec: target_batch_size=8192
+05)--------FilterExec: rank() ORDER BY [sum(users.salary) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@2 = 1, projection=[dept@0, sum(users.salary)@1]
+06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+07)------------BoundedWindowAggExec: wdw=[rank() ORDER BY [sum(users.salary) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { name: "rank() ORDER BY [sum(users.salary) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", data_type: UInt64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
+08)--------------SortPreservingMergeExec: [sum(users.salary)@1 DESC]
+09)----------------SortExec: expr=[sum(users.salary)@1 DESC], preserve_partitioning=[true]
+10)------------------AggregateExec: mode=FinalPartitioned, gby=[dept@0 as dept], aggr=[sum(users.salary)]
+11)--------------------CoalesceBatchesExec: target_batch_size=8192
+12)----------------------RepartitionExec: partitioning=Hash([dept@0], 4), input_partitions=4
+13)------------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+14)--------------------------AggregateExec: mode=Partial, gby=[dept@1 as dept], aggr=[sum(users.salary)]
+15)----------------------------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Clean up
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #17210.

## What changes are included in this PR?

- Updates select planning to search for aggregate references in `QUALIFY` and rewrites any aggregates in the `QUALIFY` clause to use column references (using the expression's schema name).
- Tests 

## Are these changes tested?

Yes

## Are there any user-facing changes?

No additional features, just fixes.
