### PR TITLE
dev: Add typos check to the local `dev/rust_lint.sh`

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Install HawkEye
+      # This CI job is bound by installation time, use `--profile dev` to speed it up
         run: cargo install hawkeye --version 6.2.0 --locked --profile dev
       - name: Run license header check
         run: ci/scripts/license_header.sh
@@ -57,3 +58,16 @@ jobs:
             README.md \
             CONTRIBUTING.md
           git diff --exit-code
+
+  typos:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Install typos-cli
+      # This CI job is bound by installation time, use `--profile dev` to speed it up
+        run: cargo install typos-cli --locked --version 1.37.0 --profile dev
+      - name: Run typos check
+        run: ci/scripts/typos_check.sh

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Install typos-cli
-      # This CI job is bound by installation time, use `--profile dev` to speed it up
-        run: cargo install typos-cli --locked --version 1.37.0 --profile dev
+        run: cargo install typos-cli --locked --version 1.37.0
       - name: Run typos check
         run: ci/scripts/typos_check.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -784,4 +784,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
-      - uses: crate-ci/typos@6d35b835f6f431bbe715c4c1ccd2c7d3264e11fb  # v1.37.0
+      - name: Install typos-cli
+        run: cargo install typos-cli --locked --version 1.37.0
+      - name: Run typos check
+        run: ci/scripts/typos_check.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -777,14 +777,3 @@ jobs:
       - name: Check datafusion-proto
         working-directory: datafusion/proto
         run: cargo msrv --output-format json --log-target stdout verify
-  typos:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-        with:
-          persist-credentials: false
-      - name: Install typos-cli
-        run: cargo install typos-cli --locked --version 1.37.0
-      - name: Run typos check
-        run: ci/scripts/typos_check.sh

--- a/ci/scripts/typos_check.sh
+++ b/ci/scripts/typos_check.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -ex
+
+typos --config typos.toml

--- a/dev/rust_lint.sh
+++ b/dev/rust_lint.sh
@@ -19,6 +19,10 @@
 
 # This script runs all the Rust lints locally the same way the
 # DataFusion CI does
+#
+# Note: The installed checking tools (e.g., taplo) are not guaranteed to match
+# teh CI versions for simplicity, there might be some minor differences. Check
+# `.github/workflows` for the CI versions.
 
 # For `.toml` format checking
 set -e
@@ -33,8 +37,15 @@ if ! command -v hawkeye &> /dev/null; then
     cargo install hawkeye --locked
 fi
 
+# For spelling checks
+if ! command -v typos &> /dev/null; then
+    echo "Installing typos using cargo"
+    cargo install typos-cli --locked
+fi
+
 ci/scripts/rust_fmt.sh
 ci/scripts/rust_clippy.sh
 ci/scripts/rust_toml_fmt.sh
 ci/scripts/rust_docs.sh
 ci/scripts/license_header.sh
+ci/scripts/typos_check.sh

--- a/typos.toml
+++ b/typos.toml
@@ -46,5 +46,9 @@ extend-exclude = [
     "dev/changelog/**",
     "benchmarks/**",
     "*.csv",
-    "docs/source/contributor-guide/governance.md"
+    "docs/source/contributor-guide/governance.md",
+    # submodules
+    "parquet-testing/**",
+    "datafusion-testing/**",
+    "testing/**",
 ]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
There is a typos check CI job introduced recently. I always end up with typos in my PRs, so I want an easier way to run this typo check locally.

`dev/rust_lint.rs` is used to perform all lint checks (fmt, clippy) locally, the typos check should also be suitable to get included.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Added `ci/scripts/typos_check.sh` for local typos check, and include it into `dev/rust_lint.sh`
2. Update CI to also use `ci/scripts/typos_check.sh` for consistency
3. Moved typo check CI job from `Rust workflow` to `Dev workflow`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, since CI job is changed, I included one typo in this PR, and it should trigger CI failure.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
