### PR TITLE
TEST: enable pushdown_filters and reorder_filters by default

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -687,12 +687,12 @@ config_namespace! {
 
         /// (reading) If true, filter expressions are be applied during the parquet decoding operation to
         /// reduce the number of rows decoded. This optimization is sometimes called "late materialization".
-        pub pushdown_filters: bool, default = false
+        pub pushdown_filters: bool, default = true
 
         /// (reading) If true, filter expressions evaluated during the parquet decoding operation
         /// will be reordered heuristically to minimize the cost of evaluation. If false,
         /// the filters are applied in the same order as written in the query
-        pub reorder_filters: bool, default = false
+        pub reorder_filters: bool, default = true
 
         /// (reading) If true, parquet reader will read columns of `Utf8/Utf8Large` with `Utf8View`,
         /// and `Binary/BinaryLarge` with `BinaryView`.


### PR DESCRIPTION
( I am using this PR to test, I don't intend to merge it yet )

## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/3463

## Rationale for this change

We have made non trivial progress in filter representation in Parquet. Let's see where performance is now. 

## What changes are included in this PR?

- base on https://github.com/apache/datafusion/pull/18820
- Enable `pushdown_filters` and `reorder_filters`

## Are these changes tested?

By CI tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
