### PR TITLE
 slt test coverage for `CASE` exprs with constant value lookup tables

### DIFF
--- a/datafusion/sqllogictest/test_files/case.slt
+++ b/datafusion/sqllogictest/test_files/case.slt
@@ -828,6 +828,11 @@ NULL N/A N/A N/A N/A
 2 two two two two
 NULL N/A N/A N/A N/A
 
+statement ok
+drop table float_source;
+
+statement ok
+drop table floats;
 
 #####
 # End of lookup table CASE tests


### PR DESCRIPTION
## Which issue does this PR close?

- follow on to https://github.com/apache/datafusion/pull/18183 from @rluvaton and @pepijnve 

## Rationale for this change

I want to ensure we have test coverage for constant value lookup tables in the SLT tests



## What changes are included in this PR?

1. Add some more slt tests that use constant value lookup tables (e.g. when the case values are all constants)

I also ran
```shell
cargo llvm-cov test --html  --test sqllogictests -- case
```

To ensure this was covering the new code

## Are these changes tested?
Only tests
## Are there any user-facing changes?
NO
