### PR TITLE
feat: change `datafusion-proto` to use `TaskContext` rather than`SessionContext` for physical plan serialization

### DIFF
--- a/benchmarks/src/imdb/run.rs
+++ b/benchmarks/src/imdb/run.rs
@@ -570,7 +570,7 @@ mod tests {
             let plan = ctx.sql(&query).await?;
             let plan = plan.create_physical_plan().await?;
             let bytes = physical_plan_to_bytes(plan.clone())?;
-            let plan2 = physical_plan_from_bytes(&bytes, &ctx)?;
+            let plan2 = physical_plan_from_bytes(&bytes, &ctx.task_ctx())?;
             let plan_formatted = format!("{}", displayable(plan.as_ref()).indent(false));
             let plan2_formatted =
                 format!("{}", displayable(plan2.as_ref()).indent(false));

--- a/benchmarks/src/tpch/run.rs
+++ b/benchmarks/src/tpch/run.rs
@@ -424,7 +424,7 @@ mod tests {
             let plan = ctx.sql(&query).await?;
             let plan = plan.create_physical_plan().await?;
             let bytes = physical_plan_to_bytes(plan.clone())?;
-            let plan2 = physical_plan_from_bytes(&bytes, &ctx)?;
+            let plan2 = physical_plan_from_bytes(&bytes, &ctx.task_ctx())?;
             let plan_formatted = format!("{}", displayable(plan.as_ref()).indent(false));
             let plan2_formatted =
                 format!("{}", displayable(plan2.as_ref()).indent(false));

--- a/datafusion-examples/examples/composed_extension_codec.rs
+++ b/datafusion-examples/examples/composed_extension_codec.rs
@@ -32,7 +32,6 @@
 
 use std::any::Any;
 use std::fmt::Debug;
-use std::ops::Deref;
 use std::sync::Arc;
 
 use datafusion::common::internal_err;
@@ -71,9 +70,8 @@ async fn main() {
         .expect("to proto");
 
     // deserialize proto back to execution plan
-    let runtime = ctx.runtime_env();
     let result_exec_plan: Arc<dyn ExecutionPlan> = proto
-        .try_into_physical_plan(&ctx.task_ctx(), runtime.deref(), &composed_codec)
+        .try_into_physical_plan(&ctx.task_ctx(), &composed_codec)
         .expect("from proto");
 
     // assert that the original and deserialized execution plans are equal

--- a/datafusion/ffi/src/plan_properties.rs
+++ b/datafusion/ffi/src/plan_properties.rs
@@ -181,6 +181,7 @@ impl TryFrom<FFI_PlanProperties> for PlanProperties {
 
         // TODO Extend FFI to get the registry and codex
         let default_ctx = SessionContext::new();
+        let task_context = default_ctx.task_ctx();
         let codex = DefaultPhysicalExtensionCodec {};
 
         let ffi_orderings = unsafe { (ffi_props.output_ordering)(&ffi_props) };
@@ -190,7 +191,7 @@ impl TryFrom<FFI_PlanProperties> for PlanProperties {
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
         let sort_exprs = parse_physical_sort_exprs(
             &proto_output_ordering.physical_sort_expr_nodes,
-            &default_ctx,
+            &task_context,
             &schema,
             &codex,
         )?;
@@ -202,7 +203,7 @@ impl TryFrom<FFI_PlanProperties> for PlanProperties {
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
         let partitioning = parse_protobuf_partitioning(
             Some(&proto_output_partitioning),
-            &default_ctx,
+            &task_context,
             &schema,
             &codex,
         )?

--- a/datafusion/ffi/src/udaf/accumulator_args.rs
+++ b/datafusion/ffi/src/udaf/accumulator_args.rs
@@ -116,16 +116,17 @@ impl TryFrom<FFI_AccumulatorArgs> for ForeignAccumulatorArgs {
         let schema = Schema::try_from(&value.schema.0)?;
 
         let default_ctx = SessionContext::new();
+        let task_ctx = default_ctx.task_ctx();
         let codex = DefaultPhysicalExtensionCodec {};
 
         let order_bys = parse_physical_sort_exprs(
             &proto_def.ordering_req,
-            &default_ctx,
+            &task_ctx,
             &schema,
             &codex,
         )?;
 
-        let exprs = parse_physical_exprs(&proto_def.expr, &default_ctx, &schema, &codex)?;
+        let exprs = parse_physical_exprs(&proto_def.expr, &task_ctx, &schema, &codex)?;
 
         Ok(Self {
             return_field,

--- a/datafusion/ffi/src/udwf/partition_evaluator_args.rs
+++ b/datafusion/ffi/src/udwf/partition_evaluator_args.rs
@@ -148,7 +148,7 @@ impl TryFrom<FFI_PartitionEvaluatorArgs> for ForeignPartitionEvaluatorArgs {
             .map_err(|e| DataFusionError::Execution(e.to_string()))?
             .iter()
             .map(|expr_node| {
-                parse_physical_expr(expr_node, &default_ctx, &schema, &codec)
+                parse_physical_expr(expr_node, &default_ctx.task_ctx(), &schema, &codec)
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -317,7 +317,7 @@ pub fn physical_plan_from_json(
     let back: protobuf::PhysicalPlanNode = serde_json::from_str(json)
         .map_err(|e| plan_datafusion_err!("Error serializing plan: {e}"))?;
     let extension_codec = DefaultPhysicalExtensionCodec {};
-    back.try_into_physical_plan(&ctx.task_ctx(), &ctx.runtime_env(), &extension_codec)
+    back.try_into_physical_plan(&ctx.task_ctx(), &extension_codec)
 }
 
 /// Deserialize a PhysicalPlan from bytes
@@ -337,5 +337,5 @@ pub fn physical_plan_from_bytes_with_extension_codec(
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let protobuf = protobuf::PhysicalPlanNode::decode(bytes)
         .map_err(|e| plan_datafusion_err!("Error decoding expr as protobuf: {e}"))?;
-    protobuf.try_into_physical_plan(ctx, &ctx.runtime_env(), extension_codec)
+    protobuf.try_into_physical_plan(ctx, extension_codec)
 }

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -24,6 +24,7 @@ use crate::physical_plan::{
     AsExecutionPlan, DefaultPhysicalExtensionCodec, PhysicalExtensionCodec,
 };
 use crate::protobuf;
+use datafusion::execution::TaskContext;
 use datafusion_common::{plan_datafusion_err, Result};
 use datafusion_expr::{
     create_udaf, create_udf, create_udwf, AggregateUDF, Expr, LogicalPlan, Volatility,
@@ -322,7 +323,7 @@ pub fn physical_plan_from_json(
 /// Deserialize a PhysicalPlan from bytes
 pub fn physical_plan_from_bytes(
     bytes: &[u8],
-    ctx: &SessionContext,
+    ctx: &TaskContext,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let extension_codec = DefaultPhysicalExtensionCodec {};
     physical_plan_from_bytes_with_extension_codec(bytes, ctx, &extension_codec)
@@ -331,7 +332,7 @@ pub fn physical_plan_from_bytes(
 /// Deserialize a PhysicalPlan from bytes
 pub fn physical_plan_from_bytes_with_extension_codec(
     bytes: &[u8],
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     extension_codec: &dyn PhysicalExtensionCodec,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let protobuf = protobuf::PhysicalPlanNode::decode(bytes)

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -317,7 +317,7 @@ pub fn physical_plan_from_json(
     let back: protobuf::PhysicalPlanNode = serde_json::from_str(json)
         .map_err(|e| plan_datafusion_err!("Error serializing plan: {e}"))?;
     let extension_codec = DefaultPhysicalExtensionCodec {};
-    back.try_into_physical_plan(ctx, &ctx.runtime_env(), &extension_codec)
+    back.try_into_physical_plan(&ctx.task_ctx(), &ctx.runtime_env(), &extension_codec)
 }
 
 /// Deserialize a PhysicalPlan from bytes

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -115,7 +115,7 @@
 //!  let bytes = physical_plan_to_bytes(physical_plan.clone())?;
 //!
 //!  // Decode bytes from somewhere (over network, etc.) back to ExecutionPlan
-//!  let physical_round_trip = physical_plan_from_bytes(&bytes, &ctx)?;
+//!  let physical_round_trip = physical_plan_from_bytes(&bytes, &ctx.task_ctx())?;
 //!  assert_eq!(format!("{:?}", physical_plan), format!("{:?}", physical_round_trip));
 //! # Ok(())
 //! # }

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -38,7 +38,7 @@ use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::datasource::physical_plan::{
     FileGroup, FileScanConfig, FileScanConfigBuilder, FileSinkConfig, FileSource,
 };
-use datafusion::execution::FunctionRegistry;
+use datafusion::execution::{FunctionRegistry, TaskContext};
 use datafusion::logical_expr::WindowFunctionDefinition;
 use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr, ScalarFunctionExpr};
 use datafusion::physical_plan::expressions::{
@@ -47,8 +47,6 @@ use datafusion::physical_plan::expressions::{
 };
 use datafusion::physical_plan::windows::{create_window_expr, schema_add_window_field};
 use datafusion::physical_plan::{Partitioning, PhysicalExpr, WindowExpr};
-use datafusion::prelude::SessionContext;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::{not_impl_err, DataFusionError, Result};
 use datafusion_proto_common::common::proto_error;
 
@@ -76,7 +74,7 @@ impl From<&protobuf::PhysicalColumn> for Column {
 /// * `codec` - An extension codec used to decode custom UDFs.
 pub fn parse_physical_sort_expr(
     proto: &protobuf::PhysicalSortExprNode,
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     input_schema: &Schema,
     codec: &dyn PhysicalExtensionCodec,
 ) -> Result<PhysicalSortExpr> {
@@ -103,7 +101,7 @@ pub fn parse_physical_sort_expr(
 /// * `codec` - An extension codec used to decode custom UDFs.
 pub fn parse_physical_sort_exprs(
     proto: &[protobuf::PhysicalSortExprNode],
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     input_schema: &Schema,
     codec: &dyn PhysicalExtensionCodec,
 ) -> Result<Vec<PhysicalSortExpr>> {
@@ -125,7 +123,7 @@ pub fn parse_physical_sort_exprs(
 /// * `codec` - An extension codec used to decode custom UDFs.
 pub fn parse_physical_window_expr(
     proto: &protobuf::PhysicalWindowExprNode,
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     input_schema: &Schema,
     codec: &dyn PhysicalExtensionCodec,
 ) -> Result<Arc<dyn WindowExpr>> {
@@ -186,7 +184,7 @@ pub fn parse_physical_window_expr(
 
 pub fn parse_physical_exprs<'a, I>(
     protos: I,
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     input_schema: &Schema,
     codec: &dyn PhysicalExtensionCodec,
 ) -> Result<Vec<Arc<dyn PhysicalExpr>>>
@@ -210,7 +208,7 @@ where
 /// * `codec` - An extension codec used to decode custom UDFs.
 pub fn parse_physical_expr(
     proto: &protobuf::PhysicalExprNode,
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     input_schema: &Schema,
     codec: &dyn PhysicalExtensionCodec,
 ) -> Result<Arc<dyn PhysicalExpr>> {
@@ -364,11 +362,8 @@ pub fn parse_physical_expr(
             let scalar_fun_def = Arc::clone(&udf);
 
             let args = parse_physical_exprs(&e.args, ctx, input_schema, codec)?;
-            let config_options =
-                match ctx.state().execution_props().config_options.as_ref() {
-                    Some(config_options) => Arc::clone(config_options),
-                    None => Arc::new(ConfigOptions::default()),
-                };
+
+            let config_options = Arc::clone(ctx.session_config().options());
 
             Arc::new(
                 ScalarFunctionExpr::new(
@@ -419,7 +414,7 @@ pub fn parse_physical_expr(
 
 fn parse_required_physical_expr(
     expr: Option<&protobuf::PhysicalExprNode>,
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     field: &str,
     input_schema: &Schema,
     codec: &dyn PhysicalExtensionCodec,
@@ -433,7 +428,7 @@ fn parse_required_physical_expr(
 
 pub fn parse_protobuf_hash_partitioning(
     partitioning: Option<&protobuf::PhysicalHashRepartition>,
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     input_schema: &Schema,
     codec: &dyn PhysicalExtensionCodec,
 ) -> Result<Option<Partitioning>> {
@@ -453,7 +448,7 @@ pub fn parse_protobuf_hash_partitioning(
 
 pub fn parse_protobuf_partitioning(
     partitioning: Option<&protobuf::Partitioning>,
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     input_schema: &Schema,
     codec: &dyn PhysicalExtensionCodec,
 ) -> Result<Option<Partitioning>> {
@@ -491,7 +486,7 @@ pub fn parse_protobuf_file_scan_schema(
 
 pub fn parse_protobuf_file_scan_config(
     proto: &protobuf::FileScanExecConf,
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     codec: &dyn PhysicalExtensionCodec,
     file_source: Arc<dyn FileSource>,
 ) -> Result<FileScanConfig> {

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -58,7 +58,7 @@ use datafusion::datasource::physical_plan::{
 use datafusion::datasource::sink::DataSinkExec;
 use datafusion::datasource::source::{DataSource, DataSourceExec};
 use datafusion::execution::runtime_env::RuntimeEnv;
-use datafusion::execution::FunctionRegistry;
+use datafusion::execution::{FunctionRegistry, TaskContext};
 use datafusion::functions_table::generate_series::{
     Empty, GenSeriesArgs, GenerateSeriesTable, GenericSeriesState, TimestampValue,
 };
@@ -98,7 +98,6 @@ use datafusion_common::config::TableParquetOptions;
 use datafusion_common::{internal_err, not_impl_err, DataFusionError, Result};
 use datafusion_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 
-use datafusion::prelude::SessionContext;
 use prost::bytes::BufMut;
 use prost::Message;
 
@@ -127,7 +126,7 @@ impl AsExecutionPlan for protobuf::PhysicalPlanNode {
 
     fn try_into_physical_plan(
         &self,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -546,7 +545,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_explain_physical_plan(
         &self,
         explain: &protobuf::ExplainExecNode,
-        _ctx: &SessionContext,
+        _ctx: &TaskContext,
         _runtime: &RuntimeEnv,
         _extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -564,7 +563,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_projection_physical_plan(
         &self,
         projection: &protobuf::ProjectionExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -596,7 +595,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_filter_physical_plan(
         &self,
         filter: &protobuf::FilterExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -644,7 +643,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_csv_scan_physical_plan(
         &self,
         scan: &protobuf::CsvScanExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         _runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -691,7 +690,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_json_scan_physical_plan(
         &self,
         scan: &protobuf::JsonScanExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         _runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -708,7 +707,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_parquet_scan_physical_plan(
         &self,
         scan: &protobuf::ParquetScanExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         _runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -769,7 +768,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_avro_scan_physical_plan(
         &self,
         scan: &protobuf::AvroScanExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         _runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -790,7 +789,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_memory_scan_physical_plan(
         &self,
         scan: &protobuf::MemoryScanExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         _runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -841,7 +840,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_coalesce_batches_physical_plan(
         &self,
         coalesce_batches: &protobuf::CoalesceBatchesExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -856,7 +855,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_merge_physical_plan(
         &self,
         merge: &protobuf::CoalescePartitionsExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -871,7 +870,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_repartition_physical_plan(
         &self,
         repart: &protobuf::RepartitionExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -892,7 +891,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_global_limit_physical_plan(
         &self,
         limit: &protobuf::GlobalLimitExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -913,7 +912,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_local_limit_physical_plan(
         &self,
         limit: &protobuf::LocalLimitExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -925,7 +924,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_window_physical_plan(
         &self,
         window_agg: &protobuf::WindowAggExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -983,7 +982,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_aggregate_physical_plan(
         &self,
         hash_agg: &protobuf::AggregateExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1151,7 +1150,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_hash_join_physical_plan(
         &self,
         hashjoin: &protobuf::HashJoinExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1269,7 +1268,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_symmetric_hash_join_physical_plan(
         &self,
         sym_join: &protobuf::SymmetricHashJoinExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1397,7 +1396,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_union_physical_plan(
         &self,
         union: &protobuf::UnionExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1411,7 +1410,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_interleave_physical_plan(
         &self,
         interleave: &protobuf::InterleaveExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1425,7 +1424,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_cross_join_physical_plan(
         &self,
         crossjoin: &protobuf::CrossJoinExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1439,7 +1438,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_empty_physical_plan(
         &self,
         empty: &protobuf::EmptyExecNode,
-        _ctx: &SessionContext,
+        _ctx: &TaskContext,
         _runtime: &RuntimeEnv,
         _extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1450,7 +1449,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_placeholder_row_physical_plan(
         &self,
         placeholder: &protobuf::PlaceholderRowExecNode,
-        _ctx: &SessionContext,
+        _ctx: &TaskContext,
         _runtime: &RuntimeEnv,
         _extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1461,7 +1460,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_sort_physical_plan(
         &self,
         sort: &protobuf::SortExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1513,7 +1512,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_sort_preserving_merge_physical_plan(
         &self,
         sort: &protobuf::SortPreservingMergeExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1566,7 +1565,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_extension_physical_plan(
         &self,
         extension: &protobuf::PhysicalExtensionNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1585,7 +1584,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_nested_loop_join_physical_plan(
         &self,
         join: &protobuf::NestedLoopJoinExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1659,7 +1658,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_analyze_physical_plan(
         &self,
         analyze: &protobuf::AnalyzeExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1676,7 +1675,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_json_sink_physical_plan(
         &self,
         sink: &protobuf::JsonSinkExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1714,7 +1713,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_csv_sink_physical_plan(
         &self,
         sink: &protobuf::CsvSinkExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1752,7 +1751,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_parquet_sink_physical_plan(
         &self,
         sink: &protobuf::ParquetSinkExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1795,7 +1794,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_unnest_physical_plan(
         &self,
         unnest: &protobuf::UnnestExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -1826,7 +1825,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_sort_join(
         &self,
         sort_join: &SortMergeJoinExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -2003,7 +2002,7 @@ impl protobuf::PhysicalPlanNode {
     fn try_into_cooperative_physical_plan(
         &self,
         field_stream: &protobuf::CooperativeExecNode,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -3276,7 +3275,7 @@ pub trait AsExecutionPlan: Debug + Send + Sync + Clone {
 
     fn try_into_physical_plan(
         &self,
-        ctx: &SessionContext,
+        ctx: &TaskContext,
         runtime: &RuntimeEnv,
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>>;
@@ -3294,7 +3293,7 @@ pub trait PhysicalExtensionCodec: Debug + Send + Sync {
         &self,
         buf: &[u8],
         inputs: &[Arc<dyn ExecutionPlan>],
-        registry: &dyn FunctionRegistry,
+        ctx: &TaskContext,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 
     fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()>;
@@ -3350,7 +3349,7 @@ impl PhysicalExtensionCodec for DefaultPhysicalExtensionCodec {
         &self,
         _buf: &[u8],
         _inputs: &[Arc<dyn ExecutionPlan>],
-        _registry: &dyn FunctionRegistry,
+        _ctx: &TaskContext,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         not_impl_err!("PhysicalExtensionCodec is not provided")
     }
@@ -3452,9 +3451,9 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         &self,
         buf: &[u8],
         inputs: &[Arc<dyn ExecutionPlan>],
-        registry: &dyn FunctionRegistry,
+        ctx: &TaskContext,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.decode_protobuf(buf, |codec, data| codec.try_decode(data, inputs, registry))
+        self.decode_protobuf(buf, |codec, data| codec.try_decode(data, inputs, ctx))
     }
 
     fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
@@ -3480,7 +3479,7 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
 
 fn into_physical_plan(
     node: &Option<Box<protobuf::PhysicalPlanNode>>,
-    ctx: &SessionContext,
+    ctx: &TaskContext,
     runtime: &RuntimeEnv,
     extension_codec: &dyn PhysicalExtensionCodec,
 ) -> Result<Arc<dyn ExecutionPlan>> {

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -57,7 +57,6 @@ use datafusion::datasource::physical_plan::{
 };
 use datafusion::datasource::sink::DataSinkExec;
 use datafusion::datasource::source::{DataSource, DataSourceExec};
-use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::execution::{FunctionRegistry, TaskContext};
 use datafusion::functions_table::generate_series::{
     Empty, GenSeriesArgs, GenerateSeriesTable, GenericSeriesState, TimestampValue,
@@ -127,7 +126,7 @@ impl AsExecutionPlan for protobuf::PhysicalPlanNode {
     fn try_into_physical_plan(
         &self,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let plan = self.physical_plan_type.as_ref().ok_or_else(|| {
@@ -136,171 +135,118 @@ impl AsExecutionPlan for protobuf::PhysicalPlanNode {
             ))
         })?;
         match plan {
-            PhysicalPlanType::Explain(explain) => self.try_into_explain_physical_plan(
-                explain,
-                ctx,
-                runtime,
-                extension_codec,
-            ),
-            PhysicalPlanType::Projection(projection) => self
-                .try_into_projection_physical_plan(
-                    projection,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
+            PhysicalPlanType::Explain(explain) => {
+                self.try_into_explain_physical_plan(explain, ctx, extension_codec)
+            }
+            PhysicalPlanType::Projection(projection) => {
+                self.try_into_projection_physical_plan(projection, ctx, extension_codec)
+            }
             PhysicalPlanType::Filter(filter) => {
-                self.try_into_filter_physical_plan(filter, ctx, runtime, extension_codec)
+                self.try_into_filter_physical_plan(filter, ctx, extension_codec)
             }
             PhysicalPlanType::CsvScan(scan) => {
-                self.try_into_csv_scan_physical_plan(scan, ctx, runtime, extension_codec)
+                self.try_into_csv_scan_physical_plan(scan, ctx, extension_codec)
             }
             PhysicalPlanType::JsonScan(scan) => {
-                self.try_into_json_scan_physical_plan(scan, ctx, runtime, extension_codec)
+                self.try_into_json_scan_physical_plan(scan, ctx, extension_codec)
             }
             #[cfg_attr(not(feature = "parquet"), allow(unused_variables))]
-            PhysicalPlanType::ParquetScan(scan) => self
-                .try_into_parquet_scan_physical_plan(scan, ctx, runtime, extension_codec),
+            PhysicalPlanType::ParquetScan(scan) => {
+                self.try_into_parquet_scan_physical_plan(scan, ctx, extension_codec)
+            }
             #[cfg_attr(not(feature = "avro"), allow(unused_variables))]
             PhysicalPlanType::AvroScan(scan) => {
-                self.try_into_avro_scan_physical_plan(scan, ctx, runtime, extension_codec)
+                self.try_into_avro_scan_physical_plan(scan, ctx, extension_codec)
             }
-            PhysicalPlanType::MemoryScan(scan) => self
-                .try_into_memory_scan_physical_plan(scan, ctx, runtime, extension_codec),
+            PhysicalPlanType::MemoryScan(scan) => {
+                self.try_into_memory_scan_physical_plan(scan, ctx, extension_codec)
+            }
             PhysicalPlanType::CoalesceBatches(coalesce_batches) => self
                 .try_into_coalesce_batches_physical_plan(
                     coalesce_batches,
                     ctx,
-                    runtime,
                     extension_codec,
                 ),
             PhysicalPlanType::Merge(merge) => {
-                self.try_into_merge_physical_plan(merge, ctx, runtime, extension_codec)
+                self.try_into_merge_physical_plan(merge, ctx, extension_codec)
             }
-            PhysicalPlanType::Repartition(repart) => self
-                .try_into_repartition_physical_plan(
-                    repart,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
-            PhysicalPlanType::GlobalLimit(limit) => self
-                .try_into_global_limit_physical_plan(
-                    limit,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
-            PhysicalPlanType::LocalLimit(limit) => self
-                .try_into_local_limit_physical_plan(limit, ctx, runtime, extension_codec),
-            PhysicalPlanType::Window(window_agg) => self.try_into_window_physical_plan(
-                window_agg,
-                ctx,
-                runtime,
-                extension_codec,
-            ),
-            PhysicalPlanType::Aggregate(hash_agg) => self
-                .try_into_aggregate_physical_plan(
-                    hash_agg,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
-            PhysicalPlanType::HashJoin(hashjoin) => self
-                .try_into_hash_join_physical_plan(
-                    hashjoin,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
+            PhysicalPlanType::Repartition(repart) => {
+                self.try_into_repartition_physical_plan(repart, ctx, extension_codec)
+            }
+            PhysicalPlanType::GlobalLimit(limit) => {
+                self.try_into_global_limit_physical_plan(limit, ctx, extension_codec)
+            }
+            PhysicalPlanType::LocalLimit(limit) => {
+                self.try_into_local_limit_physical_plan(limit, ctx, extension_codec)
+            }
+            PhysicalPlanType::Window(window_agg) => {
+                self.try_into_window_physical_plan(window_agg, ctx, extension_codec)
+            }
+            PhysicalPlanType::Aggregate(hash_agg) => {
+                self.try_into_aggregate_physical_plan(hash_agg, ctx, extension_codec)
+            }
+            PhysicalPlanType::HashJoin(hashjoin) => {
+                self.try_into_hash_join_physical_plan(hashjoin, ctx, extension_codec)
+            }
             PhysicalPlanType::SymmetricHashJoin(sym_join) => self
                 .try_into_symmetric_hash_join_physical_plan(
                     sym_join,
                     ctx,
-                    runtime,
                     extension_codec,
                 ),
             PhysicalPlanType::Union(union) => {
-                self.try_into_union_physical_plan(union, ctx, runtime, extension_codec)
+                self.try_into_union_physical_plan(union, ctx, extension_codec)
             }
-            PhysicalPlanType::Interleave(interleave) => self
-                .try_into_interleave_physical_plan(
-                    interleave,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
-            PhysicalPlanType::CrossJoin(crossjoin) => self
-                .try_into_cross_join_physical_plan(
-                    crossjoin,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
+            PhysicalPlanType::Interleave(interleave) => {
+                self.try_into_interleave_physical_plan(interleave, ctx, extension_codec)
+            }
+            PhysicalPlanType::CrossJoin(crossjoin) => {
+                self.try_into_cross_join_physical_plan(crossjoin, ctx, extension_codec)
+            }
             PhysicalPlanType::Empty(empty) => {
-                self.try_into_empty_physical_plan(empty, ctx, runtime, extension_codec)
+                self.try_into_empty_physical_plan(empty, ctx, extension_codec)
             }
             PhysicalPlanType::PlaceholderRow(placeholder) => self
                 .try_into_placeholder_row_physical_plan(
                     placeholder,
                     ctx,
-                    runtime,
                     extension_codec,
                 ),
             PhysicalPlanType::Sort(sort) => {
-                self.try_into_sort_physical_plan(sort, ctx, runtime, extension_codec)
+                self.try_into_sort_physical_plan(sort, ctx, extension_codec)
             }
             PhysicalPlanType::SortPreservingMerge(sort) => self
-                .try_into_sort_preserving_merge_physical_plan(
-                    sort,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
-            PhysicalPlanType::Extension(extension) => self
-                .try_into_extension_physical_plan(
-                    extension,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
-            PhysicalPlanType::NestedLoopJoin(join) => self
-                .try_into_nested_loop_join_physical_plan(
-                    join,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
-            PhysicalPlanType::Analyze(analyze) => self.try_into_analyze_physical_plan(
-                analyze,
-                ctx,
-                runtime,
-                extension_codec,
-            ),
+                .try_into_sort_preserving_merge_physical_plan(sort, ctx, extension_codec),
+            PhysicalPlanType::Extension(extension) => {
+                self.try_into_extension_physical_plan(extension, ctx, extension_codec)
+            }
+            PhysicalPlanType::NestedLoopJoin(join) => {
+                self.try_into_nested_loop_join_physical_plan(join, ctx, extension_codec)
+            }
+            PhysicalPlanType::Analyze(analyze) => {
+                self.try_into_analyze_physical_plan(analyze, ctx, extension_codec)
+            }
             PhysicalPlanType::JsonSink(sink) => {
-                self.try_into_json_sink_physical_plan(sink, ctx, runtime, extension_codec)
+                self.try_into_json_sink_physical_plan(sink, ctx, extension_codec)
             }
             PhysicalPlanType::CsvSink(sink) => {
-                self.try_into_csv_sink_physical_plan(sink, ctx, runtime, extension_codec)
+                self.try_into_csv_sink_physical_plan(sink, ctx, extension_codec)
             }
             #[cfg_attr(not(feature = "parquet"), allow(unused_variables))]
-            PhysicalPlanType::ParquetSink(sink) => self
-                .try_into_parquet_sink_physical_plan(sink, ctx, runtime, extension_codec),
-            PhysicalPlanType::Unnest(unnest) => {
-                self.try_into_unnest_physical_plan(unnest, ctx, runtime, extension_codec)
+            PhysicalPlanType::ParquetSink(sink) => {
+                self.try_into_parquet_sink_physical_plan(sink, ctx, extension_codec)
             }
-            PhysicalPlanType::Cooperative(cooperative) => self
-                .try_into_cooperative_physical_plan(
-                    cooperative,
-                    ctx,
-                    runtime,
-                    extension_codec,
-                ),
+            PhysicalPlanType::Unnest(unnest) => {
+                self.try_into_unnest_physical_plan(unnest, ctx, extension_codec)
+            }
+            PhysicalPlanType::Cooperative(cooperative) => {
+                self.try_into_cooperative_physical_plan(cooperative, ctx, extension_codec)
+            }
             PhysicalPlanType::GenerateSeries(generate_series) => {
                 self.try_into_generate_series_physical_plan(generate_series)
             }
             PhysicalPlanType::SortMergeJoin(sort_join) => {
-                self.try_into_sort_join(sort_join, ctx, runtime, extension_codec)
+                self.try_into_sort_join(sort_join, ctx, extension_codec)
             }
         }
     }
@@ -546,7 +492,7 @@ impl protobuf::PhysicalPlanNode {
         &self,
         explain: &protobuf::ExplainExecNode,
         _ctx: &TaskContext,
-        _runtime: &RuntimeEnv,
+
         _extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(ExplainExec::new(
@@ -564,11 +510,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         projection: &protobuf::ProjectionExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&projection.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&projection.input, ctx, extension_codec)?;
         let exprs = projection
             .expr
             .iter()
@@ -596,11 +542,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         filter: &protobuf::FilterExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&filter.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&filter.input, ctx, extension_codec)?;
 
         let predicate = filter
             .expr
@@ -644,7 +590,7 @@ impl protobuf::PhysicalPlanNode {
         &self,
         scan: &protobuf::CsvScanExecNode,
         ctx: &TaskContext,
-        _runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let escape =
@@ -691,7 +637,7 @@ impl protobuf::PhysicalPlanNode {
         &self,
         scan: &protobuf::JsonScanExecNode,
         ctx: &TaskContext,
-        _runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let scan_conf = parse_protobuf_file_scan_config(
@@ -708,7 +654,7 @@ impl protobuf::PhysicalPlanNode {
         &self,
         scan: &protobuf::ParquetScanExecNode,
         ctx: &TaskContext,
-        _runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         #[cfg(feature = "parquet")]
@@ -769,7 +715,7 @@ impl protobuf::PhysicalPlanNode {
         &self,
         scan: &protobuf::AvroScanExecNode,
         ctx: &TaskContext,
-        _runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         #[cfg(feature = "avro")]
@@ -790,7 +736,7 @@ impl protobuf::PhysicalPlanNode {
         &self,
         scan: &protobuf::MemoryScanExecNode,
         ctx: &TaskContext,
-        _runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let partitions = scan
@@ -841,11 +787,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         coalesce_batches: &protobuf::CoalesceBatchesExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&coalesce_batches.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&coalesce_batches.input, ctx, extension_codec)?;
         Ok(Arc::new(
             CoalesceBatchesExec::new(input, coalesce_batches.target_batch_size as usize)
                 .with_fetch(coalesce_batches.fetch.map(|f| f as usize)),
@@ -856,11 +802,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         merge: &protobuf::CoalescePartitionsExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&merge.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&merge.input, ctx, extension_codec)?;
         Ok(Arc::new(
             CoalescePartitionsExec::new(input)
                 .with_fetch(merge.fetch.map(|f| f as usize)),
@@ -871,11 +817,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         repart: &protobuf::RepartitionExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&repart.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&repart.input, ctx, extension_codec)?;
         let partitioning = parse_protobuf_partitioning(
             repart.partitioning.as_ref(),
             ctx,
@@ -892,11 +838,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         limit: &protobuf::GlobalLimitExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&limit.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&limit.input, ctx, extension_codec)?;
         let fetch = if limit.fetch >= 0 {
             Some(limit.fetch as usize)
         } else {
@@ -913,11 +859,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         limit: &protobuf::LocalLimitExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&limit.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&limit.input, ctx, extension_codec)?;
         Ok(Arc::new(LocalLimitExec::new(input, limit.fetch as usize)))
     }
 
@@ -925,11 +871,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         window_agg: &protobuf::WindowAggExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&window_agg.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&window_agg.input, ctx, extension_codec)?;
         let input_schema = input.schema();
 
         let physical_window_expr: Vec<Arc<dyn WindowExpr>> = window_agg
@@ -983,11 +929,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         hash_agg: &protobuf::AggregateExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&hash_agg.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&hash_agg.input, ctx, extension_codec)?;
         let mode = protobuf::AggregateMode::try_from(hash_agg.mode).map_err(|_| {
             proto_error(format!(
                 "Received a AggregateNode message with unknown AggregateMode {}",
@@ -1151,13 +1097,13 @@ impl protobuf::PhysicalPlanNode {
         &self,
         hashjoin: &protobuf::HashJoinExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let left: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&hashjoin.left, ctx, runtime, extension_codec)?;
+            into_physical_plan(&hashjoin.left, ctx, extension_codec)?;
         let right: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&hashjoin.right, ctx, runtime, extension_codec)?;
+            into_physical_plan(&hashjoin.right, ctx, extension_codec)?;
         let left_schema = left.schema();
         let right_schema = right.schema();
         let on: Vec<(PhysicalExprRef, PhysicalExprRef)> = hashjoin
@@ -1269,11 +1215,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         sym_join: &protobuf::SymmetricHashJoinExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let left = into_physical_plan(&sym_join.left, ctx, runtime, extension_codec)?;
-        let right = into_physical_plan(&sym_join.right, ctx, runtime, extension_codec)?;
+        let left = into_physical_plan(&sym_join.left, ctx, extension_codec)?;
+        let right = into_physical_plan(&sym_join.right, ctx, extension_codec)?;
         let left_schema = left.schema();
         let right_schema = right.schema();
         let on = sym_join
@@ -1397,12 +1343,12 @@ impl protobuf::PhysicalPlanNode {
         &self,
         union: &protobuf::UnionExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let mut inputs: Vec<Arc<dyn ExecutionPlan>> = vec![];
         for input in &union.inputs {
-            inputs.push(input.try_into_physical_plan(ctx, runtime, extension_codec)?);
+            inputs.push(input.try_into_physical_plan(ctx, extension_codec)?);
         }
         UnionExec::try_new(inputs)
     }
@@ -1411,12 +1357,12 @@ impl protobuf::PhysicalPlanNode {
         &self,
         interleave: &protobuf::InterleaveExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let mut inputs: Vec<Arc<dyn ExecutionPlan>> = vec![];
         for input in &interleave.inputs {
-            inputs.push(input.try_into_physical_plan(ctx, runtime, extension_codec)?);
+            inputs.push(input.try_into_physical_plan(ctx, extension_codec)?);
         }
         Ok(Arc::new(InterleaveExec::try_new(inputs)?))
     }
@@ -1425,13 +1371,13 @@ impl protobuf::PhysicalPlanNode {
         &self,
         crossjoin: &protobuf::CrossJoinExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let left: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&crossjoin.left, ctx, runtime, extension_codec)?;
+            into_physical_plan(&crossjoin.left, ctx, extension_codec)?;
         let right: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&crossjoin.right, ctx, runtime, extension_codec)?;
+            into_physical_plan(&crossjoin.right, ctx, extension_codec)?;
         Ok(Arc::new(CrossJoinExec::new(left, right)))
     }
 
@@ -1439,7 +1385,7 @@ impl protobuf::PhysicalPlanNode {
         &self,
         empty: &protobuf::EmptyExecNode,
         _ctx: &TaskContext,
-        _runtime: &RuntimeEnv,
+
         _extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let schema = Arc::new(convert_required!(empty.schema)?);
@@ -1450,7 +1396,7 @@ impl protobuf::PhysicalPlanNode {
         &self,
         placeholder: &protobuf::PlaceholderRowExecNode,
         _ctx: &TaskContext,
-        _runtime: &RuntimeEnv,
+
         _extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let schema = Arc::new(convert_required!(placeholder.schema)?);
@@ -1461,10 +1407,10 @@ impl protobuf::PhysicalPlanNode {
         &self,
         sort: &protobuf::SortExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let input = into_physical_plan(&sort.input, ctx, runtime, extension_codec)?;
+        let input = into_physical_plan(&sort.input, ctx, extension_codec)?;
         let exprs = sort
             .expr
             .iter()
@@ -1513,10 +1459,10 @@ impl protobuf::PhysicalPlanNode {
         &self,
         sort: &protobuf::SortPreservingMergeExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let input = into_physical_plan(&sort.input, ctx, runtime, extension_codec)?;
+        let input = into_physical_plan(&sort.input, ctx, extension_codec)?;
         let exprs = sort
             .expr
             .iter()
@@ -1566,13 +1512,13 @@ impl protobuf::PhysicalPlanNode {
         &self,
         extension: &protobuf::PhysicalExtensionNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let inputs: Vec<Arc<dyn ExecutionPlan>> = extension
             .inputs
             .iter()
-            .map(|i| i.try_into_physical_plan(ctx, runtime, extension_codec))
+            .map(|i| i.try_into_physical_plan(ctx, extension_codec))
             .collect::<Result<_>>()?;
 
         let extension_node =
@@ -1585,13 +1531,13 @@ impl protobuf::PhysicalPlanNode {
         &self,
         join: &protobuf::NestedLoopJoinExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let left: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&join.left, ctx, runtime, extension_codec)?;
+            into_physical_plan(&join.left, ctx, extension_codec)?;
         let right: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&join.right, ctx, runtime, extension_codec)?;
+            into_physical_plan(&join.right, ctx, extension_codec)?;
         let join_type = protobuf::JoinType::try_from(join.join_type).map_err(|_| {
             proto_error(format!(
                 "Received a NestedLoopJoinExecNode message with unknown JoinType {}",
@@ -1659,11 +1605,11 @@ impl protobuf::PhysicalPlanNode {
         &self,
         analyze: &protobuf::AnalyzeExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&analyze.input, ctx, runtime, extension_codec)?;
+            into_physical_plan(&analyze.input, ctx, extension_codec)?;
         Ok(Arc::new(AnalyzeExec::new(
             analyze.verbose,
             analyze.show_statistics,
@@ -1676,10 +1622,10 @@ impl protobuf::PhysicalPlanNode {
         &self,
         sink: &protobuf::JsonSinkExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let input = into_physical_plan(&sink.input, ctx, runtime, extension_codec)?;
+        let input = into_physical_plan(&sink.input, ctx, extension_codec)?;
 
         let data_sink: JsonSink = sink
             .sink
@@ -1714,10 +1660,10 @@ impl protobuf::PhysicalPlanNode {
         &self,
         sink: &protobuf::CsvSinkExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let input = into_physical_plan(&sink.input, ctx, runtime, extension_codec)?;
+        let input = into_physical_plan(&sink.input, ctx, extension_codec)?;
 
         let data_sink: CsvSink = sink
             .sink
@@ -1752,12 +1698,12 @@ impl protobuf::PhysicalPlanNode {
         &self,
         sink: &protobuf::ParquetSinkExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         #[cfg(feature = "parquet")]
         {
-            let input = into_physical_plan(&sink.input, ctx, runtime, extension_codec)?;
+            let input = into_physical_plan(&sink.input, ctx, extension_codec)?;
 
             let data_sink: ParquetSink = sink
                 .sink
@@ -1795,10 +1741,10 @@ impl protobuf::PhysicalPlanNode {
         &self,
         unnest: &protobuf::UnnestExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let input = into_physical_plan(&unnest.input, ctx, runtime, extension_codec)?;
+        let input = into_physical_plan(&unnest.input, ctx, extension_codec)?;
 
         Ok(Arc::new(UnnestExec::new(
             input,
@@ -1826,12 +1772,12 @@ impl protobuf::PhysicalPlanNode {
         &self,
         sort_join: &SortMergeJoinExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let left = into_physical_plan(&sort_join.left, ctx, runtime, extension_codec)?;
+        let left = into_physical_plan(&sort_join.left, ctx, extension_codec)?;
         let left_schema = left.schema();
-        let right = into_physical_plan(&sort_join.right, ctx, runtime, extension_codec)?;
+        let right = into_physical_plan(&sort_join.right, ctx, extension_codec)?;
         let right_schema = right.schema();
 
         let filter = sort_join
@@ -2003,11 +1949,10 @@ impl protobuf::PhysicalPlanNode {
         &self,
         field_stream: &protobuf::CooperativeExecNode,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let input =
-            into_physical_plan(&field_stream.input, ctx, runtime, extension_codec)?;
+        let input = into_physical_plan(&field_stream.input, ctx, extension_codec)?;
         Ok(Arc::new(CooperativeExec::new(input)))
     }
 
@@ -3276,7 +3221,7 @@ pub trait AsExecutionPlan: Debug + Send + Sync + Clone {
     fn try_into_physical_plan(
         &self,
         ctx: &TaskContext,
-        runtime: &RuntimeEnv,
+
         extension_codec: &dyn PhysicalExtensionCodec,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 
@@ -3480,11 +3425,11 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
 fn into_physical_plan(
     node: &Option<Box<protobuf::PhysicalPlanNode>>,
     ctx: &TaskContext,
-    runtime: &RuntimeEnv,
+
     extension_codec: &dyn PhysicalExtensionCodec,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     if let Some(field) = node {
-        field.try_into_physical_plan(ctx, runtime, extension_codec)
+        field.try_into_physical_plan(ctx, extension_codec)
     } else {
         Err(proto_error("Missing required field in protobuf"))
     }

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -17,7 +17,6 @@
 
 use std::any::Any;
 use std::fmt::{Display, Formatter};
-use std::ops::Deref;
 
 use std::sync::Arc;
 use std::vec;
@@ -138,9 +137,8 @@ fn roundtrip_test_and_return(
     let proto: protobuf::PhysicalPlanNode =
         protobuf::PhysicalPlanNode::try_from_physical_plan(exec_plan.clone(), codec)
             .expect("to proto");
-    let runtime = ctx.runtime_env();
     let result_exec_plan: Arc<dyn ExecutionPlan> = proto
-        .try_into_physical_plan(&ctx.task_ctx(), runtime.deref(), codec)
+        .try_into_physical_plan(&ctx.task_ctx(), codec)
         .expect("from proto");
 
     pretty_assertions::assert_eq!(
@@ -1736,11 +1734,8 @@ async fn roundtrip_coalesce() -> Result<()> {
     )?;
     let node = PhysicalPlanNode::decode(node.encode_to_vec().as_slice())
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
-    let restored = node.try_into_physical_plan(
-        &ctx.task_ctx(),
-        ctx.runtime_env().as_ref(),
-        &DefaultPhysicalExtensionCodec {},
-    )?;
+    let restored =
+        node.try_into_physical_plan(&ctx.task_ctx(), &DefaultPhysicalExtensionCodec {})?;
 
     assert_eq!(
         plan.schema(),
@@ -1775,11 +1770,8 @@ async fn roundtrip_generate_series() -> Result<()> {
     )?;
     let node = PhysicalPlanNode::decode(node.encode_to_vec().as_slice())
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
-    let restored = node.try_into_physical_plan(
-        &ctx.task_ctx(),
-        ctx.runtime_env().as_ref(),
-        &DefaultPhysicalExtensionCodec {},
-    )?;
+    let restored =
+        node.try_into_physical_plan(&ctx.task_ctx(), &DefaultPhysicalExtensionCodec {})?;
 
     assert_eq!(
         plan.schema(),
@@ -1901,11 +1893,7 @@ async fn roundtrip_physical_plan_node() {
             .unwrap();
 
     let plan = node
-        .try_into_physical_plan(
-            &ctx.task_ctx(),
-            &ctx.runtime_env(),
-            &DefaultPhysicalExtensionCodec {},
-        )
+        .try_into_physical_plan(&ctx.task_ctx(), &DefaultPhysicalExtensionCodec {})
         .unwrap();
 
     let _ = plan.execute(0, ctx.task_ctx()).unwrap();
@@ -1984,11 +1972,8 @@ async fn test_serialize_deserialize_tpch_queries() -> Result<()> {
                 PhysicalPlanNode::try_from_physical_plan(physical_plan.clone(), &codec)?;
 
             // deserialize the physical plan
-            let _deserialized_plan = proto.try_into_physical_plan(
-                &ctx.task_ctx(),
-                ctx.runtime_env().as_ref(),
-                &codec,
-            )?;
+            let _deserialized_plan =
+                proto.try_into_physical_plan(&ctx.task_ctx(), &codec)?;
         }
     }
 
@@ -2107,11 +2092,7 @@ async fn test_tpch_part_in_list_query_with_real_parquet_data() -> Result<()> {
     let proto = PhysicalPlanNode::try_from_physical_plan(physical_plan.clone(), &codec)?;
 
     // This will fail with the bug, but should succeed when fixed
-    let _deserialized_plan = proto.try_into_physical_plan(
-        &ctx.task_ctx(),
-        ctx.runtime_env().as_ref(),
-        &codec,
-    )?;
+    let _deserialized_plan = proto.try_into_physical_plan(&ctx.task_ctx(), &codec)?;
     Ok(())
 }
 
@@ -2139,11 +2120,8 @@ async fn analyze_roundtrip_unoptimized() -> Result<()> {
     let node = PhysicalPlanNode::decode(node.encode_to_vec().as_slice())
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-    let unoptimized = node.try_into_physical_plan(
-        &ctx.task_ctx(),
-        ctx.runtime_env().as_ref(),
-        &DefaultPhysicalExtensionCodec {},
-    )?;
+    let unoptimized =
+        node.try_into_physical_plan(&ctx.task_ctx(), &DefaultPhysicalExtensionCodec {})?;
 
     let physical_planner =
         datafusion::physical_planner::DefaultPhysicalPlanner::default();

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -23,13 +23,49 @@
 
 **Note:** DataFusion `51.0.0` has not been released yet. The information provided in this section pertains to features and changes that have already been merged to the main branch and are awaiting release in this version.
 
-You can see the current [status of the `51.0.0 `release here](https://github.com/apache/datafusion/issues/17558)
+You can see the current [status of the `51.0.0`release here](https://github.com/apache/datafusion/issues/17558)
 
 ### `MSRV` updated to 1.87.0
 
 The Minimum Supported Rust Version (MSRV) has been updated to [`1.87.0`].
 
 [`1.87.0`]: https://releases.rs/docs/1.87.0/
+
+### `datafusion-proto` use `TaskContext` rather than `SessionContext` in physical plan serde methods
+
+There have been changes in the public API methods of `datafusion-proto` which handle physical plan serde.
+
+Methods like `physical_plan_from_bytes`, `parse_physical_expr` and similar, expect `TaskContext` instead of `SessionContext`
+
+```diff
+- let plan2 = physical_plan_from_bytes(&bytes, &ctx)?;
++ let plan2 = physical_plan_from_bytes(&bytes, &ctx.task_ctx())?;
+```
+
+as `TaskContext` contains `RuntimeEnv` methods such as `try_into_physical_plan` will not have explicit `RuntimeEnv` parameter.
+
+```diff
+let result_exec_plan: Arc<dyn ExecutionPlan> = proto
+-   .try_into_physical_plan(&ctx, runtime.deref(), &composed_codec)
++.  .try_into_physical_plan(&ctx.task_ctx(), &composed_codec)
+```
+
+`PhysicalExtensionCodec::try_decode()` expects `TaskContext` instead of `FunctionRegistry`:
+
+```diff
+pub trait PhysicalExtensionCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+-        registry: &dyn FunctionRegistry,
++        ctx: &TaskContext,
+    ) -> Result<Arc<dyn ExecutionPlan>>;
+```
+
+See [issue #17601] for more details.
+
+[issue #17601]: https://github.com/apache/datafusion/issues/17601
 
 ## DataFusion `50.0.0`
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #17596 .

## Rationale for this change

As described in #17596  replacing `SessionContext` with `TaskContext` and aligning `PhysicalExtensionCodec::try_decode` with other interface changes. 

more details at ballista pr https://github.com/apache/datafusion-ballista/pull/1320/

## What changes are included in this PR?

- changed public good few interfaces in `datafusion_proto::physical_plan` replacing `SessionContext` with `TaskContext`
- removed `runtime: &RuntimeEnv,` from arguments as `RuntimeEnv` can be retrieved from `TaskContext` 

## Are these changes tested?

current tests

## Are there any user-facing changes?

yes, interface in good few public methods changed

Note: if we agree that change make sense I'll refactor methods which have TaskContext and RuntimeEnv such as:

```rust
    fn try_into_projection_physical_plan(
        &self,
        projection: &protobuf::ProjectionExecNode,
        ctx: &TaskContext,
        runtime: &RuntimeEnv,
        extension_codec: &dyn PhysicalExtensionCodec,
    ) -> Result<Arc<dyn ExecutionPlan>> {
```


as task context hasn runtime env as  well