### PR TITLE
[branch-51] CI: try free up space in `Rust / cargo test (amd64)` action (#18709)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -271,7 +271,21 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
+      volumes:
+        - /usr/local:/host/usr/local
     steps:
+      - name: Remove unnecessary preinstalled software
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          # remove tool cache: about 8.5GB (github has host /opt/hostedtoolcache mounted as /__t)
+          rm -rf /__t/* || true
+          # remove Haskell runtime: about 6.3GB (host /usr/local/.ghcup)
+          rm -rf /host/usr/local/.ghcup || true
+          # remove Android library: about 7.8GB (host /usr/local/lib/android)
+          rm -rf /host/usr/local/lib/android || true
+          echo "Disk space after cleanup:"
+          df -h
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           submodules: true


### PR DESCRIPTION
## Which issue does this PR close?

- part of #18843 
- Backports https://github.com/apache/datafusion/pull/18709 from @Jefffrey 

## Rationale for this change

@tobixdev  is hitting a CI failure due to out of space on a different PR:
- https://github.com/apache/datafusion/pull/19017#issuecomment-3598867164


@Jefffrey  fixed this on main with
-  https://github.com/apache/datafusion/pull/18709 

So let's backport that change to branch-51
## What changes are included in this PR?

- Backport https://github.com/apache/datafusion/pull/18709 to branch-51

## Are these changes tested?
by ci
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

no
