### PR TITLE
Fix `SortPreservingMergeExec` tree formatting with limit

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -198,15 +198,16 @@ impl DisplayAs for SortPreservingMergeExec {
                 Ok(())
             }
             DisplayFormatType::TreeRender => {
+                if let Some(fetch) = self.fetch {
+                    writeln!(f, "limit={fetch}")?;
+                };
+
                 for (i, e) in self.expr().iter().enumerate() {
                     e.fmt_sql(f)?;
                     if i != self.expr().len() - 1 {
                         write!(f, ", ")?;
                     }
                 }
-                if let Some(fetch) = self.fetch {
-                    writeln!(f, "limit={fetch}")?;
-                };
 
                 Ok(())
             }

--- a/datafusion/sqllogictest/test_files/explain_tree.slt
+++ b/datafusion/sqllogictest/test_files/explain_tree.slt
@@ -1696,10 +1696,10 @@ physical_plan
 01)┌───────────────────────────┐
 02)│  SortPreservingMergeExec  │
 03)│    --------------------   │
-04)│   ticker ASC NULLS LAST,  │
-05)│       time ASC NULLS      │
-06)│         LASTlimit:        │
-07)│             5             │
+04)│          limit: 5         │
+05)│                           │
+06)│   ticker ASC NULLS LAST,  │
+07)│     time ASC NULLS LAST   │
 08)└─────────────┬─────────────┘
 09)┌─────────────┴─────────────┐
 10)│    CoalesceBatchesExec    │


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18008.

The PR is split into two commits, the first one includes a passing test that shows the bug, and the second PR fixes the formatting and the test. 

## Rationale for this change

Fixes tree formatting for `SortPreservingMergeExec`

## What changes are included in this PR?

Fix tree formatting for `SortPreservingMergeExec` and add a test for the behavior.

## Are these changes tested?

A new slt test

## Are there any user-facing changes?

Only if a user asserts the tree-display in this case.
