### PR TITLE
Export JoinSetTracerError from datafusion-common-runtime

### DIFF
--- a/datafusion/common-runtime/src/lib.rs
+++ b/datafusion/common-runtime/src/lib.rs
@@ -30,4 +30,4 @@ mod trace_utils;
 
 pub use common::SpawnedTask;
 pub use join_set::JoinSet;
-pub use trace_utils::{set_join_set_tracer, JoinSetTracer};
+pub use trace_utils::{set_join_set_tracer, JoinSetTracer, JoinSetTracerError};


### PR DESCRIPTION
## Summary

Fixes #17876

The `JoinSetTracerError` type is returned by `set_join_set_tracer()` but was not exported in the public API, making it impossible for downstream users to properly handle errors from this function.

This change adds `JoinSetTracerError` to the re-exports in `lib.rs`.