### PR TITLE
Clippy to `extended_tests`

### DIFF
--- a/ci/scripts/rust_clippy.sh
+++ b/ci/scripts/rust_clippy.sh
@@ -18,4 +18,4 @@
 # under the License.
 
 set -ex
-cargo clippy --all-targets --workspace --features avro,pyarrow,integration-tests -- -D warnings
+cargo clippy --all-targets --workspace --features avro,pyarrow,integration-tests,extended_tests -- -D warnings

--- a/datafusion/core/tests/memory_limit/memory_limit_validation/sort_mem_validation.rs
+++ b/datafusion/core/tests/memory_limit/memory_limit_validation/sort_mem_validation.rs
@@ -123,7 +123,7 @@ fn spawn_test_process(test: &str) {
     let stdout = str::from_utf8(&output.stdout).unwrap_or("");
     let stderr = str::from_utf8(&output.stderr).unwrap_or("");
 
-    info!("{}", stdout);
+    info!("{stdout}");
 
     assert!(
         output.status.success(),


### PR DESCRIPTION
Locally i run `cargo clippy --all-targets --workspace --all-features -- -D warnings` and it makes it always shout at this one line 😅