### PR TITLE
Expose trace_future and trace_block outside of common-runtime

### DIFF
--- a/datafusion/common-runtime/src/lib.rs
+++ b/datafusion/common-runtime/src/lib.rs
@@ -30,4 +30,6 @@ mod trace_utils;
 
 pub use common::SpawnedTask;
 pub use join_set::JoinSet;
-pub use trace_utils::{set_join_set_tracer, JoinSetTracer, JoinSetTracerError};
+pub use trace_utils::{
+    set_join_set_tracer, trace_block, trace_future, JoinSetTracer, JoinSetTracerError,
+};


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #17975

## Rationale for this change

Allows extension that are not in this repo to wire the top-level configured tracing into their own async/threading models.

## What changes are included in this PR?

Making `trace_future` and `trace_block` public functions.

## Are these changes tested?

N/A

## Are there any user-facing changes?

Extends the public API by a bit, but these functions seem very stable and straight forward.
