### PR TITLE
Support negative scale decimals in decimal-to-integer conversions

### DIFF
--- a/datafusion/sqllogictest/test_files/decimal.slt
+++ b/datafusion/sqllogictest/test_files/decimal.slt
@@ -1217,3 +1217,18 @@ NULL
 
 query error Arrow error: Invalid argument error: 1.10 is too large to store in a Decimal128 of precision 2. Max is 0.99
 select cast(1.1 as decimal(2, 2)) + 1;
+
+query I
+SELECT CAST(123.45 AS INT);
+----
+123
+
+query I
+SELECT CAST(1e2 AS INT);
+----
+100
+
+query I
+SELECT CAST(1e4 AS INT);
+----
+10000


### PR DESCRIPTION
## Which issue does this PR close?

- part of #19250 

## Rationale for this change
Decimal values with negative scale represent multiplication by a power of ten, but the decimal-to-integer conversion helpers previously rejected such values. This caused valid negative-scale decimals to fail during evaluation.

## What changes are included in this PR?
Update decimal32_to_i32, decimal64_to_i64, and decimal128_to_i128 to correctly handle negative scales by multiplying

## Are these changes tested?
Yes. Existing unit tests were updated and new cases were added to validate correct behavio
