### PR TITLE
Re-export apache-avro when avro feature flag is set

### DIFF
--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -751,6 +751,9 @@ pub use object_store;
 #[cfg(feature = "parquet")]
 pub use parquet;
 
+#[cfg(feature = "avro")]
+pub use datafusion_datasource_avro::apache_avro;
+
 // re-export DataFusion sub-crates at the top level. Use `pub use *`
 // so that the contents of the subcrates appears in rustdocs
 // for details, see https://github.com/apache/datafusion/issues/6648

--- a/datafusion/datasource-avro/src/mod.rs
+++ b/datafusion/datasource-avro/src/mod.rs
@@ -30,4 +30,5 @@ pub mod avro_to_arrow;
 pub mod file_format;
 pub mod source;
 
+pub use apache_avro;
 pub use file_format::*;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/17389

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When the avro feature flag is set, it would be useful for us to be able to import apache_avro from datafusion so that the versions are always aligned, similarly to how parquet currently works.

## What changes are included in this PR?

- Exporting apache_avro from datasource_avro
- Exporting datafusion_datasource_avro::apache_avro from lib.rs

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

This change only adds an export when a feature flag is set, I don't know if there's a good way to test this, and it's a very small change that's unlikely to cause any regressions.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
