### PR TITLE
Incremental group emission in HashAggregate

### DIFF
--- a/benchmarks/src/bin/incremental_emit.rs
+++ b/benchmarks/src/bin/incremental_emit.rs
@@ -1,0 +1,246 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmark comparing incremental emission vs all-at-once emission
+//! for hash aggregation.
+//!
+//! This benchmark measures the time-to-first-row improvement from
+//! the incremental drain optimization.
+//!
+//! Usage:
+//!   cargo run --release --bin incremental_emit_bench -- --groups 1000000
+
+use arrow::array::{Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::common::Result;
+use datafusion::datasource::MemTable;
+use datafusion::prelude::*;
+use datafusion_common::instant::Instant;
+use futures::StreamExt;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+struct BenchmarkResult {
+    time_to_first_row: Duration,
+    total_time: Duration,
+    num_output_batches: usize,
+    total_output_rows: usize,
+}
+
+async fn run_aggregation_benchmark(
+    batch: RecordBatch,
+    batch_size: usize,
+) -> Result<BenchmarkResult> {
+    let config = SessionConfig::new().with_batch_size(batch_size);
+    let ctx = SessionContext::new_with_config(config);
+
+    let schema = batch.schema();
+    let table = MemTable::try_new(schema, vec![vec![batch]])?;
+    ctx.register_table("bench_data", Arc::new(table))?;
+
+    let sql = "SELECT group_key, SUM(value) as total, COUNT(*) as cnt \
+               FROM bench_data \
+               GROUP BY group_key";
+
+    let df = ctx.sql(sql).await?;
+
+    let start = Instant::now();
+    let mut stream = df.execute_stream().await?;
+
+    // Measure time to first batch
+    let first_batch = stream.next().await;
+    let time_to_first_row = start.elapsed();
+
+    let mut num_output_batches = 0;
+    let mut total_output_rows = 0;
+
+    if let Some(Ok(batch)) = first_batch {
+        num_output_batches += 1;
+        total_output_rows += batch.num_rows();
+    }
+
+    // Consume remaining batches
+    while let Some(result) = stream.next().await {
+        if let Ok(batch) = result {
+            num_output_batches += 1;
+            total_output_rows += batch.num_rows();
+        }
+    }
+
+    let total_time = start.elapsed();
+
+    Ok(BenchmarkResult {
+        time_to_first_row,
+        total_time,
+        num_output_batches,
+        total_output_rows,
+    })
+}
+
+fn create_test_data(num_groups: usize, rows_per_group: usize) -> Result<RecordBatch> {
+    let total_rows = num_groups * rows_per_group;
+
+    // Create group keys: "group_0", "group_1", ..., "group_{num_groups-1}"
+    // Each group appears rows_per_group times
+    let group_keys: Vec<String> = (0..total_rows)
+        .map(|i| format!("group_{}", i % num_groups))
+        .collect();
+
+    // Create values: just use the row index
+    let values: Vec<i64> = (0..total_rows as i64).collect();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("group_key", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(group_keys)),
+            Arc::new(Int64Array::from(values)),
+        ],
+    )?;
+
+    Ok(batch)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let num_groups = args
+        .iter()
+        .position(|s| s == "--groups")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100_000);
+
+    let rows_per_group = args
+        .iter()
+        .position(|s| s == "--rows-per-group")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+
+    let iterations = args
+        .iter()
+        .position(|s| s == "--iterations")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+
+    println!("=== Incremental Emit Benchmark ===");
+    println!("Number of groups: {num_groups}");
+    println!("Rows per group: {rows_per_group}");
+    println!("Total input rows: {}", num_groups * rows_per_group);
+    println!("Iterations: {iterations}");
+    println!();
+
+    // Batch sizes to test
+    // Note: We use num_groups as the "all-at-once" batch size to simulate the EmitTo::All behavior
+    // of emitting all groups in a single batch.
+    let batch_sizes = vec![
+        (8192, "8192 (incremental)".to_string()),
+        (32768, "32768 (larger batches)".to_string()),
+        (
+            num_groups,
+            format!("{num_groups} (all-at-once, simulates EmitTo::All behavior)"),
+        ),
+    ];
+
+    println!("Running benchmarks...");
+    println!();
+
+    for (batch_size, label) in batch_sizes {
+        println!("--- Batch size: {label} ---");
+
+        let mut first_row_times = Vec::new();
+        let mut total_times = Vec::new();
+
+        for i in 0..iterations {
+            // Create fresh test data for each run
+            let batch = create_test_data(num_groups, rows_per_group)?;
+            let result = run_aggregation_benchmark(batch, batch_size).await?;
+
+            println!(
+                "  Iteration {}: first_row={:?}, total={:?}, batches={}, rows={}",
+                i + 1,
+                result.time_to_first_row,
+                result.total_time,
+                result.num_output_batches,
+                result.total_output_rows
+            );
+
+            first_row_times.push(result.time_to_first_row);
+            total_times.push(result.total_time);
+        }
+
+        let avg_first_row: Duration =
+            first_row_times.iter().sum::<Duration>() / iterations as u32;
+        let avg_total: Duration =
+            total_times.iter().sum::<Duration>() / iterations as u32;
+
+        println!("  Average: first_row={avg_first_row:?}, total={avg_total:?}");
+        println!();
+    }
+
+    println!("=== Summary ===");
+    println!("The 'time to first row' metric shows how quickly the first output");
+    println!("batch is produced. With incremental emission (smaller batch sizes),");
+    println!("this should be significantly faster than all-at-once emission.");
+
+    Ok(())
+}
+
+/* Example output:
+
+cargo run --bin incremental_emit -- --groups 1000000 --rows-per-group 5 --iterations 3
+
+=== Incremental Emit Benchmark ===
+Number of groups: 1000000
+Rows per group: 5
+Total input rows: 5000000
+Iterations: 3
+
+Running benchmarks...
+
+--- Batch size: 8192 (incremental) ---
+  Iteration 1: first_row=514.312458ms, total=750.121625ms, batches=128, rows=1000000
+  Iteration 2: first_row=487.098583ms, total=680.311958ms, batches=128, rows=1000000
+  Iteration 3: first_row=473.02925ms, total=668.469083ms, batches=128, rows=1000000
+  Average: first_row=491.480097ms, total=699.634222ms
+
+--- Batch size: 32768 (larger batches) ---
+  Iteration 1: first_row=481.137417ms, total=497.485917ms, batches=32, rows=1000000
+  Iteration 2: first_row=478.821ms, total=496.062959ms, batches=32, rows=1000000
+  Iteration 3: first_row=524.281709ms, total=539.426584ms, batches=32, rows=1000000
+  Average: first_row=494.746708ms, total=510.99182ms
+
+--- Batch size: 1000000 (all-at-once, simulates EmitTo::All behavior) ---
+  Iteration 1: first_row=1.22554625s, total=1.303929583s, batches=16, rows=1000000
+  Iteration 2: first_row=1.237296333s, total=1.2897605s, batches=16, rows=1000000
+  Iteration 3: first_row=1.235812417s, total=1.303563667s, batches=16, rows=1000000
+  Average: first_row=1.232885s, total=1.299084583s
+
+=== Summary ===
+The 'time to first row' metric shows how quickly the first output
+batch is produced. With incremental emission (smaller batch sizes),
+this should be significantly faster than all-at-once emission.
+*/

