### PR TITLE
Refactor PhysicalExprSimplfier to &self instead of &mut self

### DIFF
--- a/datafusion/physical-expr/src/simplifier/const_evaluator.rs
+++ b/datafusion/physical-expr/src/simplifier/const_evaluator.rs
@@ -27,8 +27,8 @@ use datafusion_common::{Result, ScalarValue};
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use datafusion_physical_expr_common::physical_expr::is_volatile;
 
-use crate::expressions::{Column, Literal};
 use crate::PhysicalExpr;
+use crate::expressions::{Column, Literal};
 
 /// Simplify expressions that consist only of literals by evaluating them.
 ///


### PR DESCRIPTION
This allows it to be Arc'ed, have multiple references, etc. It's a backwards compatible change (aside from producing compiler warnings about unnecessarily mutable variables).

This will help with https://github.com/apache/datafusion/pull/19111 where we'll want to re-use a simplifier instance for predicate and projection.