### PR TITLE
Bump MSRV to 1.87.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/datafusion"
 # Define Minimum Supported Rust Version (MSRV)
-rust-version = "1.86.0"
+rust-version = "1.87.0"
 # Define DataFusion version
 version = "50.0.0"
 

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -1233,7 +1233,7 @@ mod tests {
     fn csv_values(line_number: usize) -> (i32, f64, bool, String) {
         let int_value = line_number as i32;
         let float_value = line_number as f64;
-        let bool_value = line_number % 2 == 0;
+        let bool_value = line_number.is_multiple_of(2);
         let char_value = format!("{line_number}-string");
         (int_value, float_value, bool_value, char_value)
     }

--- a/datafusion/functions-nested/src/planner.rs
+++ b/datafusion/functions-nested/src/planner.rs
@@ -108,7 +108,7 @@ impl ExprPlanner for NestedFunctionPlanner {
     }
 
     fn plan_make_map(&self, args: Vec<Expr>) -> Result<PlannerResult<Vec<Expr>>> {
-        if args.len() % 2 != 0 {
+        if !args.len().is_multiple_of(2) {
             return plan_err!("make_map requires an even number of arguments");
         }
 

--- a/datafusion/functions/src/core/named_struct.rs
+++ b/datafusion/functions/src/core/named_struct.rs
@@ -104,7 +104,7 @@ impl ScalarUDFImpl for NamedStructFunc {
             );
         }
 
-        if args.scalar_arguments.len() % 2 != 0 {
+        if !args.scalar_arguments.len().is_multiple_of(2) {
             return exec_err!(
                 "named_struct requires an even number of arguments, got {} instead",
                 args.scalar_arguments.len()

--- a/datafusion/physical-plan/src/display.rs
+++ b/datafusion/physical-plan/src/display.rs
@@ -935,7 +935,7 @@ impl TreeRenderVisitor<'_, '_> {
         } else {
             let total_spaces = max_render_width - render_width;
             let half_spaces = total_spaces / 2;
-            let extra_left_space = if total_spaces % 2 == 0 { 0 } else { 1 };
+            let extra_left_space = if total_spaces.is_multiple_of(2) { 0 } else { 1 };
             format!(
                 "{}{}{}",
                 " ".repeat(half_spaces + extra_left_space),

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -606,7 +606,7 @@ impl Unparser<'_> {
     }
 
     fn named_struct_to_sql(&self, args: &[Expr]) -> Result<ast::Expr> {
-        if args.len() % 2 != 0 {
+        if !args.len().is_multiple_of(2) {
             return internal_err!("named_struct must have an even number of arguments");
         }
 

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -27,6 +27,12 @@ You can see the current [status of the `51.0.0 `release here](https://github.com
 
 ## DataFusion `50.0.0`
 
+### `MSRV` updated to 1.87.0
+
+The Minimum Supported Rust Version (MSRV) has been updated to [`1.87.0`].
+
+[`1.87.0`]: https://releases.rs/docs/1.87.0/
+
 ### ListingTable automatically detects Hive Partitioned tables
 
 DataFusion 50.0.0 automatically infers Hive partitions when using the `ListingTableFactory` and `CREATE EXTERNAL TABLE`. Previously,


### PR DESCRIPTION
Rust 1.90.0 became stable[^1], and 1.86.0 was released more than 4 months ago.
Note that for some reason https://releases.rs/docs/1.90.0/ does not list as stable, however `rustup update` definitely does pull 1.90.0

[^1]: https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/