### PR TITLE
let PhysicalOptimizerRule accept SessionConfig instead of ConfigOptions

### DIFF
--- a/datafusion/core/benches/push_down_filter.rs
+++ b/datafusion/core/benches/push_down_filter.rs
@@ -19,8 +19,8 @@ use arrow::array::RecordBatch;
 use arrow::datatypes::{DataType, Field, Schema};
 use bytes::{BufMut, BytesMut};
 use criterion::{criterion_group, criterion_main, Criterion};
-use datafusion::config::ConfigOptions;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
+use datafusion_execution::config::SessionConfig;
 use datafusion_execution::object_store::ObjectStoreUrl;
 use datafusion_physical_optimizer::filter_pushdown::FilterPushdown;
 use datafusion_physical_optimizer::PhysicalOptimizerRule;
@@ -88,7 +88,7 @@ async fn create_plan() -> Arc<dyn ExecutionPlan> {
 #[derive(Clone)]
 struct BenchmarkPlan {
     plan: Arc<dyn ExecutionPlan>,
-    config: ConfigOptions,
+    config: SessionConfig,
 }
 
 impl std::fmt::Display for BenchmarkPlan {
@@ -102,8 +102,8 @@ fn bench_push_down_filter(c: &mut Criterion) {
     let plan = tokio::runtime::Runtime::new()
         .unwrap()
         .block_on(create_plan());
-    let mut config = ConfigOptions::default();
-    config.execution.parquet.pushdown_filters = true;
+    let mut config = SessionConfig::default();
+    config.options_mut().execution.parquet.pushdown_filters = true;
     let plan = BenchmarkPlan { plan, config };
     let optimizer = FilterPushdown::new();
 

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2118,7 +2118,7 @@ impl DefaultPhysicalPlanner {
         for optimizer in optimizers {
             let before_schema = new_plan.schema();
             new_plan = optimizer
-                .optimize(new_plan, session_state.config_options())
+                .optimize(new_plan, session_state.config())
                 .map_err(|e| {
                     DataFusionError::Context(optimizer.name().to_string(), Box::new(e))
                 })?;
@@ -2441,7 +2441,6 @@ mod tests {
     use arrow::array::{ArrayRef, DictionaryArray, Int32Array};
     use arrow::datatypes::{DataType, Field, Int32Type};
     use arrow_schema::SchemaRef;
-    use datafusion_common::config::ConfigOptions;
     use datafusion_common::{
         assert_contains, DFSchemaRef, TableReference, ToDFSchema as _,
     };
@@ -3545,7 +3544,7 @@ digraph {
         fn optimize(
             &self,
             plan: Arc<dyn ExecutionPlan>,
-            _config: &ConfigOptions,
+            _config: &SessionConfig,
         ) -> Result<Arc<dyn ExecutionPlan>> {
             Ok(plan)
         }

--- a/datafusion/core/tests/execution/coop.rs
+++ b/datafusion/core/tests/execution/coop.rs
@@ -810,8 +810,7 @@ async fn query_yields(
     task_ctx: Arc<TaskContext>,
 ) -> Result<(), Box<dyn Error>> {
     // Run plan through EnsureCooperative
-    let optimized =
-        EnsureCooperative::new().optimize(plan, task_ctx.session_config().options())?;
+    let optimized = EnsureCooperative::new().optimize(plan, task_ctx.session_config())?;
 
     // Get the stream
     let stream = physical_plan::execute_stream(optimized, task_ctx)?;

--- a/datafusion/core/tests/parquet/file_statistics.rs
+++ b/datafusion/core/tests/parquet/file_statistics.rs
@@ -38,7 +38,6 @@ use datafusion_execution::runtime_env::RuntimeEnvBuilder;
 use datafusion_expr::{col, lit, Expr};
 
 use datafusion::datasource::physical_plan::FileScanConfig;
-use datafusion_common::config::ConfigOptions;
 use datafusion_physical_optimizer::filter_pushdown::FilterPushdown;
 use datafusion_physical_optimizer::PhysicalOptimizerRule;
 use datafusion_physical_plan::filter::FilterExec;
@@ -56,8 +55,13 @@ async fn check_stats_precision_with_filter_pushdown() {
     let table = get_listing_table(&table_path, None, &opt).await;
 
     let (_, _, state) = get_cache_runtime_state();
-    let mut options: ConfigOptions = state.config().options().as_ref().clone();
-    options.execution.parquet.pushdown_filters = true;
+    let mut session_config =
+        SessionConfig::from(state.config().options().as_ref().clone());
+    session_config
+        .options_mut()
+        .execution
+        .parquet
+        .pushdown_filters = true;
 
     // Scan without filter, stats are exact
     let exec = table.scan(&state, None, &[], None).await.unwrap();
@@ -85,7 +89,7 @@ async fn check_stats_precision_with_filter_pushdown() {
             as Arc<dyn ExecutionPlan>;
 
     let optimized_exec = FilterPushdown::new()
-        .optimize(filtered_exec, &options)
+        .optimize(filtered_exec, &session_config)
         .unwrap();
 
     assert!(

--- a/datafusion/core/tests/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/core/tests/physical_optimizer/aggregate_statistics.rs
@@ -25,8 +25,8 @@ use arrow::record_batch::RecordBatch;
 use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::datasource::source::DataSourceExec;
 use datafusion_common::cast::as_int64_array;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::Result;
+use datafusion_execution::config::SessionConfig;
 use datafusion_execution::TaskContext;
 use datafusion_expr::Operator;
 use datafusion_physical_expr::expressions::{self, cast};
@@ -67,7 +67,7 @@ async fn assert_count_optim_success(
     let task_ctx = Arc::new(TaskContext::default());
     let plan: Arc<dyn ExecutionPlan> = Arc::new(plan);
 
-    let config = ConfigOptions::new();
+    let config = SessionConfig::new();
     let optimized = AggregateStatistics::new().optimize(Arc::clone(&plan), &config)?;
 
     // A ProjectionExec is a sign that the count optimization was applied
@@ -264,7 +264,7 @@ async fn test_count_inexact_stat() -> Result<()> {
         Arc::clone(&schema),
     )?;
 
-    let conf = ConfigOptions::new();
+    let conf = SessionConfig::new();
     let optimized = AggregateStatistics::new().optimize(Arc::new(final_agg), &conf)?;
 
     // check that the original ExecutionPlan was not replaced
@@ -308,7 +308,7 @@ async fn test_count_with_nulls_inexact_stat() -> Result<()> {
         Arc::clone(&schema),
     )?;
 
-    let conf = ConfigOptions::new();
+    let conf = SessionConfig::new();
     let optimized = AggregateStatistics::new().optimize(Arc::new(final_agg), &conf)?;
 
     // check that the original ExecutionPlan was not replaced

--- a/datafusion/core/tests/physical_optimizer/combine_partial_final_agg.rs
+++ b/datafusion/core/tests/physical_optimizer/combine_partial_final_agg.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use crate::physical_optimizer::test_utils::parquet_exec;
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion_common::config::ConfigOptions;
+use datafusion_execution::config::SessionConfig;
 use datafusion_functions_aggregate::count::count_udaf;
 use datafusion_functions_aggregate::sum::sum_udaf;
 use datafusion_physical_expr::aggregate::{AggregateExprBuilder, AggregateFunctionExpr};
@@ -47,7 +47,7 @@ macro_rules! assert_optimized {
     ($PLAN: expr, @ $EXPECTED_LINES: literal $(,)?) => {
         // run optimizer
         let optimizer = CombinePartialFinalAggregate {};
-        let config = ConfigOptions::new();
+        let config = SessionConfig::new();
         let optimized = optimizer.optimize($PLAN, &config)?;
         // Now format correctly
         let plan = displayable(optimized.as_ref()).indent(true).to_string();

--- a/datafusion/core/tests/physical_optimizer/filter_pushdown/mod.rs
+++ b/datafusion/core/tests/physical_optimizer/filter_pushdown/mod.rs
@@ -239,9 +239,12 @@ async fn test_dynamic_filter_pushdown_through_hash_join_with_topk() {
             .with_fetch(Some(2)),
     ) as Arc<dyn ExecutionPlan>;
 
-    let mut config = ConfigOptions::default();
-    config.optimizer.enable_dynamic_filter_pushdown = true;
-    config.execution.parquet.pushdown_filters = true;
+    let mut config = SessionConfig::default();
+    config
+        .options_mut()
+        .optimizer
+        .enable_dynamic_filter_pushdown = true;
+    config.options_mut().execution.parquet.pushdown_filters = true;
 
     // Apply the FilterPushdown optimizer rule
     let plan = FilterPushdown::new_post_optimization()
@@ -720,10 +723,14 @@ async fn test_topk_dynamic_filter_pushdown() {
     );
 
     // Actually apply the optimization to the plan and put some data through it to check that the filter is updated to reflect the TopK state
-    let mut config = ConfigOptions::default();
-    config.execution.parquet.pushdown_filters = true;
+    let mut session_config = SessionConfig::default();
+    session_config
+        .options_mut()
+        .execution
+        .parquet
+        .pushdown_filters = true;
     let plan = FilterPushdown::new_post_optimization()
-        .optimize(plan, &config)
+        .optimize(plan, &session_config)
         .unwrap();
     let config = SessionConfig::new().with_batch_size(2);
     let session_ctx = SessionContext::new_with_config(config);
@@ -803,10 +810,14 @@ async fn test_topk_dynamic_filter_pushdown_multi_column_sort() {
     );
 
     // Actually apply the optimization to the plan and put some data through it to check that the filter is updated to reflect the TopK state
-    let mut config = ConfigOptions::default();
-    config.execution.parquet.pushdown_filters = true;
+    let mut session_config = SessionConfig::default();
+    session_config
+        .options_mut()
+        .execution
+        .parquet
+        .pushdown_filters = true;
     let plan = FilterPushdown::new_post_optimization()
-        .optimize(plan, &config)
+        .optimize(plan, &session_config)
         .unwrap();
     let config = SessionConfig::new().with_batch_size(2);
     let session_ctx = SessionContext::new_with_config(config);
@@ -1049,11 +1060,18 @@ async fn test_hashjoin_dynamic_filter_pushdown() {
     );
 
     // Actually apply the optimization to the plan and execute to see the filter in action
-    let mut config = ConfigOptions::default();
-    config.execution.parquet.pushdown_filters = true;
-    config.optimizer.enable_dynamic_filter_pushdown = true;
+    let mut session_config = SessionConfig::default();
+    session_config
+        .options_mut()
+        .execution
+        .parquet
+        .pushdown_filters = true;
+    session_config
+        .options_mut()
+        .optimizer
+        .enable_dynamic_filter_pushdown = true;
     let plan = FilterPushdown::new_post_optimization()
-        .optimize(plan, &config)
+        .optimize(plan, &session_config)
         .unwrap();
 
     // Test for https://github.com/apache/datafusion/pull/17371: dynamic filter linking survives `with_new_children`
@@ -1277,11 +1295,18 @@ async fn test_hashjoin_dynamic_filter_pushdown_partitioned() {
     );
 
     // Actually apply the optimization to the plan and execute to see the filter in action
-    let mut config = ConfigOptions::default();
-    config.execution.parquet.pushdown_filters = true;
-    config.optimizer.enable_dynamic_filter_pushdown = true;
+    let mut session_config = SessionConfig::default();
+    session_config
+        .options_mut()
+        .execution
+        .parquet
+        .pushdown_filters = true;
+    session_config
+        .options_mut()
+        .optimizer
+        .enable_dynamic_filter_pushdown = true;
     let plan = FilterPushdown::new_post_optimization()
-        .optimize(plan, &config)
+        .optimize(plan, &session_config)
         .unwrap();
     let config = SessionConfig::new().with_batch_size(10);
     let session_ctx = SessionContext::new_with_config(config);
@@ -1474,11 +1499,18 @@ async fn test_hashjoin_dynamic_filter_pushdown_collect_left() {
     );
 
     // Actually apply the optimization to the plan and execute to see the filter in action
-    let mut config = ConfigOptions::default();
-    config.execution.parquet.pushdown_filters = true;
-    config.optimizer.enable_dynamic_filter_pushdown = true;
+    let mut session_config = SessionConfig::default();
+    session_config
+        .options_mut()
+        .execution
+        .parquet
+        .pushdown_filters = true;
+    session_config
+        .options_mut()
+        .optimizer
+        .enable_dynamic_filter_pushdown = true;
     let plan = FilterPushdown::new_post_optimization()
-        .optimize(plan, &config)
+        .optimize(plan, &session_config)
         .unwrap();
     let config = SessionConfig::new().with_batch_size(10);
     let session_ctx = SessionContext::new_with_config(config);
@@ -1646,11 +1678,18 @@ async fn test_nested_hashjoin_dynamic_filter_pushdown() {
     );
 
     // Execute the plan to verify the dynamic filters are properly updated
-    let mut config = ConfigOptions::default();
-    config.execution.parquet.pushdown_filters = true;
-    config.optimizer.enable_dynamic_filter_pushdown = true;
+    let mut session_config = SessionConfig::default();
+    session_config
+        .options_mut()
+        .execution
+        .parquet
+        .pushdown_filters = true;
+    session_config
+        .options_mut()
+        .optimizer
+        .enable_dynamic_filter_pushdown = true;
     let plan = FilterPushdown::new_post_optimization()
-        .optimize(outer_join, &config)
+        .optimize(outer_join, &session_config)
         .unwrap();
     let config = SessionConfig::new().with_batch_size(10);
     let session_ctx = SessionContext::new_with_config(config);

--- a/datafusion/core/tests/physical_optimizer/join_selection.rs
+++ b/datafusion/core/tests/physical_optimizer/join_selection.rs
@@ -29,6 +29,7 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::{stats::Precision, ColumnStatistics, JoinType, ScalarValue};
 use datafusion_common::{JoinSide, NullEquality};
 use datafusion_common::{Result, Statistics};
+use datafusion_execution::config::SessionConfig;
 use datafusion_execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion_expr::Operator;
 use datafusion_physical_expr::expressions::col;
@@ -227,7 +228,7 @@ async fn test_join_with_swap() {
     );
 
     let optimized_join = JoinSelection::new()
-        .optimize(join, &ConfigOptions::new())
+        .optimize(join, &SessionConfig::new())
         .unwrap();
 
     let swapping_projection = optimized_join
@@ -289,7 +290,7 @@ async fn test_left_join_no_swap() {
     );
 
     let optimized_join = JoinSelection::new()
-        .optimize(join, &ConfigOptions::new())
+        .optimize(join, &SessionConfig::new())
         .unwrap();
 
     let swapped_join = optimized_join
@@ -339,7 +340,7 @@ async fn test_join_with_swap_semi() {
         let original_schema = join.schema();
 
         let optimized_join = JoinSelection::new()
-            .optimize(Arc::new(join), &ConfigOptions::new())
+            .optimize(Arc::new(join), &SessionConfig::new())
             .unwrap();
 
         let swapped_join = optimized_join
@@ -394,7 +395,7 @@ async fn test_join_with_swap_mark() {
         let original_schema = join.schema();
 
         let optimized_join = JoinSelection::new()
-            .optimize(Arc::new(join), &ConfigOptions::new())
+            .optimize(Arc::new(join), &SessionConfig::new())
             .unwrap();
 
         let swapped_join = optimized_join
@@ -431,7 +432,7 @@ macro_rules! assert_optimized {
 
         let plan = Arc::new($PLAN);
         let optimized = JoinSelection::new()
-            .optimize(plan.clone(), &ConfigOptions::new())
+            .optimize(plan.clone(), &SessionConfig::new())
             .unwrap();
 
         let plan_string = displayable(optimized.as_ref()).indent(true).to_string();
@@ -523,7 +524,7 @@ async fn test_join_no_swap() {
     );
 
     let optimized_join = JoinSelection::new()
-        .optimize(join, &ConfigOptions::new())
+        .optimize(join, &SessionConfig::new())
         .unwrap();
 
     let swapped_join = optimized_join
@@ -572,7 +573,7 @@ async fn test_nl_join_with_swap(join_type: JoinType) {
     );
 
     let optimized_join = JoinSelection::new()
-        .optimize(join, &ConfigOptions::new())
+        .optimize(join, &SessionConfig::new())
         .unwrap();
 
     let swapping_projection = optimized_join
@@ -652,7 +653,7 @@ async fn test_nl_join_with_swap_no_proj(join_type: JoinType) {
     let optimized_join = JoinSelection::new()
         .optimize(
             Arc::<NestedLoopJoinExec>::clone(&join),
-            &ConfigOptions::new(),
+            &SessionConfig::new(),
         )
         .unwrap();
 
@@ -911,7 +912,7 @@ fn check_join_partition_mode(
     );
 
     let optimized_join = JoinSelection::new()
-        .optimize(join, &ConfigOptions::new())
+        .optimize(join, &SessionConfig::new())
         .unwrap();
 
     if !is_swapped {
@@ -1556,7 +1557,7 @@ async fn test_join_with_maybe_swap_unbounded_case(t: TestCase) -> Result<()> {
     )?) as _;
 
     let optimized_join_plan =
-        JoinSelection::new().optimize(Arc::clone(&join), &ConfigOptions::new())?;
+        JoinSelection::new().optimize(Arc::clone(&join), &SessionConfig::new())?;
 
     // If swap did happen
     let projection_added = optimized_join_plan.as_any().is::<ProjectionExec>();

--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -24,8 +24,8 @@ use crate::physical_optimizer::test_utils::{
 
 use arrow::compute::SortOptions;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
+use datafusion_execution::config::SessionConfig;
 use datafusion_expr::Operator;
 use datafusion_physical_expr::expressions::{col, lit, BinaryExpr};
 use datafusion_physical_expr::Partitioning;
@@ -102,7 +102,7 @@ fn transforms_streaming_table_exec_into_fetching_version_when_skip_is_zero() -> 
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(global_limit, &SessionConfig::new())?;
 
     let expected = [
             "StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true, fetch=5"
@@ -127,7 +127,7 @@ fn transforms_streaming_table_exec_into_fetching_version_and_keeps_the_global_li
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(global_limit, &SessionConfig::new())?;
 
     let expected = [
             "GlobalLimitExec: skip=2, fetch=5",
@@ -163,7 +163,7 @@ fn transforms_coalesce_batches_exec_into_fetching_version_and_removes_local_limi
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(global_limit, &SessionConfig::new())?;
 
     let expected = [
         "CoalescePartitionsExec: fetch=5",
@@ -195,7 +195,7 @@ fn pushes_global_limit_exec_through_projection_exec() -> Result<()> {
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(global_limit, &SessionConfig::new())?;
 
     let expected = [
             "ProjectionExec: expr=[c1@0 as c1, c2@1 as c2, c3@2 as c3]",
@@ -228,7 +228,7 @@ fn pushes_global_limit_exec_through_projection_exec_and_transforms_coalesce_batc
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(global_limit, &SessionConfig::new())?;
 
     let expected = [
             "ProjectionExec: expr=[c1@0 as c1, c2@1 as c2, c3@2 as c3]",
@@ -270,7 +270,7 @@ fn pushes_global_limit_into_multiple_fetch_plans() -> Result<()> {
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(global_limit, &SessionConfig::new())?;
 
     let expected = [
             "SortPreservingMergeExec: [c1@0 ASC], fetch=5",
@@ -306,7 +306,7 @@ fn keeps_pushed_local_limit_exec_when_there_are_multiple_input_partitions() -> R
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(global_limit, &SessionConfig::new())?;
 
     let expected = [
             "CoalescePartitionsExec: fetch=5",
@@ -336,7 +336,7 @@ fn merges_local_limit_with_local_limit() -> Result<()> {
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(parent_local_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(parent_local_limit, &SessionConfig::new())?;
 
     let expected = ["GlobalLimitExec: skip=0, fetch=10", "  EmptyExec"];
     assert_eq!(get_plan_string(&after_optimize), expected);
@@ -361,7 +361,7 @@ fn merges_global_limit_with_global_limit() -> Result<()> {
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(parent_global_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(parent_global_limit, &SessionConfig::new())?;
 
     let expected = ["GlobalLimitExec: skip=20, fetch=20", "  EmptyExec"];
     assert_eq!(get_plan_string(&after_optimize), expected);
@@ -386,7 +386,7 @@ fn merges_global_limit_with_local_limit() -> Result<()> {
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(global_limit, &SessionConfig::new())?;
 
     let expected = ["GlobalLimitExec: skip=20, fetch=20", "  EmptyExec"];
     assert_eq!(get_plan_string(&after_optimize), expected);
@@ -411,7 +411,7 @@ fn merges_local_limit_with_global_limit() -> Result<()> {
     assert_eq!(initial, expected_initial);
 
     let after_optimize =
-        LimitPushdown::new().optimize(local_limit, &ConfigOptions::new())?;
+        LimitPushdown::new().optimize(local_limit, &SessionConfig::new())?;
 
     let expected = ["GlobalLimitExec: skip=20, fetch=20", "  EmptyExec"];
     assert_eq!(get_plan_string(&after_optimize), expected);

--- a/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
@@ -59,6 +59,7 @@ use datafusion_physical_plan::streaming::{PartitionStream, StreamingTableExec};
 use datafusion_physical_plan::union::UnionExec;
 use datafusion_physical_plan::{displayable, ExecutionPlan};
 
+use datafusion_execution::config::SessionConfig;
 use insta::assert_snapshot;
 use itertools::Itertools;
 
@@ -449,7 +450,7 @@ fn test_csv_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -487,7 +488,7 @@ fn test_memory_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -583,7 +584,7 @@ fn test_streaming_table_after_projection() -> Result<()> {
     )?) as _;
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let result = after_optimize
         .as_any()
@@ -683,7 +684,7 @@ fn test_projection_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(top_projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(top_projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -751,7 +752,7 @@ fn test_output_req_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -842,7 +843,7 @@ fn test_coalesce_partitions_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -900,7 +901,7 @@ fn test_filter_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -1003,7 +1004,7 @@ fn test_join_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -1133,7 +1134,7 @@ fn test_join_after_required_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -1211,7 +1212,7 @@ fn test_nested_loop_join_after_projection() -> Result<()> {
     );
 
     let after_optimize_string =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
     let after_optimize_string = displayable(after_optimize_string.as_ref())
         .indent(true)
         .to_string();
@@ -1308,7 +1309,7 @@ fn test_hash_join_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
         .to_string();
@@ -1336,7 +1337,7 @@ fn test_hash_join_after_projection() -> Result<()> {
     )?);
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
         .to_string();
@@ -1389,7 +1390,7 @@ fn test_repartition_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -1460,7 +1461,7 @@ fn test_sort_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -1514,7 +1515,7 @@ fn test_sort_preserving_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -1559,7 +1560,7 @@ fn test_union_after_projection() -> Result<()> {
     );
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -1626,7 +1627,7 @@ fn test_partition_col_projection_pushdown() -> Result<()> {
     )?);
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)
@@ -1672,7 +1673,7 @@ fn test_partition_col_projection_pushdown_expr() -> Result<()> {
     )?);
 
     let after_optimize =
-        ProjectionPushdown::new().optimize(projection, &ConfigOptions::new())?;
+        ProjectionPushdown::new().optimize(projection, &SessionConfig::new())?;
 
     let after_optimize_string = displayable(after_optimize.as_ref())
         .indent(true)

--- a/datafusion/core/tests/physical_optimizer/sanity_checker.rs
+++ b/datafusion/core/tests/physical_optimizer/sanity_checker.rs
@@ -28,7 +28,6 @@ use arrow::compute::SortOptions;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::datasource::stream::{FileStreamProvider, StreamConfig, StreamTable};
 use datafusion::prelude::{CsvReadOptions, SessionContext};
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::{JoinType, Result, ScalarValue};
 use datafusion_physical_expr::expressions::{col, Literal};
 use datafusion_physical_expr::Partitioning;
@@ -39,6 +38,7 @@ use datafusion_physical_plan::repartition::RepartitionExec;
 use datafusion_physical_plan::{displayable, ExecutionPlan};
 
 use async_trait::async_trait;
+use datafusion_execution::config::SessionConfig;
 
 async fn register_current_csv(
     ctx: &SessionContext,
@@ -393,7 +393,7 @@ fn create_test_schema2() -> SchemaRef {
 /// Check if sanity checker should accept or reject plans.
 fn assert_sanity_check(plan: &Arc<dyn ExecutionPlan>, is_sane: bool) {
     let sanity_checker = SanityCheckPlan::new();
-    let opts = ConfigOptions::default();
+    let opts = SessionConfig::default();
     assert_eq!(
         sanity_checker.optimize(plan.clone(), &opts).is_ok(),
         is_sane

--- a/datafusion/core/tests/physical_optimizer/test_utils.rs
+++ b/datafusion/core/tests/physical_optimizer/test_utils.rs
@@ -29,12 +29,12 @@ use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::datasource::physical_plan::ParquetSource;
 use datafusion::datasource::source::DataSourceExec;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::stats::Precision;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::utils::expr::COUNT_STAR_EXPANSION;
 use datafusion_common::{ColumnStatistics, JoinType, NullEquality, Result, Statistics};
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
+use datafusion_execution::config::SessionConfig;
 use datafusion_execution::object_store::ObjectStoreUrl;
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::{WindowFrame, WindowFunctionDefinition};
@@ -641,7 +641,7 @@ pub fn build_group_by(input_schema: &SchemaRef, columns: Vec<String>) -> Physica
 }
 
 pub fn get_optimized_plan(plan: &Arc<dyn ExecutionPlan>) -> Result<String> {
-    let config = ConfigOptions::new();
+    let config = SessionConfig::new();
 
     let optimized =
         LimitedDistinctAggregation::new().optimize(Arc::clone(plan), &config)?;

--- a/datafusion/datasource-parquet/src/source.rs
+++ b/datafusion/datasource-parquet/src/source.rs
@@ -26,7 +26,6 @@ use crate::opener::ParquetOpener;
 use crate::row_filter::can_expr_be_pushed_down_with_schemas;
 use crate::DefaultParquetFileReaderFactory;
 use crate::ParquetFileReaderFactory;
-use datafusion_common::config::ConfigOptions;
 #[cfg(feature = "parquet_encryption")]
 use datafusion_common::config::EncryptionFactoryOptions;
 use datafusion_datasource::as_file_source;
@@ -54,6 +53,7 @@ use datafusion_physical_plan::DisplayFormatType;
 
 #[cfg(feature = "parquet_encryption")]
 use datafusion_common::encryption::map_config_decryption_to_decryption;
+use datafusion_execution::config::SessionConfig;
 #[cfg(feature = "parquet_encryption")]
 use datafusion_execution::parquet_encryption::EncryptionFactory;
 use itertools::Itertools;
@@ -698,7 +698,7 @@ impl FileSource for ParquetSource {
     fn try_pushdown_filters(
         &self,
         filters: Vec<Arc<dyn PhysicalExpr>>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> datafusion_common::Result<FilterPushdownPropagation<Arc<dyn FileSource>>> {
         let Some(file_schema) = self.file_schema.clone() else {
             return Ok(FilterPushdownPropagation::with_parent_pushdown_result(
@@ -712,7 +712,7 @@ impl FileSource for ParquetSource {
         // By default they are both disabled.
         // Regardless of pushdown, we will update the predicate to include the filters
         // because even if scan pushdown is disabled we can still use the filters for stats pruning.
-        let config_pushdown_enabled = config.execution.parquet.pushdown_filters;
+        let config_pushdown_enabled = config.options().execution.parquet.pushdown_filters;
         let table_pushdown_enabled = self.pushdown_filters();
         let pushdown_filters = table_pushdown_enabled || config_pushdown_enabled;
 

--- a/datafusion/datasource/src/file.rs
+++ b/datafusion/datasource/src/file.rs
@@ -27,13 +27,13 @@ use crate::file_scan_config::FileScanConfig;
 use crate::file_stream::FileOpener;
 use crate::schema_adapter::SchemaAdapterFactory;
 use arrow::datatypes::SchemaRef;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::{not_impl_err, Result, Statistics};
 use datafusion_physical_expr::{LexOrdering, PhysicalExpr};
 use datafusion_physical_plan::filter_pushdown::{FilterPushdownPropagation, PushedDown};
 use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion_physical_plan::DisplayFormatType;
 
+use datafusion_execution::config::SessionConfig;
 use object_store::ObjectStore;
 
 /// Helper function to convert any type implementing FileSource to Arc&lt;dyn FileSource&gt;
@@ -122,7 +122,7 @@ pub trait FileSource: Send + Sync {
     fn try_pushdown_filters(
         &self,
         filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn FileSource>>> {
         Ok(FilterPushdownPropagation::with_parent_pushdown_result(
             vec![PushedDown::No; filters.len()],

--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -35,7 +35,6 @@ use arrow::{
     buffer::Buffer,
     datatypes::{ArrowNativeType, DataType, Field, Schema, SchemaRef, UInt16Type},
 };
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::{
     exec_datafusion_err, exec_err, internal_datafusion_err, ColumnStatistics,
     Constraints, Result, ScalarValue, Statistics,
@@ -63,6 +62,7 @@ use std::{
     fmt::Result as FmtResult, marker::PhantomData, sync::Arc,
 };
 
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_expr::equivalence::project_orderings;
 use datafusion_physical_plan::coop::cooperative;
 use datafusion_physical_plan::execution_plan::SchedulingType;
@@ -666,7 +666,7 @@ impl DataSource for FileScanConfig {
     fn try_pushdown_filters(
         &self,
         filters: Vec<Arc<dyn PhysicalExpr>>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn DataSource>>> {
         let result = self.file_source.try_pushdown_filters(filters, config)?;
         match result.updated_node {

--- a/datafusion/datasource/src/source.rs
+++ b/datafusion/datasource/src/source.rs
@@ -37,6 +37,7 @@ use itertools::Itertools;
 use crate::file_scan_config::FileScanConfig;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{Constraints, Result, Statistics};
+use datafusion_execution::config::SessionConfig;
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_physical_expr::{EquivalenceProperties, Partitioning, PhysicalExpr};
 use datafusion_physical_expr_common::sort_expr::LexOrdering;
@@ -169,7 +170,7 @@ pub trait DataSource: Send + Sync + Debug {
     fn try_pushdown_filters(
         &self,
         filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn DataSource>>> {
         Ok(FilterPushdownPropagation::with_parent_pushdown_result(
             vec![PushedDown::No; filters.len()],
@@ -332,7 +333,7 @@ impl ExecutionPlan for DataSourceExec {
         &self,
         _phase: FilterPushdownPhase,
         child_pushdown_result: ChildPushdownResult,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
         // Push any remaining filters into our data source
         let parent_filters = child_pushdown_result

--- a/datafusion/physical-optimizer/src/aggregate_statistics.rs
+++ b/datafusion/physical-optimizer/src/aggregate_statistics.rs
@@ -16,10 +16,10 @@
 // under the License.
 
 //! Utilizing exact statistics from sources to avoid scanning data
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::scalar::ScalarValue;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::Result;
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_plan::aggregates::AggregateExec;
 use datafusion_physical_plan::placeholder_row::PlaceholderRowExec;
 use datafusion_physical_plan::projection::{ProjectionExec, ProjectionExpr};
@@ -46,7 +46,7 @@ impl PhysicalOptimizerRule for AggregateStatistics {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if let Some(partial_agg_exec) = take_optimizable(&*plan) {
             let partial_agg_exec = partial_agg_exec

--- a/datafusion/physical-optimizer/src/coalesce_async_exec_input.rs
+++ b/datafusion/physical-optimizer/src/coalesce_async_exec_input.rs
@@ -16,9 +16,9 @@
 // under the License.
 
 use crate::PhysicalOptimizerRule;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::internal_err;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_plan::async_func::AsyncFuncExec;
 use datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec;
 use datafusion_physical_plan::ExecutionPlan;
@@ -39,9 +39,9 @@ impl PhysicalOptimizerRule for CoalesceAsyncExecInput {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        let target_batch_size = config.execution.batch_size;
+        let target_batch_size = config.options().execution.batch_size;
         plan.transform(|plan| {
             if let Some(async_exec) = plan.as_any().downcast_ref::<AsyncFuncExec>() {
                 if async_exec.children().len() != 1 {

--- a/datafusion/physical-optimizer/src/coalesce_batches.rs
+++ b/datafusion/physical-optimizer/src/coalesce_batches.rs
@@ -22,8 +22,8 @@ use crate::PhysicalOptimizerRule;
 
 use std::sync::Arc;
 
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_expr::Partitioning;
 use datafusion_physical_plan::{
     coalesce_batches::CoalesceBatchesExec, filter::FilterExec, joins::HashJoinExec,
@@ -47,13 +47,14 @@ impl PhysicalOptimizerRule for CoalesceBatches {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        if !config.execution.coalesce_batches {
+        let config_options = config.options();
+        if !config_options.execution.coalesce_batches {
             return Ok(plan);
         }
 
-        let target_batch_size = config.execution.batch_size;
+        let target_batch_size = config_options.execution.batch_size;
         plan.transform_up(|plan| {
             let plan_any = plan.as_any();
             // The goal here is to detect operators that could produce small batches and only

--- a/datafusion/physical-optimizer/src/combine_partial_final_agg.rs
+++ b/datafusion/physical-optimizer/src/combine_partial_final_agg.rs
@@ -27,8 +27,8 @@ use datafusion_physical_plan::aggregates::{
 use datafusion_physical_plan::ExecutionPlan;
 
 use crate::PhysicalOptimizerRule;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_expr::aggregate::AggregateFunctionExpr;
 use datafusion_physical_expr::{physical_exprs_equal, PhysicalExpr};
 
@@ -51,7 +51,7 @@ impl PhysicalOptimizerRule for CombinePartialFinalAggregate {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         plan.transform_down(|plan| {
             // Check if the plan is AggregateExec

--- a/datafusion/physical-optimizer/src/ensure_coop.rs
+++ b/datafusion/physical-optimizer/src/ensure_coop.rs
@@ -25,9 +25,9 @@ use std::sync::Arc;
 
 use crate::PhysicalOptimizerRule;
 
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion_common::Result;
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_plan::coop::CooperativeExec;
 use datafusion_physical_plan::execution_plan::{EvaluationType, SchedulingType};
 use datafusion_physical_plan::ExecutionPlan;
@@ -65,7 +65,7 @@ impl PhysicalOptimizerRule for EnsureCooperative {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         plan.transform_up(|plan| {
             let is_leaf = plan.children().is_empty();
@@ -96,14 +96,14 @@ impl PhysicalOptimizerRule for EnsureCooperative {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_common::config::ConfigOptions;
+    use datafusion_execution::config::SessionConfig;
     use datafusion_physical_plan::{displayable, test::scan_partitioned};
     use insta::assert_snapshot;
 
     #[tokio::test]
     async fn test_cooperative_exec_for_custom_exec() {
         let test_custom_exec = scan_partitioned(1);
-        let config = ConfigOptions::new();
+        let config = SessionConfig::new();
         let optimized = EnsureCooperative::new()
             .optimize(test_custom_exec, &config)
             .unwrap();

--- a/datafusion/physical-optimizer/src/filter_pushdown.rs
+++ b/datafusion/physical-optimizer/src/filter_pushdown.rs
@@ -36,7 +36,8 @@ use std::sync::Arc;
 use crate::PhysicalOptimizerRule;
 
 use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
-use datafusion_common::{config::ConfigOptions, internal_err, Result};
+use datafusion_common::{internal_err, Result};
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_expr_common::physical_expr::is_volatile;
 use datafusion_physical_plan::filter_pushdown::{
@@ -419,7 +420,7 @@ impl PhysicalOptimizerRule for FilterPushdown {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(
             push_down_filters(Arc::clone(&plan), vec![], config, self.phase)?
@@ -440,7 +441,7 @@ impl PhysicalOptimizerRule for FilterPushdown {
 fn push_down_filters(
     node: Arc<dyn ExecutionPlan>,
     parent_predicates: Vec<Arc<dyn PhysicalExpr>>,
-    config: &ConfigOptions,
+    config: &SessionConfig,
     phase: FilterPushdownPhase,
 ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
     let mut parent_filter_pushdown_supports: Vec<Vec<PushedDown>> =

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -23,10 +23,10 @@ use std::sync::Arc;
 
 use crate::PhysicalOptimizerRule;
 
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
 use datafusion_common::tree_node::{Transformed, TreeNodeRecursion};
 use datafusion_common::utils::combine_limit;
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion_physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
@@ -63,7 +63,7 @@ impl PhysicalOptimizerRule for LimitPushdown {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let global_state = GlobalRequirements {
             fetch: None,

--- a/datafusion/physical-optimizer/src/limit_pushdown_past_window.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown_past_window.rs
@@ -16,9 +16,9 @@
 // under the License.
 
 use crate::PhysicalOptimizerRule;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::ScalarValue;
+use datafusion_execution::config::SessionConfig;
 use datafusion_expr::{LimitEffect, WindowFrameBound, WindowFrameUnits};
 use datafusion_physical_expr::window::{
     PlainAggregateWindowExpr, SlidingAggregateWindowExpr, StandardWindowExpr,
@@ -74,9 +74,9 @@ impl PhysicalOptimizerRule for LimitPushPastWindows {
     fn optimize(
         &self,
         original: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        if !config.optimizer.enable_window_limits {
+        if !config.options().optimizer.enable_window_limits {
             return Ok(original);
         }
         let mut ctx = TraverseState::default();

--- a/datafusion/physical-optimizer/src/limited_distinct_aggregation.rs
+++ b/datafusion/physical-optimizer/src/limited_distinct_aggregation.rs
@@ -24,9 +24,9 @@ use datafusion_physical_plan::aggregates::AggregateExec;
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::Result;
+use datafusion_execution::config::SessionConfig;
 
 use crate::PhysicalOptimizerRule;
 use itertools::Itertools;
@@ -161,9 +161,13 @@ impl PhysicalOptimizerRule for LimitedDistinctAggregation {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        if config.optimizer.enable_distinct_aggregation_soft_limit {
+        if config
+            .options()
+            .optimizer
+            .enable_distinct_aggregation_soft_limit
+        {
             plan.transform_down(|plan| {
                 Ok(
                     if let Some(plan) =

--- a/datafusion/physical-optimizer/src/optimizer.rs
+++ b/datafusion/physical-optimizer/src/optimizer.rs
@@ -38,8 +38,8 @@ use crate::update_aggr_exprs::OptimizeAggregateOrder;
 
 use crate::coalesce_async_exec_input::CoalesceAsyncExecInput;
 use crate::limit_pushdown_past_window::LimitPushPastWindows;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::Result;
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_plan::ExecutionPlan;
 
 /// `PhysicalOptimizerRule` transforms one ['ExecutionPlan'] into another which
@@ -54,7 +54,7 @@ pub trait PhysicalOptimizerRule: Debug {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 
     /// A human readable name for this optimizer rule

--- a/datafusion/physical-optimizer/src/output_requirements.rs
+++ b/datafusion/physical-optimizer/src/output_requirements.rs
@@ -26,9 +26,9 @@ use std::sync::Arc;
 
 use crate::PhysicalOptimizerRule;
 
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::{Result, Statistics};
+use datafusion_execution::config::SessionConfig;
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::Distribution;
 use datafusion_physical_expr_common::sort_expr::OrderingRequirements;
@@ -306,7 +306,7 @@ impl PhysicalOptimizerRule for OutputRequirements {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         match self.mode {
             RuleMode::Add => require_top_ordering(plan),

--- a/datafusion/physical-optimizer/src/projection_pushdown.rs
+++ b/datafusion/physical-optimizer/src/projection_pushdown.rs
@@ -26,11 +26,11 @@ use datafusion_common::alias::AliasGenerator;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
 };
 use datafusion_common::{JoinSide, JoinType, Result};
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use datafusion_physical_plan::joins::utils::{ColumnIndex, JoinFilter};
@@ -60,7 +60,7 @@ impl PhysicalOptimizerRule for ProjectionPushdown {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let alias_generator = AliasGenerator::new();
         let plan = plan
@@ -447,6 +447,7 @@ fn is_volatile_expression_tree(expr: &dyn PhysicalExpr) -> bool {
 mod test {
     use super::*;
     use arrow::datatypes::{DataType, Field, FieldRef, Schema};
+    use datafusion_common::config::ConfigOptions;
     use datafusion_expr_common::operator::Operator;
     use datafusion_functions::math::random;
     use datafusion_physical_expr::expressions::{binary, lit};

--- a/datafusion/physical-optimizer/src/sanity_checker.rs
+++ b/datafusion/physical-optimizer/src/sanity_checker.rs
@@ -26,9 +26,10 @@ use std::sync::Arc;
 use datafusion_common::Result;
 use datafusion_physical_plan::ExecutionPlan;
 
-use datafusion_common::config::{ConfigOptions, OptimizerOptions};
+use datafusion_common::config::OptimizerOptions;
 use datafusion_common::plan_err;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_expr::intervals::utils::{check_support, is_datatype_supported};
 use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion_physical_plan::joins::SymmetricHashJoinExec;
@@ -57,9 +58,9 @@ impl PhysicalOptimizerRule for SanityCheckPlan {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        plan.transform_up(|p| check_plan_sanity(p, &config.optimizer))
+        plan.transform_up(|p| check_plan_sanity(p, &config.options().optimizer))
             .data()
     }
 

--- a/datafusion/physical-optimizer/src/topk_aggregation.rs
+++ b/datafusion/physical-optimizer/src/topk_aggregation.rs
@@ -21,9 +21,9 @@ use std::sync::Arc;
 
 use crate::PhysicalOptimizerRule;
 use arrow::datatypes::DataType;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::Result;
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_plan::aggregates::AggregateExec;
 use datafusion_physical_plan::execution_plan::CardinalityEffect;
@@ -148,9 +148,9 @@ impl PhysicalOptimizerRule for TopKAggregation {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        if config.optimizer.enable_topk_aggregation {
+        if config.options().optimizer.enable_topk_aggregation {
             plan.transform_down(|plan| {
                 Ok(if let Some(plan) = TopKAggregation::transform_sort(&plan) {
                     Transformed::yes(plan)

--- a/datafusion/physical-optimizer/src/update_aggr_exprs.rs
+++ b/datafusion/physical-optimizer/src/update_aggr_exprs.rs
@@ -20,9 +20,9 @@
 
 use std::sync::Arc;
 
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::{plan_datafusion_err, Result};
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_expr::aggregate::AggregateFunctionExpr;
 use datafusion_physical_expr::{EquivalenceProperties, PhysicalSortRequirement};
 use datafusion_physical_plan::aggregates::{concat_slices, AggregateExec};
@@ -73,7 +73,7 @@ impl PhysicalOptimizerRule for OptimizeAggregateOrder {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         plan.transform_up(|plan| {
             if let Some(aggr_exec) = plan.as_any().downcast_ref::<AggregateExec>() {

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -40,7 +40,7 @@ use crate::filter_pushdown::{
     ChildPushdownResult, FilterDescription, FilterPushdownPhase,
     FilterPushdownPropagation,
 };
-use datafusion_common::config::ConfigOptions;
+use datafusion_execution::config::SessionConfig;
 use futures::ready;
 use futures::stream::{Stream, StreamExt};
 
@@ -229,7 +229,7 @@ impl ExecutionPlan for CoalesceBatchesExec {
         &self,
         _phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterDescription> {
         FilterDescription::from_children(parent_filters, &self.children())
     }
@@ -238,7 +238,7 @@ impl ExecutionPlan for CoalesceBatchesExec {
         &self,
         _phase: FilterPushdownPhase,
         child_pushdown_result: ChildPushdownResult,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
         Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
     }

--- a/datafusion/physical-plan/src/coalesce_partitions.rs
+++ b/datafusion/physical-plan/src/coalesce_partitions.rs
@@ -32,8 +32,8 @@ use crate::filter_pushdown::{FilterDescription, FilterPushdownPhase};
 use crate::projection::{make_with_child, ProjectionExec};
 use crate::{DisplayFormatType, ExecutionPlan, Partitioning};
 
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::{internal_err, Result};
+use datafusion_execution::config::SessionConfig;
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::PhysicalExpr;
 
@@ -268,7 +268,7 @@ impl ExecutionPlan for CoalescePartitionsExec {
         &self,
         _phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterDescription> {
         FilterDescription::from_children(parent_filters, &self.children())
     }

--- a/datafusion/physical-plan/src/coop.rs
+++ b/datafusion/physical-plan/src/coop.rs
@@ -65,7 +65,6 @@
 //! The optimizer rule currently checks the plan for exchange-like operators and leave operators
 //! that report [`SchedulingType::NonCooperative`] in their [plan properties](ExecutionPlan::properties).
 
-use datafusion_common::config::ConfigOptions;
 use datafusion_physical_expr::PhysicalExpr;
 #[cfg(datafusion_coop = "tokio_fallback")]
 use futures::Future;
@@ -90,6 +89,7 @@ use datafusion_execution::TaskContext;
 
 use crate::execution_plan::SchedulingType;
 use crate::stream::RecordBatchStreamAdapter;
+use datafusion_execution::config::SessionConfig;
 use futures::{Stream, StreamExt};
 
 /// A stream that passes record batches through unchanged while cooperating with the Tokio runtime.
@@ -300,7 +300,7 @@ impl ExecutionPlan for CooperativeExec {
         &self,
         _phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterDescription> {
         FilterDescription::from_children(parent_filters, &self.children())
     }
@@ -309,7 +309,7 @@ impl ExecutionPlan for CooperativeExec {
         &self,
         _phase: FilterPushdownPhase,
         child_pushdown_result: ChildPushdownResult,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
         Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
     }

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -53,6 +53,7 @@ use datafusion_execution::TaskContext;
 use datafusion_physical_expr::EquivalenceProperties;
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, OrderingRequirements};
 
+use datafusion_execution::config::SessionConfig;
 use futures::stream::{StreamExt, TryStreamExt};
 
 /// Represent nodes in the DataFusion Physical Plan.
@@ -553,7 +554,7 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
         &self,
         _phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterDescription> {
         Ok(FilterDescription::all_unsupported(
             &parent_filters,
@@ -644,7 +645,7 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
         &self,
         _phase: FilterPushdownPhase,
         child_pushdown_result: ChildPushdownResult,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
         Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
     }

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -45,7 +45,6 @@ use arrow::compute::filter_record_batch;
 use arrow::datatypes::{DataType, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::cast::as_boolean_array;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::stats::Precision;
 use datafusion_common::{
     internal_err, plan_err, project_schema, DataFusionError, Result, ScalarValue,
@@ -61,6 +60,7 @@ use datafusion_physical_expr::{
     ConstExpr, ExprBoundaries, PhysicalExpr,
 };
 
+use datafusion_execution::config::SessionConfig;
 use datafusion_physical_expr_common::physical_expr::fmt_sql;
 use futures::stream::{Stream, StreamExt};
 use log::trace;
@@ -449,7 +449,7 @@ impl ExecutionPlan for FilterExec {
         &self,
         phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterDescription> {
         if !matches!(phase, FilterPushdownPhase::Pre) {
             // For non-pre phase, filters pass through unchanged
@@ -478,7 +478,7 @@ impl ExecutionPlan for FilterExec {
         &self,
         phase: FilterPushdownPhase,
         child_pushdown_result: ChildPushdownResult,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
         if !matches!(phase, FilterPushdownPhase::Pre) {
             return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -41,7 +41,6 @@ use std::task::{Context, Poll};
 
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::stats::Precision;
 use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
@@ -53,6 +52,7 @@ use datafusion_physical_expr::utils::collect_columns;
 use datafusion_physical_expr_common::physical_expr::{fmt_sql, PhysicalExprRef};
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, LexRequirement};
 
+use datafusion_execution::config::SessionConfig;
 use futures::stream::{Stream, StreamExt};
 use log::trace;
 
@@ -370,7 +370,7 @@ impl ExecutionPlan for ProjectionExec {
         &self,
         _phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterDescription> {
         // TODO: In future, we can try to handle inverting aliases here.
         // For the time being, we pass through untransformed filters, so filters on aliases are not handled.
@@ -382,7 +382,7 @@ impl ExecutionPlan for ProjectionExec {
         &self,
         _phase: FilterPushdownPhase,
         child_pushdown_result: ChildPushdownResult,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
         Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
     }

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -59,6 +59,7 @@ use crate::filter_pushdown::{
     ChildPushdownResult, FilterDescription, FilterPushdownPhase,
     FilterPushdownPropagation,
 };
+use datafusion_execution::config::SessionConfig;
 use futures::stream::Stream;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use log::trace;
@@ -845,7 +846,7 @@ impl ExecutionPlan for RepartitionExec {
         &self,
         _phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterDescription> {
         FilterDescription::from_children(parent_filters, &self.children())
     }
@@ -854,7 +855,7 @@ impl ExecutionPlan for RepartitionExec {
         &self,
         _phase: FilterPushdownPhase,
         child_pushdown_result: ChildPushdownResult,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
         Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
     }

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -43,12 +43,12 @@ use crate::stream::ObservedStream;
 
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
-use datafusion_common::config::ConfigOptions;
 use datafusion_common::stats::Precision;
 use datafusion_common::{exec_err, internal_datafusion_err, internal_err, Result};
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::{calculate_union, EquivalenceProperties, PhysicalExpr};
 
+use datafusion_execution::config::SessionConfig;
 use futures::Stream;
 use itertools::Itertools;
 use log::{debug, trace, warn};
@@ -359,7 +359,7 @@ impl ExecutionPlan for UnionExec {
         &self,
         _phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        _config: &SessionConfig,
     ) -> Result<FilterDescription> {
         FilterDescription::from_children(parent_filters, &self.children())
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- No issue.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Users might want to create their own `PhysicalOptimizerRule` implementations. Users might have their own `SessionConfig.extensions`. Users might want to use their own `SessionConfig.extensions` in their custom `PhysicalOptimizerRule` implementations.

This PR is needed for https://github.com/gabotechs/datafusion/pull/7, but it was factored out as it's an isolated change that could have value on its own.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Changes signature of `PhysicalOptimizerRule.optimze` to take a `SessionConfig` rather than a `ConfigOptions`.

```rust
pub trait PhysicalOptimizerRule: Debug {
    /// Rewrite `plan` to an optimized form
    fn optimize(
        &self,
        plan: Arc<dyn ExecutionPlan>,
-       config: &ConfigOptions,
+       config: &SessionConfig,
    ) -> Result<Arc<dyn ExecutionPlan>>;
    ...
}
```

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

yes, by current tests.

## Are there any user-facing changes?

yes, `PhysicalOptimizerRule.optimze` now takes a `SessionConfig` rather than a `ConfigOptions`, which is a breaking non backwards compatible change.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
