### PR TITLE
chore: enforce clippy lint needless_pass_by_value to datafusion-proto

### DIFF
--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -2435,7 +2435,7 @@ impl protobuf::PhysicalPlanNode {
         let agg = exec
             .aggr_expr()
             .iter()
-            .map(|expr| serialize_physical_aggr_expr(&expr.to_owned(), extension_codec))
+            .map(|expr| serialize_physical_aggr_expr(expr.to_owned(), extension_codec))
             .collect::<Result<Vec<_>>>()?;
 
         let agg_names = exec

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -52,8 +52,9 @@ use crate::protobuf::{
 
 use super::PhysicalExtensionCodec;
 
+#[expect(clippy::needless_pass_by_value)]
 pub fn serialize_physical_aggr_expr(
-    aggr_expr: &Arc<AggregateFunctionExpr>,
+    aggr_expr: Arc<AggregateFunctionExpr>,
     codec: &dyn PhysicalExtensionCodec,
 ) -> Result<protobuf::PhysicalExprNode> {
     let expressions = serialize_physical_exprs(&aggr_expr.expressions(), codec)?;


### PR DESCRIPTION
## Which issue does this PR close?
- Part of parent issue #18503

## What changes are included in this PR?
enforce clippy lint `needless_pass_by_value` to `datafusion-proto`

## Are these changes tested?
yes

## Are there any user-facing changes?

no
