### PR TITLE
[branch-50] Backport: fix typos & pin action hashes (#17855)

### DIFF
--- a/.github/actions/setup-macos-aarch64-builder/action.yaml
+++ b/.github/actions/setup-macos-aarch64-builder/action.yaml
@@ -44,7 +44,7 @@ runs:
         rustup default stable
         rustup component add rustfmt
     - name: Setup rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1  # v2.8.1
       with:
            save-if: ${{ github.ref_name == 'main' }}
     - name: Configure rust runtime env

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -40,7 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        uses: taiki-e/install-action@3216b6964cbfe053bb8b9a2ef245bd9300e2061d  # v2.62.14
+        with:
+          tool: cargo-audit
       - name: Run audit check
         # Ignored until https://github.com/apache/datafusion/issues/15571
         # ignored py03 warning until arrow 55 upgrade

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -406,8 +406,9 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq clang
       - name: Setup wasm-pack
-        run: |
-          cargo install wasm-pack
+        uses: taiki-e/install-action@3216b6964cbfe053bb8b9a2ef245bd9300e2061d  # v2.62.14
+        with:
+          tool: wasm-pack
       - name: Run tests with headless mode
         working-directory: ./datafusion/wasmtest
         run: |
@@ -746,7 +747,10 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
       - name: Install cargo-msrv
-        run: cargo install cargo-msrv
+        uses: taiki-e/install-action@3216b6964cbfe053bb8b9a2ef245bd9300e2061d  # v2.62.14
+        with:
+          tool: cargo-msrv
+
       - name: Check datafusion
         working-directory: datafusion/core
         run: |
@@ -785,7 +789,7 @@ jobs:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
-      - uses: crate-ci/typos@v1
+      - uses: crate-ci/typos@6d35b835f6f431bbe715c4c1ccd2c7d3264e11fb  # v1.37.0

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -2387,7 +2387,7 @@ impl ScalarValue {
                 Arc::new(array)
             }
             // explicitly enumerate unsupported types so newly added
-            // types must be aknowledged, Time32 and Time64 types are
+            // types must be acknowledged, Time32 and Time64 types are
             // not supported if the TimeUnit is not valid (Time32 can
             // only be used with Second and Millisecond, Time64 only
             // with Microsecond and Nanosecond)

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1131,7 +1131,7 @@ impl ListingTable {
     }
 }
 
-// Expressions can be used for parttion pruning if they can be evaluated using
+// Expressions can be used for partition pruning if they can be evaluated using
 // only the partition columns and there are partition columns.
 fn can_be_evaluated_for_partition_pruning(
     partition_column_names: &[&str],

--- a/datafusion/core/tests/physical_optimizer/filter_pushdown/mod.rs
+++ b/datafusion/core/tests/physical_optimizer/filter_pushdown/mod.rs
@@ -1102,7 +1102,7 @@ async fn test_hashjoin_dynamic_filter_pushdown_partitioned() {
         Arc::new(CoalesceBatchesExec::new(hash_join, 8192)) as Arc<dyn ExecutionPlan>;
     // Top-level CoalescePartitionsExec
     let cp = Arc::new(CoalescePartitionsExec::new(cb)) as Arc<dyn ExecutionPlan>;
-    // Add a sort for determistic output
+    // Add a sort for deterministic output
     let plan = Arc::new(SortExec::new(
         LexOrdering::new(vec![PhysicalSortExpr::new(
             col("a", &probe_side_schema).unwrap(),

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -1070,7 +1070,6 @@ mod tests {
         .into_iter()
         .collect();
 
-        //let valid_array = vec![true, false, false, true, false, tru
         let null_buffer = Buffer::from([0b00101001u8]);
         let load4 = load4
             .into_data()

--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -86,7 +86,7 @@ Here are some example systems built using DataFusion:
 By using DataFusion, projects are freed to focus on their specific
 features, and avoid reimplementing general (but still necessary)
 features such as an expression representation, standard optimizations,
-parellelized streaming execution plans, file format support, etc.
+parallelized streaming execution plans, file format support, etc.
 
 ## Known Users
 

--- a/typos.toml
+++ b/typos.toml
@@ -34,6 +34,9 @@ alph = "alph"
 wih = "wih"
 Ded = "Ded"
 
+# From SLT README
+nteger = "nteger"
+
 [files]
 extend-exclude = [
     "*.slt",


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/17849
- Backports https://github.com/apache/datafusion/pull/17855

## Rationale for this change

Make CI happy on branch-50

## What changes are included in this PR?

Fixing typos and pinning GH action dependencies to commit hashes.

## Are these changes tested?

CI itself.

## Are there any user-facing changes?

No
