### PR TITLE
Perf:  Optimize `substring_index` via single-byte fast path and direct indexing

### DIFF
--- a/datafusion/functions/benches/substr_index.rs
+++ b/datafusion/functions/benches/substr_index.rs
@@ -149,20 +149,17 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     for batch_size in batch_sizes {
         group.bench_function(
-            &format!("substr_index_{}_single_delimiter", batch_size),
+            format!("substr_index_{batch_size}_single_delimiter"),
             |b| {
                 let (strings, delimiters, counts) = data(batch_size, true);
                 run_benchmark(b, strings, delimiters, counts, batch_size);
             },
         );
 
-        group.bench_function(
-            &format!("substr_index_{}_long_delimiter", batch_size),
-            |b| {
-                let (strings, delimiters, counts) = data(batch_size, false);
-                run_benchmark(b, strings, delimiters, counts, batch_size);
-            },
-        );
+        group.bench_function(format!("substr_index_{batch_size}_long_delimiter"), |b| {
+            let (strings, delimiters, counts) = data(batch_size, false);
+            run_benchmark(b, strings, delimiters, counts, batch_size);
+        });
     }
 
     group.finish();


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR improves the performance of the `substring_index` function by optimizing
delimiter search and substring extraction: 

- Single-byte fast path: introduces a specialized byte-based search for single-byte delimiters (e.g. `.`, `,`), avoiding UTF-8 pattern matching overhead.
- Efficient index discovery: replaces the split-and-sum-length approach with direct index location using `match_indices` / `rmatch_indices`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Added a fast path for `delimiter.len() == 1` using byte-based search.
- Refactored the general path to use `match_indices` and `rmatch_indices` for more efficient positioning.

### Benchmarks
- Single-byte delimiter benchmarks show ~2–3× speedup across batch sizes.
- Multi-byte delimiters see a consistent ~10–15% improvement.
```
group                                               main_substrindex                       perf_substrindex
-----                                               ----------------                       ----------------
substr_index/substr_index_10000_long_delimiter      1.12   548.2±18.39µs        ? ?/sec    1.00   488.4±15.62µs        ? ?/sec
substr_index/substr_index_10000_single_delimiter    2.14   543.4±15.12µs        ? ?/sec    1.00    254.0±7.80µs        ? ?/sec
substr_index/substr_index_1000_long_delimiter       1.12     43.1±1.63µs        ? ?/sec    1.00     38.6±2.03µs        ? ?/sec
substr_index/substr_index_1000_single_delimiter     3.51     46.4±2.21µs        ? ?/sec    1.00     13.2±0.99µs        ? ?/sec
substr_index/substr_index_100_long_delimiter        1.01      3.7±0.18µs        ? ?/sec    1.00      3.7±0.20µs        ? ?/sec
substr_index/substr_index_100_single_delimiter      2.15      3.6±0.14µs        ? ?/sec    1.00  1675.9±79.15ns        ? ?/sec
```

## Are these changes tested?

- Yes, Existing unit tests pass.
- New benchmarks added to verify performance improvement.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
