### PR TITLE
Temporarily disable failing `sql_planner` benchmark query

### DIFF
--- a/datafusion/core/benches/sql_planner.rs
+++ b/datafusion/core/benches/sql_planner.rs
@@ -664,6 +664,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     };
 
     let raw_tpcds_sql_queries = (1..100)
+        // skip query 75 until it is fixed
+        // https://github.com/apache/datafusion/issues/17801
+        .filter(|q| *q != 75)
         .map(|q| std::fs::read_to_string(format!("{tests_path}tpc-ds/{q}.sql")).unwrap())
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
## Which issue does this PR close?

- part of https://github.com/apache/datafusion/issues/17801


## Rationale for this change

I am trying to run some benchmarks with @pepijnve  on
https://github.com/apache/datafusion/pull/17419 but the benchmark queries are
now failing.

In order to unblock testing, I would like to disable the panic'ing query in the benchmark code until we fix the underlying issue.


## What changes are included in this PR?

Skip the failing test

## Are these changes tested?

I tested this manually that the previously failing code
```shell
cargo bench --profile dev --bench sql_planner -- physical_plan_tpcds_all
```

Now runs to completion

## Are there any user-facing changes?

No, this is a benchmarking change only