### PR TITLE
feat: Add `preselection_threshold` option to `BinaryExpr`

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -3828,9 +3828,7 @@ mod tests {
             .build()?;
         let e = plan(&logical_plan).await.unwrap_err().to_string();
 
-        let expected = r#"expr: BinaryExpr { left: BinaryExpr { left: Column { name: "c1", index: 0 }, op: Eq, right: Literal { value: Utf8("a"), field: Field { name: "lit", data_type: Utf8 } }, fail_on_overflow: false, preselection_threshold: 0.2 }"#;
-
-        assert_contains!(format!("{execution_plan:?}"), expected);
+        assert_contains!(&e, "Cannot cast string 'a' to value of Int64 type");
 
         Ok(())
     }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -3302,7 +3302,7 @@ mod tests {
         // verify that the plan correctly casts u8 to i64
         // the cast from u8 to i64 for literal will be simplified, and get lit(int64(5))
         // the cast here is implicit so has CastOptions with safe=true
-        let expected = r#"BinaryExpr { left: Column { name: "c7", index: 2 }, op: Lt, right: Literal { value: Int64(5), field: Field { name: "lit", data_type: Int64 } }, fail_on_overflow: false"#;
+        let expected = r#"BinaryExpr { left: Column { name: "c7", index: 2 }, op: Lt, right: Literal { value: Int64(5), field: Field { name: "lit", data_type: Int64 } }, fail_on_overflow: false, preselection_threshold: 0.2"#;
 
         assert_contains!(format!("{exec_plan:?}"), expected);
         Ok(())
@@ -3828,7 +3828,9 @@ mod tests {
             .build()?;
         let e = plan(&logical_plan).await.unwrap_err().to_string();
 
-        assert_contains!(&e, "Cannot cast string 'a' to value of Int64 type");
+        let expected = r#"expr: BinaryExpr { left: BinaryExpr { left: Column { name: "c1", index: 0 }, op: Eq, right: Literal { value: Utf8("a"), field: Field { name: "lit", data_type: Utf8 } }, fail_on_overflow: false, preselection_threshold: 0.2 }"#;
+
+        assert_contains!(format!("{execution_plan:?}"), expected);
 
         Ok(())
     }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -5221,6 +5221,74 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_preselection_threshold() {
+        // Test default threshold
+        let expr = BinaryExpr::new(
+            Arc::new(Column::new("a", 0)),
+            Operator::And,
+            Arc::new(Column::new("b", 1)),
+        );
+        assert_eq!(expr.preselection_threshold(), DEFAULT_PRESELECTION_THRESHOLD);
+        assert_eq!(expr.preselection_threshold(), 0.2);
+
+        // Test custom threshold via builder
+        let expr_custom = BinaryExpr::new(
+            Arc::new(Column::new("a", 0)),
+            Operator::And,
+            Arc::new(Column::new("b", 1)),
+        )
+        .with_preselection_threshold(0.5);
+        assert_eq!(expr_custom.preselection_threshold(), 0.5);
+
+        // Test threshold of 0.0 (disable pre-selection)
+        let expr_disabled = BinaryExpr::new(
+            Arc::new(Column::new("a", 0)),
+            Operator::And,
+            Arc::new(Column::new("b", 1)),
+        )
+        .with_preselection_threshold(0.0);
+        assert_eq!(expr_disabled.preselection_threshold(), 0.0);
+
+        // Test threshold of 1.0 (always pre-select for AND)
+        let expr_always = BinaryExpr::new(
+            Arc::new(Column::new("a", 0)),
+            Operator::And,
+            Arc::new(Column::new("b", 1)),
+        )
+        .with_preselection_threshold(1.0);
+        assert_eq!(expr_always.preselection_threshold(), 1.0);
+
+        // Test that threshold affects check_short_circuit behavior
+        // Create a boolean array with 20% true values (exactly at threshold)
+        let bool_array = BooleanArray::from(vec![true, false, false, false, false]);
+        let value = ColumnarValue::Array(Arc::new(bool_array));
+
+        // With default threshold (0.2), 20% true should trigger PreSelection
+        assert!(matches!(
+            check_short_circuit(&value, &Operator::And, 0.2),
+            ShortCircuitStrategy::PreSelection(_)
+        ));
+
+        // With threshold 0.1, 20% true should NOT trigger PreSelection
+        assert!(matches!(
+            check_short_circuit(&value, &Operator::And, 0.1),
+            ShortCircuitStrategy::None
+        ));
+
+        // With threshold 0.0, should never trigger PreSelection
+        assert!(matches!(
+            check_short_circuit(&value, &Operator::And, 0.0),
+            ShortCircuitStrategy::None
+        ));
+
+        // With threshold 1.0, should always trigger PreSelection (for mixed values)
+        assert!(matches!(
+            check_short_circuit(&value, &Operator::And, 1.0),
+            ShortCircuitStrategy::PreSelection(_)
+        ));
+    }
+
     /// Test for [pre_selection_scatter]
     /// Since [check_short_circuit] ensures that the left side does not contain null and is neither all_true nor all_false, as well as not being empty,
     /// the following tests have been designed:

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -55,6 +55,9 @@ use kernels::{
 /// Default threshold for pre-selection optimization in AND operations.
 /// When the ratio of true values in the left-hand side is below this threshold,
 /// the RecordBatch will be filtered before evaluating the right-hand side.
+///
+/// Note: this constant is intended as a sensible default and may be tuned in
+/// future releases. Downstream code should avoid depending on the exact value.
 pub const DEFAULT_PRESELECTION_THRESHOLD: f32 = 0.2;
 
 /// Binary expression
@@ -79,7 +82,10 @@ impl PartialEq for BinaryExpr {
             && self.op.eq(&other.op)
             && self.right.eq(&other.right)
             && self.fail_on_overflow.eq(&other.fail_on_overflow)
-            && self.preselection_threshold == other.preselection_threshold
+            // Compare bit patterns so NaN thresholds compare equal to themselves,
+            // keeping `PartialEq` consistent with the `Hash` implementation below.
+            && self.preselection_threshold.to_bits()
+                == other.preselection_threshold.to_bits()
     }
 }
 impl Eq for BinaryExpr {}
@@ -127,9 +133,50 @@ impl BinaryExpr {
     /// - Set to `0.0` to disable pre-selection optimization
     /// - Set to `1.0` to always apply pre-selection for AND operations
     /// - Default is [`DEFAULT_PRESELECTION_THRESHOLD`] (0.2)
+    ///
+    /// # Panics
+    ///
+    /// Panics (in debug builds) if `threshold` is not a finite value in the
+    /// range `[0.0, 1.0]`. In release builds the value is clamped to that
+    /// range, with `NaN` replaced by [`DEFAULT_PRESELECTION_THRESHOLD`].
+    ///
+    /// # Example
+    ///
+    /// Because this option is not currently exposed through `SessionConfig`,
+    /// callers typically apply it by transforming the physical plan and
+    /// rebuilding any [`BinaryExpr`] nodes with the desired threshold:
+    ///
+    /// ```ignore
+    /// use std::sync::Arc;
+    /// use datafusion_physical_expr::expressions::BinaryExpr;
+    /// use datafusion_physical_expr::PhysicalExpr;
+    ///
+    /// fn tune_threshold(expr: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
+    ///     if let Some(binary) = expr.downcast_ref::<BinaryExpr>() {
+    ///         return Arc::new(
+    ///             BinaryExpr::new(
+    ///                 Arc::clone(binary.left()),
+    ///                 *binary.op(),
+    ///                 Arc::clone(binary.right()),
+    ///             )
+    ///             .with_preselection_threshold(1.0),
+    ///         );
+    ///     }
+    ///     expr
+    /// }
+    /// ```
     pub fn with_preselection_threshold(self, threshold: f32) -> Self {
+        debug_assert!(
+            threshold.is_finite() && (0.0..=1.0).contains(&threshold),
+            "preselection_threshold must be a finite value in [0.0, 1.0], got {threshold}",
+        );
+        let preselection_threshold = if threshold.is_nan() {
+            DEFAULT_PRESELECTION_THRESHOLD
+        } else {
+            threshold.clamp(0.0, 1.0)
+        };
         Self {
-            preselection_threshold: threshold,
+            preselection_threshold,
             ..self
         }
     }
@@ -433,7 +480,8 @@ impl PhysicalExpr for BinaryExpr {
     ) -> Result<Arc<dyn PhysicalExpr>> {
         Ok(Arc::new(
             BinaryExpr::new(Arc::clone(&children[0]), self.op, Arc::clone(&children[1]))
-                .with_fail_on_overflow(self.fail_on_overflow),
+                .with_fail_on_overflow(self.fail_on_overflow)
+                .with_preselection_threshold(self.preselection_threshold),
         ))
     }
 
@@ -5290,6 +5338,90 @@ mod tests {
             check_short_circuit(&value, &Operator::And, 1.0),
             ShortCircuitStrategy::PreSelection(_)
         ));
+    }
+
+    /// Verify that `with_preselection_threshold` clamps out-of-range values in
+    /// release builds (debug builds panic via `debug_assert!`).
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn test_preselection_threshold_clamping() {
+        let build = |threshold: f32| {
+            BinaryExpr::new(
+                Arc::new(Column::new("a", 0)),
+                Operator::And,
+                Arc::new(Column::new("b", 1)),
+            )
+            .with_preselection_threshold(threshold)
+            .preselection_threshold()
+        };
+
+        assert_eq!(build(-0.5), 0.0);
+        assert_eq!(build(1.5), 1.0);
+        assert_eq!(build(f32::INFINITY), 1.0);
+        assert_eq!(build(f32::NEG_INFINITY), 0.0);
+        assert_eq!(build(f32::NAN), DEFAULT_PRESELECTION_THRESHOLD);
+    }
+
+    /// Exercise the full `evaluate` path with a custom `preselection_threshold`,
+    /// including a round-trip through `with_new_children`, to ensure the
+    /// threshold is honored end-to-end rather than only within
+    /// `check_short_circuit`.
+    #[test]
+    fn test_preselection_threshold_evaluate() -> Result<()> {
+        use arrow::array::Int32Array;
+        use datafusion_common::cast::as_boolean_array;
+
+        // Schema: a BOOLEAN, b INT32
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+
+        // Left side: 40% true values (2/5). This is above the default threshold
+        // of 0.2 but below a custom threshold of 0.5.
+        let a = Arc::new(BooleanArray::from(vec![true, false, false, true, false]));
+        let b = Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![a, b])?;
+
+        // Expression: a AND (b > 15)
+        let a_col: Arc<dyn PhysicalExpr> = Arc::new(Column::new("a", 0));
+        let b_gt_15: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("b", 1)),
+            Operator::Gt,
+            lit(15i32),
+        ));
+
+        // Sanity: default threshold should not trigger pre-selection for 40% true.
+        let default_expr =
+            BinaryExpr::new(Arc::clone(&a_col), Operator::And, Arc::clone(&b_gt_15));
+        let default_result = default_expr
+            .evaluate(&batch)?
+            .into_array(batch.num_rows())?;
+        let default_bool = as_boolean_array(&default_result)?;
+        let expected = BooleanArray::from(vec![false, false, false, true, false]);
+        assert_eq!(default_bool, &expected);
+
+        // Custom threshold of 1.0 should force pre-selection through `evaluate`.
+        let custom_expr =
+            BinaryExpr::new(Arc::clone(&a_col), Operator::And, Arc::clone(&b_gt_15))
+                .with_preselection_threshold(1.0);
+        let custom_result = custom_expr.evaluate(&batch)?.into_array(batch.num_rows())?;
+        let custom_bool = as_boolean_array(&custom_result)?;
+        assert_eq!(custom_bool, &expected);
+
+        // `with_new_children` must preserve the custom threshold so repeated
+        // plan rewrites do not silently reset it back to the default.
+        let rebuilt = Arc::new(custom_expr).with_new_children(vec![a_col, b_gt_15])?;
+        let rebuilt_binary = rebuilt
+            .downcast_ref::<BinaryExpr>()
+            .expect("rebuilt expression should still be a BinaryExpr");
+        assert_eq!(rebuilt_binary.preselection_threshold(), 1.0);
+
+        let rebuilt_result = rebuilt.evaluate(&batch)?.into_array(batch.num_rows())?;
+        let rebuilt_bool = as_boolean_array(&rebuilt_result)?;
+        assert_eq!(rebuilt_bool, &expected);
+
+        Ok(())
     }
 
     /// Test for [pre_selection_scatter]

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -52,31 +52,44 @@ use kernels::{
     regex_match_dyn_scalar,
 };
 
