### PR TITLE
Add documentation example for `PartitionPruningStatistics`

### DIFF
--- a/datafusion/common/src/pruning.rs
+++ b/datafusion/common/src/pruning.rs
@@ -172,7 +172,7 @@ impl PartitionPruningStatistics {
     ///
     /// # Example
     ///
-    /// To to create [`PartitionPruningStatistics`] for two partition columns `a` and `b`,
+    /// To create [`PartitionPruningStatistics`] for two partition columns `a` and `b`,
     /// for three containers like this:
     ///
     /// | a | b |


### PR DESCRIPTION
## Which issue does this PR close?

- Follow on to https://github.com/apache/datafusion/pull/18923

## Rationale for this change

I was confused about the argument meaning to `PartitionPruningStatistics` so let's add an example
## What changes are included in this PR?

Add a doc example

## Are these changes tested?

By CI

## Are there any user-facing changes?

New docs