### PR TITLE
fix deprecation notes with incorrect versions from #13083

### DIFF
--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -818,8 +818,8 @@ impl FileScanConfig {
     }
 
     #[deprecated(
-        since = "53.0.0",
-        note = "This method is no longer used, use eq_properties instead. It will be removed in 58.0.0."
+        since = "52.0.0",
+        note = "This method is no longer used, use eq_properties instead. It will be removed in 58.0.0 or 6 months after 52.0.0 is released, whichever comes first."
     )]
     pub fn projected_constraints(&self) -> Constraints {
         let props = self.eq_properties();
@@ -838,8 +838,8 @@ impl FileScanConfig {
     }
 
     #[deprecated(
-        since = "53.0.0",
-        note = "Use file_column_projection_indices instead. This method will be removed in 58.0.0."
+        since = "52.0.0",
+        note = "This method is no longer used, use eq_properties instead. It will be removed in 58.0.0 or 6 months after 52.0.0 is released, whichever comes first."
     )]
     pub fn file_column_projection_indices(&self) -> Option<Vec<usize>> {
         #[expect(deprecated)]

--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -412,8 +412,8 @@ impl ProjectionExprs {
     ///
     /// Panics if any expression in the projection is not a simple column reference.
     #[deprecated(
-        since = "53.0.0",
-        note = "Use column_indices() instead. This method will be removed in 58.0.0."
+        since = "52.0.0",
+        note = "Use column_indices() instead. This method will be removed in 58.0.0 or 6 months after 52.0.0 is released, whichever comes first."
     )]
     pub fn ordered_column_indices(&self) -> Vec<usize> {
         self.exprs


### PR DESCRIPTION
The current version is [51.0.0](https://github.com/apache/datafusion/releases/tag/51.0.0) so the next release is 52.0.0. Since [our policy](https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines) is to keep around for 6 releases / 6 months the final version actually was correct though.