### PR TITLE
Optimize muti-column grouping with StringView/ByteView (option 2) - 25% faster

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -118,6 +118,9 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
         self.do_append_val_inner(arr, row);
     }
 
+    // Don't inline to keep the code small and give LLVM the best chance of
+    // vectorizing the inner loop
+    #[inline(never)]
     fn vectorized_equal_to_inner<const HAS_NULLS: bool, const HAS_BUFFERS: bool>(
         &self,
         lhs_rows: &[usize],
@@ -221,6 +224,7 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
     ///
     /// Templated so that the inner compare loop can be
     /// specialized based on the input array
+    #[inline(always)]
     fn do_equal_to_inner<const HAS_NULLS: bool, const HAS_BUFFERS: bool>(
         &self,
         lhs_row: usize,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of https://github.com/apache/datafusion/issues/18411
- Closes https://github.com/apache/datafusion/pull/19344
- Closes https://github.com/apache/datafusion/pull/19364

Note this is an alternate to https://github.com/apache/datafusion/pull/19364

## Rationale for this change

@camuel found a query where DuckDB's raw grouping is is faster. 

I looked into it and much of the difference can be explained by better vectorization in the comparisons and short string optimizations

## What changes are included in this PR?

Optimize (will comment inline)

## Are these changes tested?

By CI. See also benchmark results below. I tested manually as well

Create Data:
```shell
nice tpchgen-cli --tables=lineitem --format=parquet --scale-factor 100
```

Run query:
```shell
hyperfine --warmup 3 " datafusion-cli   -c \"select l_returnflag,l_linestatus, count(*) as count_order from 'lineitem.parquet' group by l_returnflag, l_linestatus;\" "
```

Before (main): 1.368s
```shell
Benchmark 1:  datafusion-cli   -c "select l_returnflag,l_linestatus, count(*) as count_order from 'lineitem.parquet' group by l_returnflag, l_linestatus;"
  Time (mean ± σ):      1.393 s ±  0.020 s    [User: 16.778 s, System: 0.688 s]
  Range (min … max):    1.368 s …  1.438 s    10 runs
```

After (this PR) 1.022s
```shell
Benchmark 1:  ./datafusion-cli-multi-gby-try2   -c "select l_returnflag,l_linestatus, count(*) as count_order from 'lineitem.parquet' group by l_returnflag, l_linestatus;"
  Time (mean ± σ):      1.022 s ±  0.015 s    [User: 11.685 s, System: 0.644 s]
  Range (min … max):    1.005 s …  1.052 s    10 runs
```

I have a PR that improves string view hashing performance too, see
- https://github.com/apache/datafusion/pull/19374

## Are there any user-facing changes?
Faster performance
