### PR TITLE
[branch-50] Backport change to avoid debug symbols in ci builds to 50.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ rpath = false
 strip = false            # Retain debug info for flamegraphs
 
 [profile.ci]
+debug = false
 inherits = "dev"
 incremental = false
 


### PR DESCRIPTION

## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/17594

## Rationale for this change

I am trying to get a clean CI run on the `branch-50` branch but some CI is failing with "out of diskspace" errors

https://github.com/apache/datafusion/actions/runs/18017424338/job/51322145417?pr=17778

> rustc-LLVM ERROR: IO failure on output stream: No space left on device
> error: could not compile `datafusion-functions-nested` (lib test)

@rkrishn7  fixed this on main as part of https://github.com/apache/datafusion/pull/17677 (thanks to @Jefffrey  for helping me find this https://github.com/apache/datafusion/pull/17778#issuecomment-3338605948) but the fix isn't in the branch-50 branch yet

## What changes are included in this PR?

Backport the part of https://github.com/apache/datafusion/pull/17677 that reduces disk usage for tests
 
## Are these changes tested?

By CI 
## Are there any user-facing changes?

No this is an internal developemnt process change
