### PR TITLE
Update roadmap links for DataFusion Q1 2026

### DIFF
--- a/docs/source/contributor-guide/roadmap.md
+++ b/docs/source/contributor-guide/roadmap.md
@@ -53,6 +53,7 @@ roadmap using GitHub issues, approximately quarterly, and invite you to join the
 discussion.
 
 For more information:
+
 1. [Search for issues labeled `roadmap`](https://github.com/apache/datafusion/issues?q=is%3Aissue%20%20%20roadmap)
 2. [DataFusion Road Map: Q1 2026](https://github.com/apache/datafusion/issues/18494)
 3. [DataFusion Road Map: Q3-Q4 2025](https://github.com/apache/datafusion/issues/15878)


### PR DESCRIPTION
## Which issue does this PR close?
N/A
## Rationale for this change

I started a new roadmap discussion, so let's also link it in the docs

## What changes are included in this PR?

Add a link to
- https://github.com/apache/datafusion/issues/18494

## Are these changes tested?
by C I

## Are there any user-facing changes?

new link in docs