### PR TITLE
Update release download links on download page

### DIFF
--- a/docs/source/download.md
+++ b/docs/source/download.md
@@ -20,7 +20,7 @@
 # Download
 
 Most users use DataFusion as a library in their Rust projects by adding it as a dependency
-in their `Cargo.toml` file and downloading it from the Rust [crates.io] package registry. 
+in their `Cargo.toml` file and downloading it from the Rust [crates.io] package registry.
 
 For example:
 
@@ -36,9 +36,8 @@ official Apache DataFusion releases are provided as source artifacts.
 
 ## Releases
 
-You can find the latest releases, signatures and checksums on 
+You can find the latest releases, signatures and checksums on
 the [ASF Release Page](https://dist.apache.org/repos/dist/release/datafusion)
-
 
 For previous releases, please check the [archive](https://archive.apache.org/dist/datafusion/).
 
@@ -50,7 +49,7 @@ For releases earlier than 37.0.0, please check [Arrow's archive](https://archive
 - The [KEYS] file contains the public keys used for signing release. It is recommended that (when possible) a web of trust is used to confirm the identity of these keys.
 - Please download the [KEYS] file as well as the .asc signature files.
 
-[KEYS]: https://downloads.apache.org/datafusion/KEYS
+[keys]: https://downloads.apache.org/datafusion/KEYS
 
 ### To verify the signature of the release artifact
 


### PR DESCRIPTION
## Which issue does this PR close?

- part of https://github.com/apache/datafusion/issues/17558
- Related to https://github.com/apache/datafusion/pull/18549

## Rationale for this change

While working on https://github.com/apache/datafusion/pull/18549 I noticed that the release download page was out of date

https://datafusion.apache.org/download.html

<img width="816" height="456" alt="Screenshot 2025-11-08 at 6 31 50 AM" src="https://github.com/user-attachments/assets/4678bc8e-0d85-4951-91af-3b1c0ee00a26" />


## What changes are included in this PR?

Update links (I will comment more inline)

## Are these changes tested?

I manually rendered the page:

<img width="846" height="869" alt="Screenshot 2025-11-08 at 6 39 00 AM" src="https://github.com/user-attachments/assets/e8312c7c-b4af-43f9-9767-ae234c08c928" />


## Are there any user-facing changes?

Updated download page that is not outdated 