### PR TITLE
Do not accept null is_set for first_value/last_value

### DIFF
--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -1942,7 +1942,7 @@ mod tests {
         // Test TrivialFirstValueAccumulator
         let mut trivial_accumulator =
             TrivialFirstValueAccumulator::try_new(&DataType::Utf8, false)?;
-        let trivial_states = vec![value.clone(), corrupted_flag.clone()];
+        let trivial_states = vec![Arc::clone(&value), Arc::clone(&corrupted_flag)];
         let result = trivial_accumulator.merge_batch(&trivial_states);
         assert!(result.is_err());
         assert!(result
@@ -1985,7 +1985,7 @@ mod tests {
         // Test TrivialLastValueAccumulator
         let mut trivial_accumulator =
             TrivialLastValueAccumulator::try_new(&DataType::Utf8, false)?;
-        let trivial_states = vec![value.clone(), corrupted_flag.clone()];
+        let trivial_states = vec![Arc::clone(&value), Arc::clone(&corrupted_flag)];
         let result = trivial_accumulator.merge_batch(&trivial_states);
         assert!(result.is_err());
         assert!(result


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18300

## Rationale for this change

As laid out in the issue, this improves internal checks by testing an assumed invariant, instead of silently nulling data on error. The cost is a single null check on a column with a number of entries dependent on the number of partitions, not the data itself.

## What changes are included in this PR?

* Adds a null check to the second column of `merge_batch` of both `FIRST_VALUE` and `LAST_VALUE`.

## Are these changes tested?

Tests are included.

## Are there any user-facing changes?

Hopefully not.
