### PR TITLE
docs: Improve config tables' readability

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -138,3 +138,21 @@ Details: 8rem for search box etc*/
 .bd-content table tbody tr:nth-of-type(odd) {
   background-color: rgba(0, 0, 0, 0.03);
 }
+
+
+/* Ensure the config tables are readable without having to scroll horizontally. */
+
+:is(#configuration-settings, #runtime-configuration-settings) table {
+  display: table;
+  table-layout: fixed;
+}
+
+:is(#configuration-settings, #runtime-configuration-settings) th,
+:is(#configuration-settings, #runtime-configuration-settings) td {
+  word-wrap: break-word;
+}
+
+:is(#configuration-settings, #runtime-configuration-settings) th:nth-child(2),
+:is(#configuration-settings, #runtime-configuration-settings) td:nth-child(2) {
+  width: 15%;
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #19521.

## Rationale for this change

Make the config tables at https://datafusion.apache.org/user-guide/configs.html easier to read, by avoiding horizontal scrolling.

Before: 
<img width="1466" height="1001" alt="image" src="https://github.com/user-attachments/assets/bca9e64a-7d77-4f8c-8a17-78e00669fd6a" />

After: 
<img width="1510" height="1051" alt="image" src="https://github.com/user-attachments/assets/04c7d840-a4c3-4475-879a-31613157f6b4" />

Also works well on smaller screens: 
<img width="647" height="700" alt="image" src="https://github.com/user-attachments/assets/3667e2b6-1ced-47ca-9b8a-a68084a83bfe" />


## What changes are included in this PR?

- New css rules (these are only applied to the tables in the Configs page, every other table remains the same).

## Are these changes tested?

Manual checks.

## Are there any user-facing changes?

No.