### PR TITLE
chore: remove dialect settings in SLT tests that are outdated

### DIFF
--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -725,10 +725,6 @@ SELECT c2, var_samp(c12) FROM aggregate_test_100 WHERE c12 > 0.90 GROUP BY c2 OR
 4 NULL
 5 0.000269544643
 
-# Use PostgresSQL dialect
-statement ok
-set datafusion.sql_parser.dialect = 'Postgres';
-
 # csv_query_stddev_12
 query IR
 SELECT c2, var_samp(c12) FILTER (WHERE c12 > 0.95) FROM aggregate_test_100 GROUP BY c2 ORDER BY c2
@@ -738,10 +734,6 @@ SELECT c2, var_samp(c12) FILTER (WHERE c12 > 0.95) FROM aggregate_test_100 GROUP
 3 NULL
 4 NULL
 5 NULL
-
-# Restore the default dialect
-statement ok
-set datafusion.sql_parser.dialect = 'Generic';
 
 # csv_query_stddev_13
 query IR
@@ -5159,10 +5151,6 @@ select c2, count(DISTINCT cast(c1 AS DECIMAL(10, 2))) from d_table GROUP BY c2 O
 A 2
 B 2
 
-# Use PostgresSQL dialect
-statement ok
-set datafusion.sql_parser.dialect = 'Postgres';
-
 # Creating the table
 statement ok
 CREATE TABLE test_table (c1 INT, c2 INT, c3 INT)
@@ -5291,10 +5279,6 @@ select c3, count(c2), avg(c2), sum(c2), min(c2), max(c2), count(c4), sum(c4) fro
 200.2 1 20.2 20.2 20.2 20.2 0 NULL
 700.1 2 15.15 30.3 10.1 20.2 0 NULL
 NULL 1 10.1 10.1 10.1 10.1 0 NULL
-
-# Restore the default dialect
-statement ok
-set datafusion.sql_parser.dialect = 'Generic';
 
 ## Multiple distinct aggregates and dictionaries
 statement ok

--- a/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
+++ b/datafusion/sqllogictest/test_files/aggregate_skip_partial.slt
@@ -69,9 +69,6 @@ set datafusion.execution.target_partitions = 2;
 statement ok
 set datafusion.execution.batch_size = 1;
 
-statement ok
-set datafusion.sql_parser.dialect = 'Postgres';
-
 # Grouping by unique fields allows to check all accumulators
 query ITIIII
 SELECT c5, c1,
@@ -419,10 +416,6 @@ b NULL false NULL
 c true false NULL
 d NULL false NULL
 e true false NULL
-
-# Enabling PG dialect for filtered aggregates tests
-statement ok
-set datafusion.sql_parser.dialect = 'Postgres';
 
 # Test count with filter
 query III

--- a/datafusion/sqllogictest/test_files/create_function.slt
+++ b/datafusion/sqllogictest/test_files/create_function.slt
@@ -21,11 +21,6 @@
 ## Note that DataFusion provides a pluggable system for creating functions
 ## but has no built in support for doing so.
 
-# Use PostgresSQL dialect (until we upgrade to sqlparser 0.44, where CREATE FUNCTION)
-# is supported in the Generic dialect (the default)
-statement ok
-set datafusion.sql_parser.dialect = 'Postgres';
-
 # Create function will fail unless a user supplied function factory is supplied
 statement error DataFusion error: Invalid or Unsupported Configuration: Function factory has not been configured
 CREATE FUNCTION foo (DOUBLE) RETURNS DOUBLE RETURN $1 + $2;

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -2080,9 +2080,6 @@ host2 2.2 202
 host3 3.3 303
 
 statement ok
-set datafusion.sql_parser.dialect = 'Postgres';
-
-statement ok
 create table t (a float) as values (1), (2), (3);
 
 query TT
@@ -2100,9 +2097,6 @@ physical_plan
 
 statement ok
 drop table t;
-
-statement ok
-set datafusion.sql_parser.dialect = 'Generic';
 
 # test between expression with null
 query I

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -4475,10 +4475,6 @@ physical_plan
 12)----------------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
 13)------------------------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c2, c3, c4], file_type=csv, has_header=true
 
-# Use PostgreSQL dialect
-statement ok
-set datafusion.sql_parser.dialect = 'Postgres';
-
 query II
 SELECT c2, count(distinct c3) FILTER (WHERE c1 != 'a') FROM aggregate_test_100 GROUP BY c2 ORDER BY c2;
 ----
@@ -4496,10 +4492,6 @@ SELECT c2, count(distinct c3) FILTER (WHERE c1 != 'a'), count(c5) FILTER (WHERE 
 3 13 17
 4 19 18
 5 11 9
-
-# Restore the default dialect
-statement ok
-set datafusion.sql_parser.dialect = 'Generic';
 
 statement ok
 drop table aggregate_test_100;


### PR DESCRIPTION
Closes #16516
Closes #15719

These two issues have been supported for a while it seems, with default generic SQL dialect allowing filters on aggregates. Fix the SLT tests to not need to switch to postgres dialect in order to test these with generic dialect.

Also cleanup a TODO in `create_function.slt` as that seems actioned by now.