### PR TITLE
minor: make dict_from_values public

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -890,7 +890,7 @@ fn dict_from_scalar<K: ArrowDictionaryKeyType>(
 /// ["alice", "bob", "alice", null, "carol"]
 ///
 /// # Output
-/// DictionaryArray<Int32>
+/// `DictionaryArray<Int32>`
 /// {
 ///   keys:   [0, 1, 2, 3, 4],
 ///   values: ["alice", "bob", "alice", null, "carol"]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/17366.

## Rationale for this change

reduce code duplication in Datafusion Comet.

## What changes are included in this PR?

Makes the method public 

## Are these changes tested?

Existing tests

## Are there any user-facing changes?

No
