### PR TITLE
feat(docs): Enable dark mode toggle

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,135 +6,6 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-# Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-import os
-import sys
-
-# To pickup rustdoc_trim.py
-sys.path.insert(0, os.path.abspath(".."))
-
-# -- Project information -----------------------------------------------------
-
-project = "Apache DataFusion"
-copyright = "2019-2025, Apache Software Foundation"
-author = "Apache Software Foundation"
-
-
-# -- General configuration ---------------------------------------------------
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
-extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.autosummary",
-    "sphinx.ext.doctest",
-    "sphinx.ext.ifconfig",
-    "sphinx.ext.mathjax",
-    "sphinx.ext.viewcode",
-    "sphinx.ext.napoleon",
-    "myst_parser",
-    "sphinx_reredirects",
-    "rustdoc_trim",
-]
-
-source_suffix = {
-    ".rst": "restructuredtext",
-    ".md": "markdown",
-}
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
-
-# Show members for classes in .. autosummary
-autodoc_default_options = {
-    "members": None,
-    "undoc-members": None,
-    "show-inheritance": None,
-    "inherited-members": None,
-}
-
-autosummary_generate = True
-
-# -- Options for HTML output -------------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = "pydata_sphinx_theme"
-
-html_theme_options = {
-    "use_edit_page_button": True,
-    "navbar_end": ["theme-switcher", "navbar-icon-links"],
-}
-
-html_context = {
-    "github_user": "apache",
-    "github_repo": "arrow-datafusion",
-    "github_version": "main",
-    "doc_path": "docs/source",
-}
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
-
-html_logo = "_static/images/2x_bgwhite_original.png"
-
-html_css_files = ["theme_overrides.css"]
-
-html_sidebars = {
-    "**": ["docs-sidebar.html"],
-}
-
-# tell myst_parser to auto-generate anchor links for headers h1, h2, h3
-myst_heading_anchors = 3
-
-# enable nice rendering of checkboxes for the task lists
-myst_enable_extensions = ["colon_fence", "deflist", "tasklist"]
-
-# Some code blocks (sql) are not being highlighted correctly, due to the
-# presence of some special characters like: 🚀, å, {,... But this isn’t a major
-# issue for our documentation. So, suppress these warnings to keep our build
-# log cleaner.
-suppress_warnings = ["misc.highlighting_failure"]
-
-redirects = {
-    "library-user-guide/adding-udfs": "functions/index.html",
-    "user-guide/runtime_configs": "configs.html",
-}# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -218,6 +89,7 @@ html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
     "use_edit_page_button": True,
+    "navbar_end": ["theme-switcher", "navbar-icon-links"],
 }
 
 html_context = {


### PR DESCRIPTION
### Which issue does this PR close?
- Closes #18284

### Rationale for this change
This PR adds the dark mode toggle button to the documentation website, as requested in issue #18284.

### What changes are included in this PR?
Edited docs/conf.py to add "theme-switcher" to the html_theme_options.

### Are these changes tested?
Yes, I built the docs locally and confirmed the toggle appears and works.

### Are there any user-facing changes?
Yes, users will now see a dark mode toggle on the website.