### PR TITLE
Fix fmt after logical conflict

### DIFF
--- a/datafusion/physical-expr/src/simplifier/const_evaluator.rs
+++ b/datafusion/physical-expr/src/simplifier/const_evaluator.rs
@@ -27,8 +27,8 @@ use datafusion_common::{Result, ScalarValue};
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use datafusion_physical_expr_common::physical_expr::is_volatile;
 
-use crate::expressions::{Column, Literal};
 use crate::PhysicalExpr;
+use crate::expressions::{Column, Literal};
 
 /// Simplify expressions that consist only of literals by evaluating them.
 ///


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

`cargo fmt` is failing on main. Example https://github.com/apache/datafusion/actions/runs/20027361509/job/57427769604

I believe it is a logical conflict between:
- https://github.com/apache/datafusion/pull/19091
- https://github.com/apache/datafusion/pull/19130


## What changes are included in this PR?

Ran `cargo fmt` and committed the result

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
