### PR TITLE
Improve documentation for ordered set aggregate functions

### DIFF
--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -740,7 +740,20 @@ pub trait AggregateUDFImpl: Debug + DynEq + DynHash + Send + Sync {
     }
 
     /// If this function is ordered-set aggregate function, return true
-    /// If the function is not, return false
+    /// otherwise, return false
+    ///
+    /// Ordered-set aggregate functions require an explicit `ORDER BY` clause
+    /// because the calculation performed by these functions is dependent on the
+    /// specific sequence of the input rows, unlike other aggregate functions
+    /// like `SUM`, `AVG`, or `COUNT`.
+    ///
+    /// An example of an ordered-set aggregate function is `percentile_cont`
+    /// which computes a specific percentile value from a sorted list of values, and
+    /// is only meaningful when the input data is ordered.
+    ///
+    /// In SQL syntax, ordered-set aggregate functions are used with the
+    /// `WITHIN GROUP (ORDER BY ...)` clause to specify the ordering of the input
+    /// data.
     fn is_ordered_set_aggregate(&self) -> bool {
         false
     }


### PR DESCRIPTION
## Which issue does this PR close?

- related to https://github.com/apache/datafusion/pull/17731

## Rationale for this change

While reviewing https://github.com/apache/datafusion/pull/17731 from @wiedld  I had to remind myself what an "ordered set aggregate function" was and I would like to have the datafusion documentation tell me that explicitly in the future

## What changes are included in this PR?

Update documentation

## Are these changes tested?

By CI tests

## Are there any user-facing changes?
Only documentation, no functional changes intended
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
