### PR TITLE
chore: enforce lint rule `clippy::needless_pass_by_value` to `datafusion-datasource-avro`

### DIFF
--- a/datafusion/datasource-avro/src/avro_to_arrow/reader.rs
+++ b/datafusion/datasource-avro/src/avro_to_arrow/reader.rs
@@ -113,7 +113,7 @@ impl ReaderBuilder {
             None => Arc::new(super::read_avro_schema_from_reader(&mut source)?),
         };
         source.rewind()?;
-        Reader::try_new(source, schema, self.batch_size, self.projection)
+        Reader::try_new(source, &schema, self.batch_size, self.projection.as_ref())
     }
 }
 
@@ -135,12 +135,12 @@ impl<R: Read> Reader<'_, R> {
     /// useful if plucking values from a struct, e.g. getting `a.b.c.e` from `a.b.c.{d, e}`.
     pub fn try_new(
         reader: R,
-        schema: SchemaRef,
+        schema: &SchemaRef,
         batch_size: usize,
-        projection: Option<Vec<String>>,
+        projection: Option<&Vec<String>>,
     ) -> Result<Self> {
         let projected_schema = projection.as_ref().filter(|p| !p.is_empty()).map_or_else(
-            || Arc::clone(&schema),
+            || Arc::clone(schema),
             |proj| {
                 Arc::new(arrow::datatypes::Schema::new(
                     proj.iter()

--- a/datafusion/datasource-avro/src/mod.rs
+++ b/datafusion/datasource-avro/src/mod.rs
@@ -23,6 +23,8 @@
 // Make sure fast / cheap clones on Arc are explicit:
 // https://github.com/apache/datafusion/issues/11143
 #![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
+#![deny(clippy::needless_pass_by_value)]
+#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! An [Avro](https://avro.apache.org/) based [`FileSource`](datafusion_datasource::file::FileSource) implementation and related functionality.
 

--- a/datafusion/datasource-avro/src/source.rs
+++ b/datafusion/datasource-avro/src/source.rs
@@ -61,9 +61,9 @@ impl AvroSource {
     fn open<R: std::io::Read>(&self, reader: R) -> Result<AvroReader<'static, R>> {
         AvroReader::try_new(
             reader,
-            Arc::clone(self.table_schema.file_schema()),
+            &Arc::clone(self.table_schema.file_schema()),
             self.batch_size.expect("Batch size must set before open"),
-            self.projection.clone(),
+            self.projection.clone().as_ref(),
         )
     }
 }


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #18612.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Enforce lint rule `clippy::needless_pass_by_value` to `datafusion-datasource-avro`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
