### PR TITLE
fix: Percent Encoding of paths for hive style partitioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
+ "percent-encoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ parquet = { version = "58.1.0", default-features = false, features = [
 ] }
 pbjson = { version = "0.9.0" }
 pbjson-types = "0.9"
+percent-encoding = "2.3"
 # Should match arrow-flight's version of prost.
 prost = "0.14.1"
 rand = "0.9"

--- a/datafusion/catalog-listing/Cargo.toml
+++ b/datafusion/catalog-listing/Cargo.toml
@@ -46,6 +46,7 @@ futures = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 object_store = { workspace = true }
+percent-encoding = { workspace = true }
 
 [dev-dependencies]
 datafusion-datasource-parquet = { workspace = true }

--- a/datafusion/catalog-listing/src/helpers.rs
+++ b/datafusion/catalog-listing/src/helpers.rs
@@ -42,6 +42,7 @@ use datafusion_expr::{Expr, Volatility};
 use datafusion_physical_expr::create_physical_expr;
 use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore};
+use percent_encoding::percent_decode_str;
 
 /// Check whether the given expression can be resolved using only the columns `col_names`.
 /// This means that if this function returns true:
@@ -418,12 +419,15 @@ pub async fn pruned_partition_list<'a>(
 }
 
 /// Extract the partition values for the given `file_path` (in the given `table_path`)
-/// associated to the partitions defined by `table_partition_cols`
+/// associated to the partitions defined by `table_partition_cols`.
+///
+/// Partition values are URL-decoded, since object stores like S3 encode special
+/// characters (e.g., `/` becomes `%2F`) in path segments.
 pub fn parse_partitions_for_path<'a, I>(
     table_path: &ListingTableUrl,
     file_path: &'a Path,
     table_partition_cols: I,
