### PR TITLE
chore: Add missing boolean tests to `bit_count` Spark function

### DIFF
--- a/datafusion/sqllogictest/test_files/spark/bitwise/bit_count.slt
+++ b/datafusion/sqllogictest/test_files/spark/bitwise/bit_count.slt
@@ -225,3 +225,18 @@ query I
 SELECT bit_count(arrow_cast(-9223372036854775808, 'Int64'));
 ----
 1
+
+query I
+SELECT bit_count(true);
+----
+1
+
+query I
+SELECT bit_count(false);
+----
+0
+
+query I
+SELECT bit_count(cast(null as boolean));
+----
+NULL


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change
Follow up on https://github.com/apache/datafusion/pull/18841

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Adding missing bool tests for bit_count

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
