### PR TITLE
fix: Disable table name normalisation as default behaviour 

### DIFF
--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -129,7 +129,8 @@ impl Column {
     /// where `"foo.BAR"` would be parsed to a reference to column named `foo.BAR`
     pub fn from_qualified_name(flat_name: impl Into<String>) -> Self {
         let flat_name = flat_name.into();
-        Self::from_idents(parse_identifiers_normalized(&flat_name, false)).unwrap_or_else(
+
+        Self::from_idents(parse_identifiers_normalized(&flat_name, true)).unwrap_or_else(
             || Self {
                 relation: None,
                 name: flat_name,

--- a/datafusion/common/src/table_reference.rs
+++ b/datafusion/common/src/table_reference.rs
@@ -278,7 +278,7 @@ impl TableReference {
     /// identifier, normalizing `s` to lowercase.
     /// See docs on [`TableReference`] for more details.
     pub fn parse_str(s: &str) -> Self {
-        Self::parse_str_normalized(s, false)
+        Self::parse_str_normalized(s, true)
     }
 
     /// Forms a [`TableReference`] by parsing `s` as a multipart SQL
@@ -329,6 +329,26 @@ impl TableReference {
                 schema,
                 table,
             } => vec![catalog.to_string(), schema.to_string(), table.to_string()],
+        }
+    }
+
+    /// Will ignore case for all [TableReference] identifiers
+    pub fn to_ignore_case(&self) -> Self {
+        match self {
+            TableReference::Bare { table } => Self::bare(table.to_ascii_lowercase()),
+            TableReference::Partial { schema, table } => {
+                Self::partial(schema.to_ascii_lowercase(), table.to_ascii_lowercase())
+            }
+
+            TableReference::Full {
+                catalog,
+                schema,
+                table,
+            } => Self::full(
+                catalog.to_ascii_lowercase(),
+                schema.to_ascii_lowercase(),
+                table.to_ascii_lowercase(),
+            ),
         }
     }
 }

--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -416,12 +416,12 @@ mod test {
 
     #[test]
     fn normalize_cols() {
-        let expr = col("a") + col("b") + col("c");
+        let expr = col("A") + col("b") + col("c");
 
         // Schemas with some matching and some non matching cols
         let schema_a = make_schema_with_empty_metadata(
             vec![Some("tableA".into()), Some("tableA".into())],
-            vec!["a", "aa"],
+            vec!["A", "aa"],
         );
         let schema_c = make_schema_with_empty_metadata(
             vec![Some("tableC".into()), Some("tableC".into())],
@@ -442,7 +442,7 @@ mod test {
                 .unwrap();
         assert_eq!(
             normalized_expr,
-            col("tableA.a") + col("tableB.b") + col("tableC.c")
+            col("tableA.A") + col("tableB.b") + col("tableC.c")
         );
     }
 

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -2222,13 +2222,13 @@ mod tests {
                 .unwrap();
         assert_snapshot!(plan.schema().as_ref(), @"fields:[employee_csv.id, employee_csv.first_name, employee_csv.last_name, employee_csv.state, employee_csv.salary], metadata:{}");
 
-        // Note scan of "EMPLOYEE_CSV" is treated as a SQL identifier
-        // (and thus normalized to "employee"csv") as well
+        // Identifiers should be normalized at parsing time
+        // if explicitly set to uppercase it should be preserved
         let projection = None;
         let plan =
             LogicalPlanBuilder::scan("EMPLOYEE_CSV", table_source(&schema), projection)
                 .unwrap();
-        assert_snapshot!(plan.schema().as_ref(), @"fields:[employee_csv.id, employee_csv.first_name, employee_csv.last_name, employee_csv.state, employee_csv.salary], metadata:{}");
+        assert_snapshot!(plan.schema().as_ref(), @"fields:[EMPLOYEE_CSV.id, EMPLOYEE_CSV.first_name, EMPLOYEE_CSV.last_name, EMPLOYEE_CSV.state, EMPLOYEE_CSV.salary], metadata:{}");
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18675.

## Rationale for this change

There are cases for which case sensitive column names and table references are needed, so having forced `to_ascii_lowercase`  for  names breaks support for them. 

`datafusion.sql_parser.enable_ident_normalization=false` will help with column names but table names and few other things will be converted to lowercase, or not (as described in the bug)

This is potentially VERY BREAKING change, it disables forced `to_ascii_lowercase` for table reference and columns, as behaviour was hardcoded. 

## What changes are included in this PR?

- disable forced to lowercase conversion for table ref and columns 
- test to verify bug 

## Are these changes tested?

yes

## Are there any user-facing changes?

yes, some users can be affected if they have `enable_ident_normalization` disabled or if they rely on datafusion to automatically do `ident_normalization` 

