### PR TITLE
fix: `with_param_values` on `LogicalPlan::EmptyRelation` returns incorrect schema

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -216,9 +216,10 @@ impl LogicalPlanBuilder {
         if values.is_empty() {
             return plan_err!("Values list cannot be empty");
         }
-
-        // values list can have no columns, see: https://github.com/apache/datafusion/pull/12339
         let n_cols = values[0].len();
+        if n_cols == 0 {
+            return plan_err!("Values list cannot be zero length");
+        }
         for (i, row) in values.iter().enumerate() {
             if row.len() != n_cols {
                 return plan_err!(

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -32,8 +32,8 @@ use datafusion::execution::registry::SerializerRegistry;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::logical_expr::{
-    Extension, InvariantLevel, LogicalPlan, LogicalPlanBuilder, PartitionEvaluator,
-    Repartition, UserDefinedLogicalNode, Volatility,
+    Extension, InvariantLevel, LogicalPlan, PartitionEvaluator, Repartition,
+    UserDefinedLogicalNode, Values, Volatility,
 };
 use datafusion::optimizer::simplify_expressions::expr_simplifier::THRESHOLD_INLINE_INLIST;
 use datafusion::prelude::*;
@@ -1258,10 +1258,10 @@ async fn roundtrip_values() -> Result<()> {
 async fn roundtrip_values_no_columns() -> Result<()> {
     let ctx = create_context().await?;
     // "VALUES ()" is not yet supported by the SQL parser, so we construct the plan manually
-    let plan = LogicalPlanBuilder::values(
-        vec![vec![], vec![]], // two rows, no columns
-    )?
-    .build()?;
+    let plan = LogicalPlan::Values(Values {
+        values: vec![vec![], vec![]], // two rows, no columns
+        schema: DFSchemaRef::new(DFSchema::empty()),
+    });
     roundtrip_logical_plan_with_ctx(plan, ctx).await?;
     Ok(())
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #18102.

This only resolves for `LogicalPlan::EmptyRelation`.

## Rationale for this change

`with_param_values` doesn't substitute params' type if it is used on `EmptyRelation`.
Thus, causing `SELECT $1, $2` to have incorrect schema after substitution.

For example: after replacing `$1 = 1, $2 = "s"`, the schema is `[Null, Null]`, but it should
be `[Int64, Utf8]`.

This schema type mismatch is resolved before converting to physical plan by
the `type_coercion` rule in the `analyzer`. 

https://github.com/apache/datafusion/blob/814236093c4045bb3d972e4c1124727229743ed9/datafusion/optimizer/src/analyzer/type_coercion.rs#L149

## What changes are included in this PR?

- recompute the schema after replacing param values.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.