### PR TITLE
add id and update callbacks to dynamic filters

### DIFF
--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -53,6 +53,7 @@ log = { workspace = true }
 parking_lot = { workspace = true }
 paste = "^1.0"
 petgraph = "0.8.2"
+rand = { workspace = true }
 
 [dev-dependencies]
 arrow = { workspace = true, features = ["test_utils"] }

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -837,7 +837,10 @@ impl ExecutionPlan for HashJoinExec {
             )?,
             // Keep the dynamic filter, bounds accumulator will be reset
             dynamic_filter: self.dynamic_filter.clone(),
-            bounds_accumulator: None,
+            bounds_accumulator: match self.bounds_accumulator {
+                Some(_) => Some(OnceLock::new()),
+                None => None,
+            },
         }))
     }
 


### PR DESCRIPTION
The idea is that this might help in distributed systems where we want to send dynamic filter updates across the wire