### PR TITLE
Adds some POC benchmarks for pruned_partition_list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,8 @@ version = "50.3.0"
 dependencies = [
  "arrow",
  "async-trait",
+ "criterion",
+ "datafusion",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-datasource",
@@ -1900,6 +1902,8 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
+ "testcontainers",
+ "testcontainers-modules",
  "tokio",
 ]
 

--- a/datafusion/catalog-listing/Cargo.toml
+++ b/datafusion/catalog-listing/Cargo.toml
@@ -49,7 +49,17 @@ object_store = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+datafusion = { workspace = true }
 datafusion-datasource-parquet = { workspace = true }
+criterion = { workspace = true, features = ["async_tokio"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true, features = ["minio"] }
+object_store = { workspace = true, features = ["aws"] }
+
+[[bench]]
+name = "pruned_partition_list"
+harness = false
 
 [lints]
 workspace = true

--- a/datafusion/catalog-listing/benches/pruned_partition_list.rs
+++ b/datafusion/catalog-listing/benches/pruned_partition_list.rs
@@ -1,0 +1,1810 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use datafusion::prelude::SessionContext;
+use datafusion_catalog_listing::helpers::{
+    pruned_partition_list, pruned_partition_list_all,
+};
+use datafusion_datasource::ListingTableUrl;
+use futures::stream::{self, StreamExt, TryStreamExt};
+use object_store::aws::AmazonS3Builder;
+use object_store::memory::InMemory;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use std::sync::Arc;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, ImageExt};
+use testcontainers_modules::minio;
+
+/// Concurrency limit for uploading files to object store
+const CONCURRENT_UPLOADS: usize = 100;
+
+/// Configuration for generating a partition structure
+#[derive(Debug, Clone)]
+struct PartitionConfig {
+    /// Number of partition levels (e.g., 1 for /a=1/, 3 for /a=1/b=100/c=1000/)
+    depth: usize,
+    /// Number of distinct values at each partition level
+    breadth: usize,
+    /// Number of files in each leaf partition
+    files_per_partition: usize,
+}
+
+impl PartitionConfig {
+    fn new(depth: usize, breadth: usize, files_per_partition: usize) -> Self {
+        Self {
+            depth,
+            breadth,
+            files_per_partition,
+        }
+    }
+
+    /// Calculate total number of leaf partitions
+    fn total_partitions(&self) -> usize {
+        if self.depth == 0 {
+            1
+        } else {
+            self.breadth.pow(self.depth as u32)
+        }
+    }
+
+    /// Calculate total number of files
+    fn total_files(&self) -> usize {
+        self.total_partitions() * self.files_per_partition
+    }
+}
+
+/// Generate partition paths and populate the provided store
+fn generate_partition_structure(store: &dyn ObjectStore, config: &PartitionConfig) {
+    if config.depth == 0 {
+        // No partitions, just files at root
+        for file_idx in 0..config.files_per_partition {
+            let path = Path::from(format!("tablepath/data_{}.parquet", file_idx));
+            futures::executor::block_on(store.put(&path, vec![0; 5].into())).unwrap();
+        }
+        return;
+    }
+
+    // Generate all partition combinations recursively
+    let mut current_partition = Vec::new();
+    generate_partitions_recursive(store, config, 0, &mut current_partition);
+}
+
+/// Recursively generate partition paths
+fn generate_partitions_recursive(
+    store: &dyn ObjectStore,
+    config: &PartitionConfig,
+    current_depth: usize,
+    current_partition: &mut Vec<String>,
+) {
+    if current_depth == config.depth {
+        // We've reached a leaf - create files
+        let partition_path = if current_partition.is_empty() {
+            "tablepath".to_string()
+        } else {
+            format!("tablepath/{}", current_partition.join("/"))
+        };
+
+        for file_idx in 0..config.files_per_partition {
+            let file_path = format!("{}/data_{}.parquet", partition_path, file_idx);
+            let path = Path::from(file_path);
+            futures::executor::block_on(store.put(&path, vec![0; 5].into())).unwrap();
+        }
+        return;
+    }
+
+    // Generate partition values for current level
+    // Use pattern: a=1, a=2, ... for first level
+    //              b=100, b=200, ... for second level
+    //              c=1000, c=2000, ... for third level, etc.
+    let partition_name = (b'a' + current_depth as u8) as char;
+    let multiplier = 10_usize.pow(current_depth as u32);
+
+    for value_idx in 0..config.breadth {
+        let partition_value = (value_idx + 1) * multiplier;
+        let partition_part = format!("{}={}", partition_name, partition_value);
+
+        current_partition.push(partition_part);
+        generate_partitions_recursive(
+            store,
+            config,
+            current_depth + 1,
+            current_partition,
+        );
+        current_partition.pop();
+    }
+}
+
+/// Extract partition column definitions from config
+fn get_partition_columns(depth: usize) -> Vec<(String, arrow::datatypes::DataType)> {
+    (0..depth)
+        .map(|i| {
+            let name = format!("{}", (b'a' + i as u8) as char);
+            (name, arrow::datatypes::DataType::Int32)
+        })
+        .collect()
+}
+
+/// Pre-setup structure for benchmarks - contains everything needed except the actual method call
+struct BenchmarkSetup {
+    store: Arc<dyn ObjectStore>,
+    table_url: ListingTableUrl,
+    partition_cols: Vec<(String, arrow::datatypes::DataType)>,
+    expected_files: usize,
+    ctx: Arc<SessionContext>,
+}
+
+impl BenchmarkSetup {
+    fn new(store: Arc<dyn ObjectStore>, config: &PartitionConfig) -> Self {
+        generate_partition_structure(store.as_ref(), config);
+        let table_url = ListingTableUrl::parse("file:///tablepath/").unwrap();
+        let partition_cols = get_partition_columns(config.depth);
+        let expected_files = config.total_files();
+        let ctx = Arc::new(SessionContext::new());
+
+        Self {
+            store,
+            table_url,
+            partition_cols,
+            expected_files,
+            ctx,
+        }
+    }
+
+    fn new_with_path(
+        store: Arc<dyn ObjectStore>,
+        config: &PartitionConfig,
+        path_prefix: &str,
+    ) -> Self {
+        Self::generate_with_path(store.as_ref(), config, path_prefix);
+        let table_url =
+            ListingTableUrl::parse(&format!("file:///{}/", path_prefix)).unwrap();
+        let partition_cols = get_partition_columns(config.depth);
+        let expected_files = config.total_files();
+        let ctx = Arc::new(SessionContext::new());
+
+        Self {
+            store,
+            table_url,
+            partition_cols,
+            expected_files,
+            ctx,
+        }
+    }
+
+    fn generate_with_path(
+        store: &dyn ObjectStore,
+        config: &PartitionConfig,
+        path_prefix: &str,
+    ) {
+        // Collect all paths first
+        let paths = Self::collect_paths(config, path_prefix);
+
+        // Upload concurrently using async runtime
+        futures::executor::block_on(Self::upload_files_concurrent(store, paths))
+            .expect("Failed to upload files");
+    }
+
+    /// Collect all file paths that need to be created without uploading
+    fn collect_paths(config: &PartitionConfig, path_prefix: &str) -> Vec<Path> {
+        let mut paths = Vec::new();
+
+        if config.depth == 0 {
+            for file_idx in 0..config.files_per_partition {
+                paths.push(Path::from(format!(
+                    "{}/data_{}.parquet",
+                    path_prefix, file_idx
+                )));
+            }
+            return paths;
+        }
+
+        let mut current_partition = Vec::new();
+        Self::collect_paths_recursive(
+            config,
+            0,
+            &mut current_partition,
+            path_prefix,
+            &mut paths,
+        );
+        paths
+    }
+
+    /// Recursively collect partition paths
+    fn collect_paths_recursive(
+        config: &PartitionConfig,
+        current_depth: usize,
+        current_partition: &mut Vec<String>,
+        path_prefix: &str,
+        paths: &mut Vec<Path>,
+    ) {
+        if current_depth == config.depth {
+            let partition_path = if current_partition.is_empty() {
+                path_prefix.to_string()
+            } else {
+                format!("{}/{}", path_prefix, current_partition.join("/"))
+            };
+
+            for file_idx in 0..config.files_per_partition {
+                let file_path = format!("{}/data_{}.parquet", partition_path, file_idx);
+                paths.push(Path::from(file_path));
+            }
+            return;
+        }
+
+        let partition_name = (b'a' + current_depth as u8) as char;
+        let multiplier = 10_usize.pow(current_depth as u32);
+
+        for value_idx in 0..config.breadth {
+            let partition_value = (value_idx + 1) * multiplier;
+            let partition_part = format!("{}={}", partition_name, partition_value);
+
+            current_partition.push(partition_part);
+            Self::collect_paths_recursive(
+                config,
+                current_depth + 1,
+                current_partition,
+                path_prefix,
+                paths,
+            );
+            current_partition.pop();
+        }
+    }
+
+    /// Upload files concurrently with a concurrency limit
+    async fn upload_files_concurrent(
+        store: &dyn ObjectStore,
+        paths: Vec<Path>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let total = paths.len();
+        eprintln!(
+            "Uploading {} files with concurrency limit of {}...",
+            total, CONCURRENT_UPLOADS
+        );
+
+        // Use buffer_unordered to upload with controlled concurrency
+        let results: Vec<_> = stream::iter(paths)
+            .map(|path| async move { store.put(&path, vec![0; 5].into()).await })
+            .buffer_unordered(CONCURRENT_UPLOADS)
+            .collect()
+            .await;
+
+        // Check for any errors
+        for result in results {
+            result?;
+        }
+
+        eprintln!("Successfully uploaded {} files", total);
+        Ok(())
+    }
+}
+
+/// Benchmark pruned_partition_list with a given configuration (total collection time)
+/// This version has setup already done - only times the actual method call
+async fn run_pruned_partition_list_benchmark(setup: &BenchmarkSetup) {
+    let state = setup.ctx.state();
+
+    let result = pruned_partition_list(
+        &state,
+        setup.store.as_ref(),
+        &setup.table_url,
+        &[], // No filters
+        ".parquet",
+        &setup.partition_cols,
+    )
+    .await
+    .expect("pruned_partition_list failed");
+
+    let files: Vec<_> = result.try_collect().await.expect("failed to collect files");
+
+    // Verify we got the expected number of files
+    assert_eq!(
+        files.len(),
+        setup.expected_files,
+        "Expected {} files but got {}",
+        setup.expected_files,
+        files.len()
+    );
+}
+
+/// Benchmark pruned_partition_list time-to-first-result
+/// This version has setup already done - only times the actual method call + first result
+async fn run_pruned_partition_list_ttfr(setup: &BenchmarkSetup) {
+    let state = setup.ctx.state();
+
+    let mut result = pruned_partition_list(
+        &state,
+        setup.store.as_ref(),
+        &setup.table_url,
+        &[], // No filters
+        ".parquet",
+        &setup.partition_cols,
+    )
+    .await
+    .expect("pruned_partition_list failed");
+
+    // Only get the first result - measures time to first item
+    let first = result.try_next().await.expect("failed to get first result");
+    assert!(first.is_some(), "Expected at least one result");
+}
+
+/// Benchmark pruned_partition_list_all with a given configuration (total collection time)
+/// This version has setup already done - only times the actual method call
+async fn run_pruned_partition_list_all_benchmark(setup: &BenchmarkSetup) {
+    let state = setup.ctx.state();
+
+    let result = pruned_partition_list_all(
+        &state,
+        setup.store.as_ref(),
+        &setup.table_url,
+        &[], // No filters
+        ".parquet",
+        &setup.partition_cols,
+    )
+    .await
+    .expect("pruned_partition_list_all failed");
+
+    let files: Vec<_> = result.try_collect().await.expect("failed to collect files");
+
+    // Verify we got the expected number of files
+    assert_eq!(
+        files.len(),
+        setup.expected_files,
+        "Expected {} files but got {}",
+        setup.expected_files,
+        files.len()
+    );
+}
+
+/// Benchmark pruned_partition_list_all time-to-first-result
+/// This version has setup already done - only times the actual method call + first result
+async fn run_pruned_partition_list_all_ttfr(setup: &BenchmarkSetup) {
+    let state = setup.ctx.state();
+
+    let mut result = pruned_partition_list_all(
+        &state,
+        setup.store.as_ref(),
+        &setup.table_url,
+        &[], // No filters
+        ".parquet",
+        &setup.partition_cols,
+    )
+    .await
+    .expect("pruned_partition_list_all failed");
+
+    // Only get the first result - measures time to first item
+    let first = result.try_next().await.expect("failed to get first result");
+    assert!(first.is_some(), "Expected at least one result");
+}
+
+/// Benchmark varying partition depth with constant total files (in-memory)
+/// Goal: Isolate the impact of partition depth on performance
+fn bench_depth_variation_constant_files_inmemory(c: &mut Criterion) {
+    let mut group = c.benchmark_group("depth_variation_constant_files_inmemory");
+
+    const TOTAL_FILES: usize = 100_000;
+    const BREADTH: usize = 10;
+
+    for depth in [1, 2, 3, 4, 5] {
+        let partitions = BREADTH.pow(depth as u32);
+        let files_per_partition = TOTAL_FILES / partitions;
+        let config = PartitionConfig::new(depth, BREADTH, files_per_partition);
+
+        let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+        let setup = BenchmarkSetup::new(store, &config);
+        let description = format!(
+            "depth={}_partitions={}_files={}",
+            depth, partitions, TOTAL_FILES
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/total/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_benchmark(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/total/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_benchmark(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/ttfr/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_ttfr(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/ttfr/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_ttfr(setup));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark varying partition breadth with constant total files (in-memory)
+/// Goal: Isolate the impact of partition breadth on performance
+fn bench_breadth_variation_constant_files_inmemory(c: &mut Criterion) {
+    let mut group = c.benchmark_group("breadth_variation_constant_files_inmemory");
+
+    const DEPTH: usize = 3;
+
+    let configs = vec![
+        (5, 800, 100_000),
+        (10, 100, 100_000),
+        (20, 12, 96_000),
+        (30, 3, 81_000),
+        (32, 3, 98_304),
+    ];
+
+    for (breadth, files_per_partition, total_files) in configs {
+        let config = PartitionConfig::new(DEPTH, breadth, files_per_partition);
+        let partitions = config.total_partitions();
+
+        let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+        let setup = BenchmarkSetup::new(store, &config);
+        let description = format!(
+            "breadth={}_partitions={}_files={}",
+            breadth, partitions, total_files
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/total/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_benchmark(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/total/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_benchmark(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/ttfr/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_ttfr(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/ttfr/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_ttfr(setup));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark varying total file count with constant partition structure (in-memory)
+/// Goal: Isolate the impact of total file count on performance
+fn bench_scale_constant_partitions_inmemory(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scale_constant_partitions_inmemory");
+
+    const DEPTH: usize = 5;
+    const BREADTH: usize = 8;
+    const PARTITIONS: usize = 32_768; // 8^5
+
+    let files_per_partition_configs = vec![1, 5, 15];
+
+    for files_per_partition in files_per_partition_configs {
+        let config = PartitionConfig::new(DEPTH, BREADTH, files_per_partition);
+        let total_files = config.total_files();
+
+        let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+        let setup = BenchmarkSetup::new(store, &config);
+        let description = format!(
+            "files_per_part={}_partitions={}_total={}",
+            files_per_partition, PARTITIONS, total_files
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/total/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_benchmark(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/total/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_benchmark(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/ttfr/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_ttfr(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/ttfr/{}", description)),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_ttfr(setup));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Create a MinIO container and return an S3 ObjectStore connected to it
+async fn create_minio_store() -> Result<
+    (Arc<dyn ObjectStore>, ContainerAsync<minio::MinIO>),
+    Box<dyn std::error::Error>,
+> {
+    use testcontainers::core::{CmdWaitFor, ExecCommand};
+
+    const MINIO_USER: &str = "benchuser";
+    const MINIO_PASSWORD: &str = "benchpassword";
+    const BUCKET_NAME: &str = "benchmark-data";
+
+    // Start MinIO container
+    let container = minio::MinIO::default()
+        .with_env_var("MINIO_ROOT_USER", MINIO_USER)
+        .with_env_var("MINIO_ROOT_PASSWORD", MINIO_PASSWORD)
+        .start()
+        .await?;
+
+    let port = container.get_host_port_ipv4(9000).await?;
+
+    // Execute commands to set up MinIO, similar to datafusion-cli tests
+    let commands = [
+        ExecCommand::new(["/usr/bin/mc", "ready", "local"]),
+        ExecCommand::new([
+            "/usr/bin/mc",
+            "alias",
+            "set",
+            "localminio",
+            "http://localhost:9000",
+            MINIO_USER,
+            MINIO_PASSWORD,
+        ]),
+        ExecCommand::new(["/usr/bin/mc", "mb", "localminio/benchmark-data"]),
+    ];
+
+    for command in commands {
+        let command =
+            command.with_cmd_ready_condition(CmdWaitFor::Exit { code: Some(0) });
+        let cmd_ref = format!("{command:?}");
+
+        if let Err(e) = container.exec(command).await {
+            let stdout = container.stdout_to_vec().await.unwrap_or_default();
+            let stderr = container.stderr_to_vec().await.unwrap_or_default();
+
+            return Err(format!(
+                "Failed to execute command: {}\nError: {}\nStdout: {:?}\nStderr: {:?}",
+                cmd_ref,
+                e,
+                String::from_utf8_lossy(&stdout),
+                String::from_utf8_lossy(&stderr)
+            )
+            .into());
+        }
+    }
+
+    // Build S3 store pointing to MinIO
+    let s3 = AmazonS3Builder::new()
+        .with_access_key_id(MINIO_USER)
+        .with_secret_access_key(MINIO_PASSWORD)
+        .with_endpoint(format!("http://localhost:{port}"))
+        .with_bucket_name(BUCKET_NAME)
+        .with_allow_http(true)
+        .build()?;
+
+    Ok((Arc::new(s3), container))
+}
+
+/// Benchmark varying partition depth with constant total files (S3/MinIO backend)
+/// Goal: Isolate the impact of partition depth on performance
+fn bench_depth_variation_constant_files_s3(c: &mut Criterion) {
+    let mut group = c.benchmark_group("depth_variation_constant_files_s3");
+    group.sample_size(10);
+
+    const TOTAL_FILES: usize = 100_000;
+    const BREADTH: usize = 10;
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let _guard = runtime.enter();
+
+    // Shared container - initialized once when first benchmark runs
+    type ContainerData = (Arc<dyn ObjectStore>, ContainerAsync<minio::MinIO>);
+    let container_cell: Arc<std::sync::OnceLock<ContainerData>> =
+        Arc::new(std::sync::OnceLock::new());
+
+    // depth=1: 10 partitions × 10,000 files = 100,000 files
+    // depth=2: 100 partitions × 1,000 files = 100,000 files
+    // depth=3: 1,000 partitions × 100 files = 100,000 files
+    // depth=4: 10,000 partitions × 10 files = 100,000 files
+    // depth=5: 100,000 partitions × 1 file = 100,000 files
+    for (idx, depth) in [1, 2, 3, 4, 5].iter().enumerate() {
+        let partitions = BREADTH.pow(*depth as u32);
+        let files_per_partition = TOTAL_FILES / partitions;
+        let config = PartitionConfig::new(*depth, BREADTH, files_per_partition);
+        let table_path = format!("depth_const_{}", idx);
+        let description = format!(
+            "depth={}_partitions={}_files={}",
+            depth, partitions, TOTAL_FILES
+        );
+
+        // Per-benchmark lazy setup - shared across all 4 benchmark variants
+        let setup_cell: Arc<std::sync::OnceLock<BenchmarkSetup>> =
+            Arc::new(std::sync::OnceLock::new());
+
+        // original/total - initializes setup on first run
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        let container_cell_clone = Arc::clone(&container_cell);
+        let runtime_ref = &runtime;
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/total/{}", description)),
+            &(
+                setup_cell_clone,
+                container_cell_clone,
+                config.clone(),
+                table_path.clone(),
+            ),
+            |b, (setup_cell, container_cell, config, table_path)| {
+                let setup = setup_cell.get_or_init(|| {
+                    let (store, _) = container_cell.get_or_init(|| {
+                        runtime_ref
+                            .block_on(create_minio_store())
+                            .expect("Failed to create MinIO container")
+                    });
+                    BenchmarkSetup::new_with_path(Arc::clone(store), config, table_path)
+                });
+                b.to_async(runtime_ref)
+                    .iter(|| run_pruned_partition_list_benchmark(setup));
+            },
+        );
+
+        // list_all/total - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/total/{}", description)),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_benchmark(setup));
+            },
+        );
+
+        // original/ttfr - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/ttfr/{}", description)),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_ttfr(setup));
+            },
+        );
+
+        // list_all/ttfr - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/ttfr/{}", description)),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_ttfr(setup));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark varying partition breadth with constant total files (S3/MinIO backend)
+/// Goal: Isolate the impact of partition breadth on performance
+fn bench_breadth_variation_constant_files_s3(c: &mut Criterion) {
+    let mut group = c.benchmark_group("breadth_variation_constant_files_s3");
+    group.sample_size(10);
+
+    const DEPTH: usize = 3;
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let _guard = runtime.enter();
+
+    // Shared container - initialized once when first benchmark runs
+    type ContainerData = (Arc<dyn ObjectStore>, ContainerAsync<minio::MinIO>);
+    let container_cell: Arc<std::sync::OnceLock<ContainerData>> =
+        Arc::new(std::sync::OnceLock::new());
+
+    // breadth=5: 125 partitions × 800 files = 100,000 files
+    // breadth=10: 1,000 partitions × 100 files = 100,000 files
+    // breadth=20: 8,000 partitions × 12 files = 96,000 files
+    // breadth=30: 27,000 partitions × 3 files = 81,000 files
+    // breadth=32: 32,768 partitions × 3 files = 98,304 files
+    let configs = vec![
+        (5, 800, 100_000),
+        (10, 100, 100_000),
+        (20, 12, 96_000),
+        (30, 3, 81_000),
+        (32, 3, 98_304),
+    ];
+
+    for (idx, (breadth, files_per_partition, total_files)) in configs.iter().enumerate() {
+        let config = PartitionConfig::new(DEPTH, *breadth, *files_per_partition);
+        let partitions = config.total_partitions();
+        let table_path = format!("breadth_const_{}", idx);
+        let description = format!(
+            "breadth={}_partitions={}_files={}",
+            breadth, partitions, total_files
+        );
+
+        // Per-benchmark lazy setup - shared across all 4 benchmark variants
+        let setup_cell: Arc<std::sync::OnceLock<BenchmarkSetup>> =
+            Arc::new(std::sync::OnceLock::new());
+
+        // original/total - initializes setup on first run
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        let container_cell_clone = Arc::clone(&container_cell);
+        let runtime_ref = &runtime;
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/total/{}", description)),
+            &(
+                setup_cell_clone,
+                container_cell_clone,
+                config.clone(),
+                table_path.clone(),
+            ),
+            |b, (setup_cell, container_cell, config, table_path)| {
+                let setup = setup_cell.get_or_init(|| {
+                    let (store, _) = container_cell.get_or_init(|| {
+                        runtime_ref
+                            .block_on(create_minio_store())
+                            .expect("Failed to create MinIO container")
+                    });
+                    BenchmarkSetup::new_with_path(Arc::clone(store), config, table_path)
+                });
+                b.to_async(runtime_ref)
+                    .iter(|| run_pruned_partition_list_benchmark(setup));
+            },
+        );
+
+        // list_all/total - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/total/{}", description)),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_benchmark(setup));
+            },
+        );
+
+        // original/ttfr - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/ttfr/{}", description)),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_ttfr(setup));
+            },
+        );
+
+        // list_all/ttfr - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/ttfr/{}", description)),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_ttfr(setup));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark combined realistic scenarios with S3/MinIO backend
+fn bench_combined_scenarios_s3(c: &mut Criterion) {
+    let mut group = c.benchmark_group("combined_scenarios_s3");
+    group.sample_size(10);
+
+    let scenarios = vec![
+        ("tiny", PartitionConfig::new(5, 1, 1)),
+        ("small", PartitionConfig::new(1, 100, 1)),
+        ("medium", PartitionConfig::new(2, 50, 10)),
+        ("large", PartitionConfig::new(3, 20, 50)),
+        ("deep", PartitionConfig::new(5, 5, 10)),
+    ];
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let _guard = runtime.enter();
+
+    // Shared container - initialized once when first benchmark runs
+    type ContainerData = (Arc<dyn ObjectStore>, ContainerAsync<minio::MinIO>);
+    let container_cell: Arc<std::sync::OnceLock<ContainerData>> =
+        Arc::new(std::sync::OnceLock::new());
+
+    for (idx, (name, config)) in scenarios.iter().enumerate() {
+        let table_path = format!("scenario_bench_{}", idx);
+        let description = format!(
+            "{name}_d{}_b{}_f{}_partitions={}_files={}",
+            config.depth,
+            config.breadth,
+            config.files_per_partition,
+            config.total_partitions(),
+            config.total_files()
+        );
+
+        // Per-benchmark lazy setup - shared across all 4 benchmark variants
+        let setup_cell: Arc<std::sync::OnceLock<BenchmarkSetup>> =
+            Arc::new(std::sync::OnceLock::new());
+
+        // original/total - initializes setup on first run
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        let container_cell_clone = Arc::clone(&container_cell);
+        let runtime_ref = &runtime;
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/total/{description}")),
+            &(
+                setup_cell_clone,
+                container_cell_clone,
+                config.clone(),
+                table_path.clone(),
+            ),
+            |b, (setup_cell, container_cell, config, table_path)| {
+                let setup = setup_cell.get_or_init(|| {
+                    let (store, _) = container_cell.get_or_init(|| {
+                        runtime_ref
+                            .block_on(create_minio_store())
+                            .expect("Failed to create MinIO container")
+                    });
+                    BenchmarkSetup::new_with_path(Arc::clone(store), config, table_path)
+                });
+                b.to_async(runtime_ref)
+                    .iter(|| run_pruned_partition_list_benchmark(setup));
+            },
+        );
+
+        // list_all/total - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/total/{description}")),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_benchmark(setup));
+            },
+        );
+
+        // original/ttfr - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/ttfr/{description}")),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_ttfr(setup));
+            },
+        );
+
+        // list_all/ttfr - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/ttfr/{description}")),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_ttfr(setup));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark varying total file count with constant partition structure (S3/MinIO backend)
+/// Goal: Isolate the impact of total file count on performance
+fn bench_scale_constant_partitions_s3(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scale_constant_partitions_s3");
+    group.sample_size(10);
+
+    const DEPTH: usize = 5;
+    const BREADTH: usize = 8;
+    const PARTITIONS: usize = 32_768; // 8^5
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let _guard = runtime.enter();
+    // Shared container - initialized once when first benchmark runs
+    type ContainerData = (Arc<dyn ObjectStore>, ContainerAsync<minio::MinIO>);
+    let container_cell: Arc<std::sync::OnceLock<ContainerData>> =
+        Arc::new(std::sync::OnceLock::new());
+
+    // 1 file: 32,768 files
+    // 5 files: 163,840 files
+    // 15 files: 491,520 files (~500k)
+    let files_per_partition_configs = vec![1, 5, 15];
+
+    for (idx, files_per_partition) in files_per_partition_configs.iter().enumerate() {
+        let config = PartitionConfig::new(DEPTH, BREADTH, *files_per_partition);
+        let total_files = config.total_files();
+        let table_path = format!("scale_{}", idx);
+        let description = format!(
+            "files_per_part={}_partitions={}_total={}",
+            files_per_partition, PARTITIONS, total_files
+        );
+
+        // Per-benchmark lazy setup - shared across all 4 benchmark variants
+        let setup_cell: Arc<std::sync::OnceLock<BenchmarkSetup>> =
+            Arc::new(std::sync::OnceLock::new());
+
+        // original/total - initializes setup on first run
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        let container_cell_clone = Arc::clone(&container_cell);
+        let runtime_ref = &runtime;
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/total/{}", description)),
+            &(
+                setup_cell_clone,
+                container_cell_clone,
+                config.clone(),
+                table_path.clone(),
+            ),
+            |b, (setup_cell, container_cell, config, table_path)| {
+                let setup = setup_cell.get_or_init(|| {
+                    let (store, _) = container_cell.get_or_init(|| {
+                        runtime_ref
+                            .block_on(create_minio_store())
+                            .expect("Failed to create MinIO container")
+                    });
+                    BenchmarkSetup::new_with_path(Arc::clone(store), config, table_path)
+                });
+                b.to_async(runtime_ref)
+                    .iter(|| run_pruned_partition_list_benchmark(setup));
+            },
+        );
+
+        // list_all/total - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/total/{}", description)),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_benchmark(setup));
+            },
+        );
+
+        // original/ttfr - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/ttfr/{}", description)),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_ttfr(setup));
+            },
+        );
+
+        // list_all/ttfr - reuses setup
+        let setup_cell_clone = Arc::clone(&setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/ttfr/{}", description)),
+            &setup_cell_clone,
+            |b, setup_cell| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_ttfr(setup));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark combined realistic scenarios (in-memory)
+fn bench_combined_scenarios_inmemory(c: &mut Criterion) {
+    let mut group = c.benchmark_group("combined_scenarios_inmemory");
+
+    let scenarios = vec![
+        ("tiny", PartitionConfig::new(5, 1, 1)),
+        ("small", PartitionConfig::new(1, 100, 1)),
+        ("medium", PartitionConfig::new(2, 50, 10)),
+        ("large", PartitionConfig::new(3, 20, 50)),
+        ("deep", PartitionConfig::new(5, 5, 10)),
+    ];
+
+    for (name, config) in scenarios {
+        let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+        let setup = BenchmarkSetup::new(store, &config);
+        let description = format!(
+            "{name}_d{}_b{}_f{}_partitions={}_files={}",
+            config.depth,
+            config.breadth,
+            config.files_per_partition,
+            config.total_partitions(),
+            config.total_files()
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/total/{description}")),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_benchmark(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/total/{description}")),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_benchmark(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("original/ttfr/{description}")),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_ttfr(setup));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("list_all/ttfr/{description}")),
+            &setup,
+            |b, setup| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime)
+                    .iter(|| run_pruned_partition_list_all_ttfr(setup));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark partition filtering with different filter types (in-memory)
+/// Goal: Test partition pruning effectiveness
+fn bench_partition_filtering_inmemory(c: &mut Criterion) {
+    let mut group = c.benchmark_group("partition_filtering_inmemory");
+
+    // Small case: depth=2, breadth=10, 100 partitions, 10,000 files
+    let small_config = PartitionConfig::new(2, 10, 100);
+    let small_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+    let small_setup = BenchmarkSetup::new(small_store, &small_config);
+
+    // Define filter scenarios
+    let no_filter = vec![];
+    let restrictive_filter = vec![datafusion_expr::col("a")
+        .eq(datafusion_expr::lit(10))
+        .and(datafusion_expr::col("b").eq(datafusion_expr::lit(100)))];
+    let broad_filter = vec![datafusion_expr::col("a").lt_eq(datafusion_expr::lit(50))];
+
+    // Small case benchmarks
+    for (filter_name, filters, desc) in [
+        ("no_filter", &no_filter, "partitions=100_files=10000"),
+        (
+            "restrictive_filter",
+            &restrictive_filter,
+            "partitions=1_files=100_pruned=99%",
+        ),
+        (
+            "broad_filter",
+            &broad_filter,
+            "partitions=50_files=5000_pruned=50%",
+        ),
+    ] {
+        // Original implementation - total time
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "original/total/small/{}/{}",
+                filter_name, desc
+            )),
+            &(&small_setup, filters),
+            |b, (setup, filters)| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let result = pruned_partition_list(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list failed");
+                    result.try_collect::<Vec<_>>().await.unwrap()
+                });
+            },
+        );
+
+        // list_all implementation - total time
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "list_all/total/small/{}/{}",
+                filter_name, desc
+            )),
+            &(&small_setup, filters),
+            |b, (setup, filters)| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let result = pruned_partition_list_all(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list_all failed");
+                    result.try_collect::<Vec<_>>().await.unwrap()
+                });
+            },
+        );
+
+        // Original implementation - time to first result
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "original/ttfr/small/{}/{}",
+                filter_name, desc
+            )),
+            &(&small_setup, filters),
+            |b, (setup, filters)| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let mut result = pruned_partition_list(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list failed");
+                    result.try_next().await.unwrap()
+                });
+            },
+        );
+
+        // list_all implementation - time to first result
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "list_all/ttfr/small/{}/{}",
+                filter_name, desc
+            )),
+            &(&small_setup, filters),
+            |b, (setup, filters)| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let mut result = pruned_partition_list_all(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list_all failed");
+                    result.try_next().await.unwrap()
+                });
+            },
+        );
+    }
+
+    // Large case: depth=5, breadth=8, 32,768 partitions, 32,768 files
+    let large_config = PartitionConfig::new(5, 8, 1);
+    let large_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+    let large_setup = BenchmarkSetup::new(large_store, &large_config);
+
+    let no_filter = vec![];
+    let restrictive_filter = vec![datafusion_expr::col("a")
+        .eq(datafusion_expr::lit(1))
+        .and(datafusion_expr::col("b").eq(datafusion_expr::lit(8)))
+        .and(datafusion_expr::col("c").eq(datafusion_expr::lit(64)))
+        .and(datafusion_expr::col("d").eq(datafusion_expr::lit(512)))
+        .and(datafusion_expr::col("e").eq(datafusion_expr::lit(4096)))];
+    let broad_filter = vec![datafusion_expr::col("a").lt_eq(datafusion_expr::lit(4))];
+
+    // Large case benchmarks
+    for (filter_name, filters, desc) in [
+        ("no_filter", &no_filter, "partitions=32768_files=32768"),
+        (
+            "restrictive_filter",
+            &restrictive_filter,
+            "partitions=1_files=1_pruned=99.99%",
+        ),
+        (
+            "broad_filter",
+            &broad_filter,
+            "partitions=16384_files=16384_pruned=50%",
+        ),
+    ] {
+        // Original implementation - total time
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "original/total/large/{}/{}",
+                filter_name, desc
+            )),
+            &(&large_setup, filters),
+            |b, (setup, filters)| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let result = pruned_partition_list(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list failed");
+                    result.try_collect::<Vec<_>>().await.unwrap()
+                });
+            },
+        );
+
+        // list_all implementation - total time
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "list_all/total/large/{}/{}",
+                filter_name, desc
+            )),
+            &(&large_setup, filters),
+            |b, (setup, filters)| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let result = pruned_partition_list_all(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list_all failed");
+                    result.try_collect::<Vec<_>>().await.unwrap()
+                });
+            },
+        );
+
+        // Original implementation - time to first result
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "original/ttfr/large/{}/{}",
+                filter_name, desc
+            )),
+            &(&large_setup, filters),
+            |b, (setup, filters)| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let mut result = pruned_partition_list(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list failed");
+                    result.try_next().await.unwrap()
+                });
+            },
+        );
+
+        // list_all implementation - time to first result
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "list_all/ttfr/large/{}/{}",
+                filter_name, desc
+            )),
+            &(&large_setup, filters),
+            |b, (setup, filters)| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let mut result = pruned_partition_list_all(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list_all failed");
+                    result.try_next().await.unwrap()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark partition filtering with different filter types (S3/MinIO backend)
+/// Goal: Test partition pruning effectiveness with S3
+fn bench_partition_filtering_s3(c: &mut Criterion) {
+    let mut group = c.benchmark_group("partition_filtering_s3");
+    group.sample_size(10);
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let _guard = runtime.enter();
+
+    // Shared container - initialized once when first benchmark runs
+    type ContainerData = (Arc<dyn ObjectStore>, ContainerAsync<minio::MinIO>);
+    let container_cell: Arc<std::sync::OnceLock<ContainerData>> =
+        Arc::new(std::sync::OnceLock::new());
+
+    // Small case setup cell - lazy initialized
+    let small_setup_cell: Arc<std::sync::OnceLock<BenchmarkSetup>> =
+        Arc::new(std::sync::OnceLock::new());
+    let small_config = PartitionConfig::new(2, 10, 100);
+
+    // Define filter scenarios
+    let no_filter = vec![];
+    let restrictive_filter = vec![datafusion_expr::col("a")
+        .eq(datafusion_expr::lit(10))
+        .and(datafusion_expr::col("b").eq(datafusion_expr::lit(100)))];
+    let broad_filter = vec![datafusion_expr::col("a").lt_eq(datafusion_expr::lit(50))];
+
+    // Small case benchmarks
+    let part_desc = "partitions=100_files=10000";
+    for (filter_name, filters, desc) in [
+        ("no_filter", &no_filter, format!("{part_desc}_pruned=0%")),
+        (
+            "restrictive_filter",
+            &restrictive_filter,
+            format!("{part_desc}_pruned=99%"),
+        ),
+        (
+            "broad_filter",
+            &broad_filter,
+            format!("{part_desc}_pruned=50%"),
+        ),
+    ] {
+        // Original implementation - total time
+        let setup_cell_clone = Arc::clone(&small_setup_cell);
+        let container_cell_clone = Arc::clone(&container_cell);
+        let runtime_ref = &runtime;
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "original/total/small/{}/{}",
+                filter_name, desc
+            )),
+            &(
+                setup_cell_clone,
+                container_cell_clone,
+                small_config.clone(),
+                filters,
+            ),
+            |b, (setup_cell, container_cell, config, filters)| {
+                let setup = setup_cell.get_or_init(|| {
+                    let (store, _) = container_cell.get_or_init(|| {
+                        runtime_ref
+                            .block_on(create_minio_store())
+                            .expect("Failed to create MinIO container")
+                    });
+                    BenchmarkSetup::new_with_path(
+                        Arc::clone(store),
+                        config,
+                        "filter_small",
+                    )
+                });
+                b.to_async(runtime_ref).iter(|| async {
+                    let state = setup.ctx.state();
+                    let result = pruned_partition_list(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list failed");
+                    result.try_collect::<Vec<_>>().await.unwrap()
+                });
+            },
+        );
+
+        // list_all implementation - total time
+        let setup_cell_clone = Arc::clone(&small_setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "list_all/total/small/{}/{}",
+                filter_name, desc
+            )),
+            &(setup_cell_clone, filters),
+            |b, (setup_cell, filters)| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let result = pruned_partition_list_all(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list_all failed");
+                    result.try_collect::<Vec<_>>().await.unwrap()
+                });
+            },
+        );
+
+        // Original implementation - time to first result
+        let setup_cell_clone = Arc::clone(&small_setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "original/ttfr/small/{}/{}",
+                filter_name, desc
+            )),
+            &(setup_cell_clone, filters),
+            |b, (setup_cell, filters)| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let mut result = pruned_partition_list(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list failed");
+                    result.try_next().await.unwrap()
+                });
+            },
+        );
+
+        // list_all implementation - time to first result
+        let setup_cell_clone = Arc::clone(&small_setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "list_all/ttfr/small/{}/{}",
+                filter_name, desc
+            )),
+            &(setup_cell_clone, filters),
+            |b, (setup_cell, filters)| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let mut result = pruned_partition_list_all(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list_all failed");
+                    result.try_next().await.unwrap()
+                });
+            },
+        );
+    }
+
+    // Large case setup cell - lazy initialized
+    let large_setup_cell: Arc<std::sync::OnceLock<BenchmarkSetup>> =
+        Arc::new(std::sync::OnceLock::new());
+    let large_config = PartitionConfig::new(5, 8, 1);
+
+    let no_filter = vec![];
+    let restrictive_filter = vec![datafusion_expr::col("a")
+        .eq(datafusion_expr::lit(1))
+        .and(datafusion_expr::col("b").eq(datafusion_expr::lit(8)))
+        .and(datafusion_expr::col("c").eq(datafusion_expr::lit(64)))
+        .and(datafusion_expr::col("d").eq(datafusion_expr::lit(512)))
+        .and(datafusion_expr::col("e").eq(datafusion_expr::lit(4096)))];
+    let broad_filter = vec![datafusion_expr::col("a").lt_eq(datafusion_expr::lit(4))];
+
+    // Large case benchmarks
+    let part_desc = "partitions=32768_files=32768";
+    for (filter_name, filters, desc) in [
+        ("no_filter", &no_filter, format!("{part_desc}_pruned=0%")),
+        (
+            "restrictive_filter",
+            &restrictive_filter,
+            format!("{part_desc}_pruned=99.99%"),
+        ),
+        (
+            "broad_filter",
+            &broad_filter,
+            format!("{part_desc}_pruned=50%"),
+        ),
+    ] {
+        // Original implementation - total time
+        let setup_cell_clone = Arc::clone(&large_setup_cell);
+        let container_cell_clone = Arc::clone(&container_cell);
+        let runtime_ref = &runtime;
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "original/total/large/{}/{}",
+                filter_name, desc
+            )),
+            &(
+                setup_cell_clone,
+                container_cell_clone,
+                large_config.clone(),
+                filters,
+            ),
+            |b, (setup_cell, container_cell, config, filters)| {
+                let setup = setup_cell.get_or_init(|| {
+                    let (store, _) = container_cell.get_or_init(|| {
+                        runtime_ref
+                            .block_on(create_minio_store())
+                            .expect("Failed to create MinIO container")
+                    });
+                    BenchmarkSetup::new_with_path(
+                        Arc::clone(store),
+                        config,
+                        "filter_large",
+                    )
+                });
+                b.to_async(runtime_ref).iter(|| async {
+                    let state = setup.ctx.state();
+                    let result = pruned_partition_list(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list failed");
+                    result.try_collect::<Vec<_>>().await.unwrap()
+                });
+            },
+        );
+
+        // list_all implementation - total time
+        let setup_cell_clone = Arc::clone(&large_setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "list_all/total/large/{}/{}",
+                filter_name, desc
+            )),
+            &(setup_cell_clone, filters),
+            |b, (setup_cell, filters)| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let result = pruned_partition_list_all(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list_all failed");
+                    result.try_collect::<Vec<_>>().await.unwrap()
+                });
+            },
+        );
+
+        // Original implementation - time to first result
+        let setup_cell_clone = Arc::clone(&large_setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "original/ttfr/large/{}/{}",
+                filter_name, desc
+            )),
+            &(setup_cell_clone, filters),
+            |b, (setup_cell, filters)| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let mut result = pruned_partition_list(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list failed");
+                    result.try_next().await.unwrap()
+                });
+            },
+        );
+
+        // list_all implementation - time to first result
+        let setup_cell_clone = Arc::clone(&large_setup_cell);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "list_all/ttfr/large/{}/{}",
+                filter_name, desc
+            )),
+            &(setup_cell_clone, filters),
+            |b, (setup_cell, filters)| {
+                let setup = setup_cell.get().expect("Setup should be initialized");
+                b.to_async(&runtime).iter(|| async {
+                    let state = setup.ctx.state();
+                    let mut result = pruned_partition_list_all(
+                        &state,
+                        setup.store.as_ref(),
+                        &setup.table_url,
+                        filters,
+                        ".parquet",
+                        &setup.partition_cols,
+                    )
+                    .await
+                    .expect("pruned_partition_list_all failed");
+                    result.try_next().await.unwrap()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_depth_variation_constant_files_inmemory,
+    bench_breadth_variation_constant_files_inmemory,
+    bench_scale_constant_partitions_inmemory,
+    bench_combined_scenarios_inmemory,
+    bench_partition_filtering_inmemory,
+    bench_depth_variation_constant_files_s3,
+    bench_breadth_variation_constant_files_s3,
+    bench_scale_constant_partitions_s3,
+    bench_combined_scenarios_s3,
+    bench_partition_filtering_s3,
+);
+criterion_main!(benches);

--- a/datafusion/catalog-listing/benches/s3_results.txt
+++ b/datafusion/catalog-listing/benches/s3_results.txt
@@ -1,0 +1,386 @@
+## --------------------------------------------------------------------------------
+depth_variation_constant_files_s3/original/total/depth=1_partitions=10_files=100000
+                        time:   [1.8864 s 1.8987 s 1.9111 s]
+depth_variation_constant_files_s3/list_all/total/depth=1_partitions=10_files=100000
+                        time:   [13.132 s 13.146 s 13.161 s]
+Found 3 outliers among 10 measurements (30.00%)
+  1 (10.00%) low severe
+  1 (10.00%) high mild
+  1 (10.00%) high severe
+
+
+depth_variation_constant_files_s3/original/ttfr/depth=1_partitions=10_files=100000
+                        time:   [1.8640 s 1.8691 s 1.8751 s]
+Found 2 outliers among 10 measurements (20.00%)
+  1 (10.00%) high mild
+  1 (10.00%) high severe
+depth_variation_constant_files_s3/list_all/ttfr/depth=1_partitions=10_files=100000
+                        time:   [135.48 ms 136.46 ms 137.53 ms]
+
+
+## --------------------------------------------------------------------------------
+depth_variation_constant_files_s3/original/total/depth=2_partitions=100_files=100000
+                        time:   [1.2809 s 1.3590 s 1.4279 s]
+depth_variation_constant_files_s3/list_all/total/depth=2_partitions=100_files=100000
+                        time:   [13.153 s 13.186 s 13.231 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high mild
+
+
+depth_variation_constant_files_s3/original/ttfr/depth=2_partitions=100_files=100000
+                        time:   [1.1500 s 1.1619 s 1.1763 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high mild
+depth_variation_constant_files_s3/list_all/ttfr/depth=2_partitions=100_files=100000
+                        time:   [133.73 ms 134.02 ms 134.37 ms]
+
+
+## --------------------------------------------------------------------------------
+depth_variation_constant_files_s3/original/total/depth=3_partitions=1000_files=100000
+                        time:   [1.7933 s 1.8071 s 1.8198 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) low mild
+depth_variation_constant_files_s3/list_all/total/depth=3_partitions=1000_files=100000
+                        time:   [13.035 s 13.049 s 13.061 s]
+
+
+depth_variation_constant_files_s3/original/ttfr/depth=3_partitions=1000_files=100000
+                        time:   [1.7305 s 1.7353 s 1.7405 s]
+depth_variation_constant_files_s3/list_all/ttfr/depth=3_partitions=1000_files=100000
+                        time:   [133.82 ms 134.02 ms 134.26 ms]
+Found 2 outliers among 10 measurements (20.00%)
+  1 (10.00%) low mild
+  1 (10.00%) high mild
+
+
+## --------------------------------------------------------------------------------
+depth_variation_constant_files_s3/original/total/depth=4_partitions=10000_files=100000
+                        time:   [13.730 s 13.764 s 13.800 s]
+depth_variation_constant_files_s3/list_all/total/depth=4_partitions=10000_files=100000
+                        time:   [13.056 s 13.071 s 13.088 s]
+
+
+depth_variation_constant_files_s3/original/ttfr/depth=4_partitions=10000_files=100000
+                        time:   [13.729 s 13.766 s 13.804 s]
+depth_variation_constant_files_s3/list_all/ttfr/depth=4_partitions=10000_files=100000
+                        time:   [136.19 ms 136.51 ms 137.04 ms]
+
+
+## --------------------------------------------------------------------------------
+depth_variation_constant_files_s3/original/total/depth=5_partitions=100000_files=100000
+                        time:   [134.85 s 134.89 s 134.92 s]
+depth_variation_constant_files_s3/list_all/total/depth=5_partitions=100000_files=100000
+                        time:   [13.314 s 13.330 s 13.344 s]
+
+
+depth_variation_constant_files_s3/original/ttfr/depth=5_partitions=100000_files=100000
+                        time:   [134.62 s 134.67 s 134.71 s]
+depth_variation_constant_files_s3/list_all/ttfr/depth=5_partitions=100000_files=100000
+                        time:   [147.78 ms 148.04 ms 148.37 ms]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high severe
+
+
+## --------------------------------------------------------------------------------
+breadth_variation_constant_files_s3/original/total/breadth=5_partitions=125_files=100000
+                        time:   [1.4606 s 1.4765 s 1.4943 s]
+breadth_variation_constant_files_s3/list_all/total/breadth=5_partitions=125_files=100000
+                        time:   [13.156 s 13.168 s 13.181 s]
+
+
+breadth_variation_constant_files_s3/original/ttfr/breadth=5_partitions=125_files=100000
+                        time:   [1.2281 s 1.2366 s 1.2447 s]
+breadth_variation_constant_files_s3/list_all/ttfr/breadth=5_partitions=125_files=100000
+                        time:   [134.80 ms 135.32 ms 135.88 ms]
+
+
+## --------------------------------------------------------------------------------
+breadth_variation_constant_files_s3/original/total/breadth=10_partitions=1000_files=100000
+                        time:   [1.8073 s 1.8147 s 1.8244 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high mild
+breadth_variation_constant_files_s3/list_all/total/breadth=10_partitions=1000_files=100000
+                        time:   [13.039 s 13.051 s 13.062 s]
+
+
+breadth_variation_constant_files_s3/original/ttfr/breadth=10_partitions=1000_files=100000
+                        time:   [1.7326 s 1.7377 s 1.7432 s]
+breadth_variation_constant_files_s3/list_all/ttfr/breadth=10_partitions=1000_files=100000
+                        time:   [134.12 ms 135.07 ms 136.30 ms]
+
+
+## --------------------------------------------------------------------------------
+breadth_variation_constant_files_s3/original/total/breadth=20_partitions=8000_files=96000
+                        time:   [10.463 s 10.477 s 10.502 s]
+Found 2 outliers among 10 measurements (20.00%)
+  1 (10.00%) low mild
+  1 (10.00%) high severe
+breadth_variation_constant_files_s3/list_all/total/breadth=20_partitions=8000_files=96000
+                        time:   [12.644 s 12.659 s 12.677 s]
+
+
+breadth_variation_constant_files_s3/original/ttfr/breadth=20_partitions=8000_files=96000
+                        time:   [10.437 s 10.452 s 10.476 s]
+Found 2 outliers among 10 measurements (20.00%)
+  1 (10.00%) high mild
+  1 (10.00%) high severe
+breadth_variation_constant_files_s3/list_all/ttfr/breadth=20_partitions=8000_files=96000
+                        time:   [134.78 ms 135.29 ms 135.99 ms]
+
+
+## --------------------------------------------------------------------------------
+breadth_variation_constant_files_s3/original/total/breadth=30_partitions=27000_files=81000
+                        time:   [34.069 s 34.082 s 34.104 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high severe
+breadth_variation_constant_files_s3/list_all/total/breadth=30_partitions=27000_files=81000
+                        time:   [10.702 s 10.719 s 10.741 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high mild
+
+
+breadth_variation_constant_files_s3/original/ttfr/breadth=30_partitions=27000_files=81000
+                        time:   [34.034 s 34.060 s 34.095 s]
+Found 2 outliers among 10 measurements (20.00%)
+  2 (20.00%) high severe
+breadth_variation_constant_files_s3/list_all/ttfr/breadth=30_partitions=27000_files=81000
+                        time:   [139.35 ms 141.38 ms 145.28 ms]
+
+
+## --------------------------------------------------------------------------------
+breadth_variation_constant_files_s3/original/total/breadth=32_partitions=32768_files=98304
+                        time:   [41.324 s 41.347 s 41.363 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) low severe
+breadth_variation_constant_files_s3/list_all/total/breadth=32_partitions=32768_files=98304
+                        time:   [12.970 s 12.985 s 13.003 s]
+
+
+breadth_variation_constant_files_s3/original/ttfr/breadth=32_partitions=32768_files=98304
+                        time:   [41.304 s 41.310 s 41.316 s]
+breadth_variation_constant_files_s3/list_all/ttfr/breadth=32_partitions=32768_files=98304
+                        time:   [138.04 ms 138.31 ms 138.65 ms]
+
+
+## --------------------------------------------------------------------------------
+scale_constant_partitions_s3/original/total/files_per_part=1_partitions=32768_total=32768
+                        time:   [45.727 s 45.769 s 45.816 s]
+Found 2 outliers among 10 measurements (20.00%)
+  2 (20.00%) high mild
+scale_constant_partitions_s3/list_all/total/files_per_part=1_partitions=32768_total=32768
+                        time:   [4.3972 s 4.4150 s 4.4320 s]
+
+
+scale_constant_partitions_s3/original/ttfr/files_per_part=1_partitions=32768_total=32768
+                        time:   [45.701 s 45.747 s 45.803 s]
+scale_constant_partitions_s3/list_all/ttfr/files_per_part=1_partitions=32768_total=32768
+                        time:   [148.25 ms 148.95 ms 149.70 ms]
+
+
+## --------------------------------------------------------------------------------
+scale_constant_partitions_s3/original/total/files_per_part=5_partitions=32768_total=163840
+                        time:   [45.784 s 45.830 s 45.879 s]
+scale_constant_partitions_s3/list_all/total/files_per_part=5_partitions=32768_total=163840
+                        time:   [21.562 s 21.629 s 21.710 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high mild
+
+
+scale_constant_partitions_s3/original/ttfr/files_per_part=5_partitions=32768_total=163840
+                        time:   [45.693 s 45.735 s 45.780 s]
+scale_constant_partitions_s3/list_all/ttfr/files_per_part=5_partitions=32768_total=163840
+                        time:   [136.74 ms 136.94 ms 137.32 ms]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high severe
+
+
+## --------------------------------------------------------------------------------
+scale_constant_partitions_s3/original/total/files_per_part=15_partitions=32768_total=491520
+                        time:   [45.966 s 46.009 s 46.048 s]
+scale_constant_partitions_s3/list_all/total/files_per_part=15_partitions=32768_total=491520
+                        time:   [64.565 s 64.697 s 64.851 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high mild
+
+
+scale_constant_partitions_s3/original/ttfr/files_per_part=15_partitions=32768_total=491520
+                        time:   [45.819 s 45.850 s 45.876 s]
+Found 2 outliers among 10 measurements (20.00%)
+  2 (20.00%) low mild
+scale_constant_partitions_s3/list_all/ttfr/files_per_part=15_partitions=32768_total=491520
+                        time:   [135.37 ms 135.56 ms 135.75 ms]
+
+
+## --------------------------------------------------------------------------------
+combined_scenarios_s3/original/total/tiny_d5_b1_f1_partitions=1_files=1
+                        time:   [727.08 ms 728.49 ms 729.82 ms]
+combined_scenarios_s3/list_all/total/tiny_d5_b1_f1_partitions=1_files=1
+                        time:   [121.46 ms 121.68 ms 121.99 ms]
+
+
+combined_scenarios_s3/original/ttfr/tiny_d5_b1_f1_partitions=1_files=1
+                        time:   [727.92 ms 729.25 ms 730.62 ms]
+combined_scenarios_s3/list_all/ttfr/tiny_d5_b1_f1_partitions=1_files=1
+                        time:   [121.24 ms 121.44 ms 121.80 ms]
+
+
+## --------------------------------------------------------------------------------
+combined_scenarios_s3/original/total/small_d1_b100_f1_partitions=100_files=100
+                        time:   [246.29 ms 246.91 ms 247.55 ms]
+combined_scenarios_s3/list_all/total/small_d1_b100_f1_partitions=100_files=100
+                        time:   [124.23 ms 124.63 ms 125.24 ms]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high mild
+
+
+combined_scenarios_s3/original/ttfr/small_d1_b100_f1_partitions=100_files=100
+                        time:   [246.09 ms 246.46 ms 246.93 ms]
+Found 4 outliers among 10 measurements (40.00%)
+  1 (10.00%) low severe
+  1 (10.00%) low mild
+  1 (10.00%) high mild
+  1 (10.00%) high severe
+combined_scenarios_s3/list_all/ttfr/small_d1_b100_f1_partitions=100_files=100
+                        time:   [124.73 ms 125.02 ms 125.16 ms]
+
+
+## --------------------------------------------------------------------------------
+combined_scenarios_s3/original/total/medium_d2_b50_f10_partitions=2500_files=25000
+                        time:   [3.2967 s 3.2992 s 3.3017 s]
+combined_scenarios_s3/list_all/total/medium_d2_b50_f10_partitions=2500_files=25000
+                        time:   [3.3723 s 3.3783 s 3.3840 s]
+Found 2 outliers among 10 measurements (20.00%)
+  1 (10.00%) low mild
+  1 (10.00%) high mild
+
+
+combined_scenarios_s3/original/ttfr/medium_d2_b50_f10_partitions=2500_files=25000
+                        time:   [3.2905 s 3.2935 s 3.2966 s]
+combined_scenarios_s3/list_all/ttfr/medium_d2_b50_f10_partitions=2500_files=25000
+                        time:   [135.49 ms 136.11 ms 136.93 ms]
+
+
+## --------------------------------------------------------------------------------
+combined_scenarios_s3/original/total/large_d3_b20_f50_partitions=8000_files=400000
+                        time:   [10.677 s 10.683 s 10.688 s]
+combined_scenarios_s3/list_all/total/large_d3_b20_f50_partitions=8000_files=400000
+                        time:   [52.393 s 52.439 s 52.479 s]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) low mild
+
+
+combined_scenarios_s3/original/ttfr/large_d3_b20_f50_partitions=8000_files=400000
+                        time:   [10.590 s 10.599 s 10.607 s]
+Found 3 outliers among 10 measurements (30.00%)
+  2 (20.00%) low severe
+  1 (10.00%) high mild
+combined_scenarios_s3/list_all/ttfr/large_d3_b20_f50_partitions=8000_files=400000
+                        time:   [133.91 ms 134.27 ms 134.56 ms]
+
+
+## --------------------------------------------------------------------------------
+combined_scenarios_s3/original/total/deep_d5_b5_f10_partitions=3125_files=31250
+                        time:   [5.1146 s 5.1472 s 5.1810 s]
+combined_scenarios_s3/list_all/total/deep_d5_b5_f10_partitions=3125_files=31250
+                        time:   [4.2020 s 4.2150 s 4.2291 s]
+Found 3 outliers among 10 measurements (30.00%)
+  1 (10.00%) low mild
+  2 (20.00%) high mild
+
+
+combined_scenarios_s3/original/ttfr/deep_d5_b5_f10_partitions=3125_files=31250
+                        time:   [5.1345 s 5.1687 s 5.2025 s]
+combined_scenarios_s3/list_all/ttfr/deep_d5_b5_f10_partitions=3125_files=31250
+                        time:   [135.25 ms 135.57 ms 135.97 ms]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high severe
+
+
+## --------------------------------------------------------------------------------
+partition_filtering_s3/original/total/small/no_filter/partitions=100_files=10000_pruned=0%
+                        time:   [438.07 ms 439.44 ms 440.84 ms]
+partition_filtering_s3/list_all/total/small/no_filter/partitions=100_files=10000_pruned=0%
+                        time:   [1.4384 s 1.4466 s 1.4547 s]
+
+
+partition_filtering_s3/original/ttfr/small/no_filter/partitions=100_files=10000_pruned=0%
+                        time:   [436.45 ms 437.78 ms 439.09 ms]
+partition_filtering_s3/list_all/ttfr/small/no_filter/partitions=100_files=10000_pruned=0%
+                        time:   [133.83 ms 133.99 ms 134.30 ms]
+
+
+## --------------------------------------------------------------------------------
+partition_filtering_s3/original/total/small/restrictive_filter/partitions=100_files=10000_pruned=99%
+                        time:   [122.07 ms 122.24 ms 122.59 ms]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high severe
+partition_filtering_s3/list_all/total/small/restrictive_filter/partitions=100_files=10000_pruned=99%
+                        time:   [1.4556 s 1.4613 s 1.4667 s]
+
+
+partition_filtering_s3/original/ttfr/small/restrictive_filter/partitions=100_files=10000_pruned=99%
+                        time:   [122.86 ms 123.22 ms 123.76 ms]
+partition_filtering_s3/list_all/ttfr/small/restrictive_filter/partitions=100_files=10000_pruned=99%
+                        time:   [270.18 ms 271.21 ms 272.71 ms]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high severe
+
+
+## --------------------------------------------------------------------------------
+partition_filtering_s3/original/total/small/broad_filter/partitions=100_files=10000_pruned=50%
+                        time:   [437.13 ms 437.77 ms 438.44 ms]
+partition_filtering_s3/list_all/total/small/broad_filter/partitions=100_files=10000_pruned=50%
+                        time:   [1.4564 s 1.4689 s 1.4822 s]
+
+
+partition_filtering_s3/original/ttfr/small/broad_filter/partitions=100_files=10000_pruned=50%
+                        time:   [435.94 ms 436.71 ms 437.60 ms]
+partition_filtering_s3/list_all/ttfr/small/broad_filter/partitions=100_files=10000_pruned=50%
+                        time:   [134.28 ms 135.31 ms 136.18 ms]
+
+
+## --------------------------------------------------------------------------------
+partition_filtering_s3/original/total/large/no_filter/partitions=32768_files=32768_pruned=0%
+                        time:   [45.738 s 45.783 s 45.829 s]
+partition_filtering_s3/list_all/total/large/no_filter/partitions=32768_files=32768_pruned=0%
+                        time:   [4.4023 s 4.4228 s 4.4428 s]
+
+
+partition_filtering_s3/original/ttfr/large/no_filter/partitions=32768_files=32768_pruned=0%
+                        time:   [45.760 s 45.810 s 45.859 s]
+partition_filtering_s3/list_all/ttfr/large/no_filter/partitions=32768_files=32768_pruned=0%
+                        time:   [149.29 ms 163.02 ms 188.64 ms]
+Found 1 outliers among 10 measurements (10.00%)
+  1 (10.00%) high severe
+
+
+## --------------------------------------------------------------------------------
+partition_filtering_s3/original/total/large/restrictive_filter/partitions=32768_files=32768_pruned=99.99%
+                        time:   [120.79 ms 120.87 ms 121.03 ms]
+partition_filtering_s3/list_all/total/large/restrictive_filter/partitions=32768_files=32768_pruned=99.99%
+                        time:   [4.5039 s 4.5247 s 4.5467 s]
+Found 4 outliers among 10 measurements (40.00%)
+  2 (20.00%) low mild
+  1 (10.00%) high mild
+  1 (10.00%) high severe
+
+
+partition_filtering_s3/original/ttfr/large/restrictive_filter/partitions=32768_files=32768_pruned=99.99%
+                        time:   [120.93 ms 121.06 ms 121.16 ms]
+partition_filtering_s3/list_all/ttfr/large/restrictive_filter/partitions=32768_files=32768_pruned=99.99%
+                        time:   [4.4925 s 4.5200 s 4.5482 s]
+
+
+## --------------------------------------------------------------------------------
+partition_filtering_s3/original/total/large/broad_filter/partitions=32768_files=32768_pruned=50%
+                        time:   [45.730 s 45.781 s 45.838 s]
+partition_filtering_s3/list_all/total/large/broad_filter/partitions=32768_files=32768_pruned=50%
+                        time:   [4.4564 s 4.4838 s 4.5101 s]
+
+
+partition_filtering_s3/original/ttfr/large/broad_filter/partitions=32768_files=32768_pruned=50%
+                        time:   [45.699 s 45.725 s 45.758 s]
+Found 2 outliers among 10 measurements (20.00%)
+  2 (20.00%) high severe
+partition_filtering_s3/list_all/ttfr/large/broad_filter/partitions=32768_files=32768_pruned=50%
+                        time:   [149.61 ms 150.11 ms 150.37 ms]

--- a/datafusion/catalog-listing/benches/s3_results_formatted.md
+++ b/datafusion/catalog-listing/benches/s3_results_formatted.md
@@ -1,0 +1,93 @@
+# S3 Benchmark Results
+
+Benchmark results comparing `original` (main) vs `list_all` implementations for S3 partition listing.
+
+- **Total**: Time to collect all results from the file listing stream (`.collect::<Vec<_>>()`). Represents complete listing overhead.
+- **TTFR**: Time To First Result - when the stream yields its first file. DataFusion can begin downstream processing (e.g. metadata fetching) after this duration.
+- **Speedup**: Ratio of `original`/`list_all` performance (>1.0x means `list_all` is faster)
+
+---
+
+## 1. Depth Variation Tests (Constant Files = 100,000)
+
+Testing performance across different directory depth levels with a constant total file count.
+
+| Depth | Partitions | Files | Original Total | Original TTFR | List_All Total | List_All TTFR | Total Speedup | TTFR Speedup |
+|-------|-----------|-------|----------------|---------------|----------------|---------------|---------------|--------------|
+| 1 | 10 | 100,000 | 1.90s | 1.87s | 13.15s | 136ms | 0.14x | 13.75x |
+| 2 | 100 | 100,000 | 1.36s | 1.16s | 13.19s | 134ms | 0.10x | 8.66x |
+| 3 | 1,000 | 100,000 | 1.81s | 1.74s | 13.05s | 134ms | 0.14x | 12.99x |
+| 4 | 10,000 | 100,000 | 13.76s | 13.77s | 13.07s | 137ms | 1.05x | 100.51x |
+| 5 | 100,000 | 100,000 | 134.89s | 134.67s | 13.33s | 148ms | 10.12x | 909.93x |
+
+---
+
+## 2. Breadth Variation Tests (Files ≈100K)
+
+Testing performance with varying partition breadth (partitions per directory level).
+
+| Breadth | Partitions | Files | Original Total | Original TTFR | List_All Total | List_All TTFR | Total Speedup | TTFR Speedup |
+|---------|-----------|-------|----------------|---------------|----------------|---------------|---------------|--------------|
+| 5 | 125 | 100,000 | 1.48s | 1.24s | 13.17s | 135ms | 0.11x | 9.19x |
+| 10 | 1,000 | 100,000 | 1.81s | 1.74s | 13.05s | 135ms | 0.14x | 12.89x |
+| 20 | 8,000 | 96,000 | 10.48s | 10.45s | 12.66s | 135ms | 0.83x | 77.41x |
+| 30 | 27,000 | 81,000 | 34.08s | 34.06s | 10.72s | 141ms | 3.18x | 241.56x |
+| 32 | 32,768 | 98,304 | 41.35s | 41.31s | 12.99s | 138ms | 3.18x | 299.35x |
+
+---
+
+## 3. Scale Tests (Constant Partitions = 32,768)
+
+Testing performance with varying file counts while keeping partition count constant.
+
+| Files/Partition | Total Partitions | Total Files | Original Total | Original TTFR | List_All Total | List_All TTFR | Total Speedup | TTFR Speedup |
+|-----------------|-----------------|------------|----------------|---------------|----------------|---------------|---------------|--------------|
+| 1 | 32,768 | 32,768 | 45.77s | 45.75s | 4.42s | 149ms | 10.36x | 307.05x |
+| 5 | 32,768 | 163,840 | 45.83s | 45.74s | 21.63s | 137ms | 2.12x | 333.87x |
+| 15 | 32,768 | 491,520 | 46.01s | 45.85s | 64.70s | 136ms | 0.71x | 337.13x |
+
+---
+
+## 4. Combined Scenario Tests
+
+Realistic scenarios with various depth, breadth, and file combinations.
+
+| Scenario | Depth | Breadth | Files/Part | Partitions | Total Files | Original Total | Original TTFR | List_All Total | List_All TTFR | Total Speedup | TTFR Speedup |
+|----------|-------|---------|-----------|-----------|------------|----------------|---------------|----------------|---------------|---------------|--------------|
+| Tiny | 5 | 1 | 1 | 1 | 1 | 728ms | 729ms | 122ms | 121ms | 5.96x | 6.02x |
+| Small | 1 | 100 | 1 | 100 | 100 | 247ms | 246ms | 125ms | 125ms | 1.98x | 1.97x |
+| Medium | 2 | 50 | 10 | 2,500 | 25,000 | 3.30s | 3.29s | 3.38s | 136ms | 0.98x | 24.19x |
+| Large | 3 | 20 | 50 | 8,000 | 400,000 | 10.68s | 10.60s | 52.44s | 134ms | 0.20x | 79.10x |
+| Deep | 5 | 5 | 10 | 3,125 | 31,250 | 5.15s | 5.17s | 4.22s | 136ms | 1.22x | 38.01x |
+
+---
+
+## 5. Partition Filtering Tests
+
+Testing filter effectiveness with different pruning percentages.
+
+### 5.1 Small Scale (100 partitions, 10,000 files)
+
+| Filter Type | Partitions Pruned | Original Total | Original TTFR | List_All Total | List_All TTFR | Total Speedup | TTFR Speedup |
+|-------------|------------------|----------------|---------------|----------------|---------------|---------------|--------------|
+| No Filter | 0% | 439ms | 438ms | 1.45s | 134ms | 0.30x | 3.27x |
+| Restrictive | 99% | 122ms | 123ms | 1.46s | 271ms | 0.08x | 0.45x |
+| Broad | 50% | 438ms | 437ms | 1.47s | 135ms | 0.30x | 3.24x |
+
+**Filter Clauses:**
+- **Restrictive**: `WHERE a = 10 AND b = 100`
+- **Broad**: `WHERE a <= 50`
+
+### 5.2 Large Scale (32,768 partitions, 32,768 files)
+
+| Filter Type | Partitions Pruned | Original Total | Original TTFR | List_All Total | List_All TTFR | Total Speedup | TTFR Speedup |
+|-------------|------------------|----------------|---------------|----------------|---------------|---------------|--------------|
+| No Filter | 0% | 45.78s | 45.81s | 4.42s | 163ms | 10.36x | 281.04x |
+| Restrictive | 99.99% | 121ms | 121ms | 4.52s | 4.52s | 0.03x | 0.03x |
+| Broad | 50% | 45.78s | 45.73s | 4.48s | 150ms | 10.22x | 304.87x |
+
+**Filter Clauses:**
+- **Restrictive**: `WHERE a = 1 AND b = 8 AND c = 64 AND d = 512 AND e = 4096`
+- **Broad**: `WHERE a <= 4`
+
+---


### PR DESCRIPTION
## Which issue does this PR close?

N/A -- This PR is a POC meant for discussion to inform decisions related to
 - https://github.com/apache/datafusion/pull/18146

## Rationale for this change

This PR is to share the code of some benchmarks for reproduction of results and discussion of results.

## What changes are included in this PR?

This PR includes a set of benchmarks that exercise the `pruned_partition_list` method (both the `original` (current main) and the `list_all` (PR)) to allow us to make a more informed decision on the potential path(s) forward related to #18146. 

**This code is not intended for merge**. 

Please generally avert your eyes from the benchmark code, because it comes with an :rotating_light: :robot: AI generated code :robot: :rotating_light: warning. There's a bunch of _really_ silly decisions the robot made and if we actually wanted to introduce permanent benchmarks we'd likely want to pare down the cases and re-write them. At the current time I am more interested in exploring results rather than nit-picking benchmark code, however I did ensure the actual timing loops were as tight as possible to ensure the results are trustworthy representations for both implementations.

The benchmarks themselves include both an in-memory benchmark and an S3 benchmark that uses a local MinIO via `testcontainers`. The in-memory benches are more-or-less what I started with, and at this point are mostly there because they're academically interesting. The S3 benchmarks are necessary to truly understand the end-user performance for list operations because list operations for commercial object stores are paged with 1000 results per page. To add an additional dose of realism, the results included with this PR were run using a simulated latency of 120ms applied to my localhost interface using `tc` in linux. Each underlying partition structure benchmark is run twice for each implementation, once to collect all the results from the list operation, and again to collect the time-to-first-result (TTFR) from the file stream.

In order to better facilitate discussion on the results I have included both "raw" criterion results as text and a formatted table of the results as a markdown doc that's a bit easier to read. The "raw" criterion results are edited to remove some of the text-noise (improve/regression output that was not useful/accurate, warmup text etc.) and have had separators added just to make them a bit easier to navigate/digest. I think using in-line comments on the various table entries in `s3_results_formatted.md` is probably the easiest way to thread the discussion around the results, but I'm happy to facilitate other options.

## Are these changes tested?

They are tests.

## Are there any user-facing changes?
no

##
cc @alamb 
I was initially planning on adding some comments of my own interpretations to the benchmark results right after I submitted this PR to start the discussion, but in some sense I don't want the "poison the well" of additional perspectives. If you'd like me to start the discussion/interpretation I'd be happy to do so, just let me know and I can add my current thoughts.

## Additional Notes:
If anyone wants to try these locally using the simulated latency, you can use this command (run as root):
```console
tc qdisc add dev lo root handle 1:0 netem delay 60msec
```
This adds 60ms to each access across the `lo` device, resulting in a 120ms round trip latency.

Since you're unlikely to want latency on localhost forever, you can reset it:
```console
tc qdisc del dev lo root
```

I'm not sure if this functionality or similar exists on MacOS, and I don't believe there is a Windows solution.