### PR TITLE
feat: Support sort prefix removal for logical constants in Sort Pushdown

### DIFF
--- a/datafusion/physical-optimizer/src/pushdown_sort.rs
+++ b/datafusion/physical-optimizer/src/pushdown_sort.rs
@@ -169,11 +169,13 @@ mod tests {
             schema: SchemaRef,
             constant_exprs: Vec<Arc<dyn PhysicalExpr>>,
         ) -> Result<Self> {
-            let mut eq_props = EquivalenceProperties::new(schema.clone());
+            let mut eq_props = EquivalenceProperties::new(Arc::clone(&schema));
 
             let const_exprs: Vec<ConstExpr> = constant_exprs
                 .iter()
-                .map(|expr| ConstExpr::new(expr.clone(), AcrossPartitions::Uniform(None)))
+                .map(|expr| {
+                    ConstExpr::new(Arc::clone(expr), AcrossPartitions::Uniform(None))
+                })
                 .collect();
 
             eq_props.add_constants(const_exprs)?;
@@ -210,7 +212,7 @@ mod tests {
             self
         }
         fn schema(&self) -> SchemaRef {
-            self.schema.clone()
+            Arc::clone(&self.schema)
         }
         fn properties(&self) -> &PlanProperties {
             &self.cache
@@ -263,8 +265,8 @@ mod tests {
 
         let col_a = col("a", &schema)?;
         let mock_plan = Arc::new(MockPlanWithConstants::new(
-            schema.clone(),
-            vec![col_a.clone()],
+            Arc::clone(&schema),
+            vec![Arc::clone(&col_a)],
         )?);
 
         let eq_props = mock_plan.properties().equivalence_properties();


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #19403 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

After establishing the high-level API for sort pushdown (#19064), it was identified that the optimizer did not handle cases where the sort prefix is a **logical constant** (e.g., due to a filter).

For example, in a query like:
`SELECT * FROM table WHERE region = 'US' ORDER BY region, time`

The column `region` is constant. Previously, the optimizer attempted to push down `Sort(region, time)`. If the underlying source (e.g., Parquet or a custom TableProvider) only supported sorting by `time` (or had an index on `time`), the pushdown would fail or be unsupported.

By stripping the constant prefix, we can push down `Sort(time)`, which the source is more likely to support, leading to significant performance improvements (e.g., skipping row groups via dynamic top-k pushdown).

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Modified the `optimize` method in `physical-optimizer/src/pushdown_sort.rs`.
- The optimizer now checks the input's `EquivalenceProperties`.
- Any sort expression that is determined to be constant is filtered out from the `required_ordering` before calling `try_pushdown_sort` on the source.
- Added a new unit test `test_sort_pushdown_prefix_removal` that uses a `MockPlanWithConstants` to verify that a `SortExec` is correctly removed when the sort column is constant.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

- [x] Yes, a new unit test `test_sort_pushdown_prefix_removal` has been added to `datafusion/physical-optimizer/src/pushdown_sort.rs`.
- [x] Verified that the optimizer successfully strips constant columns and matches `Exact` pushdown results in the test case.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

- Users may see improved performance for queries involving `ORDER BY` and `WHERE` clauses on sorted data, as the optimizer can now push down sort requirements more aggressively.
- No changes to public APIs.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
