### PR TITLE
Reduce cloning in LogicalPlanBuilder

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -1349,17 +1349,15 @@ impl DefaultPhysicalPlanner {
                     let (left, left_col_keys, left_projected) =
                         wrap_projection_for_join_if_necessary(
                             &left_keys,
-                            original_left.as_ref().clone(),
+                            Arc::clone(original_left),
                         )?;
                     let (right, right_col_keys, right_projected) =
                         wrap_projection_for_join_if_necessary(
                             &right_keys,
-                            original_right.as_ref().clone(),
+                            Arc::clone(original_right),
                         )?;
-                    let column_on = (left_col_keys, right_col_keys);
 
-                    let left = Arc::new(left);
-                    let right = Arc::new(right);
+                    let column_on = (left_col_keys, right_col_keys);
                     let (new_join, requalified) = Join::try_new_with_project_input(
                         node,
                         Arc::clone(&left),

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -1354,17 +1354,15 @@ impl DefaultPhysicalPlanner {
                     let (left, left_col_keys, left_projected) =
                         wrap_projection_for_join_if_necessary(
                             &left_keys,
-                            original_left.as_ref().clone(),
+                            Arc::clone(original_left),
                         )?;
                     let (right, right_col_keys, right_projected) =
                         wrap_projection_for_join_if_necessary(
                             &right_keys,
-                            original_right.as_ref().clone(),
+                            Arc::clone(original_right),
                         )?;
-                    let column_on = (left_col_keys, right_col_keys);
 
-                    let left = Arc::new(left);
-                    let right = Arc::new(right);
+                    let column_on = (left_col_keys, right_col_keys);
                     let (new_join, requalified) = Join::try_new_with_project_input(
                         node,
                         Arc::clone(&left),

--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -41,7 +41,7 @@ pub use order_by::rewrite_sort_cols_by_aggs;
 
 /// Trait for rewriting [`Expr`]s into function calls.
 ///
-/// This trait is used with `FunctionRegistry::register_function_rewrite` to
+/// This trait is used with `FunctionRegistry::register_function_rewrite`
 /// to evaluating `Expr`s using functions that may not be built in to DataFusion
 ///
 /// For example, concatenating arrays `a || b` is represented as
@@ -49,7 +49,7 @@ pub use order_by::rewrite_sort_cols_by_aggs;
 /// `array_concat` from the `functions-nested` crate.
 // This is not used in datafusion internally, but it is still helpful for downstream project so don't remove it.
 pub trait FunctionRewrite: Debug {
-    /// Return a human readable name for this rewrite
+    /// Return a human-readable name for this rewrite
     fn name(&self) -> &str;
 
     /// Potentially rewrite `expr` to some other expression
@@ -222,26 +222,30 @@ pub fn strip_outer_reference(expr: Expr) -> Expr {
 /// Returns plan with expressions coerced to types compatible with
 /// schema types
 pub fn coerce_plan_expr_for_schema(
-    plan: LogicalPlan,
+    plan: impl Into<Arc<LogicalPlan>>,
     schema: &DFSchema,
-) -> Result<LogicalPlan> {
-    match plan {
+) -> Result<Arc<LogicalPlan>> {
+    let plan = plan.into();
+    if matches!(plan.as_ref(), LogicalPlan::Projection(_)) {
         // special case Projection to avoid adding multiple projections
-        LogicalPlan::Projection(Projection { expr, input, .. }) => {
-            let new_exprs = coerce_exprs_for_schema(expr, input.schema(), schema)?;
-            let projection = Projection::try_new(new_exprs, input)?;
-            Ok(LogicalPlan::Projection(projection))
-        }
-        _ => {
-            let exprs: Vec<Expr> = plan.schema().iter().map(Expr::from).collect();
-            let new_exprs = coerce_exprs_for_schema(exprs, plan.schema(), schema)?;
-            let add_project = new_exprs.iter().any(|expr| expr.try_as_col().is_none());
-            if add_project {
-                let projection = Projection::try_new(new_exprs, Arc::new(plan))?;
-                Ok(LogicalPlan::Projection(projection))
-            } else {
-                Ok(plan)
-            }
+        let LogicalPlan::Projection(Projection { expr, input, .. }) =
+            Arc::unwrap_or_clone(plan)
+        else {
+            unreachable!()
+        };
+
+        let new_exprs = coerce_exprs_for_schema(expr, input.schema(), schema)?;
+        let projection = Projection::try_new(new_exprs, input)?;
+        Ok(Arc::new(LogicalPlan::Projection(projection)))
+    } else {
+        let exprs: Vec<Expr> = plan.schema().iter().map(Expr::from).collect();
+        let new_exprs = coerce_exprs_for_schema(exprs, plan.schema(), schema)?;
+        let add_project = new_exprs.iter().any(|expr| expr.try_as_col().is_none());
+        if add_project {
+            let projection = Projection::try_new(new_exprs, plan)?;
+            Ok(Arc::new(LogicalPlan::Projection(projection)))
+        } else {
+            Ok(plan)
         }
     }
 }
@@ -445,7 +449,7 @@ mod test {
     fn normalize_cols() {
         let expr = col("a") + col("b") + col("c");
 
-        // Schemas with some matching and some non matching cols
+        // Schemas with some matching and some non-matching cols
         let schema_a = make_schema_with_empty_metadata(
             vec![Some("tableA".into()), Some("tableA".into())],
             vec!["a", "aa"],

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -61,7 +61,9 @@ use datafusion_common::{
 };
 use datafusion_expr_common::type_coercion::binary::type_union_resolution;
 
+use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use indexmap::IndexSet;
+use itertools::Itertools;
 
 /// Default table name for unnamed table
 pub const UNNAMED_TABLE: &str = "?table?";
@@ -176,9 +178,10 @@ impl LogicalPlanBuilder {
     pub fn to_recursive_query(
         self,
         name: String,
-        recursive_term: LogicalPlan,
+        recursive_term: impl Into<Arc<LogicalPlan>>,
         is_distinct: bool,
     ) -> Result<Self> {
+        let recursive_term = recursive_term.into();
         // Ensure that the static term and the recursive term have the same number of fields
         let static_fields_len = self.plan.schema().fields().len();
         let recursive_fields_len = recursive_term.schema().fields().len();
@@ -195,7 +198,7 @@ impl LogicalPlanBuilder {
         let recursive_query = RecursiveQuery::try_new(
             name,
             self.plan,
-            Arc::new(coerced_recursive_term),
+            coerced_recursive_term,
             is_distinct,
         )?;
         Ok(Self::from(LogicalPlan::RecursiveQuery(recursive_query)))
@@ -207,7 +210,7 @@ impl LogicalPlanBuilder {
     ///
     /// so it's usually better to override the default names with a table alias list.
     ///
-    /// If the values include params/binders such as $1, $2, $3, etc, then the `param_data_types` should be provided.
+    /// If the values include params/binders such as $1, $2, $3, etc. then the `param_data_types` should be provided.
     pub fn values(values: Vec<Vec<Expr>>) -> Result<Self> {
         if values.is_empty() {
             return plan_err!("Values list cannot be empty");
@@ -239,7 +242,7 @@ impl LogicalPlanBuilder {
     /// The column names are not specified by the SQL standard and different database systems do it differently,
     /// so it's usually better to override the default names with a table alias list.
     ///
-    /// If the values include params/binders such as $1, $2, $3, etc, then the `param_data_types` should be provided.
+    /// If the values include params/binders such as $1, $2, $3, etc. then the `param_data_types` should be provided.
     pub fn values_with_schema(
         values: Vec<Vec<Expr>>,
         schema: &DFSchemaRef,
@@ -420,14 +423,14 @@ impl LogicalPlanBuilder {
 
     /// Create a [CopyTo] for copying the contents of this builder to the specified file(s)
     pub fn copy_to(
-        input: LogicalPlan,
+        input: impl Into<Arc<LogicalPlan>>,
         output_url: String,
         file_type: Arc<dyn FileType>,
         options: HashMap<String, String>,
         partition_by: Vec<String>,
     ) -> Result<Self> {
         Ok(Self::new(LogicalPlan::Copy(CopyTo::new(
-            Arc::new(input),
+            input.into(),
             output_url,
             partition_by,
             file_type,
@@ -469,7 +472,7 @@ impl LogicalPlanBuilder {
     /// # }
     /// ```
     pub fn insert_into(
-        input: LogicalPlan,
+        input: impl Into<Arc<LogicalPlan>>,
         table_name: impl Into<TableReference>,
         target: Arc<dyn TableSource>,
         insert_op: InsertOp,
@@ -478,7 +481,7 @@ impl LogicalPlanBuilder {
             table_name.into(),
             target,
             WriteOp::Insert(insert_op),
-            Arc::new(input),
+            input.into(),
         ))))
     }
 
@@ -551,10 +554,10 @@ impl LogicalPlanBuilder {
 
     /// Wrap a plan in a window
     pub fn window_plan(
-        input: LogicalPlan,
+        input: impl Into<Arc<LogicalPlan>>,
         window_exprs: impl IntoIterator<Item = Expr>,
     ) -> Result<LogicalPlan> {
-        let mut plan = input;
+        let mut plan = input.into();
         let mut groups = group_window_expr_by_sort_keys(window_exprs)?;
         // To align with the behavior of PostgreSQL, we want the sort_keys sorted as same rule as PostgreSQL that first
         // we compare the sort key themselves and if one window's sort keys are a prefix of another
@@ -576,15 +579,17 @@ impl LogicalPlanBuilder {
             }
             key_b.len().cmp(&key_a.len())
         });
+
         for (_, exprs) in groups {
             let window_exprs = exprs.into_iter().collect::<Vec<_>>();
             // Partition and sorting is done at physical level, see the EnforceDistribution
             // and EnforceSorting rules.
             plan = LogicalPlanBuilder::from(plan)
                 .window(window_exprs)?
-                .build()?;
+                .build_arc()?;
         }
-        Ok(plan)
+
+        Ok(Arc::unwrap_or_clone(plan))
     }
 
     /// Apply a projection without alias.
@@ -592,7 +597,7 @@ impl LogicalPlanBuilder {
         self,
         expr: impl IntoIterator<Item = impl Into<SelectExpr>>,
     ) -> Result<Self> {
-        project(Arc::unwrap_or_clone(self.plan), expr).map(Self::new)
+        project(self.plan, expr).map(Self::new)
     }
 
     /// Apply a projection without alias with optional validation
@@ -685,7 +690,7 @@ impl LogicalPlanBuilder {
 
     /// Apply an alias
     pub fn alias(self, alias: impl Into<TableReference>) -> Result<Self> {
-        subquery_alias(Arc::unwrap_or_clone(self.plan), alias).map(Self::new)
+        subquery_alias(self.plan, alias).map(Self::new)
     }
 
     /// Add missing sort columns to all downstream projection
@@ -720,43 +725,43 @@ impl LogicalPlanBuilder {
         curr_plan: LogicalPlan,
         missing_cols: &IndexSet<Column>,
         is_distinct: bool,
-    ) -> Result<LogicalPlan> {
+    ) -> Result<Transformed<LogicalPlan>> {
         match curr_plan {
             LogicalPlan::Projection(Projection {
                 input,
                 mut expr,
-                schema: _,
+                schema,
             }) if missing_cols.iter().all(|c| input.schema().has_column(c)) => {
-                let mut missing_exprs = missing_cols
+                let missing_exprs: Vec<Expr> = missing_cols
                     .iter()
                     .map(|c| normalize_col(Expr::Column(c.clone()), &input))
-                    .collect::<Result<Vec<_>>>()?;
+                    // Do not let duplicate columns to be added, some of the
+                    // missing_cols may be already present but without the new
+                    // projected alias.
+                    .filter_ok(|e| !expr.contains(e))
+                    .try_collect()?;
 
-                // Do not let duplicate columns to be added, some of the
-                // missing_cols may be already present but without the new
-                // projected alias.
-                missing_exprs.retain(|e| !expr.contains(e));
                 if is_distinct {
                     Self::ambiguous_distinct_check(&missing_exprs, missing_cols, &expr)?;
                 }
-                expr.extend(missing_exprs);
-                project(Arc::unwrap_or_clone(input), expr)
+
+                if missing_exprs.is_empty() {
+                    Ok(Transformed::no(LogicalPlan::Projection(Projection {
+                        input,
+                        expr,
+                        schema,
+                    })))
+                } else {
+                    expr.extend(missing_exprs);
+                    project(input, expr).map(Transformed::yes)
+                }
             }
             _ => {
                 let is_distinct =
                     is_distinct || matches!(curr_plan, LogicalPlan::Distinct(_));
-                let new_inputs = curr_plan
-                    .inputs()
-                    .into_iter()
-                    .map(|input_plan| {
-                        Self::add_missing_columns(
-                            (*input_plan).clone(),
-                            missing_cols,
-                            is_distinct,
-                        )
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                curr_plan.with_new_exprs(curr_plan.expressions(), new_inputs)
+                curr_plan.map_children(|input| {
+                    Self::add_missing_columns(input, missing_cols, is_distinct)
+                })
             }
         }
     }
@@ -854,13 +859,13 @@ impl LogicalPlanBuilder {
 
         // remove pushed down sort columns
         let new_expr = schema.columns().into_iter().map(Expr::Column).collect();
-
         let is_distinct = false;
         let plan = Self::add_missing_columns(
             Arc::unwrap_or_clone(self.plan),
             &missing_cols,
             is_distinct,
-        )?;
+        )
+        .data()?;
 
         let sort_plan = LogicalPlan::Sort(Sort {
             expr: normalize_sorts(sorts, &plan)?,
@@ -874,36 +879,33 @@ impl LogicalPlanBuilder {
     }
 
     /// Apply a union, preserving duplicate rows
-    pub fn union(self, plan: LogicalPlan) -> Result<Self> {
-        union(Arc::unwrap_or_clone(self.plan), plan).map(Self::new)
+    pub fn union(self, plan: impl Into<Arc<LogicalPlan>>) -> Result<Self> {
+        union(self.plan, plan).map(Self::new)
     }
 
     /// Apply a union by name, preserving duplicate rows
-    pub fn union_by_name(self, plan: LogicalPlan) -> Result<Self> {
-        union_by_name(Arc::unwrap_or_clone(self.plan), plan).map(Self::new)
+    pub fn union_by_name(self, plan: impl Into<Arc<LogicalPlan>>) -> Result<Self> {
+        union_by_name(self.plan, plan).map(Self::new)
     }
 
     /// Apply a union by name, removing duplicate rows
-    pub fn union_by_name_distinct(self, plan: LogicalPlan) -> Result<Self> {
-        let left_plan: LogicalPlan = Arc::unwrap_or_clone(self.plan);
-        let right_plan: LogicalPlan = plan;
-
+    pub fn union_by_name_distinct(
+        self,
+        plan: impl Into<Arc<LogicalPlan>>,
+    ) -> Result<Self> {
         Ok(Self::new(LogicalPlan::Distinct(Distinct::All(Arc::new(
-            union_by_name(left_plan, right_plan)?,
+            union_by_name(self.plan, plan)?,
         )))))
     }
 
     /// Apply a union, removing duplicate rows
-    pub fn union_distinct(self, plan: LogicalPlan) -> Result<Self> {
-        let left_plan: LogicalPlan = Arc::unwrap_or_clone(self.plan);
-        let right_plan: LogicalPlan = plan;
-
+    pub fn union_distinct(self, plan: impl Into<Arc<LogicalPlan>>) -> Result<Self> {
         Ok(Self::new(LogicalPlan::Distinct(Distinct::All(Arc::new(
-            union(left_plan, right_plan)?,
+            union(self.plan, plan)?,
         )))))
     }
 
-    /// Apply deduplication: Only distinct (different) values are returned)
+    /// Apply deduplication: Only distinct (different) values are returned
     pub fn distinct(self) -> Result<Self> {
         Ok(Self::new(LogicalPlan::Distinct(Distinct::All(self.plan))))
     }
@@ -936,7 +938,7 @@ impl LogicalPlanBuilder {
     /// Note that in case of outer join, the `filter` is applied to only matched rows.
     pub fn join(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         join_keys: (Vec<impl Into<Column>>, Vec<impl Into<Column>>),
         filter: Option<Expr>,
@@ -992,7 +994,7 @@ impl LogicalPlanBuilder {
     /// ```
     pub fn join_on(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         on_exprs: impl IntoIterator<Item = Expr>,
     ) -> Result<Self> {
@@ -1030,7 +1032,7 @@ impl LogicalPlanBuilder {
     /// The `null_equality` dictates how `null` values are joined.
     pub fn join_detailed(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         join_keys: (Vec<impl Into<Column>>, Vec<impl Into<Column>>),
         filter: Option<Expr>,
@@ -1048,7 +1050,7 @@ impl LogicalPlanBuilder {
 
     pub fn join_detailed_with_options(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         join_keys: (Vec<impl Into<Column>>, Vec<impl Into<Column>>),
         filter: Option<Expr>,
@@ -1059,6 +1061,7 @@ impl LogicalPlanBuilder {
             return plan_err!("left_keys and right_keys were not the same length");
         }
 
+        let right = right.into();
         let filter = if let Some(expr) = filter {
             let filter = normalize_col_with_schemas_and_ambiguity_check(
                 expr,
@@ -1164,7 +1167,7 @@ impl LogicalPlanBuilder {
 
         Ok(Self::new(LogicalPlan::Join(Join {
             left: self.plan,
-            right: Arc::new(right),
+            right,
             on,
             filter,
             join_type,
@@ -1178,10 +1181,11 @@ impl LogicalPlanBuilder {
     /// Apply a join with using constraint, which duplicates all join columns in output schema.
     pub fn join_using(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         using_keys: Vec<Column>,
     ) -> Result<Self> {
+        let right = right.into();
         let left_keys: Vec<Column> = using_keys
             .clone()
             .into_iter()
@@ -1239,7 +1243,7 @@ impl LogicalPlanBuilder {
         } else {
             let join = Join::try_new(
                 self.plan,
-                Arc::new(right),
+                right,
                 join_on,
                 filters,
                 join_type,
@@ -1253,10 +1257,10 @@ impl LogicalPlanBuilder {
     }
 
     /// Apply a cross join
-    pub fn cross_join(self, right: LogicalPlan) -> Result<Self> {
+    pub fn cross_join(self, right: impl Into<Arc<LogicalPlan>>) -> Result<Self> {
         let join = Join::try_new(
             self.plan,
-            Arc::new(right),
+            right.into(),
             vec![],
             None,
             JoinType::Inner,
@@ -1360,8 +1364,8 @@ impl LogicalPlanBuilder {
 
     /// Process intersect set operator
     pub fn intersect(
-        left_plan: LogicalPlan,
-        right_plan: LogicalPlan,
+        left_plan: impl Into<Arc<LogicalPlan>>,
+        right_plan: impl Into<Arc<LogicalPlan>>,
         is_all: bool,
     ) -> Result<LogicalPlan> {
         LogicalPlanBuilder::intersect_or_except(
@@ -1374,8 +1378,8 @@ impl LogicalPlanBuilder {
 
     /// Process except set operator
     pub fn except(
-        left_plan: LogicalPlan,
-        right_plan: LogicalPlan,
+        left_plan: impl Into<Arc<LogicalPlan>>,
+        right_plan: impl Into<Arc<LogicalPlan>>,
         is_all: bool,
     ) -> Result<LogicalPlan> {
         LogicalPlanBuilder::intersect_or_except(
@@ -1388,11 +1392,13 @@ impl LogicalPlanBuilder {
 
     /// Process intersect or except
     fn intersect_or_except(
-        left_plan: LogicalPlan,
-        right_plan: LogicalPlan,
+        left_plan: impl Into<Arc<LogicalPlan>>,
+        right_plan: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         is_all: bool,
     ) -> Result<LogicalPlan> {
+        let left_plan = left_plan.into();
+        let right_plan = right_plan.into();
         let left_len = left_plan.schema().fields().len();
         let right_len = right_plan.schema().fields().len();
 
@@ -1418,8 +1424,8 @@ impl LogicalPlanBuilder {
             .zip(right_plan.schema().fields().iter())
             .map(|(left_field, right_field)| {
                 (
-                    (Column::from_name(left_field.name())),
-                    (Column::from_name(right_field.name())),
+                    Column::from_name(left_field.name()),
+                    Column::from_name(right_field.name()),
                 )
             })
             .unzip();
@@ -1452,13 +1458,18 @@ impl LogicalPlanBuilder {
         Ok(Arc::unwrap_or_clone(self.plan))
     }
 
+    /// Build the plan into an Arc
+    pub fn build_arc(self) -> Result<Arc<LogicalPlan>> {
+        Ok(self.plan)
+    }
+
     /// Apply a join with both explicit equijoin and non equijoin predicates.
     ///
     /// Note this is a low level API that requires identifying specific
     /// predicate types. Most users should use  [`join_on`](Self::join_on) that
     /// automatically identifies predicates appropriately.
     ///
-    /// `equi_exprs` defines equijoin predicates, of the form `l = r)` for each
+    /// `equi_exprs` defines equijoin predicates, of the form `l = r` for each
     /// `(l, r)` tuple. `l`, the first element of the tuple, must only refer
     /// to columns from the existing input. `r`, the second element of the tuple,
     /// must only refer to columns from the right input.
@@ -1468,7 +1479,7 @@ impl LogicalPlanBuilder {
     /// than the filter expressions, so they are preferred.
     pub fn join_with_expr_keys(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         equi_exprs: (Vec<impl Into<Expr>>, Vec<impl Into<Expr>>),
         filter: Option<Expr>,
@@ -1477,6 +1488,7 @@ impl LogicalPlanBuilder {
             return plan_err!("left_keys and right_keys were not the same length");
         }
 
+        let right = right.into();
         let join_key_pairs = equi_exprs
             .0
             .into_iter()
@@ -1515,7 +1527,7 @@ impl LogicalPlanBuilder {
 
         let join = Join::try_new(
             self.plan,
-            Arc::new(right),
+            right,
             join_key_pairs,
             filter,
             join_type,
@@ -1529,7 +1541,7 @@ impl LogicalPlanBuilder {
 
     /// Unnest the given column.
     pub fn unnest_column(self, column: impl Into<Column>) -> Result<Self> {
-        unnest(Arc::unwrap_or_clone(self.plan), vec![column.into()]).map(Self::new)
+        unnest(self.plan, vec![column.into()]).map(Self::new)
     }
 
     /// Unnest the given column given [`UnnestOptions`]
@@ -1538,12 +1550,7 @@ impl LogicalPlanBuilder {
         column: impl Into<Column>,
         options: UnnestOptions,
     ) -> Result<Self> {
-        unnest_with_options(
-            Arc::unwrap_or_clone(self.plan),
-            vec![column.into()],
-            options,
-        )
-        .map(Self::new)
+        unnest_with_options(self.plan, vec![column.into()], options).map(Self::new)
     }
 
     /// Unnest the given columns with the given [`UnnestOptions`]
@@ -1552,8 +1559,7 @@ impl LogicalPlanBuilder {
         columns: Vec<Column>,
         options: UnnestOptions,
     ) -> Result<Self> {
-        unnest_with_options(Arc::unwrap_or_clone(self.plan), columns, options)
-            .map(Self::new)
+        unnest_with_options(self.plan, columns, options).map(Self::new)
     }
 }
 
@@ -1907,7 +1913,7 @@ pub fn validate_unique_names<'a>(
 
 /// Union two [`LogicalPlan`]s.
 ///
-/// Constructs the UNION plan, but does not perform type-coercion. Therefore the
+/// Constructs the UNION plan, but does not perform type-coercion. Therefore, the
 /// subtree expressions will not be properly typed until the optimizer pass.
 ///
 /// If a properly typed UNION plan is needed, refer to [`TypeCoercionRewriter::coerce_union`]
@@ -1916,22 +1922,25 @@ pub fn validate_unique_names<'a>(
 ///
 /// [`TypeCoercionRewriter::coerce_union`]: https://docs.rs/datafusion-optimizer/latest/datafusion_optimizer/analyzer/type_coercion/struct.TypeCoercionRewriter.html#method.coerce_union
 /// [`coerce_union_schema`]: https://docs.rs/datafusion-optimizer/latest/datafusion_optimizer/analyzer/type_coercion/fn.coerce_union_schema.html
-pub fn union(left_plan: LogicalPlan, right_plan: LogicalPlan) -> Result<LogicalPlan> {
+pub fn union(
+    left_plan: impl Into<Arc<LogicalPlan>>,
+    right_plan: impl Into<Arc<LogicalPlan>>,
+) -> Result<LogicalPlan> {
     Ok(LogicalPlan::Union(Union::try_new_with_loose_types(vec![
-        Arc::new(left_plan),
-        Arc::new(right_plan),
+        left_plan.into(),
+        right_plan.into(),
     ])?))
 }
 
 /// Like [`union`], but combine rows from different tables by name, rather than
 /// by position.
 pub fn union_by_name(
-    left_plan: LogicalPlan,
-    right_plan: LogicalPlan,
+    left_plan: impl Into<Arc<LogicalPlan>>,
+    right_plan: impl Into<Arc<LogicalPlan>>,
 ) -> Result<LogicalPlan> {
     Ok(LogicalPlan::Union(Union::try_new_by_name(vec![
-        Arc::new(left_plan),
-        Arc::new(right_plan),
+        left_plan.into(),
+        right_plan.into(),
     ])?))
 }
 
@@ -1941,7 +1950,7 @@ pub fn union_by_name(
 /// * Two or more expressions have the same name
 /// * An invalid expression is used (e.g. a `sort` expression)
 pub fn project(
-    plan: LogicalPlan,
+    plan: impl Into<Arc<LogicalPlan>>,
     expr: impl IntoIterator<Item = impl Into<SelectExpr>>,
 ) -> Result<LogicalPlan> {
     project_with_validation(plan, expr.into_iter().map(|e| (e, true)), None)
@@ -1955,10 +1964,11 @@ pub fn project(
 /// * Two or more expressions have the same name
 /// * An invalid expression is used (e.g. a `sort` expression)
 fn project_with_validation(
-    plan: LogicalPlan,
+    plan: impl Into<Arc<LogicalPlan>>,
     expr: impl IntoIterator<Item = (impl Into<SelectExpr>, bool)>,
     schema: Option<&DFSchemaRef>,
 ) -> Result<LogicalPlan> {
+    let plan = plan.into();
     let mut projected_expr = vec![];
     let mut has_wildcard = false;
     for (e, validate) in expr {
@@ -2035,8 +2045,7 @@ fn project_with_validation(
     }
 
     validate_unique_names("Projections", projected_expr.iter())?;
-
-    Projection::try_new(projected_expr, Arc::new(plan)).map(LogicalPlan::Projection)
+    Projection::try_new(projected_expr, plan).map(LogicalPlan::Projection)
 }
 
 /// If there is a REPLACE statement in the projected expression in the form of
@@ -2063,10 +2072,10 @@ fn replace_columns(
 
 /// Create a SubqueryAlias to wrap a LogicalPlan.
 pub fn subquery_alias(
-    plan: LogicalPlan,
+    plan: impl Into<Arc<LogicalPlan>>,
     alias: impl Into<TableReference>,
 ) -> Result<LogicalPlan> {
-    SubqueryAlias::try_new(Arc::new(plan), alias).map(LogicalPlan::SubqueryAlias)
+    SubqueryAlias::try_new(plan.into(), alias).map(LogicalPlan::SubqueryAlias)
 }
 
 /// Create a LogicalPlanBuilder representing a scan of a table with the provided name and schema.
@@ -2142,8 +2151,9 @@ pub fn table_source_with_constraints(
 /// Wrap projection for a plan, if the join keys contains normal expression.
 pub fn wrap_projection_for_join_if_necessary(
     join_keys: &[Expr],
-    input: LogicalPlan,
-) -> Result<(LogicalPlan, Vec<Column>, bool)> {
+    input: impl Into<Arc<LogicalPlan>>,
+) -> Result<(Arc<LogicalPlan>, Vec<Column>, bool)> {
+    let input = input.into();
     let input_schema = input.schema();
     let alias_join_keys: Vec<Expr> = join_keys
         .iter()
@@ -2184,7 +2194,7 @@ pub fn wrap_projection_for_join_if_necessary(
 
         LogicalPlanBuilder::from(input)
             .project(projection.into_iter().map(SelectExpr::from))?
-            .build()?
+            .build_arc()?
     } else {
         input
     };
@@ -2245,7 +2255,10 @@ impl TableSource for LogicalTableSource {
 }
 
 /// Create a [`LogicalPlan::Unnest`] plan
-pub fn unnest(input: LogicalPlan, columns: Vec<Column>) -> Result<LogicalPlan> {
+pub fn unnest(
+    input: impl Into<Arc<LogicalPlan>>,
+    columns: Vec<Column>,
+) -> Result<LogicalPlan> {
     unnest_with_options(input, columns, UnnestOptions::default())
 }
 
@@ -2261,8 +2274,8 @@ pub fn get_struct_unnested_columns(
 
 /// Create a [`LogicalPlan::Unnest`] plan with options
 /// This function receive a list of columns to be unnested
-/// because multiple unnest can be performed on the same column (e.g unnest with different depth)
-/// The new schema will contains post-unnest fields replacing the original field
+/// because multiple unnest can be performed on the same column (e.g. unnest with different depth)
+/// The new schema will contain post-unnest fields replacing the original field
 ///
 /// For example:
 /// Input schema as
@@ -2289,12 +2302,12 @@ pub fn get_struct_unnested_columns(
 /// +---------+---------+---------------------+---------------------+
 /// ```
 pub fn unnest_with_options(
-    input: LogicalPlan,
+    input: impl Into<Arc<LogicalPlan>>,
     columns_to_unnest: Vec<Column>,
     options: UnnestOptions,
 ) -> Result<LogicalPlan> {
     Ok(LogicalPlan::Unnest(Unnest::try_new(
-        Arc::new(input),
+        input.into(),
         columns_to_unnest,
         options,
     )?))
@@ -2302,12 +2315,12 @@ pub fn unnest_with_options(
 
 #[cfg(test)]
 mod tests {
-    use std::vec;
-
     use super::*;
     use crate::lit_with_metadata;
     use crate::logical_plan::StringifiedPlan;
-    use crate::{col, expr, expr_fn::exists, in_subquery, scalar_subquery};
+    use crate::{col, expr, expr_fn::exists, in_subquery, lit, scalar_subquery};
+    use arrow::datatypes::Schema;
+    use std::vec;
 
     use crate::test::function_stub::sum;
     use datafusion_common::{
@@ -2669,7 +2682,7 @@ mod tests {
         ");
 
         // Check unnested field is a scalar
-        let field = plan.schema().field_with_name(None, "strings").unwrap();
+        let field = plan.schema().field_with_name(None, "strings")?;
         assert_eq!(&DataType::Utf8, field.data_type());
 
         // Unnesting the singular struct column result into 2 new columns for each subfield
@@ -2686,8 +2699,7 @@ mod tests {
             // Check unnested struct field is a scalar
             let field = plan
                 .schema()
-                .field_with_name(None, &format!("struct_singular.{field_name}"))
-                .unwrap();
+                .field_with_name(None, &format!("struct_singular.{field_name}"))?;
             assert_eq!(&DataType::UInt32, field.data_type());
         }
 
@@ -2706,7 +2718,7 @@ mod tests {
         ");
 
         // Check unnested struct list field should be a struct.
-        let field = plan.schema().field_with_name(None, "structs").unwrap();
+        let field = plan.schema().field_with_name(None, "structs")?;
         assert!(matches!(field.data_type(), DataType::Struct(_)));
 
         // Unnesting multiple fields at the same time, using infer syntax
@@ -2752,25 +2764,18 @@ mod tests {
         ");
 
         // Check output columns has correct type
-        let field = plan
-            .schema()
-            .field_with_name(None, "stringss_depth_1")
-            .unwrap();
+        let field = plan.schema().field_with_name(None, "stringss_depth_1")?;
         assert_eq!(
             &DataType::new_list(DataType::Utf8, false),
             field.data_type()
         );
-        let field = plan
-            .schema()
-            .field_with_name(None, "stringss_depth_2")
-            .unwrap();
+        let field = plan.schema().field_with_name(None, "stringss_depth_2")?;
         assert_eq!(&DataType::Utf8, field.data_type());
         // unnesting struct is still correct
         for field_name in &["a", "b"] {
             let field = plan
                 .schema()
-                .field_with_name(None, &format!("struct_singular.{field_name}"))
-                .unwrap();
+                .field_with_name(None, &format!("struct_singular.{field_name}"))?;
             assert_eq!(&DataType::UInt32, field.data_type());
         }
 

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -63,7 +63,9 @@ use datafusion_common::{
 };
 use datafusion_expr_common::type_coercion::binary::type_union_resolution;
 
+use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use indexmap::IndexSet;
+use itertools::Itertools;
 
 /// Default table name for unnamed table
 pub const UNNAMED_TABLE: &str = "?table?";
@@ -178,9 +180,10 @@ impl LogicalPlanBuilder {
     pub fn to_recursive_query(
         self,
         name: String,
-        recursive_term: LogicalPlan,
+        recursive_term: impl Into<Arc<LogicalPlan>>,
         is_distinct: bool,
     ) -> Result<Self> {
+        let recursive_term = recursive_term.into();
         // Ensure that the static term and the recursive term have the same number of fields
         let static_fields_len = self.plan.schema().fields().len();
         let recursive_fields_len = recursive_term.schema().fields().len();
@@ -197,7 +200,7 @@ impl LogicalPlanBuilder {
         let recursive_query = RecursiveQuery::try_new(
             name,
             self.plan,
-            Arc::new(coerced_recursive_term),
+            coerced_recursive_term,
             is_distinct,
         )?;
         Ok(Self::from(LogicalPlan::RecursiveQuery(recursive_query)))
@@ -209,7 +212,7 @@ impl LogicalPlanBuilder {
     ///
     /// so it's usually better to override the default names with a table alias list.
     ///
-    /// If the values include params/binders such as $1, $2, $3, etc, then the `param_data_types` should be provided.
+    /// If the values include params/binders such as $1, $2, $3, etc. then the `param_data_types` should be provided.
     pub fn values(values: Vec<Vec<Expr>>) -> Result<Self> {
         if values.is_empty() {
             return plan_err!("Values list cannot be empty");
@@ -241,7 +244,7 @@ impl LogicalPlanBuilder {
     /// The column names are not specified by the SQL standard and different database systems do it differently,
     /// so it's usually better to override the default names with a table alias list.
     ///
-    /// If the values include params/binders such as $1, $2, $3, etc, then the `param_data_types` should be provided.
+    /// If the values include params/binders such as $1, $2, $3, etc. then the `param_data_types` should be provided.
     pub fn values_with_schema(
         values: Vec<Vec<Expr>>,
         schema: &DFSchemaRef,
@@ -422,14 +425,14 @@ impl LogicalPlanBuilder {
 
     /// Create a [CopyTo] for copying the contents of this builder to the specified file(s)
     pub fn copy_to(
-        input: LogicalPlan,
+        input: impl Into<Arc<LogicalPlan>>,
         output_url: String,
         file_type: Arc<dyn FileType>,
         options: HashMap<String, String>,
         partition_by: Vec<String>,
     ) -> Result<Self> {
         Ok(Self::new(LogicalPlan::Copy(CopyTo::new(
-            Arc::new(input),
+            input.into(),
             output_url,
             partition_by,
             file_type,
@@ -471,7 +474,7 @@ impl LogicalPlanBuilder {
     /// # }
     /// ```
     pub fn insert_into(
-        input: LogicalPlan,
+        input: impl Into<Arc<LogicalPlan>>,
         table_name: impl Into<TableReference>,
         target: Arc<dyn TableSource>,
         insert_op: InsertOp,
@@ -480,7 +483,7 @@ impl LogicalPlanBuilder {
             table_name.into(),
             target,
             WriteOp::Insert(insert_op),
-            Arc::new(input),
+            input.into(),
         ))))
     }
 
@@ -553,10 +556,10 @@ impl LogicalPlanBuilder {
 
     /// Wrap a plan in a window
     pub fn window_plan(
-        input: LogicalPlan,
+        input: impl Into<Arc<LogicalPlan>>,
         window_exprs: impl IntoIterator<Item = Expr>,
     ) -> Result<LogicalPlan> {
-        let mut plan = input;
+        let mut plan = input.into();
         let mut groups = group_window_expr_by_sort_keys(window_exprs)?;
         // To align with the behavior of PostgreSQL, we want the sort_keys sorted as same rule as PostgreSQL that first
         // we compare the sort key themselves and if one window's sort keys are a prefix of another
@@ -578,15 +581,17 @@ impl LogicalPlanBuilder {
             }
             key_b.len().cmp(&key_a.len())
         });
+
         for (_, exprs) in groups {
             let window_exprs = exprs.into_iter().collect::<Vec<_>>();
             // Partition and sorting is done at physical level, see the EnforceDistribution
             // and EnforceSorting rules.
             plan = LogicalPlanBuilder::from(plan)
                 .window(window_exprs)?
-                .build()?;
+                .build_arc()?;
         }
-        Ok(plan)
+
+        Ok(Arc::unwrap_or_clone(plan))
     }
 
     /// Apply a projection without alias.
@@ -594,7 +599,7 @@ impl LogicalPlanBuilder {
         self,
         expr: impl IntoIterator<Item = impl Into<SelectExpr>>,
     ) -> Result<Self> {
-        project(Arc::unwrap_or_clone(self.plan), expr).map(Self::new)
+        project(self.plan, expr).map(Self::new)
     }
 
     /// Apply a projection without alias with optional validation
@@ -687,7 +692,7 @@ impl LogicalPlanBuilder {
 
     /// Apply an alias
     pub fn alias(self, alias: impl Into<TableReference>) -> Result<Self> {
-        subquery_alias(Arc::unwrap_or_clone(self.plan), alias).map(Self::new)
+        subquery_alias(self.plan, alias).map(Self::new)
     }
 
     /// Add missing sort columns to all downstream projection
@@ -722,43 +727,43 @@ impl LogicalPlanBuilder {
         curr_plan: LogicalPlan,
         missing_cols: &IndexSet<Column>,
         is_distinct: bool,
-    ) -> Result<LogicalPlan> {
+    ) -> Result<Transformed<LogicalPlan>> {
         match curr_plan {
             LogicalPlan::Projection(Projection {
                 input,
                 mut expr,
-                schema: _,
+                schema,
             }) if missing_cols.iter().all(|c| input.schema().has_column(c)) => {
-                let mut missing_exprs = missing_cols
+                let missing_exprs: Vec<Expr> = missing_cols
                     .iter()
                     .map(|c| normalize_col(Expr::Column(c.clone()), &input))
-                    .collect::<Result<Vec<_>>>()?;
+                    // Do not let duplicate columns to be added, some of the
+                    // missing_cols may be already present but without the new
+                    // projected alias.
+                    .filter_ok(|e| !expr.contains(e))
+                    .try_collect()?;
 
-                // Do not let duplicate columns to be added, some of the
-                // missing_cols may be already present but without the new
-                // projected alias.
-                missing_exprs.retain(|e| !expr.contains(e));
                 if is_distinct {
                     Self::ambiguous_distinct_check(&missing_exprs, missing_cols, &expr)?;
                 }
-                expr.extend(missing_exprs);
-                project(Arc::unwrap_or_clone(input), expr)
+
+                if missing_exprs.is_empty() {
+                    Ok(Transformed::no(LogicalPlan::Projection(Projection {
+                        expr,
+                        input,
+                        schema,
+                    })))
+                } else {
+                    expr.extend(missing_exprs);
+                    project(input, expr).map(Transformed::yes)
+                }
             }
             _ => {
                 let is_distinct =
                     is_distinct || matches!(curr_plan, LogicalPlan::Distinct(_));
-                let new_inputs = curr_plan
-                    .inputs()
-                    .into_iter()
-                    .map(|input_plan| {
-                        Self::add_missing_columns(
-                            (*input_plan).clone(),
-                            missing_cols,
-                            is_distinct,
-                        )
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                curr_plan.with_new_exprs(curr_plan.expressions(), new_inputs)
+                curr_plan.map_children(|input| {
+                    Self::add_missing_columns(input, missing_cols, is_distinct)
+                })
             }
         }
     }
@@ -856,13 +861,13 @@ impl LogicalPlanBuilder {
 
         // remove pushed down sort columns
         let new_expr = schema.columns().into_iter().map(Expr::Column).collect();
-
         let is_distinct = false;
         let plan = Self::add_missing_columns(
             Arc::unwrap_or_clone(self.plan),
             &missing_cols,
             is_distinct,
-        )?;
+        )
+        .data()?;
 
         let sort_plan = LogicalPlan::Sort(Sort {
             expr: normalize_sorts(sorts, &plan)?,
@@ -876,36 +881,33 @@ impl LogicalPlanBuilder {
     }
 
     /// Apply a union, preserving duplicate rows
-    pub fn union(self, plan: LogicalPlan) -> Result<Self> {
-        union(Arc::unwrap_or_clone(self.plan), plan).map(Self::new)
+    pub fn union(self, plan: impl Into<Arc<LogicalPlan>>) -> Result<Self> {
+        union(self.plan, plan).map(Self::new)
     }
 
     /// Apply a union by name, preserving duplicate rows
-    pub fn union_by_name(self, plan: LogicalPlan) -> Result<Self> {
-        union_by_name(Arc::unwrap_or_clone(self.plan), plan).map(Self::new)
+    pub fn union_by_name(self, plan: impl Into<Arc<LogicalPlan>>) -> Result<Self> {
+        union_by_name(self.plan, plan).map(Self::new)
     }
 
     /// Apply a union by name, removing duplicate rows
-    pub fn union_by_name_distinct(self, plan: LogicalPlan) -> Result<Self> {
-        let left_plan: LogicalPlan = Arc::unwrap_or_clone(self.plan);
-        let right_plan: LogicalPlan = plan;
-
+    pub fn union_by_name_distinct(
+        self,
+        plan: impl Into<Arc<LogicalPlan>>,
+    ) -> Result<Self> {
         Ok(Self::new(LogicalPlan::Distinct(Distinct::All(Arc::new(
-            union_by_name(left_plan, right_plan)?,
+            union_by_name(self.plan, plan)?,
         )))))
     }
 
     /// Apply a union, removing duplicate rows
-    pub fn union_distinct(self, plan: LogicalPlan) -> Result<Self> {
-        let left_plan: LogicalPlan = Arc::unwrap_or_clone(self.plan);
-        let right_plan: LogicalPlan = plan;
-
+    pub fn union_distinct(self, plan: impl Into<Arc<LogicalPlan>>) -> Result<Self> {
         Ok(Self::new(LogicalPlan::Distinct(Distinct::All(Arc::new(
-            union(left_plan, right_plan)?,
+            union(self.plan, plan)?,
         )))))
     }
 
-    /// Apply deduplication: Only distinct (different) values are returned)
+    /// Apply deduplication: Only distinct (different) values are returned
     pub fn distinct(self) -> Result<Self> {
         Ok(Self::new(LogicalPlan::Distinct(Distinct::All(self.plan))))
     }
@@ -938,7 +940,7 @@ impl LogicalPlanBuilder {
     /// Note that in case of outer join, the `filter` is applied to only matched rows.
     pub fn join(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         join_keys: (Vec<impl Into<Column>>, Vec<impl Into<Column>>),
         filter: Option<Expr>,
@@ -994,7 +996,7 @@ impl LogicalPlanBuilder {
     /// ```
     pub fn join_on(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         on_exprs: impl IntoIterator<Item = Expr>,
     ) -> Result<Self> {
@@ -1154,7 +1156,7 @@ impl LogicalPlanBuilder {
     /// The `null_equality` dictates how `null` values are joined.
     pub fn join_detailed(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         join_keys: (Vec<impl Into<Column>>, Vec<impl Into<Column>>),
         filter: Option<Expr>,
@@ -1172,7 +1174,7 @@ impl LogicalPlanBuilder {
 
     pub fn join_detailed_with_options(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         join_keys: (Vec<impl Into<Column>>, Vec<impl Into<Column>>),
         filter: Option<Expr>,
@@ -1183,6 +1185,7 @@ impl LogicalPlanBuilder {
             return plan_err!("left_keys and right_keys were not the same length");
         }
 
+        let right = right.into();
         let filter = if let Some(expr) = filter {
             let filter = normalize_col_with_schemas_and_ambiguity_check(
                 expr,
@@ -1288,7 +1291,7 @@ impl LogicalPlanBuilder {
 
         Ok(Self::new(LogicalPlan::Join(Join {
             left: self.plan,
-            right: Arc::new(right),
+            right,
             on,
             filter,
             join_type,
@@ -1302,10 +1305,11 @@ impl LogicalPlanBuilder {
     /// Apply a join with using constraint, which duplicates all join columns in output schema.
     pub fn join_using(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         using_keys: Vec<Column>,
     ) -> Result<Self> {
+        let right = right.into();
         let left_keys: Vec<Column> = using_keys
             .clone()
             .into_iter()
@@ -1363,7 +1367,7 @@ impl LogicalPlanBuilder {
         } else {
             let join = Join::try_new(
                 self.plan,
-                Arc::new(right),
+                right,
                 join_on,
                 filters,
                 join_type,
@@ -1377,10 +1381,10 @@ impl LogicalPlanBuilder {
     }
 
     /// Apply a cross join
-    pub fn cross_join(self, right: LogicalPlan) -> Result<Self> {
+    pub fn cross_join(self, right: impl Into<Arc<LogicalPlan>>) -> Result<Self> {
         let join = Join::try_new(
             self.plan,
-            Arc::new(right),
+            right.into(),
             vec![],
             None,
             JoinType::Inner,
@@ -1484,8 +1488,8 @@ impl LogicalPlanBuilder {
 
     /// Process intersect set operator
     pub fn intersect(
-        left_plan: LogicalPlan,
-        right_plan: LogicalPlan,
+        left_plan: impl Into<Arc<LogicalPlan>>,
+        right_plan: impl Into<Arc<LogicalPlan>>,
         is_all: bool,
     ) -> Result<LogicalPlan> {
         LogicalPlanBuilder::intersect_or_except(
@@ -1498,8 +1502,8 @@ impl LogicalPlanBuilder {
 
     /// Process except set operator
     pub fn except(
-        left_plan: LogicalPlan,
-        right_plan: LogicalPlan,
+        left_plan: impl Into<Arc<LogicalPlan>>,
+        right_plan: impl Into<Arc<LogicalPlan>>,
         is_all: bool,
     ) -> Result<LogicalPlan> {
         LogicalPlanBuilder::intersect_or_except(
@@ -1512,11 +1516,13 @@ impl LogicalPlanBuilder {
 
     /// Process intersect or except
     fn intersect_or_except(
-        left_plan: LogicalPlan,
-        right_plan: LogicalPlan,
+        left_plan: impl Into<Arc<LogicalPlan>>,
+        right_plan: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         is_all: bool,
     ) -> Result<LogicalPlan> {
+        let left_plan = left_plan.into();
+        let right_plan = right_plan.into();
         let left_len = left_plan.schema().fields().len();
         let right_len = right_plan.schema().fields().len();
 
@@ -1542,8 +1548,8 @@ impl LogicalPlanBuilder {
             .zip(right_plan.schema().fields().iter())
             .map(|(left_field, right_field)| {
                 (
-                    (Column::from_name(left_field.name())),
-                    (Column::from_name(right_field.name())),
+                    Column::from_name(left_field.name()),
+                    Column::from_name(right_field.name()),
                 )
             })
             .unzip();
@@ -1567,13 +1573,18 @@ impl LogicalPlanBuilder {
         Ok(Arc::unwrap_or_clone(self.plan))
     }
 
+    /// Build the plan into an Arc
+    pub fn build_arc(self) -> Result<Arc<LogicalPlan>> {
+        Ok(self.plan)
+    }
+
     /// Apply a join with both explicit equijoin and non equijoin predicates.
     ///
     /// Note this is a low level API that requires identifying specific
     /// predicate types. Most users should use  [`join_on`](Self::join_on) that
     /// automatically identifies predicates appropriately.
     ///
-    /// `equi_exprs` defines equijoin predicates, of the form `l = r)` for each
+    /// `equi_exprs` defines equijoin predicates, of the form `l = r` for each
     /// `(l, r)` tuple. `l`, the first element of the tuple, must only refer
     /// to columns from the existing input. `r`, the second element of the tuple,
     /// must only refer to columns from the right input.
@@ -1583,7 +1594,7 @@ impl LogicalPlanBuilder {
     /// than the filter expressions, so they are preferred.
     pub fn join_with_expr_keys(
         self,
-        right: LogicalPlan,
+        right: impl Into<Arc<LogicalPlan>>,
         join_type: JoinType,
         equi_exprs: (Vec<impl Into<Expr>>, Vec<impl Into<Expr>>),
         filter: Option<Expr>,
@@ -1592,6 +1603,7 @@ impl LogicalPlanBuilder {
             return plan_err!("left_keys and right_keys were not the same length");
         }
 
+        let right = right.into();
         let join_key_pairs = equi_exprs
             .0
             .into_iter()
@@ -1630,7 +1642,7 @@ impl LogicalPlanBuilder {
 
         let join = Join::try_new(
             self.plan,
-            Arc::new(right),
+            right,
             join_key_pairs,
             filter,
             join_type,
@@ -1644,7 +1656,7 @@ impl LogicalPlanBuilder {
 
     /// Unnest the given column.
     pub fn unnest_column(self, column: impl Into<Column>) -> Result<Self> {
-        unnest(Arc::unwrap_or_clone(self.plan), vec![column.into()]).map(Self::new)
+        unnest(self.plan, vec![column.into()]).map(Self::new)
     }
 
     /// Unnest the given column given [`UnnestOptions`]
@@ -1653,12 +1665,7 @@ impl LogicalPlanBuilder {
         column: impl Into<Column>,
         options: UnnestOptions,
     ) -> Result<Self> {
-        unnest_with_options(
-            Arc::unwrap_or_clone(self.plan),
-            vec![column.into()],
-            options,
-        )
-        .map(Self::new)
+        unnest_with_options(self.plan, vec![column.into()], options).map(Self::new)
     }
 
     /// Unnest the given columns with the given [`UnnestOptions`]
@@ -1667,8 +1674,7 @@ impl LogicalPlanBuilder {
         columns: Vec<Column>,
         options: UnnestOptions,
     ) -> Result<Self> {
-        unnest_with_options(Arc::unwrap_or_clone(self.plan), columns, options)
-            .map(Self::new)
+        unnest_with_options(self.plan, columns, options).map(Self::new)
     }
 }
 
@@ -2032,7 +2038,7 @@ pub fn validate_unique_names<'a>(
 
 /// Union two [`LogicalPlan`]s.
 ///
-/// Constructs the UNION plan, but does not perform type-coercion. Therefore the
+/// Constructs the UNION plan, but does not perform type-coercion. Therefore, the
 /// subtree expressions will not be properly typed until the optimizer pass.
 ///
 /// If a properly typed UNION plan is needed, refer to [`TypeCoercionRewriter::coerce_union`]
@@ -2041,22 +2047,25 @@ pub fn validate_unique_names<'a>(
 ///
 /// [`TypeCoercionRewriter::coerce_union`]: https://docs.rs/datafusion-optimizer/latest/datafusion_optimizer/analyzer/type_coercion/struct.TypeCoercionRewriter.html#method.coerce_union
 /// [`coerce_union_schema`]: https://docs.rs/datafusion-optimizer/latest/datafusion_optimizer/analyzer/type_coercion/fn.coerce_union_schema.html
-pub fn union(left_plan: LogicalPlan, right_plan: LogicalPlan) -> Result<LogicalPlan> {
+pub fn union(
+    left_plan: impl Into<Arc<LogicalPlan>>,
+    right_plan: impl Into<Arc<LogicalPlan>>,
+) -> Result<LogicalPlan> {
     Ok(LogicalPlan::Union(Union::try_new_with_loose_types(vec![
-        Arc::new(left_plan),
-        Arc::new(right_plan),
+        left_plan.into(),
+        right_plan.into(),
     ])?))
 }
 
 /// Like [`union`], but combine rows from different tables by name, rather than
 /// by position.
 pub fn union_by_name(
-    left_plan: LogicalPlan,
-    right_plan: LogicalPlan,
+    left_plan: impl Into<Arc<LogicalPlan>>,
+    right_plan: impl Into<Arc<LogicalPlan>>,
 ) -> Result<LogicalPlan> {
     Ok(LogicalPlan::Union(Union::try_new_by_name(vec![
-        Arc::new(left_plan),
-        Arc::new(right_plan),
+        left_plan.into(),
+        right_plan.into(),
     ])?))
 }
 
@@ -2066,7 +2075,7 @@ pub fn union_by_name(
 /// * Two or more expressions have the same name
 /// * An invalid expression is used (e.g. a `sort` expression)
 pub fn project(
-    plan: LogicalPlan,
+    plan: impl Into<Arc<LogicalPlan>>,
     expr: impl IntoIterator<Item = impl Into<SelectExpr>>,
 ) -> Result<LogicalPlan> {
     project_with_validation(plan, expr.into_iter().map(|e| (e, true)), None)
@@ -2080,10 +2089,11 @@ pub fn project(
 /// * Two or more expressions have the same name
 /// * An invalid expression is used (e.g. a `sort` expression)
 fn project_with_validation(
-    plan: LogicalPlan,
+    plan: impl Into<Arc<LogicalPlan>>,
     expr: impl IntoIterator<Item = (impl Into<SelectExpr>, bool)>,
     schema: Option<&DFSchemaRef>,
 ) -> Result<LogicalPlan> {
+    let plan = plan.into();
     let mut projected_expr = vec![];
     let mut has_wildcard = false;
     for (e, validate) in expr {
@@ -2160,8 +2170,7 @@ fn project_with_validation(
     }
 
     validate_unique_names("Projections", projected_expr.iter())?;
-
-    Projection::try_new(projected_expr, Arc::new(plan)).map(LogicalPlan::Projection)
+    Projection::try_new(projected_expr, plan).map(LogicalPlan::Projection)
 }
 
 /// If there is a REPLACE statement in the projected expression in the form of
@@ -2188,10 +2197,10 @@ fn replace_columns(
 
 /// Create a SubqueryAlias to wrap a LogicalPlan.
 pub fn subquery_alias(
-    plan: LogicalPlan,
+    plan: impl Into<Arc<LogicalPlan>>,
     alias: impl Into<TableReference>,
 ) -> Result<LogicalPlan> {
-    SubqueryAlias::try_new(Arc::new(plan), alias).map(LogicalPlan::SubqueryAlias)
+    SubqueryAlias::try_new(plan.into(), alias).map(LogicalPlan::SubqueryAlias)
 }
 
 /// Create a LogicalPlanBuilder representing a scan of a table with the provided name and schema.
@@ -2267,8 +2276,9 @@ pub fn table_source_with_constraints(
 /// Wrap projection for a plan, if the join keys contains normal expression.
 pub fn wrap_projection_for_join_if_necessary(
     join_keys: &[Expr],
-    input: LogicalPlan,
-) -> Result<(LogicalPlan, Vec<Column>, bool)> {
+    input: impl Into<Arc<LogicalPlan>>,
+) -> Result<(Arc<LogicalPlan>, Vec<Column>, bool)> {
+    let input = input.into();
     let input_schema = input.schema();
     let alias_join_keys: Vec<Expr> = join_keys
         .iter()
@@ -2309,7 +2319,7 @@ pub fn wrap_projection_for_join_if_necessary(
 
         LogicalPlanBuilder::from(input)
             .project(projection.into_iter().map(SelectExpr::from))?
-            .build()?
+            .build_arc()?
     } else {
         input
     };
@@ -2370,7 +2380,10 @@ impl TableSource for LogicalTableSource {
 }
 
 /// Create a [`LogicalPlan::Unnest`] plan
-pub fn unnest(input: LogicalPlan, columns: Vec<Column>) -> Result<LogicalPlan> {
+pub fn unnest(
+    input: impl Into<Arc<LogicalPlan>>,
+    columns: Vec<Column>,
+) -> Result<LogicalPlan> {
     unnest_with_options(input, columns, UnnestOptions::default())
 }
 
@@ -2386,8 +2399,8 @@ pub fn get_struct_unnested_columns(
 
 /// Create a [`LogicalPlan::Unnest`] plan with options
 /// This function receive a list of columns to be unnested
-/// because multiple unnest can be performed on the same column (e.g unnest with different depth)
-/// The new schema will contains post-unnest fields replacing the original field
+/// because multiple unnest can be performed on the same column (e.g. unnest with different depth)
+/// The new schema will contain post-unnest fields replacing the original field
 ///
 /// For example:
 /// Input schema as
@@ -2414,12 +2427,12 @@ pub fn get_struct_unnested_columns(
 /// +---------+---------+---------------------+---------------------+
 /// ```
 pub fn unnest_with_options(
-    input: LogicalPlan,
+    input: impl Into<Arc<LogicalPlan>>,
     columns_to_unnest: Vec<Column>,
     options: UnnestOptions,
 ) -> Result<LogicalPlan> {
     Ok(LogicalPlan::Unnest(Unnest::try_new(
-        Arc::new(input),
+        input.into(),
         columns_to_unnest,
         options,
     )?))
@@ -2427,12 +2440,12 @@ pub fn unnest_with_options(
 
 #[cfg(test)]
 mod tests {
-    use std::vec;
-
     use super::*;
     use crate::lit_with_metadata;
     use crate::logical_plan::StringifiedPlan;
-    use crate::{col, expr, expr_fn::exists, in_subquery, scalar_subquery};
+    use crate::{col, expr, expr_fn::exists, in_subquery, lit, scalar_subquery};
+    use arrow::datatypes::Schema;
+    use std::vec;
 
     use crate::test::function_stub::sum;
     use datafusion_common::{
@@ -2794,7 +2807,7 @@ mod tests {
         ");
 
         // Check unnested field is a scalar
-        let field = plan.schema().field_with_name(None, "strings").unwrap();
+        let field = plan.schema().field_with_name(None, "strings")?;
         assert_eq!(&DataType::Utf8, field.data_type());
 
         // Unnesting the singular struct column result into 2 new columns for each subfield
@@ -2811,8 +2824,7 @@ mod tests {
             // Check unnested struct field is a scalar
             let field = plan
                 .schema()
-                .field_with_name(None, &format!("struct_singular.{field_name}"))
-                .unwrap();
+                .field_with_name(None, &format!("struct_singular.{field_name}"))?;
             assert_eq!(&DataType::UInt32, field.data_type());
         }
 
@@ -2831,7 +2843,7 @@ mod tests {
         ");
 
         // Check unnested struct list field should be a struct.
-        let field = plan.schema().field_with_name(None, "structs").unwrap();
+        let field = plan.schema().field_with_name(None, "structs")?;
         assert!(matches!(field.data_type(), DataType::Struct(_)));
 
         // Unnesting multiple fields at the same time, using infer syntax
@@ -2877,25 +2889,18 @@ mod tests {
         ");
 
         // Check output columns has correct type
-        let field = plan
-            .schema()
-            .field_with_name(None, "stringss_depth_1")
-            .unwrap();
+        let field = plan.schema().field_with_name(None, "stringss_depth_1")?;
         assert_eq!(
             &DataType::new_list(DataType::Utf8, false),
             field.data_type()
         );
-        let field = plan
-            .schema()
-            .field_with_name(None, "stringss_depth_2")
-            .unwrap();
+        let field = plan.schema().field_with_name(None, "stringss_depth_2")?;
         assert_eq!(&DataType::Utf8, field.data_type());
         // unnesting struct is still correct
         for field_name in &["a", "b"] {
             let field = plan
                 .schema()
-                .field_with_name(None, &format!("struct_singular.{field_name}"))
-                .unwrap();
+                .field_with_name(None, &format!("struct_singular.{field_name}"))?;
             assert_eq!(&DataType::UInt32, field.data_type());
         }
 

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -86,7 +86,7 @@ fn coerce_output(plan: LogicalPlan, config: &ConfigOptions) -> Result<LogicalPla
     }
 
     if let Some(dfschema) = transform_schema_to_nonview(plan.schema()) {
-        coerce_plan_expr_for_schema(plan, &dfschema?)
+        coerce_plan_expr_for_schema(plan, &dfschema?).map(Arc::unwrap_or_clone)
     } else {
         Ok(plan)
     }
@@ -326,9 +326,8 @@ impl<'a> TypeCoercionRewriter<'a> {
             .inputs
             .into_iter()
             .map(|p| {
-                let plan =
-                    coerce_plan_expr_for_schema(Arc::unwrap_or_clone(p), &union_schema)?;
-                match plan {
+                match Arc::unwrap_or_clone(coerce_plan_expr_for_schema(p, &union_schema)?)
+                {
                     LogicalPlan::Projection(Projection { expr, input, .. }) => {
                         Ok(Arc::new(project_with_column_index(
                             expr,

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -86,7 +86,7 @@ fn coerce_output(plan: LogicalPlan, config: &ConfigOptions) -> Result<LogicalPla
     }
 
     if let Some(dfschema) = transform_schema_to_nonview(plan.schema()) {
-        coerce_plan_expr_for_schema(plan, &dfschema?)
+        coerce_plan_expr_for_schema(plan, &dfschema?).map(Arc::unwrap_or_clone)
     } else {
         Ok(plan)
     }
@@ -295,9 +295,8 @@ impl<'a> TypeCoercionRewriter<'a> {
             .inputs
             .into_iter()
             .map(|p| {
-                let plan =
-                    coerce_plan_expr_for_schema(Arc::unwrap_or_clone(p), &union_schema)?;
-                match plan {
+                match Arc::unwrap_or_clone(coerce_plan_expr_for_schema(p, &union_schema)?)
+                {
                     LogicalPlan::Projection(Projection { expr, input, .. }) => {
                         Ok(Arc::new(project_with_column_index(
                             expr,

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -908,7 +908,7 @@ mod tests {
     use crate::optimize_projections::OptimizeProjections;
     use crate::optimizer::Optimizer;
     use crate::test::{
-        assert_fields_eq, scan_empty, test_table_scan, test_table_scan_fields,
+        assert_fields_eq, test_table_scan, test_table_scan_fields,
         test_table_scan_with_name,
     };
     use crate::{OptimizerContext, OptimizerRule};
@@ -1915,7 +1915,8 @@ mod tests {
         let table_scan = test_table_scan()?;
 
         let schema = Schema::new(vec![Field::new("c1", DataType::UInt32, false)]);
-        let table2_scan = scan_empty(Some("test2"), &schema, None)?.build()?;
+        let table2_scan =
+            datafusion_expr::table_scan(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .join(table2_scan, JoinType::Left, (vec!["a"], vec!["c1"]), None)?
@@ -1967,7 +1968,8 @@ mod tests {
         let table_scan = test_table_scan()?;
 
         let schema = Schema::new(vec![Field::new("c1", DataType::UInt32, false)]);
-        let table2_scan = scan_empty(Some("test2"), &schema, None)?.build()?;
+        let table2_scan =
+            datafusion_expr::table_scan(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .join(table2_scan, JoinType::Left, (vec!["a"], vec!["c1"]), None)?
@@ -2022,7 +2024,8 @@ mod tests {
         let table_scan = test_table_scan()?;
 
         let schema = Schema::new(vec![Field::new("a", DataType::UInt32, false)]);
-        let table2_scan = scan_empty(Some("test2"), &schema, None)?.build()?;
+        let table2_scan =
+            datafusion_expr::table_scan(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .join_using(table2_scan, JoinType::Left, vec!["a".into()])?

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -899,7 +899,7 @@ mod tests {
     use crate::optimize_projections::OptimizeProjections;
     use crate::optimizer::Optimizer;
     use crate::test::{
-        assert_fields_eq, scan_empty, test_table_scan, test_table_scan_fields,
+        assert_fields_eq, test_table_scan, test_table_scan_fields,
         test_table_scan_with_name,
     };
     use crate::{OptimizerContext, OptimizerRule};
@@ -1843,7 +1843,8 @@ mod tests {
         let table_scan = test_table_scan()?;
 
         let schema = Schema::new(vec![Field::new("c1", DataType::UInt32, false)]);
-        let table2_scan = scan_empty(Some("test2"), &schema, None)?.build()?;
+        let table2_scan =
+            datafusion_expr::table_scan(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .join(table2_scan, JoinType::Left, (vec!["a"], vec!["c1"]), None)?
@@ -1895,7 +1896,8 @@ mod tests {
         let table_scan = test_table_scan()?;
 
         let schema = Schema::new(vec![Field::new("c1", DataType::UInt32, false)]);
-        let table2_scan = scan_empty(Some("test2"), &schema, None)?.build()?;
+        let table2_scan =
+            datafusion_expr::table_scan(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .join(table2_scan, JoinType::Left, (vec!["a"], vec!["c1"]), None)?
@@ -1950,7 +1952,8 @@ mod tests {
         let table_scan = test_table_scan()?;
 
         let schema = Schema::new(vec![Field::new("a", DataType::UInt32, false)]);
-        let table2_scan = scan_empty(Some("test2"), &schema, None)?.build()?;
+        let table2_scan =
+            datafusion_expr::table_scan(Some("test2"), &schema, None)?.build()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .join_using(table2_scan, JoinType::Left, vec!["a".into()])?

--- a/datafusion/optimizer/src/optimize_unions.rs
+++ b/datafusion/optimizer/src/optimize_unions.rs
@@ -22,7 +22,6 @@ use datafusion_common::Result;
 use datafusion_common::tree_node::Transformed;
 use datafusion_expr::expr_rewriter::coerce_plan_expr_for_schema;
 use datafusion_expr::{Distinct, LogicalPlan, Projection, Union};
-use itertools::Itertools;
 use std::sync::Arc;
 
 #[derive(Default, Debug)]
@@ -64,7 +63,7 @@ impl OptimizerRule for OptimizeUnions {
                 let inputs = inputs
                     .into_iter()
                     .flat_map(extract_plans_from_union)
-                    .map(|plan| Ok(Arc::new(coerce_plan_expr_for_schema(plan, &schema)?)))
+                    .map(|plan| coerce_plan_expr_for_schema(plan, &schema))
                     .collect::<Result<Vec<_>>>()?;
 
                 Ok(Transformed::yes(LogicalPlan::Union(Union {
@@ -84,7 +83,7 @@ impl OptimizerRule for OptimizeUnions {
 
                         Ok(Transformed::yes(LogicalPlan::Distinct(Distinct::All(
                             Arc::new(LogicalPlan::Union(Union {
-                                inputs: inputs.into_iter().map(Arc::new).collect_vec(),
+                                inputs,
                                 schema: Arc::clone(&schema),
                             })),
                         ))))

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -2343,7 +2343,7 @@ mod tests {
         ]);
         let right = table_scan(Some("test1"), &schema, None)?
             .project(vec![col("d"), col("e"), col("f")])?
-            .build()?;
+            .build_arc()?;
         let filter = and(col("test.a").eq(lit(1)), col("test1.d").gt(lit(2)));
         let plan = LogicalPlanBuilder::from(left)
             .cross_join(right)?
@@ -2373,7 +2373,7 @@ mod tests {
         let right_table_scan = test_table_scan_with_name("test1")?;
         let right = LogicalPlanBuilder::from(right_table_scan)
             .project(vec![col("a"), col("b"), col("c")])?
-            .build()?;
+            .build_arc()?;
         let filter = and(col("test.a").eq(lit(1)), col("test1.a").gt(lit(2)));
         let plan = LogicalPlanBuilder::from(left)
             .cross_join(right)?

--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -120,10 +120,10 @@ impl OptimizerRule for ScalarSubqueryToJoin {
                 );
 
                 // iterate through all subqueries in predicate, turning each into a left join
-                let mut cur_input = filter.input.as_ref().clone();
+                let mut cur_input = Arc::clone(&filter.input);
                 for (subquery, alias) in subqueries {
                     if let Some((optimized_subquery, compensation_exprs)) =
-                        build_join(&subquery, &cur_input, &alias)?
+                        build_join(subquery, cur_input, &alias)?
                     {
                         if !compensation_exprs.is_empty() {
                             rewrite_expr = rewrite_expr
@@ -141,7 +141,7 @@ impl OptimizerRule for ScalarSubqueryToJoin {
                         }
                         cur_input = optimized_subquery;
                     } else {
-                        // if we can't handle all of the subqueries then bail for now
+                        // if we can't handle all the subqueries then bail for now
                         return Ok(Transformed::no(LogicalPlan::Filter(filter)));
                     }
                 }
@@ -188,11 +188,12 @@ impl OptimizerRule for ScalarSubqueryToJoin {
                     !all_subqueries.is_empty(),
                     "Expected subqueries not found in projection"
                 );
+
                 // iterate through all subqueries in predicate, turning each into a left join
-                let mut cur_input = projection.input.as_ref().clone();
+                let mut cur_input = Arc::clone(&projection.input);
                 for (subquery, alias) in all_subqueries {
                     if let Some((optimized_subquery, compensation_exprs)) =
-                        build_join(&subquery, &cur_input, &alias)?
+                        build_join(subquery, cur_input, &alias)?
                     {
                         cur_input = optimized_subquery;
                         if !compensation_exprs.is_empty()
@@ -214,7 +215,7 @@ impl OptimizerRule for ScalarSubqueryToJoin {
                             rewrite_exprs[idx] = new_expr;
                         }
                     } else {
-                        // if we can't handle all of the subqueries then bail for now
+                        // if we can't handle all the subqueries then bail for now
                         return Ok(Transformed::no(LogicalPlan::Projection(projection)));
                     }
                 }
@@ -290,10 +291,10 @@ impl TreeNodeRewriter for ExtractScalarSubQuery<'_> {
                     .subquery
                     .head_output_expr()?
                     .map_or(plan_err!("single expression required."), Ok)?;
-                let subqry_alias = self.alias_gen.next("__scalar_sq");
+                let subquery_alias = self.alias_gen.next("__scalar_sq");
                 let col =
-                    create_col_from_scalar_expr(&scalar_expr, subqry_alias.clone())?;
-                self.sub_query_info.push((subquery, subqry_alias));
+                    create_col_from_scalar_expr(&scalar_expr, subquery_alias.clone())?;
+                self.sub_query_info.push((subquery, subquery_alias));
                 Ok(Transformed::new(
                     Expr::Column(col),
                     true,
@@ -342,17 +343,18 @@ impl TreeNodeRewriter for ExtractScalarSubQuery<'_> {
 /// column to its `CASE WHEN __always_true IS NULL THEN ... END` compensation
 /// expression, which the caller must substitute into any expression that
 /// references those columns.
+#[expect(clippy::type_complexity)]
 fn build_join(
-    subquery: &Subquery,
-    outer_input: &LogicalPlan,
+    subquery: Subquery,
+    outer_input: Arc<LogicalPlan>,
     subquery_alias: &str,
-) -> Result<Option<(LogicalPlan, HashMap<Column, Expr>)>> {
+) -> Result<Option<(Arc<LogicalPlan>, HashMap<Column, Expr>)>> {
     // `build_join` also handles uncorrelated scalar subqueries (as a left
     // join with `Boolean(true)`) when the
     // `enable_physical_uncorrelated_scalar_subquery` option is disabled.
-    let subquery_plan = subquery.subquery.as_ref();
+    let subquery_plan = Arc::unwrap_or_clone(subquery.subquery);
     let mut pull_up = PullUpCorrelatedExpr::new().with_need_handle_count_bug(true);
-    let decorrelated_subquery = subquery_plan.clone().rewrite(&mut pull_up).data()?;
+    let decorrelated_subquery = subquery_plan.rewrite(&mut pull_up).data()?;
     if !pull_up.can_pull_up {
         return Ok(None);
     }
@@ -363,7 +365,7 @@ fn build_join(
         .cloned();
     let aliased_subquery = LogicalPlanBuilder::from(decorrelated_subquery)
         .alias(subquery_alias.to_string())?
-        .build()?;
+        .build_arc()?;
 
     let all_correlated_cols: BTreeSet<Column> = pull_up
         .correlated_subquery_cols_map
@@ -386,9 +388,9 @@ fn build_join(
     // columns.
     let join_filter = join_filter_opt.or_else(|| Some(lit(true)));
 
-    let new_plan = LogicalPlanBuilder::from(outer_input.clone())
+    let new_plan = LogicalPlanBuilder::from(outer_input)
         .join_on(aliased_subquery, JoinType::Left, join_filter)?
-        .build()?;
+        .build_arc()?;
 
     // Add count-bug compensation for each of the subquery's projected
     // expressions that yield non-NULL values on empty input. We wrap each

--- a/datafusion/optimizer/src/test/mod.rs
+++ b/datafusion/optimizer/src/test/mod.rs
@@ -21,7 +21,7 @@ use crate::{OptimizerContext, OptimizerRule};
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{Result, assert_contains};
-use datafusion_expr::{LogicalPlan, LogicalPlanBuilder, logical_plan::table_scan};
+use datafusion_expr::{LogicalPlan, logical_plan::table_scan};
 use std::sync::Arc;
 
 pub mod udfs;
@@ -66,15 +66,6 @@ pub fn test_table_scan_with_name(name: &str) -> Result<LogicalPlan> {
 /// some tests share a common table
 pub fn test_table_scan() -> Result<LogicalPlan> {
     test_table_scan_with_name("test")
-}
-
-/// Scan an empty data source, mainly used in tests
-pub fn scan_empty(
-    name: Option<&str>,
-    table_schema: &Schema,
-    projection: Option<Vec<usize>>,
-) -> Result<LogicalPlanBuilder> {
-    table_scan(name, table_schema, projection)
 }
 
 pub fn assert_fields_eq(plan: &LogicalPlan, expected: Vec<&str>) {

--- a/datafusion/optimizer/src/unions_to_filter.rs
+++ b/datafusion/optimizer/src/unions_to_filter.rs
@@ -293,9 +293,9 @@ fn strip_passthrough_nodes(mut plan: LogicalPlan) -> LogicalPlan {
 }
 
 fn align_plan_to_schema(
-    plan: LogicalPlan,
+    plan: Arc<LogicalPlan>,
     schema: datafusion_common::DFSchemaRef,
-) -> Result<LogicalPlan> {
+) -> Result<Arc<LogicalPlan>> {
     if plan.schema() == &schema {
         return Ok(plan);
     }
@@ -309,13 +309,11 @@ fn align_plan_to_schema(
                 plan.schema().qualified_field(i),
             ))
         })
-        .collect::<Vec<_>>();
+        .collect();
 
-    Ok(LogicalPlan::Projection(Projection::try_new_with_schema(
-        expr,
-        Arc::new(plan),
-        schema,
-    )?))
+    Ok(Arc::new(LogicalPlan::Projection(
+        Projection::try_new_with_schema(expr, plan, schema)?,
+    )))
 }
 
 fn is_mergeable_predicate(expr: &Expr) -> bool {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related to #4628 but goes in the other direction, using `Arc<LogicalPlan>` in `LogicalPlanBuilder`

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Since currently we do have `Arc<LogicalPlan>` in the tree it's a bit weird that the plan builder forces us to unwrap and/or clone these plans in many cases and prevents node sharing when using the builder APIs.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

 - Migrate function arguments from `LogicalPlan` to `impl Into<Arc<LogicalPlan>>`
 - ~Migrate function arguments from `&Schema` to `impl Into<SchemaRef>`~
 - Add a new `LogicalPlanBuilder::build_arc` function
 - Update usages (mostly in tests)

## Are these changes tested?

Relying on existing tests, this is mostly a compile-time change.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

Yes, a lot functions in `LogicalPlanBuilder` have changed signatures.
 * functions that accepted an owned `LogicalPlan` will continue to work as-is but now also accept `Arc<LogicalPlan>`
 * ~functions that accepted `&Schema` and cloned internally will break user code, so this is up for debate~
 * add a new `LogicalPlanBuilder::build_arc` function

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
