### PR TITLE
docs: Render `--` properly in profiling docs

### DIFF
--- a/docs/source/library-user-guide/profiling.md
+++ b/docs/source/library-user-guide/profiling.md
@@ -48,7 +48,7 @@ Ensure that you're in the directory containing the necessary data files for your
 
 ### Step 3: Running the Flamegraph Tool
 
-To generate a flamegraph, you'll need to use the -- separator to pass arguments to the binary you're profiling. For datafusion-cli, you need to make sure to run the command with sudo permissions (especially on macOS, where DTrace requires elevated privileges).
+To generate a flamegraph, you'll need to use the `--` separator to pass arguments to the binary you're profiling. For datafusion-cli, you need to make sure to run the command with sudo permissions (especially on macOS, where DTrace requires elevated privileges).
 
 Here is a general example:
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
- Closes #.
-->


## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I noticed in the profiling docs the `--` renders as a larger dash in the text (top of the pic). I figured, I'd submit a quick fix since the "Edit this page" button is so conveniently there :).
<img width="562" height="173" alt="image" src="https://github.com/user-attachments/assets/1cd2a5f6-8fd8-4cfa-90f2-5268c06f3c9a" />



## What changes are included in this PR?
Adds backticks to render it properly. It should now render it as two separate dash in orange similar to this text later in the page 
<img width="334" height="71" alt="image" src="https://github.com/user-attachments/assets/6ee6fa73-8df1-44df-80ac-e3527a493baa" />

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

<!--
## Are these changes tested?

We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

<!--
## Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
