### PR TITLE
Fix Partial AggregateExec correctness issue dropping rows

### DIFF
--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -1318,7 +1318,7 @@ mod tests {
 
         // Create constrained memory to trigger early emission but not completely fail
         let runtime = RuntimeEnvBuilder::default()
-            .with_memory_limit(1024, 1.0) // 100KB - enough to start but will trigger pressure
+            .with_memory_limit(1024, 1.0) // small enough to start but will trigger pressure
             .build_arc()?;
 
         let mut task_ctx = TaskContext::default().with_runtime(runtime);


### PR DESCRIPTION
## Which issue does this PR close?
More detail is in the issue. 
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/18701

## Rationale for this change
This is a pretty major correctness issue.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Fixes issue and reorders skip aggregate and emit early within partial aggregate execution 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, the unit test that's added here previously failed before this change.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
