### PR TITLE
feat: add configurable cache mode (local_cache) with LogicalPlan::Cache (#17297)

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -17,6 +17,7 @@
 
 //! Planner for [`LogicalPlan`] to [`ExecutionPlan`]
 
+use datafusion::physical_plan::memory::MemoryExec;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -944,6 +945,18 @@ impl DefaultPhysicalPlanner {
                     schema,
                     options.clone(),
                 ))
+            }
+
+            // Handle caching logical plan
+            LogicalPlan::Cache { id, lineage } => {
+                // Step 1: Plan the child logical plan first
+                let child_exec =
+                    self.create_physical_plan(lineage, session_state).await?;
+
+                // Step 2: Wrap in a caching execution plan if you want to actually cache in-memory
+                // For now, we just pass through the child plan
+                // TODO: later you can wrap this in a memory cache executor
+                child_exec
             }
 
             // 2 Children


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #17297

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, `DataFrame.cache()` always performs eager caching using an in-memory `MemTable`.  
This works fine in local mode but causes problems in distributed environments (e.g., Ballista),  
where caching should be deferred until distributed execution.  

This PR introduces a configuration flag (`local_cache`) to support both eager and lazy caching.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Added `LogicalPlan::Cache { id, lineage }` for lazy caching.  
- Updated `DataFrame.cache()`:
  - If `local_cache = true` → uses current eager caching with `MemTable`.  
  - If `local_cache = false` → returns a `LogicalPlan::Cache` node for lazy evaluation.  
- Extended physical planner to handle `LogicalPlan::Cache`.  

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

- Builds on existing logical/physical plan tests.  
- No new dedicated distributed caching tests are included in this PR.  

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

- Yes, a new configuration option:  
  - `datafusion.execution.local_cache = true` (default) → eager caching.  
  - `datafusion.execution.local_cache = false` → lazy caching with `LogicalPlan::Cache`.  

This is a **non-breaking change** because the default behavior remains unchanged.  
