### PR TITLE
Adds DELETE and HEAD instrumentation to CLI

### DIFF
--- a/datafusion-cli/tests/cli_integration.rs
+++ b/datafusion-cli/tests/cli_integration.rs
@@ -411,8 +411,8 @@ async fn test_object_store_profiling() {
     // Output:
     // <TIMESTAMP> operation=Get duration=[DURATION] size=1006 path=cars.csv
     settings.add_filter(
-        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?[+-]\d{2}:\d{2} operation=(Get|Put|Delete|List|Head) duration=\d+\.\d{6}s size=(\d+) path=(.*)",
-        "<TIMESTAMP> operation=$1 duration=[DURATION] size=$2 path=$3",
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?[+-]\d{2}:\d{2} operation=(Get|Put|Delete|List|Head) duration=\d+\.\d{6}s (size=\d+\s+)?path=(.*)",
+        "<TIMESTAMP> operation=$1 duration=[DURATION] ${2}path=$3",
     );
 
     // We also need to filter out the summary statistics (anything with an 's' at the end)

--- a/datafusion-cli/tests/snapshots/object_store_profiling.snap
+++ b/datafusion-cli/tests/snapshots/object_store_profiling.snap
@@ -37,6 +37,7 @@ ObjectStore Profile mode set to Trace
 
 Object Store Profiling
 Instrumented Object Store: instrument_mode: Trace, inner: AmazonS3(data)
+<TIMESTAMP> operation=Head duration=[DURATION] path=cars.csv
 <TIMESTAMP> operation=Get duration=[DURATION] size=1006 path=cars.csv
 
 Summaries:
@@ -45,6 +46,8 @@ Summaries:
 +-----------+----------+-----------+-----------+-----------+-----------+-------+
 | Get        | duration | ...NORMALIZED...| 1     |
 | Get       | size     | 1006 B    | 1006 B    | 1006 B    | 1006 B    | 1     |
+| Head       | duration | ...NORMALIZED...| 1     |
+| Head      | size     |           |           |           |           | 1     |
 +-----------+----------+-----------+-----------+-----------+-----------+-------+
 ObjectStore Profile mode set to Summary
 +-----+-------+---------------------+
@@ -63,6 +66,8 @@ Summaries:
 +-----------+----------+-----------+-----------+-----------+-----------+-------+
 | Get        | duration | ...NORMALIZED...| 1     |
 | Get       | size     | 1006 B    | 1006 B    | 1006 B    | 1006 B    | 1     |
+| Head       | duration | ...NORMALIZED...| 1     |
+| Head      | size     |           |           |           |           | 1     |
 +-----------+----------+-----------+-----------+-----------+-----------+-------+
 ObjectStore Profile mode set to Disabled
 +-----+-------+---------------------+


### PR DESCRIPTION


## Which issue does this PR close?


This does not fully close, but is an incremental building block component for: 
 - https://github.com/apache/datafusion/issues/17207

The full context of how this code is likely to progress can be seen in the POC for this effort:
 - https://github.com/apache/datafusion/pull/17266

## Rationale for this change

Further fills out method instrumentation

## What changes are included in this PR?

 - Adds instrumentation to head requests in the instrumented object store
 - Adds instrumentatin to delete requests in the instrumented object store
 - Adds tests for new code

## Are these changes tested?

Yes. New unit tests have been added.

## Are there any user-facing changes?

No-ish

##
cc @alamb 
