### PR TITLE
bug: Support null as argument to to_local_time

### DIFF
--- a/datafusion/functions/src/datetime/to_local_time.rs
+++ b/datafusion/functions/src/datetime/to_local_time.rs
@@ -119,6 +119,7 @@ impl ToLocalTimeFunc {
 
         let arg_type = time_value.data_type();
         match arg_type {
+            DataType::Null => Ok(ColumnarValue::Scalar(ScalarValue::Null)),
             Timestamp(_, None) => {
                 // if no timezone specified, just return the input
                 Ok(time_value.clone())
@@ -360,6 +361,7 @@ impl ScalarUDFImpl for ToLocalTimeFunc {
 
         match time_value {
             Timestamp(timeunit, _) => Ok(Timestamp(*timeunit, None)),
+            DataType::Null => Ok(Timestamp(Nanosecond, None)),
             _ => exec_err!(
                 "The to_local_time function can only accept timestamp as the arg, got {:?}", time_value
             )
@@ -385,6 +387,7 @@ impl ScalarUDFImpl for ToLocalTimeFunc {
 
         let first_arg = arg_types[0].clone();
         match &first_arg {
+            DataType::Null => Ok(vec![Timestamp(Nanosecond, None)]),
             Timestamp(Nanosecond, timezone) => {
                 Ok(vec![Timestamp(Nanosecond, timezone.clone())])
             }

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -3236,6 +3236,11 @@ select to_local_time('2024-04-01T00:00:20Z'::timestamp AT TIME ZONE 'Europe/Brus
 ----
 2024-04-01T00:00:20
 
+query P
+select to_local_time(NULL);
+----
+NULL
+
 query PTPT
 select
   time,

--- a/datafusion/sqllogictest/test_files/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/timestamps.slt
@@ -3268,6 +3268,7 @@ select date_bin(interval '1 day', to_local_time('2024-04-01T00:00:20Z'::timestam
 statement ok
 create table t AS
 VALUES
+  (NULL),
   ('2024-01-01T00:00:01Z'),
   ('2024-02-01T00:00:01Z'),
   ('2024-03-01T00:00:01Z'),
@@ -3295,6 +3296,7 @@ from t;
 query PPT
 select column1, to_local_time(column1::timestamp), arrow_typeof(to_local_time(column1::timestamp)) from t_utc;
 ----
+NULL NULL Timestamp(Nanosecond, None)
 2024-01-01T00:00:01Z 2024-01-01T00:00:01 Timestamp(Nanosecond, None)
 2024-02-01T00:00:01Z 2024-02-01T00:00:01 Timestamp(Nanosecond, None)
 2024-03-01T00:00:01Z 2024-03-01T00:00:01 Timestamp(Nanosecond, None)
@@ -3311,6 +3313,7 @@ select column1, to_local_time(column1::timestamp), arrow_typeof(to_local_time(co
 query PPT
 select column1, to_local_time(column1), arrow_typeof(to_local_time(column1)) from t_utc;
 ----
+NULL NULL Timestamp(Nanosecond, None)
 2024-01-01T00:00:01Z 2024-01-01T00:00:01 Timestamp(Nanosecond, None)
 2024-02-01T00:00:01Z 2024-02-01T00:00:01 Timestamp(Nanosecond, None)
 2024-03-01T00:00:01Z 2024-03-01T00:00:01 Timestamp(Nanosecond, None)
@@ -3327,6 +3330,7 @@ select column1, to_local_time(column1), arrow_typeof(to_local_time(column1)) fro
 query PPT
 select column1, to_local_time(column1), arrow_typeof(to_local_time(column1)) from t_timezone;
 ----
+NULL NULL Timestamp(Nanosecond, None)
 2024-01-01T00:00:01+01:00 2024-01-01T00:00:01 Timestamp(Nanosecond, None)
 2024-02-01T00:00:01+01:00 2024-02-01T00:00:01 Timestamp(Nanosecond, None)
 2024-03-01T00:00:01+01:00 2024-03-01T00:00:01 Timestamp(Nanosecond, None)
@@ -3344,6 +3348,7 @@ select column1, to_local_time(column1), arrow_typeof(to_local_time(column1)) fro
 query P
 select date_bin(interval '1 day', to_local_time(column1)) AT TIME ZONE 'Europe/Brussels' as date_bin from t_utc;
 ----
+NULL
 2024-01-01T00:00:00+01:00
 2024-02-01T00:00:00+01:00
 2024-03-01T00:00:00+01:00
@@ -3360,6 +3365,7 @@ select date_bin(interval '1 day', to_local_time(column1)) AT TIME ZONE 'Europe/B
 query P
 select date_bin(interval '1 day', to_local_time(column1)) AT TIME ZONE 'Europe/Brussels' as date_bin from t_timezone;
 ----
+NULL
 2024-01-01T00:00:00+01:00
 2024-02-01T00:00:00+01:00
 2024-03-01T00:00:00+01:00


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #17472

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
See issue.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Add support for null argument to to_local_time function

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Added both scalar and array tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
Yes
