### PR TITLE
Add preserve_empty_as_null option to unnest for Spark explode_outer compatibility

### DIFF
--- a/datafusion/physical-plan/src/unnest.rs
+++ b/datafusion/physical-plan/src/unnest.rs
@@ -749,9 +749,15 @@ fn build_batch(
 ///
 /// whereas if `preserve_nulls` is true, the longest length array will be:
 ///
-///
 /// ```ignore
 /// longest_length: [3, 1, 1, 2]
+/// ```
+///
+/// If `preserve_empty_as_null` is true (Spark's explode_outer behavior),
+/// empty arrays are treated like NULL arrays:
+///
+/// ```ignore
+/// longest_length: [3, 1, 1, 2]  // empty array [] at index 1 gets length 1
 /// ```
 fn find_longest_length(
     list_arrays: &[ArrayRef],
@@ -763,14 +769,36 @@ fn find_longest_length(
     } else {
         Scalar::new(Int64Array::from_value(0, 1))
     };
+
+    // The length to use for empty arrays when preserve_empty_as_null is true
+    let empty_length = Scalar::new(Int64Array::from_value(1, 1));
+    let zero_length = Scalar::new(Int64Array::from_value(0, 1));
+
     let list_lengths: Vec<ArrayRef> = list_arrays
         .iter()
         .map(|list_array| {
             let mut length_array = length(list_array)?;
             // Make sure length arrays have the same type. Int64 is the most general one.
             length_array = cast(&length_array, &DataType::Int64)?;
+
+            // Handle empty arrays when preserve_empty_as_null is true
+            // This must be done BEFORE handling NULLs, because we need to distinguish
+            // between actual empty arrays (length 0, not null) and NULL arrays.
+            // Empty arrays have length 0 but are not null, so we need to
+            // replace 0 lengths with 1 to produce a NULL output row (Spark's explode_outer behavior)
+            if options.preserve_empty_as_null {
+                // Only replace 0 with 1 for non-null entries (actual empty arrays)
+                let is_not_null_mask = is_not_null(&length_array)?;
+                let is_zero = kernels::cmp::eq(&length_array, &zero_length)?;
+                // is_empty_array = not null AND length == 0
+                let is_empty_array = kernels::boolean::and(&is_not_null_mask, &is_zero)?;
+                length_array = zip(&is_empty_array, &empty_length, &length_array)?;
+            }
+
+            // Handle NULL arrays: replace null lengths with null_length
             length_array =
                 zip(&is_not_null(&length_array)?, &length_array, &null_length)?;
+
             Ok(length_array)
         })
         .collect::<Result<_>>()?;
@@ -1193,6 +1221,7 @@ mod tests {
             &HashSet::default(),
             &UnnestOptions {
                 preserve_nulls: true,
+                preserve_empty_as_null: false,
                 recursions: vec![],
             },
         )?
@@ -1278,8 +1307,18 @@ mod tests {
         preserve_nulls: bool,
         expected: Vec<i64>,
     ) -> Result<()> {
+        verify_longest_length_with_options(list_arrays, preserve_nulls, false, expected)
+    }
+
+    fn verify_longest_length_with_options(
+        list_arrays: &[ArrayRef],
+        preserve_nulls: bool,
+        preserve_empty_as_null: bool,
+        expected: Vec<i64>,
+    ) -> Result<()> {
         let options = UnnestOptions {
             preserve_nulls,
+            preserve_empty_as_null,
             recursions: vec![],
         };
         let longest_length = find_longest_length(list_arrays, &options)?;
@@ -1322,6 +1361,43 @@ mod tests {
         let list_arrays = vec![Arc::clone(&list1), Arc::clone(&list2)];
         verify_longest_length(&list_arrays, false, vec![3, 0, 2, 1, 2, 2])?;
         verify_longest_length(&list_arrays, true, vec![3, 1, 2, 1, 2, 2])?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_longest_list_length_preserve_empty_as_null() -> Result<()> {
+        // Test with single ListArray
+        //  [A, B, C], [], NULL, [D], NULL, [NULL, F]
+        // With preserve_empty_as_null=true, empty arrays [] get length 1
+        let list_array = Arc::new(make_generic_array::<i32>()) as ArrayRef;
+
+        // preserve_nulls=false, preserve_empty_as_null=true
+        // NULL arrays still get length 0, but empty arrays get length 1
+        verify_longest_length_with_options(
+            &[Arc::clone(&list_array)],
+            false, // preserve_nulls
+            true,  // preserve_empty_as_null
+            vec![3, 1, 0, 1, 0, 2], // index 1 (empty []) now gets length 1
+        )?;
+
+        // preserve_nulls=true, preserve_empty_as_null=true (Spark's explode_outer behavior)
+        // Both NULL arrays and empty arrays get length 1
+        verify_longest_length_with_options(
+            &[Arc::clone(&list_array)],
+            true, // preserve_nulls
+            true, // preserve_empty_as_null
+            vec![3, 1, 1, 1, 1, 2], // index 1 (empty []) gets length 1, NULLs also get 1
+        )?;
+
+        // Test with single LargeListArray
+        let list_array = Arc::new(make_generic_array::<i64>()) as ArrayRef;
+        verify_longest_length_with_options(
+            &[Arc::clone(&list_array)],
+            true,
+            true,
+            vec![3, 1, 1, 1, 1, 2],
+        )?;
 
         Ok(())
     }

--- a/datafusion/physical-plan/src/unnest.rs
+++ b/datafusion/physical-plan/src/unnest.rs
@@ -1376,8 +1376,8 @@ mod tests {
         // NULL arrays still get length 0, but empty arrays get length 1
         verify_longest_length_with_options(
             &[Arc::clone(&list_array)],
-            false, // preserve_nulls
-            true,  // preserve_empty_as_null
+            false,                  // preserve_nulls
+            true,                   // preserve_empty_as_null
             vec![3, 1, 0, 1, 0, 2], // index 1 (empty []) now gets length 1
         )?;
 
@@ -1385,8 +1385,8 @@ mod tests {
         // Both NULL arrays and empty arrays get length 1
         verify_longest_length_with_options(
             &[Arc::clone(&list_array)],
-            true, // preserve_nulls
-            true, // preserve_empty_as_null
+            true,                   // preserve_nulls
+            true,                   // preserve_empty_as_null
             vec![3, 1, 1, 1, 1, 2], // index 1 (empty []) gets length 1, NULLs also get 1
         )?;
 

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -311,6 +311,7 @@ message ColumnUnnestListRecursion {
 message UnnestOptions {
   bool preserve_nulls = 1;
   repeated RecursionUnnestOption recursions = 2;
+  bool preserve_empty_as_null = 3;
 }
 
 message RecursionUnnestOption {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -23472,12 +23472,18 @@ impl serde::Serialize for UnnestOptions {
         if !self.recursions.is_empty() {
             len += 1;
         }
+        if self.preserve_empty_as_null {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion.UnnestOptions", len)?;
         if self.preserve_nulls {
             struct_ser.serialize_field("preserveNulls", &self.preserve_nulls)?;
         }
         if !self.recursions.is_empty() {
             struct_ser.serialize_field("recursions", &self.recursions)?;
+        }
+        if self.preserve_empty_as_null {
+            struct_ser.serialize_field("preserveEmptyAsNull", &self.preserve_empty_as_null)?;
         }
         struct_ser.end()
     }
@@ -23492,12 +23498,15 @@ impl<'de> serde::Deserialize<'de> for UnnestOptions {
             "preserve_nulls",
             "preserveNulls",
             "recursions",
+            "preserve_empty_as_null",
+            "preserveEmptyAsNull",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             PreserveNulls,
             Recursions,
+            PreserveEmptyAsNull,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -23521,6 +23530,7 @@ impl<'de> serde::Deserialize<'de> for UnnestOptions {
                         match value {
                             "preserveNulls" | "preserve_nulls" => Ok(GeneratedField::PreserveNulls),
                             "recursions" => Ok(GeneratedField::Recursions),
+                            "preserveEmptyAsNull" | "preserve_empty_as_null" => Ok(GeneratedField::PreserveEmptyAsNull),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -23542,6 +23552,7 @@ impl<'de> serde::Deserialize<'de> for UnnestOptions {
             {
                 let mut preserve_nulls__ = None;
                 let mut recursions__ = None;
+                let mut preserve_empty_as_null__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::PreserveNulls => {
@@ -23556,11 +23567,18 @@ impl<'de> serde::Deserialize<'de> for UnnestOptions {
                             }
                             recursions__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::PreserveEmptyAsNull => {
+                            if preserve_empty_as_null__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("preserveEmptyAsNull"));
+                            }
+                            preserve_empty_as_null__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(UnnestOptions {
                     preserve_nulls: preserve_nulls__.unwrap_or_default(),
                     recursions: recursions__.unwrap_or_default(),
+                    preserve_empty_as_null: preserve_empty_as_null__.unwrap_or_default(),
                 })
             }
         }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -516,6 +516,8 @@ pub struct UnnestOptions {
     pub preserve_nulls: bool,
     #[prost(message, repeated, tag = "2")]
     pub recursions: ::prost::alloc::vec::Vec<RecursionUnnestOption>,
+    #[prost(bool, tag = "3")]
+    pub preserve_empty_as_null: bool,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RecursionUnnestOption {

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -57,6 +57,7 @@ impl From<&protobuf::UnnestOptions> for UnnestOptions {
     fn from(opts: &protobuf::UnnestOptions) -> Self {
         Self {
             preserve_nulls: opts.preserve_nulls,
+            preserve_empty_as_null: opts.preserve_empty_as_null,
             recursions: opts
                 .recursions
                 .iter()

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -54,6 +54,7 @@ impl From<&UnnestOptions> for protobuf::UnnestOptions {
     fn from(opts: &UnnestOptions) -> Self {
         Self {
             preserve_nulls: opts.preserve_nulls,
+            preserve_empty_as_null: opts.preserve_empty_as_null,
             recursions: opts
                 .recursions
                 .iter()


### PR DESCRIPTION
## Rationale for this change
Spark's `explode_outer` function treats empty arrays `[]` the same as NULL arrays - both produce an output row with NULL. Currently, DataFusion's `unnest` with `preserve_nulls=true` only handles NULL arrays, and empty arrays produce no output rows.

This makes it tricky to achieve Spark-compatible behavior when migrating workloads.

## What changes are included in this PR?
Added a new `preserve_empty_as_null` flag to `UnnestOptions`:
- When `false` (default): empty arrays produce 0 rows (existing behavior, backwards compatible)
- When `true`: empty arrays produce 1 row with NULL value (Spark's explode_outer behavior)

Example with `preserve_nulls=true` and `preserve_empty_as_null=true`:

**Input:**
| Column 1  | Column 2 |
|-----------|----------|
| {1, 2}    | A        |
| null      | B        |
| {}        | C        |
| {3}       | D        |

**Output:**
| Column 1  | Column 2 |
|-----------|----------|
| 1         | A        |
| 2         | A        |
| null      | B        |
| null      | C        | ← empty {} now outputs null
| 3         | D        |

## Files changed:
- `datafusion/common/src/unnest.rs` - added the new option and builder method
- `datafusion/physical-plan/src/unnest.rs` - updated `find_longest_length()` to handle empty arrays
- `datafusion/proto/*` - updated proto definitions for serialization

## How are these changes tested?
Added new unit test `test_longest_list_length_preserve_empty_as_null` that verifies:
- Empty arrays get length 1 when the flag is enabled
- NULL arrays still behave correctly based on `preserve_nulls` setting
- The two flags work independently

## Are these changes safe?
Yes - the default value is `false`, so existing behavior is unchanged. Users have to explicitly opt-in to the new behavior.