### PR TITLE
fix: Add custom nullability for Spark LIKE function

### DIFF
--- a/datafusion/spark/src/function/string/like.rs
+++ b/datafusion/spark/src/function/string/like.rs
@@ -18,7 +18,7 @@
 use arrow::array::ArrayRef;
 use arrow::compute::like;
 use arrow::datatypes::{DataType, Field, FieldRef};
-use datafusion_common::{exec_err, internal_err, Result};
+use datafusion_common::{Result, exec_err, internal_err};
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::{
     ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #19176 

## Rationale for this change

This PR adds custom nullability handling for the Spark LIKE function. Previously, the function was using the default is_nullable which always returns true, which is not correct. 

## What changes are included in this PR?

- Implemented return_field_from_args() to handle custom nullability logic
  - The result is nullable if any of the input arguments is nullable
  - This matches Spark's behavior where LIKE(NULL, pattern) or LIKE(str, NULL) returns NULL
- Updated return_type() to use internal_err! pattern to enforce use of return_field_from_args
- Added comprehensive nullability tests covering all combinations:
  - Non-nullable when both inputs are non-nullable
  - Nullable when first input is nullable
  - Nullable when second input is nullable
  - Nullable when both inputs are nullable

## Testing
All existing tests pass, including the addition add ones.

The implementation follows the same pattern used by other Spark functions in the codebase (like shuffle and array).