### PR TITLE
Use upstream arrow-rs record_batch! and create_array! macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,6 +3022,7 @@ dependencies = [
  "abi_stable",
  "arrow",
  "datafusion",
+ "datafusion-common",
  "datafusion-ffi",
  "ffi_module_interface",
 ]

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
@@ -25,6 +25,7 @@ publish = false
 abi_stable = "0.11.3"
 arrow = { workspace = true }
 datafusion = { workspace = true }
+datafusion-common = { workspace = true }
 datafusion-ffi = { workspace = true }
 ffi_module_interface = { path = "../ffi_module_interface" }
 

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/src/lib.rs
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/src/lib.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use abi_stable::{export_root_module, prefix_type::PrefixTypeTrait};
 use arrow::array::RecordBatch;
 use arrow::datatypes::{DataType, Field, Schema};
-use datafusion::{common::record_batch, datasource::MemTable};
+use datafusion::datasource::MemTable;
 use datafusion_ffi::table_provider::FFI_TableProvider;
 use ffi_module_interface::{TableProviderModule, TableProviderModuleRef};
 
@@ -29,7 +29,10 @@ fn create_record_batch(start_value: i32, num_values: usize) -> RecordBatch {
     let a_vals: Vec<i32> = (start_value..end_value).collect();
     let b_vals: Vec<f64> = a_vals.iter().map(|v| *v as f64).collect();
 
-    record_batch!(("a", Int32, a_vals), ("b", Float64, b_vals)).unwrap()
+    // TODO: Use arrow::record_batch! once it supports variables
+    // See https://github.com/apache/arrow-rs/issues/6553
+    datafusion_common::record_batch_old!(("a", Int32, a_vals), ("b", Float64, b_vals))
+        .unwrap()
 }
 
 /// Here we only wish to create a simple table provider as an example.

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -64,6 +64,8 @@ pub mod utils;
 
 /// Reexport arrow crate
 pub use arrow;
