### PR TITLE
minor: Ensure `datafusion-sql` package dependencies have `sql` flag

### DIFF
--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -63,7 +63,7 @@ ctor = { workspace = true }
 # please do not move these dependencies to the main dependencies section
 datafusion-functions = { workspace = true, default-features = true }
 datafusion-functions-aggregate = { workspace = true }
-datafusion-functions-nested = { workspace = true }
+datafusion-functions-nested = { workspace = true, features = ["sql"] }
 datafusion-functions-window = { workspace = true }
 env_logger = { workspace = true }
 insta = { workspace = true }


### PR DESCRIPTION
If trying to run tests on `datafusion-sql` alone, currently running into build errors:

```bash
datafusion$ cargo test -p datafusion-sql
   Compiling datafusion-functions-nested v50.0.0 (/Users/jeffrey/Code/datafusion/datafusion/functions-nested)
error[E0308]: mismatched types
  --> datafusion/functions-nested/src/planner.rs:58:18
   |
58 |         if op == BinaryOperator::StringConcat {
   |            --    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `BinaryOperator`, found `Operator`
   |            |
   |            expected because this is `BinaryOperator`

error[E0308]: mismatched types
  --> datafusion/functions-nested/src/planner.rs:82:32
   |
82 |         } else if matches!(op, BinaryOperator::AtArrow | BinaryOperator::ArrowAt) {
   |                            --  ^^^^^^^^^^^^^^^^^^^^^^^ expected `BinaryOperator`, found `Operator`
   |                            |
   |                            this expression has type `BinaryOperator`

error[E0308]: mismatched types
  --> datafusion/functions-nested/src/planner.rs:82:58
   |
82 |         } else if matches!(op, BinaryOperator::AtArrow | BinaryOperator::ArrowAt) {
   |                            --                            ^^^^^^^^^^^^^^^^^^^^^^^ expected `BinaryOperator`, found `Operator`
   |                            |
   |                            this expression has type `BinaryOperator`

error[E0308]: mismatched types
  --> datafusion/functions-nested/src/planner.rs:89:26
   |
89 |                 if op == BinaryOperator::AtArrow {
   |                    --    ^^^^^^^^^^^^^^^^^^^^^^^ expected `BinaryOperator`, found `Operator`
   |                    |
   |                    expected because this is `BinaryOperator`

error[E0308]: mismatched types
   --> datafusion/functions-nested/src/planner.rs:126:23
    |
126 |         if expr.op == BinaryOperator::Eq {
    |            -------    ^^^^^^^^^^^^^^^^^^ expected `BinaryOperator`, found `Operator`
    |            |
    |            expected because this is `BinaryOperator`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `datafusion-functions-nested` (lib) due to 5 previous errors
```

Need to ensure `datafusion-functions-nested` in dev-dependencies has `sql` feature flag enabled so can successfully run `datafusion-sql` tests.

Reference: #17332