### PR TITLE
feat: allow to skip named parameters and fill skipped with NULL

### DIFF
--- a/datafusion/expr/src/arguments.rs
+++ b/datafusion/expr/src/arguments.rs
@@ -420,12 +420,7 @@ mod tests {
         // Call with: func(100, 200, p5 => 500, p7 => 700)
         // Positional p1, p2, skip p3, p4, named p5, skip p6, named p7
         let args = vec![lit(100), lit(200), lit(500), lit(700)];
-        let arg_names = vec![
-            None,
-            None,
-            Some("p5".to_string()),
-            Some("p7".to_string()),
-        ];
+        let arg_names = vec![None, None, Some("p5".to_string()), Some("p7".to_string())];
 
         let result = resolve_function_arguments(&param_names, args, arg_names).unwrap();
 
@@ -453,10 +448,12 @@ mod tests {
 
         let result = resolve_function_arguments(&param_names, args, arg_names);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown parameter name"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unknown parameter name")
+        );
     }
 
     #[test]
@@ -501,10 +498,7 @@ mod tests {
     }
 
     fn is_null(expr: &Expr) -> bool {
-        matches!(
-            expr,
-            Expr::Literal(datafusion_common::ScalarValue::Null, _)
-        )
+        matches!(expr, Expr::Literal(datafusion_common::ScalarValue::Null, _))
     }
 
     fn assert_result_pattern(result: &[Expr], pattern: &[Option<Expr>]) {
@@ -528,7 +522,8 @@ mod tests {
                     assert!(
                         is_null(actual),
                         "Expected NULL at position {}, got {:?}",
-                        i, actual
+                        i,
+                        actual
                     );
                 }
             }

--- a/datafusion/expr/src/arguments.rs
+++ b/datafusion/expr/src/arguments.rs
@@ -1,7 +1,7 @@
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
-// regarding copyrigrht ownership.  The ASF licenses this file
+// regarding copyright ownership.  The ASF licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/datafusion/expr/src/arguments.rs
+++ b/datafusion/expr/src/arguments.rs
@@ -514,16 +514,13 @@ mod tests {
                 Some(expected_expr) => {
                     assert_eq!(
                         actual, expected_expr,
-                        "Mismatch at position {}: expected {:?}, got {:?}",
-                        i, expected_expr, actual
+                        "Mismatch at position {i}: expected {expected_expr:?}, got {actual:?}"
                     );
                 }
                 None => {
                     assert!(
                         is_null(actual),
-                        "Expected NULL at position {}, got {:?}",
-                        i,
-                        actual
+                        "Expected NULL at position {i}, got {actual:?}"
                     );
                 }
             }

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -143,6 +143,11 @@ impl TestContext {
                 info!("Registering dummy async udf");
                 register_async_abs_udf(test_ctx.session_ctx())
             }
+            "named_arguments.slt" => {
+                info!("Registering test UDF with many optional parameters");
+                let test_udf = create_optional_params_test_udf();
+                test_ctx.ctx.register_udf(test_udf);
+            }
             _ => {
                 info!("Using default SessionContext");
             }
@@ -512,4 +517,99 @@ fn register_async_abs_udf(ctx: &SessionContext) {
     let async_abs = AsyncAbs::new();
     let udf = AsyncScalarUDF::new(Arc::new(async_abs));
     ctx.register_udf(udf.into_scalar_udf());
+}
+
+/// Creates a test UDF with many optional parameters to test named argument skipping
+fn create_optional_params_test_udf() -> ScalarUDF {
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::logical_expr::{TypeSignature, Coercion};
+    use datafusion::common::types::{NativeType, logical_int64};
+
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct TestOptionalParamsUDF {
+        signature: Signature,
+    }
+
+    impl TestOptionalParamsUDF {
+        fn new() -> Self {
+            let int64_coercion = Coercion::new_implicit(
+                datafusion::logical_expr::TypeSignatureClass::Native(logical_int64()),
+                vec![],
+                NativeType::Int64,
+            );
+
+            Self {
+                signature: Signature::one_of(
+                    vec![
+                        // Support 1 to 7 parameters
+                        TypeSignature::Coercible(vec![int64_coercion.clone()]),
+                        TypeSignature::Coercible(vec![int64_coercion.clone(), int64_coercion.clone()]),
+                        TypeSignature::Coercible(vec![int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone()]),
+                        TypeSignature::Coercible(vec![int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone()]),
+                        TypeSignature::Coercible(vec![int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone()]),
+                        TypeSignature::Coercible(vec![int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone()]),
+                        TypeSignature::Coercible(vec![int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone(), int64_coercion.clone()]),
+                    ],
+                    Volatility::Immutable,
+                )
+                .with_parameter_names(vec![
+                    "p1".to_string(),
+                    "p2".to_string(),
+                    "p3".to_string(),
+                    "p4".to_string(),
+                    "p5".to_string(),
+                    "p6".to_string(),
+                    "p7".to_string(),
+                ])
+                .expect("valid parameter names"),
+            }
+        }
+    }
+
+    impl ScalarUDFImpl for TestOptionalParamsUDF {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn name(&self) -> &str {
+            "test_optional_params"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+
+        fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Int64)
+        }
+
+        fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+            // Sum all non-NULL parameters
+            let arrays = args.args.iter().map(|arg| match arg {
+                ColumnarValue::Array(arr) => arr.clone(),
+                ColumnarValue::Scalar(scalar) => {
+                    scalar.to_array_of_size(1).expect("Failed to convert scalar to array")
+                }
+            }).collect::<Vec<_>>();
+
+            let len = arrays.first().map(|a| a.len()).unwrap_or(1);
+            let mut result = Vec::with_capacity(len);
+
+            for row_idx in 0..len {
+                let mut sum: i64 = 0;
+                for array in &arrays {
+                    let int_array = array.as_any().downcast_ref::<Int64Array>()
+                        .expect("Expected Int64Array");
+                    if let Some(value) = int_array.value(row_idx.min(int_array.len() - 1)).into() {
+                        sum += value;
+                    }
+                }
+                result.push(Some(sum));
+            }
+
+            Ok(ColumnarValue::Array(Arc::new(Int64Array::from(result))))
+        }
+    }
+
+    ScalarUDF::from(TestOptionalParamsUDF::new())
 }

