### PR TITLE
Support join cardinality estimation less conservatively

### DIFF
--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -565,12 +565,12 @@ fn estimate_inner_join_cardinality(
     {
         // Break if we don't have enough information to calculate a distinct count
         // If distinct_count isn't provided directly, we need min and max to be provided
-        if (left_stat.distinct_count.get_value().is_none()
-            && (left_stat.min_value.get_value().is_none()
-                || left_stat.max_value.get_value().is_none()))
-            || (right_stat.distinct_count.get_value().is_none()
-                && (right_stat.min_value.get_value().is_none()
-                    || right_stat.max_value.get_value().is_none()))
+        let has_enough_info = |stat: &ColumnStatistics| {
+            stat.distinct_count.get_value().is_some()
+                || (stat.min_value.get_value().is_some()
+                    && stat.max_value.get_value().is_some())
+        };
+        if !has_enough_info(left_stat) || !has_enough_info(right_stat)
         {
             return None;
         }

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -570,8 +570,7 @@ fn estimate_inner_join_cardinality(
                 || (stat.min_value.get_value().is_some()
                     && stat.max_value.get_value().is_some())
         };
-        if !has_enough_info(left_stat) || !has_enough_info(right_stat)
-        {
+        if !has_enough_info(left_stat) || !has_enough_info(right_stat) {
             return None;
         }
 
@@ -2017,22 +2016,28 @@ mod tests {
                 (20, Inexact(1), Inexact(40), Absent, Absent),
                 Some(Inexact(10)),
             ),
-            // When we have distinct count.
+            // Distinct count matches the range
             (
-                (10, Absent, Absent, Inexact(10), Absent),
-                (10, Absent, Absent, Inexact(10), Absent),
+                (10, Inexact(1), Inexact(10), Inexact(10), Absent),
+                (10, Inexact(1), Inexact(10), Inexact(10), Absent),
+                Some(Inexact(10)),
+            ),
+            // Distinct count takes precedence over the range
+            (
+                (10, Inexact(1), Inexact(3), Inexact(10), Absent),
+                (10, Inexact(1), Inexact(3), Inexact(10), Absent),
                 Some(Inexact(10)),
             ),
             // distinct(left) > distinct(right)
             (
-                (10, Absent, Absent, Inexact(5), Absent),
-                (10, Absent, Absent, Inexact(2), Absent),
+                (10, Inexact(1), Inexact(10), Inexact(5), Absent),
+                (10, Inexact(1), Inexact(10), Inexact(2), Absent),
                 Some(Inexact(20)),
             ),
             // distinct(right) > distinct(left)
             (
-                (10, Absent, Absent, Inexact(2), Absent),
-                (10, Absent, Absent, Inexact(5), Absent),
+                (10, Inexact(1), Inexact(10), Inexact(2), Absent),
+                (10, Inexact(1), Inexact(10), Inexact(5), Absent),
                 Some(Inexact(20)),
             ),
             // min(left) < 0 (range(left) > range(right))
@@ -2072,16 +2077,21 @@ mod tests {
                 (10, Absent, Absent, Absent, Absent),
                 None,
             ),
-            // No min or max (or both).
+            // No min or max (or both), but distinct available.
             (
-                (10, Absent, Absent, Absent, Absent),
-                (10, Absent, Absent, Absent, Absent),
-                None,
+                (10, Absent, Absent, Inexact(3), Absent),
+                (10, Absent, Absent, Inexact(3), Absent),
+                Some(Inexact(33)),
             ),
             (
-                (10, Inexact(2), Absent, Absent, Absent),
-                (10, Absent, Inexact(5), Absent, Absent),
-                None,
+                (10, Inexact(2), Absent, Inexact(3), Absent),
+                (10, Absent, Inexact(5), Inexact(3), Absent),
+                Some(Inexact(33)),
+            ),
+            (
+                (10, Absent, Inexact(3), Inexact(3), Absent),
+                (10, Inexact(1), Absent, Inexact(3), Absent),
+                Some(Inexact(33)),
             ),
             (
                 (10, Absent, Inexact(3), Absent, Absent),


### PR DESCRIPTION
The goal of this PR is to allow cardinality statistics being passed through joins even if fields don't have max and min values set, as long as a distinct value estimate is provided.

Currently we require max and min to be set, as they might be used to estimate the distinct count. This is unnecessarily conservative if distinct_count has actually been provided, in which case max and min won't be used at all and the presence of max or min has no influence over how good of an estimate it is.