### PR TITLE
fix: CteWorkTable: properly apply TableProvider::scan projection argument

### DIFF
--- a/datafusion/catalog/src/cte_worktable.rs
+++ b/datafusion/catalog/src/cte_worktable.rs
@@ -25,8 +25,8 @@ use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion_common::error::Result;
 use datafusion_expr::{Expr, LogicalPlan, TableProviderFilterPushDown, TableType};
-use datafusion_physical_plan::work_table::WorkTableExec;
 use datafusion_physical_plan::ExecutionPlan;
+use datafusion_physical_plan::work_table::WorkTableExec;
 
 use crate::{ScanArgs, ScanResult, Session, TableProvider};
 

--- a/datafusion/physical-plan/src/work_table.rs
+++ b/datafusion/physical-plan/src/work_table.rs
@@ -320,7 +320,7 @@ mod tests {
                 .unwrap();
 
         // We inject the work table
-        let work_table = Arc::new(WorkTable::new());
+        let work_table = Arc::new(WorkTable::new("wt".into()));
         let work_table_exec = work_table_exec
             .with_new_state(Arc::clone(&work_table) as _)
             .unwrap();


### PR DESCRIPTION
It was previously ignored

## Which issue does this PR close?

- Closes #18992.

## Rationale for this change

All `TableProvider` implementations must support the `projection` argument of the `scan` method. This was not the case in `CteWorkTable`.

## What changes are included in this PR?

Minimal implementation of the projection support. The projection applied before the plan node return results. It might be nice to push it further inside of the recursion implementation to reduce memory consumption but I preferred to keep the fix minimal.

## Are these changes tested?

I have not figured out yet a nice SQL query to trigger an error without this change. Some existing queries in `cte.slt` have set projection (i.e. not `None`) so the code is very likely working. There is also a test on the projection itself in `WorkTableExec`