### PR TITLE
fix: Remove parquet encryption feature from root deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,6 @@ parquet = { version = "56.1.0", default-features = false, features = [
     "arrow",
     "async",
     "object_store",
-    "encryption",
 ] }
 pbjson = { version = "0.7.0" }
 pbjson-types = "0.7"


### PR DESCRIPTION
## Which issue does this PR close?

This PR adds to #16649 . That PR separates the `parquet` feature into `parquet` and `parquet_encryption`, making encryption optional. As with that PR, this one also relates to issue #16650 .

## Rationale for this change

Even with the previous PR, `parquet/encryption` remains enabled because it is set in the top-level `Cargo.toml`. The PR fixes this.
This PR ensures that the `parquet/encryption` feature isn't enabled by default.

## Are these changes tested?

I'm honestly not fully familiar with datafusion tests relating to the parquet encryption feature. I believe that no further adjustment to existing tests or creation of new tests is required since this is a very minor change.

## Are there any user-facing changes?

Same as for #16649 , no user-facing changes.