### PR TITLE
Minor: Remove unneccessary vec! in SortMergeJoinStream initialization

### DIFF
--- a/datafusion/physical-plan/src/joins/sort_merge_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/stream.rs
@@ -604,7 +604,7 @@ impl Stream for SortMergeJoinStream {
                                             // Append filtered batch to the output buffer
                                             self.output = concat_batches(
                                                 &self.schema(),
-                                                vec![&self.output, &out_filtered_batch],
+                                                [&self.output, &out_filtered_batch],
                                             )?;
 
                                             // Send to output if the output buffer surpassed the `batch_size`


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Remove a unnecessary vec allocation in SortMergeJoinStream initialization

## Rationale for this change

Remove a unnecessary vec allocation in SortMergeJoinStream initialization

## What changes are included in this PR?

Remove a unnecessary vec allocation in SortMergeJoinStream initialization

## Are these changes tested?

Covered by existing

## Are there any user-facing changes?

No