+/// Default threshold for pre-selection optimization in AND operations.
+/// When the ratio of true values in the left-hand side is below this threshold,
+/// the RecordBatch will be filtered before evaluating the right-hand side.
+pub const DEFAULT_PRESELECTION_THRESHOLD: f32 = 0.2;
+
 /// Binary expression
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone)]
 pub struct BinaryExpr {
     left: Arc<dyn PhysicalExpr>,
     op: Operator,
     right: Arc<dyn PhysicalExpr>,
     /// Specifies whether an error is returned on overflow or not
     fail_on_overflow: bool,
+    /// Threshold ratio (0.0 to 1.0) for pre-selection optimization in AND operations.
+    /// When the ratio of true values in the LHS is <= this threshold, pre-selection is applied.
+    /// Set to 0.0 to disable pre-selection, or 1.0 to always enable it for AND operations.
+    preselection_threshold: f32,
 }
 
-// Manually derive PartialEq and Hash to work around https://github.com/rust-lang/rust/issues/78808
+// Manually derive PartialEq, Eq and Hash to work around https://github.com/rust-lang/rust/issues/78808
+// and because f32 doesn't implement Eq
 impl PartialEq for BinaryExpr {
     fn eq(&self, other: &Self) -> bool {
         self.left.eq(&other.left)
             && self.op.eq(&other.op)
             && self.right.eq(&other.right)
             && self.fail_on_overflow.eq(&other.fail_on_overflow)
+            && self.preselection_threshold == other.preselection_threshold
     }
 }
