### PR TITLE
   perf: Improve performance of hex encoding in spark functions

### DIFF
--- a/datafusion/spark/src/function/hash/sha1.rs
+++ b/datafusion/spark/src/function/hash/sha1.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::any::Any;
-use std::fmt::Write;
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, StringArray};
@@ -95,11 +94,16 @@ impl ScalarUDFImpl for SparkSha1 {
     }
 }
 
+/// Hex encoding lookup table for fast byte-to-hex conversion
+const HEX_CHARS_LOWER: &[u8; 16] = b"0123456789abcdef";
+
+#[inline]
 fn spark_sha1_digest(value: &[u8]) -> String {
     let result = Sha1::digest(value);
     let mut s = String::with_capacity(result.len() * 2);
-    for b in result.as_slice() {
-        write!(&mut s, "{b:02x}").unwrap();
+    for &b in result.as_slice() {
+        s.push(HEX_CHARS_LOWER[(b >> 4) as usize] as char);
+        s.push(HEX_CHARS_LOWER[(b & 0x0f) as usize] as char);
     }
     s
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #19569

## Rationale for this change

Completes the hex encoding optimization work from #19568 by replacing `write!` format strings with lookup tables in the remaining instances (`hex` and `sha1` functions in spark module).

## What changes are included in this PR?
Avoid using `write!` with a format string and use a more efficient approach

## Are these changes tested?

Yes

## Are there any user-facing changes?

No.