### PR TITLE
 CI : Enforce clippy: :needless_pass_by_value rule to datafusion-functions-aggregate

### DIFF
--- a/datafusion/functions-aggregate/src/approx_percentile_cont.rs
+++ b/datafusion/functions-aggregate/src/approx_percentile_cont.rs
@@ -164,7 +164,7 @@ impl ApproxPercentileCont {
 
     pub(crate) fn create_accumulator(
         &self,
-        args: AccumulatorArgs,
+        args: &AccumulatorArgs,
     ) -> Result<ApproxPercentileAccumulator> {
         let percentile =
             validate_percentile_expr(&args.exprs[1], "APPROX_PERCENTILE_CONT")?;
@@ -300,7 +300,7 @@ impl AggregateUDFImpl for ApproxPercentileCont {
 
     #[inline]
     fn accumulator(&self, acc_args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
-        Ok(Box::new(self.create_accumulator(acc_args)?))
+        Ok(Box::new(self.create_accumulator(&acc_args)?))
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {

--- a/datafusion/functions-aggregate/src/approx_percentile_cont_with_weight.rs
+++ b/datafusion/functions-aggregate/src/approx_percentile_cont_with_weight.rs
@@ -244,7 +244,7 @@ impl AggregateUDFImpl for ApproxPercentileContWithWeight {
             is_distinct: acc_args.is_distinct,
         };
         let approx_percentile_cont_accumulator =
-            self.approx_percentile_cont.create_accumulator(sub_args)?;
+            self.approx_percentile_cont.create_accumulator(&sub_args)?;
         let accumulator = ApproxPercentileWithWeightAccumulator::new(
             approx_percentile_cont_accumulator,
         );

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -209,7 +209,7 @@ impl AggregateUDFImpl for FirstValue {
         args: AccumulatorArgs,
     ) -> Result<Box<dyn GroupsAccumulator>> {
         fn create_accumulator<T: ArrowPrimitiveType + Send>(
-            args: AccumulatorArgs,
+            args: &AccumulatorArgs,
         ) -> Result<Box<dyn GroupsAccumulator>> {
             let Some(ordering) = LexOrdering::new(args.order_bys.to_vec()) else {
                 return internal_err!("Groups accumulator must have an ordering.");
@@ -231,50 +231,50 @@ impl AggregateUDFImpl for FirstValue {
         }
 
         match args.return_field.data_type() {
-            DataType::Int8 => create_accumulator::<Int8Type>(args),
-            DataType::Int16 => create_accumulator::<Int16Type>(args),
-            DataType::Int32 => create_accumulator::<Int32Type>(args),
-            DataType::Int64 => create_accumulator::<Int64Type>(args),
-            DataType::UInt8 => create_accumulator::<UInt8Type>(args),
-            DataType::UInt16 => create_accumulator::<UInt16Type>(args),
-            DataType::UInt32 => create_accumulator::<UInt32Type>(args),
-            DataType::UInt64 => create_accumulator::<UInt64Type>(args),
-            DataType::Float16 => create_accumulator::<Float16Type>(args),
-            DataType::Float32 => create_accumulator::<Float32Type>(args),
-            DataType::Float64 => create_accumulator::<Float64Type>(args),
+            DataType::Int8 => create_accumulator::<Int8Type>(&args),
+            DataType::Int16 => create_accumulator::<Int16Type>(&args),
+            DataType::Int32 => create_accumulator::<Int32Type>(&args),
+            DataType::Int64 => create_accumulator::<Int64Type>(&args),
+            DataType::UInt8 => create_accumulator::<UInt8Type>(&args),
+            DataType::UInt16 => create_accumulator::<UInt16Type>(&args),
+            DataType::UInt32 => create_accumulator::<UInt32Type>(&args),
+            DataType::UInt64 => create_accumulator::<UInt64Type>(&args),
+            DataType::Float16 => create_accumulator::<Float16Type>(&args),
+            DataType::Float32 => create_accumulator::<Float32Type>(&args),
+            DataType::Float64 => create_accumulator::<Float64Type>(&args),
 
-            DataType::Decimal32(_, _) => create_accumulator::<Decimal32Type>(args),
-            DataType::Decimal64(_, _) => create_accumulator::<Decimal64Type>(args),
-            DataType::Decimal128(_, _) => create_accumulator::<Decimal128Type>(args),
-            DataType::Decimal256(_, _) => create_accumulator::<Decimal256Type>(args),
+            DataType::Decimal32(_, _) => create_accumulator::<Decimal32Type>(&args),
+            DataType::Decimal64(_, _) => create_accumulator::<Decimal64Type>(&args),
+            DataType::Decimal128(_, _) => create_accumulator::<Decimal128Type>(&args),
+            DataType::Decimal256(_, _) => create_accumulator::<Decimal256Type>(&args),
 
             DataType::Timestamp(TimeUnit::Second, _) => {
-                create_accumulator::<TimestampSecondType>(args)
+                create_accumulator::<TimestampSecondType>(&args)
             }
             DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                create_accumulator::<TimestampMillisecondType>(args)
+                create_accumulator::<TimestampMillisecondType>(&args)
             }
             DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                create_accumulator::<TimestampMicrosecondType>(args)
+                create_accumulator::<TimestampMicrosecondType>(&args)
             }
             DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                create_accumulator::<TimestampNanosecondType>(args)
+                create_accumulator::<TimestampNanosecondType>(&args)
             }
 
-            DataType::Date32 => create_accumulator::<Date32Type>(args),
-            DataType::Date64 => create_accumulator::<Date64Type>(args),
+            DataType::Date32 => create_accumulator::<Date32Type>(&args),
+            DataType::Date64 => create_accumulator::<Date64Type>(&args),
             DataType::Time32(TimeUnit::Second) => {
-                create_accumulator::<Time32SecondType>(args)
+                create_accumulator::<Time32SecondType>(&args)
             }
             DataType::Time32(TimeUnit::Millisecond) => {
-                create_accumulator::<Time32MillisecondType>(args)
+                create_accumulator::<Time32MillisecondType>(&args)
             }
 
             DataType::Time64(TimeUnit::Microsecond) => {
-                create_accumulator::<Time64MicrosecondType>(args)
+                create_accumulator::<Time64MicrosecondType>(&args)
             }
             DataType::Time64(TimeUnit::Nanosecond) => {
-                create_accumulator::<Time64NanosecondType>(args)
+                create_accumulator::<Time64NanosecondType>(&args)
             }
 
             _ => internal_err!(
@@ -1171,7 +1171,7 @@ impl AggregateUDFImpl for LastValue {
         args: AccumulatorArgs,
     ) -> Result<Box<dyn GroupsAccumulator>> {
         fn create_accumulator<T>(
-            args: AccumulatorArgs,
+            args: &AccumulatorArgs,
         ) -> Result<Box<dyn GroupsAccumulator>>
         where
             T: ArrowPrimitiveType + Send,
@@ -1195,50 +1195,50 @@ impl AggregateUDFImpl for LastValue {
         }
 
         match args.return_field.data_type() {
-            DataType::Int8 => create_accumulator::<Int8Type>(args),
-            DataType::Int16 => create_accumulator::<Int16Type>(args),
-            DataType::Int32 => create_accumulator::<Int32Type>(args),
-            DataType::Int64 => create_accumulator::<Int64Type>(args),
-            DataType::UInt8 => create_accumulator::<UInt8Type>(args),
-            DataType::UInt16 => create_accumulator::<UInt16Type>(args),
-            DataType::UInt32 => create_accumulator::<UInt32Type>(args),
-            DataType::UInt64 => create_accumulator::<UInt64Type>(args),
-            DataType::Float16 => create_accumulator::<Float16Type>(args),
-            DataType::Float32 => create_accumulator::<Float32Type>(args),
-            DataType::Float64 => create_accumulator::<Float64Type>(args),
+            DataType::Int8 => create_accumulator::<Int8Type>(&args),
+            DataType::Int16 => create_accumulator::<Int16Type>(&args),
+            DataType::Int32 => create_accumulator::<Int32Type>(&args),
+            DataType::Int64 => create_accumulator::<Int64Type>(&args),
+            DataType::UInt8 => create_accumulator::<UInt8Type>(&args),
+            DataType::UInt16 => create_accumulator::<UInt16Type>(&args),
+            DataType::UInt32 => create_accumulator::<UInt32Type>(&args),
+            DataType::UInt64 => create_accumulator::<UInt64Type>(&args),
+            DataType::Float16 => create_accumulator::<Float16Type>(&args),
+            DataType::Float32 => create_accumulator::<Float32Type>(&args),
+            DataType::Float64 => create_accumulator::<Float64Type>(&args),
 
-            DataType::Decimal32(_, _) => create_accumulator::<Decimal32Type>(args),
-            DataType::Decimal64(_, _) => create_accumulator::<Decimal64Type>(args),
-            DataType::Decimal128(_, _) => create_accumulator::<Decimal128Type>(args),
-            DataType::Decimal256(_, _) => create_accumulator::<Decimal256Type>(args),
+            DataType::Decimal32(_, _) => create_accumulator::<Decimal32Type>(&args),
+            DataType::Decimal64(_, _) => create_accumulator::<Decimal64Type>(&args),
+            DataType::Decimal128(_, _) => create_accumulator::<Decimal128Type>(&args),
+            DataType::Decimal256(_, _) => create_accumulator::<Decimal256Type>(&args),
 
             DataType::Timestamp(TimeUnit::Second, _) => {
-                create_accumulator::<TimestampSecondType>(args)
+                create_accumulator::<TimestampSecondType>(&args)
             }
             DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                create_accumulator::<TimestampMillisecondType>(args)
+                create_accumulator::<TimestampMillisecondType>(&args)
             }
             DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                create_accumulator::<TimestampMicrosecondType>(args)
+                create_accumulator::<TimestampMicrosecondType>(&args)
             }
             DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                create_accumulator::<TimestampNanosecondType>(args)
+                create_accumulator::<TimestampNanosecondType>(&args)
             }
 
-            DataType::Date32 => create_accumulator::<Date32Type>(args),
-            DataType::Date64 => create_accumulator::<Date64Type>(args),
+            DataType::Date32 => create_accumulator::<Date32Type>(&args),
+            DataType::Date64 => create_accumulator::<Date64Type>(&args),
             DataType::Time32(TimeUnit::Second) => {
-                create_accumulator::<Time32SecondType>(args)
+                create_accumulator::<Time32SecondType>(&args)
             }
             DataType::Time32(TimeUnit::Millisecond) => {
-                create_accumulator::<Time32MillisecondType>(args)
+                create_accumulator::<Time32MillisecondType>(&args)
             }
 
             DataType::Time64(TimeUnit::Microsecond) => {
-                create_accumulator::<Time64MicrosecondType>(args)
+                create_accumulator::<Time64MicrosecondType>(&args)
             }
             DataType::Time64(TimeUnit::Nanosecond) => {
-                create_accumulator::<Time64NanosecondType>(args)
+                create_accumulator::<Time64NanosecondType>(&args)
             }
 
             _ => {

--- a/datafusion/functions-aggregate/src/lib.rs
+++ b/datafusion/functions-aggregate/src/lib.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// https://github.com/apache/datafusion/issues/18503
+#![deny(clippy::needless_pass_by_value)]
+#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg",
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"

--- a/datafusion/functions-aggregate/src/percentile_cont.rs
+++ b/datafusion/functions-aggregate/src/percentile_cont.rs
@@ -152,7 +152,7 @@ impl PercentileCont {
         }
     }
 
-    fn create_accumulator(&self, args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
+    fn create_accumulator(&self, args: &AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
         let percentile = validate_percentile_expr(&args.exprs[1], "PERCENTILE_CONT")?;
 
         let is_descending = args
@@ -291,7 +291,7 @@ impl AggregateUDFImpl for PercentileCont {
     }
 
     fn accumulator(&self, acc_args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
-        self.create_accumulator(acc_args)
+        self.create_accumulator(&acc_args)
     }
 
     fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #18759 and part of #18503 
## What changes are included in this PR?
enforce clippy lint needless_pass_by_value to datafusion-functions-aggregate crate.
## Are these changes tested?
yes
## Are there any user-facing changes?
no
