### PR TITLE
fix: prevent UnionExec panic with empty inputs

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -1245,7 +1245,7 @@ impl DefaultPhysicalPlanner {
             }
 
             // N Children
-            LogicalPlan::Union(_) => Arc::new(UnionExec::new(children.vec())),
+            LogicalPlan::Union(_) => Arc::new(UnionExec::new(children.vec())?),
             LogicalPlan::Extension(Extension { node }) => {
                 let mut maybe_plan = None;
                 let children = children.vec();

--- a/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
@@ -1783,7 +1783,7 @@ fn union_to_interleave() -> Result<()> {
     );
 
     //  Union
-    let plan = Arc::new(UnionExec::new(vec![left, right]));
+    let plan = Arc::new(UnionExec::new(vec![left, right])?);
 
     // final agg
     let plan =
@@ -1827,7 +1827,7 @@ fn union_not_to_interleave() -> Result<()> {
     );
 
     //  Union
-    let plan = Arc::new(UnionExec::new(vec![left, right]));
+    let plan = Arc::new(UnionExec::new(vec![left, right])?);
 
     // final agg
     let plan =

--- a/datafusion/core/tests/physical_optimizer/partition_statistics.rs
+++ b/datafusion/core/tests/physical_optimizer/partition_statistics.rs
@@ -357,7 +357,7 @@ mod test {
     async fn test_statistic_by_partition_of_union() -> Result<()> {
         let scan = create_scan_exec_with_statistics(None, Some(2)).await;
         let union_exec: Arc<dyn ExecutionPlan> =
-            Arc::new(UnionExec::new(vec![scan.clone(), scan]));
+            Arc::new(UnionExec::new(vec![scan.clone(), scan])?);
         let statistics = (0..union_exec.output_partitioning().partition_count())
             .map(|idx| union_exec.partition_statistics(Some(idx)))
             .collect::<Result<Vec<_>>>()?;

--- a/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
@@ -1535,7 +1535,7 @@ fn test_sort_preserving_after_projection() -> Result<()> {
 #[test]
 fn test_union_after_projection() -> Result<()> {
     let csv = create_simple_csv_exec();
-    let union = Arc::new(UnionExec::new(vec![csv.clone(), csv.clone(), csv]));
+    let union = Arc::new(UnionExec::new(vec![csv.clone(), csv.clone(), csv])?);
     let projection: Arc<dyn ExecutionPlan> = Arc::new(ProjectionExec::try_new(
         vec![
             ProjectionExpr::new(Arc::new(Column::new("c", 2)), "c".to_string()),

--- a/datafusion/core/tests/physical_optimizer/test_utils.rs
+++ b/datafusion/core/tests/physical_optimizer/test_utils.rs
@@ -304,7 +304,7 @@ pub fn sort_preserving_merge_exec_with_fetch(
 }
 
 pub fn union_exec(input: Vec<Arc<dyn ExecutionPlan>>) -> Arc<dyn ExecutionPlan> {
-    Arc::new(UnionExec::new(input))
+    Arc::new(UnionExec::new(input).expect("Failed to create UnionExec"))
 }
 
 pub fn local_limit_exec(

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -1783,7 +1783,7 @@ mod test {
         let source1 = sorted_memory_exec(&schema, sort_exprs.clone());
         let source2 = sorted_memory_exec(&schema, sort_exprs);
         // output has multiple partitions, and is sorted
-        let union = UnionExec::new(vec![source1, source2]);
+        let union = UnionExec::new(vec![source1, source2])?;
         let exec =
             RepartitionExec::try_new(Arc::new(union), Partitioning::RoundRobinBatch(10))
                 .unwrap()
@@ -1825,7 +1825,7 @@ mod test {
         let source1 = memory_exec(&schema);
         let source2 = memory_exec(&schema);
         // output has multiple partitions, but is not sorted
-        let union = UnionExec::new(vec![source1, source2]);
+        let union = UnionExec::new(vec![source1, source2])?;
         let exec =
             RepartitionExec::try_new(Arc::new(union), Partitioning::RoundRobinBatch(10))
                 .unwrap()


### PR DESCRIPTION
## Summary

This PR fixes a panic in `UnionExec` when constructed with empty inputs, replacing the crash with proper error handling and descriptive error messages.

**Fixes:** #17052

## Problem

When `UnionExec::new(vec![])` was called with an empty input vector, it would panic with:

```
thread '...' panicked at datafusion/physical-plan/src/union.rs:542:24:
index out of bounds: the len is 0 but the index is 0
```

This occurred because `union_schema()` directly accessed `inputs[0]` without checking if the array was empty.

## Solution

### Core Changes

1. **Made `UnionExec::new()` return `Result<Self>`**:
   - Added validation: returns error if `inputs.is_empty()`
   - Provides clear error message: `"UnionExec requires at least one input"`

2. **Made `union_schema()` return `Result<SchemaRef>`**:
   - Added empty input validation before accessing `inputs[0]`
   - Returns descriptive error: `"Cannot create union schema from empty inputs"`

3. **Updated all call sites** (7 files):
   - `physical_planner.rs` - Core DataFusion integration
   - `repartition/mod.rs` - Internal dependencies
   - 4 test files - Updated to handle `Result` return type

### Error Handling

- **Before**: Index out of bounds panic (unhelpful)
- **After**: Clear error messages that guide users

```rust
// Before: panic!
let union = UnionExec::new(vec![]); // PANIC!

// After: proper error handling
match UnionExec::new(vec![]) {
    Ok(_) => { /* use union */ }
    Err(e) => println!("Error: {}", e); // "UnionExec requires at least one input"
}
```

## Testing

Added 4 comprehensive tests:

1. **`test_union_empty_inputs()`** - Verifies empty input validation
2. **`test_union_schema_empty_inputs()`** - Tests schema creation with empty inputs  
3. **`test_union_single_input()`** - Ensures single input still works
4. **`test_union_multiple_inputs_still_works()`** - Verifies existing functionality unchanged

**Test Results:**
- ✅ All new tests pass
- ✅ All existing union tests pass (8/8)
- ✅ All physical planner integration tests pass

## Backward Compatibility

- **Existing functionality unchanged** for valid inputs (≥1 input)
- **Only adds error handling** for previously crashing invalid inputs
- **API change**: `UnionExec::new()` now returns `Result<Self>` instead of `Self`

This is a **breaking change** but justified because:
1. The previous behavior (panic) was incorrect 
2. Empty inputs are invalid by design (no logical meaning)
3. Consistent with logical `Union` which requires ≥2 inputs
4. Better error handling improves user experience

## Files Changed

- `datafusion/physical-plan/src/union.rs` - Core fix + tests (main changes)
- `datafusion/core/src/physical_planner.rs` - Handle `Result` return
- `datafusion/physical-plan/src/repartition/mod.rs` - Update internal calls
- 4 test files - Update test utilities and test cases

The fix provides robust error handling while maintaining all existing functionality for valid use cases.