### PR TITLE
handle index access in get_field, eliminating array_element

### DIFF
--- a/datafusion/functions-nested/src/expr_ext.rs
+++ b/datafusion/functions-nested/src/expr_ext.rs
@@ -37,7 +37,7 @@ use crate::extract::{array_element, array_slice};
 /// # use datafusion_expr::{lit, col, Expr};
 /// # use datafusion_functions_nested::expr_ext::IndexAccessor;
 /// let expr = col("c1").index(lit(3));
-/// assert_eq!(expr.schema_name().to_string(), "c1[Int32(3)]");
+/// assert!(expr.schema_name().to_string().starts_with("c1["));
 /// ```
 pub trait IndexAccessor {
     fn index(self, key: Expr) -> Expr;
@@ -66,7 +66,7 @@ impl IndexAccessor for Expr {
 /// # use datafusion_expr::{lit, col};
 /// # use datafusion_functions_nested::expr_ext::SliceAccessor;
 /// let expr = col("c1").range(lit(2), lit(4));
-/// assert_eq!(expr.schema_name().to_string(), "c1[Int32(2):Int32(4)]");
+/// assert!(expr.schema_name().to_string().starts_with("c1["));
 /// ```
 pub trait SliceAccessor {
     fn range(self, start: Expr, stop: Expr) -> Expr;

--- a/datafusion/functions/src/core/getfield.rs
+++ b/datafusion/functions/src/core/getfield.rs
@@ -19,14 +19,16 @@ use std::any::Any;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, BooleanArray, Capacities, MutableArrayData, Scalar, make_array,
-    make_comparator,
+    Array, BooleanArray, Capacities, GenericListArray, Int64Array, MutableArrayData,
+    OffsetSizeTrait, Scalar, make_array, make_comparator,
 };
+use arrow::buffer::NullBuffer;
 use arrow::compute::SortOptions;
 use arrow::datatypes::{DataType, Field, FieldRef};
-use arrow_buffer::NullBuffer;
 
-use datafusion_common::cast::{as_map_array, as_struct_array};
+use datafusion_common::cast::{
+    as_large_list_array, as_list_array, as_map_array, as_struct_array,
+};
 use datafusion_common::{
     Result, ScalarValue, exec_err, internal_err, plan_datafusion_err,
 };
@@ -37,6 +39,27 @@ use datafusion_expr::{
     ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion_macros::user_doc;
+
+/// Format a field access argument for display.
+/// - String literals: show as the string value (for struct field names)
+/// - Integer literals: show as the numeric value (for array indices)
+/// - Other: use schema_name()
+fn format_field_access_arg(expr: &Expr) -> String {
+    match expr {
+        Expr::Literal(sv, _) => {
+            // For integers, show as bare number (array index)
+            if sv.data_type().is_integer() {
+                return sv.to_string();
+            }
+            // For strings, show the string value
+            if let Some(s) = sv.try_as_str().flatten() {
+                return s.to_string();
+            }
+            sv.to_string()
+        }
+        other => other.schema_name().to_string(),
+    }
+}
 
 #[user_doc(
     doc_section(label = "Other Functions"),
@@ -191,7 +214,20 @@ fn process_map_with_nested_key(
     Ok(ColumnarValue::Array(data))
 }
 
-/// Extract a single field from a struct or map array
+/// Extract a single field from a struct or map array.
+///
+/// # Field Name Requirements
+/// The field name must be a **scalar** value known at planning time. Dynamic field
+/// names (array of field names) are not supported because:
+/// - Struct field access requires compile-time type inference (different fields may have different types)
+/// - The return type would be indeterminate if the field name varied per row
+///
+/// This is in contrast to array element access, where all elements share the same type,
+/// allowing dynamic indices.
+///
+/// # Supported Types
+/// - **Struct**: Field name must be a UTF-8 string
+/// - **Map**: Key can be any scalar type matching the map's key type
 fn extract_single_field(base: ColumnarValue, name: ScalarValue) -> Result<ColumnarValue> {
     let arrays = ColumnarValue::values_to_arrays(&[base])?;
     let array = Arc::clone(&arrays[0]);
@@ -232,6 +268,492 @@ fn extract_single_field(base: ColumnarValue, name: ScalarValue) -> Result<Column
     }
 }
 
+/// Extract element at 1-indexed position from array.
+///
+/// # Index Semantics
+/// - 1-indexed: index `1` returns the first element
+/// - Negative indices count from end: `-1` is the last element
+/// - Out-of-bounds access returns null
+///
+/// # Input Combinations and Output Cardinality
+///
+/// | Base       | Index      | Output      | Description                                    |
+/// |------------|------------|-------------|------------------------------------------------|
+/// | Array(N)   | Scalar     | Array(N)    | Same index applied to each list row            |
+/// | Scalar     | Array(N)   | Array(N)    | Different indices into the same list           |
+/// | Array(N)   | Array(N)   | Array(N)    | Zipped: row i uses base[i] and index[i]        |
+/// | Array(N)   | Array(M)   | Error       | Length mismatch (N ≠ M)                        |
+/// | Scalar     | Scalar     | Scalar      | Single element extraction                      |
+///
+/// # Performance
+/// Scalar cases (Array/Scalar, Scalar/Array, Scalar/Scalar) are handled directly
+/// without array expansion for efficiency, avoiding unnecessary allocations.
+fn extract_array_element_columnar(
+    base: ColumnarValue,
+    index: ColumnarValue,
+) -> Result<ColumnarValue> {
+    match (base, index) {
+        // Fast path: Array base with scalar index (most common case, e.g., arr[3])
+        (ColumnarValue::Array(array), ColumnarValue::Scalar(index_scalar)) => {
+            let index = scalar_to_i64(&index_scalar)?;
+            extract_array_element_array_scalar(&array, index)
+        }
+        // Fast path: Scalar base with array indices (e.g., literal_list[idx_column])
+        (ColumnarValue::Scalar(list_scalar), ColumnarValue::Array(indexes)) => {
+            let indexes = cast_to_int64_array(&indexes)?;
+            extract_array_element_scalar_array(&list_scalar, &indexes)
+        }
+        // Fast path: Both scalar (e.g., literal_list[3])
+        (ColumnarValue::Scalar(list_scalar), ColumnarValue::Scalar(index_scalar)) => {
+            let index = scalar_to_i64(&index_scalar)?;
+            extract_array_element_scalar_scalar(&list_scalar, index)
+        }
+        // General path: Both arrays (zipped, must have equal lengths)
+        (ColumnarValue::Array(array), ColumnarValue::Array(indexes)) => {
+            let indexes = cast_to_int64_array(&indexes)?;
+            if array.len() != indexes.len() {
+                return exec_err!(
+                    "Array element access requires equal length arrays, got {} and {}",
+                    array.len(),
+                    indexes.len()
+                );
+            }
+            extract_array_element_array_array(&array, &indexes)
+        }
+    }
+}
+
+/// Convert a scalar value to i64 for use as an array index.
+fn scalar_to_i64(scalar: &ScalarValue) -> Result<Option<i64>> {
+    if scalar.is_null() {
+        return Ok(None);
+    }
+    match scalar {
+        ScalarValue::Int8(v) => Ok(v.map(|x| x as i64)),
+        ScalarValue::Int16(v) => Ok(v.map(|x| x as i64)),
+        ScalarValue::Int32(v) => Ok(v.map(|x| x as i64)),
+        ScalarValue::Int64(v) => Ok(*v),
+        ScalarValue::UInt8(v) => Ok(v.map(|x| x as i64)),
+        ScalarValue::UInt16(v) => Ok(v.map(|x| x as i64)),
+        ScalarValue::UInt32(v) => Ok(v.map(|x| x as i64)),
+        ScalarValue::UInt64(v) => Ok(v.map(|x| x as i64)),
+        other => exec_err!(
+            "Array index must be an integer type, got {}",
+            other.data_type()
+        ),
+    }
+}
+
+/// Cast an integer array to Int64Array for use as array indices.
+fn cast_to_int64_array(array: &dyn Array) -> Result<Int64Array> {
+    if array.data_type() == &DataType::Int64 {
+        // Already Int64, just downcast
+        return Ok(datafusion_common::cast::as_int64_array(array)?.clone());
+    }
+
+    // Cast to Int64
+    let casted = arrow::compute::cast(array, &DataType::Int64).map_err(|e| {
+        datafusion_common::DataFusionError::Internal(format!(
+            "Failed to cast index array to Int64: {e}"
+        ))
+    })?;
+
+    Ok(datafusion_common::cast::as_int64_array(&casted)?.clone())
+}
+
+/// Extract elements from an array column using a scalar index.
+///
+/// For each row in the list array, extracts the element at the given index.
+/// Returns an array with the same length as the input list array.
+fn extract_array_element_array_scalar(
+    array: &Arc<dyn Array>,
+    index: Option<i64>,
+) -> Result<ColumnarValue> {
+    // Null index returns all nulls
+    let Some(index) = index else {
+        let element_type = match array.data_type() {
+            DataType::List(f) | DataType::LargeList(f) => f.data_type().clone(),
+            DataType::Null => return Ok(ColumnarValue::Scalar(ScalarValue::Null)),
+            dt => {
+                return exec_err!(
+                    "get_field array element access does not support type {dt}"
+                );
+            }
+        };
+        return Ok(ColumnarValue::Array(Arc::new(
+            arrow::array::new_null_array(&element_type, array.len()),
+        )));
+    };
+
+    match array.data_type() {
+        DataType::List(_) => {
+            let list_array = as_list_array(array)?;
+            general_array_element_scalar::<i32>(list_array, index)
+        }
+        DataType::LargeList(_) => {
+            let list_array = as_large_list_array(array)?;
+            general_array_element_scalar::<i64>(list_array, index)
+        }
+        DataType::Null => Ok(ColumnarValue::Scalar(ScalarValue::Null)),
+        dt => exec_err!("get_field array element access does not support type {dt}"),
+    }
+}
+
+/// Extract elements from a scalar list using an array of indices.
+///
+/// The same list is indexed by each value in the indices array.
+/// Returns an array with the same length as the indices array.
+fn extract_array_element_scalar_array(
+    list_scalar: &ScalarValue,
+    indexes: &Int64Array,
+) -> Result<ColumnarValue> {
+    // Convert scalar to single-element list array, then use optimized path
+    let list_array = list_scalar.to_array()?;
+
+    match list_array.data_type() {
+        DataType::List(_) => {
+            let list_array = as_list_array(&list_array)?;
+            general_array_element_broadcast_list::<i32>(list_array, indexes)
+        }
+        DataType::LargeList(_) => {
+            let list_array = as_large_list_array(&list_array)?;
+            general_array_element_broadcast_list::<i64>(list_array, indexes)
+        }
+        DataType::Null => Ok(ColumnarValue::Array(Arc::new(
+            arrow::array::new_null_array(&DataType::Null, indexes.len()),
+        ))),
+        dt => exec_err!("get_field array element access does not support type {dt}"),
+    }
+}
+
+/// Extract a single element from a scalar list using a scalar index.
+///
+/// Returns a scalar value.
+fn extract_array_element_scalar_scalar(
+    list_scalar: &ScalarValue,
+    index: Option<i64>,
+) -> Result<ColumnarValue> {
+    // Null index returns null
+    let Some(index) = index else {
+        let element_type = match list_scalar {
+            ScalarValue::List(arr) => arr.value_type(),
+            ScalarValue::LargeList(arr) => arr.value_type(),
+            ScalarValue::Null => return Ok(ColumnarValue::Scalar(ScalarValue::Null)),
+            other => {
+                return exec_err!(
+                    "get_field array element access does not support type {}",
+                    other.data_type()
+                );
+            }
+        };
+        return Ok(ColumnarValue::Scalar(ScalarValue::try_from(&element_type)?));
+    };
+
+    // Extract the list's values and compute the element
+    let (values, len) = match list_scalar {
+        ScalarValue::List(arr) => {
+            let list = arr
+                .as_any()
+                .downcast_ref::<arrow::array::ListArray>()
+                .ok_or_else(|| {
+                    datafusion_common::DataFusionError::Internal(
+                        "Failed to downcast to ListArray".to_string(),
+                    )
+                })?;
+            if list.is_empty() || list.is_null(0) {
+                return Ok(ColumnarValue::Scalar(ScalarValue::try_from(
+                    list.value_type(),
+                )?));
+            }
+            let values = list.value(0);
+            let len = values.len() as i64;
+            (values, len)
+        }
+        ScalarValue::LargeList(arr) => {
+            let list = arr
+                .as_any()
+                .downcast_ref::<arrow::array::LargeListArray>()
+                .ok_or_else(|| {
+                    datafusion_common::DataFusionError::Internal(
+                        "Failed to downcast to LargeListArray".to_string(),
+                    )
+                })?;
+            if list.is_empty() || list.is_null(0) {
+                return Ok(ColumnarValue::Scalar(ScalarValue::try_from(
+                    list.value_type(),
+                )?));
+            }
+            let values = list.value(0);
+            let len = values.len() as i64;
+            (values, len)
+        }
+        ScalarValue::Null => return Ok(ColumnarValue::Scalar(ScalarValue::Null)),
+        other => {
+            return exec_err!(
+                "get_field array element access does not support type {}",
+                other.data_type()
+            );
+        }
+    };
+
+    // Adjust index (1-indexed, negative from end)
+    let adjusted = if index < 0 { index + len } else { index - 1 };
+
+    if adjusted >= 0 && adjusted < len {
+        let scalar = ScalarValue::try_from_array(&values, adjusted as usize)?;
+        Ok(ColumnarValue::Scalar(scalar))
+    } else {
+        // Out of bounds
+        Ok(ColumnarValue::Scalar(ScalarValue::try_from(
+            values.data_type(),
+        )?))
+    }
+}
+
+/// Extract elements from array columns with array indices (zipped).
+///
+/// Row i of the output is extracted from row i of the list array using
+/// the index at row i of the indices array. Arrays must have equal length.
+fn extract_array_element_array_array(
+    array: &Arc<dyn Array>,
+    indexes: &Int64Array,
+) -> Result<ColumnarValue> {
+    match array.data_type() {
+        DataType::List(_) => {
+            let list_array = as_list_array(array)?;
+            general_array_element_array::<i32>(list_array, indexes)
+        }
+        DataType::LargeList(_) => {
+            let list_array = as_large_list_array(array)?;
+            general_array_element_array::<i64>(list_array, indexes)
+        }
+        DataType::Null => Ok(ColumnarValue::Scalar(ScalarValue::Null)),
+        dt => exec_err!("get_field array element access does not support type {dt}"),
+    }
+}
+
+/// Generic array element extraction for List/LargeList types with array indices (Array/Array case).
+///
+/// Extracts elements by zipping the list array with the index array: row i of the output
+/// is the element at `indexes[i]` from `array[i]`. Both arrays must have the same length.
+fn general_array_element_array<O: OffsetSizeTrait>(
+    array: &GenericListArray<O>,
+    indexes: &Int64Array,
+) -> Result<ColumnarValue>
+where
+    i64: TryInto<O>,
+{
+    let values = array.values();
+    if values.data_type().is_null() {
+        return Ok(ColumnarValue::Array(Arc::new(
+            arrow::array::NullArray::new(array.len()),
+        )));
+    }
+
+    let original_data = values.to_data();
+    let capacity = Capacities::Array(original_data.len());
+    let mut mutable =
+        MutableArrayData::with_capacities(vec![&original_data], true, capacity);
+
+    for (row_index, offset_window) in array.offsets().windows(2).enumerate() {
+        let start = offset_window[0];
+        let end = offset_window[1];
+        let len = end - start;
+
+        // Empty array or null index returns null
+        if len == O::usize_as(0) || indexes.is_null(row_index) {
+            mutable.extend_nulls(1);
+            continue;
+        }
+
+        let index = indexes.value(row_index);
+
+        // Adjust index: 1-indexed, negative counts from end
+        let adjusted_index = if index < 0 {
+            let idx: O = match index.try_into() {
+                Ok(v) => v,
+                Err(_) => {
+                    mutable.extend_nulls(1);
+                    continue;
+                }
+            };
+            idx + len
+        } else {
+            let idx: O = match index.try_into() {
+                Ok(v) => v,
+                Err(_) => {
+                    mutable.extend_nulls(1);
+                    continue;
+                }
+            };
+            idx - O::usize_as(1)
+        };
+
+        if adjusted_index >= O::usize_as(0) && adjusted_index < len {
+            let abs_index = start.as_usize() + adjusted_index.as_usize();
+            mutable.extend(0, abs_index, abs_index + 1);
+        } else {
+            // Out of bounds
+            mutable.extend_nulls(1);
+        }
+    }
+
+    let data = mutable.freeze();
+    Ok(ColumnarValue::Array(make_array(data)))
+}
+
+/// Generic array element extraction with a scalar index (Array/Scalar case).
+///
+/// Extracts the element at the given index from each row of the list array.
+/// This is the most common case (e.g., `arr[3]`) and avoids creating an
+/// index array filled with the same value.
+fn general_array_element_scalar<O: OffsetSizeTrait>(
+    array: &GenericListArray<O>,
+    index: i64,
+) -> Result<ColumnarValue>
+where
+    i64: TryInto<O>,
+{
+    let values = array.values();
+    if values.data_type().is_null() {
+        return Ok(ColumnarValue::Array(Arc::new(
+            arrow::array::NullArray::new(array.len()),
+        )));
+    }
+
+    let original_data = values.to_data();
+    let capacity = Capacities::Array(array.len());
+    let mut mutable =
+        MutableArrayData::with_capacities(vec![&original_data], true, capacity);
+
+    for offset_window in array.offsets().windows(2) {
+        let start = offset_window[0];
+        let end = offset_window[1];
+        let len = end - start;
+
+        // Empty array returns null
+        if len == O::usize_as(0) {
+            mutable.extend_nulls(1);
+            continue;
+        }
+
+        // Adjust index: 1-indexed, negative counts from end
+        let adjusted_index = if index < 0 {
+            let idx: O = match index.try_into() {
+                Ok(v) => v,
+                Err(_) => {
+                    mutable.extend_nulls(1);
+                    continue;
+                }
+            };
+            idx + len
+        } else {
+            let idx: O = match index.try_into() {
+                Ok(v) => v,
+                Err(_) => {
+                    mutable.extend_nulls(1);
+                    continue;
+                }
+            };
+            idx - O::usize_as(1)
+        };
+
+        if adjusted_index >= O::usize_as(0) && adjusted_index < len {
+            let abs_index = start.as_usize() + adjusted_index.as_usize();
+            mutable.extend(0, abs_index, abs_index + 1);
+        } else {
+            // Out of bounds
+            mutable.extend_nulls(1);
+        }
+    }
+
+    let data = mutable.freeze();
+    Ok(ColumnarValue::Array(make_array(data)))
+}
+
+/// Generic array element extraction broadcasting a single list to multiple indices (Scalar/Array case).
+///
+/// The single list (row 0 of the array) is indexed by each value in the indices array.
+/// Returns an array with the same length as the indices array.
+fn general_array_element_broadcast_list<O: OffsetSizeTrait>(
+    array: &GenericListArray<O>,
+    indexes: &Int64Array,
+) -> Result<ColumnarValue>
+where
+    i64: TryInto<O>,
+{
+    // The array should have exactly one row (the scalar list)
+    if array.is_empty() || array.is_null(0) {
+        return Ok(ColumnarValue::Array(Arc::new(
+            arrow::array::new_null_array(&array.value_type(), indexes.len()),
+        )));
+    }
+
+    let values = array.values();
+    if values.data_type().is_null() {
+        return Ok(ColumnarValue::Array(Arc::new(
+            arrow::array::NullArray::new(indexes.len()),
+        )));
+    }
+
+    // Get the single list's bounds
+    let start = array.offsets()[0];
+    let end = array.offsets()[1];
+    let len = end - start;
+
+    let original_data = values.to_data();
+    let capacity = Capacities::Array(indexes.len());
+    let mut mutable =
+        MutableArrayData::with_capacities(vec![&original_data], true, capacity);
+
+    for i in 0..indexes.len() {
+        if indexes.is_null(i) {
+            mutable.extend_nulls(1);
+            continue;
+        }
+
+        let index = indexes.value(i);
+
+        // Empty list returns null
+        if len == O::usize_as(0) {
+            mutable.extend_nulls(1);
+            continue;
+        }
+
+        // Adjust index: 1-indexed, negative counts from end
+        let adjusted_index = if index < 0 {
+            let idx: O = match index.try_into() {
+                Ok(v) => v,
+                Err(_) => {
+                    mutable.extend_nulls(1);
+                    continue;
+                }
+            };
+            idx + len
+        } else {
+            let idx: O = match index.try_into() {
+                Ok(v) => v,
+                Err(_) => {
+                    mutable.extend_nulls(1);
+                    continue;
+                }
+            };
+            idx - O::usize_as(1)
+        };
+
+        if adjusted_index >= O::usize_as(0) && adjusted_index < len {
+            let abs_index = start.as_usize() + adjusted_index.as_usize();
+            mutable.extend(0, abs_index, abs_index + 1);
+        } else {
+            // Out of bounds
+            mutable.extend_nulls(1);
+        }
+    }
+
+    let data = mutable.freeze();
+    Ok(ColumnarValue::Array(make_array(data)))
+}
+
 impl GetFieldFunc {
     pub fn new() -> Self {
         Self {
@@ -259,13 +781,8 @@ impl ScalarUDFImpl for GetFieldFunc {
         }
 
         let base = &args[0];
-        let field_names: Vec<String> = args[1..]
-            .iter()
-            .map(|f| match f {
-                Expr::Literal(name, _) => name.to_string(),
-                other => other.schema_name().to_string(),
-            })
-            .collect();
+        let field_names: Vec<String> =
+            args[1..].iter().map(format_field_access_arg).collect();
 
         Ok(format!("{}[{}]", base, field_names.join("][")))
     }
@@ -279,13 +796,8 @@ impl ScalarUDFImpl for GetFieldFunc {
         }
 
         let base = &args[0];
-        let field_names: Vec<String> = args[1..]
-            .iter()
-            .map(|f| match f {
-                Expr::Literal(name, _) => name.to_string(),
-                other => other.schema_name().to_string(),
-            })
-            .collect();
+        let field_names: Vec<String> =
+            args[1..].iter().map(format_field_access_arg).collect();
 
         Ok(format!(
             "{}[{}]",
@@ -368,9 +880,34 @@ impl ScalarUDFImpl for GetFieldFunc {
                 DataType::Null => {
                     return Ok(Field::new(self.name(), DataType::Null, true).into());
                 }
+                // Array types: List, LargeList, ListView, LargeListView, FixedSizeList
+                DataType::List(element_field)
+                | DataType::LargeList(element_field)
+                | DataType::ListView(element_field)
+                | DataType::LargeListView(element_field)
+                | DataType::FixedSizeList(element_field, _) => {
+                    // Check argument type to determine access mode
+                    // Use scalar value type if available, otherwise fall back to field type
+                    let arg_type = sv
+                        .as_ref()
+                        .map(|s| s.data_type())
+                        .unwrap_or_else(|| args.arg_fields[i].data_type().clone());
+
+                    if arg_type.is_integer() {
+                        // Array element access - return element type (nullable for out-of-bounds)
+                        current_field =
+                            Arc::new(element_field.as_ref().clone().with_nullable(true));
+                    } else {
+                        return exec_err!(
+                            "Array access at argument {} requires integer index, got {}",
+                            i,
+                            arg_type
+                        );
+                    }
+                }
                 other => {
                     return exec_err!(
-                        "Cannot access field at argument {}: type {} is not Struct, Map, or Null",
+                        "Cannot access field at argument {}: type {} is not Struct, Map, List, or Null",
                         i,
                         other
                     );
@@ -396,18 +933,52 @@ impl ScalarUDFImpl for GetFieldFunc {
             return Ok(ColumnarValue::Scalar(ScalarValue::Null));
         }
 
-        // Iterate through each field name
-        for field_name in args.args.iter().skip(1) {
-            let field_name_scalar = match field_name {
-                ColumnarValue::Scalar(name) => name.clone(),
+        // Iterate through each field name/index
+        for field_arg in args.args.iter().skip(1) {
+            // Dispatch based on current type and argument
+            let current_type = current.data_type();
+            let arg_type = field_arg.data_type();
+
+            current = match &current_type {
+                // Array types: dispatch to array element or slice extraction
+                //
+                // Array indices can be scalar or array (for expressions like arr[i + 1]).
+                // Dynamic indices are supported because all array elements share the same
+                // type, so the return type is known regardless of which index is used.
+                DataType::List(_)
+                | DataType::LargeList(_)
+                | DataType::ListView(_)
+                | DataType::LargeListView(_)
+                | DataType::FixedSizeList(_, _) => {
+                    if arg_type.is_integer() {
+                        extract_array_element_columnar(current, field_arg.clone())?
+                    } else {
+                        return exec_err!(
+                            "Array access requires integer index, got {}",
+                            arg_type
+                        );
+                    }
+                }
+                // Struct/Map types: use existing field extraction (requires scalar field name)
+                //
+                // Unlike array element access which supports dynamic indices (because all
+                // elements have the same type), struct/map field access requires the field
+                // name to be a scalar known at planning time. This is because:
+                // 1. Different struct fields may have different types
+                // 2. The return type must be determined at planning time for type inference
+                // 3. Dynamic field names would make the return type indeterminate
                 _ => {
-                    return exec_err!(
-                        "get_field function requires all field_name arguments to be scalars"
-                    );
+                    let field_name_scalar = match field_arg {
+                        ColumnarValue::Scalar(name) => name.clone(),
+                        _ => {
+                            return exec_err!(
+                                "Struct/Map field access requires scalar field name"
+                            );
+                        }
+                    };
+                    extract_single_field(current, field_name_scalar)?
                 }
             };
-
-            current = extract_single_field(current, field_name_scalar)?;
 
             // Early exit if we hit null
             if current.data_type().is_null() {

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -918,7 +918,7 @@ async fn roundtrip_expr_api() -> Result<()> {
             make_array(vec![lit(1), lit(4)]),
         ),
         array_resize(make_array(vec![lit(1), lit(2), lit(3)]), lit(5), lit(0)),
-        array_element(make_array(vec![lit(1), lit(2), lit(3)]), lit(2)),
+        get_field(make_array(vec![lit(1), lit(2), lit(3)]), 2),
         array_slice(
             make_array(vec![lit(1), lit(2), lit(3)]),
             lit(1),

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1800,8 +1800,8 @@ mod tests {
     use arrow::array::{LargeListArray, ListArray};
     use arrow::datatypes::{DataType::Int8, Field, Int32Type, Schema, TimeUnit};
     use ast::ObjectName;
+    use datafusion_common::TableReference;
     use datafusion_common::datatype::DataTypeExt;
-    use datafusion_common::{Spans, TableReference};
     use datafusion_expr::expr::WildcardOptions;
     use datafusion_expr::{
         ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
@@ -1814,7 +1814,7 @@ mod tests {
     use datafusion_functions::expr_fn::{get_field, named_struct};
     use datafusion_functions_aggregate::count::count_udaf;
     use datafusion_functions_aggregate::expr_fn::sum;
-    use datafusion_functions_nested::expr_fn::{array_element, make_array};
+    use datafusion_functions_nested::expr_fn::make_array;
     use datafusion_functions_nested::map::map;
     use datafusion_functions_window::rank::rank_udwf;
     use datafusion_functions_window::row_number::row_number_udwf;
@@ -2265,9 +2265,9 @@ mod tests {
                 r#"UNNEST("table".array_col)"#,
             ),
             (make_array(vec![lit(1), lit(2), lit(3)]), "[1, 2, 3]"),
-            (array_element(col("array_col"), lit(1)), "array_col[1]"),
+            (get_field(col("array_col"), 1), "array_col[1]"),
             (
-                array_element(make_array(vec![lit(1), lit(2), lit(3)]), lit(1)),
+                get_field(make_array(vec![lit(1), lit(2), lit(3)]), 1),
                 "[1, 2, 3][1]",
             ),
             (

--- a/datafusion/sqllogictest/test_files/struct.slt
+++ b/datafusion/sqllogictest/test_files/struct.slt
@@ -667,7 +667,7 @@ select get_field({'a': {'b': {'c': 42}}}, 'a', 'b', 'c');
 42
 
 # Test type validation error - accessing field on non-struct
-query error Cannot access field at argument 2: type Int64 is not Struct, Map, or Null
+query error Cannot access field at argument 2: type Int64 is not Struct, Map, List, or Null
 select get_field({'a': 1}, 'a', 'b');
 
 # Test that bracket syntax produces a single get_field call (not nested)
@@ -762,11 +762,11 @@ statement ok
 drop table null_mid_test;
 
 # Type validation error at argument 3
-query error Cannot access field at argument 3: type Int64 is not Struct, Map, or Null
+query error Cannot access field at argument 3: type Int64 is not Struct, Map, List, or Null
 select get_field({'a': {'b': 2}}, 'a', 'b', 'c');
 
 # Type validation error at argument 4
-query error Cannot access field at argument 4: type Int64 is not Struct, Map, or Null
+query error Cannot access field at argument 4: type Int64 is not Struct, Map, List, or Null
 select get_field({'a': {'b': {'c': 3}}}, 'a', 'b', 'c', 'd');
 
 # Non-existent field at first level
@@ -824,3 +824,290 @@ NULL
 
 statement ok
 drop table nullable_parent_test;
+
+###############################################
+# Array element access tests
+# Tests all combinations of scalar/array for base and index
+###############################################
+
+# Setup table for array access tests
+statement ok
+create table array_access_test (
+    arr INT[],
+    idx INT
+) as values
+    ([10, 20, 30], 1),
+    ([40, 50, 60], 2),
+    ([70, 80, 90], 3),
+    ([100, 110, 120], -1);
+
+# Case 1: Array/Scalar - column of lists with literal index (most common case)
+# Each row's list is indexed by the same scalar value
+query I
+select arr[1] from array_access_test;
+----
+10
+40
+70
+100
+
+query I
+select arr[2] from array_access_test;
+----
+20
+50
+80
+110
+
+# Negative index (from end)
+query I
+select arr[-1] from array_access_test;
+----
+30
+60
+90
+120
+
+query I
+select arr[-2] from array_access_test;
+----
+20
+50
+80
+110
+
+# Out of bounds returns NULL
+query I
+select arr[100] from array_access_test;
+----
+NULL
+NULL
+NULL
+NULL
+
+query I
+select arr[0] from array_access_test;
+----
+NULL
+NULL
+NULL
+NULL
+
+# Case 2: Scalar/Array - literal list with column of indices
+# The same list is indexed by different values per row
+query I
+select [100, 200, 300][idx] from array_access_test;
+----
+100
+200
+300
+300
+
+# Negative indices in column
+query I
+select [100, 200, 300, 400][-idx] from array_access_test;
+----
+400
+300
+200
+100
+
+# Case 3: Scalar/Scalar - literal list with literal index
+# Pure constant expression
+query I
+select [1, 2, 3][1];
+----
+1
+
+query I
+select [1, 2, 3][2];
+----
+2
+
+query I
+select [1, 2, 3][-1];
+----
+3
+
+query T
+select ['a', 'b', 'c'][2];
+----
+b
+
+# Out of bounds
+query I
+select [1, 2, 3][0];
+----
+NULL
+
+query I
+select [1, 2, 3][100];
+----
+NULL
+
+# Case 4: Array/Array - column of lists with column of indices (zipped)
+# Row i uses arr[i] indexed by idx[i]
+query I
+select arr[idx] from array_access_test;
+----
+10
+50
+90
+120
+
+# Test with expression producing array index
+query I
+select arr[idx + 1] from array_access_test;
+----
+20
+60
+NULL
+NULL
+
+# Test null handling
+
+# Null index returns NULL (must cast NULL to integer type)
+query I
+select arr[CAST(NULL AS INT)] from array_access_test;
+----
+NULL
+NULL
+NULL
+NULL
+
+# Null in scalar list
+query I
+select [1, NULL, 3][2];
+----
+NULL
+
+# Table with null arrays
+statement ok
+create table null_array_test (
+    arr INT[],
+    idx INT
+) as values
+    ([1, 2, 3], 1),
+    (NULL, 2),
+    ([4, 5, 6], NULL),
+    (NULL, NULL);
+
+query I
+select arr[1] from null_array_test;
+----
+1
+NULL
+4
+NULL
+
+query I
+select arr[idx] from null_array_test;
+----
+1
+NULL
+NULL
+NULL
+
+query I
+select [10, 20, 30][idx] from null_array_test;
+----
+10
+20
+NULL
+NULL
+
+# Empty array returns NULL for any index
+query I
+select CAST([] AS INT[])[1];
+----
+NULL
+
+# Test with nested arrays
+statement ok
+create table nested_array_test (
+    nested INT[][]
+) as values
+    ([[1, 2], [3, 4]]),
+    ([[5, 6], [7, 8]]);
+
+query ?
+select nested[1] from nested_array_test;
+----
+[1, 2]
+[5, 6]
+
+query I
+select nested[1][2] from nested_array_test;
+----
+2
+6
+
+query I
+select nested[2][1] from nested_array_test;
+----
+3
+7
+
+# Test with struct containing arrays
+statement ok
+create table struct_with_array (
+    s STRUCT(nums INT[], name VARCHAR)
+) as values
+    ({'nums': [10, 20, 30], 'name': 'first'}),
+    ({'nums': [40, 50, 60], 'name': 'second'});
+
+query I
+select s['nums'][1] from struct_with_array;
+----
+10
+40
+
+query I
+select s['nums'][2] from struct_with_array;
+----
+20
+50
+
+# Cleanup
+statement ok
+drop table array_access_test;
+
+statement ok
+drop table null_array_test;
+
+statement ok
+drop table nested_array_test;
+
+statement ok
+drop table struct_with_array;
+
+###############################################
+# Struct/Map field access with dynamic field names
+# Documents unsupported cases (dynamic field names require scalar)
+###############################################
+
+# Setup for dynamic field name tests
+statement ok
+create table dynamic_field_test (key_col VARCHAR) as values ('a'), ('b');
+
+# Scalar struct with column field name - should error
+# The field name must be known at planning time for type inference
+query error Field name must be a non-empty string
+select {a: 1, b: 2}[key_col] from dynamic_field_test;
+
+# Scalar map with column key - should error
+query error Struct/Map field access requires scalar field name
+select map(['a', 'b'], [1, 2])[key_col] from dynamic_field_test;
+
+statement ok
+drop table dynamic_field_test;
+
+# Array struct with column field name - should error
+statement ok
+create table struct_dynamic_test as select named_struct('a', 1, 'b', 2) as s, 'a' as key_col;
+
+query error Field name must be a non-empty string
+select s[key_col] from struct_dynamic_test;
+
+statement ok
+drop table struct_dynamic_test;


### PR DESCRIPTION
I did this as exploration for another change. It ultimately wasn't helpful but I thought it was an interesting idea nonetheless. Unfortunately combining range access (`list_col[1...3]`) was too difficult, so it's only a halfway change. I'll open and close this to record the change for posterity.