### PR TITLE
Minor: remove unnecessary unit tests for fixed size binary

### DIFF
--- a/datafusion/functions/src/encoding/inner.rs
+++ b/datafusion/functions/src/encoding/inner.rs
@@ -574,29 +574,3 @@ fn decode(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     }?;
     decode_process(expression, encoding)
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_encode_fsb() {
-        use super::*;
-
-        let value = vec![0u8; 16];
-        let array = arrow::array::FixedSizeBinaryArray::try_from_sparse_iter_with_size(
-            vec![Some(value)].into_iter(),
-            16,
-        )
-        .unwrap();
-        let value = ColumnarValue::Array(Arc::new(array));
-
-        let ColumnarValue::Array(result) =
-            encode_process(&value, Encoding::Base64).unwrap()
-        else {
-            panic!("unexpected value");
-        };
-
-        let string_array = result.as_any().downcast_ref::<StringArray>().unwrap();
-        let result_value = string_array.value(0);
-        assert_eq!(result_value, "AAAAAAAAAAAAAAAAAAAAAA");
-    }
-}


### PR DESCRIPTION
## Which issue does this PR close?

- Follow on to https://github.com/apache/datafusion/pull/18950

## Rationale for this change

Per @timsaucer 's comment https://github.com/apache/datafusion/pull/18950#discussion_r2608304739

> Ok to remove now that we have SLT.

These unit tests duplicate coverage we have with SLT so let's remove them to avoid redundancy

## What changes are included in this PR?

remove duplicate tests added https://github.com/apache/datafusion/pull/18950
## Are these changes tested?
by ci

## Are there any user-facing changes?

No