-) -> Option<Vec<&'a str>>
+) -> Option<Vec<String>>
 where
     I: IntoIterator<Item = &'a str>,
 {
@@ -432,7 +436,10 @@ where
     let mut part_values = vec![];
     for (part, expected_partition) in subpath.zip(table_partition_cols) {
         match part.split_once('=') {
-            Some((name, val)) if name == expected_partition => part_values.push(val),
+            Some((name, val)) if name == expected_partition => {
+                let decoded = percent_decode_str(val).decode_utf8().ok()?;
+                part_values.push(decoded.into_owned());
+            }
             _ => {
                 debug!(
                     "Ignoring file: file_path='{file_path}', table_path='{table_path}', part='{part}', partition_col='{expected_partition}'",
@@ -508,7 +515,7 @@ mod tests {
     #[test]
     fn test_parse_partitions_for_path() {
         assert_eq!(
-            Some(vec![]),
+            Some(vec![] as Vec<String>),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::from("bucket/mytable/file.csv"),
@@ -532,15 +539,25 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["v1"]),
+            Some(vec!["v1".to_string()]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::from("bucket/mytable/mypartition=v1/file.csv"),
                 vec!["mypartition"]
             )
         );
+        // URL-encoded partition values should be decoded
+        // Use Path::parse to avoid double-encoding (Path::from encodes % as %25)
         assert_eq!(
-            Some(vec!["v1"]),
+            Some(vec!["v/1".to_string()]),
+            parse_partitions_for_path(
+                &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
+                &Path::parse("bucket/mytable/mypartition=v%2F1/file.csv").unwrap(),
+                vec!["mypartition"]
+            )
+        );
+        assert_eq!(
+            Some(vec!["v1".to_string()]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable/").unwrap(),
                 &Path::from("bucket/mytable/mypartition=v1/file.csv"),
@@ -557,7 +574,7 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["v1", "v2"]),
+            Some(vec!["v1".to_string(), "v2".to_string()]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::from("bucket/mytable/mypartition=v1/otherpartition=v2/file.csv"),
@@ -565,11 +582,51 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["v1"]),
+            Some(vec!["v1".to_string()]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::from("bucket/mytable/mypartition=v1/otherpartition=v2/file.csv"),
                 vec!["mypartition"]
+            )
+        );
+        assert_eq!(
+            Some(vec!["John Doe".to_string()]),
+            parse_partitions_for_path(
+                &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
+                &Path::parse("bucket/mytable/name=John%20Doe/file.csv").unwrap(),
+                vec!["name"]
+            )
+        );
+        assert_eq!(
+            Some(vec!["a/b".to_string(), "c d".to_string()]),
+            parse_partitions_for_path(
+                &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
+                &Path::parse("bucket/mytable/p1=a%2Fb/p2=c%20d/file.csv").unwrap(),
+                vec!["p1", "p2"]
+            )
+        );
+        assert_eq!(
+            Some(vec!["Müller".to_string()]),
+            parse_partitions_for_path(
+                &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
+                &Path::parse("bucket/mytable/name=M%C3%BCller/file.csv").unwrap(),
+                vec!["name"]
+            )
+        );
+        assert_eq!(
+            Some(vec!["invalid%XX".to_string()]),
+            parse_partitions_for_path(
+                &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
+                &Path::parse("bucket/mytable/p1=invalid%XX/file.csv").unwrap(),
+                vec!["p1"]
+            )
+        );
+        assert_eq!(
+            None,
+            parse_partitions_for_path(
+                &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
+                &Path::parse("bucket/mytable/p1=%FF/file.csv").unwrap(),
+                vec!["p1"]
             )
         );
     }

--- a/datafusion/catalog-listing/src/helpers.rs
+++ b/datafusion/catalog-listing/src/helpers.rs
@@ -17,6 +17,7 @@
 
 //! Helper functions for the table implementation
 
+use std::borrow::Cow;
 use std::mem;
 use std::sync::Arc;
 
@@ -354,7 +355,7 @@ fn try_into_partitioned_file(
         .flatten()
         .zip(partition_cols)
         .map(|(parsed, (_, datatype))| {
-            ScalarValue::try_from_string(parsed.to_string(), datatype)
+            ScalarValue::try_from_string(parsed.into_owned(), datatype)
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -427,7 +428,7 @@ pub fn parse_partitions_for_path<'a, I>(
     table_path: &ListingTableUrl,
     file_path: &'a Path,
     table_partition_cols: I,
-) -> Option<Vec<String>>
+) -> Option<Vec<Cow<'a, str>>>
 where
     I: IntoIterator<Item = &'a str>,
 {
@@ -437,8 +438,10 @@ where
     for (part, expected_partition) in subpath.zip(table_partition_cols) {
         match part.split_once('=') {
             Some((name, val)) if name == expected_partition => {
-                let decoded = percent_decode_str(val).decode_utf8().ok()?;
-                part_values.push(decoded.into_owned());
+                let decoded = percent_decode_str(val)
+                    .decode_utf8()
+                    .unwrap_or(Cow::Borrowed(val));
+                part_values.push(decoded);
             }
             _ => {
                 debug!(
@@ -515,7 +518,7 @@ mod tests {
     #[test]
     fn test_parse_partitions_for_path() {
         assert_eq!(
-            Some(vec![] as Vec<String>),
+            Some(vec![] as Vec<Cow<'_, str>>),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::from("bucket/mytable/file.csv"),
@@ -539,7 +542,7 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["v1".to_string()]),
+            Some(vec![Cow::Borrowed("v1")]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::from("bucket/mytable/mypartition=v1/file.csv"),
@@ -549,7 +552,7 @@ mod tests {
         // URL-encoded partition values should be decoded
         // Use Path::parse to avoid double-encoding (Path::from encodes % as %25)
         assert_eq!(
-            Some(vec!["v/1".to_string()]),
+            Some(vec![Cow::<str>::Owned("v/1".to_string())]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::parse("bucket/mytable/mypartition=v%2F1/file.csv").unwrap(),
@@ -557,7 +560,7 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["v1".to_string()]),
+            Some(vec![Cow::Borrowed("v1")]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable/").unwrap(),
                 &Path::from("bucket/mytable/mypartition=v1/file.csv"),
@@ -574,7 +577,7 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["v1".to_string(), "v2".to_string()]),
+            Some(vec![Cow::Borrowed("v1"), Cow::Borrowed("v2")]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::from("bucket/mytable/mypartition=v1/otherpartition=v2/file.csv"),
@@ -582,7 +585,7 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["v1".to_string()]),
+            Some(vec![Cow::Borrowed("v1")]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::from("bucket/mytable/mypartition=v1/otherpartition=v2/file.csv"),
@@ -590,7 +593,7 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["John Doe".to_string()]),
+            Some(vec![Cow::<str>::Owned("John Doe".to_string())]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::parse("bucket/mytable/name=John%20Doe/file.csv").unwrap(),
@@ -598,7 +601,10 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["a/b".to_string(), "c d".to_string()]),
+            Some(vec![
+                Cow::<str>::Owned("a/b".to_string()),
+                Cow::<str>::Owned("c d".to_string()),
+            ]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::parse("bucket/mytable/p1=a%2Fb/p2=c%20d/file.csv").unwrap(),
@@ -606,7 +612,7 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["Müller".to_string()]),
+            Some(vec![Cow::<str>::Owned("Müller".to_string())]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::parse("bucket/mytable/name=M%C3%BCller/file.csv").unwrap(),
@@ -614,15 +620,16 @@ mod tests {
             )
         );
         assert_eq!(
-            Some(vec!["invalid%XX".to_string()]),
+            Some(vec![Cow::Borrowed("invalid%XX")]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::parse("bucket/mytable/p1=invalid%XX/file.csv").unwrap(),
                 vec!["p1"]
             )
         );
+        // Invalid UTF-8 after percent-decoding falls back to raw value
         assert_eq!(
-            None,
+            Some(vec![Cow::Borrowed("%FF")]),
             parse_partitions_for_path(
                 &ListingTableUrl::parse("file:///bucket/mytable").unwrap(),
                 &Path::parse("bucket/mytable/p1=%FF/file.csv").unwrap(),


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #19650.

## Rationale for this change

Currently, when DataFusion parses Hive-style partitioned paths (e.g., `s3://bucket/table/city=San%20Francisco/`), it extracts the partition value literally as `San%20Francisco`. 

Standard practice in tools like Apache Spark and Apache Hive is to URL-encode special characters in partition values when writing to object stores. This PR ensures DataFusion correctly decodes these values (to `San Francisco`) during the listing process, preventing data mismatches and ensuring consistent behavior with other engines.

## What changes are included in this PR?

1.  **Logic Update**: Updated `parse_partitions_for_path` in `datafusion/catalog-listing/src/helpers.rs` to percent-decode partition values.
2.  **Signature Change**: Changed the return type of `parse_partitions_for_path` from `Option<Vec<&str>>` to `Option<Vec<String>>` because decoded strings require new allocations.
3.  **Call Site Updates**: Updated internal callers in `datafusion-catalog-listing` to accommodate the owned `String` return type.
4.  **Dependencies**: Added `percent-encoding` crate to `datafusion-catalog-listing`.

## Are these changes tested?

Yes, new unit tests were added to `datafusion/catalog-listing/src/helpers.rs` covering:
- Standard URL-encoded characters (e.g., `%2F` for `/`).
- Spaces encoded as `%20`.
- Multi-byte UTF-8 characters.
- Forgiving behavior for malformed encoding (matching `percent-encoding` crate defaults).

## Are there any user-facing changes?

Yes:
- **Data Behavior**: Partition values extracted from file paths will now be correctly decoded instead of remaining URL-encoded.
- **API Change**: The public helper function `parse_partitions_for_path` now returns `Vec<String>` instead of `Vec<&str>`.

