### PR TITLE
Adds instrumentation to LIST operations in CLI

### DIFF
--- a/datafusion-cli/src/object_storage/instrumented.rs
+++ b/datafusion-cli/src/object_storage/instrumented.rs
@@ -114,6 +114,11 @@ impl InstrumentedObjectStore {
         req.drain(..).collect()
     }
 
+    fn enabled(&self) -> bool {
+        self.instrument_mode.load(Ordering::Relaxed)
+            != InstrumentedObjectStoreMode::Disabled as u8
+    }
+
     async fn instrumented_get_opts(
         &self,
         location: &Path,
@@ -137,6 +142,26 @@ impl InstrumentedObjectStore {
         });
 
         Ok(ret)
+    }
+
+    fn instrumented_list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
+        let timestamp = Utc::now();
+        let ret = self.inner.list(prefix);
+
+        self.requests.lock().push(RequestDetails {
+            op: Operation::List,
+            path: prefix.cloned().unwrap_or_else(|| Path::from("")),
+            timestamp,
+            duration: None, // list returns a stream, so the duration isn't meaningful
+            size: None,
+            range: None,
+            extra_display: None,
+        });
+
+        ret
     }
 }
 
@@ -172,9 +197,7 @@ impl ObjectStore for InstrumentedObjectStore {
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
-        if self.instrument_mode.load(Ordering::Relaxed)
-            != InstrumentedObjectStoreMode::Disabled as u8
-        {
+        if self.enabled() {
             return self.instrumented_get_opts(location, options).await;
         }
 
@@ -186,6 +209,10 @@ impl ObjectStore for InstrumentedObjectStore {
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+        if self.enabled() {
+            return self.instrumented_list(prefix);
+        }
+
         self.inner.list(prefix)
     }
 
@@ -213,7 +240,7 @@ pub enum Operation {
     _Delete,
     Get,
     _Head,
-    _List,
+    List,
     _Put,
 }
 
@@ -477,8 +504,9 @@ mod tests {
         assert_eq!(reg.stores().len(), 1);
     }
 
-    #[tokio::test]
-    async fn instrumented_store() {
+    // Returns an `InstrumentedObjectStore` with some data loaded for testing and the path to
+    // access the data
+    async fn setup_test_store() -> (InstrumentedObjectStore, Path) {
         let store = Arc::new(object_store::memory::InMemory::new());
         let mode = AtomicU8::new(InstrumentedObjectStoreMode::default() as u8);
         let instrumented = InstrumentedObjectStore::new(store, mode);
@@ -487,6 +515,13 @@ mod tests {
         let path = Path::from("test/data");
         let payload = PutPayload::from_static(b"test_data");
         instrumented.put(&path, payload).await.unwrap();
+
+        (instrumented, path)
+    }
+
+    #[tokio::test]
+    async fn instrumented_store_get() {
+        let (instrumented, path) = setup_test_store().await;
 
         // By default no requests should be instrumented/stored
         assert!(instrumented.requests.lock().is_empty());
@@ -508,6 +543,29 @@ mod tests {
         assert!(request.duration.is_some());
         assert_eq!(request.size, Some(9));
         assert_eq!(request.range, None);
+        assert!(request.extra_display.is_none());
+    }
+
+    #[tokio::test]
+    async fn instrumented_store_list() {
+        let (instrumented, path) = setup_test_store().await;
+
+        // By default no requests should be instrumented/stored
+        assert!(instrumented.requests.lock().is_empty());
+        let _ = instrumented.list(Some(&path));
+        assert!(instrumented.requests.lock().is_empty());
+
+        instrumented.set_instrument_mode(InstrumentedObjectStoreMode::Trace);
+        assert!(instrumented.requests.lock().is_empty());
+        let _ = instrumented.list(Some(&path));
+        assert_eq!(instrumented.requests.lock().len(), 1);
+
+        let request = instrumented.take_requests().pop().unwrap();
+        assert_eq!(request.op, Operation::List);
+        assert_eq!(request.path, path);
+        assert!(request.duration.is_none());
+        assert!(request.size.is_none());
+        assert!(request.range.is_none());
         assert!(request.extra_display.is_none());
     }
 


### PR DESCRIPTION

## Which issue does this PR close?

This does not fully close, but is an incremental building block component for: 
 - https://github.com/apache/datafusion/issues/17207

The full context of how this code is likely to progress can be seen in the POC for this effort:
 - https://github.com/apache/datafusion/pull/17266

## Rationale for this change

Continued progress filling out the methods that are instrumented for the instrumented object store.

## What changes are included in this PR?

 - Adds instrumentation around basic list operations into the instrumented object store
 - Adds test cases for new code

## Are these changes tested?

Yes.

Example output:
```sql
DataFusion CLI v50.2.0
> \object_store_profiling trace
ObjectStore Profile mode set to Trace
> CREATE EXTERNAL TABLE nyc_taxi_rides
STORED AS PARQUET
LOCATION 's3://altinity-clickhouse-data/nyc_taxi_rides/data/tripdata_parquet';
0 row(s) fetched.
Elapsed 2.679 seconds.

Object Store Profiling
Instrumented Object Store: instrument_mode: Trace, inner: AmazonS3(altinity-clickhouse-data)
2025-10-16T18:53:09.512970085+00:00 operation=List path=nyc_taxi_rides/data/tripdata_parquet

Summaries:
List
count: 1

Instrumented Object Store: instrument_mode: Trace, inner: AmazonS3(altinity-clickhouse-data)
2025-10-16T18:53:09.929709943+00:00 operation=List path=nyc_taxi_rides/data/tripdata_parquet
2025-10-16T18:53:10.106757629+00:00 operation=List path=nyc_taxi_rides/data/tripdata_parquet
2025-10-16T18:53:10.220555058+00:00 operation=Get duration=0.230604s size=8 range: bytes=222192975-222192982 path=nyc_taxi_rides/data/tripdata_parquet/data-200901.parquet
2025-10-16T18:53:10.226399832+00:00 operation=Get duration=0.263826s size=8 range: bytes=233123927-233123934 path=nyc_taxi_rides/data/tripdata_parquet/data-201104.parquet
2025-10-16T18:53:10.226194195+00:00 operation=Get duration=0.269754s size=8 range: bytes=252843253-252843260 path=nyc_taxi_rides/data/tripdata_parquet/data-201103.parquet

. . .

2025-10-16T18:53:11.928787014+00:00 operation=Get duration=0.072248s size=18278 range: bytes=201384109-201402386 path=nyc_taxi_rides/data/tripdata_parquet/data-201509.parquet
2025-10-16T18:53:11.933475464+00:00 operation=Get duration=0.068880s size=17175 range: bytes=195411804-195428978 path=nyc_taxi_rides/data/tripdata_parquet/data-201601.parquet
2025-10-16T18:53:11.949629591+00:00 operation=Get duration=0.065645s size=19872 range: bytes=214807880-214827751 path=nyc_taxi_rides/data/tripdata_parquet/data-201603.parquet

Summaries:
List
count: 2

Get
count: 288
duration min: 0.060930s
duration max: 0.444601s
duration avg: 0.133339s
size min: 8 B
size max: 44247 B
size avg: 18870 B
size sum: 5434702 B

>
```


## Are there any user-facing changes?
No-ish

##
cc @alamb 