### PR TITLE
feat: Support binary data types for `SortMergeJoin` `on` clause

### DIFF
--- a/datafusion/physical-plan/src/joins/sort_merge_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/stream.rs
@@ -1915,6 +1915,10 @@ fn compare_join_arrays(
             DataType::Utf8 => compare_value!(StringArray),
             DataType::Utf8View => compare_value!(StringViewArray),
             DataType::LargeUtf8 => compare_value!(LargeStringArray),
+            DataType::Binary => compare_value!(BinaryArray),
+            DataType::BinaryView => compare_value!(BinaryViewArray),
+            DataType::FixedSizeBinary(_) => compare_value!(FixedSizeBinaryArray),
+            DataType::LargeBinary => compare_value!(LargeBinaryArray),
             DataType::Decimal128(..) => compare_value!(Decimal128Array),
             DataType::Timestamp(time_unit, None) => match time_unit {
                 TimeUnit::Second => compare_value!(TimestampSecondArray),
@@ -1983,6 +1987,10 @@ fn is_join_arrays_equal(
             DataType::Utf8 => compare_value!(StringArray),
             DataType::Utf8View => compare_value!(StringViewArray),
             DataType::LargeUtf8 => compare_value!(LargeStringArray),
+            DataType::Binary => compare_value!(BinaryArray),
+            DataType::BinaryView => compare_value!(BinaryViewArray),
+            DataType::FixedSizeBinary(_) => compare_value!(FixedSizeBinaryArray),
+            DataType::LargeBinary => compare_value!(LargeBinaryArray),
             DataType::Decimal128(..) => compare_value!(Decimal128Array),
             DataType::Timestamp(time_unit, None) => match time_unit {
                 TimeUnit::Second => compare_value!(TimestampSecondArray),

--- a/datafusion/sqllogictest/test_files/sort_merge_join.slt
+++ b/datafusion/sqllogictest/test_files/sort_merge_join.slt
@@ -833,9 +833,61 @@ t2 as (
 11 14
 12 15
 
+statement ok
+set datafusion.execution.batch_size = 8192;
+
+
+######
+## Tests for Binary, LargeBinary, BinaryView, FixedSizeBinary join keys
+######
+statement ok
+create table t1(x varchar, id1 int) as values ('aa', 1), ('bb', 2), ('aa', 3), (null, 4), ('ee', 5);
+
+statement ok
+create table t2(y varchar, id2 int) as values ('ee', 10), ('bb', 20), ('cc', 30), ('cc', 40), (null, 50);
+
+# Binary join keys
+query ?I?I
+with t1 as (select arrow_cast(x, 'Binary') as x, id1 from t1),
+     t2 as (select arrow_cast(y, 'Binary') as y, id2 from t2)
+select * from t1 join t2 on t1.x = t2.y order by id1, id2
+----
+6262 2 6262 20
+6565 5 6565 10
+
+# LargeBinary join keys
+query ?I?I
+with t1 as (select arrow_cast(x, 'LargeBinary') as x, id1 from t1),
+     t2 as (select arrow_cast(y, 'LargeBinary') as y, id2 from t2)
+select * from t1 join t2 on t1.x = t2.y order by id1, id2
+----
+6262 2 6262 20
+6565 5 6565 10
+
+# BinaryView join keys
+query ?I?I
+with t1 as (select arrow_cast(x, 'BinaryView') as x, id1 from t1),
+     t2 as (select arrow_cast(y, 'BinaryView') as y, id2 from t2)
+select * from t1 join t2 on t1.x = t2.y order by id1, id2
+----
+6262 2 6262 20
+6565 5 6565 10
+
+# FixedSizeBinary join keys
+query ?I?I
+with t1 as (select arrow_cast(arrow_cast(x, 'Binary'), 'FixedSizeBinary(2)') as x, id1 from t1),
+     t2 as (select arrow_cast(arrow_cast(y, 'Binary'), 'FixedSizeBinary(2)') as y, id2 from t2)
+select * from t1 join t2 on t1.x = t2.y order by id1, id2
+----
+6262 2 6262 20
+6565 5 6565 10
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;
+
 # return sql params back to default values
 statement ok
 set datafusion.optimizer.prefer_hash_join = true;
-
-statement ok
-set datafusion.execution.batch_size = 8192;


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Adds the ability for the `SortMergeJoin` physical node to join on binary types:

- `Binary`,
- `FixedSizeBinary`
- `BinaryView`
- `LargeBinary`

## What changes are included in this PR?

- An update to the comparitor functions to support the listed binary types
- Tests to verify binary types are supported via the `ON` clause

## Are these changes tested?

✅ 

## Are there any user-facing changes?

The documentation does not list the subset of types supported by the `ON` clause of `SortMergeJoin`.
