### PR TITLE
minor: Ensure `proto` crate has datetime & unicode expr flags in datafusion dev dependency

### DIFF
--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -57,7 +57,7 @@ serde = { version = "1.0", optional = true }
 serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
-datafusion = { workspace = true, default-features = false, features = ["sql"] }
+datafusion = { workspace = true, default-features = false, features = ["sql", "datetime_expressions", "unicode_expressions"] }
 datafusion-functions = { workspace = true, default-features = true }
 datafusion-functions-aggregate = { workspace = true }
 datafusion-functions-window-common = { workspace = true }


### PR DESCRIPTION
Running cargo test on proto crate alone is not succeeding on main:

```shell
datafusion$ cargo test -p datafusion-proto
   Compiling datafusion-proto v50.0.0 (/Users/jeffrey/Code/datafusion/datafusion/proto)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.45s
     Running unittests src/lib.rs (/Users/jeffrey/.cargo_target_cache/debug/deps/datafusion_proto-cb229ee6e416f3eb)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/proto_integration.rs (/Users/jeffrey/.cargo_target_cache/debug/deps/proto_integration-6481a41df0f2e420)

running 126 tests
test cases::roundtrip_logical_plan::round_trip_scalar_types ... ok
...
test cases::roundtrip_physical_plan::test_round_trip_date_part_display ... FAILED
test cases::roundtrip_physical_plan::test_round_trip_groups_display ... ok
test cases::roundtrip_physical_plan::roundtrip_sym_hash_join ... ok
test cases::roundtrip_physical_plan::test_round_trip_human_display ... ok
test cases::roundtrip_logical_plan::roundtrip_expr_api ... ok
test cases::serialize::bad_decode - should panic ... ok
test cases::serialize::udf_roundtrip_without_registry - should panic ... ok
test cases::serialize::roundtrip_deeply_nested ... ok
test cases::roundtrip_physical_plan::test_round_trip_tpch_queries ... FAILED
test cases::roundtrip_physical_plan::test_serialize_deserialize_tpch_queries ... FAILED
test cases::serialize::roundtrip_deeply_nested_binary_expr ... ok

failures:

---- cases::roundtrip_physical_plan::test_round_trip_date_part_display stdout ----
Error: NotImplemented("Extract not supported by ExprPlanner: [Literal(Utf8(\"YEAR\"), None), Column(Column { relation: Some(Bare { table: \"lineitem\" }), name: \"l_shipdate\" })]")

---- cases::roundtrip_physical_plan::test_round_trip_tpch_queries stdout ----
Error: NotImplemented("Extract not supported by ExprPlanner: [Literal(Utf8(\"YEAR\"), None), Column(Column { relation: Some(Bare { table: \"lineitem\" }), name: \"l_shipdate\" })]")

---- cases::roundtrip_physical_plan::test_serialize_deserialize_tpch_queries stdout ----
Error: NotImplemented("Extract not supported by ExprPlanner: [Literal(Utf8(\"YEAR\"), None), Column(Column { relation: Some(Bare { table: \"lineitem\" }), name: \"l_shipdate\" })]")


failures:
    cases::roundtrip_physical_plan::test_round_trip_date_part_display
    cases::roundtrip_physical_plan::test_round_trip_tpch_queries
    cases::roundtrip_physical_plan::test_serialize_deserialize_tpch_queries

test result: FAILED. 123 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s

error: test failed, to rerun pass `-p datafusion-proto --test proto_integration`
```

Needs to ensure the datetime & unicode planners are being added as defaults from core here:

https://github.com/apache/datafusion/blob/d587b8d3b7a0c0e943055de7576a06c45a383388/datafusion/core/src/execution/session_state_defaults.rs#L84-L102