### PR TITLE
chore: enforce clippy lint needless_pass_by_value to datafusion-execution

### DIFF
--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -79,7 +79,7 @@ impl DiskManagerBuilder {
                 used_disk_space: Arc::new(AtomicU64::new(0)),
             }),
             DiskManagerMode::Directories(conf_dirs) => {
-                let local_dirs = create_local_dirs(conf_dirs)?;
+                let local_dirs = create_local_dirs(&conf_dirs)?;
                 debug!(
                     "Created local dirs {local_dirs:?} as DataFusion working directory"
                 );
@@ -188,7 +188,7 @@ impl DiskManager {
                 used_disk_space: Arc::new(AtomicU64::new(0)),
             })),
             DiskManagerConfig::NewSpecified(conf_dirs) => {
-                let local_dirs = create_local_dirs(conf_dirs)?;
+                let local_dirs = create_local_dirs(&conf_dirs)?;
                 debug!(
                     "Created local dirs {local_dirs:?} as DataFusion working directory"
                 );
@@ -408,7 +408,7 @@ impl Drop for RefCountedTempFile {
 }
 
 /// Setup local dirs by creating one new dir in each of the given dirs
-fn create_local_dirs(local_dirs: Vec<PathBuf>) -> Result<Vec<Arc<TempDir>>> {
+fn create_local_dirs(local_dirs: &[PathBuf]) -> Result<Vec<Arc<TempDir>>> {
     local_dirs
         .iter()
         .map(|root| {

--- a/datafusion/execution/src/lib.rs
+++ b/datafusion/execution/src/lib.rs
@@ -23,6 +23,9 @@
 // Make sure fast / cheap clones on Arc are explicit:
 // https://github.com/apache/datafusion/issues/11143
 #![deny(clippy::clone_on_ref_ptr)]
+// https://github.com/apache/datafusion/issues/18503
+#![deny(clippy::needless_pass_by_value)]
+#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! DataFusion execution configuration and runtime structures
 

--- a/datafusion/execution/src/memory_pool/pool.rs
+++ b/datafusion/execution/src/memory_pool/pool.rs
@@ -466,8 +466,8 @@ impl<I: MemoryPool> MemoryPool for TrackConsumersPool<I> {
                     DataFusionError::ResourcesExhausted(
                         provide_top_memory_consumers_to_error_msg(
                             &reservation.consumer().name,
-                            e,
-                            self.report_top(self.top.into()),
+                            &e,
+                            &self.report_top(self.top.into()),
                         ),
                     )
                 }
@@ -494,8 +494,8 @@ impl<I: MemoryPool> MemoryPool for TrackConsumersPool<I> {
 
 fn provide_top_memory_consumers_to_error_msg(
     consumer_name: &str,
-    error_msg: String,
-    top_consumers: String,
+    error_msg: &str,
+    top_consumers: &str,
 ) -> String {
     format!("Additional allocation failed for {consumer_name} with top memory consumers (across reservations) as:\n{top_consumers}\nError: {error_msg}")
 }


### PR DESCRIPTION
## Which issue does this PR close?
- Part of parent #18503

## What changes are included in this PR?

enforce clippy lint `needless_pass_by_value` to `datafusion-execution`

## Are these changes tested?

yes

## Are there any user-facing changes?
no