### PR TITLE
chore: Format examples in doc strings - proto, pruning, and session

### DIFF
--- a/datafusion/proto-common/src/lib.rs
+++ b/datafusion/proto-common/src/lib.rs
@@ -62,28 +62,33 @@
 //! # use datafusion_proto_common::protobuf_common;
 //! # use prost::Message;
 //! # fn main() -> Result<()>{
-//!     // Create a new ScalarValue
-//!     let val = ScalarValue::UInt64(Some(3));
-//!     let mut buffer = BytesMut::new();
-//!     let protobuf: protobuf_common::ScalarValue = match val {
-//!         ScalarValue::UInt64(Some(val)) => {
-//!             protobuf_common::ScalarValue{value: Some(protobuf_common::scalar_value::Value::Uint64Value(val))}
-//!         }
-//!         _ => unreachable!(),
-//!     };
+//! // Create a new ScalarValue
+//! let val = ScalarValue::UInt64(Some(3));
+//! let mut buffer = BytesMut::new();
+//! let protobuf: protobuf_common::ScalarValue = match val {
+//!     ScalarValue::UInt64(Some(val)) => protobuf_common::ScalarValue {
+//!         value: Some(protobuf_common::scalar_value::Value::Uint64Value(val)),
+//!     },
+//!     _ => unreachable!(),
+//! };
 //!
-//!     protobuf.encode(&mut buffer)
+//! protobuf
+//!     .encode(&mut buffer)
 //!     .map_err(|e| plan_datafusion_err!("Error encoding protobuf as bytes: {e}"))?;
-//!     // Convert it to bytes (for sending over the network, etc.)
-//!     let bytes: Bytes = buffer.into();
+//! // Convert it to bytes (for sending over the network, etc.)
+//! let bytes: Bytes = buffer.into();
 //!
-//!     let protobuf = protobuf_common::ScalarValue::decode(bytes).map_err(|e| plan_datafusion_err!("Error decoding ScalarValue as protobuf: {e}"))?;
-//!     // Decode bytes from somewhere (over network, etc.) back to ScalarValue
-//!     let decoded_val: ScalarValue = match protobuf.value {
-//!         Some(protobuf_common::scalar_value::Value::Uint64Value(val)) => ScalarValue::UInt64(Some(val)),
-//!         _ => unreachable!(),
-//!     };
-//!     assert_eq!(val, decoded_val);
+//! let protobuf = protobuf_common::ScalarValue::decode(bytes).map_err(|e| {
+//!     plan_datafusion_err!("Error decoding ScalarValue as protobuf: {e}")
+//! })?;
+//! // Decode bytes from somewhere (over network, etc.) back to ScalarValue
+//! let decoded_val: ScalarValue = match protobuf.value {
+//!     Some(protobuf_common::scalar_value::Value::Uint64Value(val)) => {
+//!         ScalarValue::UInt64(Some(val))
+//!     }
+//!     _ => unreachable!(),
+//! };
+//! assert_eq!(val, decoded_val);
 //! # Ok(())
 //! # }
 //! ```

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -64,15 +64,15 @@
 //! # use datafusion_expr::{col, lit, Expr};
 //! # use datafusion_proto::bytes::Serializeable;
 //! # fn main() -> Result<()>{
-//!  // Create a new `Expr` a < 32
-//!  let expr = col("a").lt(lit(5i32));
+//! // Create a new `Expr` a < 32
+//! let expr = col("a").lt(lit(5i32));
 //!
-//!  // Convert it to bytes (for sending over the network, etc.)
-//!  let bytes = expr.to_bytes()?;
+//! // Convert it to bytes (for sending over the network, etc.)
+//! let bytes = expr.to_bytes()?;
 //!
-//!  // Decode bytes from somewhere (over network, etc.) back to Expr
-//!  let decoded_expr = Expr::from_bytes(&bytes)?;
-//!  assert_eq!(expr, decoded_expr);
+//! // Decode bytes from somewhere (over network, etc.) back to Expr
+//! let decoded_expr = Expr::from_bytes(&bytes)?;
+//! assert_eq!(expr, decoded_expr);
 //! # Ok(())
 //! # }
 //! ```

--- a/datafusion/pruning/src/pruning_predicate.rs
+++ b/datafusion/pruning/src/pruning_predicate.rs
@@ -882,7 +882,7 @@ impl From<Vec<(phys_expr::Column, StatisticsType, Field)>> for RequiredColumns {
 /// ```text
 /// ("s1", Min, Field:s1_min)
 /// ("s2", Max, field:s2_max)
-///```
+/// ```
 ///
 /// And the input statistics had
 /// ```text
@@ -5108,7 +5108,6 @@ mod tests {
     ///
     /// `expected` is a vector of bools, where true means the row group should
     /// be kept, and false means it should be pruned.
-    ///
     // TODO refactor other tests to use this to reduce boiler plate
     fn prune_with_expr(
         expr: Expr,

--- a/datafusion/session/src/session.rs
+++ b/datafusion/session/src/session.rs
@@ -57,9 +57,12 @@ use std::sync::{Arc, Weak};
 /// // Given a `Session` reference, get the concrete `SessionState` reference
 /// // Note: this may stop working in future versions,
 /// fn session_state_from_session(session: &dyn Session) -> Result<&SessionState> {
-///    session.as_any()
-///     .downcast_ref::<SessionState>()
-///     .ok_or_else(|| exec_datafusion_err!("Failed to downcast Session to SessionState"))
+///     session
+///         .as_any()
+///         .downcast_ref::<SessionState>()
+///         .ok_or_else(|| {
+///             exec_datafusion_err!("Failed to downcast Session to SessionState")
+///         })
 /// }
 /// ```
 ///


### PR DESCRIPTION
## Which issue does this PR close?
Part of #16915

## Rationale for this change
Format code examples in documentation comments to improve readability and maintain consistent code style across the codebase. This is part of a multi-PR effort to format all doc comment examples and eventually enable CI checks to enforce this formatting.

## What changes are included in this PR?
Run `cargo fmt -p <crate> -- --config format_code_in_doc_comments=true` for the following datasource-related crates:
  - `datafusion-proto`
  - `datafusion-proto-common`
  - `datafusion-pruning`
  - `datafusion-session`

## Are these changes tested?
No testing needed - this is purely a formatting change with no functional modifications.

## Are there any user-facing changes?
No - this only affects documentation formatting.