### PR TITLE
Add support for calling async UDF as aggregation expression

### DIFF
--- a/datafusion/sqllogictest/test_files/async_udf.slt
+++ b/datafusion/sqllogictest/test_files/async_udf.slt
@@ -1,0 +1,46 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+statement ok
+create table data(x int) as values (-10), (2);
+
+# Async udf can be used in aggregation
+query I
+select min(async_abs(x)) from data;
+----
+2
+
+# Async udf can be used in aggregation with group by
+query I rowsort
+select min(async_abs(x)) from data group by async_abs(x);
+----
+10
+2
+
+# Async udf can be used in filter
+query I
+select * from data where async_abs(x) < 5;
+----
+2
+
+# Async udf can be used in projection
+query I rowsort
+select async_abs(x) from data;
+----
+10
+2

--- a/datafusion/sqllogictest/test_files/async_udf.slt
+++ b/datafusion/sqllogictest/test_files/async_udf.slt
@@ -25,6 +25,21 @@ select min(async_abs(x)) from data;
 ----
 2
 
+query TT
+explain select min(async_abs(x)) from data;
+----
+logical_plan
+01)Aggregate: groupBy=[[]], aggr=[[min(async_abs(data.x))]]
+02)--TableScan: data projection=[x]
+physical_plan
+01)AggregateExec: mode=Final, gby=[], aggr=[min(async_abs(data.x))]
+02)--CoalescePartitionsExec
+03)----AggregateExec: mode=Partial, gby=[], aggr=[min(async_abs(data.x))]
+04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+05)--------AsyncFuncExec: async_expr=[async_expr(name=__async_fn_0, expr=async_abs(x@0))]
+06)----------CoalesceBatchesExec: target_batch_size=8192
+07)------------DataSourceExec: partitions=1, partition_sizes=[1]
+
 # Async udf can be used in aggregation with group by
 query I rowsort
 select min(async_abs(x)) from data group by async_abs(x);
@@ -32,11 +47,45 @@ select min(async_abs(x)) from data group by async_abs(x);
 10
 2
 
+query TT
+explain select min(async_abs(x)) from data group by async_abs(x);
+----
+logical_plan
+01)Projection: min(async_abs(data.x))
+02)--Aggregate: groupBy=[[__common_expr_1 AS async_abs(data.x)]], aggr=[[min(__common_expr_1 AS async_abs(data.x))]]
+03)----Projection: async_abs(data.x) AS __common_expr_1
+04)------TableScan: data projection=[x]
+physical_plan
+01)ProjectionExec: expr=[min(async_abs(data.x))@1 as min(async_abs(data.x))]
+02)--AggregateExec: mode=FinalPartitioned, gby=[async_abs(data.x)@0 as async_abs(data.x)], aggr=[min(async_abs(data.x))]
+03)----CoalesceBatchesExec: target_batch_size=8192
+04)------RepartitionExec: partitioning=Hash([async_abs(data.x)@0], 4), input_partitions=4
+05)--------AggregateExec: mode=Partial, gby=[__common_expr_1@0 as async_abs(data.x)], aggr=[min(async_abs(data.x))]
+06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+07)------------ProjectionExec: expr=[__async_fn_0@1 as __common_expr_1]
+08)--------------AsyncFuncExec: async_expr=[async_expr(name=__async_fn_0, expr=async_abs(x@0))]
+09)----------------CoalesceBatchesExec: target_batch_size=8192
+10)------------------DataSourceExec: partitions=1, partition_sizes=[1]
+
 # Async udf can be used in filter
 query I
 select * from data where async_abs(x) < 5;
 ----
 2
+
+query TT
+explain select * from data where async_abs(x) < 5;
+----
+logical_plan
+01)Filter: async_abs(data.x) < Int32(5)
+02)--TableScan: data projection=[x]
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=8192
+02)--FilterExec: __async_fn_0@1 < 5, projection=[x@0]
+03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------AsyncFuncExec: async_expr=[async_expr(name=__async_fn_0, expr=async_abs(x@0))]
+05)--------CoalesceBatchesExec: target_batch_size=8192
+06)----------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Async udf can be used in projection
 query I rowsort
@@ -44,3 +93,15 @@ select async_abs(x) from data;
 ----
 10
 2
+
+query TT
+explain select async_abs(x) from data;
+----
+logical_plan
+01)Projection: async_abs(data.x)
+02)--TableScan: data projection=[x]
+physical_plan
+01)ProjectionExec: expr=[__async_fn_0@1 as async_abs(data.x)]
+02)--AsyncFuncExec: async_expr=[async_expr(name=__async_fn_0, expr=async_abs(x@0))]
+03)----CoalesceBatchesExec: target_batch_size=8192
+04)------DataSourceExec: partitions=1, partition_sizes=[1]


### PR DESCRIPTION

## Which issue does this PR close?



<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Fixes https://github.com/apache/datafusion/issues/17619
## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add support for using async UDFs as arguments to aggregation functions.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Rewrite arguments to aggregation functions so that they are executed async
- Update the sqlogictest runner so it adds a `async_abs` function
- Add slt test

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, added slt test

## Are there any user-facing changes?

Yes, async UDF can now be used in more places

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
