### PR TITLE
minor: fix compilation issue for extended tests due to missing parquet encryption flag

### DIFF
--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -1433,6 +1433,7 @@ mod test {
             schema_adapter_factory: Arc::new(CustomSchemaAdapterFactory),
             enable_row_group_stats_pruning: false,
             coerce_int96: None,
+            #[cfg(feature = "parquet_encryption")]
             file_decryption_properties: None,
             expr_adapter_factory: None,
             #[cfg(feature = "parquet_encryption")]


### PR DESCRIPTION
`Datafusion extended tests / cargo test hash collisions (amd64) (push)` currently failing on main:

```
 error[E0560]: struct `ParquetOpener` has no field named `file_decryption_properties`
    --> datafusion/datasource-parquet/src/opener.rs:1436:13
     |
1436 |             file_decryption_properties: None,
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ `ParquetOpener` does not have this field
     |
     = note: all struct fields are already assigned

For more information about this error, try `rustc --explain E0560`.
error: could not compile `datafusion-datasource-parquet` (lib test) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```