### PR TITLE
refactor: Refactor spark make_interval signature away from user defined

### DIFF
--- a/datafusion/spark/src/function/datetime/make_interval.rs
+++ b/datafusion/spark/src/function/datetime/make_interval.rs
@@ -57,15 +57,20 @@ impl SparkMakeInterval {
 
         let variants = vec![
             TypeSignature::Nullary,
+            // year
             TypeSignature::Coercible(vec![int32.clone()]),
+            // year, month
             TypeSignature::Coercible(vec![int32.clone(), int32.clone()]),
+            // year, month, week
             TypeSignature::Coercible(vec![int32.clone(), int32.clone(), int32.clone()]),
+            // year, month, week, day
             TypeSignature::Coercible(vec![
                 int32.clone(),
                 int32.clone(),
                 int32.clone(),
                 int32.clone(),
             ]),
+            // year, month, week, day, hour
             TypeSignature::Coercible(vec![
                 int32.clone(),
                 int32.clone(),
@@ -73,6 +78,7 @@ impl SparkMakeInterval {
                 int32.clone(),
                 int32.clone(),
             ]),
+            // year, month, week, day, hour, minute
             TypeSignature::Coercible(vec![
                 int32.clone(),
                 int32.clone(),
@@ -81,6 +87,7 @@ impl SparkMakeInterval {
                 int32.clone(),
                 int32.clone(),
             ]),
+            // year, month, week, day, hour, minute, second
             TypeSignature::Coercible(vec![
                 int32.clone(),
                 int32.clone(),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of #12725

## Rationale for this change

As per the goal stated that we should avoid using the `user_defined` in useful places

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Refactored the `spark/mark_interval`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
