### PR TITLE
fix: Track elapsed_compute metric for CSV scans

### DIFF
--- a/datafusion/datasource-csv/src/source.rs
+++ b/datafusion/datasource-csv/src/source.rs
@@ -399,8 +399,7 @@ impl FileOpener for CsvOpener {
 
                     let mut reader = config.open(decoder)?;
 
-                    // We use std::iter::from_fn to wrap the *execution* of the iterator's next() method.
-                    // This ensures the timer runs while the CSV is actually being parsed.
+                    // Use std::iter::from_fn to wrap execution of iterator's next() method.
                     let iterator = std::iter::from_fn(move || {
                         let mut timer = baseline_metrics.elapsed_compute().timer();
                         let result = reader.next();


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18795 

## Rationale for this change

Currently, scanning CSV files does not correctly report the `elapsed_compute` metric in `BaselineMetrics`. When running `EXPLAIN ANALYZE` on a CSV table, the `elapsed_compute` time is reported as negligible (e.g., `1ns` or `42ns`), even for large files, because the time spent parsing the CSV data is not being measured.

This PR ensures that the time spent reading and parsing CSV batches is correctly accounted for in the execution metrics.

## What changes are included in this PR?

- Modified `datafusion/datasource-csv/src/source.rs`.

- Updated `CsvOpener` to store the `partition_index`.

- Initialized `BaselineMetrics` within C`svOpener::open`.

- Wrapped the underlying CSV reader iterator using `std::iter::from_fn`. This allows us to start a timer before calling `reader.next()` and stop it immediately after, ensuring the CPU time spent parsing the CSV is captured in `elapsed_compute`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. Existing unit tests passed (`cargo test -p datafusion-datasource-csv`).

Additionally, I verified the fix manually using `datafusion-cli` and `EXPLAIN ANALYZE`.

**Before the fix:** elapsed_compute was reported as 85ns (effectively zero).

```
DataSourceExec: ... metrics=[output_rows=3, elapsed_compute=85ns, ... time_elapsed_processing=1.54ms ...]
```

**After the fix**: elapsed_compute is reported as 1.11ms, accurately reflecting the parsing time.

```
DataSourceExec: ... metrics=[output_rows=3, elapsed_compute=1.11ms, ... time_elapsed_processing=1.26ms ...]
```

## Are there any user-facing changes?

Users viewing `EXPLAIN ANALYZE` output for queries involving CSV files will now see accurate `elapsed_compute` values instead of near-zero values.
