### PR TITLE
Fix out-of-bounds access in SLT runner

### DIFF
--- a/datafusion/sqllogictest/src/util.rs
+++ b/datafusion/sqllogictest/src/util.rs
@@ -95,7 +95,7 @@ pub fn df_value_validator(
             warn!("[{i}] {}<eol>", normalized_actual[i]);
             warn!(
                 "[{i}] {}<eol>",
-                if normalized_expected.len() >= i {
+                if normalized_expected.len() > i {
                     &normalized_expected[i]
                 } else {
                     "No more results"


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

A small fix for a rare case in SLT runner when it panics instead of printing result.

## What changes are included in this PR?

Code change in sqllogictest

## Are these changes tested?

Manual test

## Are there any user-facing changes?

No
