### PR TITLE
Docs: Enhance contributor guide with testing section

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -30,10 +30,10 @@ In addition to submitting new PRs, we have a healthy tradition of community
 members reviewing each other's PRs. Doing so is a great way to help the
 community as well as get more familiar with Rust and the relevant codebases.
 
-## Development Environment + Testing
+## Development Environment
 
 Setup your development environment [here](development_environment.md), and learn
-how to test the code [here](testing).
+how to test the code [here](testing.md).
 
 ## Finding and Creating Issues to Work On
 


### PR DESCRIPTION
Updated the contributor guide to include testing information.

## Which issue does this PR close?

- part of https://github.com/apache/datafusion/issues/7013

## Rationale for this change

Similarly to https://github.com/apache/datafusion/pull/18851, 

I was trying to find the right documentation to point people (and AI tools) at for running the tests wanted to make it easier to find the testing instructions immediately on the contributing landing page: https://datafusion.apache.org/contributor-guide/index.html#development-environment

<img width="672" height="153" alt="Screenshot 2025-11-20 at 12 45 35 PM" src="https://github.com/user-attachments/assets/403d7047-fe37-4c78-b108-f56870a5c9ab" />


## What changes are included in this PR?

Add a link to the testing page directly 

## Are these changes tested?

I ran it locally

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
