### PR TITLE
fix: Maintain `SUM` precision during two-phase aggregation

### DIFF
--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -46,6 +46,7 @@ chrono = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
 datafusion-expr-common = { workspace = true }
+datafusion-functions-aggregate = { workspace = true }
 datafusion-physical-expr = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -7611,3 +7611,31 @@ NULL NULL NULL NULL
 
 statement ok
 drop table distinct_avg;
+
+
+# Regression test for https://github.com/apache/datafusion/issues/17699
+
+statement ok
+CREATE TABLE orders (
+    o_orderkey INT,
+    o_totalprice DECIMAL(15, 2)
+);
+
+statement ok
+INSERT INTO orders VALUES (1, 10.00);
+
+query R
+SELECT total_spent
+FROM (
+    SELECT
+        SUM(o_totalprice) AS total_spent,
+        COUNT(DISTINCT o_orderkey) AS order_count
+    FROM orders
+) t
+WHERE total_spent > 0;
+----
+10
+
+
+statement ok
+DROP TABLE orders;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #17699 

## What changes are included in this PR?

- Allows configuration of Sum aggregate UDF to maintain decimal precision
- Rewrites `SUM`s during logical optimizer rule `SingleDistinctToGroupBy`

## Are these changes tested?

Yes

## Are there any user-facing changes?

Adds `SumProperties`

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
