### PR TITLE
[branch-51] Update Changelog

### DIFF
--- a/dev/changelog/51.0.0.md
+++ b/dev/changelog/51.0.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # Apache DataFusion 51.0.0 Changelog
 
-This release consists of 531 commits from 128 contributors. See credits at the end of this changelog for more information.
+This release consists of 533 commits from 128 contributors. See credits at the end of this changelog for more information.
 
 See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgrading.html) for information on how to upgrade from previous versions.
 
@@ -126,7 +126,6 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - feat: Add `reduction_factor` metric to `AggregateExec` for EXPLAIN ANALYZE [#18455](https://github.com/apache/datafusion/pull/18455) (petern48)
 - feat: support named arguments for aggregate and window udfs [#18389](https://github.com/apache/datafusion/pull/18389) (bubulalabu)
 - feat: Add selectivity metric to NestedLoopJoinExec for EXPLAIN ANALYZE [#18481](https://github.com/apache/datafusion/pull/18481) (petern48)
-- feat: Enhance `array_slice` functionality to support `ListView` and `LargeListView` types [#18432](https://github.com/apache/datafusion/pull/18432) (Weijun-H)
 
 **Fixed bugs:**
 
@@ -260,6 +259,8 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - Fix instances of "the the" to be "the" in comments/docs [#18478](https://github.com/apache/datafusion/pull/18478) (corasaurus-hex)
 - Update roadmap links for DataFusion Q1 2026 [#18495](https://github.com/apache/datafusion/pull/18495) (alamb)
 - Add a SpillingPool to manage collections of spill files [#18207](https://github.com/apache/datafusion/pull/18207) (adriangb)
+- [branch-51] Update version to 51.0.0, add Changelog [#18551](https://github.com/apache/datafusion/pull/18551) (alamb)
+- [branch-51] Revert rewrite for coalesce, `nvl` and `nvl2` simplification [#18567](https://github.com/apache/datafusion/pull/18567) (alamb)
 
 **Other:**
 
@@ -572,8 +573,6 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - Add comments to Cargo.toml about workspace overrides [#18526](https://github.com/apache/datafusion/pull/18526) (alamb)
 - minor: Remove inconsistent comment [#18539](https://github.com/apache/datafusion/pull/18539) (2010YOUY01)
 - Refactor `log()` signature to use coercion API + fixes [#18519](https://github.com/apache/datafusion/pull/18519) (Jefffrey)
-- chore(deps): bump taiki-e/install-action from 2.62.46 to 2.62.47 [#18508](https://github.com/apache/datafusion/pull/18508) (dependabot[bot])
-- Consolidate builtin functions examples (#18142) [#18523](https://github.com/apache/datafusion/pull/18523) (cj-zhukov)
 
 ## Credits
 
@@ -582,7 +581,7 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
 ```
     88	dependabot[bot]
     49	Jeffrey Vo
-    32	Andrew Lamb
+    34	Andrew Lamb
     20	Yongting You
     19	Adrian Garcia Badaracco
     14	Blake Orth


### PR DESCRIPTION
## Which issue does this PR close?

- part of https://github.com/apache/datafusion/issues/17558

## Rationale for this change

Per @xudong963  in https://github.com/apache/datafusion/pull/18567#issuecomment-3509612847, we should update the changelog on `branch-51` to incorporate
-  https://github.com/apache/datafusion/pull/18567

## What changes are included in this PR?

Ran
```shell
./dev/release/generate-changelog.py 50.3.0 branch-51 51.0.0 > dev/changelog/51.0.0.md
npx prettier@2.7.1 --write             '{datafusion,datafusion-cli,datafusion-examples,dev,docs}/**/*.md'             '!datafusion/CHANGELOG.md'             README.md             CONTRIBUTING.md
```

And checked in the results
## Are these changes tested?

By CI
## Are there any user-facing changes?
New changelog content