--- a/datafusion/sqllogictest/test_files/named_arguments.slt
+++ b/datafusion/sqllogictest/test_files/named_arguments.slt
@@ -269,3 +269,43 @@ SELECT row_number(value => 1) OVER (ORDER BY id) FROM window_test;
 # Cleanup
 statement ok
 DROP TABLE window_test;
+
+#############
+## Test UDF with Many Optional Parameters (test_optional_params - sums p1 through p7)
+#############
+
+# Skip multiple middle parameters
+query I
+SELECT test_optional_params(p1 => 100, p3 => 300, p5 => 500, p7 => 700);
+----
+1600
+
+# Alternating pattern
+query I
+SELECT test_optional_params(p1 => 1, p3 => 3, p5 => 5, p7 => 7);
+----
+16
+
+# Only first and last
+query I
+SELECT test_optional_params(p1 => 5, p7 => 10);
+----
+15
+
+# Only last parameter
+query I
+SELECT test_optional_params(p7 => 42);
+----
+42
+
+# Reverse order with skips
+query I
+SELECT test_optional_params(p7 => 7, p5 => 5, p3 => 3, p1 => 1);
+----
+16
+
+# Mixed positional and named with skips
+query I
+SELECT test_optional_params(10, 20, p5 => 50, p7 => 70);
+----
+150

--- a/datafusion/sqllogictest/test_files/named_arguments.slt
+++ b/datafusion/sqllogictest/test_files/named_arguments.slt
@@ -309,3 +309,40 @@ query I
 SELECT test_optional_params(10, 20, p5 => 50, p7 => 70);
 ----
 150
+
+#############
+## Test NULL handling - explicit NULL vs skipped parameters
+#############
+
+# Positional NULL
+query I
+SELECT test_optional_params(100, NULL, 300);
+----
+400
+
+# Named parameter with explicit NULL
+query I
+SELECT test_optional_params(p1 => 100, p2 => NULL, p3 => 300);
+----
+400
+
+# Skipped parameter (implicit NULL)
+query I
+SELECT test_optional_params(p1 => 100, p3 => 300);
+----
+400
+
+# Test that NULL is accepted by different type signatures
+# substr expects (string, int64, int64)
+
+# NULL in int64 position (start_pos)
+query T
+SELECT substr(str => 'hello world', start_pos => NULL, length => 5);
+----
+NULL
+
+# NULL in string position
+query T
+SELECT substr(str => NULL, start_pos => 1, length => 5);
+----
+NULL


### PR DESCRIPTION
Relates to:

- #17379

## Rationale for this change

Named arguments currently require all parameters from the first to the last provided argument to be explicitly specified. This forces verbose workarounds like `func(a => 1, b => NULL, c => NULL, d => 5)` instead of the cleaner `func(a => 1, d => 5)`.

## What changes are included in this PR?

Modified `datafusion/expr/src/arguments.rs` to automatically fill skipped parameters with NULL when using named arguments. The algorithm finds the highest provided parameter index and fills any gaps with NULL expressions.

This means:
- `func(100, NULL, 300)` (positional NULL)
- `func(p1 => 100, p2 => NULL, p3 => 300)` (explicit NULL)
- `func(p1 => 100, p3 => 300)` (skipped parameter)

All three are equivalent - they pass the same NULL value to the function at position 2.

## Are these changes tested?

Yes. Added unit tests in `arguments.rs` and SQL integration tests in `named_arguments.slt`, including tests that verify explicit NULL and skipped parameters behave identically across different type signatures (Int64, String, etc.).

## Are there any user-facing changes?

Yes. Users can now skip middle parameters with named arguments - they will be filled with NULL. The function signature validation accepts NULL for any type, and it's up to the UDF implementation to handle NULL values appropriately.

This change is fully backward compatible - all existing queries continue to work unchanged.
