### PR TITLE
Adds prefix filtering for table URLs

### DIFF
--- a/datafusion/catalog-listing/src/helpers.rs
+++ b/datafusion/catalog-listing/src/helpers.rs
@@ -380,8 +380,14 @@ pub async fn pruned_partition_list<'a>(
     file_extension: &'a str,
     partition_cols: &'a [(String, DataType)],
 ) -> Result<BoxStream<'a, Result<PartitionedFile>>> {
+    let prefix = if !partition_cols.is_empty() {
+        evaluate_partition_prefix(partition_cols, filters)
+    } else {
+        None
+    };
+
     let objects = table_path
-        .list_all_files(ctx, store, file_extension)
+        .list_prefixed_files(ctx, store, prefix, file_extension)
         .await?
         .try_filter(|object_meta| futures::future::ready(object_meta.size > 0));
 

--- a/datafusion/core/tests/datasource/object_store_access.rs
+++ b/datafusion/core/tests/datasource/object_store_access.rs
@@ -166,7 +166,7 @@ async fn query_partitioned_csv_file() {
     ------- Object Store Request Summary -------
     RequestCountingObjectStore()
     Total Requests: 2
-    - LIST prefix=data
+    - LIST prefix=data/a=2
     - GET  (opts) path=data/a=2/b=20/c=200/file_2.csv
     "
     );
@@ -220,7 +220,7 @@ async fn query_partitioned_csv_file() {
     ------- Object Store Request Summary -------
     RequestCountingObjectStore()
     Total Requests: 2
-    - LIST prefix=data
+    - LIST prefix=data/a=2/b=20
     - GET  (opts) path=data/a=2/b=20/c=200/file_2.csv
     "
     );


### PR DESCRIPTION

## Which issue does this PR close?

This is a follow-on PR spurred by this comment chain:
- https://github.com/apache/datafusion/pull/18146#discussion_r2491693118

This work is associated with:
- https://github.com/apache/datafusion/issues/17211

## Rationale for this change

The implementation prior to merging https://github.com/apache/datafusion/pull/18146 was capable of only listing files under a specific prefix when the known prefixes could be matched to filters. This PR re-introduces that capability, alleviating the need to list and filter every file for a table when the filters match.

## What changes are included in this PR?

 - Adds the ability to list files backing a table URL optionally filtered by a path prefix
 - Reintroduces the ability for partitioned listing tables to only list prefixes that match an input filter
 - Adds tests for new functionality

## Are these changes tested?

Yes. There is existing coverage on many of the changes, new tests have been added, and existing integration tests have been updated to show the change in behavior.

## Are there any user-facing changes?

no

##
cc @alamb 