### PR TITLE
chore: enforce clippy lint needless_pass_by_value to physical-expr-common

### DIFF
--- a/datafusion/physical-expr-common/src/lib.rs
+++ b/datafusion/physical-expr-common/src/lib.rs
@@ -23,6 +23,9 @@
 // Make sure fast / cheap clones on Arc are explicit:
 // https://github.com/apache/datafusion/issues/11143
 #![deny(clippy::clone_on_ref_ptr)]
+// https://github.com/apache/datafusion/issues/18503
+#![deny(clippy::needless_pass_by_value)]
+#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Physical Expr Common packages for [DataFusion]
 //! This package contains high level PhysicalExpr trait


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18543

## What changes are included in this PR?
enforce clippy lint `needless_pass_by_value` to `datafusion-physical-expr-common`

## Are these changes tested?

yes

## Are there any user-facing changes?

no
