### PR TITLE
docs: Fix 'Clicking a link in optimizer docs downloads the file instead of redirecting to github'

### DIFF
--- a/docs/source/library-user-guide/query-optimizer.md
+++ b/docs/source/library-user-guide/query-optimizer.md
@@ -68,7 +68,7 @@ fn observer(plan: &LogicalPlan, rule: &dyn OptimizerRule) {
 ## Writing Optimization Rules
 
 Please refer to the
-[optimizer_rule.rs](../../../datafusion-examples/examples/optimizer_rule.rs)
+[optimizer_rule.rs](https://github.com/apache/datafusion/blob/main/datafusion-examples/examples/optimizer_rule.rs)
 example to learn more about the general approach to writing optimizer rules and
 then move onto studying the existing rules.
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #17722

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Clicking a link in the optimizer docs downloads the file instead of redirecting to GitHub. This seems to be only a problem for `.rs` files. `.md` files are fine. Looking at other files (example below), the approach has been to use the GitHub links instead of a relative path. I also grepped through the docs to check if there were any more relative paths to `.rs` files, and found this is the only one left.

example of how links are formatted in other files:
https://github.com/apache/datafusion/blob/a8d5016b97481d837857036ddd450574455a1b4e/docs/source/library-user-guide/functions/adding-udfs.md?plain=1#L34-L35

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Use github link instead of relative link to optimizer_rule.rs. 

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
N/A

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
N/A
