### PR TITLE
fix(deps): add unicode expressions dev dependency to Substrait crate

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { workspace = true, features = ["fs"] }
 uuid = { version = "1.17.0", features = ["v4"] }
 
 [dev-dependencies]
-datafusion = { workspace = true, features = ["nested_expressions"] }
+datafusion = { workspace = true, features = ["nested_expressions", "unicode_expressions"] }
 datafusion-functions-aggregate = { workspace = true }
 serde_json = "1.0"
 tokio = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #17607.


## Rationale for this change

- When running `cargo test` directly in the `datafusion/substrait` crate, it would run into issues:

```
failures:

---- cases::roundtrip_logical_plan::simple_scalar_function_substr stdout ----
Error: NotImplemented("Substring could not be planned by registered expr planner. Hint: Please try with `unicode_expressions` DataFusion feature enabled")


failures:
    cases::roundtrip_logical_plan::simple_scalar_function_substr

test result: FAILED. 161 passed; 1 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.28s

error: test failed, to rerun pass `--test substrait_integration`
```

Which does not happen when running `cargo test` in the project root, so this may be why this was sneaky / not causing CI issues.


## What changes are included in this PR?

Just following the recommendation from the build and adding `unicode_expressions` as a dev-dependency for the `datafusion/substrait` crate.


## Are these changes tested?

Not entirely sure how to test or why this wasn't picked up by CI.

However, running `cargo test` in that folder now runs cleanly:

```
test result: ok. 162 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.27s
```

## Are there any user-facing changes?

n/a