### PR TITLE
Make OOM error messages more readable.

### DIFF
--- a/datafusion-cli/tests/snapshots/cli_top_memory_consumers@top2.snap
+++ b/datafusion-cli/tests/snapshots/cli_top_memory_consumers@top2.snap
@@ -16,7 +16,7 @@ exit_code: 1
 [CLI_VERSION]
 Error: Not enough memory to continue external sort. Consider increasing the memory limit, or decreasing sort_spill_reservation_bytes
 caused by
-Resources exhausted: Additional allocation failed for ExternalSorter[0] with top memory consumers (across reservations) as:
+Resources exhausted: Additional allocation failed for ExternalSorter[partition=0] with top memory consumers (across reservations) as:
   Consumer(can spill: bool) consumed XB, peak XB,
   Consumer(can spill: bool) consumed XB, peak XB.
 Error: Failed to allocate 

--- a/datafusion-cli/tests/snapshots/cli_top_memory_consumers@top3_default.snap
+++ b/datafusion-cli/tests/snapshots/cli_top_memory_consumers@top3_default.snap
@@ -14,7 +14,7 @@ exit_code: 1
 [CLI_VERSION]
 Error: Not enough memory to continue external sort. Consider increasing the memory limit, or decreasing sort_spill_reservation_bytes
 caused by
-Resources exhausted: Additional allocation failed for ExternalSorter[0] with top memory consumers (across reservations) as:
+Resources exhausted: Additional allocation failed for ExternalSorter[partition=0] with top memory consumers (across reservations) as:
   Consumer(can spill: bool) consumed XB, peak XB,
   Consumer(can spill: bool) consumed XB, peak XB,
   Consumer(can spill: bool) consumed XB, peak XB.

--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -153,7 +153,7 @@ async fn join_by_expression() {
     TestCase::new()
         .with_query("select t1.* from t t1 JOIN t t2 ON t1.service != t2.service")
         .with_expected_errors(vec![
-           "Resources exhausted: Additional allocation failed", "with top memory consumers (across reservations) as:\n  NestedLoopJoinLoad[0]",
+           "Resources exhausted: Additional allocation failed", "with top memory consumers (across reservations) as:\n  NestedLoopJoinLoad[partition=0]",
         ])
         .with_memory_limit(1_000)
         .run()
@@ -375,7 +375,7 @@ async fn oom_parquet_sink() {
         ))
         .with_expected_errors(vec![
             "Failed to allocate additional",
-            "for ParquetSink(ArrowColumnWriter)",
+            "ParquetSink(ArrowColumnWriter(col=1))",
         ])
         .with_memory_limit(200_000)
         .run()
