### PR TITLE
perf: Optimize `multi_group_by` when there are a lot of unique groups

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
@@ -175,6 +175,35 @@ impl<T: ArrowPrimitiveType, const NULLABLE: bool> GroupColumn
         Ok(())
     }
 
+    fn append_array_slice(
+        &mut self,
+        array: &ArrayRef,
+        start: usize,
+        length: usize,
+    ) -> Result<()> {
+        let array = array.as_primitive::<T>();
+
+        if NULLABLE {
+            if let Some(nulls) = array.nulls().filter(|n| n.null_count() > 0) {
+                self.nulls.append_buffer(&nulls.slice(start, length));
+            } else {
+                self.nulls.append_n(length, false);
+            }
+        } else {
+            assert_eq!(
+                array.null_count(),
+                0,
+                "unexpected nulls in non nullable input"
+            );
+            self.nulls.append_n(length, false);
+        }
+
+        self.group_values
+            .extend_from_slice(&array.values()[start..start + length]);
+
+        Ok(())
+    }
+
     fn len(&self) -> usize {
         self.group_values.len()
     }

--- a/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
@@ -61,6 +61,13 @@ impl MaybeNullBufferBuilder {
         }
     }
 
+    /// Append [`NullBuffer`] to this [`NullBufferBuilder`]
+    ///
+    /// This is useful when you want to concatenate two null buffers.
+    pub fn append_buffer(&mut self, other: &NullBuffer) {
+        self.nulls.append_buffer(other);
+    }
+
     /// return the number of heap allocated bytes used by this structure to store boolean values
     pub fn allocated_size(&self) -> usize {
         // NullBufferBuilder builder::allocated_size returns capacity in bits


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

I want fast grouping when there are a lot of columns to group by and there are a lot of unique groups

## What changes are included in this PR?

This optimization is fairly simple:
if the row indices to append are continues (i.e. `append_row_indices[i] + 1 == append_row_indices[i + 1]`) we will call an optimized function for that case

the optimized function should copy all the data in a single pass making it very fast as opposed to item by item

## Are these changes tested?

Existing tests but I want to add more, before I do I wanna see the benchmark results (I'm 99% it will be faster but still)

## Are there any user-facing changes?

Nope
