### PR TITLE
feat(spark): implement Spark `map` function `map_from_arrays`

### DIFF
--- a/datafusion/spark/src/function/map/map_from_arrays.rs
+++ b/datafusion/spark/src/function/map/map_from_arrays.rs
@@ -178,8 +178,8 @@ fn map_deduplicate_keys(
     new_offsets.push(new_last_offset);
 
     let mut needed_rows_builder = BooleanBuilder::new();
-    for next_row_num in 1..offsets_len {
-        let num_entries = offsets[next_row_num] as usize - cur_offset;
+    for next_offset in offsets.iter().skip(1) {
+        let num_entries = *next_offset as usize - cur_offset;
         let mut seen_keys = HashSet::new();
         let mut needed_rows_one = [false].repeat(num_entries);
         for cur_entry_idx in (0..num_entries).rev() {

--- a/datafusion/spark/src/function/map/map_from_arrays.rs
+++ b/datafusion/spark/src/function/map/map_from_arrays.rs
@@ -1,0 +1,207 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::any::Any;
+use std::borrow::Cow;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, AsArray, BooleanBuilder, MapArray, StructArray};
+use arrow::buffer::OffsetBuffer;
+use arrow::compute::filter;
+use arrow::datatypes::{DataType, Field, Fields};
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{exec_err, internal_err, Result, ScalarValue};
+use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
+use datafusion_functions::utils::make_scalar_function;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct MapFromArrays {
+    signature: Signature,
+}
+
+impl Default for MapFromArrays {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MapFromArrays {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for MapFromArrays {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "map_from_arrays"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        let [key_type, value_type] = take_function_args("map_from_arrays", arg_types)?;
+        Ok(return_type_from_key_value_types(
+            get_element_type(key_type)?,
+            get_element_type(value_type)?,
+        ))
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: datafusion_expr::ScalarFunctionArgs,
+    ) -> Result<ColumnarValue> {
+        make_scalar_function(map_from_arrays_inner, vec![])(&args.args)
+    }
+}
+
+fn get_list_field(data_type: &DataType) -> Result<&Arc<Field>> {
+    match data_type {
+        DataType::List(element)
+        | DataType::LargeList(element)
+        | DataType::FixedSizeList(element, _) => Ok(element),
+        _ => exec_err!(
+            "map_from_arrays expects 2 listarrays for keys and values as arguments, got {data_type:?}"
+        ),
+    }
+}
+
+fn get_element_type(data_type: &DataType) -> Result<&DataType> {
+    get_list_field(data_type).map(|field| field.data_type())
+}
+
+pub fn return_type_from_key_value_types(
+    key_type: &DataType,
+    value_type: &DataType,
+) -> DataType {
+    DataType::Map(
+        Arc::new(Field::new(
+            "entries",
+            DataType::Struct(Fields::from(vec![
+                // the key must not be nullable
+                Field::new("key", key_type.clone(), false),
+                Field::new("value", value_type.clone(), true),
+            ])),
+            false, // the entry is not nullable
+        )),
+        false, // the keys are not sorted
+    )
+}
+
+fn get_list_values(array: &ArrayRef) -> Result<&ArrayRef> {
+    match array.data_type() {
+        DataType::List(_) => Ok(array.as_list::<i32>().values()),
+        DataType::LargeList(_) => Ok(array.as_list::<i64>().values()),
+        DataType::FixedSizeList(..) => Ok(array.as_fixed_size_list().values()),
+        wrong_type => internal_err!(
+            "get_list_values expects List/LargeList/FixedSizeList as argument, got {wrong_type:?}"
+        ),
+    }
+}
+
+fn map_from_arrays_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [keys, values] = take_function_args("map_from_arrays", args)?;
+
+    let flat_keys = get_list_values(keys)?;
+    let flat_values = get_list_values(values)?;
+
+    let offsets: Cow<[i32]> = match keys.data_type() {
+        DataType::List(_) => Ok(Cow::Borrowed(keys.as_list::<i32>().offsets().as_ref())),
+        DataType::LargeList(_) => Ok(Cow::Owned(
+            keys.as_list::<i64>()
+                .offsets()
+                .iter()
+                .map(|i| *i as i32)
+                .collect::<Vec<_>>(),
+        )),
+        DataType::FixedSizeList(_, size) => Ok(Cow::Owned(
+             (0..=keys.len() as i32).map(|i| size * i).collect()
+        )),
+        wrong_type => internal_err!(
+            "map_from_arrays expects List/LargeList/FixedSizeList as first argument, got {wrong_type:?}"
+        ),
+    }?;
+
+    map_from_keys_values_offsets(flat_keys, flat_values, &offsets)
+}
+
+pub fn map_from_keys_values_offsets(
+    keys: &ArrayRef,
+    values: &ArrayRef,
+    offsets: &[i32],
+) -> Result<ArrayRef> {
+    let (keys, values, offsets) = map_deduplicate_keys(keys, values, offsets)?;
+
+    let fields = Fields::from(vec![
+        Field::new("key", keys.data_type().clone(), false),
+        Field::new("value", values.data_type().clone(), true),
+    ]);
+    let entries = StructArray::try_new(fields.clone(), vec![keys, values], None)?;
+    let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
+    Ok(Arc::new(MapArray::try_new(
+        field, offsets, entries, None, false,
+    )?))
+}
+
+pub fn map_deduplicate_keys(
+    keys: &ArrayRef,
+    values: &ArrayRef,
+    offsets: &[i32],
+) -> Result<(ArrayRef, ArrayRef, OffsetBuffer<i32>)> {
+    let num_rows = offsets.len() - 1;
+    let mut new_offsets = Vec::with_capacity(num_rows + 1);
+    new_offsets.push(0);
+    let mut last_offset = 0;
+
+    let mut needed_rows_builder = BooleanBuilder::new();
+    for row_num in 0..num_rows {
+        let cur_offset = offsets[row_num] as usize;
+        let next_offset = offsets[row_num + 1] as usize;
+        let num_entries = next_offset - cur_offset;
+        let keys_slice = keys.slice(cur_offset, num_entries);
+        let mut seen_keys = HashSet::new();
+        let mut needed_rows_one = [false].repeat(num_entries);
+        for index in (0..num_entries).rev() {
+            let key = ScalarValue::try_from_array(&keys_slice, index)?.compacted();
+            if seen_keys.contains(&key) {
+                // TODO: implement configuration and logic for spark.sql.mapKeyDedupPolicy=EXCEPTION (this is default spark-config)
+                // exec_err!("invalid argument: duplicate keys in map")
+                // https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961
+            } else {
+                // This code implements deduplication logic for spark.sql.mapKeyDedupPolicy=LAST_WIN (this is NOT default spark-config)
+                needed_rows_one[index] = true;
+                seen_keys.insert(key);
+                last_offset += 1;
+            }
+        }
+        needed_rows_builder.append_array(&needed_rows_one.into());
+        new_offsets.push(last_offset);
+    }
+    let needed_rows = needed_rows_builder.finish();
+    let needed_keys = filter(&keys, &needed_rows)?;
+    let needed_values = filter(&values, &needed_rows)?;
+    let offsets = OffsetBuffer::new(new_offsets.into());
+    Ok((needed_keys, needed_values, offsets))
+}

--- a/datafusion/spark/src/function/map/map_from_arrays.rs
+++ b/datafusion/spark/src/function/map/map_from_arrays.rs
@@ -17,18 +17,20 @@
 
 use std::any::Any;
 use std::borrow::Cow;
-use std::collections::HashSet;
-use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, AsArray, BooleanBuilder, MapArray, StructArray};
-use arrow::buffer::OffsetBuffer;
-use arrow::compute::filter;
-use arrow::datatypes::{DataType, Field, Fields};
+use crate::function::map::utils::{
+    map_from_keys_values_offsets_nulls, map_type_from_key_value_types,
+};
+use arrow::array::{Array, ArrayRef, AsArray, NullArray};
+use arrow::compute::kernels::cast;
+use arrow::datatypes::DataType;
 use datafusion_common::utils::take_function_args;
-use datafusion_common::{exec_err, internal_err, Result, ScalarValue};
+use datafusion_common::{exec_err, internal_err, Result};
 use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use datafusion_functions::utils::make_scalar_function;
 
+/// Spark-compatible `map_from_arrays` expression
+/// <https://spark.apache.org/docs/latest/api/sql/index.html#map_from_arrays>
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct MapFromArrays {
     signature: Signature,
@@ -63,7 +65,7 @@ impl ScalarUDFImpl for MapFromArrays {
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         let [key_type, value_type] = take_function_args("map_from_arrays", arg_types)?;
-        Ok(return_type_from_key_value_types(
+        Ok(map_type_from_key_value_types(
             get_element_type(key_type)?,
             get_element_type(value_type)?,
         ))
@@ -77,41 +79,21 @@ impl ScalarUDFImpl for MapFromArrays {
     }
 }
 
-fn get_list_field(data_type: &DataType) -> Result<&Arc<Field>> {
+fn get_element_type(data_type: &DataType) -> Result<&DataType> {
     match data_type {
+        DataType::Null => Ok(data_type),
         DataType::List(element)
         | DataType::LargeList(element)
-        | DataType::FixedSizeList(element, _) => Ok(element),
+        | DataType::FixedSizeList(element, _) => Ok(element.data_type()),
         _ => exec_err!(
             "map_from_arrays expects 2 listarrays for keys and values as arguments, got {data_type:?}"
         ),
     }
 }
 
-fn get_element_type(data_type: &DataType) -> Result<&DataType> {
-    get_list_field(data_type).map(|field| field.data_type())
-}
-
-pub fn return_type_from_key_value_types(
-    key_type: &DataType,
-    value_type: &DataType,
-) -> DataType {
-    DataType::Map(
-        Arc::new(Field::new(
-            "entries",
-            DataType::Struct(Fields::from(vec![
-                // the key must not be nullable
-                Field::new("key", key_type.clone(), false),
-                Field::new("value", value_type.clone(), true),
-            ])),
-            false, // the entry is not nullable
-        )),
-        false, // the keys are not sorted
-    )
-}
-
 fn get_list_values(array: &ArrayRef) -> Result<&ArrayRef> {
     match array.data_type() {
+        DataType::Null => Ok(array),
         DataType::List(_) => Ok(array.as_list::<i32>().values()),
         DataType::LargeList(_) => Ok(array.as_list::<i64>().values()),
         DataType::FixedSizeList(..) => Ok(array.as_fixed_size_list().values()),
@@ -121,88 +103,46 @@ fn get_list_values(array: &ArrayRef) -> Result<&ArrayRef> {
     }
 }
 
-fn map_from_arrays_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
-    let [keys, values] = take_function_args("map_from_arrays", args)?;
-
-    let flat_keys = get_list_values(keys)?;
-    let flat_values = get_list_values(values)?;
-
-    let offsets: Cow<[i32]> = match keys.data_type() {
-        DataType::List(_) => Ok(Cow::Borrowed(keys.as_list::<i32>().offsets().as_ref())),
+fn get_list_offsets(array: &ArrayRef) -> Result<Cow<'_, [i32]>> {
+    match array.data_type() {
+        DataType::List(_) => Ok(Cow::Borrowed(array.as_list::<i32>().offsets().as_ref())),
         DataType::LargeList(_) => Ok(Cow::Owned(
-            keys.as_list::<i64>()
+            array.as_list::<i64>()
                 .offsets()
                 .iter()
                 .map(|i| *i as i32)
                 .collect::<Vec<_>>(),
         )),
         DataType::FixedSizeList(_, size) => Ok(Cow::Owned(
-             (0..=keys.len() as i32).map(|i| size * i).collect()
+             (0..=array.len() as i32).map(|i| size * i).collect()
         )),
         wrong_type => internal_err!(
             "map_from_arrays expects List/LargeList/FixedSizeList as first argument, got {wrong_type:?}"
         ),
-    }?;
-
-    map_from_keys_values_offsets(flat_keys, flat_values, &offsets)
-}
-
-pub fn map_from_keys_values_offsets(
-    keys: &ArrayRef,
-    values: &ArrayRef,
-    offsets: &[i32],
-) -> Result<ArrayRef> {
-    let (keys, values, offsets) = map_deduplicate_keys(keys, values, offsets)?;
-
-    let fields = Fields::from(vec![
-        Field::new("key", keys.data_type().clone(), false),
-        Field::new("value", values.data_type().clone(), true),
-    ]);
-    let entries = StructArray::try_new(fields.clone(), vec![keys, values], None)?;
-    let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
-    Ok(Arc::new(MapArray::try_new(
-        field, offsets, entries, None, false,
-    )?))
-}
-
-fn map_deduplicate_keys(
-    keys: &ArrayRef,
-    values: &ArrayRef,
-    offsets: &[i32],
-) -> Result<(ArrayRef, ArrayRef, OffsetBuffer<i32>)> {
-    let offsets_len = offsets.len();
-    let mut new_offsets = Vec::with_capacity(offsets_len);
-
-    let mut cur_offset = 0;
-    let mut new_last_offset = 0;
-    new_offsets.push(new_last_offset);
-
-    let mut needed_rows_builder = BooleanBuilder::new();
-    for next_offset in offsets.iter().skip(1) {
-        let num_entries = *next_offset as usize - cur_offset;
-        let mut seen_keys = HashSet::new();
-        let mut needed_rows_one = [false].repeat(num_entries);
-        for cur_entry_idx in (0..num_entries).rev() {
-            let key = ScalarValue::try_from_array(&keys, cur_offset + cur_entry_idx)?
-                .compacted();
-            if seen_keys.contains(&key) {
-                // TODO: implement configuration and logic for spark.sql.mapKeyDedupPolicy=EXCEPTION (this is default spark-config)
-                // exec_err!("invalid argument: duplicate keys in map")
-                // https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961
-            } else {
-                // This code implements deduplication logic for spark.sql.mapKeyDedupPolicy=LAST_WIN (this is NOT default spark-config)
-                needed_rows_one[cur_entry_idx] = true;
-                seen_keys.insert(key);
-                new_last_offset += 1;
-            }
-        }
-        needed_rows_builder.append_array(&needed_rows_one.into());
-        new_offsets.push(new_last_offset);
-        cur_offset += num_entries;
     }
-    let needed_rows = needed_rows_builder.finish();
-    let needed_keys = filter(&keys, &needed_rows)?;
-    let needed_values = filter(&values, &needed_rows)?;
-    let offsets = OffsetBuffer::new(new_offsets.into());
-    Ok((needed_keys, needed_values, offsets))
+}
+
+fn map_from_arrays_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [keys, values] = take_function_args("map_from_arrays", args)?;
+
+    if matches!(keys.data_type(), DataType::Null)
+        || matches!(values.data_type(), DataType::Null)
+    {
+        return Ok(cast(
+            &NullArray::new(keys.len()),
+            &map_type_from_key_value_types(
+                get_element_type(keys.data_type())?,
+                get_element_type(values.data_type())?,
+            ),
+        )?);
+    }
+
+    map_from_keys_values_offsets_nulls(
+        get_list_values(keys)?,
+        get_list_values(values)?,
+        &get_list_offsets(keys)?,
+        &get_list_offsets(values)?,
+        keys.nulls(),
+        values.nulls(),
+    )
 }

--- a/datafusion/spark/src/function/map/mod.rs
+++ b/datafusion/spark/src/function/map/mod.rs
@@ -15,11 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub mod map_from_arrays;
+
 use datafusion_expr::ScalarUDF;
+use datafusion_functions::make_udf_function;
 use std::sync::Arc;
 
-pub mod expr_fn {}
+make_udf_function!(map_from_arrays::MapFromArrays, map_from_arrays);
+
+pub mod expr_fn {
+    use datafusion_functions::export_functions;
+
+    export_functions!((
+        map_from_arrays,
+        "Creates a map from arrays of keys and values.",
+        keys values
+    ));
+}
 
 pub fn functions() -> Vec<Arc<ScalarUDF>> {
-    vec![]
+    vec![map_from_arrays()]
 }

--- a/datafusion/spark/src/function/map/mod.rs
+++ b/datafusion/spark/src/function/map/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 pub mod map_from_arrays;
+mod utils;
 
 use datafusion_expr::ScalarUDF;
 use datafusion_functions::make_udf_function;

--- a/datafusion/spark/src/function/map/utils.rs
+++ b/datafusion/spark/src/function/map/utils.rs
@@ -62,7 +62,7 @@ pub fn map_type_from_key_value_types(
 /// So more permissive `LAST_WIN` option is used in this implementation (instead of `EXCEPTION`)<br>
 /// `EXCEPTION` behaviour can still be achieved externally in cost of performance:<br>
 /// `when(array_length(array_distinct(keys)) == array_length(keys), constructed_map)`<br>
-/// `.otherwise(raise_error("duplicate keys occured during map construction"))`
+/// `.otherwise(raise_error("duplicate keys occurred during map construction"))`
 pub fn map_from_keys_values_offsets_nulls(
     flat_keys: &ArrayRef,
     flat_values: &ArrayRef,

--- a/datafusion/spark/src/function/map/utils.rs
+++ b/datafusion/spark/src/function/map/utils.rs
@@ -52,17 +52,16 @@ pub fn map_type_from_key_value_types(
 /// Logic is close to `datafusion_functions_nested::map::make_map_array_internal`<br>
 /// But there are some core differences:
 /// 1. Input arrays are not [`ListArrays`](arrow::array::ListArray) itself, but their flattened [`values`](arrow::array::ListArray::values)<br>
-/// So the inputs can be [`ListArray`](`arrow::array::ListArray`)/[`LargeListArray`](`arrow::array::LargeListArray`)/[`FixedSizeListArray`](`arrow::array::FixedSizeListArray`)<br>
-/// To preserve the row info, [`offsets`](arrow::array::ListArray::offsets) and [`nulls`](arrow::array::ListArray::nulls) need to be provided<br>
-/// The function will fail if key and value arrays have different offsets so one offset array is ok<br>
-/// [`FixedSizeListArray`](`arrow::array::FixedSizeListArray`) has no `offsets`, so they can be generated as a cumulative sum of it's `Size`
+///    So the inputs can be [`ListArray`](`arrow::array::ListArray`)/[`LargeListArray`](`arrow::array::LargeListArray`)/[`FixedSizeListArray`](`arrow::array::FixedSizeListArray`)<br>
+///    To preserve the row info, [`offsets`](arrow::array::ListArray::offsets) and [`nulls`](arrow::array::ListArray::nulls) for both keys and values need to be provided<br>
+///    [`FixedSizeListArray`](`arrow::array::FixedSizeListArray`) has no `offsets`, so they can be generated as a cumulative sum of it's `Size`
 /// 2. Spark provides [spark.sql.mapKeyDedupPolicy](https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961)
-/// to handle duplicate keys<br>
-/// For now, configurable functions are not supported by Datafusion<br>
-/// So more permissive `LAST_WIN` option is used in this implementation (instead of `EXCEPTION`)<br>
-/// `EXCEPTION` behaviour can still be achieved externally in cost of performance:<br>
-/// `when(array_length(array_distinct(keys)) == array_length(keys), constructed_map)`<br>
-/// `.otherwise(raise_error("duplicate keys occurred during map construction"))`
+///    to handle duplicate keys<br>
+///    For now, configurable functions are not supported by Datafusion<br>
+///    So more permissive `LAST_WIN` option is used in this implementation (instead of `EXCEPTION`)<br>
+///    `EXCEPTION` behaviour can still be achieved externally in cost of performance:<br>
+///    `when(array_length(array_distinct(keys)) == array_length(keys), constructed_map)`<br>
+///    `.otherwise(raise_error("duplicate keys occurred during map construction"))`
 pub fn map_from_keys_values_offsets_nulls(
     flat_keys: &ArrayRef,
     flat_values: &ArrayRef,

--- a/datafusion/spark/src/function/map/utils.rs
+++ b/datafusion/spark/src/function/map/utils.rs
@@ -28,7 +28,7 @@ use datafusion_common::{exec_err, Result, ScalarValue};
 /// Helper function to get element [`DataType`]
 /// from [`List`](DataType::List)/[`LargeList`](DataType::LargeList)/[`FixedSizeList`](DataType::FixedSizeList)<br>
 /// [`Null`](DataType::Null) can be coerced to `ListType`([`Null`](DataType::Null)), so [`Null`](DataType::Null) is returned<br>
-/// For all other types [`exec_err`](exec_err) is raised
+/// For all other types [`exec_err`] is raised
 pub fn get_element_type(data_type: &DataType) -> Result<&DataType> {
     match data_type {
         DataType::Null => Ok(data_type),
@@ -44,7 +44,7 @@ pub fn get_element_type(data_type: &DataType) -> Result<&DataType> {
 /// Helper function to get [`values`](arrow::array::ListArray::values)
 /// from [`ListArray`](arrow::array::ListArray)/[`LargeListArray`](arrow::array::LargeListArray)/[`FixedSizeListArray`](arrow::array::FixedSizeListArray)<br>
 /// [`NullArray`](arrow::array::NullArray) can be coerced to `ListType`([`Null`](DataType::Null)), so [`NullArray`](arrow::array::NullArray) is returned<br>
-/// For all other types [`exec_err`](exec_err) is raised
+/// For all other types [`exec_err`] is raised
 pub fn get_list_values(array: &ArrayRef) -> Result<&ArrayRef> {
     match array.data_type() {
         DataType::Null => Ok(array),
@@ -59,7 +59,7 @@ pub fn get_list_values(array: &ArrayRef) -> Result<&ArrayRef> {
 
 /// Helper function to get [`offsets`](arrow::array::ListArray::offsets)
 /// from [`ListArray`](arrow::array::ListArray)/[`LargeListArray`](arrow::array::LargeListArray)/[`FixedSizeListArray`](arrow::array::FixedSizeListArray)<br>
-/// For all other types [`exec_err`](exec_err) is raised
+/// For all other types [`exec_err`] is raised
 pub fn get_list_offsets(array: &ArrayRef) -> Result<Cow<'_, [i32]>> {
     match array.data_type() {
         DataType::List(_) => Ok(Cow::Borrowed(array.as_list::<i32>().offsets().as_ref())),

--- a/datafusion/spark/src/function/map/utils.rs
+++ b/datafusion/spark/src/function/map/utils.rs
@@ -176,29 +176,35 @@ fn map_deduplicate_keys(
         let mut keys_mask_one = [false].repeat(num_keys_entries);
         let mut values_mask_one = [false].repeat(num_values_entries);
 
-        if (num_values_entries != num_keys_entries)
-            && keys_nulls.is_none_or(|buf| buf.is_valid(row_idx))
-            && values_nulls.is_none_or(|buf| buf.is_valid(row_idx))
-        {
-            return exec_err!("map_deduplicate_keys: keys and values lists in the same row must have equal lengths");
-        }
+        if num_keys_entries != num_values_entries {
+            let key_is_valid = keys_nulls.is_none_or(|buf| buf.is_valid(row_idx));
+            let value_is_valid = values_nulls.is_none_or(|buf| buf.is_valid(row_idx));
+            if key_is_valid && value_is_valid {
+                return exec_err!("map_deduplicate_keys: keys and values lists in the same row must have equal lengths");
+            }
+            // else the result entry is NULL
+            // both current row offsets are skipped
+            // keys or values in the current row are marked false in the masks
+        } else if num_keys_entries != 0 {
+            let mut seen_keys = HashSet::new();
 
-        let mut seen_keys = HashSet::new();
-
-        for cur_entry_idx in (0..num_keys_entries).rev() {
-            let key =
-                ScalarValue::try_from_array(&flat_keys, cur_keys_offset + cur_entry_idx)?
-                    .compacted();
-            if seen_keys.contains(&key) {
-                // TODO: implement configuration and logic for spark.sql.mapKeyDedupPolicy=EXCEPTION (this is default spark-config)
-                // exec_err!("invalid argument: duplicate keys in map")
-                // https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961
-            } else {
-                // This code implements deduplication logic for spark.sql.mapKeyDedupPolicy=LAST_WIN (this is NOT default spark-config)
-                keys_mask_one[cur_entry_idx] = true;
-                values_mask_one[cur_entry_idx] = true;
-                seen_keys.insert(key);
-                new_last_offset += 1;
+            for cur_entry_idx in (0..num_keys_entries).rev() {
+                let key = ScalarValue::try_from_array(
+                    &flat_keys,
+                    cur_keys_offset + cur_entry_idx,
+                )?
+                .compacted();
+                if seen_keys.contains(&key) {
+                    // TODO: implement configuration and logic for spark.sql.mapKeyDedupPolicy=EXCEPTION (this is default spark-config)
+                    // exec_err!("invalid argument: duplicate keys in map")
+                    // https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961
+                } else {
+                    // This code implements deduplication logic for spark.sql.mapKeyDedupPolicy=LAST_WIN (this is NOT default spark-config)
+                    keys_mask_one[cur_entry_idx] = true;
+                    values_mask_one[cur_entry_idx] = true;
+                    seen_keys.insert(key);
+                    new_last_offset += 1;
+                }
             }
         }
         keys_mask_builder.append_array(&keys_mask_one.into());

--- a/datafusion/sqllogictest/test_files/spark/map/map_from_arrays.slt
+++ b/datafusion/sqllogictest/test_files/spark/map/map_from_arrays.slt
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Spark doctests
+query ?
+SELECT map_from_arrays(array(1.0, 3.0), array('2', '4'));
+----
+{1.0: 2, 3.0: 4}
+
+query ?
+SELECT map_from_arrays(array(2, 5), array('a', 'b'));
+----
+{2: a, 5: b}
+
+query ?
+SELECT map_from_arrays(array(1, 2), array('a', NULL));
+----
+{1: a, 2: NULL}
+
+query ?
+SELECT map_from_arrays(cast(array() as array<int>), cast(array() as array<string>));
+----
+{}
+
+# Test with complex types
+query ?
+SELECT map_from_arrays(array(array('a', 'b'), array('c', 'd')), array(struct(1, 2, 3), struct(4, 5, 6)));
+----
+{[a, b]: {c0: 1, c1: 2, c2: 3}, [c, d]: {c0: 4, c1: 5, c2: 6}}
+
+# Test with duplicate keys
+query ?
+SELECT map_from_arrays(array(true, false, true), array('a', NULL, 'b'));
+----
+{false: NULL, true: b}
+
+# Tests with different list types
+query ?
+SELECT map_from_arrays(arrow_cast(array(2, 5), 'LargeList(Int32)'), arrow_cast(array('a', 'b'), 'FixedSizeList(2, Utf8)'));
+----
+{2: a, 5: b}
+
+query ?
+SELECT map_from_arrays(arrow_cast(array('a', 'b', 'c'), 'FixedSizeList(3, Utf8)'), arrow_cast(array(1, 2, 3), 'LargeList(Int32)'));
+----
+{a: 1, b: 2, c: 3}

--- a/datafusion/sqllogictest/test_files/spark/map/map_from_arrays.slt
+++ b/datafusion/sqllogictest/test_files/spark/map/map_from_arrays.slt
@@ -62,6 +62,35 @@ SELECT map_from_arrays(array(), array('a', 'b'));
 query error DataFusion error: Execution error: map_deduplicate_keys: keys and values lists in the same row must have equal lengths
 SELECT map_from_arrays(array(1, 2, 3), array());
 
+query error DataFusion error: Execution error: map_deduplicate_keys: keys and values lists in the same row must have equal lengths
+select map_from_arrays(a, b)
+from values 
+    (array[1], array[1]),
+    (array[2, 3, 4], array[2, 3]),
+    (array[5], array[4])
+as tab(a, b);
+
+#Test with multiple rows: good, empty and nullable
+query ?
+select map_from_arrays(a, b)
+from values 
+    (array[1], array['a']), 
+    (NULL, NULL),
+    (array[1,2,3], NULL),
+    (NULL, array['b', 'c']), 
+    (array[4, 5], array['d', 'e']), 
+    (array[], array[]),
+    (array[6, 7, 8], array['f', 'g', 'h']) 
+as tab(a, b);
+----
+{1: a}
+NULL
+NULL
+NULL
+{4: d, 5: e}
+{}
+{6: f, 7: g, 8: h}
+
 # Test with complex types
 query ?
 SELECT map_from_arrays(array(array('a', 'b'), array('c', 'd')), array(struct(1, 2, 3), struct(4, 5, 6)));

--- a/datafusion/sqllogictest/test_files/spark/map/map_from_arrays.slt
+++ b/datafusion/sqllogictest/test_files/spark/map/map_from_arrays.slt
@@ -42,6 +42,27 @@ SELECT map_from_arrays(array(array('a', 'b'), array('c', 'd')), array(struct(1, 
 ----
 {[a, b]: {c0: 1, c1: 2, c2: 3}, [c, d]: {c0: 4, c1: 5, c2: 6}}
 
+# Test with nested function calls
+query ?
+SELECT
+    map_from_arrays(
+        array['outer_key1', 'outer_key2'],
+        array[
+            -- value for outer_key1: a map itself
+            map_from_arrays(
+                array['inner_a', 'inner_b'],
+                array[1, 2]
+            ),
+            -- value for outer_key2: another map
+            map_from_arrays(
+                array['inner_x', 'inner_y', 'inner_z'],
+                array[10, 20, 30]
+            )
+        ]
+    ) AS nested_map;
+----
+{outer_key1: {inner_a: 1, inner_b: 2}, outer_key2: {inner_x: 10, inner_y: 20, inner_z: 30}}
+
 # Test with duplicate keys
 query ?
 SELECT map_from_arrays(array(true, false, true), array('a', NULL, 'b'));

--- a/datafusion/sqllogictest/test_files/spark/map/map_from_arrays.slt
+++ b/datafusion/sqllogictest/test_files/spark/map/map_from_arrays.slt
@@ -36,6 +36,32 @@ SELECT map_from_arrays(cast(array() as array<int>), cast(array() as array<string
 ----
 {}
 
+# Tests with DataType:Null input arrays
+query ?
+SELECT map_from_arrays(NULL, NULL);
+----
+NULL
+
+query ?
+SELECT map_from_arrays(array(1), NULL);
+----
+NULL
+
+query ?
+SELECT map_from_arrays(NULL, array(1));
+----
+NULL
+
+# Tests with different inner lists lengths
+query error DataFusion error: Execution error: map_deduplicate_keys: keys and values lists in the same row must have equal lengths
+SELECT map_from_arrays(array(1, 2, 3), array('a', 'b'));
+
+query error DataFusion error: Execution error: map_deduplicate_keys: keys and values lists in the same row must have equal lengths
+SELECT map_from_arrays(array(), array('a', 'b'));
+
+query error DataFusion error: Execution error: map_deduplicate_keys: keys and values lists in the same row must have equal lengths
+SELECT map_from_arrays(array(1, 2, 3), array());
+
 # Test with complex types
 query ?
 SELECT map_from_arrays(array(array('a', 'b'), array('c', 'd')), array(struct(1, 2, 3), struct(4, 5, 6)));


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

part of #15914 

## Rationale for this change

Migrate spark functions from https://github.com/lakehq/sail/ to datafusion engine to unify codebase

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

implement spark udf `map_from_arrays`
https://spark.apache.org/docs/latest/api/sql/index.html#map_from_arrays
 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

sqllogictests added

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

map_from_arrays(keys_array_col, values_array_col) now can be called in queries

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
