### PR TITLE
fix: Remove duplicate filter from `CrossJoin` unparsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,6 +2654,7 @@ dependencies = [
  "arrow",
  "bigdecimal",
  "ctor",
+ "datafusion",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions",
@@ -2669,6 +2670,7 @@ dependencies = [
  "regex",
  "rstest",
  "sqlparser",
+ "tokio",
 ]
 
 [[package]]

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -61,6 +61,7 @@ sqlparser = { workspace = true }
 [dev-dependencies]
 ctor = { workspace = true }
 # please do not move these dependencies to the main dependencies section
+datafusion = { workspace = true }
 datafusion-functions = { workspace = true, default-features = true }
 datafusion-functions-aggregate = { workspace = true }
 datafusion-functions-nested = { workspace = true }
@@ -69,3 +70,4 @@ env_logger = { workspace = true }
 insta = { workspace = true }
 paste = "^1.0"
 rstest = { workspace = true }
+tokio = { workspace = true }

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -696,13 +696,6 @@ impl Unparser<'_> {
                     join_filters.as_ref(),
                 )?;
 
-                self.select_to_sql_recursively(
-                    right_plan.as_ref(),
-                    query,
-                    select,
-                    &mut right_relation,
-                )?;
-
                 let right_projection: Option<Vec<ast::SelectItem>> = if !already_projected
                 {
                     Some(select.pop_projections())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #17359.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Removes the second recursive traversal inside `LogicalPlan::Join`, it was causing duplicate filters to pop up when gathering filters. Not sure what the reasoning for this second right side traversal was in the first place.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
