### PR TITLE
fix: ignore non-existent columns when adding filter equivalence info in `FileScanConfig`

### DIFF
--- a/datafusion/datasource/src/test_util.rs
+++ b/datafusion/datasource/src/test_util.rs
@@ -34,6 +34,14 @@ pub(crate) struct MockSource {
     metrics: ExecutionPlanMetricsSet,
     projected_statistics: Option<Statistics>,
     schema_adapter_factory: Option<Arc<dyn SchemaAdapterFactory>>,
+    filter: Option<Arc<dyn PhysicalExpr>>,
+}
+
+impl MockSource {
+    pub fn with_filter(mut self, filter: Arc<dyn PhysicalExpr>) -> Self {
+        self.filter = Some(filter);
+        self
+    }
 }
 
 impl FileSource for MockSource {
@@ -48,6 +56,10 @@ impl FileSource for MockSource {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn filter(&self) -> Option<Arc<dyn PhysicalExpr>> {
+        self.filter.clone()
     }
 
     fn with_batch_size(&self, _batch_size: usize) -> Arc<dyn FileSource> {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/17511

## Rationale for this change

When building equal conditions in a data source node, we want to ignore any stale references to columns that may have been swapped out (e.g. from `try_swapping_with_projection`).

The current code reassigns predicate columns from the filter to refer to the corresponding ones in the updated schema. However, it only ignores non-projected columns. `reassign_predicate_columns` builds an invalid column expression (with index `usize::MAX`) if the column is not projected in the current schema. We don't want to refer to this in the equal conditions we build.


## What changes are included in this PR?

Ignores any binary expressions that reference non-existent columns in the current schema (e.g. due to unnecessary projections being removed).

## Are these changes tested?

Yes, unit test added

## Are there any user-facing changes?

N/A
