### PR TITLE
minor: refactor Spark ascii function to reuse DataFusion ascii function code

### DIFF
--- a/datafusion/functions/src/string/ascii.rs
+++ b/datafusion/functions/src/string/ascii.rs
@@ -87,9 +87,7 @@ impl ScalarUDFImpl for AsciiFunc {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        use DataType::*;
-
-        Ok(Int32)
+        Ok(DataType::Int32)
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -186,6 +184,8 @@ mod tests {
         test_ascii!(Some(String::from("a")), Ok(Some(97)));
         test_ascii!(Some(String::from("")), Ok(Some(0)));
         test_ascii!(Some(String::from("🚀")), Ok(Some(128640)));
+        test_ascii!(Some(String::from("\n")), Ok(Some(10)));
+        test_ascii!(Some(String::from("\t")), Ok(Some(9)));
         test_ascii!(None, Ok(None));
         Ok(())
     }

--- a/datafusion/spark/src/function/string/ascii.rs
+++ b/datafusion/spark/src/function/string/ascii.rs
@@ -15,21 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{ArrayAccessor, ArrayIter, ArrayRef, AsArray, Int32Array};
 use arrow::datatypes::DataType;
-use arrow::error::ArrowError;
-use datafusion_common::{internal_err, plan_err, Result};
+use datafusion_common::Result;
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion_functions::string::ascii::ascii;
 use datafusion_functions::utils::make_scalar_function;
 use std::any::Any;
-use std::sync::Arc;
 
-/// <https://spark.apache.org/docs/latest/api/sql/index.html#ascii>
+/// Spark compatible version of the [ascii] function. Differs from the [default ascii function]
+/// in that it is more permissive of input types, for example casting numeric input to string
+/// before executing the function (default version doesn't allow numeric input).
+///
+/// [ascii]: https://spark.apache.org/docs/latest/api/sql/index.html#ascii
+/// [default ascii function]: datafusion_functions::string::ascii::AsciiFunc
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkAscii {
     signature: Signature,
-    aliases: Vec<String>,
 }
 
 impl Default for SparkAscii {
@@ -42,7 +44,6 @@ impl SparkAscii {
     pub fn new() -> Self {
         Self {
             signature: Signature::user_defined(Volatility::Immutable),
-            aliases: vec![],
         }
     }
 }
@@ -68,107 +69,7 @@ impl ScalarUDFImpl for SparkAscii {
         make_scalar_function(ascii, vec![])(&args.args)
     }
 
-    fn aliases(&self) -> &[String] {
-        &self.aliases
-    }
-
-    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        if arg_types.len() != 1 {
-            return plan_err!(
-                "The {} function requires 1 argument, but got {}.",
-                self.name(),
-                arg_types.len()
-            );
-        }
+    fn coerce_types(&self, _arg_types: &[DataType]) -> Result<Vec<DataType>> {
         Ok(vec![DataType::Utf8])
-    }
-}
-
-fn calculate_ascii<'a, V>(array: V) -> Result<ArrayRef, ArrowError>
-where
-    V: ArrayAccessor<Item = &'a str>,
-{
-    let iter = ArrayIter::new(array);
-    let result = iter
-        .map(|string| {
-            string.map(|s| {
-                let mut chars = s.chars();
-                chars.next().map_or(0, |v| v as i32)
-            })
-        })
-        .collect::<Int32Array>();
-
-    Ok(Arc::new(result) as ArrayRef)
-}
-
-/// Returns the numeric code of the first character of the argument.
-pub fn ascii(args: &[ArrayRef]) -> Result<ArrayRef> {
-    match args[0].data_type() {
-        DataType::Utf8 => {
-            let string_array = args[0].as_string::<i32>();
-            Ok(calculate_ascii(string_array)?)
-        }
-        DataType::LargeUtf8 => {
-            let string_array = args[0].as_string::<i64>();
-            Ok(calculate_ascii(string_array)?)
-        }
-        DataType::Utf8View => {
-            let string_array = args[0].as_string_view();
-            Ok(calculate_ascii(string_array)?)
-        }
-        _ => internal_err!("Unsupported data type"),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::function::string::ascii::SparkAscii;
-    use crate::function::utils::test::test_scalar_function;
-    use arrow::array::{Array, Int32Array};
-    use arrow::datatypes::DataType::Int32;
-    use datafusion_common::{Result, ScalarValue};
-    use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
-
-    macro_rules! test_ascii_string_invoke {
-        ($INPUT:expr, $EXPECTED:expr) => {
-            test_scalar_function!(
-                SparkAscii::new(),
-                vec![ColumnarValue::Scalar(ScalarValue::Utf8($INPUT))],
-                $EXPECTED,
-                i32,
-                Int32,
-                Int32Array
-            );
-
-            test_scalar_function!(
-                SparkAscii::new(),
-                vec![ColumnarValue::Scalar(ScalarValue::LargeUtf8($INPUT))],
-                $EXPECTED,
-                i32,
-                Int32,
-                Int32Array
-            );
-
-            test_scalar_function!(
-                SparkAscii::new(),
-                vec![ColumnarValue::Scalar(ScalarValue::Utf8View($INPUT))],
-                $EXPECTED,
-                i32,
-                Int32,
-                Int32Array
-            );
-        };
-    }
-
-    #[test]
-    fn test_ascii_invoke() -> Result<()> {
-        test_ascii_string_invoke!(Some(String::from("x")), Ok(Some(120)));
-        test_ascii_string_invoke!(Some(String::from("a")), Ok(Some(97)));
-        test_ascii_string_invoke!(Some(String::from("")), Ok(Some(0)));
-        test_ascii_string_invoke!(Some(String::from("\n")), Ok(Some(10)));
-        test_ascii_string_invoke!(Some(String::from("\t")), Ok(Some(9)));
-        test_ascii_string_invoke!(None, Ok(None));
-
-        Ok(())
     }
 }

--- a/datafusion/spark/src/lib.rs
+++ b/datafusion/spark/src/lib.rs
@@ -37,7 +37,8 @@
 //! # Example: using all function packages
 //!
 //! You can register all the functions in all packages using the [`register_all`]
-//! function as shown below.
+//! function as shown below. Any existing functions will be overwritten, with these
+//! Spark functions taking priority.
 //!
 //! ```
 //! # use datafusion_execution::FunctionRegistry;
@@ -68,10 +69,9 @@
 //! # async fn stub() -> Result<()> {
 //! // Create a new session context
 //! let mut ctx = SessionContext::new();
-//! // register all spark functions with the context
+//! // Rgister all Spark functions with the context
 //! datafusion_spark::register_all(&mut ctx)?;
-//! // run a query. Note the `sha2` function is now available which
-//! // has Spark semantics
+//! // Run a query using the `sha2` function which is now available and has Spark semantics
 //! let df = ctx.sql("SELECT sha2('The input String', 256)").await?;
 //! # Ok(())
 //! # }
@@ -170,7 +170,8 @@ pub fn all_default_table_functions() -> Vec<Arc<TableFunction>> {
     function::table::functions()
 }
 
-/// Registers all enabled packages with a [`FunctionRegistry`]
+/// Registers all enabled packages with a [`FunctionRegistry`], overriding any existing
+/// functions if there is a name clash.
 pub fn register_all(registry: &mut dyn FunctionRegistry) -> Result<()> {
     let scalar_functions: Vec<Arc<ScalarUDF>> = all_default_scalar_functions();
     scalar_functions.into_iter().try_for_each(|udf| {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #17964

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Some of the internals are the same; reuse this code.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Refactor SparkAscii to reuse the DataFusion Ascii internal code, adding doc comments to SparkAscii to explain difference with DataFusion version (hence why they are separate functions). Also update some of the Spark function documentation to clarify behaviour when it has overlapping function names with DataFusion functions.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
