### PR TITLE
Fix incorrect link for sql_query.rs example in README

### DIFF
--- a/datafusion-examples/README.md
+++ b/datafusion-examples/README.md
@@ -93,7 +93,7 @@ cargo run --example dataframe
 - [`sql_analysis.rs`](examples/sql_analysis.rs): Analyse SQL queries with DataFusion structures
 - [`sql_frontend.rs`](examples/sql_frontend.rs): Create LogicalPlans (only) from sql strings
 - [`sql_dialect.rs`](examples/sql_dialect.rs): Example of implementing a custom SQL dialect on top of `DFParser`
-- [`sql_query.rs`](examples/memtable.rs): Query data using SQL (in memory `RecordBatches`, local Parquet files)
+- [`sql_query.rs`](examples/sql_query.rs): Query data using SQL (in memory `RecordBatches`, local Parquet files)
 
 ## Distributed
 


### PR DESCRIPTION
 ## What was wrong
   When clicking on the `sql_query.rs` example link in the README, it was taking users to `memtable.rs` instead of the correct file.
   
   ## What this fixes
   The link now correctly points to `examples/sql_query.rs` so people can find the right example code.
   
   ## Changes made
   - Fixed one line in `datafusion-examples/README.md` (line 96)
   - Changed the link from `examples/memtable.rs` to `examples/sql_query.rs`