### PR TITLE
chore: enforce clippy lint needless_pass_by_value to datafusion-functions-aggregate-common

### DIFF
--- a/datafusion/functions-aggregate-common/src/lib.rs
+++ b/datafusion/functions-aggregate-common/src/lib.rs
@@ -30,6 +30,9 @@
 // Make sure fast / cheap clones on Arc are explicit:
 // https://github.com/apache/datafusion/issues/11143
 #![deny(clippy::clone_on_ref_ptr)]
+// https://github.com/apache/datafusion/issues/18503
+#![deny(clippy::needless_pass_by_value)]
+#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 pub mod accumulator;
 pub mod aggregate;

--- a/datafusion/functions-aggregate-common/src/tdigest.rs
+++ b/datafusion/functions-aggregate-common/src/tdigest.rs
@@ -163,6 +163,7 @@ impl TDigest {
         }
     }
 
+    #[expect(clippy::needless_pass_by_value)]
     pub fn new_with_centroid(max_size: usize, centroid: Centroid) -> Self {
         TDigest {
             centroids: vec![centroid.clone()],


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #18503

## What changes are included in this PR?
 enforce clippy lint ` needless_pass_by_value` to `datafusion-functions-aggregate-common`
## Are these changes tested?
yes
## Are there any user-facing changes?
no
