### PR TITLE
Optimize hashing for StringView and ByteView (15-70% faster)

### DIFF
--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -888,17 +888,12 @@ mod tests {
 
                 let binary_array: ArrayRef =
                     Arc::new(binary.iter().cloned().collect::<$ARRAY>());
-                let ref_array: ArrayRef =
-                    Arc::new(binary.iter().cloned().collect::<BinaryArray>());
 
                 let random_state = RandomState::with_seeds(0, 0, 0, 0);
 
                 let mut binary_hashes = vec![0; binary.len()];
                 create_hashes(&[binary_array], &random_state, &mut binary_hashes)
                     .unwrap();
-
-                let mut ref_hashes = vec![0; binary.len()];
-                create_hashes(&[ref_array], &random_state, &mut ref_hashes).unwrap();
 
                 // Null values result in a zero hash,
                 for (val, hash) in binary.iter().zip(binary_hashes.iter()) {
@@ -907,9 +902,6 @@ mod tests {
                         None => assert_eq!(*hash, 0),
                     }
                 }
-
-                // same logical values should hash to the same hash value
-                assert_eq!(binary_hashes, ref_hashes);
 
                 // Same values should map to same hash values
                 assert_eq!(binary[0], binary[5]);
@@ -922,6 +914,7 @@ mod tests {
     }
 
     create_hash_binary!(binary_array, BinaryArray);
+    create_hash_binary!(large_binary_array, LargeBinaryArray);
     create_hash_binary!(binary_view_array, BinaryViewArray);
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- builds on https://github.com/apache/datafusion/pull/19373
- part of https://github.com/apache/datafusion/issues/18411
- Broken out of https://github.com/apache/datafusion/pull/19344
- Closes https://github.com/apache/datafusion/pull/19344

## Rationale for this change

While looking at performance as part of https://github.com/apache/datafusion/issues/18411, I noticed we could speed up string view hashing by optimizing for small strings

## What changes are included in this PR?

Optimize StringView hashing, specifically by using the inlined view for short strings

## Are these changes tested?

Functionally by existing coverage

Performance by benchmarks (added in https://github.com/apache/datafusion/pull/19373) which show 
* 15%-20% faster for mixed short/long strings
* 50%-70%  faster for "short" arrays where we know there are no strings longer than 12 bytes

```
utf8_view (small): multiple, no nulls        1.00     47.9±1.71µs        ? ?/sec    4.00    191.6±1.15µs        ? ?/sec
utf8_view (small): multiple, nulls           1.00     78.4±0.48µs        ? ?/sec    3.08    241.6±1.11µs        ? ?/sec
utf8_view (small): single, no nulls          1.00     13.9±0.19µs        ? ?/sec    4.29     59.7±0.30µs        ? ?/sec
utf8_view (small): single, nulls             1.00     23.8±0.20µs        ? ?/sec    3.10     73.7±1.03µs        ? ?/sec
utf8_view: multiple, no nulls                1.00    235.4±2.14µs        ? ?/sec    1.11    262.2±1.34µs        ? ?/sec
utf8_view: multiple, nulls                   1.00    227.2±2.11µs        ? ?/sec    1.34    303.9±2.23µs        ? ?/sec
utf8_view: single, no nulls                  1.00     71.6±0.74µs        ? ?/sec    1.05     75.2±1.27µs        ? ?/sec
utf8_view: single, nulls                     1.00     71.5±1.92µs        ? ?/sec    1.28     91.6±4.65µs  
```


<details><summary>Details</summary>
<p>

```
Gnuplot not found, using plotters backend
utf8_view: single, no nulls
                        time:   [20.872 µs 20.906 µs 20.944 µs]
                        change: [−15.863% −15.614% −15.331%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) high mild
  5 (5.00%) high severe

utf8_view: single, nulls
                        time:   [22.968 µs 23.050 µs 23.130 µs]
                        change: [−17.796% −17.384% −16.918%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

utf8_view: multiple, no nulls
                        time:   [66.005 µs 66.155 µs 66.325 µs]
                        change: [−19.077% −18.785% −18.512%] (p = 0.00 < 0.05)
                        Performance has improved.

utf8_view: multiple, nulls
                        time:   [72.155 µs 72.375 µs 72.649 µs]
                        change: [−17.944% −17.612% −17.266%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

utf8_view (small): single, no nulls
                        time:   [6.1401 µs 6.1563 µs 6.1747 µs]
                        change: [−69.623% −69.484% −69.333%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

utf8_view (small): single, nulls
                        time:   [10.234 µs 10.250 µs 10.270 µs]
                        change: [−53.969% −53.815% −53.666%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high severe

utf8_view (small): multiple, no nulls
                        time:   [20.853 µs 20.905 µs 20.961 µs]
                        change: [−66.006% −65.883% −65.759%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

utf8_view (small): multiple, nulls
                        time:   [32.519 µs 32.600 µs 32.675 µs]
                        change: [−53.937% −53.581% −53.232%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

</p>
</details> 

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
