### PR TITLE
fix: fix failing test compilation on main

### DIFF
--- a/datafusion/datasource-csv/src/file_format.rs
+++ b/datafusion/datasource-csv/src/file_format.rs
@@ -823,7 +823,7 @@ mod tests {
             HashSet::from([DataType::Utf8]), // col5
         ];
 
-        let schema = build_schema_helper(column_names, &column_type_possibilities);
+        let schema = build_schema_helper(column_names, column_type_possibilities);
 
         // Verify schema has 5 columns
         assert_eq!(schema.fields().len(), 5);
@@ -853,7 +853,7 @@ mod tests {
             HashSet::from([DataType::Utf8]),                     // Should remain Utf8
         ];
 
-        let schema = build_schema_helper(column_names, &column_type_possibilities);
+        let schema = build_schema_helper(column_names, column_type_possibilities);
 
         // col1 should be Float64 due to Int64 + Float64 = Float64
         assert_eq!(*schema.field(0).data_type(), DataType::Float64);
@@ -871,7 +871,7 @@ mod tests {
             HashSet::from([DataType::Boolean, DataType::Int64, DataType::Utf8]), // Should resolve to Utf8 due to conflicts
         ];
 
-        let schema = build_schema_helper(column_names, &column_type_possibilities);
+        let schema = build_schema_helper(column_names, column_type_possibilities);
 
         // Should default to Utf8 for conflicting types
         assert_eq!(*schema.field(0).data_type(), DataType::Utf8);


### PR DESCRIPTION
Forgot to merge #17553 with main before I merged it in, seems a previous merged commit conflicted in a way and is causing build failure on main tests:

```sh
error[E0308]: mismatched types
   --> datafusion/datasource-csv/src/file_format.rs:826:56
    |
826 |         let schema = build_schema_helper(column_names, &column_type_possibilities);
    |                      -------------------               ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<HashSet<DataType>>`, found `&Vec<HashSet<DataType>>`
    |                      |
    |                      arguments to this function are incorrect
    |
    = note: expected struct `Vec<_>`
            found reference `&Vec<_>`
note: function defined here
   --> datafusion/datasource-csv/src/file_format.rs:619:4
    |
619 | fn build_schema_helper(names: Vec<String>, types: Vec<HashSet<DataType>>) -> Schema {
    |    ^^^^^^^^^^^^^^^^^^^                     -----------------------------
help: consider removing the borrow
    |
826 -         let schema = build_schema_helper(column_names, &column_type_possibilities);
826 +         let schema = build_schema_helper(column_names, column_type_possibilities);
    |

error[E0308]: mismatched types
   --> datafusion/datasource-csv/src/file_format.rs:856:56
    |
856 |         let schema = build_schema_helper(column_names, &column_type_possibilities);
    |                      -------------------               ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<HashSet<DataType>>`, found `&Vec<HashSet<DataType>>`
    |                      |
    |                      arguments to this function are incorrect
    |
    = note: expected struct `Vec<_>`
            found reference `&Vec<_>`
note: function defined here
   --> datafusion/datasource-csv/src/file_format.rs:619:4
    |
619 | fn build_schema_helper(names: Vec<String>, types: Vec<HashSet<DataType>>) -> Schema {
    |    ^^^^^^^^^^^^^^^^^^^                     -----------------------------
help: consider removing the borrow
    |
856 -         let schema = build_schema_helper(column_names, &column_type_possibilities);
856 +         let schema = build_schema_helper(column_names, column_type_possibilities);
    |

error[E0308]: mismatched types
   --> datafusion/datasource-csv/src/file_format.rs:874:56
    |
874 |         let schema = build_schema_helper(column_names, &column_type_possibilities);
    |                      -------------------               ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<HashSet<DataType>>`, found `&Vec<HashSet<DataType>>`
    |                      |
    |                      arguments to this function are incorrect
    |
    = note: expected struct `Vec<_>`
            found reference `&Vec<_>`
note: function defined here
   --> datafusion/datasource-csv/src/file_format.rs:619:4
    |
619 | fn build_schema_helper(names: Vec<String>, types: Vec<HashSet<DataType>>) -> Schema {
    |    ^^^^^^^^^^^^^^^^^^^                     -----------------------------
help: consider removing the borrow
    |
874 -         let schema = build_schema_helper(column_names, &column_type_possibilities);
874 +         let schema = build_schema_helper(column_names, column_type_possibilities);
    |

For more information about this error, try `rustc --explain E0308`.
error: could not compile `datafusion-datasource-csv` (lib test) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
```

Fixing this