### PR TITLE
feat: Add LATERAL table function support (#18121)

### DIFF
--- a/datafusion/core/src/execution/lateral_table_function.rs
+++ b/datafusion/core/src/execution/lateral_table_function.rs
@@ -1,0 +1,450 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Execution plan for LATERAL table functions
+
+use std::any::Any;
+use std::fmt;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::array::ArrayRef;
+use arrow::compute::concat_batches;
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use datafusion_catalog::TableFunction;
+use datafusion_common::{internal_err, Result, ScalarValue};
+use datafusion_execution::TaskContext;
+use datafusion_expr::{ColumnarValue, Expr};
+use datafusion_physical_expr::{EquivalenceProperties, PhysicalExpr};
+use datafusion_physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    RecordBatchStream, SendableRecordBatchStream,
+};
+use futures::future::BoxFuture;
+use futures::stream::Stream;
+use futures::{ready, FutureExt, StreamExt};
+
+use crate::execution::session_state::SessionState;
+
+/// Execution plan for LATERAL table functions
+///
+/// This operator evaluates a table function for each row from the input,
+/// allowing the table function to reference columns from the outer query.
+#[derive(Debug, Clone)]
+pub struct LateralTableFunctionExec {
+    /// Input execution plan (the "outer" table)
+    input: Arc<dyn ExecutionPlan>,
+    /// Name of the table function to call
+    function_name: String,
+    /// The table function instance
+    table_function: Arc<TableFunction>,
+    /// Physical expressions for table function arguments
+    args: Vec<Arc<dyn PhysicalExpr>>,
+    /// Complete output schema (input columns + table function columns).
+    /// Used when creating the final output batches that combine both.
+    schema: SchemaRef,
+    /// Table function output schema only (excludes input columns).
+    /// Used when concatenating batches from the table function before
+    /// combining them with input columns.
+    table_function_schema: SchemaRef,
+    /// Session state for accessing catalog and scanning
+    session_state: Arc<SessionState>,
+    /// Cached plan properties (partitioning, ordering, equivalences, etc.).
+    /// Computed once during construction to avoid expensive recalculation
+    /// during query optimization.
+    cache: PlanProperties,
+}
+
+impl LateralTableFunctionExec {
+    pub fn new(
+        input: Arc<dyn ExecutionPlan>,
+        function_name: String,
+        table_function: Arc<TableFunction>,
+        args: Vec<Arc<dyn PhysicalExpr>>,
+        schema: SchemaRef,
+        table_function_schema: SchemaRef,
+        session_state: Arc<SessionState>,
+    ) -> Self {
+        let cache = Self::compute_properties(&input, Arc::clone(&schema));
+        Self {
+            input,
+            function_name,
+            table_function,
+            args,
+            schema,
+            table_function_schema,
+            session_state,
+            cache,
+        }
+    }
+
+    fn compute_properties(
+        input: &Arc<dyn ExecutionPlan>,
+        schema: SchemaRef,
+    ) -> PlanProperties {
+        let eq_properties = EquivalenceProperties::new(schema);
+        PlanProperties::new(
+            eq_properties,
+            input.output_partitioning().clone(),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        )
+    }
+
+    pub fn function_name(&self) -> &str {
+        &self.function_name
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+}
+
+impl DisplayAs for LateralTableFunctionExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "LateralTableFunctionExec: function={}(..)",
+                    self.function_name
+                )
+            }
+            DisplayFormatType::TreeRender => {
+                write!(f, "LateralTableFunction({})", self.function_name)
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for LateralTableFunctionExec {
+    fn name(&self) -> &str {
+        "LateralTableFunctionExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return internal_err!(
+                "LateralTableFunctionExec expects exactly one child, got {}",
+                children.len()
+            );
+        }
+
+        Ok(Arc::new(LateralTableFunctionExec::new(
+            Arc::clone(&children[0]),
+            self.function_name.clone(),
+            Arc::clone(&self.table_function),
+            self.args.clone(),
+            Arc::clone(&self.schema),
+            Arc::clone(&self.table_function_schema),
+            Arc::clone(&self.session_state),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let input_stream = self.input.execute(partition, Arc::clone(&context))?;
+
+        Ok(Box::pin(LateralTableFunctionStream {
+            input: input_stream,
+            table_function: Arc::clone(&self.table_function),
+            args: self.args.clone(),
+            table_function_schema: Arc::clone(&self.table_function_schema),
+            schema: Arc::clone(&self.schema),
+            session_state: Arc::clone(&self.session_state),
+            context,
+            state: ProcessingState::ReadingInput,
+        }))
+    }
+}
+
+enum ProcessingState {
+    ReadingInput,
+    ProcessingRow {
+        input_batch: RecordBatch,
+        row_idx: usize,
+        output_batches: Vec<RecordBatch>,
+    },
+    ScanningTableFunction {
+        input_batch: RecordBatch,
+        row_idx: usize,
+        output_batches: Vec<RecordBatch>,
+        scan_future: BoxFuture<'static, Result<Arc<dyn ExecutionPlan>>>,
+    },
+    ReadingTableStream {
+        input_batch: RecordBatch,
+        row_idx: usize,
+        output_batches: Vec<RecordBatch>,
+        table_stream: SendableRecordBatchStream,
+        table_batches: Vec<RecordBatch>,
+    },
+}
+
+struct LateralTableFunctionStream {
+    input: SendableRecordBatchStream,
+    table_function: Arc<TableFunction>,
+    args: Vec<Arc<dyn PhysicalExpr>>,
+    table_function_schema: SchemaRef,
+    schema: SchemaRef,
+    session_state: Arc<SessionState>,
+    context: Arc<TaskContext>,
+    state: ProcessingState,
+}
+
+impl Stream for LateralTableFunctionStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        loop {
+            let state = std::mem::replace(
+                &mut self.state,
+                ProcessingState::ReadingInput,
+            );
+
+            match state {
+                ProcessingState::ReadingInput => {
+                    match ready!(self.input.poll_next_unpin(cx)) {
+                        Some(Ok(batch)) => {
+                            if batch.num_rows() == 0 {
+                                return Poll::Ready(Some(Ok(RecordBatch::new_empty(
+                                    Arc::clone(&self.schema),
+                                ))));
+                            }
+                            self.state = ProcessingState::ProcessingRow {
+                                input_batch: batch,
+                                row_idx: 0,
+                                output_batches: Vec::new(),
+                            };
+                        }
+                        Some(Err(e)) => return Poll::Ready(Some(Err(e))),
+                        None => return Poll::Ready(None),
+                    }
+                }
+
+                ProcessingState::ProcessingRow {
+                    input_batch,
+                    row_idx,
+                    output_batches,
+                } => {
+                    if row_idx >= input_batch.num_rows() {
+                        let result = self.combine_output_batches(&output_batches)?;
+                        return Poll::Ready(Some(Ok(result)));
+                    }
+
+                    let arg_values = match self.evaluate_args(&input_batch, row_idx) {
+                        Ok(args) => args,
+                        Err(e) => {
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    };
+
+                    let table_provider =
+                        match self.table_function.function().call(&arg_values) {
+                            Ok(provider) => provider,
+                            Err(e) => {
+                                return Poll::Ready(Some(Err(e)));
+                            }
+                        };
+
+                    let session_state = Arc::clone(&self.session_state);
+                    let scan_future = async move {
+                        table_provider
+                            .scan(session_state.as_ref(), None, &[], None)
+                            .await
+                    }
+                    .boxed();
+
+                    self.state = ProcessingState::ScanningTableFunction {
+                        input_batch,
+                        row_idx,
+                        output_batches,
+                        scan_future,
+                    };
+                }
+
+                ProcessingState::ScanningTableFunction {
+                    input_batch,
+                    row_idx,
+                    output_batches,
+                    mut scan_future,
+                } => {
+                    let table_exec = ready!(scan_future.poll_unpin(cx));
+                    let table_exec = match table_exec {
+                        Ok(exec) => exec,
+                        Err(e) => {
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    };
+
+                    let table_stream = match table_exec.execute(0, Arc::clone(&self.context))
+                    {
+                        Ok(stream) => stream,
+                        Err(e) => {
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    };
+
+                    self.state = ProcessingState::ReadingTableStream {
+                        input_batch,
+                        row_idx,
+                        output_batches,
+                        table_stream,
+                        table_batches: Vec::new(),
+                    };
+                }
+
+                ProcessingState::ReadingTableStream {
+                    input_batch,
+                    row_idx,
+                    mut output_batches,
+                    mut table_stream,
+                    mut table_batches,
+                } => {
+                    match ready!(table_stream.poll_next_unpin(cx)) {
+                        Some(Ok(batch)) => {
+                            table_batches.push(batch);
+                            self.state = ProcessingState::ReadingTableStream {
+                                input_batch,
+                                row_idx,
+                                output_batches,
+                                table_stream,
+                                table_batches,
+                            };
+                        }
+                        Some(Err(e)) => {
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                        None => {
+                            if !table_batches.is_empty() {
+                                match self.combine_row_with_table_output(
+                                    &input_batch,
+                                    row_idx,
+                                    &table_batches,
+                                ) {
+                                    Ok(output_batch) => {
+                                        output_batches.push(output_batch);
+                                    }
+                                    Err(e) => {
+                                        return Poll::Ready(Some(Err(e)));
+                                    }
+                                }
+                            }
+
+                            self.state = ProcessingState::ProcessingRow {
+                                input_batch,
+                                row_idx: row_idx + 1,
+                                output_batches,
+                            };
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl LateralTableFunctionStream {
+    fn evaluate_args(
+        &self,
+        input_batch: &RecordBatch,
+        row_idx: usize,
+    ) -> Result<Vec<Expr>> {
+        self.args
+            .iter()
+            .map(|arg_expr| {
+                let columnar_value = arg_expr.evaluate(input_batch)?;
+                match columnar_value {
+                    ColumnarValue::Scalar(scalar) => Ok(Expr::Literal(scalar, None)),
+                    ColumnarValue::Array(array) => {
+                        let scalar = ScalarValue::try_from_array(&array, row_idx)?;
+                        Ok(Expr::Literal(scalar, None))
+                    }
+                }
+            })
+            .collect::<Result<Vec<_>>>()
+    }
+
+    fn combine_row_with_table_output(
+        &self,
+        input_batch: &RecordBatch,
+        row_idx: usize,
+        table_batches: &[RecordBatch],
+    ) -> Result<RecordBatch> {
+        let combined_table_batch = if table_batches.len() == 1 {
+            table_batches[0].clone()
+        } else {
+            concat_batches(&self.table_function_schema, table_batches)?
+        };
+
+        let input_row_arrays: Vec<ArrayRef> = input_batch
+            .columns()
+            .iter()
+            .map(|col| {
+                let scalar = ScalarValue::try_from_array(col, row_idx)?;
+                scalar.to_array_of_size(combined_table_batch.num_rows())
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut output_columns = input_row_arrays;
+        output_columns.extend(combined_table_batch.columns().iter().cloned());
+
+        RecordBatch::try_new(Arc::clone(&self.schema), output_columns)
+            .map_err(Into::into)
+    }
+
+    fn combine_output_batches(
+        &self,
+        output_batches: &[RecordBatch],
+    ) -> Result<RecordBatch> {
+        if output_batches.is_empty() {
+            Ok(RecordBatch::new_empty(Arc::clone(&self.schema)))
+        } else if output_batches.len() == 1 {
+            Ok(output_batches[0].clone())
+        } else {
+            concat_batches(&self.schema, output_batches).map_err(Into::into)
+        }
+    }
+}
+
+impl RecordBatchStream for LateralTableFunctionStream {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}

--- a/datafusion/core/src/execution/mod.rs
+++ b/datafusion/core/src/execution/mod.rs
@@ -18,6 +18,7 @@
 //! Shared state for query planning and execution.
 
 pub mod context;
+pub mod lateral_table_function;
 pub mod session_state;
 pub use session_state::{SessionState, SessionStateBuilder};
 

--- a/datafusion/expr/src/logical_plan/display.rs
+++ b/datafusion/expr/src/logical_plan/display.rs
@@ -22,9 +22,9 @@ use std::fmt;
 
 use crate::{
     expr_vec_fmt, Aggregate, DescribeTable, Distinct, DistinctOn, DmlStatement, Expr,
-    Filter, Join, Limit, LogicalPlan, Partitioning, Projection, RecursiveQuery,
-    Repartition, Sort, Subquery, SubqueryAlias, TableProviderFilterPushDown, TableScan,
-    Unnest, Values, Window,
+    Filter, Join, LateralTableFunction, Limit, LogicalPlan, Partitioning, Projection,
+    RecursiveQuery, Repartition, Sort, Subquery, SubqueryAlias,
+    TableProviderFilterPushDown, TableScan, Unnest, Values, Window,
 };
 
 use crate::dml::CopyTo;
@@ -317,6 +317,17 @@ impl<'a, 'b> PgJsonVisitor<'a, 'b> {
                 json!({
                     "Node Type": "RecursiveQuery",
                     "Is Distinct": is_distinct,
+                })
+            }
+            LogicalPlan::LateralTableFunction(LateralTableFunction {
+                ref function_name,
+                ref args,
+                ..
+            }) => {
+                json!({
+                    "Node Type": "LateralTableFunction",
+                    "Function": function_name,
+                    "Args": expr_vec_fmt!(args)
                 })
             }
             LogicalPlan::Values(Values { ref values, .. }) => {

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -40,9 +40,10 @@ pub use dml::{DmlStatement, WriteOp};
 pub use plan::{
     projection_schema, Aggregate, Analyze, ColumnUnnestList, DescribeTable, Distinct,
     DistinctOn, EmptyRelation, Explain, ExplainOption, Extension, FetchType, Filter,
-    Join, JoinConstraint, JoinType, Limit, LogicalPlan, Partitioning, PlanType,
-    Projection, RecursiveQuery, Repartition, SkipType, Sort, StringifiedPlan, Subquery,
-    SubqueryAlias, TableScan, ToStringifiedPlan, Union, Unnest, Values, Window,
+    Join, JoinConstraint, JoinType, LateralTableFunction, Limit, LogicalPlan,
+    Partitioning, PlanType, Projection, RecursiveQuery, Repartition, SkipType, Sort,
+    StringifiedPlan, Subquery, SubqueryAlias, TableScan, ToStringifiedPlan, Union,
+    Unnest, Values, Window,
 };
 pub use statement::{
     Deallocate, Execute, Prepare, SetVariable, Statement, TransactionAccessMode,

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -586,6 +586,7 @@ impl OptimizerRule for CommonSubexprEliminate {
             | LogicalPlan::Dml(_)
             | LogicalPlan::Copy(_)
             | LogicalPlan::Unnest(_)
+            | LogicalPlan::LateralTableFunction(_)
             | LogicalPlan::RecursiveQuery(_) => {
                 // This rule handles recursion itself in a `ApplyOrder::TopDown` like
                 // manner.

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -322,6 +322,7 @@ fn optimize_projections(
         | LogicalPlan::Analyze(_)
         | LogicalPlan::Subquery(_)
         | LogicalPlan::Statement(_)
+        | LogicalPlan::LateralTableFunction(_)
         | LogicalPlan::Distinct(Distinct::All(_)) => {
             // These plans require all their fields, and their children should
             // be treated as final plans -- otherwise, we may have schema a

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1788,6 +1788,9 @@ impl AsLogicalPlan for LogicalPlanNode {
                     ))),
                 })
             }
+            LogicalPlan::LateralTableFunction(_) => Err(proto_error(
+                "LogicalPlan serde is not yet implemented for LateralTableFunction",
+            )),
         }
     }
 }

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -124,6 +124,7 @@ impl Unparser<'_> {
             | LogicalPlan::Copy(_)
             | LogicalPlan::DescribeTable(_)
             | LogicalPlan::RecursiveQuery(_)
+            | LogicalPlan::LateralTableFunction(_)
             | LogicalPlan::Unnest(_) => not_impl_err!("Unsupported plan: {plan:?}"),
         }
     }

--- a/datafusion/sqllogictest/test_files/lateral_table_functions.slt
+++ b/datafusion/sqllogictest/test_files/lateral_table_functions.slt
@@ -1,0 +1,162 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for LATERAL table functions
+# LATERAL allows table-valued functions to reference columns from outer queries
+
+####
+# Setup test data
+####
+
+statement ok
+CREATE TABLE orders(order_id BIGINT, quantity BIGINT, customer_id BIGINT) AS VALUES
+(1, 3, 100),
+(2, 2, 101),
+(3, 5, 100),
+(4, 1, 102);
+
+####
+# Basic LATERAL tests with generate_series
+####
+
+# Basic LATERAL with generate_series
+query III rowsort
+SELECT order_id, quantity, s.value
+FROM orders o
+CROSS JOIN LATERAL generate_series(1, o.quantity) AS s(value);
+----
+1 3 1
+1 3 2
+1 3 3
+2 2 1
+2 2 2
+3 5 1
+3 5 2
+3 5 3
+3 5 4
+3 5 5
+4 1 1
+
+# LATERAL with WHERE clause on outer table
+query III rowsort
+SELECT order_id, quantity, s.value
+FROM orders o
+CROSS JOIN LATERAL generate_series(1, o.quantity) AS s(value)
+WHERE o.customer_id = 100;
+----
+1 3 1
+1 3 2
+1 3 3
+3 5 1
+3 5 2
+3 5 3
+3 5 4
+3 5 5
+
+# LATERAL with range function (exclusive end)
+query III rowsort
+SELECT order_id, quantity, s.value
+FROM orders o
+CROSS JOIN LATERAL range(0, o.quantity) AS s(value);
+----
+1 3 0
+1 3 1
+1 3 2
+2 2 0
+2 2 1
+3 5 0
+3 5 1
+3 5 2
+3 5 3
+3 5 4
+4 1 0
+
+# LATERAL with aggregation
+query II
+SELECT customer_id, SUM(s.value) as total
+FROM orders o
+CROSS JOIN LATERAL generate_series(1, o.quantity) AS s(value)
+GROUP BY customer_id
+ORDER BY customer_id;
+----
+100 21
+101 3
+102 1
+
+# LATERAL with multiple outer references
+statement ok
+CREATE TABLE products(product_id BIGINT, min_qty BIGINT, max_qty BIGINT) AS VALUES
+(1, 1, 3),
+(2, 2, 4);
+
+query III rowsort
+SELECT product_id, min_qty, s.value
+FROM products p
+CROSS JOIN LATERAL generate_series(p.min_qty, p.max_qty) AS s(value);
+----
+1 1 1
+1 1 2
+1 1 3
+2 2 2
+2 2 3
+2 2 4
+
+# LATERAL with projected columns only
+query I rowsort
+SELECT s.value
+FROM orders o
+CROSS JOIN LATERAL generate_series(1, o.quantity) AS s(value)
+WHERE order_id = 2;
+----
+1
+2
+
+# Multiple LATERAL joins - sequential application
+query IIII rowsort
+SELECT o1.order_id, o1.quantity, s1.value as series1, s2.value as series2
+FROM orders o1
+CROSS JOIN LATERAL generate_series(1, o1.quantity) AS s1(value)
+CROSS JOIN LATERAL generate_series(1, s1.value) AS s2(value)
+WHERE o1.order_id = 2;
+----
+2 2 1 1
+2 2 2 1
+2 2 2 2
+
+# LATERAL with ORDER BY
+query III
+SELECT order_id, quantity, s.value
+FROM orders o
+CROSS JOIN LATERAL generate_series(1, o.quantity) AS s(value)
+ORDER BY order_id, s.value
+LIMIT 5;
+----
+1 3 1
+1 3 2
+1 3 3
+2 2 1
+2 2 2
+
+####
+# Cleanup
+####
+
+statement ok
+DROP TABLE orders;
+
+statement ok
+DROP TABLE products;

--- a/datafusion/substrait/src/logical_plan/producer/rel/mod.rs
+++ b/datafusion/substrait/src/logical_plan/producer/rel/mod.rs
@@ -74,5 +74,8 @@ pub fn to_substrait_rel(
         LogicalPlan::RecursiveQuery(plan) => {
             not_impl_err!("Unsupported plan type: {plan:?}")?
         }
+        LogicalPlan::LateralTableFunction(plan) => {
+            not_impl_err!("Unsupported plan type: {plan:?}")?
+        }
     }
 }


### PR DESCRIPTION
# LATERAL Table Function Support

## Which issue does this PR close?

Closes #18121.

## Rationale for this change

DataFusion's `TableFunction` API currently cannot access data from columns in outer queries, preventing LATERAL joins with table functions. Users attempting queries like:

```sql
SELECT t1.id, t2.x, t2.y
FROM my_table AS t1,
     LATERAL my_transform(t1.a, t1.b, t1.c) AS t2(x, y)
```

encounter errors: `This feature is not implemented: Physical plan does not support logical expression OuterReferenceColumn`.

## What changes are included in this PR?

This PR attempts to add LATERAL table function support, enabling table functions to reference columns from outer queries. I'm sure there are improvements that can be made; feedback is very welcome

### Core Components

1. **Logical Plan Node** (`LateralTableFunction`)
   - Represents table function calls with outer column references
   - Stores both combined output schema and function-only schema for clarity

2. **Physical Execution Plan** (`LateralTableFunctionExec`)
   - Evaluates table function once per input row
   - Handles outer column references by extracting values from each row
   - Combines input columns with function output
   - Implements streaming execution via `RecordBatchStream`

3. **SQL Planning** (`relation/join.rs`)
   - Detects LATERAL table function calls during join planning
   - Performs schema inference using placeholder values when outer references exist
   - Creates `LateralTableFunction` nodes instead of regular scans

4. **Schema Inference**
   - When table function arguments contain outer references, replaces them with placeholder values to infer output schema
   - Uses incrementing values (1, 2, 3...) to ensure valid ranges for functions like `generate_series(start, end)`
   - Stores inferred schema in logical plan for use during physical planning

### Example Usage

```sql
-- Generate series based on table values
SELECT t.id, s.value
FROM my_table t,
     LATERAL generate_series(t.start_val, t.end_val) s;

-- Transform row data through UDTF
SELECT t.id, result.x, result.y
FROM data t,
     LATERAL my_transform(t.a, t.b, t.c) AS result(x, y);
```

## Implementation Approach

I'd appreciate feedback on these design choices - there may be better approaches I haven't considered:

1. **Schema Inference via Placeholders**

   The implementation replaces outer references with placeholder literal values (1, 2, 3...) to infer the table function's output schema. This works because table functions need concrete values to execute, but outer references aren't resolved until runtime.

   **Known limitation**: This approach has an inherent weakness - schema inference can fail if the placeholder values are semantically invalid for the function. For example, `generate_series(start, end)` will error during planning if the placeholder for `start` is greater than `end`, even though the actual runtime values might be valid. For the sake of getting it to work I used incrementing placeholder values, but that's by no means a robust solution.

   I considered the TableFunction provide explicit schema declarations. If there's a better approach for schema inference, I'd love to hear suggestions!

2. **Row-by-Row Sequential Execution**

   The current implementation executes the table function once per input row, sequentially (not parallelized or batched). I chose this conservative approach because we don't have metadata about whether table functions have side effects, are thread-safe, maintain internal state, or can be safely executed in parallel.

   **Trade-off**: This has performance implications. Batched or parallel execution would likely be faster, but would require additional API changes to let table functions declare their safety characteristics.

3 **Dual Schema Storage**

   The logical plan stores both the combined schema (input + function output) and the function-only schema. This is slightly redundant (we could derive one from the other), but I found it made the code clearer and easier to understand. 

### Error Handling

Updated error message for non-LATERAL table functions with column references:
```
Before: "Table functions with outer references are not yet supported. This requires LATERAL table function support."
After:  "Table function arguments cannot reference columns without LATERAL keyword. Use: FROM other_table, LATERAL table_func(other_table.column)"
```

## Are these changes tested?

Yes, I added a dedicated sql logic test file.

## Are there any user-facing changes?

### New Functionality

Users can now use LATERAL with table functions to reference outer columns:

```sql
-- This now works! (previously failed)
SELECT t.id, s.value
FROM my_table t,
     LATERAL generate_series(t.min, t.max) s;
```

### API Changes

1 **`ScalarValue::try_new_placeholder()`** (new)
   - Public utility method for creating placeholder values
   - Useful for schema inference scenarios

2 **No Breaking Changes**
   - All existing APIs remain unchanged
   - Backward compatible with existing table functions
   - Existing SQL queries continue to work

### Performance Characteristics

- LATERAL table functions execute once per input row (not batched)

## Additional Context

### Future Enhancements

Potential follow-up work (out of scope for this PR):

1. **Batch Execution**: Execute table function on multiple rows at once (requires UDTF API changes)
2. **Parallel Execution**: Partition input and execute table functions in parallel

---

**Disclosure**: This PR was developed with the assistance of an LLM and has been thoroughly reviewed and tested by me. All design decisions, code implementation, and testing were validated through manual review and execution.
