### PR TITLE
feat: Add accumulator` for `Perfect Hash Join`

### DIFF
--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -746,12 +746,20 @@ fn null_count_for_multiple_cols(values: &[ArrayRef]) -> usize {
 /// more efficient such as [`PrimitiveDistinctCountAccumulator`] and
 /// [`BytesDistinctCountAccumulator`]
 #[derive(Debug)]
-struct DistinctCountAccumulator {
+pub struct DistinctCountAccumulator {
     values: HashSet<ScalarValue, RandomState>,
     state_data_type: DataType,
 }
 
 impl DistinctCountAccumulator {
+    /// Creates new `DistinctCountAccumulator`
+    pub fn try_new(data_type: &DataType) -> Self {
+        Self {
+            values: HashSet::with_hasher(RandomState::new()),
+            state_data_type: data_type.clone(),
+        }
+    }
+
     // calculating the size for fixed length values, taking first batch size *
     // number of batches This method is faster than .full_size(), however it is
     // not suitable for variable length values like strings or complex types

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -760,6 +760,11 @@ impl DistinctCountAccumulator {
         }
     }
 
+    /// Returns the number of distinct values. Avoids the conversion from `ScalarValue` compared to `evaluate()`
+    pub fn evaluate_as_usize(&mut self) -> Result<usize> {
+        Ok(self.values.len())
+    }
+
     // calculating the size for fixed length values, taking first batch size *
     // number of batches This method is faster than .full_size(), however it is
     // not suitable for variable length values like strings or complex types

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -53,6 +53,7 @@ datafusion-common = { workspace = true, default-features = true }
 datafusion-common-runtime = { workspace = true, default-features = true }
 datafusion-execution = { workspace = true }
 datafusion-expr = { workspace = true }
+datafusion-functions-aggregate = { workspace = true }
 datafusion-functions-aggregate-common = { workspace = true }
 datafusion-functions-window-common = { workspace = true }
 datafusion-physical-expr = { workspace = true, default-features = true }

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -1548,9 +1548,9 @@ async fn collect_left_input(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    // Compute bounds for dynamic filter if enabled. At this point the bound accumulator could
-    // have been initialized for pushdown min/max, perfect hash join min/distinct,
-    // or both.
+    // Compute statistics for dynamic filter or perfect hash join if enabled. At this point 
+    // the bound accumulator could have been initialized for pushdown min/max, perfect hash 
+    // join min/distinct, or both.
     let (bounds, min_value) = match (bounds_accumulators, num_rows > 0) {
         (Some(accs), true) => {
             let mut bounds_vec =

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -1210,6 +1210,7 @@ impl OneSideHashJoiner {
             &mut self.hashes_buffer,
             self.deleted_offset,
             false,
+            None,
         )?;
         Ok(())
     }

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -1663,12 +1663,18 @@ pub fn update_hash(
     hashes_buffer: &mut Vec<u64>,
     deleted_offset: usize,
     fifo_hashmap: bool,
+    non_null_row_count: Option<&mut usize>,
 ) -> Result<()> {
     // evaluate the keys
     let keys_values = on
         .iter()
         .map(|c| c.evaluate(batch)?.into_array(batch.num_rows()))
         .collect::<Result<Vec<_>>>()?;
+
+    if let Some(null_rows) = non_null_row_count {
+        // Only need the first key because perfect hash join can only allow one join key
+        *null_rows += keys_values[0].len() - keys_values[0].null_count();
+    };
 
     // calculate the hash values
     let hash_values = create_hashes(&keys_values, random_state, hashes_buffer)?;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Mentioned by @Dandandan in a previous join discussion.

## Rationale for this change
DuckDB implements a perfect hash join https://github.com/duckdb/duckdb/pull/1959 which we can also do in datafusion.

Perfect Hash Join execution is valid under the following:
 - Inner Join
 - Single join key
 - Integer key only
 - Distinct non null values.
 
 The reason these conditions

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
This pull request only tackles changes to check if the hash join exec is valid for a perfect hash join execution. It then passes  `Some(min_value)` to 

### Inner Join, Single Join Key, Integer Key Only
 - During exec phase pass a flag to `collect_left_input` to see if the join is an inner join, single join key, and the PhysicalExpr for the join filter has an integer output.

### Distinct Non Null Values (Build side)
 - Keep a counter for the non null values as the hashmap is being updated.
 - Added distinct count accumulator alongside the current `CollectLeftAccumulatr` that is used for filter pushdown.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Adding tests a bit weird for this part. I would rather add tests with the `PerfectHashJoin` execution follow up. 
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
