### PR TITLE
Fix syntax error in DDL documentation example

### DIFF
--- a/docs/source/user-guide/sql/ddl.md
+++ b/docs/source/user-guide/sql/ddl.md
@@ -207,7 +207,7 @@ CREATE EXTERNAL TABLE test (
     c13 VARCHAR NOT NULL
 )
 STORED AS CSV
-WITH ORDER (c2 ASC, c5 + c8 DESC NULL FIRST)
+WITH ORDER (c2 ASC, c5 + c8 DESC NULLS FIRST)
 LOCATION '/path/to/aggregate_test_100.csv'
 OPTIONS ('has_header' 'true');
 ```


### PR DESCRIPTION
## Which issue does this PR close?

None since this is just a small documentation fix

## Rationale for this change

SQL syntax is incorrect

## What changes are included in this PR?

Adds a single `S`

## Are these changes tested?

Manually tested the fixed query

## Are there any user-facing changes?

No