### PR TITLE
Adds Instrument Mode for InstrumentedObjectStore in datafusion-cli

### DIFF
--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -33,7 +33,9 @@ use datafusion::logical_expr::ExplainFormat;
 use datafusion::prelude::SessionContext;
 use datafusion_cli::catalog::DynamicObjectStoreCatalog;
 use datafusion_cli::functions::{MetadataCacheFunc, ParquetMetadataFunc};
-use datafusion_cli::object_storage::instrumented::InstrumentedObjectStoreRegistry;
+use datafusion_cli::object_storage::instrumented::{
+    InstrumentedObjectStoreMode, InstrumentedObjectStoreRegistry,
+};
 use datafusion_cli::{
     exec,
     pool_type::PoolType,
@@ -208,9 +210,10 @@ async fn main_inner() -> Result<()> {
         rt_builder = rt_builder.with_disk_manager_builder(builder);
     }
 
-    let instrumented_registry = Arc::new(InstrumentedObjectStoreRegistry::new(Arc::new(
-        DefaultObjectStoreRegistry::new(),
-    )));
+    let instrumented_registry = Arc::new(InstrumentedObjectStoreRegistry::new(
+        Arc::new(DefaultObjectStoreRegistry::new()),
+        InstrumentedObjectStoreMode::default(),
+    ));
     rt_builder = rt_builder.with_object_store_registry(instrumented_registry.clone());
 
     let runtime_env = rt_builder.build_arc()?;


### PR DESCRIPTION

## Which issue does this PR close?

This does not fully close, but is an incremental building block component for: 
 - https://github.com/apache/datafusion/issues/17207

Functionally this code currently does nothing, but it will allow users to change the mode of an instrumented object store through either a CLI flag or with a runtime command.

The full context of how this code is likely to progress can be seen in the POC for this effort:
 - https://github.com/apache/datafusion/pull/17266

## Rationale for this change

This is another bite-sized  building block on the road to completing #17207

## What changes are included in this PR?

 - Adds mode type to allow changing the mode of an InstrumentedObjectStore to datafusion-cli
 - Implements string parsing and u8 conversion for InstrumentedObjectStoreMode
 - Adds tests to validate trait implementations

## Are these changes tested?

Yes. Unit tests have been added for the trait implementations on this new type.

## Are there any user-facing changes?

No.

cc @alamb

(I'm trying to keep these as small as possible and have them still make sense, however the PRs following this one will likely start to introduce real functionality and may end up being a bit larger)
