### PR TITLE
feat: add support for schema-scoped table functions

### DIFF
--- a/datafusion/catalog/src/memory/schema.rs
+++ b/datafusion/catalog/src/memory/schema.rs
@@ -188,16 +188,13 @@ mod tests {
             Arc::new(DummyTableFunc),
         ));
 
-        // Register
         let result = schema.register_udtf("my_func".to_string(), func.clone());
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
 
-        // Verify exists
         assert!(schema.udtf_exist("my_func"));
         assert_eq!(schema.udtf_names(), vec!["my_func"]);
 
-        // Retrieve
         let retrieved = schema.udtf("my_func").unwrap();
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().name(), "my_func");
@@ -215,7 +212,6 @@ mod tests {
             .register_udtf("my_func".to_string(), func.clone())
             .unwrap();
 
-        // Second registration should fail
         let result = schema.register_udtf("my_func".to_string(), func.clone());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("already exists"));
@@ -232,13 +228,11 @@ mod tests {
         schema.register_udtf("my_func".to_string(), func).unwrap();
         assert!(schema.udtf_exist("my_func"));
 
-        // Deregister
         let removed = schema.deregister_udtf("my_func").unwrap();
         assert!(removed.is_some());
         assert!(!schema.udtf_exist("my_func"));
         assert_eq!(schema.udtf_names(), Vec::<String>::new());
 
-        // Deregister non-existent should return None
         let removed = schema.deregister_udtf("my_func").unwrap();
         assert!(removed.is_none());
     }
