### PR TITLE
perf: skip double lookup in multi group by hash map

### DIFF
--- a/datafusion/common/src/utils/proxy.rs
+++ b/datafusion/common/src/utils/proxy.rs
@@ -145,6 +145,14 @@ pub trait HashTableAllocExt {
         hasher: impl Fn(&Self::T) -> u64,
         accounting: &mut usize,
     );
+
+    /// Return the amount of memory allocated by this HashTable to store elements
+    /// (`size_of<T> * capacity`).
+    ///
+    /// Note this calculation is not recursive, and does not include any heap
+    /// allocations contained within the HashTable's elements. Does not include the
+    /// size of `self`
+    fn allocated_size(&self) -> usize;
 }
 
 impl<T> HashTableAllocExt for HashTable<T>
@@ -178,5 +186,9 @@ where
                 self.entry(hash, |y| y == &x, hasher).insert(x);
             }
         }
+    }
+
+    fn allocated_size(&self) -> usize {
+        size_of::<T>() * self.capacity()
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Making DataFusion faster.

the `insert_accounted` first find the entry (without increasing the capacity) and if missing insert using `entry().insert()` which search again the entry from what I understand. so avoided using  `insert_accounted` and always use `entry` and insert of missing which will prepare for insert if the table doesn't have enough space

## What changes are included in this PR?

1. remove usages of `insert_accounted` on `hashbrown::HashTable` with `entry()` and insert if missing
2. added `allocated_size` to `hashbrown::HashTable`
3. remove `map_size` and calculate it on call to `size` as it is very cheap

## Are these changes tested?

Existing tests

## Are there any user-facing changes?

added `allocated_size` similar to `allocated_size` for `Vec` that we added.



-----

from my local tests, it showed good perf improvements