### PR TITLE
refactor: reduce duplication in make_udf_function macro

### DIFF
--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -83,7 +83,7 @@ macro_rules! export_functions {
 /// This is used to ensure creating the list of `ScalarUDF` only happens once.
 #[macro_export]
 macro_rules! make_udf_function {
-    ($UDF:ty, $NAME:ident) => {
+    ($UDF:ty, $NAME:ident, $CTOR:expr) => {
         #[allow(rustdoc::redundant_explicit_links)]
         #[doc = concat!("Return a [`ScalarUDF`](datafusion_expr::ScalarUDF) implementation of ", stringify!($NAME))]
         pub fn $NAME() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
@@ -92,26 +92,14 @@ macro_rules! make_udf_function {
                 std::sync::Arc<datafusion_expr::ScalarUDF>,
             > = std::sync::LazyLock::new(|| {
                 std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
-                    <$UDF>::new(),
+                    ($CTOR)(),
                 ))
             });
             std::sync::Arc::clone(&INSTANCE)
         }
     };
-    ($UDF:ty, $NAME:ident, $CTOR:path) => {
-        #[allow(rustdoc::redundant_explicit_links)]
-        #[doc = concat!("Return a [`ScalarUDF`](datafusion_expr::ScalarUDF) implementation of ", stringify!($NAME))]
-        pub fn $NAME() -> std::sync::Arc<datafusion_expr::ScalarUDF> {
-            // Singleton instance of the function
-            static INSTANCE: std::sync::LazyLock<
-                std::sync::Arc<datafusion_expr::ScalarUDF>,
-            > = std::sync::LazyLock::new(|| {
-                std::sync::Arc::new(datafusion_expr::ScalarUDF::new_from_impl(
-                    $CTOR(),
-                ))
-            });
-            std::sync::Arc::clone(&INSTANCE)
-        }
+    ($UDF:ty, $NAME:ident) => {
+        make_udf_function!($UDF, $NAME, <$UDF>::new);
     };
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #18669

## Rationale for this change

The `make_udf_function!` macro had significant code duplication between its two arms. Both arms contained nearly identical 16-line implementations that only differed in the constructor call. Additionally, the `$UDF` parameter was unused in the second arm, which was inefficient.

This refactoring eliminates the duplication by applying a delegation pattern, where the simpler 2-parameter arm now delegates to the more complete 3-parameter arm with a default constructor.

## What changes are included in this PR?

- **Reordered macro arms**: The 3-parameter arm (with `$CTOR`) is now first and contains the full implementation
- **Delegation pattern**: The 2-parameter arm now delegates to the 3-parameter arm by calling `make_udf_function!($UDF, $NAME, <$UDF>::new)`
- **Parameter type change**: Changed `$CTOR` from `:path` to `:expr` and wrap the call as `($CTOR)()` for flexibility
- **Fixed unused parameter**: The `$UDF` type parameter is now utilized in the 2-parameter arm to construct the default constructor path
- **Code reduction**: Reduced the macro from 33 lines to 25 lines by eliminating duplication

## Are these changes tested?

Yes 

## Are there any user-facing changes?

No 