### PR TITLE
fix: inverted null_percent logic in in_list benchmark

### DIFF
--- a/datafusion/physical-expr/benches/in_list.rs
+++ b/datafusion/physical-expr/benches/in_list.rs
@@ -49,10 +49,12 @@ fn do_benches(
     null_percent: f64,
 ) {
     let mut rng = StdRng::seed_from_u64(120320);
+    let non_null_percent = 1.0 - null_percent;
+
     for string_length in [5, 10, 20] {
         let values: StringArray = (0..array_length)
             .map(|_| {
-                rng.random_bool(null_percent)
+                rng.random_bool(non_null_percent)
                     .then(|| random_string(&mut rng, string_length))
             })
             .collect();
@@ -72,7 +74,7 @@ fn do_benches(
     }
 
     let values: Float32Array = (0..array_length)
-        .map(|_| rng.random_bool(null_percent).then(|| rng.random()))
+        .map(|_| rng.random_bool(non_null_percent).then(|| rng.random()))
         .collect();
 
     let in_list: Vec<_> = (0..in_list_length)
@@ -87,7 +89,7 @@ fn do_benches(
     );
 
     let values: Int32Array = (0..array_length)
-        .map(|_| rng.random_bool(null_percent).then(|| rng.random()))
+        .map(|_| rng.random_bool(non_null_percent).then(|| rng.random()))
         .collect();
 
     let in_list: Vec<_> = (0..in_list_length)


### PR DESCRIPTION
## Which issue does this PR close?

N/A - benchmark fix discovered during performance analysis of #18832.

## Rationale for this change

The `in_list` benchmark (introduced in #4068) had inverted null generation logic: `null_percent=0` was producing 100% nulls instead of 0% nulls.

## What changes are included in this PR?

Fix the `random_bool(null_percent).then(...)` pattern to use `random_bool(1.0 - null_percent)` so that `null_percent` correctly represents the percentage of null values.

## Are these changes tested?

Benchmark-only change. Verified by running the benchmark and observing expected performance characteristics.

## Are there any user-facing changes?

No.