### PR TITLE
feat: support stateless physical plans

### DIFF
--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -1303,10 +1303,8 @@ mod test {
     }
 
     fn make_dynamic_expr(expr: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
-        Arc::new(DynamicFilterPhysicalExpr::new(
-            expr.children().into_iter().map(Arc::clone).collect(),
-            expr,
-        ))
+        let children = expr.children().into_iter().map(Arc::clone).collect();
+        Arc::new(DynamicFilterPhysicalExpr::new(expr, children))
     }
 
     #[tokio::test]

--- a/datafusion/execution/src/metrics/mod.rs
+++ b/datafusion/execution/src/metrics/mod.rs
@@ -89,9 +89,9 @@ pub struct Metric {
 ///   will be shown.
 /// - When set to `summary`, only metrics with type `MetricType::Summary` are shown.
 ///
-/// # Difference from `EXPLAIN ANALYZE VERBOSE`:  
-/// The `VERBOSE` keyword controls whether per-partition metrics are shown (when specified),  
-/// or aggregated metrics are displayed (when omitted).  
+/// # Difference from `EXPLAIN ANALYZE VERBOSE`:
+/// The `VERBOSE` keyword controls whether per-partition metrics are shown (when specified),
+/// or aggregated metrics are displayed (when omitted).
 /// In contrast, the `analyze_level` configuration determines which categories or
 /// levels of metrics are displayed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -211,6 +211,16 @@ impl MetricsSet {
     /// Create a new container of metrics
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Return a number of metrics.
+    pub fn len(&self) -> usize {
+        self.metrics.len()
+    }
+
+    /// Check if the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Add the specified metric

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -45,7 +45,7 @@ pub use cast::{CastExpr, cast};
 pub use cast_column::CastColumnExpr;
 pub use column::{Column, col, with_new_schema};
 pub use datafusion_expr::utils::format_state_name;
-pub use dynamic_filters::DynamicFilterPhysicalExpr;
+pub use dynamic_filters::{DynamicFilterPhysicalExpr, PlannedDynamicFilterPhysicalExpr};
 pub use in_list::{InListExpr, in_list};
 pub use is_not_null::{IsNotNullExpr, is_not_null};
 pub use is_null::{IsNullExpr, is_null};

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -42,6 +42,9 @@ force_hash_collisions = []
 test_utils = ["arrow/test_utils"]
 tokio_coop = []
 tokio_coop_fallback = []
+# Force physical plans to keep state separately from itself, making
+# them re-executable.
+stateless_plan = []
 
 [lib]
 name = "datafusion_physical_plan"

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -94,6 +94,10 @@ name = "partial_ordering"
 
 [[bench]]
 harness = false
+name = "plan_reuse"
+
+[[bench]]
+harness = false
 name = "spill_io"
 
 [[bench]]

--- a/datafusion/physical-plan/benches/plan_reuse.rs
+++ b/datafusion/physical-plan/benches/plan_reuse.rs
@@ -1,0 +1,192 @@
+use std::sync::{Arc, LazyLock};
+
+use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
+use criterion::{Criterion, criterion_group, criterion_main};
+use datafusion_common::Result;
+use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_execution::TaskContext;
+use datafusion_expr::Operator;
+use datafusion_functions_aggregate::average::avg_udaf;
+use datafusion_physical_expr::aggregate::AggregateExprBuilder;
+use datafusion_physical_expr::expressions::{self, binary, lit};
+use datafusion_physical_expr::{Partitioning, PhysicalExpr};
+use datafusion_physical_plan::aggregates::{
+    AggregateExec, AggregateMode, PhysicalGroupBy,
+};
+use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion_physical_plan::repartition::RepartitionExec;
+use datafusion_physical_plan::{
+    ExecutionPlan, execute_stream, filter::FilterExec, test::TestMemoryExec,
+};
+
+const NUM_FIELDS: usize = 1000;
+
+static SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(Schema::new(
+        (0..NUM_FIELDS)
+            .map(|i| Arc::new(Field::new(format!("x_{i}"), DataType::Int64, false)))
+            .collect::<Fields>(),
+    ))
+});
+
+fn partitioning() -> Partitioning {
+    Partitioning::RoundRobinBatch(16)
+}
+
+fn col_name(i: usize) -> String {
+    format!("x_{i}")
+}
+
+fn aggr_name(i: usize) -> String {
+    format!("aggr({})", col_name(i))
+}
+
+fn col(i: usize) -> Arc<dyn PhysicalExpr> {
+    expressions::col(&col_name(i), &SCHEMA).unwrap()
+}
+
+/// Returns a typical plan for the query like:
+///
+/// ```sql
+/// SELECT aggr1(col1) as aggr1, aggr2(col2) as aggr2 FROM t
+/// WHERE p1
+/// HAVING p2
+/// ```
+///
+/// A plan looks like:
+///
+/// ```text
+/// ProjectionExec
+///   FilterExec
+///     AggregateExec: mode=Final
+///       CoalescePartitionsExec
+///         AggregateExec: mode=Partial
+///           RepartitionExec
+///             FilterExec
+///               TestMemoryExec
+/// ```
+///
+fn query1_plan() -> Result<Arc<dyn ExecutionPlan>> {
+    let schema = Arc::clone(&SCHEMA);
+    let input = TestMemoryExec::try_new(&[vec![]], Arc::clone(&schema), None)?;
+
+    let plan = FilterExec::try_new(
+        // Some predicate.
+        binary(
+            binary(col(0), Operator::Eq, col(1), &schema)?,
+            Operator::And,
+            binary(col(2), Operator::Eq, lit(42_i64), &schema)?,
+            &schema,
+        )?,
+        Arc::new(input),
+    )?;
+
+    let plan = RepartitionExec::try_new(Arc::new(plan), partitioning())?;
+
+    let plan = {
+        // Partial aggregation.
+        let aggr_expr = (0..NUM_FIELDS)
+            .map(|i| {
+                AggregateExprBuilder::new(avg_udaf(), vec![col(i)])
+                    .schema(Arc::clone(&schema))
+                    .alias(aggr_name(i))
+                    .build()
+                    .map(Arc::new)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let filter_expr = (0..aggr_expr.len()).map(|_| None).collect();
+
+        AggregateExec::try_new(
+            AggregateMode::Partial,
+            PhysicalGroupBy::new(vec![], vec![], vec![], false),
+            aggr_expr,
+            filter_expr,
+            Arc::new(plan),
+            Arc::clone(&schema),
+        )?
+    };
+
+    let plan = CoalescePartitionsExec::new(Arc::new(plan));
+
+    let schema = plan.schema();
+    let plan = {
+        // Final aggregation.
+        let aggr_expr = (0..NUM_FIELDS)
+            .map(|i| {
+                AggregateExprBuilder::new(
+                    avg_udaf(),
+                    vec![Arc::new(expressions::Column::new(&aggr_name(i), i))],
+                )
+                .schema(Arc::clone(&schema))
+                .alias(aggr_name(i))
+                .build()
+                .map(Arc::new)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let filter_expr = (0..aggr_expr.len()).map(|_| None).collect();
+
+        AggregateExec::try_new(
+            AggregateMode::Partial,
+            PhysicalGroupBy::new(vec![], vec![], vec![], false),
+            aggr_expr,
+            filter_expr,
+            Arc::new(plan),
+            Arc::clone(&schema),
+        )?
+    };
+
+    let schema = plan.schema();
+    let plan = {
+        let predicate = (0..schema.fields.len()).fold(lit(true), |expr, i| {
+            binary(
+                expr,
+                Operator::And,
+                binary(
+                    Arc::new(expressions::Column::new(schema.field(i).name(), i)),
+                    Operator::Gt,
+                    lit(i as i64),
+                    &schema,
+                )
+                .unwrap(),
+                &schema,
+            )
+            .unwrap()
+        });
+
+        FilterExec::try_new(predicate, Arc::new(plan))?
+    };
+
+    Ok(Arc::new(plan))
+}
+
+#[cfg(not(feature = "stateless_plan"))]
+fn reset_plan_states(plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    plan.transform_up(|plan| {
+        let new_plan = Arc::clone(&plan).reset_state()?;
+        Ok(Transformed::yes(new_plan))
+    })
+    .unwrap()
+    .data
+}
+
+fn bench_plan_execute(c: &mut Criterion) {
+    let task_ctx = Arc::new(TaskContext::default());
+    let plan = query1_plan().unwrap();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    c.bench_function("execute", |b| {
+        b.iter(|| {
+            #[cfg(not(feature = "stateless_plan"))]
+            let plan = reset_plan_states(Arc::clone(&plan));
+
+            #[cfg(feature = "stateless_plan")]
+            let plan = Arc::clone(&plan);
+
+            let _stream =
+                rt.block_on(async { execute_stream(plan, Arc::clone(&task_ctx)) });
+        });
+    });
+}
+
+criterion_group!(benches, bench_plan_execute);
+criterion_main!(benches);

--- a/datafusion/physical-plan/src/dynamic_filter.rs
+++ b/datafusion/physical-plan/src/dynamic_filter.rs
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Utilities for working with dynamic filters in both stateful and stateless plan modes.
+//!
+//! Each dynamic filter can exist in two states: planning and executable.The difference
+//! between these two states is that a planned filter does not assume concurrent modifications,
+//! while an executable filter does. During the planning or optimization stage, a filter is created
+//! as a planned filter and then converted into an executable form when [`execute`] is called.
+//!
+//! For stateful (default) plan mode, there is no need to distinguish between planned
+//! and executable filters, as they are stored directly within the owner's [`ExecutionPlan`]
+//! and shared with children during the planning stage via filter push-down optimization.
+//! In this mode, both states are represented by the same type: [`DynamicFilterPhysicalExpr`].
+//!
+//! For stateless plan mode, filters are similarly pushed from the owner's [`ExecutionPlan`]
+//! to a child during filter push-down. However, because the [`ExecutionPlan`] is stateless,
+//! it cannot store a shared version of the filter. Instead, the executable filter is created
+//! when [`execute`] is called. In this mode, the two states are represented by different types:
+//! the planned version is [`PlannedDynamicFilterPhysicalExpr`] from the physical-expr crate,
+//! and the executable version remains [`DynamicFilterPhysicalExpr`].
+//!
+//! [`ExecutionPlan`]: crate::ExecutionPlan
+//! [`execute`]: crate::ExecutionPlan::execute
+//!
+
+use std::sync::Arc;
+
+use datafusion_physical_expr::PhysicalExpr;
+
+pub use datafusion_physical_expr::expressions::DynamicFilterPhysicalExpr;
+
+#[cfg(feature = "stateless_plan")]
+pub use datafusion_physical_expr::expressions::PlannedDynamicFilterPhysicalExpr;
+
+/// For stateful plans planned and executable filters are the same.
+#[cfg(not(feature = "stateless_plan"))]
+pub type PlannedDynamicFilterPhysicalExpr = DynamicFilterPhysicalExpr;
+
+/// Helper to make a new planning stage dynamic filter.
+#[cfg(feature = "stateless_plan")]
+pub fn make_planned_dynamic_filter(
+    expr: Arc<dyn PhysicalExpr>,
+    children: Vec<Arc<dyn PhysicalExpr>>,
+) -> PlannedDynamicFilterPhysicalExpr {
+    PlannedDynamicFilterPhysicalExpr::new(expr, children)
+}
+
+#[cfg(not(feature = "stateless_plan"))]
+pub fn make_planned_dynamic_filter(
+    expr: Arc<dyn PhysicalExpr>,
+    children: Vec<Arc<dyn PhysicalExpr>>,
+) -> PlannedDynamicFilterPhysicalExpr {
+    // For stateful plans executable planned and executable filters are the same.
+    make_executable_dynamic_filter(expr, children)
+}
+
+/// Helper to make a new execution stage [`DynamicFilterPhysicalExpr`].
+#[cfg(feature = "stateless_plan")]
+#[cfg(test)]
+pub fn make_executable_dynamic_filter(
+    expr: Arc<dyn PhysicalExpr>,
+    children: Vec<Arc<dyn PhysicalExpr>>,
+) -> DynamicFilterPhysicalExpr {
+    PlannedDynamicFilterPhysicalExpr::new(expr, children).to_executable()
+}
+
+#[cfg(not(feature = "stateless_plan"))]
+pub fn make_executable_dynamic_filter(
+    expr: Arc<dyn PhysicalExpr>,
+    children: Vec<Arc<dyn PhysicalExpr>>,
+) -> DynamicFilterPhysicalExpr {
+    DynamicFilterPhysicalExpr::new(expr, children)
+}

--- a/datafusion/physical-plan/src/explain.rs
+++ b/datafusion/physical-plan/src/explain.rs
@@ -22,6 +22,8 @@ use std::sync::Arc;
 
 use super::{DisplayAs, PlanProperties, SendableRecordBatchStream};
 use crate::execution_plan::{Boundedness, EmissionType};
+#[cfg(feature = "stateless_plan")]
+use crate::state::PlanStateNode;
 use crate::stream::RecordBatchStreamAdapter;
 use crate::{DisplayFormatType, ExecutionPlan, Partitioning};
 
@@ -132,6 +134,7 @@ impl ExecutionPlan for ExplainExec {
         &self,
         partition: usize,
         context: Arc<TaskContext>,
+        #[cfg(feature = "stateless_plan")] _state: &Arc<PlanStateNode>,
     ) -> Result<SendableRecordBatchStream> {
         trace!(
             "Start ExplainExec::execute for partition {} of context session_id {} and task_id {:?}",

--- a/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
+++ b/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
@@ -655,6 +655,7 @@ mod tests {
     use super::*;
     use crate::{
         ExecutionPlan, common,
+        execution_plan::execute_plan,
         joins::PiecewiseMergeJoinExec,
         test::{TestMemoryExec, build_table_i32},
     };
@@ -762,7 +763,7 @@ mod tests {
         let join = join(left, right, on, operator, join_type)?;
         let columns = columns(&join.schema());
 
-        let stream = join.execute(0, task_ctx)?;
+        let stream = execute_plan(Arc::new(join), 0, task_ctx)?;
         let batches = common::collect(stream).await?;
         Ok((columns, batches))
     }

--- a/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
@@ -32,11 +32,12 @@ use crate::joins::utils::{
     estimate_join_statistics, reorder_output_after_swap,
     symmetric_join_output_partitioning,
 };
-use crate::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use crate::projection::{
     ProjectionExec, join_allows_pushdown, join_table_borders, new_join_children,
     physical_to_column_exprs, update_join_on,
 };
+#[cfg(feature = "stateless_plan")]
+use crate::state::PlanStateNode;
 use crate::{
     DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, ExecutionPlanProperties,
     PlanProperties, SendableRecordBatchStream, Statistics,
@@ -50,6 +51,8 @@ use datafusion_common::{
 };
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::MemoryConsumer;
+#[cfg(not(feature = "stateless_plan"))]
+use datafusion_execution::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion_physical_expr::equivalence::join_equivalence_properties;
 use datafusion_physical_expr_common::physical_expr::{PhysicalExprRef, fmt_sql};
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, OrderingRequirements};
@@ -116,8 +119,6 @@ pub struct SortMergeJoinExec {
     pub join_type: JoinType,
     /// The schema once the join is applied
     schema: SchemaRef,
-    /// Execution metrics
-    metrics: ExecutionPlanMetricsSet,
     /// The left SortExpr
     left_sort_exprs: LexOrdering,
     /// The right SortExpr
@@ -128,6 +129,9 @@ pub struct SortMergeJoinExec {
     pub null_equality: NullEquality,
     /// Cache holding plan properties like equivalences, output partitioning etc.
     cache: PlanProperties,
+    /// Execution metrics
+    #[cfg(not(feature = "stateless_plan"))]
+    metrics: ExecutionPlanMetricsSet,
 }
 
 impl SortMergeJoinExec {
@@ -193,12 +197,13 @@ impl SortMergeJoinExec {
             filter,
             join_type,
             schema,
-            metrics: ExecutionPlanMetricsSet::new(),
             left_sort_exprs,
             right_sort_exprs,
             sort_options,
             null_equality,
             cache,
+            #[cfg(not(feature = "stateless_plan"))]
+            metrics: ExecutionPlanMetricsSet::new(),
         })
     }
 
@@ -457,7 +462,13 @@ impl ExecutionPlan for SortMergeJoinExec {
         &self,
         partition: usize,
         context: Arc<TaskContext>,
+        #[cfg(feature = "stateless_plan")] state: &Arc<PlanStateNode>,
     ) -> Result<SendableRecordBatchStream> {
+        #[cfg(not(feature = "stateless_plan"))]
+        #[expect(unused)]
+        let state = ();
+        use crate::{execute_input, plan_metrics};
+
         let left_partitions = self.left.output_partitioning().partition_count();
         let right_partitions = self.right.output_partitioning().partition_count();
         assert_eq_or_internal_err!(
@@ -467,13 +478,14 @@ impl ExecutionPlan for SortMergeJoinExec {
                  consider using RepartitionExec"
         );
         let (on_left, on_right) = self.on.iter().cloned().unzip();
-        let (streamed, buffered, on_streamed, on_buffered) =
+        let (streamed, buffered, on_streamed, on_buffered, streamed_child_num) =
             if SortMergeJoinExec::probe_side(&self.join_type) == JoinSide::Left {
                 (
                     Arc::clone(&self.left),
                     Arc::clone(&self.right),
                     on_left,
                     on_right,
+                    0,
                 )
             } else {
                 (
@@ -481,12 +493,27 @@ impl ExecutionPlan for SortMergeJoinExec {
                     Arc::clone(&self.left),
                     on_right,
                     on_left,
+                    1,
                 )
             };
 
         // execute children plans
-        let streamed = streamed.execute(partition, Arc::clone(&context))?;
-        let buffered = buffered.execute(partition, Arc::clone(&context))?;
+        let streamed = execute_input!(
+            streamed_child_num,
+            streamed,
+            partition,
+            Arc::clone(&context),
+            state
+        )?;
+        let buffered = execute_input!(
+            1 - streamed_child_num,
+            buffered,
+            partition,
+            Arc::clone(&context),
+            state
+        )?;
+
+        let _ = streamed_child_num;
 
         // create output buffer
         let batch_size = context.session_config().batch_size();
@@ -508,12 +535,13 @@ impl ExecutionPlan for SortMergeJoinExec {
             self.filter.clone(),
             self.join_type,
             batch_size,
-            SortMergeJoinMetrics::new(partition, &self.metrics),
+            SortMergeJoinMetrics::new(partition, plan_metrics!(self, state)),
             reservation,
             context.runtime_env(),
         )?))
     }
 
+    #[cfg(not(feature = "stateless_plan"))]
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -43,10 +43,12 @@ pub use datafusion_physical_expr::{
 };
 
 pub use crate::display::{DefaultDisplay, DisplayAs, DisplayFormatType, VerboseDisplay};
+#[cfg(not(feature = "stateless_plan"))]
+pub use crate::execution_plan::execute_input_stream;
 pub use crate::execution_plan::{
     ExecutionPlan, ExecutionPlanProperties, PlanProperties, collect, collect_partitioned,
-    displayable, execute_input_stream, execute_stream, execute_stream_partitioned,
-    get_plan_string, with_new_children_if_necessary,
+    displayable, execute_stream, execute_stream_partitioned, get_plan_string,
+    with_new_children_if_necessary,
 };
 pub use crate::metrics::Metric;
 pub use crate::ordering::InputOrderMode;
@@ -57,6 +59,7 @@ pub use crate::visitor::{ExecutionPlanVisitor, accept, visit_execution_plan};
 pub use crate::work_table::WorkTable;
 pub use spill::spill_manager::SpillManager;
 
+mod dynamic_filter;
 mod ordering;
 mod render_tree;
 mod topk;
@@ -87,6 +90,8 @@ pub mod repartition;
 pub mod sort_pushdown;
 pub mod sorts;
 pub mod spill;
+#[cfg(feature = "stateless_plan")]
+pub mod state;
 pub mod stream;
 pub mod streaming;
 pub mod tree_node;

--- a/datafusion/physical-plan/src/state.rs
+++ b/datafusion/physical-plan/src/state.rs
@@ -1,0 +1,431 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{
+    any::Any,
+    sync::{Arc, OnceLock, Weak},
+};
+
+use arrow::array::RecordBatch;
+use datafusion_common::{
+    Result, internal_err,
+    tree_node::{Transformed, TreeNode},
+};
+use datafusion_execution::{
+    RecordBatchStream, SendableRecordBatchStream, metrics::MetricsSet,
+};
+use datafusion_physical_expr::{
+    PhysicalExpr,
+    expressions::{DynamicFilterPhysicalExpr, PlannedDynamicFilterPhysicalExpr},
+};
+use futures::{Stream, StreamExt};
+use parking_lot::Mutex;
+
+use crate::{ExecutionPlan, WorkTable, metrics::ExecutionPlanMetricsSet};
+
+/// [`PlanStateNode`] contains the state required during plan execution.
+/// It is maintained so that each partition of a given plan receives the
+/// same state node during a single query execution.
+///
+/// A [`PlanStateNode`] tree, built during the [`ExecutionPlan::execute`] stage,
+/// mirrors the structure of the [`ExecutionPlan`] tree itself. It is designed
+/// to store plan state that is created during execution and must later be
+/// associated with the corresponding plan nodes—for example, metrics.
+///
+/// Each plan can store its state in the corresponding state node by implementing
+/// [`PlanState`] for its specific state structure.
+///
+/// # Passing data to child nodes
+///
+/// State tree allows to pass state from some plan to children, for example,
+/// work tables for recursive queries or dynamic filters. For the details,
+/// see [`PlanState`] trait.
+///
+/// [`ExecutionPlan`]: crate::ExecutionPlan
+/// [`ExecutionPlan::execute`]: crate::ExecutionPlan::execute
+///
+pub struct PlanStateNode {
+    /// Corresponding plan node.
+    pub plan_node: Arc<dyn ExecutionPlan>,
+    /// Parent of the current node if exists.
+    /// [`None`] if node is root.
+    parent_node: Option<Weak<PlanStateNode>>,
+    /// Plan specific state initialized once per execution.
+    pub(super) plan_state: OnceLock<Arc<dyn PlanState>>,
+    /// Metrics associated with this plan node.
+    pub metrics: ExecutionPlanMetricsSet,
+    /// State for each plan child lazily initialized.
+    children_state: Mutex<Box<[OnceLock<Arc<PlanStateNode>>]>>,
+}
+
+impl PlanStateNode {
+    /// Make a new [`PlanStateNode`].
+    fn new(
+        plan_node: Arc<dyn ExecutionPlan>,
+        parent_node: Option<Weak<PlanStateNode>>,
+    ) -> Self {
+        let num_children = plan_node.children().len();
+        Self {
+            plan_node,
+            parent_node,
+            plan_state: OnceLock::default(),
+            metrics: ExecutionPlanMetricsSet::new(),
+            children_state: Mutex::new(
+                (0..num_children).map(|_| OnceLock::default()).collect(),
+            ),
+        }
+    }
+
+    /// Make a new arced [`PlanStateNode`].
+    fn new_arc(
+        plan_node: Arc<dyn ExecutionPlan>,
+        parent_node: Option<Weak<PlanStateNode>>,
+    ) -> Arc<Self> {
+        Arc::new(Self::new(plan_node, parent_node))
+    }
+
+    /// Make a new [`PlanStateNode`] for a root plan node.
+    pub fn new_root(plan_node: Arc<dyn ExecutionPlan>) -> Self {
+        Self::new(plan_node, None)
+    }
+
+    /// Make a new arced [`PlanStateNode`] for a root plan node.
+    pub fn new_root_arc(plan_node: Arc<dyn ExecutionPlan>) -> Arc<Self> {
+        Arc::new(Self::new_root(plan_node))
+    }
+
+    /// Find metrics of the plan within state tree. Returns [`None`] if the
+    /// `plan` is not found among state tree plan nodes.
+    pub fn metrics_of(
+        self: &Arc<Self>,
+        plan: &Arc<dyn ExecutionPlan>,
+    ) -> Option<MetricsSet> {
+        let mut metrics = None;
+        accept_state(self, &mut |state: &Arc<PlanStateNode>| -> Result<bool> {
+            if Arc::ptr_eq(&state.plan_node, plan) {
+                metrics = Some(state.metrics.clone_inner());
+                Ok(false)
+            } else {
+                Ok(true)
+            }
+        })
+        .unwrap();
+        metrics
+    }
+
+    /// Get or init state using passed `f`. Returns a reference to the state.
+    ///
+    /// # Panics
+    ///
+    /// State is already initialized and cannot be downcast to `S`.
+    ///
+    pub fn get_or_init_state<S: PlanState>(&self, f: impl FnOnce() -> S) -> &S {
+        self.plan_state
+            .get_or_init(|| Arc::new(f()))
+            .as_any()
+            .downcast_ref::<S>()
+            .unwrap()
+    }
+
+    /// Make a child state node if it not initialized and return it.
+    ///
+    /// # Panics
+    ///
+    /// `child_idx` is more than the corresponding plan children number.
+    ///
+    pub fn child_state(self: &Arc<Self>, child_idx: usize) -> Arc<PlanStateNode> {
+        Arc::clone(self.children_state.lock()[child_idx].get_or_init(|| {
+            Self::new_arc(
+                Arc::clone(self.plan_node.children()[child_idx]),
+                // Set node parent.
+                Some(Arc::downgrade(self)),
+            )
+        }))
+    }
+
+    /// Lookup for the last [`WorkTable`] owner node over the path from root
+    /// to the current node.
+    ///
+    /// This function is intended  to be called by plan node that should operate
+    /// with a work table during [`ExecutionPlan::execute`] call to find table set
+    /// by work table owner, typically it is a [`RecursiveQueryExec`].
+    ///
+    /// [`RecursiveQueryExec`]: crate::recursive_query::RecursiveQueryExec
+    ///
+    pub fn work_table(&self) -> Option<Arc<WorkTable>> {
+        self.inspect_root_path(|node| {
+            node.plan_state.get().and_then(|state| state.work_table())
+        })
+    }
+
+    /// Replace all planned dynamic filters in the given expression,
+    /// converting them into executable versions by deriving shared
+    /// state from the filter owner.
+    ///
+    /// This function is intended to be called by a plan node that supports
+    /// dynamic filters during [`ExecutionPlan::execute`]. It converts stored
+    /// planning-time filters into execution-time filters by looking up the
+    /// filters stored in one of the parent nodes along the path to the
+    /// state tree root.
+    ///
+    pub fn planned_dynamic_filter_to_executable(
+        &self,
+        expr: Arc<dyn PhysicalExpr>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        expr.transform_up(|expr| {
+            let Some(dynamic_filter) = expr
+                .as_any()
+                .downcast_ref::<PlannedDynamicFilterPhysicalExpr>()
+            else {
+                return Ok(Transformed::no(expr));
+            };
+            let filter = match self.dynamic_filter_for(dynamic_filter) {
+                None => {
+                    return internal_err!(
+                        "dynamic filter cannot be resolved to executable"
+                    );
+                }
+                Some(filter) => filter,
+            };
+            Ok(Transformed::yes(filter as _))
+        })
+        .map(|tnr| tnr.data)
+    }
+
+    /// Lookup for the execution time dynamic filter by its origin.
+    fn dynamic_filter_for(
+        &self,
+        origin: &PlannedDynamicFilterPhysicalExpr,
+    ) -> Option<Arc<DynamicFilterPhysicalExpr>> {
+        self.inspect_root_path(|node| {
+            if let Some(state) = node.plan_state.get() {
+                for filter in state.dynamic_filters() {
+                    if let Some(res) = filter.as_dynamic_for(origin) {
+                        return Some(res);
+                    }
+                }
+            }
+            None
+        })
+    }
+
+    fn inspect_root_path<T>(&self, f: impl Fn(&PlanStateNode) -> Option<T>) -> Option<T> {
+        if let Some(res) = f(self) {
+            return Some(res);
+        }
+        let mut current_node = self.parent_node.as_ref().and_then(|p| p.upgrade());
+        while let Some(node) = current_node {
+            if let Some(res) = f(&node) {
+                return Some(res);
+            }
+            current_node = node.parent_node.as_ref().and_then(|p| p.upgrade());
+        }
+        None
+    }
+}
+
+/// Generic execution stage plan state.
+pub trait PlanState: Send + Sync + 'static {
+    /// Returns the state as [`Any`] so that it can be downcast to
+    /// a specific implementation.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Return dynamic filters maintained by this node.
+    ///
+    /// This function is used to push shared mutable dynamic filters
+    /// from an owner to a child that accepted the filter during the
+    /// planning stage via filter push-down optimization.
+    ///
+    fn dynamic_filters(&self) -> Vec<Arc<DynamicFilterPhysicalExpr>> {
+        vec![]
+    }
+
+    /// Return [`WorkTable`] maintained by this node.
+    fn work_table(&self) -> Option<Arc<WorkTable>> {
+        None
+    }
+}
+
+/// Describes a data associated with a [`PlanStateNode`].
+pub struct WithPlanStateNode<T> {
+    inner: T,
+    state: Arc<PlanStateNode>,
+}
+
+impl<T> WithPlanStateNode<T> {
+    /// Make a new [`WithPlanStateNode`].
+    pub fn new(inner: T, state: Arc<PlanStateNode>) -> Self {
+        Self { inner, state }
+    }
+
+    /// Project an inner data.
+    pub fn as_inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Project an inner mutable data.
+    pub fn as_inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Project a state.
+    pub fn state(&self) -> &Arc<PlanStateNode> {
+        &self.state
+    }
+
+    /// Borrow an inner data, preserving the state node.
+    pub fn as_ref(&self) -> WithPlanStateNode<&T> {
+        WithPlanStateNode {
+            inner: &self.inner,
+            state: Arc::clone(&self.state),
+        }
+    }
+
+    /// Map an inner data, preserving the state node.
+    pub fn map<V>(self, f: impl FnOnce(T) -> V) -> WithPlanStateNode<V> {
+        WithPlanStateNode {
+            inner: f(self.inner),
+            state: self.state,
+        }
+    }
+
+    /// Try to map an inner data, preserving the state node.
+    pub fn try_map<V>(
+        self,
+        f: impl FnOnce(T) -> Result<V>,
+    ) -> Result<WithPlanStateNode<V>> {
+        let inner = f(self.inner)?;
+        Ok(WithPlanStateNode {
+            inner,
+            state: self.state,
+        })
+    }
+
+    /// Try to apply async map `f`, preserving the state node.
+    pub async fn try_map_async<V, Fut>(
+        self,
+        f: impl FnOnce(T) -> Fut,
+    ) -> Result<WithPlanStateNode<V>>
+    where
+        Fut: Future<Output = Result<V>>,
+    {
+        let inner = f(self.inner).await?;
+        Ok(WithPlanStateNode {
+            inner,
+            state: self.state,
+        })
+    }
+
+    /// Consume `self` and convert into inner.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    /// Consume `self` and convert into node state.
+    pub fn into_state(self) -> Arc<PlanStateNode> {
+        self.state
+    }
+
+    /// Return stored parts.
+    pub fn into_parts(self) -> (T, Arc<PlanStateNode>) {
+        (self.inner, self.state)
+    }
+}
+
+impl<T> WithPlanStateNode<Result<T>> {
+    /// Represent self as a result.
+    pub fn as_result(self) -> Result<WithPlanStateNode<T>> {
+        self.inner.map(|inner| WithPlanStateNode {
+            inner,
+            state: self.state,
+        })
+    }
+}
+
+impl Stream for WithPlanStateNode<SendableRecordBatchStream> {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.as_inner_mut().poll_next_unpin(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.as_inner().size_hint()
+    }
+}
+
+impl RecordBatchStream for WithPlanStateNode<SendableRecordBatchStream> {
+    fn schema(&self) -> arrow_schema::SchemaRef {
+        self.as_inner().schema()
+    }
+}
+
+/// Visit all children of this state using passing `visitor`.
+pub fn accept_state<V: ExecutionPlanStateVisitor>(
+    state: &Arc<PlanStateNode>,
+    visitor: &mut V,
+) -> Result<bool, V::Error> {
+    if !visitor.pre_visit(state)? {
+        return Ok(false);
+    };
+    for i in 0..state.plan_node.children().len() {
+        if !accept_state(&state.child_state(i), visitor)? {
+            return Ok(false);
+        }
+    }
+    if !visitor.post_visit(state)? {
+        return Ok(false);
+    };
+    Ok(true)
+}
+
+/// Trait that implements the [Visitor
+/// pattern](https://en.wikipedia.org/wiki/Visitor_pattern) for a
+/// depth first walk of [`PlanStateNode`] nodes. `pre_visit` is called
+/// before any children are visited, and then `post_visit` is called
+/// after all children have been visited.
+pub trait ExecutionPlanStateVisitor {
+    /// The type of error returned by this visitor.
+    type Error;
+
+    /// Invoked on an [`PlanStateNode`] before any of its child have
+    /// been visited. If Ok(true) is returned, the recursion continues.
+    /// If Err(..) or Ok(false) are returned, the recursion stops immediately
+    /// and the error, if any, is returned.
+    fn pre_visit(&mut self, state: &Arc<PlanStateNode>) -> Result<bool, Self::Error>;
+
+    /// Invoked on an [`PlanStateNode`] plan *after* all of its child
+    /// inputs have been visited. The return value is handled the same
+    /// as the return value of `pre_visit`.
+    fn post_visit(&mut self, _state: &Arc<PlanStateNode>) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+impl<E, F> ExecutionPlanStateVisitor for F
+where
+    F: FnMut(&Arc<PlanStateNode>) -> Result<bool, E>,
+{
+    type Error = E;
+
+    fn pre_visit(&mut self, state: &Arc<PlanStateNode>) -> Result<bool, Self::Error> {
+        (self)(state)
+    }
+}

--- a/datafusion/physical-plan/src/test.rs
+++ b/datafusion/physical-plan/src/test.rs
@@ -148,7 +148,7 @@ impl ExecutionPlan for TestMemoryExec {
         self: Arc<Self>,
         _: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        unimplemented!()
+        Ok(self)
     }
 
     fn repartitioned(

--- a/datafusion/physical-plan/src/test/exec.rs
+++ b/datafusion/physical-plan/src/test/exec.rs
@@ -24,6 +24,8 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(feature = "stateless_plan")]
+use crate::state::PlanStateNode;
 use crate::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     RecordBatchStream, SendableRecordBatchStream, Statistics, common,
@@ -212,6 +214,7 @@ impl ExecutionPlan for MockExec {
         &self,
         partition: usize,
         _context: Arc<TaskContext>,
+        #[cfg(feature = "stateless_plan")] _state: &Arc<PlanStateNode>,
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(partition, 0);
 
@@ -369,14 +372,14 @@ impl ExecutionPlan for BarrierExec {
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        unimplemented!()
+        vec![]
     }
 
     fn with_new_children(
         self: Arc<Self>,
         _: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        unimplemented!()
+        Ok(self)
     }
 
     /// Returns a stream which yields data
@@ -384,6 +387,7 @@ impl ExecutionPlan for BarrierExec {
         &self,
         partition: usize,
         _context: Arc<TaskContext>,
+        #[cfg(feature = "stateless_plan")] _state: &Arc<PlanStateNode>,
     ) -> Result<SendableRecordBatchStream> {
         assert!(partition < self.data.len());
 
@@ -492,14 +496,14 @@ impl ExecutionPlan for ErrorExec {
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        unimplemented!()
+        vec![]
     }
 
     fn with_new_children(
         self: Arc<Self>,
         _: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        unimplemented!()
+        Ok(self)
     }
 
     /// Returns a stream which yields data
@@ -507,6 +511,7 @@ impl ExecutionPlan for ErrorExec {
         &self,
         partition: usize,
         _context: Arc<TaskContext>,
+        #[cfg(feature = "stateless_plan")] _state: &Arc<PlanStateNode>,
     ) -> Result<SendableRecordBatchStream> {
         internal_err!("ErrorExec, unsurprisingly, errored in partition {partition}")
     }
@@ -596,6 +601,7 @@ impl ExecutionPlan for StatisticsExec {
         &self,
         _partition: usize,
         _context: Arc<TaskContext>,
+        #[cfg(feature = "stateless_plan")] _state: &Arc<PlanStateNode>,
     ) -> Result<SendableRecordBatchStream> {
         unimplemented!("This plan only serves for testing statistics")
     }
@@ -704,6 +710,7 @@ impl ExecutionPlan for BlockingExec {
         &self,
         _partition: usize,
         _context: Arc<TaskContext>,
+        #[cfg(feature = "stateless_plan")] _state: &Arc<PlanStateNode>,
     ) -> Result<SendableRecordBatchStream> {
         Ok(Box::pin(BlockingStream {
             schema: Arc::clone(&self.schema),
@@ -850,6 +857,7 @@ impl ExecutionPlan for PanicExec {
         &self,
         partition: usize,
         _context: Arc<TaskContext>,
+        #[cfg(feature = "stateless_plan")] _state: &Arc<PlanStateNode>,
     ) -> Result<SendableRecordBatchStream> {
         Ok(Box::pin(PanicStream {
             partition,

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -1067,6 +1067,8 @@ impl RecordBatchStore {
 
 #[cfg(test)]
 mod tests {
+    use crate::dynamic_filter::make_executable_dynamic_filter;
+
     use super::*;
     use arrow::array::{Float64Array, Int32Array, RecordBatch};
     use arrow::datatypes::{DataType, Field, Schema};
@@ -1149,7 +1151,7 @@ mod tests {
             runtime,
             &metrics,
             Arc::new(RwLock::new(TopKDynamicFilters::new(Arc::new(
-                DynamicFilterPhysicalExpr::new(vec![], lit(true)),
+                make_executable_dynamic_filter(lit(true), vec![]),
             )))),
         )?;
 
@@ -1222,7 +1224,7 @@ mod tests {
         let metrics = ExecutionPlanMetricsSet::new();
 
         // Create a dynamic filter that we'll check for completion
-        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(vec![], lit(true)));
+        let dynamic_filter = Arc::new(make_executable_dynamic_filter(lit(true), vec![]));
         let dynamic_filter_clone = Arc::clone(&dynamic_filter);
 
         // Create a TopK instance

--- a/datafusion/pruning/src/pruning_predicate.rs
+++ b/datafusion/pruning/src/pruning_predicate.rs
@@ -2987,7 +2987,7 @@ mod tests {
             .map(|c| Arc::new(c.clone()) as Arc<dyn PhysicalExpr>)
             .collect_vec();
         let dynamic_phys_expr =
-            Arc::new(DynamicFilterPhysicalExpr::new(children, phys_expr))
+            Arc::new(DynamicFilterPhysicalExpr::new(phys_expr, children))
                 as Arc<dyn PhysicalExpr>;
         // Simulate the partition value substitution that would happen in ParquetOpener
         let remapped_expr = dynamic_phys_expr
@@ -4682,7 +4682,7 @@ mod tests {
             true,
             // s1 ["AB", "A\u{10ffff}\u{10ffff}\u{10ffff}"]  ==> some rows could pass (must keep)
             true,
-            // s1 ["A\u{10ffff}\u{10ffff}", "A\u{10ffff}\u{10ffff}"]  ==> no row match. (min, max) maybe truncate 
+            // s1 ["A\u{10ffff}\u{10ffff}", "A\u{10ffff}\u{10ffff}"]  ==> no row match. (min, max) maybe truncate
             // original (min, max) maybe ("A\u{10ffff}\u{10ffff}\u{10ffff}", "A\u{10ffff}\u{10ffff}\u{10ffff}\u{10ffff}")
             true,
         ];


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion/issues/19351

## What changes are included in this PR?

This patch introduces the stateless physical plan feature. Currently, the physical-plan crate is fully supported. This feature allows for the reuse of physical plans and their concurrent execution.

The feature is implemented by adding a separate **Cargo feature** named "stateless_plan". The implementation consists of several parts:

### State tree

With the "stateless_plan" feature enabled, the plans themselves do not store state. The state is stored in a separate tree composed of PlanStateNodes, which is built lazily during plan execution. Each node of the tree stores not only the shared state of the plan but also its metrics. The shape of the state tree matches the shape of the execution plan tree.

### Metrics

Metrics are stored in the nodes of the state tree and can be accessed after plan execution. Support is provided for performing EXPLAIN using the state.

### Dynamic Filters

In the case of stateless plans, dynamic filters cannot simply be stored inside the plans, as the same plan can be executed concurrently. To overcome this, a dynamic filter is split into two parts: a planning-time version and an execution-time version. The plans contain the planning-time version, which is transformed into the execution version during the execution phase and then passed from parent nodes to child nodes using the state tree.

### WorkTable

Instead of explicitly injecting the WorkTable into nodes, RecursiveExec exposes the WorkTable in the state stored within the State Tree. Then, a node interested in obtaining the WorkTable traverses up the State Tree and thus retrieves the current WorkTable.

## Are these changes tested?

Currently only locally as the patch introduces a new isolated feature which is not tested in CI yet.

## Following work

- Support stateless plan for all other DataFusion crates.
- Enable running tests with this feature in CI.
- Deprecate stateful plans to eventually transition completely to the stateless version.
- Add `fmt_as_with_state` to allow plans to include state-specific details in the EXPLAIN output, such as dynamic filters.


