### PR TITLE
Use `LimitedBatchCoalescer` in FilterExec

### DIFF
--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use arrow::array::RecordBatch;
-use arrow::compute::BatchCoalescer;
+use arrow::compute::{filter_record_batch, BatchCoalescer};
 use arrow::datatypes::SchemaRef;
 use datafusion_common::{assert_or_internal_err, DataFusionError, Result};
 
@@ -118,6 +118,22 @@ impl LimitedBatchCoalescer {
         self.inner.push_batch(batch)?;
 
         Ok(PushBatchStatus::Continue)
+    }
+
+    /// Pushes the batch into this coalescer, after applying the filter
+    pub fn push_batch_with_filter(
+        &mut self,
+        batch: RecordBatch,
+        filter: &arrow::array::BooleanArray,
+    ) -> Result<PushBatchStatus> {
+        // If there is a limit, fall back to the non-optimized path
+        if self.fetch.is_some() {
+            self.push_batch(filter_record_batch(&batch, filter)?)
+        } else {
+            // use optimized path when no fetch limit is set
+            self.inner.push_batch_with_filter(batch, filter)?;
+            Ok(PushBatchStatus::Continue)
+        }
     }
 
     /// Return true if there is no data buffered

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -778,9 +778,7 @@ impl Stream for FilterExecStream {
                             match as_boolean_array(&array) {
                                 Ok(filter_array) => {
                                     self.metrics.selectivity.add_total(batch.num_rows());
-                                    // TODO: support push_batch_with_filter in LimitedBatchCoalescer
-                                    let batch = filter_record_batch(&batch, filter_array)?;
-                                    let state = self.batch_coalescer.push_batch(batch)?;
+                                    let state = self.batch_coalescer.push_batch_with_filter(batch, filter_array)?;
                                     Ok(state)
                                 }
                                 Err(_) => {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change


Complete a TODO from https://github.com/apache/datafusion/pull/18630#discussion_r2524632651 from @Dandandan

https://github.com/apache/datafusion/blob/bd30fe2375318d13fc5b66e06e53da63ca4d0928/datafusion/physical-plan/src/filter.rs#L781

I am hoping to drive more optimizations into `BatchCoalescer` over time so I want to send as much through to the underlying arrow kernel as possible

## What changes are included in this PR?
1. Add `LimitedBatchCoalescer::push_batch_with_filter`
2. Call it from FilterExec

## Are these changes tested?

By existing CI

## Are there any user-facing changes?

No
