### PR TITLE
minor: add builder setting `NdJsonReadOptions::schema_infer_max_records`

### DIFF
--- a/datafusion/core/src/datasource/file_format/options.rs
+++ b/datafusion/core/src/datasource/file_format/options.rs
@@ -523,6 +523,12 @@ impl<'a> NdJsonReadOptions<'a> {
         self.file_sort_order = file_sort_order;
         self
     }
+
+    /// Specify how many rows to read for schema inference
+    pub fn schema_infer_max_records(mut self, schema_infer_max_records: usize) -> Self {
+        self.schema_infer_max_records = schema_infer_max_records;
+        self
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
Noticed this was missing, meaning would have to do something awkward like:

```rust
    ctx.read_json(
        "/Users/jeffrey/Downloads/a.json",
        NdJsonReadOptions {
            schema_infer_max_records: 2,
            ..Default::default()
        },
    )
    .await?
    .show()
    .await?;
```

Add this builder method to be consistent with the other options and be more ergonomic to use.