+impl Eq for BinaryExpr {}
 impl Hash for BinaryExpr {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.left.hash(state);
         self.op.hash(state);
         self.right.hash(state);
         self.fail_on_overflow.hash(state);
+        self.preselection_threshold.to_bits().hash(state);
     }
 }
 
@@ -92,16 +105,32 @@ impl BinaryExpr {
             op,
             right,
             fail_on_overflow: false,
+            preselection_threshold: DEFAULT_PRESELECTION_THRESHOLD,
         }
     }
 
     /// Create new binary expression with explicit fail_on_overflow value
     pub fn with_fail_on_overflow(self, fail_on_overflow: bool) -> Self {
         Self {
-            left: self.left,
-            op: self.op,
-            right: self.right,
             fail_on_overflow,
+            ..self
+        }
+    }
+
+    /// Set the pre-selection threshold for AND operations.
+    ///
+    /// When evaluating `lhs AND rhs`, if the ratio of true values in `lhs`
+    /// is less than or equal to this threshold, the RecordBatch will be
+    /// filtered before evaluating `rhs`, which can improve performance
+    /// when `rhs` is expensive to evaluate.
+    ///
+    /// - Set to `0.0` to disable pre-selection optimization
+    /// - Set to `1.0` to always apply pre-selection for AND operations
+    /// - Default is [`DEFAULT_PRESELECTION_THRESHOLD`] (0.2)
+    pub fn with_preselection_threshold(self, threshold: f32) -> Self {
+        Self {
+            preselection_threshold: threshold,
+            ..self
         }
     }
 
