### PR TITLE
chore:enforce clippy::allow_attributes for FFI

### DIFF
--- a/datafusion/ffi/src/catalog_provider.rs
+++ b/datafusion/ffi/src/catalog_provider.rs
@@ -37,7 +37,6 @@ use crate::{df_result, rresult_return};
 /// A stable struct for sharing [`CatalogProvider`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_CatalogProvider {
     pub schema_names: unsafe extern "C" fn(provider: &Self) -> RVec<RString>,
 

--- a/datafusion/ffi/src/catalog_provider_list.rs
+++ b/datafusion/ffi/src/catalog_provider_list.rs
@@ -34,7 +34,6 @@ use crate::proto::logical_extension_codec::FFI_LogicalExtensionCodec;
 /// A stable struct for sharing [`CatalogProviderList`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_CatalogProviderList {
     /// Register a catalog
     pub register_catalog: unsafe extern "C" fn(

--- a/datafusion/ffi/src/execution/task_ctx.rs
+++ b/datafusion/ffi/src/execution/task_ctx.rs
@@ -36,7 +36,6 @@ use crate::udwf::FFI_WindowUDF;
 /// A stable struct for sharing [`TaskContext`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_TaskContext {
     /// Return the session ID.
     pub session_id: unsafe extern "C" fn(&Self) -> RString,

--- a/datafusion/ffi/src/execution/task_ctx_provider.rs
+++ b/datafusion/ffi/src/execution/task_ctx_provider.rs
@@ -33,7 +33,6 @@ use crate::{df_result, rresult};
 /// additional information.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_TaskContextProvider {
     /// Retrieve the current [`TaskContext`] provided the provider has not
     /// gone out of scope. This function will return an error if the weakly

--- a/datafusion/ffi/src/execution_plan.rs
+++ b/datafusion/ffi/src/execution_plan.rs
@@ -37,7 +37,6 @@ use crate::{df_result, rresult};
 /// A stable struct for sharing a [`ExecutionPlan`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_ExecutionPlan {
     /// Return the plan properties
     pub properties: unsafe extern "C" fn(plan: &Self) -> FFI_PlanProperties,

--- a/datafusion/ffi/src/expr/columnar_value.rs
+++ b/datafusion/ffi/src/expr/columnar_value.rs
@@ -25,7 +25,6 @@ use crate::arrow_wrappers::WrappedArray;
 /// Scalar values are passed as an Arrow array of length 1.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub enum FFI_ColumnarValue {
     Array(WrappedArray),
     Scalar(WrappedArray),

--- a/datafusion/ffi/src/expr/distribution.rs
+++ b/datafusion/ffi/src/expr/distribution.rs
@@ -29,7 +29,6 @@ use crate::expr::interval::FFI_Interval;
 /// See ['Distribution'] for the meaning of each variant.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 #[expect(clippy::large_enum_variant)]
 pub enum FFI_Distribution {
     Uniform(FFI_UniformDistribution),
@@ -69,14 +68,12 @@ impl TryFrom<FFI_Distribution> for Distribution {
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_UniformDistribution {
     interval: FFI_Interval,
 }
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_ExponentialDistribution {
     rate: WrappedArray,
     offset: WrappedArray,
@@ -85,7 +82,6 @@ pub struct FFI_ExponentialDistribution {
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_GaussianDistribution {
     mean: WrappedArray,
     variance: WrappedArray,
@@ -93,14 +89,12 @@ pub struct FFI_GaussianDistribution {
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_BernoulliDistribution {
     p: WrappedArray,
 }
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_GenericDistribution {
     mean: WrappedArray,
     median: WrappedArray,

--- a/datafusion/ffi/src/expr/expr_properties.rs
+++ b/datafusion/ffi/src/expr/expr_properties.rs
@@ -26,7 +26,6 @@ use crate::expr::interval::FFI_Interval;
 /// See [`ExprProperties`] for the meaning of each field.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_ExprProperties {
     sort_properties: FFI_SortProperties,
     range: FFI_Interval,
@@ -62,7 +61,6 @@ impl TryFrom<FFI_ExprProperties> for ExprProperties {
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub enum FFI_SortProperties {
     Ordered(FFI_SortOptions),
     Unordered,
@@ -91,7 +89,6 @@ impl From<&FFI_SortProperties> for SortProperties {
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_SortOptions {
     pub descending: bool,
     pub nulls_first: bool,

--- a/datafusion/ffi/src/expr/interval.rs
+++ b/datafusion/ffi/src/expr/interval.rs
@@ -26,7 +26,6 @@ use crate::arrow_wrappers::WrappedArray;
 /// are passed as Arrow arrays of length 1.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_Interval {
     lower: WrappedArray,
     upper: WrappedArray,

--- a/datafusion/ffi/src/insert_op.rs
+++ b/datafusion/ffi/src/insert_op.rs
@@ -21,7 +21,6 @@ use datafusion_expr::logical_plan::dml::InsertOp;
 /// FFI safe version of [`InsertOp`].
 #[repr(C)]
 #[derive(StableAbi)]
-#[allow(non_camel_case_types)]
 pub enum FFI_InsertOp {
     Append,
     Overwrite,

--- a/datafusion/ffi/src/lib.rs
+++ b/datafusion/ffi/src/lib.rs
@@ -23,7 +23,8 @@
 // Make sure fast / cheap clones on Arc are explicit:
 // https://github.com/apache/datafusion/issues/11143
 #![deny(clippy::clone_on_ref_ptr)]
-#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
+#![deny(clippy::allow_attributes)]
+#![cfg_attr(test, expect(clippy::needless_pass_by_value))]
 
 pub mod arrow_wrappers;
 pub mod catalog_provider;

--- a/datafusion/ffi/src/physical_expr/mod.rs
+++ b/datafusion/ffi/src/physical_expr/mod.rs
@@ -51,7 +51,6 @@ use crate::{df_result, rresult, rresult_return};
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_PhysicalExpr {
     pub data_type: unsafe extern "C" fn(
         &Self,

--- a/datafusion/ffi/src/physical_expr/partitioning.rs
+++ b/datafusion/ffi/src/physical_expr/partitioning.rs
@@ -28,7 +28,6 @@ use crate::physical_expr::FFI_PhysicalExpr;
 /// See ['Partitioning'] for the meaning of each variant.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub enum FFI_Partitioning {
     RoundRobinBatch(usize),
     Hash(RVec<FFI_PhysicalExpr>, usize),

--- a/datafusion/ffi/src/physical_expr/sort.rs
+++ b/datafusion/ffi/src/physical_expr/sort.rs
@@ -29,7 +29,6 @@ use crate::physical_expr::FFI_PhysicalExpr;
 /// See [`PhysicalSortExpr`] for the meaning of each field.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_PhysicalSortExpr {
     expr: FFI_PhysicalExpr,
     options: FFI_SortOptions,

--- a/datafusion/ffi/src/plan_properties.rs
+++ b/datafusion/ffi/src/plan_properties.rs
@@ -34,7 +34,6 @@ use crate::physical_expr::sort::FFI_PhysicalSortExpr;
 /// A stable struct for sharing [`PlanProperties`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_PlanProperties {
     /// The output partitioning of the plan.
     pub output_partitioning: unsafe extern "C" fn(plan: &Self) -> FFI_Partitioning,
@@ -196,7 +195,6 @@ impl TryFrom<FFI_PlanProperties> for PlanProperties {
 
 /// FFI safe version of [`Boundedness`].
 #[repr(C)]
-#[allow(non_camel_case_types)]
 #[derive(Clone, StableAbi)]
 pub enum FFI_Boundedness {
     Bounded,
@@ -231,7 +229,6 @@ impl From<FFI_Boundedness> for Boundedness {
 
 /// FFI safe version of [`EmissionType`].
 #[repr(C)]
-#[allow(non_camel_case_types)]
 #[derive(Clone, StableAbi)]
 pub enum FFI_EmissionType {
     Incremental,

--- a/datafusion/ffi/src/proto/logical_extension_codec.rs
+++ b/datafusion/ffi/src/proto/logical_extension_codec.rs
@@ -47,7 +47,6 @@ use crate::{df_result, rresult_return};
 /// A stable struct for sharing [`LogicalExtensionCodec`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_LogicalExtensionCodec {
     /// Decode bytes into a table provider.
     try_decode_table_provider: unsafe extern "C" fn(

--- a/datafusion/ffi/src/proto/physical_extension_codec.rs
+++ b/datafusion/ffi/src/proto/physical_extension_codec.rs
@@ -40,7 +40,6 @@ use crate::{df_result, rresult_return};
 /// A stable struct for sharing [`PhysicalExtensionCodec`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_PhysicalExtensionCodec {
     /// Decode bytes into an execution plan.
     try_decode: unsafe extern "C" fn(

--- a/datafusion/ffi/src/record_batch_stream.rs
+++ b/datafusion/ffi/src/record_batch_stream.rs
@@ -36,7 +36,6 @@ use crate::util::FFIResult;
 /// We use the async-ffi crate for handling async calls across libraries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_RecordBatchStream {
     /// This mirrors the `poll_next` of [`RecordBatchStream`] but does so
     /// in a FFI safe manner.

--- a/datafusion/ffi/src/schema_provider.rs
+++ b/datafusion/ffi/src/schema_provider.rs
@@ -39,7 +39,6 @@ use crate::{df_result, rresult_return};
 /// A stable struct for sharing [`SchemaProvider`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_SchemaProvider {
     pub owner_name: ROption<RString>,
 

--- a/datafusion/ffi/src/session/config.rs
+++ b/datafusion/ffi/src/session/config.rs
@@ -36,7 +36,6 @@ use datafusion_execution::config::SessionConfig;
 /// value over this version.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_SessionConfig {
     /// Return a hash map from key to value of the config options represented
     /// by string values.

--- a/datafusion/ffi/src/session/mod.rs
+++ b/datafusion/ffi/src/session/mod.rs
@@ -75,7 +75,6 @@ pub mod config;
 /// we know the [`Session`] lifetimes are valid.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub(crate) struct FFI_SessionRef {
     session_id: unsafe extern "C" fn(&Self) -> RStr,
 

--- a/datafusion/ffi/src/table_provider.rs
+++ b/datafusion/ffi/src/table_provider.rs
@@ -90,7 +90,6 @@ use crate::{df_result, rresult_return};
 /// side of the interface each object refers to.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_TableProvider {
     /// Return the table schema
     schema: unsafe extern "C" fn(provider: &Self) -> WrappedSchema,

--- a/datafusion/ffi/src/table_source.rs
+++ b/datafusion/ffi/src/table_source.rs
@@ -21,7 +21,6 @@ use datafusion_expr::{TableProviderFilterPushDown, TableType};
 /// FFI safe version of [`TableProviderFilterPushDown`].
 #[repr(C)]
 #[derive(StableAbi)]
-#[allow(non_camel_case_types)]
 pub enum FFI_TableProviderFilterPushDown {
     Unsupported,
     Inexact,
@@ -58,7 +57,6 @@ impl From<&TableProviderFilterPushDown> for FFI_TableProviderFilterPushDown {
 
 /// FFI safe version of [`TableType`].
 #[repr(C)]
-#[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, StableAbi)]
 pub enum FFI_TableType {
     Base,

--- a/datafusion/ffi/src/tests/async_provider.rs
+++ b/datafusion/ffi/src/tests/async_provider.rs
@@ -252,7 +252,7 @@ impl Stream for AsyncTestRecordBatchStream {
     ) -> std::task::Poll<Option<Self::Item>> {
         let mut this = self.as_mut();
 
-        #[allow(clippy::disallowed_methods)]
+        #[expect(clippy::disallowed_methods)]
         tokio::spawn(async move {
             // Nothing to do. We just need to simulate an async
             // task running

--- a/datafusion/ffi/src/udaf/accumulator.rs
+++ b/datafusion/ffi/src/udaf/accumulator.rs
@@ -37,7 +37,6 @@ use crate::{df_result, rresult, rresult_return};
 /// defined in [`Accumulator`].
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_Accumulator {
     pub update_batch: unsafe extern "C" fn(
         accumulator: &mut Self,

--- a/datafusion/ffi/src/udaf/accumulator_args.rs
+++ b/datafusion/ffi/src/udaf/accumulator_args.rs
@@ -36,7 +36,6 @@ use crate::util::{rvec_wrapped_to_vec_fieldref, vec_fieldref_to_rvec_wrapped};
 /// defined in [`AccumulatorArgs`].
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_AccumulatorArgs {
     return_field: WrappedSchema,
     schema: WrappedSchema,

--- a/datafusion/ffi/src/udaf/groups_accumulator.rs
+++ b/datafusion/ffi/src/udaf/groups_accumulator.rs
@@ -37,7 +37,6 @@ use crate::{df_result, rresult, rresult_return};
 /// defined in [`GroupsAccumulator`].
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_GroupsAccumulator {
     pub update_batch: unsafe extern "C" fn(
         accumulator: &mut Self,
@@ -438,7 +437,6 @@ impl GroupsAccumulator for ForeignGroupsAccumulator {
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub enum FFI_EmitTo {
     All,
     First(usize),

--- a/datafusion/ffi/src/udaf/mod.rs
+++ b/datafusion/ffi/src/udaf/mod.rs
@@ -55,7 +55,6 @@ mod groups_accumulator;
 /// A stable struct for sharing a [`AggregateUDF`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_AggregateUDF {
     /// FFI equivalent to the `name` of a [`AggregateUDF`]
     pub name: RString,
@@ -94,7 +93,6 @@ pub struct FFI_AggregateUDF {
         -> FFIResult<FFI_Accumulator>,
 
     /// FFI equivalent to [`AggregateUDF::state_fields`]
-    #[allow(clippy::type_complexity)]
     pub state_fields: unsafe extern "C" fn(
         udaf: &FFI_AggregateUDF,
         name: &RStr,
@@ -612,7 +610,6 @@ impl AggregateUDFImpl for ForeignAggregateUDF {
 
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub enum FFI_AggregateOrderSensitivity {
     Insensitive,
     HardRequirement,

--- a/datafusion/ffi/src/udf/mod.rs
+++ b/datafusion/ffi/src/udf/mod.rs
@@ -49,7 +49,6 @@ pub mod return_type_args;
 /// A stable struct for sharing a [`ScalarUDF`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_ScalarUDF {
     /// FFI equivalent to the `name` of a [`ScalarUDF`]
     pub name: RString,
@@ -68,7 +67,6 @@ pub struct FFI_ScalarUDF {
 
     /// Execute the underlying [`ScalarUDF`] and return the result as a `FFI_ArrowArray`
     /// within an AbiStable wrapper.
-    #[allow(clippy::type_complexity)]
     pub invoke_with_args: unsafe extern "C" fn(
         udf: &Self,
         args: RVec<WrappedArray>,

--- a/datafusion/ffi/src/udf/return_type_args.rs
+++ b/datafusion/ffi/src/udf/return_type_args.rs
@@ -29,7 +29,6 @@ use crate::util::{rvec_wrapped_to_vec_fieldref, vec_fieldref_to_rvec_wrapped};
 /// A stable struct for sharing a [`ReturnFieldArgs`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_ReturnFieldArgs {
     arg_fields: RVec<WrappedSchema>,
     scalar_arguments: RVec<ROption<RVec<u8>>>,

--- a/datafusion/ffi/src/udtf.rs
+++ b/datafusion/ffi/src/udtf.rs
@@ -42,7 +42,6 @@ use crate::{df_result, rresult_return};
 /// A stable struct for sharing a [`TableFunctionImpl`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_TableFunction {
     /// Equivalent to the `call` function of the TableFunctionImpl.
     /// The arguments are Expr passed as protobuf encoded bytes.

--- a/datafusion/ffi/src/udwf/mod.rs
+++ b/datafusion/ffi/src/udwf/mod.rs
@@ -51,7 +51,6 @@ use crate::{df_result, rresult, rresult_return};
 /// A stable struct for sharing a [`WindowUDF`] across FFI boundaries.
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_WindowUDF {
     /// FFI equivalent to the `name` of a [`WindowUDF`]
     pub name: RString,
@@ -370,7 +369,6 @@ impl WindowUDFImpl for ForeignWindowUDF {
 
 #[repr(C)]
 #[derive(Debug, StableAbi, Clone)]
-#[allow(non_camel_case_types)]
 pub struct FFI_SortOptions {
     pub descending: bool,
     pub nulls_first: bool,

--- a/datafusion/ffi/src/udwf/partition_evaluator.rs
+++ b/datafusion/ffi/src/udwf/partition_evaluator.rs
@@ -38,7 +38,6 @@ use crate::{df_result, rresult, rresult_return};
 /// defined in [`PartitionEvaluator`].
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_PartitionEvaluator {
     pub evaluate_all: unsafe extern "C" fn(
         evaluator: &mut Self,

--- a/datafusion/ffi/src/udwf/partition_evaluator_args.rs
+++ b/datafusion/ffi/src/udwf/partition_evaluator_args.rs
@@ -35,7 +35,6 @@ use crate::util::rvec_wrapped_to_vec_fieldref;
 /// defined in [`PartitionEvaluatorArgs`].
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_PartitionEvaluatorArgs {
     input_exprs: RVec<FFI_PhysicalExpr>,
     input_fields: RVec<WrappedSchema>,

--- a/datafusion/ffi/src/udwf/range.rs
+++ b/datafusion/ffi/src/udwf/range.rs
@@ -24,7 +24,6 @@ use abi_stable::StableAbi;
 /// defined in [`Range`].
 #[repr(C)]
 #[derive(Debug, StableAbi)]
-#[allow(non_camel_case_types)]
 pub struct FFI_Range {
     pub start: usize,
     pub end: usize,

--- a/datafusion/ffi/src/volatility.rs
+++ b/datafusion/ffi/src/volatility.rs
@@ -20,7 +20,6 @@ use datafusion_expr::Volatility;
 
 #[repr(C)]
 #[derive(Debug, StableAbi, Clone)]
-#[allow(non_camel_case_types)]
 pub enum FFI_Volatility {
     Immutable,
     Stable,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of  #18881 .

## Rationale for this change

We want to use #[expect] in place of #[allow] on the workspace level but to get there we wanted to do this in few crates at a time before enabling it in workspace.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

- Added #![deny(clippy::allow_attributes)] to enforce the lint
- When I converted #[allow] → #[expect], clippy reported that most lint expectations were unfulfilled, meaning those lints are no longer triggered. It happened for the `non_camel_case_types`,  we can safely remove this attribute because the `#[repr(C)]` attribute automatically suppresses the `non_camel_case_types` lint which is what our `FFI` code uses. I verified this creating a small code and running the similar lint.

- Without `[repr(C)]`
<img width="819" height="149" alt="image" src="https://github.com/user-attachments/assets/92d0a4ab-d2c5-4d3e-9974-92905c3cbc99" />

- With `[repr(C)]`
<img width="662" height="146" alt="image" src="https://github.com/user-attachments/assets/a4b97941-2d86-475d-8b06-21fee4d1f052" />




<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

All tests pass

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
