### PR TITLE
Test grouping by FixedSizeList

### DIFF
--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -8062,7 +8062,19 @@ select arrow_typeof(a) from fixed_size_col_table;
 FixedSizeList(Field { name: "item", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, 3)
 FixedSizeList(Field { name: "item", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, 3)
 
-statement error
+query ? rowsort
+SELECT DISTINCT a FROM fixed_size_col_table
+----
+[1, 2, 3]
+[4, 5, 6]
+
+query ?I rowsort
+SELECT a, count(*) FROM fixed_size_col_table GROUP BY a
+----
+[1, 2, 3] 1
+[4, 5, 6] 1
+
+statement error Cast error: Cannot cast to FixedSizeList\(3\): value at index 0 has length 2
 create table varying_fixed_size_col_table (a int[3]) as values ([1,2,3]), ([4,5]);
 
 # https://github.com/apache/datafusion/issues/16187


### PR DESCRIPTION
Support for grouping by FixedSizeList values was added in Arrow. This adds a regression test in DataFusion for the SQL-level feature this unlocked.

- closes https://github.com/apache/datafusion/issues/16442