### PR TITLE
minor: cleanup unnecessary config in `decimal.slt`

### DIFF
--- a/datafusion/sqllogictest/test_files/decimal.slt
+++ b/datafusion/sqllogictest/test_files/decimal.slt
@@ -614,21 +614,10 @@ select a / b from foo;
 ----
 0.2
 
-statement ok
-create table t as values (arrow_cast(123, 'Decimal256(5,2)'));
-
-# make sure query below runs in single partition
-# otherwise error message may not be deterministic
-statement ok
-set datafusion.execution.target_partitions = 1;
-
 query R
-select AVG(column1) from t;
+select AVG(column1) from values (arrow_cast(123, 'Decimal256(5,2)'));
 ----
 123
-
-statement ok
-drop table t;
 
 statement ok
 CREATE EXTERNAL TABLE decimal256_simple (


### PR DESCRIPTION
Config was introduced as part of https://github.com/apache/datafusion/commit/60e00b3a6542b0a88ea392bfddf12a5295470225#diff-2cb6f61b93633f0057da2135f3556e966e32cd77bd9825dbdb0694c30b0839f1

However the test now succeeds:

https://github.com/apache/datafusion/blob/02c647ae1ee5da3605a7f92330b687a42e72d0b6/datafusion/sqllogictest/test_files/decimal.slt#L625-L628

So no need for this config in SLT anymore.

Also fold the table into the query for compactness.