### PR TITLE
bench: fix `vectorized_equal_to` bench mutated between iterations

### DIFF
--- a/datafusion/physical-plan/benches/aggregate_vectorized.rs
+++ b/datafusion/physical-plan/benches/aggregate_vectorized.rs
@@ -158,6 +158,7 @@ fn bytes_bench(
             (0..size).map(|_| d.sample(&mut rng)).collect::<Vec<_>>()
         },
     );
+    // Not adding 0 true case here as if we optimize for 0 true cases the caller should avoid calling this method at all
 }
 
 fn primitive_vectorized_append(c: &mut Criterion) {
@@ -265,6 +266,7 @@ fn bench_single_primitive<const NULLABLE: bool>(
             (0..size).map(|_| d.sample(&mut rng)).collect::<Vec<_>>()
         },
     );
+    // Not adding 0 true case here as if we optimize for 0 true cases the caller should avoid calling this method at all
 }
 
 /// Test `vectorized_equal_to` with different number of true in the initial results


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

In the benchmark `aggregate_vectorized` when benchmarking `vectorized_equal_to` passing the same `equal_to_result` mutable slice, causing the next iteration to skip any comparison. this is bad as it doesn't benchmark the actual comparison and it make benchmarks run dependent on the prev run

## What changes are included in this PR?

always pass a new mutable slice of equal to result, and added 3 more benchmark cases:
1. 0.75 equal to result true
2. 0.5 equal to result true
3. 0.25 equal to result true

## Are these changes tested?

Benchmarks

## Are there any user-facing changes?

Nope
