### PR TITLE
feat: Expose `DefaultPhysicalPlanner::create_project_physical_exec`

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2344,7 +2344,25 @@ impl DefaultPhysicalPlanner {
         Ok(mem_exec)
     }
 
-    fn create_project_physical_exec(
+    /// Creates a physical [`ProjectionExec`] from logical projection expressions.
+    ///
+    /// This method converts logical projection expressions into physical expressions,
+    /// handling column name mapping between logical and physical schemas. It also
+    /// detects and plans asynchronous expressions (e.g., async UDFs) by wrapping them
+    /// in an [`AsyncFuncExec`] when needed.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_state`: The session state for accessing configuration and resources
+    /// * `input_exec`: The physical execution plan providing input data
+    /// * `input`: The logical plan corresponding to the input execution plan
+    /// * `expr`: The logical projection expressions to convert
+    ///
+    /// # Returns
+    ///
+    /// A [`ProjectionExec`] for synchronous expressions, or a [`ProjectionExec`]
+    /// wrapping an [`AsyncFuncExec`] when async expressions are detected.
+    pub fn create_project_physical_exec(
         &self,
         session_state: &SessionState,
         input_exec: Arc<dyn ExecutionPlan>,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

Exposes `DefaultPhysicalPlanner::create_project_physical_exec` for use outside of the crate

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Exposes `DefaultPhysicalPlanner::create_project_physical_exec`
- Adds documentation

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
