### PR TITLE
CI: add clippy::needless_pass_by_value rule to datafusion-functions-window crate

### DIFF
--- a/datafusion/functions-window/src/lead_lag.rs
+++ b/datafusion/functions-window/src/lead_lag.rs
@@ -264,7 +264,7 @@ impl WindowUDFImpl for WindowShift {
     ) -> Result<Box<dyn PartitionEvaluator>> {
         let shift_offset =
             get_scalar_value_from_args(partition_evaluator_args.input_exprs(), 1)?
-                .map(get_signed_integer)
+                .map(|v| get_signed_integer(&v))
                 .map_or(Ok(None), |v| v.map(Some))
                 .map(|n| self.kind.shift_offset(n))
                 .map(|offset| {

--- a/datafusion/functions-window/src/lib.rs
+++ b/datafusion/functions-window/src/lib.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// https://github.com/apache/datafusion/issues/18503
+#![deny(clippy::needless_pass_by_value)]
+#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg",
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"

--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -282,7 +282,7 @@ impl WindowUDFImpl for NthValue {
                     exec_datafusion_err!(
                 "Expected a signed integer literal for the second argument of nth_value")
                 })?
-                .map(get_signed_integer)
+                .map(|v| get_signed_integer(&v))
             {
                 Some(Ok(n)) => {
                     if partition_evaluator_args.is_reversed() {

--- a/datafusion/functions-window/src/ntile.rs
+++ b/datafusion/functions-window/src/ntile.rs
@@ -135,10 +135,10 @@ impl WindowUDFImpl for Ntile {
         }
 
         if scalar_n.is_unsigned() {
-            let n = get_unsigned_integer(scalar_n)?;
+            let n = get_unsigned_integer(&scalar_n)?;
             Ok(Box::new(NtileEvaluator { n }))
         } else {
-            let n: i64 = get_signed_integer(scalar_n)?;
+            let n: i64 = get_signed_integer(&scalar_n)?;
             if n <= 0 {
                 return exec_err!("NTILE requires a positive integer");
             }

--- a/datafusion/functions-window/src/utils.rs
+++ b/datafusion/functions-window/src/utils.rs
@@ -21,7 +21,7 @@ use datafusion_physical_expr::expressions::Literal;
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use std::sync::Arc;
 
-pub(crate) fn get_signed_integer(value: ScalarValue) -> Result<i64> {
+pub(crate) fn get_signed_integer(value: &ScalarValue) -> Result<i64> {
     if value.is_null() {
         return Ok(0);
     }
@@ -52,7 +52,7 @@ pub(crate) fn get_scalar_value_from_args(
     })
 }
 
-pub(crate) fn get_unsigned_integer(value: ScalarValue) -> Result<u64> {
+pub(crate) fn get_unsigned_integer(value: &ScalarValue) -> Result<u64> {
     if value.is_null() {
         return Ok(0);
     }


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #18834 and part of #18503
## What changes are included in this PR?
- enforces clippy rule to the datafusion-functions-window crate
## Are these changes tested?
- yes
## Are there any user-facing changes?
- no