### PR TITLE
fix: pre-warm listing file statistics cache during listing table creation

### DIFF
--- a/datafusion/core/src/datasource/listing_table_factory.rs
+++ b/datafusion/core/src/datasource/listing_table_factory.rs
@@ -193,7 +193,9 @@ impl TableProviderFactory for ListingTableFactory {
 
         // Pre-warm statistics cache if collect_statistics is enabled
         if session_state.config().collect_statistics() {
-            if let Err(e) = table.list_files_for_scan(state, &[], None).await {
+            let filters = &[];
+            let limit = None;
+            if let Err(e) = table.list_files_for_scan(state, filters, limit).await {
                 log::warn!("Failed to pre-warm statistics cache: {e}");
             }
         }


### PR DESCRIPTION
Pre-warm listing file statistics cache during create listing table flow as suggested in https://github.com/apache/datafusion/issues/18952.
Reused `list_files_for_scan` to pre-warm.

## Which issue does this PR close?


<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/18952.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes unit tested.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
