### PR TITLE
Revert "Disable failing benchmark query (#17809)"

### DIFF
--- a/datafusion/core/benches/sql_planner.rs
+++ b/datafusion/core/benches/sql_planner.rs
@@ -664,9 +664,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     };
 
     let raw_tpcds_sql_queries = (1..100)
-        // skip query 75 until it is fixed
-        // https://github.com/apache/datafusion/issues/17801
-        .filter(|q| *q != 75)
         .map(|q| std::fs::read_to_string(format!("{tests_path}tpc-ds/{q}.sql")).unwrap())
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
This reverts commit 5cc0be51f9b60224c0667b89dd0318a591e733d9.

## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/17801
- Reverts https://github.com/apache/datafusion/pull/17809

## Rationale for this change

I disabled a failing test while we fix it for real (see https://github.com/apache/datafusion/pull/17813). I do not want to forget about the test

## What changes are included in this PR?

This PR re-enables the test, so i don't forget about it

## Are these changes tested?

I will verify it manually via

```shell
cargo bench --profile dev --bench sql_planner -- physical_plan_tpcds_all
```

## Are there any user-facing changes?

No