### PR TITLE
Feat: Add an option for fast tests by gating slow tests to extended_tests feature

### DIFF
--- a/datafusion/core/tests/fuzz.rs
+++ b/datafusion/core/tests/fuzz.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// Run all tests that are found in the `fuzz_cases` directory
+/// Run all tests that are found in the `fuzz_cases` directory.
+/// Fuzz tests are slow and gated behind the `extended_tests` feature.
+/// Run with: cargo test --features extended_tests
+#[cfg(feature = "extended_tests")]
 mod fuzz_cases;
 
 #[cfg(test)]


### PR DESCRIPTION
## Which issue does this PR close?
Closes #19228 

## Rationale for this change
This PR gates all fuzz tests behind the ```extended_tests``` feature flag, allowing developers to run a fast test suite (ideally under 1 minute) during development while still being able to run the full test suite in CI or when needed.

## What changes are included in this PR?
Added #[cfg(feature = "extended_tests")] to all fuzz test modules in mod.rs. This includes the following modules:
 - aggregate_fuzz
 - distinct_count_string_fuzz
 - join_fuzz
 - merge_fuzz
 - sort_fuzz
 - sort_query_fuzz
 - topk_filter_pushdown
 - aggregation_fuzzer
 - equivalence
 - pruning
 - limit_fuzz
 - sort_preserving_repartition_fuzz
 - window_fuzz
 - Utility modules

## Are these changes tested?
Without the extended_tests feature:

```cargo test --package datafusion --test fuzz -- --list```


This shows 0 tests.

With the extended_tests feature:

```cargo test --package datafusion --test fuzz --features extended_tests -- --list```


This shows all ~100+ fuzz tests.

## Are there any user-facing changes?
Yes. Users can now run:

Fast test suite (default):

```cargo test```


or

```cargo nextest run```


Full test suite with fuzz tests:

```cargo test --features extended_tests```


or

```cargo nextest run --features extended_tests```
