### PR TITLE
[datafusion-spark]: Refactor hex's signature away from user_defined

### DIFF
--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -337,7 +337,7 @@ pub enum TypeSignatureClass {
     Float,
     Decimal,
     Numeric,
-    /// Encompasses Binary, FixedSizeBinary, and LargeBinary types
+    /// Encompasses both the native Binary/LargeBinary types as well as arbitrarily sized FixedSizeBinary types
     Binary,
 }
 

--- a/datafusion/spark/src/function/math/hex.rs
+++ b/datafusion/spark/src/function/math/hex.rs
@@ -26,9 +26,7 @@ use arrow::{
 };
 use datafusion_common::cast::as_large_binary_array;
 use datafusion_common::cast::as_string_view_array;
-use datafusion_common::types::{
-    logical_binary, logical_int64, logical_string, NativeType,
-};
+use datafusion_common::types::{logical_int64, logical_string, NativeType};
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{
     cast::{as_binary_array, as_fixed_size_binary_array, as_int64_array},
@@ -63,11 +61,7 @@ impl SparkHex {
 
         let string = Coercion::new_exact(TypeSignatureClass::Native(logical_string()));
 
-        let binary = Coercion::new_implicit(
-            TypeSignatureClass::Native(logical_binary()),
-            vec![TypeSignatureClass::Binary],
-            NativeType::Binary,
-        );
+        let binary = Coercion::new_exact(TypeSignatureClass::Binary);
 
         let variants = vec![
             // accepts numeric types

--- a/datafusion/sqllogictest/test_files/spark/math/hex.slt
+++ b/datafusion/sqllogictest/test_files/spark/math/hex.slt
@@ -49,20 +49,12 @@ SELECT hex(column1) FROM t_utf8view;
 NULL
 666F6F62617262617A
 
-statement ok
-CREATE TABLE t_largebinary as VALUES (arrow_cast(arrow_cast('hello', 'Binary'), 'LargeBinary')), (NULL), (arrow_cast(arrow_cast('world', 'Binary'), 'LargeBinary'));
-
 query T
-SELECT hex(column1) FROM t_largebinary;
+SELECT hex(column1) FROM VALUES (arrow_cast('hello', 'LargeBinary')), (NULL), (arrow_cast('world', 'LargeBinary'));
 ----
 68656C6C6F
 NULL
 776F726C64
-
-query T
-SELECT hex(arrow_cast(arrow_cast('!hallucinations!', 'Binary'), 'LargeBinary'));
-----
-2168616C6C7563696E6174696F6E7321
 
 statement error Function 'hex' expects 1 arguments but received 2
 SELECT hex(1, 2);


### PR DESCRIPTION
## Which issue does this PR close?
- part of #12725 
## Rationale for this change
moving `hex` away from a user defined signature as it is out of scope and added a UT for checking correct number of args
## Are these changes tested?
existing tests 
## Are there any user-facing changes?
yes

