### PR TITLE
Include .proto files in datafusion-proto distribution

### DIFF
--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -28,9 +28,6 @@ license = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
 
-# Exclude proto files so crates.io consumers don't need protoc
-exclude = ["*.proto"]
-
 [package.metadata.docs.rs]
 all-features = true
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #19489

## Rationale for this change

Allow consumers of `datafusion-proto` crate to reference the crate types in their own `.proto` definitions

## What changes are included in this PR?

Change to `Cargo.toml` to enable publishing of `datafusion.proto` as part of crate

## Are these changes tested?

N/A as this PR only changes packaging

## Are there any user-facing changes?

No