### PR TITLE
Fix input handling for encoding functions & various refactors

### DIFF
--- a/datafusion/functions/src/encoding/inner.rs
+++ b/datafusion/functions/src/encoding/inner.rs
@@ -30,8 +30,8 @@ use base64::{
     engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
 };
 use datafusion_common::{
-    DataFusionError, Result, ScalarValue, exec_datafusion_err, exec_err,
-    internal_datafusion_err, internal_err, not_impl_err, plan_err,
+    DataFusionError, Result, ScalarValue, exec_datafusion_err, exec_err, internal_err,
+    not_impl_err, plan_err,
     types::{NativeType, logical_string},
     utils::take_function_args,
 };
@@ -436,16 +436,15 @@ impl Encoding {
             // only write input / 2 bytes to buf
             let out_len = input.len() / 2;
             let buf = &mut buf[..out_len];
-            hex::decode_to_slice(input, buf).map_err(|e| {
-                internal_datafusion_err!("Failed to decode from hex: {e}")
-            })?;
+            hex::decode_to_slice(input, buf)
+                .map_err(|e| exec_datafusion_err!("Failed to decode from hex: {e}"))?;
             Ok(out_len)
         }
 
         fn base64_decode(input: &[u8], buf: &mut [u8]) -> Result<usize> {
-            BASE64_ENGINE.decode_slice(input, buf).map_err(|e| {
-                internal_datafusion_err!("Failed to decode from base64: {e}")
-            })
+            BASE64_ENGINE
+                .decode_slice(input, buf)
+                .map_err(|e| exec_datafusion_err!("Failed to decode from base64: {e}"))
         }
 
         match self {
@@ -473,16 +472,15 @@ impl Encoding {
             // only write input / 2 bytes to buf
             let out_len = input.len() / 2;
             let buf = &mut buf[..out_len];
-            hex::decode_to_slice(input, buf).map_err(|e| {
-                internal_datafusion_err!("Failed to decode from hex: {e}")
-            })?;
+            hex::decode_to_slice(input, buf)
+                .map_err(|e| exec_datafusion_err!("Failed to decode from hex: {e}"))?;
             Ok(out_len)
         }
 
         fn base64_decode(input: &[u8], buf: &mut [u8]) -> Result<usize> {
-            BASE64_ENGINE.decode_slice(input, buf).map_err(|e| {
-                internal_datafusion_err!("Failed to decode from base64: {e}")
-            })
+            BASE64_ENGINE
+                .decode_slice(input, buf)
+                .map_err(|e| exec_datafusion_err!("Failed to decode from base64: {e}"))
         }
 
         fn delegated_decode<DecodeFunction>(

--- a/datafusion/sqllogictest/test_files/encoding.slt
+++ b/datafusion/sqllogictest/test_files/encoding.slt
@@ -197,3 +197,9 @@ FROM values
 ----
 0123456789abcdef 0123456789abcdef
 ffffffffffffffff ffffffffffffffff
+
+query error DataFusion error: Execution error: Failed to decode value using base64
+select decode('invalid', 'base64');
+
+query error DataFusion error: Execution error: Failed to decode value using hex
+select decode('invalid', 'hex');


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #12725

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Started refactoring encoding functions (`encode`, `decode`) to remove user defined signature (per linked issue). However, discovered in the process it was bugged in handling of certain inputs. For example on main we get these errors:

```sql
DataFusion CLI v51.0.0
> select encode(arrow_cast(column1, 'LargeUtf8'), 'hex') from values ('a'), ('b');
Internal error: Function 'encode' returned value of type 'Utf8' while the following type was promised at planning time and expected: 'LargeUtf8'.
This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
> select encode(arrow_cast(column1, 'LargeBinary'), 'hex') from values ('a'), ('b');
Internal error: Function 'encode' returned value of type 'Utf8' while the following type was promised at planning time and expected: 'LargeUtf8'.
This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
> select encode(arrow_cast(column1, 'BinaryView'), 'hex') from values ('a'), ('b');
Error during planning: Execution error: Function 'encode' user-defined coercion failed with "Error during planning: 1st argument should be Utf8 or Binary or Null, got BinaryView" No function matches the given name and argument types 'encode(BinaryView, Utf8)'. You might need to add explicit type casts.
        Candidate functions:
        encode(UserDefined)
```

- LargeUtf8/LargeBinary array inputs are broken
- BinaryView input not supported (but Utf8View input is supported)

So went about fixing this input handling as well as doing various refactors to try simplify the code.

(I also discovered #18746 in the process of this refactor).

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Refactor signatures away from user defined to the signature coercion API; importantly, we now accept only binary inputs, letting string inputs be coerced by type coercion. This simplifies the internal code of encode/decode to only need to consider binary inputs, instead of duplicating essentially exact code for string inputs (given for string inputs we just grabbed the underlying bytes anyway)

Consolidating the inner functions used by encode/decode to try simplify/inline where possible.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added new SLTs.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
