### PR TITLE
test: add prepare alias slt test

### DIFF
--- a/datafusion/sqllogictest/test_files/prepare.slt
+++ b/datafusion/sqllogictest/test_files/prepare.slt
@@ -327,3 +327,35 @@ EXECUTE my_plan('a', 'b');
 ----
 1 a
 2 b
+
+statement ok
+SET datafusion.explain.logical_plan_only=false;
+
+statement ok
+DEALLOCATE my_plan
+
+statement ok
+SET datafusion.explain.logical_plan_only=true;
+
+# Prepare with alias
+query TT
+EXPLAIN PREPARE my_plan(INT, INT) AS SELECT $1 AS one, $2 AS two;
+----
+logical_plan
+01)Prepare: "my_plan" [Int32, Int32]
+02)--Projection: $1 AS one, $2 AS two
+03)----EmptyRelation: rows=1
+
+statement ok
+PREPARE my_plan(INT, INT) AS SELECT $1 AS one, $2 AS two;
+
+query II
+EXECUTE my_plan(1, 2)
+----
+1 2
+
+statement ok
+SET datafusion.explain.logical_plan_only=false;
+
+statement ok
+DEALLOCATE my_plan


### PR DESCRIPTION
## Which issue does this PR close?


This did not work (https://github.com/apache/datafusion/issues/18102#issuecomment-3412355785):

```sql
DataFusion CLI v50.3.0
> prepare myplan as select $1 as one, $2 as two;
Schema error: No field named one.
```

But now it does (https://github.com/apache/datafusion/issues/18102#issuecomment-3493941636):

```sql
DataFusion CLI v50.3.0
> PREPARE my_plan(INT, INT) AS SELECT $1 AS one, $2 AS two;
0 row(s) fetched.
Elapsed 0.004 seconds.

>
```

## Rationale for this change

This PR add a testcase for placeholder aliases.

## What changes are included in this PR?

Add test case in `prepare.slt`

## Are these changes tested?

Yes

## Are there any user-facing changes?

No