### PR TITLE
feat: support spark sec

### DIFF
--- a/datafusion/spark/src/function/math/mod.rs
+++ b/datafusion/spark/src/function/math/mod.rs
@@ -35,6 +35,7 @@ make_udf_function!(modulus::SparkPmod, pmod);
 make_udf_function!(rint::SparkRint, rint);
 make_udf_function!(width_bucket::SparkWidthBucket, width_bucket);
 make_udf_function!(trigonometry::SparkCsc, csc);
+make_udf_function!(trigonometry::SparkSec, sec);
 
 pub mod expr_fn {
     use datafusion_functions::export_functions;
@@ -51,6 +52,7 @@ pub mod expr_fn {
     export_functions!((rint, "Returns the double value that is closest in value to the argument and is equal to a mathematical integer.", arg1));
     export_functions!((width_bucket, "Returns the bucket number into which the value of this expression would fall after being evaluated.", arg1 arg2 arg3 arg4));
     export_functions!((csc, "Returns the cosecant of expr.", arg1));
+    export_functions!((sec, "Returns the secant of expr.", arg1));
 }
 
 pub fn functions() -> Vec<Arc<ScalarUDF>> {
@@ -63,5 +65,6 @@ pub fn functions() -> Vec<Arc<ScalarUDF>> {
         rint(),
         width_bucket(),
         csc(),
+        sec(),
     ]
 }

--- a/datafusion/sqllogictest/test_files/spark/math/sec.slt
+++ b/datafusion/sqllogictest/test_files/spark/math/sec.slt
@@ -23,5 +23,23 @@
 
 ## Original Query: SELECT sec(0);
 ## PySpark 3.5.5 Result: {'SEC(0)': 1.0, 'typeof(SEC(0))': 'double', 'typeof(0)': 'int'}
-#query
-#SELECT sec(0::int);
+query R
+SELECT sec(0::int);
+----
+1
+
+query R
+SELECT sec(a) FROM (VALUES (0::INT), (1::INT), (-1::INT), (null)) AS t(a);
+----
+1
+1.850815717680926
+1.850815717680926
+NULL
+
+query R
+SELECT sec(a) FROM (VALUES (pi()), (3 * pi()/2), (pi()/2) , (arrow_cast('NAN','Float32'))) AS t(a);
+----
+-1
+-5443746451065123
+16331239353195370
+NaN


### PR DESCRIPTION
## Which issue does this PR close?

Partially implements #15914 

## Rationale for this change

Spark has support for secant https://spark.apache.org/docs/latest/api/sql/index.html#sec.

This function is not there in other in DB's like postgres, mysql and sqlite3. Hence I have added this function into datafusion-spark

## What changes are included in this PR?

## Are these changes tested?

Yes, Unit tests with inputs/outputs obtained from spark

## Are there any user-facing changes?

Yes
