### PR TITLE
Use `pastey` instead of `paste` which is unmaintained

### DIFF
--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -57,7 +57,7 @@ datafusion-functions-window-common = { workspace = true }
 datafusion-physical-expr-common = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-paste = "^1.0"
+paste = { package = "pastey", version = "*" }
 recursive = { workspace = true, optional = true }
 serde_json = { workspace = true }
 sqlparser = { workspace = true, optional = true }


### PR DESCRIPTION
The paste crate is no longer maintained according to https://osv.dev/vulnerability/RUSTSEC-2024-0436 

`pastey` claims to be a drop in replacement; following [instructions](https://docs.rs/pastey/latest/pastey/) added 

```
+ paste = { package = "pastey", version = "*" }
```
