### PR TITLE
fix: NULL handling in arrow_intersect and arrow_union

### DIFF
--- a/datafusion/functions-nested/src/set_ops.rs
+++ b/datafusion/functions-nested/src/set_ops.rs
@@ -22,7 +22,7 @@ use arrow::array::{
     Array, ArrayRef, GenericListArray, LargeListArray, ListArray, OffsetSizeTrait,
     new_null_array,
 };
-use arrow::buffer::OffsetBuffer;
+use arrow::buffer::{NullBuffer, OffsetBuffer};
 use arrow::compute;
 use arrow::datatypes::DataType::{LargeList, List, Null};
 use arrow::datatypes::{DataType, Field, FieldRef};
@@ -363,17 +363,22 @@ fn generic_set_lists<OffsetSize: OffsetSizeTrait>(
 
     let mut offsets = vec![OffsetSize::usize_as(0)];
     let mut new_arrays = vec![];
+    let mut new_null_buf = vec![];
     let converter = RowConverter::new(vec![SortField::new(l.value_type())])?;
     for (first_arr, second_arr) in l.iter().zip(r.iter()) {
+        let mut ele_should_be_null = false;
+
         let l_values = if let Some(first_arr) = first_arr {
             converter.convert_columns(&[first_arr])?
         } else {
+            ele_should_be_null = true;
             converter.empty_rows(0, 0)
         };
 
         let r_values = if let Some(second_arr) = second_arr {
             converter.convert_columns(&[second_arr])?
         } else {
+            ele_should_be_null = true;
             converter.empty_rows(0, 0)
         };
 
@@ -414,13 +419,19 @@ fn generic_set_lists<OffsetSize: OffsetSizeTrait>(
             }
         };
 
+        new_null_buf.push(!ele_should_be_null);
         new_arrays.push(array);
     }
 
     let offsets = OffsetBuffer::new(offsets.into());
     let new_arrays_ref: Vec<_> = new_arrays.iter().map(|v| v.as_ref()).collect();
     let values = compute::concat(&new_arrays_ref)?;
-    let arr = GenericListArray::<OffsetSize>::try_new(field, offsets, values, None)?;
+    let arr = GenericListArray::<OffsetSize>::try_new(
+        field,
+        offsets,
+        values,
+        Some(NullBuffer::new(new_null_buf.into())),
+    )?;
     Ok(Arc::new(arr))
 }
 

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -4834,9 +4834,9 @@ from array_intersect_table_1D_NULL;
 [1, 2, 3, 4]
 [2, 3]
 [3, 4]
-[3, 4]
-[1, 2]
-[]
+NULL
+NULL
+NULL
 
 # list_to_string scalar function #4 (function alias `array_to_string`)
 query TTT
@@ -6793,9 +6793,9 @@ from array_intersect_table_1D_NULL;
 [2, 3]
 [3]
 [3]
-[]
-[]
-[]
+NULL
+NULL
+NULL
 
 query ??
 select array_intersect(column1, column2),


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #9706 

## Rationale for this change

Mentioned in issue.

## What changes are included in this PR?

`RowConverter` API seems to have changed since initial implementation. Columns needs to be exactly same as schema passed in, so when we were handling case of `l_values` or `r_values` being `None`, us passing empty columns was causing an assert to fail in `RowConverter`.

## Are these changes tested?

`cargo test --test sqllogictests -- array` passes

For query mentioned in original issue, current result is:
```
> select array_intersect(column1, column2) from array_intersect_table;
+------------------------------------------------------------------------------+
| array_intersect(array_intersect_table.column1,array_intersect_table.column2) |
+------------------------------------------------------------------------------+
| [2, 3]                                                                       |
| [3]                                                                          |
| [3]                                                                          |
| []                                                                           |
| []                                                                           |
| []                                                                           |
+------------------------------------------------------------------------------+
6 row(s) fetched. 
Elapsed 0.012 seconds.
```

## Are there any user-facing changes?

No