@@ -402,8 +402,8 @@ async fn oom_with_tracked_consumer_pool() {
         ))
         .with_expected_errors(vec![
             "Failed to allocate additional",
-            "for ParquetSink(ArrowColumnWriter)",
-            "Additional allocation failed", "with top memory consumers (across reservations) as:\n  ParquetSink(ArrowColumnWriter)"
+            "for ParquetSink(ArrowColumnWriter(col=2))",
+            "Additional allocation failed", "with top memory consumers (across reservations) as:\n  ParquetSink(ArrowColumnWriter(col=8))"
         ])
         .with_memory_pool(Arc::new(
             TrackConsumersPool::new(

--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -1268,8 +1268,9 @@ impl FileSink for ParquetSink {
                         parquet_props.clone(),
                     )
                     .await?;
-                let mut reservation = MemoryConsumer::new(format!("ParquetSink[{path}]"))
-                    .register(context.memory_pool());
+                let mut reservation =
+                    MemoryConsumer::new(format!("ParquetSink[path={path}]"))
+                        .register(context.memory_pool());
                 file_write_tasks.spawn(async move {
                     while let Some(batch) = rx.recv().await {
                         writer.write(&batch).await?;

--- a/datafusion/physical-plan/src/aggregates/no_grouping.rs
+++ b/datafusion/physical-plan/src/aggregates/no_grouping.rs
@@ -88,8 +88,9 @@ impl AggregateStream {
         };
         let accumulators = create_accumulators(&agg.aggr_expr)?;
 
-        let reservation = MemoryConsumer::new(format!("AggregateStream[{partition}]"))
-            .register(context.memory_pool());
+        let reservation =
+            MemoryConsumer::new(format!("AggregateStream[partition={partition}]"))
+                .register(context.memory_pool());
 
         let inner = AggregateStreamInner {
             schema: Arc::clone(&agg.schema),

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -953,7 +953,7 @@ impl ExecutionPlan for HashJoinExec {
                 let left_stream = self.left.execute(partition, Arc::clone(&context))?;
 
                 let reservation =
-                    MemoryConsumer::new(format!("HashJoinInput[{partition}]"))
+                    MemoryConsumer::new(format!("HashJoinInput[partition={partition}]"))
                         .register(context.memory_pool());
 
                 OnceFut::new(collect_left_input(

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -496,7 +496,7 @@ impl ExecutionPlan for NestedLoopJoinExec {
 
         // Initialization reservation for load of inner table
         let load_reservation =
-            MemoryConsumer::new(format!("NestedLoopJoinLoad[{partition}]"))
+            MemoryConsumer::new(format!("NestedLoopJoinLoad[partition={partition}]"))
                 .register(context.memory_pool());
 
         let build_side_data = self.build_side_data.try_once(|| {

--- a/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
@@ -491,8 +491,9 @@ impl ExecutionPlan for SortMergeJoinExec {
         let batch_size = context.session_config().batch_size();
 
         // create memory reservation
-        let reservation = MemoryConsumer::new(format!("SMJStream[{partition}]"))
-            .register(context.memory_pool());
+        let reservation =
+            MemoryConsumer::new(format!("SMJStream[partition={partition}]"))
+                .register(context.memory_pool());
 
         // create join stream
         Ok(Box::pin(SortMergeJoinStream::try_new(

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -524,8 +524,10 @@ impl ExecutionPlan for SymmetricHashJoinExec {
             context.session_config().enforce_batch_size_in_joins();
 
         let reservation = Arc::new(Mutex::new(
-            MemoryConsumer::new(format!("SymmetricHashJoinStream[{partition}]"))
-                .register(context.memory_pool()),
+            MemoryConsumer::new(format!(
+                "SymmetricHashJoinStream[partition={partition}]"
+            ))
+            .register(context.memory_pool()),
         ));
         if let Some(g) = graph.as_ref() {
             reservation.lock().try_grow(g.size())?;

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -204,7 +204,7 @@ impl RepartitionExecState {
         let mut channels = HashMap::with_capacity(txs.len());
         for (partition, (tx, rx)) in txs.into_iter().zip(rxs).enumerate() {
             let reservation = Arc::new(Mutex::new(
-                MemoryConsumer::new(format!("{name}[{partition}]"))
+                MemoryConsumer::new(format!("{name}[partition={partition}]"))
                     .register(context.memory_pool()),
             ));
             channels.insert(partition, (tx, rx, reservation));

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -280,12 +280,13 @@ impl ExternalSorter {
         runtime: Arc<RuntimeEnv>,
     ) -> Result<Self> {
         let metrics = ExternalSorterMetrics::new(metrics, partition_id);
-        let reservation = MemoryConsumer::new(format!("ExternalSorter[{partition_id}]"))
-            .with_can_spill(true)
-            .register(&runtime.memory_pool);
+        let reservation =
+            MemoryConsumer::new(format!("ExternalSorter[partition={partition_id}]"))
+                .with_can_spill(true)
+                .register(&runtime.memory_pool);
 
         let merge_reservation =
-            MemoryConsumer::new(format!("ExternalSorterMerge[{partition_id}]"))
+            MemoryConsumer::new(format!("ExternalSorterMerge[partition={partition_id}]"))
                 .register(&runtime.memory_pool);
 
         let spill_manager = SpillManager::new(

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -292,9 +292,10 @@ impl ExecutionPlan for SortPreservingMergeExec {
         );
         let schema = self.schema();
 
-        let reservation =
-            MemoryConsumer::new(format!("SortPreservingMergeExec[{partition}]"))
-                .register(&context.runtime_env().memory_pool);
+        let reservation = MemoryConsumer::new(format!(
+            "SortPreservingMergeExec[partition={partition}]"
+        ))
+        .register(&context.runtime_env().memory_pool);
 
         match input_partitions {
             0 => internal_err!(

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -188,7 +188,7 @@ impl TopK {
         metrics: &ExecutionPlanMetricsSet,
         filter: Arc<RwLock<TopKDynamicFilters>>,
     ) -> Result<Self> {
-        let reservation = MemoryConsumer::new(format!("TopK[{partition_id}]"))
+        let reservation = MemoryConsumer::new(format!("TopK[partition={partition_id}]"))
             .register(&runtime.memory_pool);
 
         let sort_fields = build_sort_fields(&expr, &schema)?;


### PR DESCRIPTION
## Which issue does this PR close?
Part of #16904 

## Rationale for this change

By adding the full Error message in the OOM test assertions, we can clearly see what errors the user will see.

## What changes are included in this PR?

* No more magic numbers. Have each number be labeled for what it is: https://github.com/apache/datafusion/commit/f6c1f18fd42e84654060df437e09968df7fe358c
* Have OOM integration tests assert the whole (normalized) error message: https://github.com/apache/datafusion/commit/f4cd2db4b2ebb029eb589decce148738b857e73b


## Are these changes tested?

Yes

## Are there any user-facing changes?

No
