### PR TITLE
feat: Add Hash trait to StatsType enum

### DIFF
--- a/datafusion/functions-aggregate-common/src/stats.rs
+++ b/datafusion/functions-aggregate-common/src/stats.rs
@@ -17,7 +17,7 @@
 
 /// TODO: Move this to functions-aggregate module
 /// Enum used for differentiating population and sample for statistical functions
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub enum StatsType {
     /// Population
     Population,


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

To be able to use `derive(hash)`

## What changes are included in this PR?

Add `Hash` to the `StatsType` enum

## Are these changes tested?

No need

## Are there any user-facing changes?

kinda