### PR TITLE
fix(docs): remove navbar padding breaking ui on mobile

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -69,14 +69,6 @@ html[data-theme="dark"] .dark-logo {
   margin-left: auto;
 }
 
-/* Ensure the logo is properly displayed */
-
-.navbar-brand {
-  height: auto;
-  width: auto;
-  padding: 0 2em;
-}
-
 /* This is the bootstrap CSS style for "table-striped". Since the theme does
 not yet provide an easy way to configure this globally, it easier to simply
 include this snippet here than updating each table in all rst files to


### PR DESCRIPTION
## Which issue does this PR close?

NA

## Rationale for this change
I just noticed that an existing css was forcing extra padding in the navbar, which resulted in breaking the navbar ui in certain small screen (mobile) devices.

| Old | New (fixed) |
|:---:|:------------:|
| <img width="384" height="120" alt="Screenshot 2025-10-31 at 14-22-44 DataFrame API — Apache DataFusion documentation" src="https://github.com/user-attachments/assets/c4e23471-cfde-4988-b887-13060da9faf1" /> | <img width="384" height="117" alt="Screenshot 2025-10-31 at 14-23-19 DataFrame API — Apache DataFusion documentation" src="https://github.com/user-attachments/assets/152c7b8d-cf0e-4a62-a616-264398d074a1" /> |

*notice how the right side navbar element is breaking out of the layout

To replicate this issue  (firefox-browser) :
- Open https://datafusion.apache.org/ in "responsive design mode" (ctrl+shift+m)
- Select "Galaxy S20 Android 11" or "iPhone 12/13 + Pro iOS 14.6" ...etc device.

## What changes are included in this PR?
Removed an existing css that was responsible for this behavior.

