### PR TITLE
feat: added  lint rule to, solved all errors that arose and updated tests to pass

### DIFF
--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -31,8 +31,12 @@ rust-version = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
-[lints]
-workspace = true
+[lints] # Overrides / extends workspace.lints
+[lints.clippy]
+# Avoid unnecessary clones for performance, okay to ignore for tests or intentional
+# moves.
+# Reference: <https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value>
+needless_pass_by_value = "deny"
 
 [lib]
 name = "datafusion_expr"

--- a/datafusion/expr/src/arguments.rs
+++ b/datafusion/expr/src/arguments.rs
@@ -162,7 +162,7 @@ mod tests {
     fn test_all_positional() {
         let param_names = vec!["a".to_string(), "b".to_string()];
 
-        let args = vec![lit(1), lit("hello")];
+        let args = vec![lit(&1), lit(&"hello")];
         let arg_names = vec![None, None];
 
         let result =
@@ -174,7 +174,7 @@ mod tests {
     fn test_all_named() {
         let param_names = vec!["a".to_string(), "b".to_string()];
 
-        let args = vec![lit(1), lit("hello")];
+        let args = vec![lit(&1), lit(&"hello")];
         let arg_names = vec![Some("a".to_string()), Some("b".to_string())];
 
         let result = resolve_function_arguments(&param_names, args, arg_names).unwrap();
@@ -186,7 +186,7 @@ mod tests {
         let param_names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
 
         // Call with: func(c => 3.0, a => 1, b => "hello")
-        let args = vec![lit(3.0), lit(1), lit("hello")];
+        let args = vec![lit(&3.0), lit(&1), lit(&"hello")];
         let arg_names = vec![
             Some("c".to_string()),
             Some("a".to_string()),
@@ -197,9 +197,9 @@ mod tests {
 
         // Should be reordered to [a, b, c] = [1, "hello", 3.0]
         assert_eq!(result.len(), 3);
-        assert_eq!(result[0], lit(1));
-        assert_eq!(result[1], lit("hello"));
-        assert_eq!(result[2], lit(3.0));
+        assert_eq!(result[0], lit(&1));
+        assert_eq!(result[1], lit(&"hello"));
+        assert_eq!(result[2], lit(&3.0));
     }
 
     #[test]
@@ -207,16 +207,16 @@ mod tests {
         let param_names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
 
         // Call with: func(1, c => 3.0, b => "hello")
-        let args = vec![lit(1), lit(3.0), lit("hello")];
+        let args = vec![lit(&1), lit(&3.0), lit(&"hello")];
         let arg_names = vec![None, Some("c".to_string()), Some("b".to_string())];
 
         let result = resolve_function_arguments(&param_names, args, arg_names).unwrap();
 
         // Should be reordered to [a, b, c] = [1, "hello", 3.0]
         assert_eq!(result.len(), 3);
-        assert_eq!(result[0], lit(1));
-        assert_eq!(result[1], lit("hello"));
-        assert_eq!(result[2], lit(3.0));
+        assert_eq!(result[0], lit(&1));
+        assert_eq!(result[1], lit(&"hello"));
+        assert_eq!(result[2], lit(&3.0));
     }
 
     #[test]
@@ -224,7 +224,7 @@ mod tests {
         let param_names = vec!["a".to_string(), "b".to_string()];
 
         // Call with: func(a => 1, "hello") - ERROR
-        let args = vec![lit(1), lit("hello")];
+        let args = vec![lit(&1), lit(&"hello")];
         let arg_names = vec![Some("a".to_string()), None];
 
         let result = resolve_function_arguments(&param_names, args, arg_names);
@@ -240,7 +240,7 @@ mod tests {
         let param_names = vec!["a".to_string(), "b".to_string()];
 
         // Call with: func(x => 1, b => "hello") - ERROR
-        let args = vec![lit(1), lit("hello")];
+        let args = vec![lit(&1), lit(&"hello")];
         let arg_names = vec![Some("x".to_string()), Some("b".to_string())];
 
         let result = resolve_function_arguments(&param_names, args, arg_names);
@@ -256,7 +256,7 @@ mod tests {
         let param_names = vec!["a".to_string(), "b".to_string()];
 
         // Call with: func(a => 1, a => 2) - ERROR
-        let args = vec![lit(1), lit(2)];
+        let args = vec![lit(&1), lit(&2)];
         let arg_names = vec![Some("a".to_string()), Some("a".to_string())];
 
         let result = resolve_function_arguments(&param_names, args, arg_names);
@@ -272,7 +272,7 @@ mod tests {
         let param_names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
 
         // Call with: func(a => 1, c => 3.0) - missing 'b'
-        let args = vec![lit(1), lit(3.0)];
+        let args = vec![lit(&1), lit(&3.0)];
         let arg_names = vec![Some("a".to_string()), Some("c".to_string())];
 
         let result = resolve_function_arguments(&param_names, args, arg_names);

--- a/datafusion/expr/src/conditional_expressions.rs
+++ b/datafusion/expr/src/conditional_expressions.rs
@@ -112,16 +112,16 @@ mod tests {
 
     #[test]
     fn case_when_same_literal_then_types() -> Result<()> {
-        let _ = when(col("state").eq(lit("CO")), lit(303))
-            .when(col("state").eq(lit("NY")), lit(212))
+        let _ = when(col("state").eq(lit(&"CO")), lit(&303))
+            .when(col("state").eq(lit(&"NY")), lit(&212))
             .end()?;
         Ok(())
     }
 
     #[test]
     fn case_when_different_literal_then_types() {
-        let maybe_expr = when(col("state").eq(lit("CO")), lit(303))
-            .when(col("state").eq(lit("NY")), lit("212"))
+        let maybe_expr = when(col("state").eq(lit(&"CO")), lit(&303))
+            .when(col("state").eq(lit(&"NY")), lit(&"212"))
             .end();
         assert!(maybe_expr.is_err());
     }

--- a/datafusion/expr/src/execution_props.rs
+++ b/datafusion/expr/src/execution_props.rs
@@ -104,11 +104,11 @@ impl ExecutionProps {
     /// Returns the provider for the `var_type`, if any
     pub fn get_var_provider(
         &self,
-        var_type: VarType,
+        var_type: &VarType,
     ) -> Option<Arc<dyn VarProvider + Send + Sync>> {
         self.var_providers
             .as_ref()
-            .and_then(|var_providers| var_providers.get(&var_type).cloned())
+            .and_then(|var_providers| var_providers.get(var_type).cloned())
     }
 
     /// Returns the configuration properties for this execution

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -3661,9 +3661,9 @@ mod test {
     #[test]
     fn format_case_when() -> Result<()> {
         let expr = case(col("a"))
-            .when(lit(1), lit(true))
-            .when(lit(0), lit(false))
-            .otherwise(lit(ScalarValue::Null))?;
+            .when(lit(&1), lit(&true))
+            .when(lit(&0), lit(&false))
+            .otherwise(lit(&ScalarValue::Null))?;
         let expected = "CASE a WHEN Int32(1) THEN Boolean(true) WHEN Int32(0) THEN Boolean(false) ELSE NULL END";
         assert_eq!(expected, format!("{expr}"));
         Ok(())
@@ -3687,9 +3687,9 @@ mod test {
     fn test_partial_ord() {
         // Test validates that partial ord is defined for Expr, not
         // intended to exhaustively test all possibilities
-        let exp1 = col("a") + lit(1);
-        let exp2 = col("a") + lit(2);
-        let exp3 = !(col("a") + lit(2));
+        let exp1 = col("a") + lit(&1);
+        let exp2 = col("a") + lit(&2);
+        let exp3 = !(col("a") + lit(&2));
 
         assert!(exp1 < exp2);
         assert!(exp3 > exp2);
@@ -3708,7 +3708,7 @@ mod test {
 
         // multiple columns
         {
-            let expr = col("a") + col("b") + lit(1);
+            let expr = col("a") + col("b") + lit(&1);
             let columns = expr.column_refs();
             assert_eq!(2, columns.len());
             assert!(columns.contains(&Column::from_name("a")));
@@ -3721,35 +3721,35 @@ mod test {
     #[test]
     fn test_logical_ops() {
         assert_eq!(
-            format!("{}", lit(1u32).eq(lit(2u32))),
+            format!("{}", lit(&1u32).eq(lit(&2u32))),
             "UInt32(1) = UInt32(2)"
         );
         assert_eq!(
-            format!("{}", lit(1u32).not_eq(lit(2u32))),
+            format!("{}", lit(&1u32).not_eq(lit(&2u32))),
             "UInt32(1) != UInt32(2)"
         );
         assert_eq!(
-            format!("{}", lit(1u32).gt(lit(2u32))),
+            format!("{}", lit(&1u32).gt(lit(&2u32))),
             "UInt32(1) > UInt32(2)"
         );
         assert_eq!(
-            format!("{}", lit(1u32).gt_eq(lit(2u32))),
+            format!("{}", lit(&1u32).gt_eq(lit(&2u32))),
             "UInt32(1) >= UInt32(2)"
         );
         assert_eq!(
-            format!("{}", lit(1u32).lt(lit(2u32))),
+            format!("{}", lit(&1u32).lt(lit(&2u32))),
             "UInt32(1) < UInt32(2)"
         );
         assert_eq!(
-            format!("{}", lit(1u32).lt_eq(lit(2u32))),
+            format!("{}", lit(&1u32).lt_eq(lit(&2u32))),
             "UInt32(1) <= UInt32(2)"
         );
         assert_eq!(
-            format!("{}", lit(1u32).and(lit(2u32))),
+            format!("{}", lit(&1u32).and(lit(&2u32))),
             "UInt32(1) AND UInt32(2)"
         );
         assert_eq!(
-            format!("{}", lit(1u32).or(lit(2u32))),
+            format!("{}", lit(&1u32).or(lit(&2u32))),
             "UInt32(1) OR UInt32(2)"
         );
     }
@@ -3896,7 +3896,7 @@ mod test {
             format!(
                 "{}",
                 SchemaDisplay(
-                    &lit(1).alias_qualified("table_name".into(), "column_name")
+                    &lit(&1).alias_qualified("table_name".into(), "column_name")
                 )
             ),
             "table_name.column_name"
@@ -3908,7 +3908,7 @@ mod test {
         assert_eq!(
             format!(
                 "{}",
-                SchemaDisplay(&lit(1).alias_qualified(None::<&str>, "column_name"))
+                SchemaDisplay(&lit(&1).alias_qualified(None::<&str>, "column_name"))
             ),
             "column_name"
         );
@@ -3949,7 +3949,7 @@ mod test {
     fn test_accept_exprs() {
         fn accept_exprs<E: AsRef<Expr>>(_: &[E]) {}
 
-        let expr = || -> Expr { lit(1) };
+        let expr = || -> Expr { lit(&1) };
 
         // Call accept_exprs with owned expressions
         let owned_exprs = vec![expr(), expr()];

--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -390,7 +390,7 @@ mod test {
                     } else {
                         utf8_val
                     };
-                    Ok(Transformed::yes(lit_with_metadata(utf8_val, metadata)))
+                    Ok(Transformed::yes(lit_with_metadata(&utf8_val, metadata)))
                 }
                 // otherwise, return None
                 _ => Ok(Transformed::no(expr)),
@@ -399,19 +399,19 @@ mod test {
 
         // rewrites "foo" --> "bar"
         let rewritten = col("state")
-            .eq(lit("foo"))
+            .eq(lit(&"foo"))
             .transform(transformer)
             .data()
             .unwrap();
-        assert_eq!(rewritten, col("state").eq(lit("bar")));
+        assert_eq!(rewritten, col("state").eq(lit(&"bar")));
 
         // doesn't rewrite
         let rewritten = col("state")
-            .eq(lit("baz"))
+            .eq(lit(&"baz"))
             .transform(transformer)
             .data()
             .unwrap();
-        assert_eq!(rewritten, col("state").eq(lit("baz")));
+        assert_eq!(rewritten, col("state").eq(lit(&"baz")));
     }
 
     #[test]
@@ -486,7 +486,7 @@ mod test {
     #[test]
     fn rewriter_visit() {
         let mut rewriter = RecordingRewriter::default();
-        col("state").eq(lit("CO")).rewrite(&mut rewriter).unwrap();
+        col("state").eq(lit(&"CO")).rewrite(&mut rewriter).unwrap();
 
         assert_eq!(
             rewriter.v,
@@ -514,7 +514,7 @@ mod test {
         );
 
         // change literal type from i32 to i64
-        test_rewrite(col("a").add(lit(1i32)), col("a").add(lit(1i64)));
+        test_rewrite(col("a").add(lit(&1i32)), col("a").add(lit(&1i64)));
 
         // test preserve qualifier
         test_rewrite(

--- a/datafusion/expr/src/expr_rewriter/order_by.rs
+++ b/datafusion/expr/src/expr_rewriter/order_by.rs
@@ -52,7 +52,7 @@ fn rewrite_sort_col_by_aggs(expr: Expr, plan: &LogicalPlan) -> Result<Expr> {
     // on top of them)
     if plan_inputs.len() == 1 {
         let proj_exprs = plan.expressions();
-        rewrite_in_terms_of_projection(expr, proj_exprs, plan_inputs[0])
+        rewrite_in_terms_of_projection(expr, &proj_exprs, plan_inputs[0])
     } else {
         Ok(expr)
     }
@@ -71,7 +71,7 @@ fn rewrite_sort_col_by_aggs(expr: Expr, plan: &LogicalPlan) -> Result<Expr> {
 /// 2. t produces an output schema with two columns "a", "b + c"
 fn rewrite_in_terms_of_projection(
     expr: Expr,
-    proj_exprs: Vec<Expr>,
+    proj_exprs: &[Expr],
     input: &LogicalPlan,
 ) -> Result<Expr> {
     // assumption is that each item in exprs, such as "b + c" is
@@ -104,7 +104,7 @@ fn rewrite_in_terms_of_projection(
 
         // look for the column named the same as this expr
         let mut found = None;
-        for proj_expr in &proj_exprs {
+        for proj_expr in proj_exprs {
             proj_expr.apply(|e| {
                 if expr_match(&search_col, e) {
                     found = Some(e.clone());
@@ -215,7 +215,7 @@ mod test {
             //  projects out an expression "c1" that is different than the column "c1"
             .project(vec![
                 // c1 + 1 as c1,
-                col("c1").add(lit(1)).alias("c1"),
+                col("c1").add(lit(&1)).alias("c1"),
                 // min(c2)
                 min(col("c2")),
                 // avg("c3") as average

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -178,7 +178,7 @@ impl ExprSchemable for Expr {
                             },
                             utils::generate_signature_error_msg(
                                 func.name(),
-                                func.signature().clone(),
+                                func.signature(),
                                 &data_types
                             )
                         )
@@ -525,7 +525,7 @@ impl ExprSchemable for Expr {
                             },
                             utils::generate_signature_error_msg(
                                 func.name(),
-                                func.signature().clone(),
+                                func.signature(),
                                 &arg_types,
                             )
                         )
@@ -554,7 +554,7 @@ impl ExprSchemable for Expr {
                             },
                             utils::generate_signature_error_msg(
                                 func.name(),
-                                func.signature().clone(),
+                                func.signature(),
                                 &arg_types,
                             )
                         )
@@ -684,7 +684,7 @@ impl Expr {
                             },
                             utils::generate_signature_error_msg(
                                 fun.name(),
-                                fun.signature(),
+                                &fun.signature(),
                                 &data_types
                             )
                         )
@@ -712,7 +712,7 @@ impl Expr {
                             },
                             utils::generate_signature_error_msg(
                                 fun.name(),
-                                fun.signature(),
+                                &fun.signature(),
                                 &data_types
                             )
                         )
@@ -779,14 +779,14 @@ mod tests {
 
     macro_rules! test_is_expr_nullable {
         ($EXPR_TYPE:ident) => {{
-            let expr = lit(ScalarValue::Null).$EXPR_TYPE();
+            let expr = lit(&ScalarValue::Null).$EXPR_TYPE();
             assert!(!expr.nullable(&MockExprSchema::new()).unwrap());
         }};
     }
 
     #[test]
     fn expr_schema_nullability() {
-        let expr = col("foo").eq(lit(1));
+        let expr = col("foo").eq(lit(&1));
         assert!(!expr.nullable(&MockExprSchema::new()).unwrap());
         assert!(expr
             .nullable(&MockExprSchema::new().with_nullable(true))
@@ -810,16 +810,16 @@ mod tests {
                 .with_nullable(nullable)
         };
 
-        let expr = col("foo").between(lit(1), lit(2));
+        let expr = col("foo").between(lit(&1), lit(&2));
         assert!(!expr.nullable(&get_schema(false)).unwrap());
         assert!(expr.nullable(&get_schema(true)).unwrap());
 
-        let null = lit(ScalarValue::Int32(None));
+        let null = lit(&ScalarValue::Int32(None));
 
-        let expr = col("foo").between(null.clone(), lit(2));
+        let expr = col("foo").between(null.clone(), lit(&2));
         assert!(expr.nullable(&get_schema(false)).unwrap());
 
-        let expr = col("foo").between(lit(1), null.clone());
+        let expr = col("foo").between(lit(&1), null.clone());
         assert!(expr.nullable(&get_schema(false)).unwrap());
 
         let expr = col("foo").between(null.clone(), null);
@@ -834,7 +834,7 @@ mod tests {
                 .with_nullable(nullable)
         };
 
-        let expr = col("foo").in_list(vec![lit(1); 5], false);
+        let expr = col("foo").in_list(vec![lit(&1); 5], false);
         assert!(!expr.nullable(&get_schema(false)).unwrap());
         assert!(expr.nullable(&get_schema(true)).unwrap());
         // Testing nullable() returns an error.
@@ -842,12 +842,12 @@ mod tests {
             .nullable(&get_schema(false).with_error_on_nullable(true))
             .is_err());
 
-        let null = lit(ScalarValue::Int32(None));
-        let expr = col("foo").in_list(vec![null, lit(1)], false);
+        let null = lit(&ScalarValue::Int32(None));
+        let expr = col("foo").in_list(vec![null, lit(&1)], false);
         assert!(expr.nullable(&get_schema(false)).unwrap());
 
         // Testing on long list
-        let expr = col("foo").in_list(vec![lit(1); 6], false);
+        let expr = col("foo").in_list(vec![lit(&1); 6], false);
         assert!(expr.nullable(&get_schema(false)).unwrap());
     }
 
@@ -859,11 +859,11 @@ mod tests {
                 .with_nullable(nullable)
         };
 
-        let expr = col("foo").like(lit("bar"));
+        let expr = col("foo").like(lit(&"bar"));
         assert!(!expr.nullable(&get_schema(false)).unwrap());
         assert!(expr.nullable(&get_schema(true)).unwrap());
 
-        let expr = col("foo").like(lit(ScalarValue::Utf8(None)));
+        let expr = col("foo").like(lit(&ScalarValue::Utf8(None)));
         assert!(expr.nullable(&get_schema(false)).unwrap());
     }
 

--- a/datafusion/expr/src/literal.rs
+++ b/datafusion/expr/src/literal.rs
@@ -21,11 +21,11 @@ use crate::Expr;
 use datafusion_common::{metadata::FieldMetadata, ScalarValue};
 
 /// Create a literal expression
-pub fn lit<T: Literal>(n: T) -> Expr {
+pub fn lit<T: Literal>(n: &T) -> Expr {
     n.lit()
 }
 
-pub fn lit_with_metadata<T: Literal>(n: T, metadata: Option<FieldMetadata>) -> Expr {
+pub fn lit_with_metadata<T: Literal>(n: &T, metadata: Option<FieldMetadata>) -> Expr {
     let Some(metadata) = metadata else {
         return n.lit();
     };
@@ -45,7 +45,7 @@ pub fn lit_with_metadata<T: Literal>(n: T, metadata: Option<FieldMetadata>) -> E
 }
 
 /// Create a literal timestamp expression
-pub fn lit_timestamp_nano<T: TimestampLiteral>(n: T) -> Expr {
+pub fn lit_timestamp_nano<T: TimestampLiteral>(n: &T) -> Expr {
     n.lit_timestamp_nano()
 }
 
@@ -202,24 +202,24 @@ mod test {
 
     #[test]
     fn test_lit_nonzero() {
-        let expr = col("id").eq(lit(NonZeroU32::new(1).unwrap()));
-        let expected = col("id").eq(lit(ScalarValue::UInt32(Some(1))));
+        let expr = col("id").eq(lit(&NonZeroU32::new(1).unwrap()));
+        let expected = col("id").eq(lit(&ScalarValue::UInt32(Some(1))));
         assert_eq!(expr, expected);
     }
 
     #[test]
     fn test_lit_timestamp_nano() {
-        let expr = col("time").eq(lit_timestamp_nano(10)); // 10 is an implicit i32
+        let expr = col("time").eq(lit_timestamp_nano(&10)); // 10 is an implicit i32
         let expected =
-            col("time").eq(lit(ScalarValue::TimestampNanosecond(Some(10), None)));
+            col("time").eq(lit(&ScalarValue::TimestampNanosecond(Some(10), None)));
         assert_eq!(expr, expected);
 
         let i: i64 = 10;
-        let expr = col("time").eq(lit_timestamp_nano(i));
+        let expr = col("time").eq(lit_timestamp_nano(&i));
         assert_eq!(expr, expected);
 
         let i: u32 = 10;
-        let expr = col("time").eq(lit_timestamp_nano(i));
+        let expr = col("time").eq(lit_timestamp_nano(&i));
         assert_eq!(expr, expected);
     }
 }

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -642,9 +642,9 @@ impl LogicalPlanBuilder {
         let skip_expr = if skip == 0 {
             None
         } else {
-            Some(lit(skip as i64))
+            Some(lit(&(skip as i64)))
         };
-        let fetch_expr = fetch.map(|f| lit(f as i64));
+        let fetch_expr = fetch.map(|f| lit(&(f as i64)));
         self.limit_by_expr(skip_expr, fetch_expr)
     }
 
@@ -2200,7 +2200,7 @@ mod tests {
     fn plan_builder_simple() -> Result<()> {
         let plan =
             table_scan(Some("employee_csv"), &employee_schema(), Some(vec![0, 3]))?
-                .filter(col("state").eq(lit("CO")))?
+                .filter(col("state").eq(lit(&"CO")))?
                 .project(vec![col("id")])?
                 .build()?;
 
@@ -2318,7 +2318,7 @@ mod tests {
     fn plan_builder_simple_distinct() -> Result<()> {
         let plan =
             table_scan(Some("employee_csv"), &employee_schema(), Some(vec![0, 3]))?
-                .filter(col("state").eq(lit("CO")))?
+                .filter(col("state").eq(lit(&"CO")))?
                 .project(vec![col("id")])?
                 .distinct()?
                 .build()?;
@@ -2691,7 +2691,7 @@ mod tests {
 
     #[test]
     fn test_union_after_join() -> Result<()> {
-        let values = vec![vec![lit(1)]];
+        let values = vec![vec![lit(&1)]];
 
         let left = LogicalPlanBuilder::values(values.clone())?
             .alias("left")?
@@ -2816,8 +2816,8 @@ mod tests {
                 .collect();
         let metadata = FieldMetadata::from(metadata);
         let values = LogicalPlanBuilder::values(vec![
-            vec![lit_with_metadata(1, Some(metadata.clone()))],
-            vec![lit_with_metadata(2, Some(metadata.clone()))],
+            vec![lit_with_metadata(&1, Some(metadata.clone()))],
+            vec![lit_with_metadata(&2, Some(metadata.clone()))],
         ])?
         .build()?;
         assert_eq!(*values.schema().field(0).metadata(), metadata.to_hashmap());
@@ -2829,8 +2829,8 @@ mod tests {
                 .collect();
         let metadata2 = FieldMetadata::from(metadata2);
         assert!(LogicalPlanBuilder::values(vec![
-            vec![lit_with_metadata(1, Some(metadata.clone()))],
-            vec![lit_with_metadata(2, Some(metadata2.clone()))],
+            vec![lit_with_metadata(&1, Some(metadata.clone()))],
+            vec![lit_with_metadata(&2, Some(metadata2.clone()))],
         ])
         .is_err());
 

--- a/datafusion/expr/src/operation.rs
+++ b/datafusion/expr/src/operation.rs
@@ -179,57 +179,57 @@ mod tests {
     fn test_operators() {
         // Add
         assert_eq!(
-            format!("{}", lit(1u32) + lit(2u32)),
+            format!("{}", lit(&1u32) + lit(&2u32)),
             "UInt32(1) + UInt32(2)"
         );
         // Sub
         assert_eq!(
-            format!("{}", lit(1u32) - lit(2u32)),
+            format!("{}", lit(&1u32) - lit(&2u32)),
             "UInt32(1) - UInt32(2)"
         );
         // Mul
         assert_eq!(
-            format!("{}", lit(1u32) * lit(2u32)),
+            format!("{}", lit(&1u32) * lit(&2u32)),
             "UInt32(1) * UInt32(2)"
         );
         // Div
         assert_eq!(
-            format!("{}", lit(1u32) / lit(2u32)),
+            format!("{}", lit(&1u32) / lit(&2u32)),
             "UInt32(1) / UInt32(2)"
         );
         // Rem
         assert_eq!(
-            format!("{}", lit(1u32) % lit(2u32)),
+            format!("{}", lit(&1u32) % lit(&2u32)),
             "UInt32(1) % UInt32(2)"
         );
         // BitAnd
         assert_eq!(
-            format!("{}", lit(1u32) & lit(2u32)),
+            format!("{}", lit(&1u32) & lit(&2u32)),
             "UInt32(1) & UInt32(2)"
         );
         // BitOr
         assert_eq!(
-            format!("{}", lit(1u32) | lit(2u32)),
+            format!("{}", lit(&1u32) | lit(&2u32)),
             "UInt32(1) | UInt32(2)"
         );
         // BitXor
         assert_eq!(
-            format!("{}", lit(1u32) ^ lit(2u32)),
+            format!("{}", lit(&1u32) ^ lit(&2u32)),
             "UInt32(1) BIT_XOR UInt32(2)"
         );
         // Shl
         assert_eq!(
-            format!("{}", lit(1u32) << lit(2u32)),
+            format!("{}", lit(&1u32) << lit(&2u32)),
             "UInt32(1) << UInt32(2)"
         );
         // Shr
         assert_eq!(
-            format!("{}", lit(1u32) >> lit(2u32)),
+            format!("{}", lit(&1u32) >> lit(&2u32)),
             "UInt32(1) >> UInt32(2)"
         );
         // Neg
-        assert_eq!(format!("{}", -lit(1u32)), "(- UInt32(1))");
+        assert_eq!(format!("{}", -lit(&1u32)), "(- UInt32(1))");
         // Not
-        assert_eq!(format!("{}", !lit(1u32)), "NOT UInt32(1)");
+        assert_eq!(format!("{}", !lit(&1u32)), "NOT UInt32(1)");
     }
 }

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -260,7 +260,7 @@ impl WindowFrame {
                 // ORDER BY clause is present but has more than one column,
                 // it is unchanged. Note that this follows PostgreSQL behavior.
                 if order_by.is_empty() {
-                    order_by.push(lit(1u64).sort(true, false));
+                    order_by.push(lit(&(1u64)).sort(true, false));
                 }
             }
             WindowFrameUnits::Range if order_by.len() != 1 => {


### PR DESCRIPTION
## Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
- Closes #18504.

## Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Mostly followed suggestions from the linter.


## What changes are included in this PR?
* Followed linter suggestions, substituting moves for borrows where appropriate.
* Updated tests to reflect the new function signatures and passed appropriate references.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, I ran `cargo test --package datafusion-expr` and all but one passed (based on my observations, it seems to not be related to my changes). The failed test is:
`test expr_rewriter::order_by::test::rewrite_sort_cols_by_agg_alias ... FAILED`
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
I am not entirely familiar with the codebase so let me know if any external API/documentation needs to change. Many function signatures have been updated to accept references wrt suggestions from the lint rule.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
