### PR TITLE
chore: rename Schema `print_schema_tree` to `tree_string`

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -876,7 +876,7 @@ impl DFSchema {
             .zip(self.inner.fields().iter())
             .map(|(qualifier, field)| (qualifier.as_ref(), field))
     }
-    /// Print schema in tree format
+    /// Returns a tree-like string representation of the schema.
     ///
     /// This method formats the schema
     /// with a tree-like structure showing field names, types, and nullability.
@@ -896,12 +896,12 @@ impl DFSchema {
     ///     HashMap::new()
     /// ).unwrap();
     ///
-    /// assert_eq!(schema.print_schema_tree().to_string(),
+    /// assert_eq!(schema.tree_string().to_string(),
     /// r#"root
     ///  |-- id: int32 (nullable = false)
     ///  |-- name: utf8 (nullable = true)"#);
     /// ```
-    pub fn print_schema_tree(&self) -> impl Display + '_ {
+    pub fn tree_string(&self) -> impl Display + '_ {
         let mut result = String::from("root\n");
 
         for (qualifier, field) in self.iter() {
@@ -1982,7 +1982,7 @@ mod tests {
         )
         .unwrap();
 
-        let output = schema.print_schema_tree();
+        let output = schema.tree_string();
 
         insta::assert_snapshot!(output, @r"
         root
@@ -2004,7 +2004,7 @@ mod tests {
         )
         .unwrap();
 
-        let output = schema.print_schema_tree();
+        let output = schema.tree_string();
 
         insta::assert_snapshot!(output, @r"
         root
@@ -2042,7 +2042,7 @@ mod tests {
         )
         .unwrap();
 
-        let output = schema.print_schema_tree();
+        let output = schema.tree_string();
         insta::assert_snapshot!(output, @r"
         root
          |-- id: int32 (nullable = false)
@@ -2058,7 +2058,7 @@ mod tests {
     #[test]
     fn test_print_schema_empty() {
         let schema = DFSchema::empty();
-        let output = schema.print_schema_tree();
+        let output = schema.tree_string();
         insta::assert_snapshot!(output, @r###"root"###);
     }
 
@@ -2131,7 +2131,7 @@ mod tests {
         )
         .unwrap();
 
-        let output = schema.print_schema_tree();
+        let output = schema.tree_string();
 
         insta::assert_snapshot!(output, @r"
         root
@@ -2174,7 +2174,7 @@ mod tests {
         )
         .unwrap();
 
-        let output = schema.print_schema_tree();
+        let output = schema.tree_string();
 
         insta::assert_snapshot!(output, @r"
         root
@@ -2213,7 +2213,7 @@ mod tests {
         )
         .unwrap();
 
-        let output = schema.print_schema_tree();
+        let output = schema.tree_string();
 
         insta::assert_snapshot!(output, @r"
         root
@@ -2355,7 +2355,7 @@ mod tests {
         )
         .unwrap();
 
-        let output = schema.print_schema_tree();
+        let output = schema.tree_string();
 
         insta::assert_snapshot!(output, @r"
         root
@@ -2430,7 +2430,7 @@ mod tests {
         )
         .unwrap();
 
-        let output = schema.print_schema_tree();
+        let output = schema.tree_string();
 
         insta::assert_snapshot!(output, @r"
         root


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

Related https://github.com/apache/datafusion/issues/17466
## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Rename `print_schema_tree` to `tree_string` to better reflect the method purpose. The method returns a tree string, and doesn't print anything
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