@@ -118,6 +147,11 @@ impl BinaryExpr {
     /// Get the operator for this binary expression
     pub fn op(&self) -> &Operator {
         &self.op
+    }
+
+    /// Get the pre-selection threshold for AND operations
+    pub fn preselection_threshold(&self) -> f32 {
+        self.preselection_threshold
     }
 }
 
@@ -275,7 +309,7 @@ impl PhysicalExpr for BinaryExpr {
         let lhs = self.left.evaluate(batch)?;
 
         // Check if we can apply short-circuit evaluation.
-        match check_short_circuit(&lhs, &self.op) {
+        match check_short_circuit(&lhs, &self.op, self.preselection_threshold) {
             ShortCircuitStrategy::None => {}
             ShortCircuitStrategy::ReturnLeft => return Ok(lhs),
             ShortCircuitStrategy::ReturnRight => {
@@ -730,10 +764,6 @@ enum ShortCircuitStrategy<'a> {
     PreSelection(&'a BooleanArray),
 }
 
-/// Based on the results calculated from the left side of the short-circuit operation,
-/// if the proportion of `true` is less than 0.2 and the current operation is an `and`,
-/// the `RecordBatch` will be filtered in advance.
-const PRE_SELECTION_THRESHOLD: f32 = 0.2;
 
 /// Checks if a logical operator (`AND`/`OR`) can short-circuit evaluation based on the left-hand side (lhs) result.
 ///
@@ -741,14 +771,14 @@ const PRE_SELECTION_THRESHOLD: f32 = 0.2;
 /// - For `AND`:
 ///    - if LHS is all false => short-circuit → return LHS
 ///    - if LHS is all true  => short-circuit → return RHS
-///    - if LHS is mixed and true_count/sum_count <= [`PRE_SELECTION_THRESHOLD`] -> pre-selection
+///    - if LHS is mixed and true_count/sum_count <= `preselection_threshold` -> pre-selection
 /// - For `OR`:
 ///    - if LHS is all true  => short-circuit → return LHS
 ///    - if LHS is all false => short-circuit → return RHS
 /// # Arguments
 /// * `lhs` - The left-hand side (lhs) columnar value (array or scalar)
-/// * `lhs` - The left-hand side (lhs) columnar value (array or scalar)
 /// * `op` - The logical operator (`AND` or `OR`)
+/// * `preselection_threshold` - Threshold ratio for pre-selection optimization in AND operations
 ///
 /// # Implementation Notes
 /// 1. Only works with Boolean-typed arguments (other types automatically return `false`)
@@ -757,6 +787,7 @@ const PRE_SELECTION_THRESHOLD: f32 = 0.2;
 fn check_short_circuit<'a>(
     lhs: &'a ColumnarValue,
     op: &Operator,
+    preselection_threshold: f32,
 ) -> ShortCircuitStrategy<'a> {
     // Quick reject for non-logical operators,and quick judgment when op is and
     let is_and = match op {
@@ -800,7 +831,7 @@ fn check_short_circuit<'a>(
                     }
 
                     // determine if we can pre-selection
-                    if true_count as f32 / len as f32 <= PRE_SELECTION_THRESHOLD {
+                    if true_count as f32 / len as f32 <= preselection_threshold {
                         return ShortCircuitStrategy::PreSelection(bool_array);
                     }
                 } else {

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -764,7 +764,6 @@ enum ShortCircuitStrategy<'a> {
     PreSelection(&'a BooleanArray),
 }
 
-
 /// Checks if a logical operator (`AND`/`OR`) can short-circuit evaluation based on the left-hand side (lhs) result.
 ///
 /// Short-circuiting occurs under these circumstances:
@@ -5033,7 +5032,11 @@ mod tests {
         let left_expr = logical2physical(&logical_col("a").eq(expr_lit(2)), &schema);
         let left_value = left_expr.evaluate(&batch).unwrap();
         assert!(matches!(
-            check_short_circuit(&left_value, &Operator::And),
+            check_short_circuit(
+                &left_value,
+                &Operator::And,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::ReturnLeft
         ));
 
@@ -5043,9 +5046,11 @@ mod tests {
         let ColumnarValue::Array(array) = &left_value else {
             panic!("Expected ColumnarValue::Array");
         };
-        let ShortCircuitStrategy::PreSelection(value) =
-            check_short_circuit(&left_value, &Operator::And)
-        else {
+        let ShortCircuitStrategy::PreSelection(value) = check_short_circuit(
+            &left_value,
+            &Operator::And,
+            DEFAULT_PRESELECTION_THRESHOLD,
+        ) else {
             panic!("Expected ShortCircuitStrategy::PreSelection");
         };
         let expected_boolean_arr: Vec<_> =
@@ -5057,7 +5062,11 @@ mod tests {
         let left_expr = logical2physical(&logical_col("a").gt(expr_lit(0)), &schema);
         let left_value = left_expr.evaluate(&batch).unwrap();
         assert!(matches!(
-            check_short_circuit(&left_value, &Operator::Or),
+            check_short_circuit(
+                &left_value,
+                &Operator::Or,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::ReturnLeft
         ));
 
@@ -5066,7 +5075,11 @@ mod tests {
             logical2physical(&logical_col("a").gt(expr_lit(2)), &schema);
         let left_value = left_expr.evaluate(&batch).unwrap();
         assert!(matches!(
-            check_short_circuit(&left_value, &Operator::Or),
+            check_short_circuit(
+                &left_value,
+                &Operator::Or,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::None
         ));
 
@@ -5102,13 +5115,21 @@ mod tests {
         let mixed_nulls = logical2physical(&logical_col("c"), &schema_nullable);
         let mixed_nulls_value = mixed_nulls.evaluate(&batch_nullable).unwrap();
         assert!(matches!(
-            check_short_circuit(&mixed_nulls_value, &Operator::And),
+            check_short_circuit(
+                &mixed_nulls_value,
+                &Operator::And,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::None
         ));
 
         // Case: Mixed values with nulls - shouldn't short-circuit for OR
         assert!(matches!(
-            check_short_circuit(&mixed_nulls_value, &Operator::Or),
+            check_short_circuit(
+                &mixed_nulls_value,
+                &Operator::Or,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::None
         ));
 
@@ -5125,11 +5146,19 @@ mod tests {
 
         // All nulls shouldn't short-circuit for AND or OR
         assert!(matches!(
-            check_short_circuit(&null_value, &Operator::And),
+            check_short_circuit(
+                &null_value,
+                &Operator::And,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::None
         ));
         assert!(matches!(
-            check_short_circuit(&null_value, &Operator::Or),
+            check_short_circuit(
+                &null_value,
+                &Operator::Or,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::None
         ));
 
@@ -5137,33 +5166,57 @@ mod tests {
         // Scalar true
         let scalar_true = ColumnarValue::Scalar(ScalarValue::Boolean(Some(true)));
         assert!(matches!(
-            check_short_circuit(&scalar_true, &Operator::Or),
+            check_short_circuit(
+                &scalar_true,
+                &Operator::Or,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::ReturnLeft
         )); // Should short-circuit OR
         assert!(matches!(
-            check_short_circuit(&scalar_true, &Operator::And),
+            check_short_circuit(
+                &scalar_true,
+                &Operator::And,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::ReturnRight
         )); // Should return the RHS for AND
 
         // Scalar false
         let scalar_false = ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)));
         assert!(matches!(
-            check_short_circuit(&scalar_false, &Operator::And),
+            check_short_circuit(
+                &scalar_false,
+                &Operator::And,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::ReturnLeft
         )); // Should short-circuit AND
         assert!(matches!(
-            check_short_circuit(&scalar_false, &Operator::Or),
+            check_short_circuit(
+                &scalar_false,
+                &Operator::Or,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::ReturnRight
         )); // Should return the RHS for OR
 
         // Scalar null
         let scalar_null = ColumnarValue::Scalar(ScalarValue::Boolean(None));
         assert!(matches!(
-            check_short_circuit(&scalar_null, &Operator::And),
+            check_short_circuit(
+                &scalar_null,
+                &Operator::And,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::None
         ));
         assert!(matches!(
-            check_short_circuit(&scalar_null, &Operator::Or),
+            check_short_circuit(
+                &scalar_null,
+                &Operator::Or,
+                DEFAULT_PRESELECTION_THRESHOLD
+            ),
             ShortCircuitStrategy::None
         ));
     }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -5229,7 +5229,10 @@ mod tests {
             Operator::And,
             Arc::new(Column::new("b", 1)),
         );
-        assert_eq!(expr.preselection_threshold(), DEFAULT_PRESELECTION_THRESHOLD);
+        assert_eq!(
+            expr.preselection_threshold(),
+            DEFAULT_PRESELECTION_THRESHOLD
+        );
         assert_eq!(expr.preselection_threshold(), 0.2);
 
         // Test custom threshold via builder

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -612,14 +612,14 @@ mod test {
         )
         .unwrap();
         let snap = dynamic_filter_1.snapshot().unwrap().unwrap();
-        insta::assert_snapshot!(format!("{snap:?}"), @r#"BinaryExpr { left: Column { name: "a", index: 0 }, op: Eq, right: Literal { value: Int32(42), field: Field { name: "lit", data_type: Int32 } }, fail_on_overflow: false }"#);
+        insta::assert_snapshot!(format!("{snap:?}"), @r#"BinaryExpr { left: Column { name: "a", index: 0 }, op: Eq, right: Literal { value: Int32(42), field: Field { name: "lit", data_type: Int32 } }, fail_on_overflow: false, preselection_threshold: 0.2 }"#);
         let dynamic_filter_2 = reassign_expr_columns(
             Arc::clone(&dynamic_filter) as Arc<dyn PhysicalExpr>,
             &filter_schema_2,
         )
         .unwrap();
         let snap = dynamic_filter_2.snapshot().unwrap().unwrap();
-        insta::assert_snapshot!(format!("{snap:?}"), @r#"BinaryExpr { left: Column { name: "a", index: 1 }, op: Eq, right: Literal { value: Int32(42), field: Field { name: "lit", data_type: Int32 } }, fail_on_overflow: false }"#);
+        insta::assert_snapshot!(format!("{snap:?}"), @r#"BinaryExpr { left: Column { name: "a", index: 1 }, op: Eq, right: Literal { value: Int32(42), field: Field { name: "lit", data_type: Int32 } }, fail_on_overflow: false, preselection_threshold: 0.2 }"#);
         // Both filters allow evaluating the same expression
         let batch_1 = RecordBatch::try_new(
             Arc::clone(&filter_schema_1),

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -40,7 +40,7 @@ pub use crate::PhysicalSortExpr;
 /// Module with some convenient methods used in expression building
 pub use crate::aggregate::stats::StatsType;
 
-pub use binary::{BinaryExpr, binary, similar_to};
+pub use binary::{BinaryExpr, DEFAULT_PRESELECTION_THRESHOLD, binary, similar_to};
 pub use case::{CaseExpr, case};
 pub use cast::{CastExpr, cast};
 pub use column::{Column, col, with_new_schema};

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -1008,6 +1008,11 @@ message PhysicalBinaryExprNode {
   // Linearized operands for chains of the same operator (e.g. a AND b AND c).
   // When present, `l` and `r` are ignored and `operands` holds the flattened list.
   repeated PhysicalExprNode operands = 4;
+  // Optional pre-selection threshold for AND operations. When absent, the
+  // default threshold is used on decode. Stored as a scalar-wrapped float so
+  // it can round-trip distinguishably from "unset" while remaining
+  // backwards-compatible with existing plans.
+  optional float preselection_threshold = 5;
 }
 
 message PhysicalDateTimeIntervalExprNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -16128,6 +16128,9 @@ impl serde::Serialize for PhysicalBinaryExprNode {
         if !self.operands.is_empty() {
             len += 1;
         }
+        if self.preselection_threshold.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion.PhysicalBinaryExprNode", len)?;
         if let Some(v) = self.l.as_ref() {
             struct_ser.serialize_field("l", v)?;
@@ -16140,6 +16143,9 @@ impl serde::Serialize for PhysicalBinaryExprNode {
         }
         if !self.operands.is_empty() {
             struct_ser.serialize_field("operands", &self.operands)?;
+        }
+        if let Some(v) = self.preselection_threshold.as_ref() {
+            struct_ser.serialize_field("preselectionThreshold", v)?;
         }
         struct_ser.end()
     }
@@ -16155,6 +16161,8 @@ impl<'de> serde::Deserialize<'de> for PhysicalBinaryExprNode {
             "r",
             "op",
             "operands",
+            "preselection_threshold",
+            "preselectionThreshold",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -16163,6 +16171,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalBinaryExprNode {
             R,
             Op,
             Operands,
+            PreselectionThreshold,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -16188,6 +16197,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalBinaryExprNode {
                             "r" => Ok(GeneratedField::R),
                             "op" => Ok(GeneratedField::Op),
                             "operands" => Ok(GeneratedField::Operands),
+                            "preselectionThreshold" | "preselection_threshold" => Ok(GeneratedField::PreselectionThreshold),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -16211,6 +16221,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalBinaryExprNode {
                 let mut r__ = None;
                 let mut op__ = None;
                 let mut operands__ = None;
+                let mut preselection_threshold__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::L => {
@@ -16237,6 +16248,14 @@ impl<'de> serde::Deserialize<'de> for PhysicalBinaryExprNode {
                             }
                             operands__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::PreselectionThreshold => {
+                            if preselection_threshold__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("preselectionThreshold"));
+                            }
+                            preselection_threshold__ = 
+                                map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| x.0)
+                            ;
+                        }
                     }
                 }
                 Ok(PhysicalBinaryExprNode {
@@ -16244,6 +16263,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalBinaryExprNode {
                     r: r__,
                     op: op__.unwrap_or_default(),
                     operands: operands__.unwrap_or_default(),
+                    preselection_threshold: preselection_threshold__,
                 })
             }
         }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1518,6 +1518,12 @@ pub struct PhysicalBinaryExprNode {
     /// When present, `l` and `r` are ignored and `operands` holds the flattened list.
     #[prost(message, repeated, tag = "4")]
     pub operands: ::prost::alloc::vec::Vec<PhysicalExprNode>,
+    /// Optional pre-selection threshold for AND operations. When absent, the
+    /// default threshold is used on decode. Stored as a scalar-wrapped float so
+    /// it can round-trip distinguishably from "unset" while remaining
+    /// backwards-compatible with existing plans.
+    #[prost(float, optional, tag = "5")]
+    pub preselection_threshold: ::core::option::Option<f32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PhysicalDateTimeIntervalExprNode {

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -275,6 +275,17 @@ pub fn parse_physical_expr_with_converter(
         ExprType::Literal(scalar) => Arc::new(Literal::new(scalar.try_into()?)),
         ExprType::BinaryExpr(binary_expr) => {
             let op = logical_plan::from_proto::from_proto_binary_op(&binary_expr.op)?;
+            let threshold = binary_expr.preselection_threshold;
+            let build_binary = |left: Arc<dyn PhysicalExpr>,
+                                right: Arc<dyn PhysicalExpr>|
+             -> Arc<dyn PhysicalExpr> {
+                let mut expr = BinaryExpr::new(left, op, right);
+                if let Some(t) = threshold {
+                    expr = expr.with_preselection_threshold(t);
+                }
+                Arc::new(expr)
+            };
+
             if !binary_expr.operands.is_empty() {
                 // New linearized format: reduce the flat operands list back into
                 // a nested binary expression tree.
@@ -290,15 +301,12 @@ pub fn parse_physical_expr_with_converter(
                     ));
                 }
 
-                operands
-                    .into_iter()
-                    .reduce(|left, right| Arc::new(BinaryExpr::new(left, op, right)))
-                    .expect(
-                        "Binary expression could not be reduced to a single expression.",
-                    )
+                operands.into_iter().reduce(&build_binary).expect(
+                    "Binary expression could not be reduced to a single expression.",
+                )
             } else {
                 // Legacy format with l/r fields
-                Arc::new(BinaryExpr::new(
+                build_binary(
                     parse_required_physical_expr(
                         binary_expr.l.as_deref(),
                         ctx,
@@ -306,7 +314,6 @@ pub fn parse_physical_expr_with_converter(
                         input_schema,
                         proto_converter,
                     )?,
-                    op,
                     parse_required_physical_expr(
                         binary_expr.r.as_deref(),
                         ctx,
@@ -314,7 +321,7 @@ pub fn parse_physical_expr_with_converter(
                         input_schema,
                         proto_converter,
                     )?,
-                ))
+                )
             }
         }
         ExprType::AggregateExpr(_) => {

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -36,9 +36,9 @@ use datafusion_physical_expr::scalar_subquery::ScalarSubqueryExpr;
 use datafusion_physical_expr::window::{SlidingAggregateWindowExpr, StandardWindowExpr};
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
 use datafusion_physical_plan::expressions::{
-    BinaryExpr, CaseExpr, CastExpr, Column, DynamicFilterPhysicalExpr, InListExpr,
-    IsNotNullExpr, IsNullExpr, LikeExpr, Literal, NegativeExpr, NotExpr, TryCastExpr,
-    UnKnownColumn,
+    BinaryExpr, CaseExpr, CastExpr, Column, DEFAULT_PRESELECTION_THRESHOLD,
+    DynamicFilterPhysicalExpr, InListExpr, IsNotNullExpr, IsNullExpr, LikeExpr, Literal,
+    NegativeExpr, NotExpr, TryCastExpr, UnKnownColumn,
 };
 use datafusion_physical_plan::joins::{HashExpr, HashTableLookupExpr};
 use datafusion_physical_plan::udaf::AggregateFunctionExpr;
@@ -307,12 +307,19 @@ pub fn serialize_physical_expr_with_converter(
     } else if let Some(expr) = expr.downcast_ref::<BinaryExpr>() {
         // Linearize a nested binary expression tree of the same operator
         // into a flat vector of operands to avoid deep recursion in proto.
+        //
+        // When linearizing we only fold children that share both the same
+        // operator *and* the same `preselection_threshold`, so the threshold
+        // survives a round trip through protobuf even for nested AND chains.
         let op = expr.op();
+        let threshold = expr.preselection_threshold();
         let mut operand_refs: Vec<&Arc<dyn PhysicalExpr>> = vec![expr.right()];
         let mut current_expr: &BinaryExpr = expr;
         loop {
             match current_expr.left().downcast_ref::<BinaryExpr>() {
-                Some(bin) if bin.op() == op => {
+                Some(bin)
+                    if bin.op() == op && bin.preselection_threshold() == threshold =>
+                {
                     operand_refs.push(bin.right());
                     current_expr = bin;
                 }
@@ -331,11 +338,20 @@ pub fn serialize_physical_expr_with_converter(
             .map(|e| proto_converter.physical_expr_to_proto(e, codec))
             .collect::<Result<Vec<_>>>()?;
 
+        // Only emit the threshold if it differs from the default, so plans
+        // produced by older encoders still deserialize identically.
+        let preselection_threshold = if threshold == DEFAULT_PRESELECTION_THRESHOLD {
+            None
+        } else {
+            Some(threshold)
+        };
+
         let binary_expr = Box::new(protobuf::PhysicalBinaryExprNode {
             l: None,
             r: None,
             op: format!("{:?}", op),
             operands,
+            preselection_threshold,
         });
 
         Ok(protobuf::PhysicalExprNode {

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -3465,6 +3465,86 @@ fn test_linearization_stops_at_different_op() -> Result<()> {
     Ok(())
 }
 
+/// Verify that a non-default `preselection_threshold` on `BinaryExpr` survives
+/// a protobuf round trip, both for a simple two-operand node and when nested
+/// with a mix of default-threshold children.
+#[test]
+fn roundtrip_binary_expr_preselection_threshold() -> Result<()> {
+    let field_a = Field::new("a", DataType::Boolean, false);
+    let field_b = Field::new("b", DataType::Boolean, false);
+    let field_c = Field::new("c", DataType::Boolean, false);
+    let schema = Arc::new(Schema::new(vec![field_a, field_b, field_c]));
+
+    let codec = DefaultPhysicalExtensionCodec {};
+    let proto_converter = DefaultPhysicalProtoConverter {};
+
+    // Case 1: a single AND with a custom threshold.
+    let expr: Arc<dyn PhysicalExpr> = Arc::new(
+        BinaryExpr::new(col("a", &schema)?, Operator::And, col("b", &schema)?)
+            .with_preselection_threshold(0.75),
+    );
+
+    let proto = proto_converter.physical_expr_to_proto(&expr, &codec)?;
+    match &proto.expr_type {
+        Some(protobuf::physical_expr_node::ExprType::BinaryExpr(b)) => {
+            assert_eq!(b.preselection_threshold, Some(0.75));
+        }
+        other => panic!("Expected BinaryExpr, got {other:?}"),
+    }
+
+    let ctx = SessionContext::new();
+    let task_ctx = ctx.task_ctx();
+    let decode_ctx = PhysicalPlanDecodeContext::new(&task_ctx, &codec);
+    let decoded = proto_converter.proto_to_physical_expr(&proto, &schema, &decode_ctx)?;
+    let decoded_binary = decoded
+        .downcast_ref::<BinaryExpr>()
+        .expect("decoded expression should be a BinaryExpr");
+    assert_eq!(decoded_binary.preselection_threshold(), 0.75);
+
+    // Case 2: an AND chain where only the outer node carries a custom
+    // threshold. Linearization must stop at the inner AND (which uses the
+    // default) so the thresholds are preserved on both halves of the tree.
+    let inner: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+        col("a", &schema)?,
+        Operator::And,
+        col("b", &schema)?,
+    ));
+    let outer: Arc<dyn PhysicalExpr> = Arc::new(
+        BinaryExpr::new(inner, Operator::And, col("c", &schema)?)
+            .with_preselection_threshold(1.0),
+    );
+
+    let outer_proto = proto_converter.physical_expr_to_proto(&outer, &codec)?;
+    match &outer_proto.expr_type {
+        Some(protobuf::physical_expr_node::ExprType::BinaryExpr(b)) => {
+            assert_eq!(b.preselection_threshold, Some(1.0));
+            assert_eq!(
+                b.operands.len(),
+                2,
+                "linearization must not fold children with different thresholds"
+            );
+        }
+        other => panic!("Expected BinaryExpr, got {other:?}"),
+    }
+
+    let decoded_outer =
+        proto_converter.proto_to_physical_expr(&outer_proto, &schema, &decode_ctx)?;
+    let decoded_outer_binary = decoded_outer
+        .downcast_ref::<BinaryExpr>()
+        .expect("decoded outer should be a BinaryExpr");
+    assert_eq!(decoded_outer_binary.preselection_threshold(), 1.0);
+    let decoded_inner = decoded_outer_binary
+        .left()
+        .downcast_ref::<BinaryExpr>()
+        .expect("decoded inner should be a BinaryExpr");
+    assert_eq!(
+        decoded_inner.preselection_threshold(),
+        datafusion::physical_expr::expressions::DEFAULT_PRESELECTION_THRESHOLD,
+    );
+
+    Ok(())
+}
+
 /// returns a SessionContext with an empty `netflow` table registered
 fn netflow_context() -> Result<SessionContext> {
     let ctx = SessionContext::new();


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

I encountered a short-circuit evaluation issue with `BinaryExpr` when using DataFusion. The operator on the right side may be a function, which should only be called after the left-side condition is satisfied; otherwise, executing the function may result in errors (such as illegal content exceptions).
The previously implemented short-circuit operation has a default ratio of 0.2, and this value cannot be modified externally. For this specific case, a larger value may need to be set.

https://github.com/apache/auron/issues/1763

## What changes are included in this PR?

Supports setting the `preselection_threshold` for `BinaryExpr`

## Are these changes tested?


## Are there any user-facing changes?
