### PR TITLE
Revert "Always run CI checks"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -50,13 +50,6 @@ github:
     main:
       required_pull_request_reviews:
         required_approving_review_count: 1
-      required_status_checks:
-        contexts:
-          - "Check License Header"
-          - "Use prettier to check formatting of documents"
-          - "check-files"
-          # This job marks steps in `.github/workflows/rust.yml` as required
-          - "Validate Rust Required Checks"
     # needs to be updated as part of the release process
     # .asf.yaml doesn't support wildcard branch protection rules, only exact branch names
     # https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#branch-protection

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,35 +25,26 @@ on:
   push:
     branches-ignore:
       - 'gh-readonly-queue/**'
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   merge_group:
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
-  #
-  # Note, we use merge queue for this repo. If you'd like to add a new "required" check, that should be checked before
-  # the PR is merged, you should add your step to `rust-required-checks`
   workflow_dispatch:
 
 jobs:
-  # This job checks if heavy-weight jobs can be skipped, because only doc or non-code files were changed
-  # More on this: https://github.com/orgs/community/discussions/45899
-  pre-job:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          concurrent_skipping: 'never'
-          skip_after_successful_duplicate: 'false'
-          paths_ignore: '["**.md", "docs/**", ".github/ISSUE_TEMPLATE/**", ".github/pull_request_template.md"]'
-
   # Check crate compiles and base cargo check passes
   linux-build-lib:
     name: linux build test
-    needs: pre-job
-    if: needs.pre-job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -81,8 +72,7 @@ jobs:
   # subset of the features packages enabled.
   linux-datafusion-common-features:
     name: cargo check datafusion-common features
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -107,8 +97,7 @@ jobs:
   # subset of the features packages enabled.
   linux-datafusion-substrait-features:
     name: cargo check datafusion-substrait features
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -145,8 +134,7 @@ jobs:
   # subset of the features packages enabled.
   linux-datafusion-proto-features:
     name: cargo check datafusion-proto features
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -177,8 +165,7 @@ jobs:
   # subset of the features packages enabled.
   linux-cargo-check-datafusion:
     name: cargo check datafusion features
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -245,8 +232,7 @@ jobs:
   # subset of the features packages enabled.
   linux-cargo-check-datafusion-functions:
     name: cargo check datafusion-functions features
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -281,8 +267,7 @@ jobs:
   # Library and integration tests
   linux-test:
     name: cargo test (amd64)
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -298,8 +283,8 @@ jobs:
       - name: Rust Dependency Cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
         with:
-          save-if: ${{ github.ref_name == 'main' }}
-          shared-key: "amd-ci"
+         save-if: ${{ github.ref_name == 'main' }}
+         shared-key: "amd-ci"
       - name: Run tests (excluding doctests and datafusion-cli)
         env:
           RUST_BACKTRACE: 1
@@ -321,8 +306,7 @@ jobs:
   # datafusion-cli tests
   linux-test-datafusion-cli:
     name: cargo test datafusion-cli (amd64)
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     # should be uncommented once https://github.com/apache/datafusion/pull/16644 is merged
     # and cache should be added
@@ -350,8 +334,7 @@ jobs:
 
   linux-test-example:
     name: cargo examples (amd64)
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -381,8 +364,7 @@ jobs:
   # Run `cargo test doc` (test documentation examples)
   linux-test-doc:
     name: cargo test doc (amd64)
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -403,8 +385,7 @@ jobs:
   # Run `cargo doc` to ensure the rustdoc is clean
   linux-rustdoc:
     name: cargo doc
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -442,8 +423,7 @@ jobs:
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:
     name: verify benchmark results (amd64)
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -476,8 +456,7 @@ jobs:
 
   sqllogictest-postgres:
     name: "Run sqllogictest with Postgres runner"
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -515,8 +494,7 @@ jobs:
 
   sqllogictest-substrait:
     name: "Run sqllogictest in Substrait round-trip mode"
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -587,8 +565,7 @@ jobs:
 
   test-datafusion-pyarrow:
     name: cargo test pyarrow (amd64)
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust:bullseye # Use the bullseye tag image which comes with python3.9
@@ -612,8 +589,6 @@ jobs:
 
   vendor:
     name: Verify Vendored Code
-    needs: pre-job
-    if: needs.pre-job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -631,8 +606,6 @@ jobs:
 
   check-fmt:
     name: Check cargo fmt
-    needs: pre-job
-    if: needs.pre-job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -691,8 +664,7 @@ jobs:
 
   clippy:
     name: clippy
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -717,8 +689,7 @@ jobs:
 
   cargo-toml-formatting-checks:
     name: check Cargo.toml formatting
-    needs: [linux-build-lib, pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -739,8 +710,7 @@ jobs:
 
   config-docs-check:
     name: check configs.md and ***_functions.md is up-to-date
-    needs: [linux-build-lib]
-    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: linux-build-lib
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -774,8 +744,6 @@ jobs:
   # - datafusion-cli
   msrv:
     name: Verify MSRV (Min Supported Rust Version)
-    needs: [pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -824,44 +792,9 @@ jobs:
         run: cargo msrv --output-format json --log-target stdout verify
   typos:
     name: Spell Check with Typos
-    needs: [pre-job]
-    if: needs.pre-job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           persist-credentials: false
       - uses: crate-ci/typos@v1
-
-  rust-required-checks:
-    name: Validate Rust Required Checks
-    needs: [ linux-rustdoc,
-             linux-wasm-pack,
-             linux-build-lib,
-             macos-aarch64,
-             vendor,
-             check-fmt,
-             msrv,
-             linux-datafusion-common-features,
-             linux-datafusion-substrait-features,
-             linux-datafusion-proto-features,
-             linux-cargo-check-datafusion,
-             linux-cargo-check-datafusion-functions,
-             linux-test,
-             linux-test-example,
-             linux-test-doc,
-             verify-benchmark-results,
-             sqllogictest-postgres,
-             sqllogictest-substrait,
-             test-datafusion-pyarrow,
-             clippy,
-             cargo-toml-formatting-checks,
-             linux-test-datafusion-cli,
-             config-docs-check
-    ]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-      - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'
-


### PR DESCRIPTION
Reverts apache/datafusion#17538


Sadly, got one more unexpected error that didn't come up during testing: 


<img width="1227" height="369" alt="Zen Browser 2025-09-17 12 03 37" src="https://github.com/user-attachments/assets/3485bec1-2ad4-4311-b376-46f00117ee71" />


Just pinged the infra team to unblock us so we can merge this