### PR TITLE
fix(docs): resolve extra outline on tables

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -94,6 +94,13 @@ Details: 8rem for search box etc*/
   max-width: 100%;
 }
 
+/* Make table container width fit content instead of spanning full width. */
+.pst-scrollable-table-container {
+  display: inline-block;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
 /* Restore proper table display to maintain column alignment */
 .bd-content table thead,
 .bd-content table tbody { display: table-row-group; }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18189.

## What changes are included in this PR?

This PR fixes the extra outline extending beyond the table content in the documentation.

<img width="924" height="240" alt="image" src="https://github.com/user-attachments/assets/d079ae42-8ce3-4afc-9eaa-bff21069ba83" />
