### PR TITLE
chore: Format examples in doc strings - execution

### DIFF
--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -44,12 +44,15 @@ use datafusion_common::{
 /// shorthand for setting `datafusion.execution.batch_size`.
 ///
 /// ```
-/// use datafusion_execution::config::SessionConfig;
 /// use datafusion_common::ScalarValue;
+/// use datafusion_execution::config::SessionConfig;
 ///
 /// let config = SessionConfig::new()
-///    .set("datafusion.execution.batch_size", &ScalarValue::UInt64(Some(1234)))
-///    .set_bool("datafusion.execution.parquet.pushdown_filters", true);
+///     .set(
+///         "datafusion.execution.batch_size",
+///         &ScalarValue::UInt64(Some(1234)),
+///     )
+///     .set_bool("datafusion.execution.parquet.pushdown_filters", true);
 ///
 /// assert_eq!(config.batch_size(), 1234);
 /// assert_eq!(config.options().execution.batch_size, 1234);
@@ -502,8 +505,8 @@ impl SessionConfig {
     ///
     /// # Example
     /// ```
-    /// use std::sync::Arc;
     /// use datafusion_execution::config::SessionConfig;
+    /// use std::sync::Arc;
     ///
     /// // application-specific extension types
     /// struct Ext1(u8);
@@ -545,8 +548,8 @@ impl SessionConfig {
     ///
     /// # Example
     /// ```
-    /// use std::sync::Arc;
     /// use datafusion_execution::config::SessionConfig;
+    /// use std::sync::Arc;
     ///
     /// // application-specific extension types
     /// struct Ext1(u8);

--- a/datafusion/execution/src/memory_pool/pool.rs
+++ b/datafusion/execution/src/memory_pool/pool.rs
@@ -346,8 +346,10 @@ impl<I: MemoryPool> TrackConsumersPool<I> {
     /// # Example
     ///
     /// ```rust
+    /// use datafusion_execution::memory_pool::{
+    ///     FairSpillPool, GreedyMemoryPool, TrackConsumersPool,
+    /// };
     /// use std::num::NonZeroUsize;
-    /// use datafusion_execution::memory_pool::{TrackConsumersPool, GreedyMemoryPool, FairSpillPool};
     ///
     /// // Create with a greedy pool backend, reporting top 3 consumers in error messages
     /// let tracked_greedy = TrackConsumersPool::new(

--- a/datafusion/execution/src/runtime_env.rs
+++ b/datafusion/execution/src/runtime_env.rs
@@ -67,9 +67,9 @@ use url::Url;
 /// // restrict to using at most 100MB of memory
 /// let pool_size = 100 * 1024 * 1024;
 /// let runtime_env = RuntimeEnvBuilder::new()
-///   .with_memory_pool(Arc::new(GreedyMemoryPool::new(pool_size)))
-///   .build()
-///   .unwrap();
+///     .with_memory_pool(Arc::new(GreedyMemoryPool::new(pool_size)))
+///     .build()
+///     .unwrap();
 /// ```
 pub struct RuntimeEnv {
     /// Runtime memory management


### PR DESCRIPTION
## Which issue does this PR close?
Part of #16915

## Rationale for this change
Format code examples in documentation comments to improve readability and maintain consistent code style across the codebase. This is part of a multi-PR effort to format all doc comment examples and eventually enable CI checks to enforce this formatting.

## What changes are included in this PR?
Run `cargo fmt -p datafusion-execution -- --config format_code_in_doc_comments=true`

## Are these changes tested?
No testing needed - this is purely a formatting change with no functional modifications.

## Are there any user-facing changes?
No - this only affects documentation formatting.