### PR TITLE
perf: Faster `string_agg()` aggregate function (1000x speed for no DISTINCT and ORDER case)

### DIFF
--- a/datafusion/functions-aggregate/src/string_agg.rs
+++ b/datafusion/functions-aggregate/src/string_agg.rs
@@ -25,9 +25,14 @@ use crate::array_agg::ArrayAgg;
 
 use arrow::array::ArrayRef;
 use arrow::datatypes::{DataType, Field, FieldRef};
-use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
-use datafusion_common::{internal_err, not_impl_err, Result, ScalarValue};
+use datafusion_common::cast::{
+    as_generic_string_array, as_string_array, as_string_view_array,
+};
+use datafusion_common::{
+    internal_datafusion_err, internal_err, not_impl_err, Result, ScalarValue,
+};
 use datafusion_expr::function::AccumulatorArgs;
+use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
     Accumulator, AggregateUDFImpl, Documentation, Signature, TypeSignature, Volatility,
 };
@@ -120,6 +125,8 @@ impl Default for StringAgg {
     }
 }
 
+/// If there is no `distinct` and `order by` required by the `string_agg` call, a
+/// more efficient accumulator `SimpleStringAggAccumulator` will be used.
 impl AggregateUDFImpl for StringAgg {
     fn as_any(&self) -> &dyn Any {
         self
@@ -138,7 +145,21 @@ impl AggregateUDFImpl for StringAgg {
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
-        self.array_agg.state_fields(args)
+        // See comments in `impl AggregateUDFImpl ...` for more detail
+        let no_order_no_distinct =
+            (args.ordering_fields.is_empty()) && (!args.is_distinct);
+        if no_order_no_distinct {
+            // Case `SimpleStringAggAccumulator`
+            Ok(vec![Field::new(
+                format_state_name(args.name, "string_agg"),
+                DataType::LargeUtf8,
+                true,
+            )
+            .into()])
+        } else {
+            // Case `StringAggAccumulator`
+            self.array_agg.state_fields(args)
+        }
     }
 
     fn accumulator(&self, acc_args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
@@ -161,21 +182,31 @@ impl AggregateUDFImpl for StringAgg {
             );
         };
 
-        let array_agg_acc = self.array_agg.accumulator(AccumulatorArgs {
-            return_field: Field::new(
-                "f",
-                DataType::new_list(acc_args.return_field.data_type().clone(), true),
-                true,
-            )
-            .into(),
-            exprs: &filter_index(acc_args.exprs, 1),
-            ..acc_args
-        })?;
+        // See comments in `impl AggregateUDFImpl ...` for more detail
+        let no_order_no_distinct =
+            acc_args.order_bys.is_empty() && (!acc_args.is_distinct);
 
-        Ok(Box::new(StringAggAccumulator::new(
-            array_agg_acc,
-            delimiter,
-        )))
+        if no_order_no_distinct {
+            // simple case (more efficient)
+            Ok(Box::new(SimpleStringAggAccumulator::new(delimiter)))
+        } else {
+            // general case
+            let array_agg_acc = self.array_agg.accumulator(AccumulatorArgs {
+                return_field: Field::new(
+                    "f",
+                    DataType::new_list(acc_args.return_field.data_type().clone(), true),
+                    true,
+                )
+                .into(),
+                exprs: &filter_index(acc_args.exprs, 1),
+                ..acc_args
+            })?;
+
+            Ok(Box::new(StringAggAccumulator::new(
+                array_agg_acc,
+                delimiter,
+            )))
+        }
     }
 
     fn reverse_expr(&self) -> datafusion_expr::ReversedUDAF {
@@ -187,6 +218,7 @@ impl AggregateUDFImpl for StringAgg {
     }
 }
 
+/// StringAgg accumulator for the general case (with order or distinct specified)
 #[derive(Debug)]
 pub(crate) struct StringAggAccumulator {
     array_agg_acc: Box<dyn Accumulator>,
@@ -267,6 +299,105 @@ fn filter_index<T: Clone>(values: &[T], index: usize) -> Vec<T> {
         .map(|(_, v)| v)
         .cloned()
         .collect::<Vec<_>>()
+}
+
+/// StringAgg accumulator for the simple case (no order or distinct specified)
+/// This accumulator is more efficient than `StringAggAccumulator`
+#[derive(Debug)]
+pub(crate) struct SimpleStringAggAccumulator {
+    delimiter: String,
+    // Updating during `update_batch()`. e.g. "foo,bar"
+    in_progress_string: String,
+    has_value: bool,
+}
+
+impl SimpleStringAggAccumulator {
+    pub fn new(delimiter: &str) -> Self {
+        Self {
+            delimiter: delimiter.to_string(),
+            in_progress_string: "".to_string(),
+            has_value: false,
+        }
+    }
+
+    #[inline]
+    fn append_strings<'a, I>(&mut self, iter: I)
+    where
+        I: Iterator<Item = Option<&'a str>>,
+    {
+        for value in iter {
+            if let Some(value) = value {
+                if self.has_value {
+                    self.in_progress_string.push_str(&self.delimiter);
+                }
+
+                self.in_progress_string.push_str(value);
+                self.has_value = true;
+            }
+        }
+    }
+}
+
+impl Accumulator for SimpleStringAggAccumulator {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        let string_arr = values.get(0).ok_or_else(|| {
+            internal_datafusion_err!(
+                "Planner should ensure its first arg is Utf8/Utf8View"
+            )
+        })?;
+
+        match string_arr.data_type() {
+            DataType::Utf8 => {
+                let array = as_string_array(string_arr)?;
+                self.append_strings(array.iter());
+            }
+            DataType::LargeUtf8 => {
+                let array = as_generic_string_array::<i64>(string_arr)?;
+                self.append_strings(array.iter());
+            }
+            DataType::Utf8View => {
+                let array = as_string_view_array(string_arr)?;
+                self.append_strings(array.iter());
+            }
+            other => {
+                return internal_err!(
+                    "Planner should ensure string_agg first argument is Utf8-like, found {other}"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        let result = if self.has_value {
+            ScalarValue::LargeUtf8(Some(std::mem::take(&mut self.in_progress_string)))
+        } else {
+            ScalarValue::LargeUtf8(None)
+        };
+
+        self.has_value = false;
+        Ok(result)
+    }
+
+    fn size(&self) -> usize {
+        size_of_val(self) + self.delimiter.capacity() + self.in_progress_string.capacity()
+    }
+
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        let result = if self.has_value {
+            ScalarValue::LargeUtf8(Some(std::mem::take(&mut self.in_progress_string)))
+        } else {
+            ScalarValue::LargeUtf8(None)
+        };
+        self.has_value = false;
+
+        Ok(vec![result])
+    }
+
+    fn merge_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        self.update_batch(values)
+    }
 }
 
 #[cfg(test)]

--- a/datafusion/functions-aggregate/src/string_agg.rs
+++ b/datafusion/functions-aggregate/src/string_agg.rs
@@ -308,7 +308,7 @@ fn filter_index<T: Clone>(values: &[T], index: usize) -> Vec<T> {
 #[derive(Debug)]
 pub(crate) struct SimpleStringAggAccumulator {
     delimiter: String,
-    // Updating during `update_batch()`. e.g. "foo,bar"
+    /// Updated during `update_batch()`. e.g. "foo,bar"
     accumulated_string: String,
     has_value: bool,
 }

--- a/datafusion/functions-aggregate/src/string_agg.rs
+++ b/datafusion/functions-aggregate/src/string_agg.rs
@@ -325,22 +325,20 @@ impl SimpleStringAggAccumulator {
     where
         I: Iterator<Item = Option<&'a str>>,
     {
-        for value in iter {
-            if let Some(value) = value {
-                if self.has_value {
-                    self.in_progress_string.push_str(&self.delimiter);
-                }
-
-                self.in_progress_string.push_str(value);
-                self.has_value = true;
+        for value in iter.flatten() {
+            if self.has_value {
+                self.in_progress_string.push_str(&self.delimiter);
             }
+
+            self.in_progress_string.push_str(value);
+            self.has_value = true;
         }
     }
 }
 
 impl Accumulator for SimpleStringAggAccumulator {
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
-        let string_arr = values.get(0).ok_or_else(|| {
+        let string_arr = values.first().ok_or_else(|| {
             internal_datafusion_err!(
                 "Planner should ensure its first arg is Utf8/Utf8View"
             )

--- a/datafusion/functions-aggregate/src/string_agg.rs
+++ b/datafusion/functions-aggregate/src/string_agg.rs
@@ -303,6 +303,8 @@ fn filter_index<T: Clone>(values: &[T], index: usize) -> Vec<T> {
 
 /// StringAgg accumulator for the simple case (no order or distinct specified)
 /// This accumulator is more efficient than `StringAggAccumulator`
+/// because it accumulates the string directly,
+/// whereas `StringAggAccumulator` uses `ArrayAggAccumulator`.
 #[derive(Debug)]
 pub(crate) struct SimpleStringAggAccumulator {
     delimiter: String,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

part of #17789 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
`string_agg` is slow, see the tracking issue for details.

This PR added a new `Accumulator` implementation for the simple case: if there is no `DISTINCT` and `ORDER BY` like `string_agg(distinct str, ',' ORDER BY str)`, use `SimpleStringAggAccumulator` instead. The original `StringAggAccumulator` is used for the general case with potential `DISTINCT` and `ORDER BY`s.

While @vegarsti is working on a `GroupsAccumulator` solution that can further speed it up potentially, I think this PR is still necessary because the single group case like `select string_agg(str, ',') from t1` is still using the `Accumulator` interface instead of `GroupsAccumulator`

I haven't checked the original implementation yet, and I don't know why is it so slow. It's using `array_agg` internally, and memory bloat can be observed. I guess the reason is redundant transcoding, and incorrect operations on `StringView` buffers.
There are several ongoing work to improve `arrray_agg`: https://github.com/apache/datafusion/issues/17829

### Benchmark
It's around 1000x faster. See the original issue for data setup, scaling factor 0.1 is used for the table.

```
DataFusion CLI v50.0.0
> CREATE EXTERNAL TABLE partsupp
STORED AS PARQUET
LOCATION '/Users/yongting/Code/datafusion-sqlstorm/data/partsupp.parquet';

> select ps_partkey, string_agg(ps_comment, ';')
from partsupp
group by ps_partkey;
```

Before: ~50s
PR: 0.05s

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Implemented a `SimpleStringAggAccumulator` for `string_agg`
2. In the aggregate function implementation, opt for the new accumulator if there is no `DISTINCT` and `ORDER BY` in the `string_agg()` aggregate function.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Existing tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
