### PR TITLE
[branch-50] Partial AggregateMode will generate duplicate field names which will fail DFSchema construct to branch-50

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -913,7 +913,11 @@ impl TryFrom<SchemaRef> for DFSchema {
             field_qualifiers: vec![None; field_count],
             functional_dependencies: FunctionalDependencies::empty(),
         };
-        dfschema.check_names()?;
+        // Without checking names, because schema here may have duplicate field names.
+        // For example, Partial AggregateMode will generate duplicate field names from
+        // state_fields.
+        // See <https://github.com/apache/datafusion/issues/17715>
+        // dfschema.check_names()?;
         Ok(dfschema)
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/17662

Cherry-pick https://github.com/apache/datafusion/pull/17706 to branch-50

## Rationale for this change

Cherry-pick https://github.com/apache/datafusion/pull/17706 to branch-50

## What changes are included in this PR?

Cherry-pick https://github.com/apache/datafusion/pull/17706 to branch-50

## Are these changes tested?

yes

## Are there any user-facing changes?

No