### PR TITLE
Adds Instrumented Object Store to CLI

### DIFF
--- a/datafusion-cli/src/object_storage/instrumented.rs
+++ b/datafusion-cli/src/object_storage/instrumented.rs
@@ -96,7 +96,7 @@ impl ObjectStore for InstrumentedObjectStore {
     }
 }
 
-/// Provides access to [`InstrumentedObjectStore`] instances that record requests for reporting
+/// Provides access to [`ObjectStore`] instances that record requests for reporting
 #[derive(Debug)]
 pub struct InstrumentedObjectStoreRegistry {
     inner: Arc<dyn ObjectStoreRegistry>,


### PR DESCRIPTION
## Which issue does this PR close?
This does not fully close, but is an incremental building block component for: 
 - https://github.com/apache/datafusion/issues/17207

Functionally this code currently does nothing, but it's an important component that will allow instrumentation of object stores. The full context of how this code is likely to progress can be seen in the POC for this effort:
 - https://github.com/apache/datafusion/pull/17266

## Rationale for this change

This is another bite-sized  building block on the road to completing #17207

## What changes are included in this PR?

 - Adds the InstrumentedObjectStore to datafusion-cli to support building instrumented output for queries executed via the cli
 - Integrates the new InstrumentedObjectStore into the InstrumentedObjectStoreRegistry to ensure any ObjectStore instance registered gets instrumentation

## Are these changes tested?

Yes. While no additional tests have been added, the `InstrumentedObjectStoreRegistry` now automatically invokes the `InstrumentedObjectStore` which means all new code is exercised under existing tests.

## Are there any user-facing changes?

No

cc @alamb 