### PR TITLE
Fix function doc CI check

### DIFF
--- a/datafusion/functions/src/string/uuid.rs
+++ b/datafusion/functions/src/string/uuid.rs
@@ -31,7 +31,7 @@ use datafusion_macros::user_doc;
 
 #[user_doc(
     doc_section(label = "String Functions"),
-    description = "Returns [`UUID v4`](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) string value which is unique per row.",
+    description = "Returns [`UUID v4`](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_%28random%29) string value which is unique per row.",
     syntax_example = "uuid()",
     sql_example = r#"```sql
 > select uuid();


### PR DESCRIPTION
## Which issue does this PR close?



## Rationale for this change

CI is failing on main. For example see : https://github.com/apache/datafusion/actions/runs/19938148766/job/57168950868

```diff
diff --git a/docs/source/user-guide/sql/scalar_functions.md b/docs/source/user-guide/sql/scalar_functions.md
index fab6221..c5380b2 100644
--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -2125,7 +2125,7 @@ upper(str)
 
 ### `uuid`
 
-Returns [`UUID v4`](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_%28random%29) string value which is unique per row.
+Returns [`UUID v4`](<https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)>) string value which is unique per row.
 
 ```sql
 uuid()
```

The problem is that I updated the markdown in  https://github.com/apache/datafusion/pull/19088 but not the original code in the function


## What changes are included in this PR?

Fix the issue

## Are these changes tested?

Yes by CI

## Are there any user-facing changes?

I will also file a ticket to track this testing hole:
- https://github.com/apache/datafusion/issues/19095