### PR TITLE
Keep `approx_percentile_cont` names unique when missing an order-by

### DIFF
--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -792,7 +792,7 @@ pub fn udaf_default_schema_name<F: AggregateUDFImpl + ?Sized>(
 
     // exclude the first function argument(= column) in ordered set aggregate function,
     // because it is duplicated with the WITHIN GROUP clause in schema name.
-    let args = if func.is_ordered_set_aggregate() {
+    let args = if func.is_ordered_set_aggregate() && !order_by.is_empty() {
         &args[1..]
     } else {
         &args[..]

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -1823,8 +1823,14 @@ e 115
 
 
 # using approx_percentile_cont on 2 columns with same signature
-query error DataFusion error: Schema error: Schema contains duplicate unqualified field name "approx_percentile_cont\(Float64\(0\.95\)\)"
+query TII
 SELECT c1, approx_percentile_cont(c2, 0.95) AS c2, approx_percentile_cont(c3, 0.95) AS c3 FROM aggregate_test_100 GROUP BY 1 ORDER BY 1
+----
+a 5 73
+b 5 68
+c 5 122
+d 5 124
+e 5 115
 
 # error is unique to this UDAF
 query TRR

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -1821,6 +1821,23 @@ c 122
 d 124
 e 115
 
+
+# using approx_percentile_cont on 2 columns with same signature
+query error DataFusion error: Schema error: Schema contains duplicate unqualified field name "approx_percentile_cont\(Float64\(0\.95\)\)"
+SELECT c1, approx_percentile_cont(c2, 0.95) AS c2, approx_percentile_cont(c3, 0.95) AS c3 FROM aggregate_test_100 GROUP BY 1 ORDER BY 1
+
+# error is unique to this UDAF
+query TRR
+SELECT c1, avg(c2) AS c2, avg(c3) AS c3 FROM aggregate_test_100 GROUP BY 1 ORDER BY 1
+----
+a 2.857142857143 -18.333333333333
+b 3.263157894737 -5.842105263158
+c 2.666666666667 -1.333333333333
+d 2.444444444444 25.444444444444
+e 3 40.333333333333
+
+
+
 query TI
 SELECT c1, approx_percentile_cont(0.95) WITHIN GROUP (ORDER BY c3 DESC) AS c3_p95 FROM aggregate_test_100 GROUP BY 1 ORDER BY 1
 ----


### PR DESCRIPTION
## Which issue does this PR close?

Closes #17730


## Rationale for this change

The schema names are kept unique using the `WITHIN GROUP clause`. But since we permit this clause to be missing, we need to maintain uniqueness by not shaving off the column identifier. See test case for details.

Also, note the commit with initial failure: https://github.com/influxdata/arrow-datafusion/commit/5cbeb1c6d2957b5124ebfdfe9cc59e4117ad2ed3

## What changes are included in this PR?

Adds to a conditional.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

Fixes a regression.
