### PR TITLE
fix: track elapsed_compute for file stream

### DIFF
--- a/datafusion/datasource/src/file_stream.rs
+++ b/datafusion/datasource/src/file_stream.rs
@@ -115,6 +115,7 @@ impl FileStream {
     /// Since file opening is mostly IO (and may involve a
     /// bunch of sequential IO), it can be parallelized with decoding.
     fn start_next_file(&mut self) -> Option<Result<(FileOpenFuture, Vec<ScalarValue>)>> {
+        let _timer = self.baseline_metrics.elapsed_compute().timer();
         let part_file = self.file_iter.pop_front()?;
 
         let partition_values = part_file.partition_values.clone();
@@ -213,6 +214,7 @@ impl FileStream {
                         Some(Ok(batch)) => {
                             self.file_stream_metrics.time_scanning_until_data.stop();
                             self.file_stream_metrics.time_scanning_total.stop();
+                            let _timer = self.baseline_metrics.elapsed_compute().timer();
                             let result = self
                                 .pc_projector
                                 .project(batch, partition_values)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Address `elapsed_compute` baseline metrics not counting issue mentioned in https://github.com/apache/datafusion/issues/18195.

Before

```
> create external table customer 
stored as parquet
location '/Users/jizezhang/datafusion/benchmarks/data/tpch_sf1/customer';
0 row(s) fetched. 
Elapsed 0.026 seconds.

> explain analyze
select * from customer;
... elapsed_compute=8ns ...

```
After
```
> create external table customer 
stored as parquet
location '/Users/jizezhang/datafusion/benchmarks/data/tpch_sf1/customer';
0 row(s) fetched. 
Elapsed 0.033 seconds.

> explain analyze
select * from customer;
... elapsed_compute=1.786625ms ...
```

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