+/// Reexport arrow-rs macros for creating arrays and record batches
+pub use arrow::array::{create_array, record_batch};
 pub use column::Column;
 pub use dfschema::{
     qualified_name, DFSchema, DFSchemaRef, ExprSchema, SchemaExt, ToDFSchema,

--- a/datafusion/core/src/datasource/mod.rs
+++ b/datafusion/core/src/datasource/mod.rs
@@ -166,14 +166,14 @@ mod tests {
         let (mapper, indices) = adapter.map_schema(&file_schema).unwrap();
         assert_eq!(indices, vec![1]);
 
-        let file_batch = record_batch!(("b", Float64, vec![1.0, 2.0])).unwrap();
+        let file_batch = record_batch!(("b", Float64, [1.0, 2.0])).unwrap();
 
         let mapped_batch = mapper.map_batch(file_batch).unwrap();
 
         // the mapped batch has the correct schema and the "b" column has been cast to Utf8
         let expected_batch = record_batch!(
-            ("a", Int32, vec![None, None]), // missing column filled with nulls
-            ("b", Utf8, vec!["1.0", "2.0"])  // b was cast to string and order was changed
+            ("a", Int32, [None, None]),  // missing column filled with nulls
+            ("b", Utf8, ["1.0", "2.0"])  // b was cast to string and order was changed
         )
         .unwrap();
         assert_eq!(mapped_batch, expected_batch);
@@ -194,7 +194,7 @@ mod tests {
         let (mapper, indices) = adapter.map_schema(&file_schema).unwrap();
         assert_eq!(indices, vec![0]);
 
-        let file_batch = record_batch!(("b", Float64, vec![1.0, 2.0])).unwrap();
+        let file_batch = record_batch!(("b", Float64, [1.0, 2.0])).unwrap();
 
         // Mapping fails because it tries to fill in a non-nullable column with nulls
         let err = mapper.map_batch(file_batch).unwrap_err().to_string();

--- a/datafusion/core/tests/macro_hygiene/mod.rs
+++ b/datafusion/core/tests/macro_hygiene/mod.rs
@@ -46,7 +46,7 @@ mod record_batch {
 
     #[test]
     fn test_macro() {
-        record_batch!(("column_name", Int32, vec![1, 2, 3])).unwrap();
+        record_batch!(("column_name", Int32, [1, 2, 3])).unwrap();
     }
 }
 

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -730,7 +730,7 @@ mod test {
 
     use arrow::{
         compute::cast,
-        datatypes::{DataType, Field, Schema, SchemaRef},
+        datatypes::{self as arrow_schema, DataType, Field, Schema, SchemaRef},
     };
     use bytes::{BufMut, BytesMut};
     use datafusion_common::{
@@ -819,8 +819,8 @@ mod test {
         let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
 
         let batch = record_batch!(
-            ("a", Int32, vec![Some(1), Some(2), Some(2)]),
-            ("b", Float32, vec![Some(1.0), Some(2.0), None])
+            ("a", Int32, [Some(1), Some(2), Some(2)]),
+            ("b", Float32, [Some(1.0), Some(2.0), None])
         )
         .unwrap();
 
@@ -896,7 +896,7 @@ mod test {
     async fn test_prune_on_partition_statistics_with_dynamic_expression() {
         let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
 
-        let batch = record_batch!(("a", Int32, vec![Some(1), Some(2), Some(3)])).unwrap();
+        let batch = record_batch!(("a", Int32, [Some(1), Some(2), Some(3)])).unwrap();
         let data_size =
             write_parquet(Arc::clone(&store), "part=1/file.parquet", batch.clone()).await;
 
@@ -974,8 +974,8 @@ mod test {
         let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
 
         let batch = record_batch!(
-            ("a", Int32, vec![Some(1), Some(2), Some(3)]),
-            ("b", Float64, vec![Some(1.0), Some(2.0), None])
+            ("a", Int32, [Some(1), Some(2), Some(3)]),
+            ("b", Float64, [Some(1.0), Some(2.0), None])
         )
         .unwrap();
         let data_size =
@@ -1077,7 +1077,7 @@ mod test {
         let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
 
         // Note: number 3 is missing!
-        let batch = record_batch!(("a", Int32, vec![Some(1), Some(2), Some(4)])).unwrap();
+        let batch = record_batch!(("a", Int32, [Some(1), Some(2), Some(4)])).unwrap();
         let data_size =
             write_parquet(Arc::clone(&store), "part=1/file.parquet", batch.clone()).await;
 
@@ -1169,7 +1169,7 @@ mod test {
     async fn test_opener_pruning_skipped_on_static_filters() {
         let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
 
-        let batch = record_batch!(("a", Int32, vec![Some(1), Some(2), Some(3)])).unwrap();
+        let batch = record_batch!(("a", Int32, [Some(1), Some(2), Some(3)])).unwrap();
         let data_size =
             write_parquet(Arc::clone(&store), "part=1/file.parquet", batch.clone()).await;
 
@@ -1327,7 +1327,7 @@ mod test {
 
         // Test that if no expression rewriter is provided we use a schemaadapter to adapt the data to the expression
         let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
-        let batch = record_batch!(("a", Int32, vec![Some(1), Some(2), Some(3)])).unwrap();
+        let batch = record_batch!(("a", Int32, [Some(1), Some(2), Some(3)])).unwrap();
         // Write out the batch to a Parquet file
         let data_size =
             write_parquet(Arc::clone(&store), "test.parquet", batch.clone()).await;

--- a/datafusion/ffi/src/record_batch_stream.rs
+++ b/datafusion/ffi/src/record_batch_stream.rs
@@ -227,8 +227,8 @@ mod tests {
     #[tokio::test]
     async fn test_round_trip_record_batch_stream() -> Result<()> {
         let record_batch = record_batch!(
-            ("a", Int32, vec![1, 2, 3]),
-            ("b", Float64, vec![Some(4.0), None, Some(5.0)])
+            ("a", Int32, [1, 2, 3]),
+            ("b", Float64, [Some(4.0), None, Some(5.0)])
         )?;
         let original_rbs = bounded_stream(record_batch.clone(), 1);
 

--- a/datafusion/ffi/src/tests/catalog.rs
+++ b/datafusion/ffi/src/tests/catalog.rs
@@ -58,15 +58,11 @@ pub fn fruit_table() -> Arc<dyn TableProvider + 'static> {
 
     let partitions = vec![
         record_batch!(
-            ("units", Int32, vec![10, 20, 30]),
-            ("price", Float64, vec![1.0, 2.0, 5.0])
+            ("units", Int32, [10, 20, 30]),
+            ("price", Float64, [1.0, 2.0, 5.0])
         )
         .unwrap(),
-        record_batch!(
-            ("units", Int32, vec![5, 7]),
-            ("price", Float64, vec![1.5, 2.5])
-        )
-        .unwrap(),
+        record_batch!(("units", Int32, [5, 7]), ("price", Float64, [1.5, 2.5])).unwrap(),
     ];
 
     Arc::new(MemTable::try_new(schema, vec![partitions]).unwrap())

--- a/datafusion/ffi/src/tests/mod.rs
+++ b/datafusion/ffi/src/tests/mod.rs
@@ -106,7 +106,10 @@ pub fn create_record_batch(start_value: i32, num_values: usize) -> RecordBatch {
     let a_vals: Vec<i32> = (start_value..end_value).collect();
     let b_vals: Vec<f64> = a_vals.iter().map(|v| *v as f64).collect();
 
-    record_batch!(("a", Int32, a_vals), ("b", Float64, b_vals)).unwrap()
+    // TODO: Use arrow::record_batch! once it supports variables
+    // See https://github.com/apache/arrow-rs/issues/6553
+    datafusion_common::record_batch_old!(("a", Int32, a_vals), ("b", Float64, b_vals))
+        .unwrap()
 }
 
 /// Here we only wish to create a simple table provider as an example.

--- a/datafusion/ffi/src/udaf/accumulator.rs
+++ b/datafusion/ffi/src/udaf/accumulator.rs
@@ -326,7 +326,7 @@ mod tests {
         let mut foreign_accum: ForeignAccumulator = ffi_accum.into();
 
         // Send in an array to average. There are 5 values and it should average to 30.0
-        let values = create_array!(Float64, vec![10., 20., 30., 40., 50.]);
+        let values = create_array!(Float64, [10., 20., 30., 40., 50.]);
         foreign_accum.update_batch(&[values])?;
 
         let avg = foreign_accum.evaluate()?;
@@ -340,8 +340,8 @@ mod tests {
         // To verify merging batches works, create a second state to add in
         // This should cause our average to go down to 25.0
         let second_states = vec![
-            make_array(create_array!(UInt64, vec![1]).to_data()),
-            make_array(create_array!(Float64, vec![0.0]).to_data()),
+            make_array(create_array!(UInt64, [1]).to_data()),
+            make_array(create_array!(Float64, [0.0]).to_data()),
         ];
 
         foreign_accum.merge_batch(&second_states)?;
@@ -350,7 +350,7 @@ mod tests {
 
         // If we remove a batch that is equivalent to the state we added
         // we should go back to our original value of 30.0
-        let values = create_array!(Float64, vec![0.0]);
+        let values = create_array!(Float64, [0.0]);
         foreign_accum.retract_batch(&[values])?;
         let avg = foreign_accum.evaluate()?;
         assert_eq!(avg, ScalarValue::Float64(Some(30.0)));

--- a/datafusion/ffi/src/udaf/groups_accumulator.rs
+++ b/datafusion/ffi/src/udaf/groups_accumulator.rs
@@ -446,9 +446,8 @@ mod tests {
         let mut foreign_accum: ForeignGroupsAccumulator = ffi_accum.into();
 
         // Send in an array to evaluate. We want a mean of 30 and standard deviation of 4.
-        let values = create_array!(Boolean, vec![true, true, true, false, true, true]);
-        let opt_filter =
-            create_array!(Boolean, vec![true, true, true, true, false, false]);
+        let values = create_array!(Boolean, [true, true, true, false, true, true]);
+        let opt_filter = create_array!(Boolean, [true, true, true, true, false, false]);
         foreign_accum.update_batch(
             &[values],
             &[0, 0, 1, 1, 2, 2],
@@ -461,7 +460,7 @@ mod tests {
 
         assert_eq!(
             groups_bool,
-            create_array!(Boolean, vec![Some(true), Some(false), None]).as_ref()
+            create_array!(Boolean, [Some(true), Some(false), None]).as_ref()
         );
 
         let state = foreign_accum.state(EmitTo::All)?;
@@ -469,26 +468,25 @@ mod tests {
 
         // To verify merging batches works, create a second state to add in
         // This should cause our average to go down to 25.0
-        let second_states =
-            vec![make_array(create_array!(Boolean, vec![false]).to_data())];
+        let second_states = vec![make_array(create_array!(Boolean, [false]).to_data())];
 
-        let opt_filter = create_array!(Boolean, vec![true]);
+        let opt_filter = create_array!(Boolean, [true]);
         foreign_accum.merge_batch(&second_states, &[0], Some(opt_filter.as_ref()), 1)?;
         let groups_bool = foreign_accum.evaluate(EmitTo::All)?;
         assert_eq!(groups_bool.len(), 1);
         assert_eq!(
             groups_bool.as_ref(),
-            make_array(create_array!(Boolean, vec![false]).to_data()).as_ref()
+            make_array(create_array!(Boolean, [false]).to_data()).as_ref()
         );
 
-        let values = create_array!(Boolean, vec![false]);
-        let opt_filter = create_array!(Boolean, vec![true]);
+        let values = create_array!(Boolean, [false]);
+        let opt_filter = create_array!(Boolean, [true]);
         let groups_bool =
             foreign_accum.convert_to_state(&[values], Some(opt_filter.as_ref()))?;
 
         assert_eq!(
             groups_bool[0].as_ref(),
-            make_array(create_array!(Boolean, vec![false]).to_data()).as_ref()
+            make_array(create_array!(Boolean, [false]).to_data()).as_ref()
         );
 
         Ok(())

--- a/datafusion/ffi/src/udaf/mod.rs
+++ b/datafusion/ffi/src/udaf/mod.rs
@@ -713,7 +713,7 @@ mod tests {
             exprs: &[col("a", &schema)?],
         };
         let mut accumulator = foreign_udaf.accumulator(acc_args)?;
-        let values = create_array!(Float64, vec![10., 20., 30., 40., 50.]);
+        let values = create_array!(Float64, [10., 20., 30., 40., 50.]);
         accumulator.update_batch(&[values])?;
         let resultant_value = accumulator.evaluate()?;
         assert_eq!(resultant_value, ScalarValue::Float64(Some(150.)));
@@ -791,7 +791,7 @@ mod tests {
         };
 
         let mut accumulator = foreign_udaf.create_sliding_accumulator(acc_args)?;
-        let values = create_array!(Float64, vec![10., 20., 30., 40., 50.]);
+        let values = create_array!(Float64, [10., 20., 30., 40., 50.]);
         accumulator.update_batch(&[values])?;
         let resultant_value = accumulator.evaluate()?;
         assert_eq!(resultant_value, ScalarValue::Float64(Some(150.)));

--- a/datafusion/ffi/tests/ffi_udaf.rs
+++ b/datafusion/ffi/tests/ffi_udaf.rs
@@ -44,8 +44,8 @@ mod tests {
 
         let ctx = SessionContext::default();
         let record_batch = record_batch!(
-            ("a", Int32, vec![1, 2, 2, 4, 4, 4, 4]),
-            ("b", Float64, vec![1.0, 2.0, 2.0, 4.0, 4.0, 4.0, 4.0])
+            ("a", Int32, [1, 2, 2, 4, 4, 4, 4]),
+            ("b", Float64, [1.0, 2.0, 2.0, 4.0, 4.0, 4.0, 4.0])
         )
         .unwrap();
 
@@ -61,8 +61,8 @@ mod tests {
         let result = df.collect().await?;
 
         let expected = record_batch!(
-            ("a", Int32, vec![1, 2, 4]),
-            ("sum_b", Float64, vec![1.0, 4.0, 16.0])
+            ("a", Int32, [1, 2, 4]),
+            ("sum_b", Float64, [1.0, 4.0, 16.0])
         )?;
 
         assert_eq!(result[0], expected);
@@ -86,11 +86,11 @@ mod tests {
 
         let ctx = SessionContext::default();
         let record_batch = record_batch!(
-            ("a", Int32, vec![1, 2, 2, 4, 4, 4, 4]),
+            ("a", Int32, [1, 2, 2, 4, 4, 4, 4]),
             (
                 "b",
                 Float64,
-                vec![
+                [
                     1.0,
                     2.0,
                     2.0 + 2.0_f64.sqrt(),

--- a/datafusion/ffi/tests/ffi_udf.rs
+++ b/datafusion/ffi/tests/ffi_udf.rs
@@ -58,10 +58,10 @@ mod tests {
         let result = df.collect().await?;
 
         let expected = record_batch!(
-            ("a", Int32, vec![-5, -4, -3, -2, -1]),
-            ("b", Float64, vec![-5., -4., -3., -2., -1.]),
-            ("abs_a", Int32, vec![5, 4, 3, 2, 1]),
-            ("abs_b", Float64, vec![5., 4., 3., 2., 1.])
+            ("a", Int32, [-5, -4, -3, -2, -1]),
+            ("b", Float64, [-5., -4., -3., -2., -1.]),
+            ("abs_a", Int32, [5, 4, 3, 2, 1]),
+            ("abs_b", Float64, [5., 4., 3., 2., 1.])
         )?;
 
         assert!(result.len() == 1);

--- a/datafusion/physical-expr-adapter/src/schema_rewriter.rs
+++ b/datafusion/physical-expr-adapter/src/schema_rewriter.rs
@@ -445,7 +445,7 @@ impl<'a> DefaultPhysicalExprAdapterRewriter<'a> {
 mod tests {
     use super::*;
     use arrow::array::{RecordBatch, RecordBatchOptions};
-    use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+    use arrow::datatypes::{self as arrow_schema, DataType, Field, Schema, SchemaRef};
     use datafusion_common::{assert_contains, record_batch, Result, ScalarValue};
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{col, lit, CastExpr, Column, Literal};
@@ -758,8 +758,8 @@ mod tests {
     #[test]
     fn test_adapt_batches() {
         let physical_batch = record_batch!(
-            ("a", Int32, vec![Some(1), None, Some(3)]),
-            ("extra", Utf8, vec![Some("x"), Some("y"), None])
+            ("a", Int32, [Some(1), None, Some(3)]),
+            ("extra", Utf8, [Some("x"), Some("y"), None])
         )
         .unwrap();
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #13037

## Rationale for this change

DataFusion previously maintained custom implementations of `record_batch!` and `create_array!` macros. These macros are now available upstream in arrow-rs (added in https://github.com/apache/arrow-rs/pull/6588), so we should use those instead to reduce code duplication and align with the Arrow ecosystem.

## What changes are included in this PR?

- Removed custom `record_batch!` and `create_array!` macro definitions from `datafusion/common/src/test_util.rs`
- Re-exported the macros from `arrow::array` instead
- Updated all 67 usages across 24 files from `vec![...]` syntax to array literal `[...]` syntax to match arrow-rs macro expectations
- Added `arrow_schema` module aliases in test modules for macro compatibility
- Replaced macro usage with manual `RecordBatch::try_new()` construction in cases where variables are passed (macros only support literal values)

## Are these changes tested?

- All existing tests pass (no new test failures introduced)
- Verified with `cargo test --lib` across all modified packages
- `cargo clippy` and `cargo fmt` checks pass on modified code

## Are there any user-facing changes?

No user-facing changes. The macros maintain the same public API, just sourced from arrow-rs instead of DataFusion.