@@ -247,7 +241,6 @@ mod tests {
     fn test_udtf_not_found() {
         let schema = MemorySchemaProvider::new();
 
-        // Non-existent function
         assert!(!schema.udtf_exist("nonexistent"));
         let result = schema.udtf("nonexistent").unwrap();
         assert!(result.is_none());

--- a/datafusion/catalog/src/schema.rs
+++ b/datafusion/catalog/src/schema.rs
@@ -96,8 +96,7 @@ pub trait SchemaProvider: Debug + Sync + Send {
 
     /// Retrieves a specific table function from the schema by name, if it exists,
     /// otherwise returns `None`.
-    fn udtf(&self, name: &str) -> Result<Option<Arc<TableFunction>>> {
-        let _ = name; // suppress unused warning
+    fn udtf(&self, _name: &str) -> Result<Option<Arc<TableFunction>>> {
         Ok(None)
     }
 
@@ -123,8 +122,7 @@ pub trait SchemaProvider: Debug + Sync + Send {
     }
 
     /// Returns true if table function exists in the schema provider, false otherwise.
-    fn udtf_exist(&self, name: &str) -> bool {
-        let _ = name;
+    fn udtf_exist(&self, _name: &str) -> bool {
         false
     }
 }

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -1701,7 +1701,6 @@ impl ContextProvider for SessionContextProvider<'_> {
     ) -> datafusion_common::Result<Arc<dyn TableSource>> {
         let table_ref = TableReference::parse_str(name);
 
-        // Simplify arguments first (needed for both paths)
         let dummy_schema = DFSchema::empty();
         let simplifier =
             ExprSimplifier::new(SessionSimplifyProvider::new(self.state, &dummy_schema));
@@ -1710,8 +1709,6 @@ impl ContextProvider for SessionContextProvider<'_> {
             .map(|arg| simplifier.simplify(arg))
             .collect::<datafusion_common::Result<Vec<_>>>()?;
 
-        // If name is qualified (e.g., "schema.func" or "catalog.schema.func"),
-        // look in the schema
         let tbl_func = if table_ref.schema().is_some() {
             let func_name = table_ref.table().to_string();
             let schema = self.state.schema_for_ref(table_ref)?;
@@ -1720,7 +1717,6 @@ impl ContextProvider for SessionContextProvider<'_> {
                 plan_datafusion_err!("Table function '{}' not found in schema", name)
             })?
         } else {
-            // Unqualified name: look in global registry (backward compatible)
             self.state
                 .table_functions
                 .get(name)

--- a/datafusion/core/tests/user_defined/user_defined_table_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_table_functions.rs
@@ -109,12 +109,10 @@ async fn test_deregister_udtf() -> Result<()> {
     Ok(())
 }
 
-/// Test schema-qualified UDTF names
 #[tokio::test]
 async fn test_schema_qualified_udtf() -> Result<()> {
     let ctx = SessionContext::new();
 
-    // Register UDTF in schema
     let catalog = ctx.catalog("datafusion").unwrap();
     let schema = catalog.schema("public").unwrap();
     let memory_schema = schema
@@ -130,7 +128,6 @@ async fn test_schema_qualified_udtf() -> Result<()> {
         .register_udtf("schema_func".to_string(), func)
         .unwrap();
 
-    // Test qualified name
     let csv_file = "tests/tpch-csv/nation.csv";
     let rbs = ctx
         .sql(format!("SELECT * FROM public.schema_func('{csv_file}', 3);").as_str())
@@ -148,10 +145,8 @@ async fn test_schema_qualified_udtf() -> Result<()> {
 async fn test_unqualified_uses_global_registry() -> Result<()> {
     let ctx = SessionContext::new();
 
-    // Register globally
     ctx.register_udtf("global_func", Arc::new(SimpleCsvTableFunc {}));
 
-    // Unqualified name should resolve from global registry
     let csv_file = "tests/tpch-csv/nation.csv";
     let rbs = ctx
         .sql(format!("SELECT * FROM global_func('{csv_file}', 2);").as_str())
@@ -164,15 +159,12 @@ async fn test_unqualified_uses_global_registry() -> Result<()> {
     Ok(())
 }
 
-/// Test that schema-qualified names don't fallback to global
 #[tokio::test]
 async fn test_schema_qualified_not_in_global() -> Result<()> {
     let ctx = SessionContext::new();
 
-    // Register only globally
     ctx.register_udtf("global_only", Arc::new(SimpleCsvTableFunc {}));
 
-    // Trying to access with qualified name should fail
     let csv_file = "tests/tpch-csv/nation.csv";
     let result = ctx
         .sql(format!("SELECT * FROM public.global_only('{csv_file}');").as_str())

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -43,7 +43,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 name, alias, args, ..
             } => {
                 if let Some(func_args) = args {
-                    // Convert name parts to fully qualified name (supports schema.func)
                     let tbl_func_name = name
                         .0
                         .iter()
@@ -180,7 +179,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         _ => plan_err!("Unsupported function argument: {arg:?}"),
                     })
                     .collect::<Result<Vec<Expr>>>()?;
-                // Pass the full qualified name to support schema.func resolution
                 let qualified_name = tbl_func_ref.to_string();
                 let provider = self
                     .context_provider

--- a/datafusion/sqllogictest/test_files/table_functions.slt
+++ b/datafusion/sqllogictest/test_files/table_functions.slt
@@ -496,7 +496,7 @@ SELECT c, f.*  FROM json_table, LATERAL generate_series(1,2) f;
 2 2
 
 #
-# Test schema-qualified table function names (Phase 3)
+# Test schema-qualified table function names
 # Global table functions are not accessible via qualified names
 #
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #18021.

## Rationale for this change

Currently, table functions (UDTFs) can only be registered globally via `SessionContext::register_udtf()`. This means all table functions share a global namespace, which can lead to naming conflicts and makes it difficult to organize functions by schema.

This PR adds support for registering table functions at the schema level, allowing users to organize table functions by schema while maintaining full backward compatibility with existing global registration.

## What changes are included in this PR?

1. **Extended `SchemaProvider` trait** with 5 new methods for table function management:
   - `udtf_names()` - list table functions in the schema
   - `udtf()` - retrieve a specific table function
   - `register_udtf()` - register a table function to the schema
   - `deregister_udtf()` - remove a table function from the schema
   - `udtf_exist()` - check if a table function exists

2. **Implemented table function storage in `MemorySchemaProvider`** using `DashMap` for thread-safe concurrent access

3. **Updated `ContextProvider` lookup logic** to support qualified table function names (e.g., `schema.function_name` or `catalog.schema.function_name`)

4. **Modified SQL parser** to correctly handle qualified table function names in SQL queries

**Backward Compatibility:**
- Unqualified names (e.g., `SELECT * FROM my_func()`) continue to resolve from the global registry
- Qualified names (e.g., `SELECT * FROM public.my_func()`) look up functions in the specified schema only
- All new trait methods have default implementations that maintain existing behavior
- No breaking changes to existing APIs

## Are these changes tested?

Yes, comprehensive tests have been added:

- **5 unit tests** for `MemorySchemaProvider` covering registration, deregistration, retrieval, and error cases
- **3 Rust integration tests** verifying:
  - Schema-qualified UDTF resolution
  - Global registry backward compatibility
  - Proper error handling for non-existent functions
- **5 SQL logic tests** validating:
  - Unqualified names resolve from global registry
  - Qualified names check schema only
  - Proper error messages for both cases

All existing tests continue to pass (369/369).

## Are there any user-facing changes?

**New functionality (non-breaking):**
- Users can now register table functions to specific schemas by calling `register_udtf()` on a `SchemaProvider` instance
- Users can use qualified names in SQL to call schema-scoped table functions: `SELECT * FROM myschema.my_function(args)`

**Backward compatibility:**
- Existing code using `ctx.register_udtf()` continues to work unchanged
- Unqualified table function names in SQL continue to resolve from the global registry
- No API changes that would break existing code

**Example usage:**
```rust
// Get schema and register UDTF to it
let schema = ctx.catalog("datacatalog")
    .unwrap()
    .schema("myschema")
    .unwrap();

let memory_schema = schema.as_any()
    .downcast_ref::<MemorySchemaProvider>()
    .unwrap();

memory_schema.register_udtf(
    "my_func".to_string(),
    Arc::new(TableFunction::new("my_func".to_string(), Arc::new(MyFunc)))
)?;

// Use it in SQL with qualified name
ctx.sql("SELECT * FROM myschema.my_func(1, 2, 3)").await?;
```

## Open Questions

### 1. SchemaProvider API Design

The current implementation adds 5 new methods directly to the `SchemaProvider` trait:
- `udtf_names()`, `udtf()`, `register_udtf()`, `deregister_udtf()`, `udtf_exist()`

**Concern:** As we add support for other UDF types (scalar UDFs, aggregate UDFs, window UDFs) to schemas, this approach will significantly expand the `SchemaProvider` interface, potentially making it noisy and harder to maintain.

**Alternative approach:** Introduce a `UdfContainer` or `FunctionRegistry` trait that manages all types of user-defined functions:

```rust
pub trait SchemaProvider {
    // ... existing methods ...

    /// Returns a function registry for managing UDFs in this schema
    fn function_registry(&self) -> Option<Arc<dyn FunctionRegistry>> {
        None
    }
}

pub trait FunctionRegistry {
    // Table functions
    fn udtf_names(&self) -> Vec<String>;
    fn udtf(&self, name: &str) -> Result<Option<Arc<TableFunction>>>;
    fn register_udtf(&self, name: String, function: Arc<TableFunction>) -> Result<Option<Arc<TableFunction>>>;

    // Future: scalar UDFs, aggregate UDFs, window UDFs
    // fn udf_names(&self) -> Vec<String>;
    // fn register_udf(&self, name: String, function: Arc<ScalarUDF>) -> Result<...>;
    // ...
}
```

**Benefits:**
- Cleaner `SchemaProvider` interface
- Extensible design for future UDF types
- Single point of management for all schema-scoped functions

**Tradeoffs:**
- Additional abstraction layer
- More complex for simple use cases
- Requires more boilerplate for implementations

**Question:** Should we refactor to use a `FunctionRegistry` pattern before merging, or is the current direct-method approach acceptable?

### 2. Information Schema Exposure

Should schema-scoped table functions be exposed via `information_schema.routines` or a new `information_schema.table_functions` table?

**Arguments for:**
- Provides discoverability of available functions
- Consistent with how tables are exposed via information_schema
- Useful for tooling and introspection

**Arguments against:**
- Additional implementation complexity
- Uncertain user demand
- Global table functions would not appear (they're not in schemas)

**Current state:** Not implemented in this PR.

**Question:** Is information_schema support desired for the initial implementation, or can it be added in a follow-up PR?

---

Feedback on these design decisions would be appreciated before finalizing this PR.