### PR TITLE
make Union::try_new pub

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2753,7 +2753,8 @@ pub struct Union {
 
 impl Union {
     /// Constructs new Union instance deriving schema from inputs.
-    fn try_new(inputs: Vec<Arc<LogicalPlan>>) -> Result<Self> {
+    /// Schema data types must match exactly.
+    pub fn try_new(inputs: Vec<Arc<LogicalPlan>>) -> Result<Self> {
         let schema = Self::derive_schema_from_inputs(&inputs, false, false)?;
         Ok(Union { inputs, schema })
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18126.

## Rationale for this change

It's a useful constructor for users manipulating logical plans where they know the schemas will match exactly. We already expose other constructors for Union and constructors for logical plans.

## What changes are included in this PR?

Makes `Union::try_new` a public function.

## Are these changes tested?

Seems unnecessary.

## Are there any user-facing changes?

The function is now public. Not a breaking change, but going forward changes to it would breaking changes to users of the logical plan API.