### PR TITLE
docs: fix trim for `rust,ignore` blocks

### DIFF
--- a/docs/rustdoc_trim.py
+++ b/docs/rustdoc_trim.py
@@ -19,7 +19,7 @@ import re
 from sphinx.application import Sphinx
 
 # Regex pattern to match Rust code blocks in Markdown
-RUST_CODE_BLOCK_PATTERN = re.compile(r"```rust\s*(.*?)```", re.DOTALL)
+RUST_CODE_BLOCK_PATTERN = re.compile(r"```rust(?:,ignore)?\s*(.*?)```", re.DOTALL)
 
 
 def remove_hashtag_lines_in_rust_blocks(markdown_content):


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Issue was raised as comment: https://github.com/apache/datafusion/issues/17913#issuecomment-3395344103

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

On current website can see:

<img width="752" height="458" alt="image" src="https://github.com/user-attachments/assets/7df06070-528f-432d-8a11-cf92f86f5f34" />

- https://datafusion.apache.org/library-user-guide/upgrading.html#projectionexpr-changed-from-type-alias-to-struct

Source document:

https://github.com/apache/datafusion/blob/408e1e4e2c46d673a067e05f3e363a6f51e641c4/docs/source/library-user-guide/upgrading.md?plain=1#L204-L218

<img width="771" height="711" alt="image" src="https://github.com/user-attachments/assets/9472b6b6-1a7e-42f3-a9ae-17d55adfb491" />

-https://datafusion.apache.org/library-user-guide/extending-operators.html#optimizing-logical-plan

Source document:

https://github.com/apache/datafusion/blob/408e1e4e2c46d673a067e05f3e363a6f51e641c4/docs/source/library-user-guide/extending-operators.md?plain=1#L32-L57

`,ignore` should also be trimmed out.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix regex used in trimming rust blocks to account for optional `ignore`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Tested locally:

<img width="791" height="441" alt="image" src="https://github.com/user-attachments/assets/ff679228-812a-47d5-876e-6fc8fb552bed" />

<img width="762" height="681" alt="image" src="https://github.com/user-attachments/assets/7c551441-3579-4f65-bf41-325ac81fcc76" />

Existing blocks (with only `rust` and not `rust,ignore`) unaffected, e.g. in catalogs page:

<img width="764" height="543" alt="image" src="https://github.com/user-attachments/assets/c18376d5-974c-4510-89e4-4c777c860ca0" />


## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No, doc changes.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
