### PR TITLE
fix: wrong simplification for >= >, <= <

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions/simplify_predicates.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_predicates.rs
@@ -194,7 +194,7 @@ fn find_most_restrictive_predicate(
     let mut best_value: Option<&ScalarValue> = None;
 
     for (idx, pred) in predicates.iter().enumerate() {
-        if let Expr::BinaryExpr(BinaryExpr { left, op: _, right }) = pred {
+        if let Expr::BinaryExpr(BinaryExpr { left, op, right }) = pred {
             // Extract the literal value based on which side has it
             let scalar_value = match (right.as_literal(), left.as_literal()) {
                 (Some(scalar), _) => Some(scalar),
@@ -207,8 +207,12 @@ fn find_most_restrictive_predicate(
                     let comparison = scalar.try_cmp(current_best)?;
                     let is_better = if find_greater {
                         comparison == std::cmp::Ordering::Greater
+                            || (comparison == std::cmp::Ordering::Equal
+                                && op == &Operator::Gt)
                     } else {
                         comparison == std::cmp::Ordering::Less
+                            || (comparison == std::cmp::Ordering::Equal
+                                && op == &Operator::Lt)
                     };
 
                     if is_better {

--- a/datafusion/sqllogictest/test_files/simplify_predicates.slt
+++ b/datafusion/sqllogictest/test_files/simplify_predicates.slt
@@ -230,5 +230,17 @@ logical_plan
 01)Filter: test_data.int_col > Int32(5) AND test_data.int_col > Int32(6) OR test_data.float_col < Float32(10) AND test_data.float_col < Float32(8)
 02)--TableScan: test_data projection=[int_col, float_col, str_col, date_col, bool_col]
 
+
+query TT
+EXPLAIN SELECT * FROM (
+  SELECT * FROM test_data 
+  WHERE int_col > 1 AND int_col < 10
+) WHERE int_col >= 1 AND int_col <= 10;
+----
+logical_plan
+01)Filter: test_data.int_col > Int32(1) AND test_data.int_col < Int32(10)
+02)--TableScan: test_data projection=[int_col, float_col, str_col, date_col, bool_col]
+
+
 statement ok
 set datafusion.explain.logical_plan_only=false;


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #18214.

## Rationale for this change

In find_most_restrictive_predicate, operation is ignored, but it should be considered when boundaries are equal.

## What changes are included in this PR?

check the operator, when boundaries are equal.

## Are these changes tested?

UT

## Are there any user-facing changes?

No
