### PR TITLE
fix: `rstest` is a DEV dependency

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -152,7 +152,6 @@ parking_lot = { workspace = true }
 parquet = { workspace = true, optional = true, default-features = true }
 rand = { workspace = true }
 regex = { workspace = true }
-rstest = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 sqlparser = { workspace = true, optional = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?
\-

## Rationale for this change
No need to compile this for production, esp. for downstream users.

## What changes are included in this PR?
Fix `Cargo.toml`.

## Are these changes tested?
Still compiles & tests.

## Are there any user-facing changes?
Less stuff to compile.