### PR TITLE
chore: fix wasm-pack installation link in wasmtest README

### DIFF
--- a/datafusion/wasmtest/README.md
+++ b/datafusion/wasmtest/README.md
@@ -32,7 +32,7 @@ Some of DataFusion's downstream projects compile to WASM to run in the browser. 
 
 ## Setup
 
-First, [install wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
+First, [install wasm-pack](https://drager.github.io/wasm-pack/installer/)
 
 Then use wasm-pack to compile the crate from within this directory
 


### PR DESCRIPTION
https://rustwasm.github.io/wasm-pack/installer/ is broken and is now available here instead: https://drager.github.io/wasm-pack/installer/

Context: [Sunsetting the rustwasm GitHub org](https://blog.rust-lang.org/inside-rust/2025/07/21/sunsetting-the-rustwasm-github-org/)