### PR TITLE
refactor: refactor spark like function to use datafusion like

### DIFF
--- a/datafusion/spark/src/function/string/like.rs
+++ b/datafusion/spark/src/function/string/like.rs
@@ -71,8 +71,8 @@ impl ScalarUDFImpl for SparkLike {
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        match (arg_types.first(), arg_types.get(1)) {
-            (Some(lhs), Some(rhs)) => {
+        match arg_types {
+            [lhs, rhs] => {
                 let common_type = like_coercion(lhs, rhs).ok_or_else(|| {
                     plan_datafusion_err!(
                         "LIKE does not support argument types {:?} and {:?}",


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of #17964 

## Rationale for this change

There are several Spark functions which have the equivalent Datafusion functions, our goal is to reduce this duplication.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

- Spark LIKE keeps its wrapper but now uses DF’s l`ike_coercion` and delegates execution to `arrow::compute::like`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

All previouse tests pass

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