--- a/datafusion/ffi/src/udaf/groups_accumulator.rs
+++ b/datafusion/ffi/src/udaf/groups_accumulator.rs
@@ -438,15 +438,15 @@ impl GroupsAccumulator for ForeignGroupsAccumulator {
 #[repr(C)]
 #[derive(Debug, StableAbi)]
 pub enum FFI_EmitTo {
-    All,
     First(usize),
+    Next(usize),
 }
 
 impl From<EmitTo> for FFI_EmitTo {
     fn from(value: EmitTo) -> Self {
         match value {
-            EmitTo::All => Self::All,
             EmitTo::First(v) => Self::First(v),
+            EmitTo::Next(v) => Self::Next(v),
         }
     }
 }
@@ -454,8 +454,8 @@ impl From<EmitTo> for FFI_EmitTo {
 impl From<FFI_EmitTo> for EmitTo {
     fn from(value: FFI_EmitTo) -> Self {
         match value {
-            FFI_EmitTo::All => Self::All,
             FFI_EmitTo::First(v) => Self::First(v),
+            FFI_EmitTo::Next(v) => Self::Next(v),
         }
     }
 }
@@ -491,7 +491,7 @@ mod tests {
             3,
         )?;
 
-        let groups_bool = foreign_accum.evaluate(EmitTo::All)?;
+        let groups_bool = foreign_accum.evaluate(EmitTo::Next(usize::MAX))?;
         let groups_bool = groups_bool.as_any().downcast_ref::<BooleanArray>().unwrap();
 
         assert_eq!(
@@ -499,7 +499,7 @@ mod tests {
             create_array!(Boolean, vec![Some(true), Some(false), None]).as_ref()
         );
 
-        let state = foreign_accum.state(EmitTo::All)?;
+        let state = foreign_accum.state(EmitTo::Next(usize::MAX))?;
         assert_eq!(state.len(), 1);
 
         // To verify merging batches works, create a second state to add in
@@ -509,7 +509,7 @@ mod tests {
 
         let opt_filter = create_array!(Boolean, vec![true]);
         foreign_accum.merge_batch(&second_states, &[0], Some(opt_filter.as_ref()), 1)?;
-        let groups_bool = foreign_accum.evaluate(EmitTo::All)?;
+        let groups_bool = foreign_accum.evaluate(EmitTo::Next(usize::MAX))?;
         assert_eq!(groups_bool.len(), 1);
         assert_eq!(
             groups_bool.as_ref(),
@@ -540,7 +540,7 @@ mod tests {
     /// This test ensures all enum values are properly translated
     #[test]
     fn test_all_emit_to_round_trip() -> Result<()> {
-        test_emit_to_round_trip(EmitTo::All)?;
+        test_emit_to_round_trip(EmitTo::Next(usize::MAX))?;
         test_emit_to_round_trip(EmitTo::First(10))?;
 
         Ok(())

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/bool_op.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/bool_op.rs
@@ -108,7 +108,6 @@ where
         let values = self.values.finish();
 
         let values = match emit_to {
-            EmitTo::All => values,
             EmitTo::First(n) => {
                 let first_n: BooleanBuffer = values.iter().take(n).collect();
                 // put n+1 back into self.values
@@ -116,6 +115,22 @@ where
                     self.values.append(v);
                 }
                 first_n
+            }
+            EmitTo::Next(batch_size) => {
+                // For Next, we take up to batch_size from the current position
+                let len = values.len();
+                let n = batch_size.min(len);
+                if n == len {
+                    // Taking everything
+                    values
+                } else {
+                    // Take first n and keep the rest
+                    let first_n: BooleanBuffer = values.iter().take(n).collect();
+                    for v in values.iter().skip(n) {
+                        self.values.append(v);
+                    }
+                    first_n
+                }
             }
         };
 

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -412,8 +412,7 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
 
     fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
         let n = match emit_to {
-            EmitTo::All => self.count.len(),
-            EmitTo::First(n) => n,
+            EmitTo::First(n) | EmitTo::Next(n) => n.min(self.count.len()),
         };
 
         let mut values = Vec::with_capacity(n);
@@ -471,8 +470,7 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
 
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         let n = match emit_to {
-            EmitTo::All => self.count.len(),
-            EmitTo::First(n) => n,
+            EmitTo::First(n) | EmitTo::Next(n) => n.min(self.count.len()),
         };
 
         Ok(vec![

--- a/datafusion/functions-aggregate/src/variance.rs
+++ b/datafusion/functions-aggregate/src/variance.rs
@@ -602,7 +602,7 @@ mod tests {
         let mut acc = VarianceGroupsAccumulator::new(StatsType::Sample);
         acc.merge_batch(&state_1, &[0], None, 1)?;
         acc.merge_batch(&state_2, &[0], None, 1)?;
-        let result = acc.evaluate(EmitTo::All)?;
+        let result = acc.evaluate(EmitTo::Next(usize::MAX))?;
         let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result.value(0), 1.0);

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes_view.rs
@@ -91,10 +91,6 @@ impl GroupValues for GroupValuesBytesView {
         let map_contents = self.map.take().into_state();
 
         let group_values = match emit_to {
-            EmitTo::All => {
-                self.num_groups -= map_contents.len();
-                map_contents
-            }
             EmitTo::First(n) if n == self.len() => {
                 self.num_groups -= map_contents.len();
                 map_contents
@@ -114,6 +110,23 @@ impl GroupValues for GroupValuesBytesView {
 
                 // Verify that the group indexes were assigned in the correct order
                 assert_eq!(0, group_indexes[0]);
+
+                emit_group_values
+            }
+            EmitTo::Next(batch_size) => {
+                let n = batch_size.min(map_contents.len());
+                if n == 0 {
+                    self.num_groups = 0;
+                    return Ok(vec![map_contents.slice(0, 0)]);
+                }
+
+                let emit_group_values = map_contents.slice(0, n);
+                let remaining_group_values =
+                    map_contents.slice(n, map_contents.len() - n);
+
+                self.num_groups = 0;
+                let mut group_indexes = vec![];
+                self.intern(&[remaining_group_values], &mut group_indexes)?;
 
                 emit_group_values
             }

--- a/datafusion/physical-plan/src/aggregates/order/full.rs
+++ b/datafusion/physical-plan/src/aggregates/order/full.rs
@@ -92,7 +92,8 @@ impl GroupOrderingFull {
                     Some(EmitTo::First(*current))
                 }
             }
-            State::Complete => Some(EmitTo::All),
+            // When complete, emit all remaining groups using Next with max size
+            State::Complete => Some(EmitTo::Next(usize::MAX)),
         }
     }
 

--- a/datafusion/physical-plan/src/aggregates/order/partial.rs
+++ b/datafusion/physical-plan/src/aggregates/order/partial.rs
@@ -153,7 +153,8 @@ impl GroupOrderingPartial {
                     Some(EmitTo::First(*current_sort))
                 }
             }
-            State::Complete => Some(EmitTo::All),
+            // When complete, emit all remaining groups using Next with max size
+            State::Complete => Some(EmitTo::Next(usize::MAX)),
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #18907

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This is another attempt to solve the long polls observed and explained in #18907. Mostly inspired by @alamb's comment https://github.com/apache/datafusion/pull/18906#discussion_r2635687188 on the first attempt PR.


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR is an exploratory implementation to gauge the scope and complexity of supporting incremental group emission in `GroupedHashAggregateStream`. The goal is to understand how large this change would be and identify a path to ship it in smaller, reviewable increments.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
- Test coverage from preexisting aggregate tests
- Benchmark `incremental_emit` included to prove the benefits of these changes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
