### PR TITLE
TEST: use new async parquet reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,8 +226,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df8bb5b0bd64c0b9bc61317fcc480bad0f00e56d3bc32c69a4c8dada4786bae"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -250,8 +249,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a640186d3bd30a24cb42264c2dafb30e236a6f50d510e56d40b708c9582491"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -264,8 +262,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219fe420e6800979744c8393b687afb0252b3f8a89b91027d27887b72aa36d31"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -283,8 +280,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76885a2697a7edf6b59577f568b456afc94ce0e2edc15b784ce3685b6c3c5c27"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "bytes",
  "half",
@@ -295,12 +291,12 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9ebb4c987e6b3b236fb4a14b20b34835abfdd80acead3ccf1f9bf399e1f168"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -316,8 +312,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92386159c8d4bce96f8bd396b0642a0d544d471bdc2ef34d631aec80db40a09c"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -331,8 +326,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727681b95de313b600eddc2a37e736dcb21980a40f640314dcf360e2f36bc89b"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -344,8 +338,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70bb56412a007b0cfc116d15f24dda6adeed9611a213852a004cda20085a3b9"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -372,8 +365,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9ba92e3de170295c98a84e5af22e2b037f0c7b32449445e6c493b5fca27f27"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -388,8 +380,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b969b4a421ae83828591c6bf5450bd52e6d489584142845ad6a861f42fe35df8"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -412,8 +403,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141c05298b21d03e88062317a1f1a73f5ba7b6eb041b350015b1cd6aabc0519b"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -425,8 +415,7 @@ dependencies = [
 [[package]]
 name = "arrow-pyarrow"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcfb2be2e9096236f449c11f425cddde18c4cc540f516d90f066f10a29ed515"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-array",
  "arrow-data",
@@ -437,8 +426,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f3c06a6abad6164508ed283c7a02151515cef3de4b4ff2cebbcaeb85533db2"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -450,8 +438,7 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cfa7a03d1eee2a4d061476e1840ad5c9867a544ca6c4c59256496af5d0a8be5"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "bitflags 2.9.4",
  "serde",
@@ -462,8 +449,7 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa595babaad59f2455f4957d0f26448fb472722c186739f4fac0823a1bdb47"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -476,8 +462,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f46457dbbb99f2650ff3ac23e46a929e0ab81db809b02aa5511c258348bef2"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4472,8 +4457,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "57.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0f31027ef1af7549f7cec603a9a21dce706d3f8d7c2060a68f43c1773be95a"
+source = "git+https://github.com/apache/arrow-rs.git?rev=776ee65abe14f6aac7d92c729e945e729ba8d4a1#776ee65abe14f6aac7d92c729e945e729ba8d4a1"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,3 +262,20 @@ incremental = false
 inherits = "release"
 debug = true
 strip = false
+
+
+
+# Test with https://github.com/apache/arrow-rs/pull/8159 (push decoder)
+[patch.crates-io]
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }
+parquet = { git = "https://github.com/apache/arrow-rs.git", rev = "776ee65abe14f6aac7d92c729e945e729ba8d4a1" }


### PR DESCRIPTION
This is a test PR to confirm the changes in 

- https://github.com/apache/arrow-rs/pull/8159

Do not cause any performance regressions