### PR TITLE
Minor: fix link errors in docs

### DIFF
--- a/docs/source/contributor-guide/inviting.md
+++ b/docs/source/contributor-guide/inviting.md
@@ -126,7 +126,7 @@ explicitly add them to the roster on the [Whimsy Roster Tool].
 ### Step 4: Announce and Celebrate the New Committer
 
 Email to Send an email such as the following to
-[dev@datafusion.apache.org](mailto:dev@datafusion.apache.org]) to celebrate and
+[dev@datafusion.apache.org](mailto:dev@datafusion.apache.org) to celebrate and
 acknowledge the new committer to the community.
 
 ```

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -2125,7 +2125,7 @@ upper(str)
 
 ### `uuid`
 
-Returns [`UUID v4`](<https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)>) string value which is unique per row.
+Returns [`UUID v4`](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_%28random%29) string value which is unique per row.
 
 ```sql
 uuid()


### PR DESCRIPTION
I had an AI tool (`codex`) look for broken links in the docs and it found two. I tested both changes locally