### PR TITLE
Avoid double optimizing in tpchds_planning tests to avoid masking errors

### DIFF
--- a/datafusion/core/tests/tpcds_planning.rs
+++ b/datafusion/core/tests/tpcds_planning.rs
@@ -1051,10 +1051,13 @@ async fn regression_test(query_no: u8, create_physical: bool) -> Result<()> {
 
     for sql in &sql {
         let df = ctx.sql(sql).await?;
-        let (state, plan) = df.into_parts();
-        let plan = state.optimize(&plan)?;
-        if create_physical {
-            let _ = state.create_physical_plan(&plan).await?;
+        // attempt to mimic planning steps
+        if !create_physical {
+            let (state, plan) = df.into_parts();
+            let _ = state.optimize(&plan)?;
+        } else {
+            // this is what df.execute() does internally
+            let _ = df.create_physical_plan().await?;
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/17801

## Rationale for this change

We made a change that causes a regression in planning one of the tpcds benchmarks (see https://github.com/apache/datafusion/issues/17801)

However, we only found the problem when running planning benchmarks. The normal CI test pass. We have a `tpchds_planning` suite to test for exactly this scenario, so that test should have failed as well

Debugging more it turns out that the test somewhat non obviously calls `optimize` twice on the LogicalPlan which in this case masks the error. 

## What changes are included in this PR?

1. avoid calling optimize twice in the test 

Note that due to https://github.com/apache/datafusion/issues/17801 the test now fails like this:

```shell
cargo test --test tpcds_planning
```

```
---- tpcds_physical_q75 stdout ----
Error: Internal("Physical input schema should be the same as the one converted from logical input schema. Differences: \n\t- field nullability at index 5 [sales_cnt]: (physical) true vs (logical) false\n\t- field nullability at index 6 [sales_amt]: (physical) true vs (logical) false")

```


## Are these changes tested?
They are only tests

## Are there any user-facing changes?

No, this is an internal only change