### PR TITLE
Revert "chore: revert tests (#18065)"

### DIFF
--- a/datafusion/sqllogictest/test_files/current_date_timezone.slt
+++ b/datafusion/sqllogictest/test_files/current_date_timezone.slt
@@ -19,64 +19,62 @@
 ## current_date with timezone tests
 ##########
 
-# CI Fails https://github.com/apache/datafusion/issues/18062
-
 # Test 1: Verify current_date is consistent within the same query (default UTC)
-# query B
-# SELECT current_date() = current_date();
-# ----
-# true
+query B
+SELECT current_date() = current_date();
+----
+true
 
 # Test 2: Verify alias 'today' works the same as current_date
-# query B
-# SELECT current_date() = today();
-# ----
-# true
+query B
+SELECT current_date() = today();
+----
+true
 
 # Test 3: Set timezone to +05:00 and verify current_date is still stable
-# statement ok
-# SET datafusion.execution.time_zone = '+05:00';
+statement ok
+SET datafusion.execution.time_zone = '+05:00';
 
-# query B
-# SELECT current_date() = current_date();
-# ----
-# true
+query B
+SELECT current_date() = current_date();
+----
+true
 
-# Test 4: Verify current_date matches cast(now() as date) in the same timezone
-# query B
-# SELECT current_date() = cast(now() as date);
-# ----
-# true
+#Test 4: Verify current_date matches cast(now() as date) in the same timezone
+query B
+SELECT current_date() = cast(now() as date);
+----
+true
 
 # Test 5: Test with negative offset timezone
-# statement ok
-# SET datafusion.execution.time_zone = '-08:00';
+statement ok
+SET datafusion.execution.time_zone = '-08:00';
 
-# query B
-# SELECT current_date() = today();
-# ----
-# true
+query B
+SELECT current_date() = today();
+----
+true
 
 # Test 6: Test with named timezone (America/New_York)
-# statement ok
-# SET datafusion.execution.time_zone = 'America/New_York';
+statement ok
+SET datafusion.execution.time_zone = 'America/New_York';
 
-# query B
-# SELECT current_date() = current_date();
-# ----
-# true
+query B
+SELECT current_date() = current_date();
+----
+true
 
 # Test 7: Verify date type is preserved
-# query T
-# SELECT arrow_typeof(current_date());
-# ----
-# Date32
+query T
+SELECT arrow_typeof(current_date());
+----
+Date32
 
 # Test 8: Reset to UTC
-# statement ok
-# SET datafusion.execution.time_zone = '+00:00';
+statement ok
+SET datafusion.execution.time_zone = '+00:00';
 
-# query B
-# SELECT current_date() = today();
-# ----
-# true
+query B
+SELECT current_date() = today();
+----
+true


### PR DESCRIPTION
## Which issue does this PR close?

- Relates #18062 
- Relates #18065

## Rationale for this change

We disabled these tests because CI was failing on main.

The test: `current_date() = cast(now() as date)` was added in #18034 
 requires `now` to use configured timezone, but it is only available after #18017.

Since #18017 has been merged, these tests should be enable.

## What changes are included in this PR?

This reverts commit a65a2cbd6070b392ff7ed5ccd2aa0accaf42177a.

## Are these changes tested?

Yes.

## Are there any user-facing changes?
No.
