### PR TITLE
Add heap_size for statistics

### DIFF
--- a/datafusion/common/src/stats.rs
+++ b/datafusion/common/src/stats.rs
@@ -321,6 +321,13 @@ impl Statistics {
         }
     }
 
+    /// Returns the memory size in bytes.
+    pub fn heap_size(&self) -> usize {
+        // column_statistics + num_rows + total_byte_size
+        self.column_statistics.capacity() * size_of::<ColumnStatistics>()
+            + size_of::<Precision<usize>>() * 2
+    }
+
     /// Calculates `total_byte_size` based on the schema and `num_rows`.
     /// If any of the columns has non-primitive width, `total_byte_size` is set to inexact.
     pub fn calculate_total_byte_size(&mut self, schema: &Schema) {
@@ -1756,5 +1763,47 @@ mod tests {
 
         // total_byte_size should fall back to scaling: 8000 * 0.1 = 800
         assert_eq!(result.total_byte_size, Precision::Inexact(800));
+    }
+
+    #[test]
+    fn test_statistics_heap_size() {
+        let stats = Statistics {
+            num_rows: Precision::Exact(100),
+            total_byte_size: Precision::Exact(100),
+            column_statistics: vec![ColumnStatistics {
+                null_count: Precision::Absent,
+                max_value: Precision::Absent,
+                min_value: Precision::Absent,
+                sum_value: Precision::Absent,
+                distinct_count: Precision::Absent,
+                byte_size: Precision::Exact(100),
+            }],
+        };
+
+        assert_eq!(stats.heap_size(), 320);
+
+        let stats = Statistics {
+            num_rows: Precision::Exact(100),
+            total_byte_size: Precision::Exact(100),
+            column_statistics: vec![
+                ColumnStatistics {
+                    null_count: Precision::Absent,
+                    max_value: Precision::Absent,
+                    min_value: Precision::Absent,
+                    sum_value: Precision::Absent,
+                    distinct_count: Precision::Absent,
+                    byte_size: Precision::Exact(100),
+                },
+                ColumnStatistics {
+                    null_count: Precision::Exact(10),
+                    max_value: Precision::Absent,
+                    min_value: Precision::Absent,
+                    sum_value: Precision::Absent,
+                    distinct_count: Precision::Absent,
+                    byte_size: Precision::Exact(100),
+                },
+            ],
+        };
+        assert_eq!(stats.heap_size(), 608);
     }
 }

--- a/datafusion/execution/src/cache/cache_unit.rs
+++ b/datafusion/execution/src/cache/cache_unit.rs
@@ -55,7 +55,7 @@ impl FileStatisticsCache for DefaultFileStatisticsCache {
                     num_rows: stats.num_rows,
                     num_columns: stats.column_statistics.len(),
                     table_size_bytes: stats.total_byte_size,
-                    statistics_size_bytes: 0, // TODO: set to the real size in the future
+                    statistics_size_bytes: stats.heap_size(),
                 },
             );
         }
@@ -196,7 +196,7 @@ mod tests {
                     num_rows: Precision::Absent,
                     num_columns: 1,
                     table_size_bytes: Precision::Absent,
-                    statistics_size_bytes: 0,
+                    statistics_size_bytes: 320,
                 }
             )])
         );


### PR DESCRIPTION
This adds a heap_size method retuning the amount of memory a statistics struct allocates on the heap.

## Which issue does this PR close?

This follows the suggestion from https://github.com/apache/datafusion/issues/19052#issuecomment-3603796097 step 1 to resolve https://github.com/apache/datafusion/issues/19052.

## Rationale for this change

This adds a method to retrieve the size of the allocation on the heap for a given `Statistics` struct.

## What changes are included in this PR?


## Are these changes tested?

Yes

## Are there any user-facing changes?

Yes, a new method heap_size on `Statistics`.
