### PR TITLE
fix: Implement Substrait consumer support for like_match, like_imatch, and negated variants

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer/expr/scalar_function.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/expr/scalar_function.rs
@@ -510,7 +510,7 @@ mod tests {
                         reference_type: Some(substrait::proto::expression::field_reference::ReferenceType::DirectReference(
                             substrait::proto::expression::ReferenceSegment {
                                 reference_type: Some(substrait::proto::expression::reference_segment::ReferenceType::StructField(
-                                    Box::new(substrait::proto::expression::reference_segment::StructField { // <--- Added Box::new here
+                                    Box::new(substrait::proto::expression::reference_segment::StructField {
                                         field: 0,
                                         child: None,
                                     })
@@ -547,11 +547,11 @@ mod tests {
             .await?;
 
         if let Expr::Like(like) = result {
-            assert_eq!(like.negated, false);
-            assert_eq!(like.case_insensitive, false);
+            assert!(!like.negated);
+            assert!(!like.case_insensitive);
             assert_eq!(format!("{}", like.pattern), "Utf8(\"foo\")");
         } else {
-            panic!("Expected Expr::Like, got {:?}", result);
+            panic!("Expected Expr::Like, got {result:?}");
         }
 
         // 4. Test "like_not_match" (NOT LIKE)
@@ -566,10 +566,10 @@ mod tests {
             .await?;
 
         if let Expr::Like(like) = result {
-            assert_eq!(like.negated, true); // Should be true
-            assert_eq!(like.case_insensitive, false);
+            assert!(like.negated);
+            assert!(!like.case_insensitive);
         } else {
-            panic!("Expected Expr::Like (negated), got {:?}", result);
+            panic!("Expected Expr::Like (negated), got {result:?}");
         }
 
         Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #16293 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, DataFusion fails to consume Substrait plans that utilize `like_match`, `like_imatch`, or their negated variants (`like_not_match`, `like_not_imatch`). This results in a panic with `DataFusion error: This feature is not implemented: Unsupported function name: "like_match"` during round-trip planning.

This PR implements the missing mapping logic in the Substrait consumer to correctly translate these function names into DataFusion `Expr::Like` expressions.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Updated `BuiltinExprBuilder` in `scalar_function.rs` to recognize:
  - `like_match` (LIKE)
  - `like_imatch` (ILIKE)
  - `like_not_match` (NOT LIKE)
  - `like_not_imatch` (NOT ILIKE)
- Modified the internal `build_like_expr` helper to accept a `negated` boolean flag (previously hardcoded to `false`).
- Added a new unit test `test_like_match_conversion` to verify the correct conversion of these functions and their arguments.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. I added a new unit test `test_like_match_conversion` in `datafusion/substrait/src/logical_plan/consumer/expr/scalar_function.rs`.

This test explicitly constructs Substrait plans for `like_match` and `like_not_match` and asserts that they are consumed into correct DataFusion `Expr::Like` variants with the appropriate `negated` and `case_insensitive` flags.

**Note: Verification was done via unit test rather than the standard `sqllogictest` suite because `predicates.slt` was experiencing unrelated environment-specific failures locally.**

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

- No breaking changes.
- Users relying on Substrait round-trips for LIKE/ILIKE expressions will now see these queries succeed instead of failing.