### PR TITLE
Docs: Enhance testing documentation with examples and links

### DIFF
--- a/docs/source/contributor-guide/testing.md
+++ b/docs/source/contributor-guide/testing.md
@@ -63,13 +63,14 @@ The [test_util] module provides useful macros to write unit tests effectively, s
 
 ## sqllogictests Tests
 
-DataFusion's SQL implementation is tested using [sqllogictest](https://github.com/apache/datafusion/tree/main/datafusion/sqllogictest). You can run these tests with a command like this:
+DataFusion's SQL implementation is tested using [sqllogictest](https://github.com/apache/datafusion/tree/main/datafusion/sqllogictest). You can run these tests with commands like:
 
 ```shell
+# Run all tests
 cargo test --profile=ci --test sqllogictests
-```
-
-```shell
+# Run a specific test file
+cargo test --profile=ci --test sqllogictests -- aggregate.slt
+# Run and update expected outputs
 cargo test --profile=ci --test sqllogictests -- --complete
 ```
 


### PR DESCRIPTION
## Which issue does this PR close?

-  part of #7013 

## Rationale for this change

I was trying to find the right documentation to point people (and AI tools) at for running the tests and found some improvements to the existing testing page that would be nice: https://datafusion.apache.org/contributor-guide/testing.html

## What changes are included in this PR?

Added examples and links for running tests and using test utilities in the contributor guide.

## Are these changes tested?

I downloaded it locally

## Are there any user-facing changes?

Better testing guide
