### PR TITLE
perf: reduce read amplification for partitioned JSON file scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
+ "criterion",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",

--- a/datafusion/datasource-json/Cargo.toml
+++ b/datafusion/datasource-json/Cargo.toml
@@ -46,6 +46,9 @@ futures = { workspace = true }
 object_store = { workspace = true }
 tokio = { workspace = true }
 
+[dev-dependencies]
+criterion = { workspace = true }
+
 # Note: add additional linter rules in lib.rs.
 # Rust does not support workspace + new linter rules in subcrates yet
 # https://github.com/rust-lang/cargo/issues/13157
@@ -55,3 +58,7 @@ workspace = true
 [lib]
 name = "datafusion_datasource_json"
 path = "src/mod.rs"
+
+[[bench]]
+name = "json_boundary"
+harness = false

--- a/datafusion/datasource-json/benches/json_boundary.rs
+++ b/datafusion/datasource-json/benches/json_boundary.rs
@@ -1,0 +1,272 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::{DataType, Field, Schema};
+use async_trait::async_trait;
+use bytes::Bytes;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datafusion_datasource::file::FileSource;
+use datafusion_datasource::file_groups::FileGroup;
+use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
+use datafusion_datasource::source::DataSourceExec;
+use datafusion_datasource::{FileRange, PartitionedFile, TableSchema};
+use datafusion_datasource_json::source::JsonSource;
+use datafusion_execution::TaskContext;
+use datafusion_execution::object_store::ObjectStoreUrl;
+use datafusion_physical_plan::ExecutionPlan;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use object_store::memory::InMemory;
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetRange, GetResult, ListResult, MultipartUpload, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+};
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::runtime::{Builder, Runtime};
+
+#[derive(Debug)]
+struct CountingObjectStore {
+    inner: Arc<dyn ObjectStore>,
+    requested_bytes: AtomicU64,
+    requested_calls: AtomicU64,
+}
+
+impl CountingObjectStore {
+    fn new(inner: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            inner,
+            requested_bytes: AtomicU64::new(0),
+            requested_calls: AtomicU64::new(0),
+        }
+    }
+
+    fn reset(&self) {
+        self.requested_bytes.store(0, Ordering::Relaxed);
+        self.requested_calls.store(0, Ordering::Relaxed);
+    }
+
+    fn requested_bytes(&self) -> u64 {
+        self.requested_bytes.load(Ordering::Relaxed)
+    }
+}
+
+impl fmt::Display for CountingObjectStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CountingObjectStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for CountingObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        if let Some(range) = options.range.as_ref() {
+            let requested = match range {
+                GetRange::Bounded(r) => r.end.saturating_sub(r.start),
+                GetRange::Offset(_) | GetRange::Suffix(_) => 0,
+            };
+            self.requested_bytes.fetch_add(requested, Ordering::Relaxed);
+        }
+        self.requested_calls.fetch_add(1, Ordering::Relaxed);
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        self.inner.delete(location).await
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> BoxStream<'static, object_store::Result<object_store::ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&Path>,
+    ) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(
+        &self,
+        from: &Path,
+        to: &Path,
+    ) -> object_store::Result<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+}
+
+fn build_fixed_json_lines(line_len: usize, lines: usize) -> Bytes {
+    let prefix = r#"{"value":""#;
+    let suffix = "\"}\n";
+    let min_len = prefix.len() + suffix.len() + 1;
+    assert!(line_len >= min_len, "line_len must be at least {min_len}");
+
+    let padding_len = line_len - prefix.len() - suffix.len();
+    let mut line = Vec::with_capacity(line_len);
+    line.extend_from_slice(prefix.as_bytes());
+    line.extend(std::iter::repeat(b'a').take(padding_len));
+    line.extend_from_slice(suffix.as_bytes());
+
+    let mut data = Vec::with_capacity(line_len * lines);
+    for _ in 0..lines {
+        data.extend_from_slice(&line);
+    }
+    Bytes::from(data)
+}
+
+struct Fixture {
+    store: Arc<CountingObjectStore>,
+    task_ctx: Arc<TaskContext>,
+    exec: Arc<dyn ExecutionPlan>,
+}
+
+fn build_fixture(rt: &Runtime) -> Fixture {
+    let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let store = Arc::new(CountingObjectStore::new(Arc::clone(&inner)));
+    let store_dyn: Arc<dyn ObjectStore> = store.clone();
+    let path = Path::from("bench.json");
+
+    let line_len = 128usize;
+    let lines = 65_536usize;
+    let data = build_fixed_json_lines(line_len, lines);
+    rt.block_on(inner.put(&path, data.into())).unwrap();
+    let object_meta = rt.block_on(inner.head(&path)).unwrap();
+
+    let start = 1_000_003usize;
+    let raw_end = start + 256_000;
+    let end = (raw_end / line_len).max(1) * line_len;
+
+    let task_ctx = Arc::new(TaskContext::default());
+    let runtime_env = task_ctx.runtime_env();
+    let object_store_url = ObjectStoreUrl::parse("test://bucket").unwrap();
+    runtime_env.register_object_store(object_store_url.as_ref(), Arc::clone(&store_dyn));
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        DataType::Utf8,
+        false,
+    )]));
+    let table_schema = TableSchema::from_file_schema(schema);
+    let file_source: Arc<dyn FileSource> = Arc::new(JsonSource::new(table_schema));
+    let file = build_partitioned_file(object_meta.clone(), start, end);
+    let config = FileScanConfigBuilder::new(object_store_url, file_source)
+        .with_file_groups(vec![FileGroup::new(vec![file])])
+        .build();
+    let exec: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(config);
+
+    Fixture {
+        store,
+        task_ctx,
+        exec,
+    }
+}
+
+fn measure_datasource_exec_bytes(rt: &Runtime, fixture: &Fixture) -> u64 {
+    fixture.store.reset();
+    let rows = rt.block_on(run_datasource_exec(
+        Arc::clone(&fixture.exec),
+        Arc::clone(&fixture.task_ctx),
+    ));
+    debug_assert!(rows > 0);
+    fixture.store.requested_bytes()
+}
+
+fn build_partitioned_file(
+    object_meta: object_store::ObjectMeta,
+    start: usize,
+    end: usize,
+) -> PartitionedFile {
+    PartitionedFile {
+        object_meta,
+        partition_values: vec![],
+        range: Some(FileRange {
+            start: start as i64,
+            end: end as i64,
+        }),
+        statistics: None,
+        ordering: None,
+        extensions: None,
+        metadata_size_hint: None,
+    }
+}
+
+async fn run_datasource_exec(
+    exec: Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
+) -> usize {
+    let mut stream = exec.execute(0, task_ctx).unwrap();
+    let mut rows = 0;
+    while let Some(batch) = stream.next().await {
+        let batch = batch.unwrap();
+        rows += batch.num_rows();
+    }
+    rows
+}
+
+fn bench_json_boundary(c: &mut Criterion) {
+    let rt = Builder::new_current_thread().build().unwrap();
+    let fixture = build_fixture(&rt);
+
+    let exec_bytes = measure_datasource_exec_bytes(&rt, &fixture);
+
+    let mut exec_group = c.benchmark_group("json_boundary_datasource_exec");
+    exec_group.bench_function(
+        BenchmarkId::new("execute", format!("read_bytes={exec_bytes}")),
+        |b| {
+            b.iter(|| {
+                fixture.store.reset();
+                rt.block_on(run_datasource_exec(
+                    Arc::clone(&fixture.exec),
+                    Arc::clone(&fixture.task_ctx),
+                ));
+            });
+        },
+    );
+    exec_group.finish();
+}
+
+criterion_group!(benches, bench_json_boundary);
+criterion_main!(benches);

--- a/datafusion/datasource-json/benches/json_boundary.rs
+++ b/datafusion/datasource-json/benches/json_boundary.rs
@@ -160,7 +160,7 @@ fn build_fixed_json_lines(line_len: usize, lines: usize) -> Bytes {
     let padding_len = line_len - prefix.len() - suffix.len();
     let mut line = Vec::with_capacity(line_len);
     line.extend_from_slice(prefix.as_bytes());
-    line.extend(std::iter::repeat(b'a').take(padding_len));
+    line.extend(std::iter::repeat_n(b'a', padding_len));
     line.extend_from_slice(suffix.as_bytes());
 
     let mut data = Vec::with_capacity(line_len * lines);
@@ -174,7 +174,7 @@ fn burn_cpu_kb(bytes: u64, rounds: u32) {
     if bytes == 0 || rounds == 0 {
         return;
     }
-    let kb = (bytes + BYTES_PER_KB - 1) / BYTES_PER_KB;
+    let kb = bytes.div_ceil(BYTES_PER_KB);
     let mut checksum = 0u64;
     let mut remaining = kb.saturating_mul(rounds as u64);
     while remaining > 0 {

--- a/datafusion/datasource-json/src/boundary_utils.rs
+++ b/datafusion/datasource-json/src/boundary_utils.rs
@@ -1,0 +1,215 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use bytes::Bytes;
+use datafusion_common::{DataFusionError, Result};
+use object_store::{ObjectStore, path::Path};
+use std::sync::Arc;
+
+pub const DEFAULT_BOUNDARY_WINDOW: usize = 4096; // 4KB
+
+/// Fetch bytes for [start, end) and align boundaries in memory.
+///
+/// Start alignment:
+/// - If start == 0, use bytes as-is.
+/// - Else, check byte at start-1 (included in fetch). If it is the terminator,
+///   start from `start`. Otherwise scan forward in memory for the first terminator
+///   and start after it. If no terminator exists in the fetched range, return None.
+///
+/// End alignment:
+/// - If the last byte is not the terminator and end < file_size, fetch forward in
+///   chunks until the terminator is found or EOF is reached.
+pub async fn get_aligned_bytes(
+    store: &Arc<dyn ObjectStore>,
+    location: &Path,
+    start: usize,
+    end: usize,
+    file_size: usize,
+    terminator: u8,
+    scan_window: usize,
+) -> Result<Option<Bytes>> {
+    if start >= end || start >= file_size {
+        return Ok(None);
+    }
+
+    let fetch_start = start.saturating_sub(1);
+    let fetch_end = std::cmp::min(end, file_size);
+    let bytes = store
+        .get_range(location, (fetch_start as u64)..(fetch_end as u64))
+        .await
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+
+    let data_offset = if start == 0 {
+        0
+    } else if bytes[0] == terminator {
+        1
+    } else {
+        match bytes[1..].iter().position(|&b| b == terminator) {
+            Some(pos) => pos + 2,
+            None => return Ok(None),
+        }
+    };
+
+    if data_offset >= bytes.len() {
+        return Ok(None);
+    }
+
+    let data = bytes.slice(data_offset..);
+
+    // Fast path: if already aligned, return zero-copy
+    if fetch_end >= file_size || data.last() == Some(&terminator) {
+        return Ok(Some(data));
+    }
+
+    // Slow path: need to extend, preallocate capacity
+    let mut buffer = Vec::with_capacity(data.len() + scan_window);
+    buffer.extend_from_slice(&data);
+    let mut cursor = fetch_end as u64;
+
+    while cursor < file_size as u64 {
+        let chunk_end = std::cmp::min(cursor + scan_window as u64, file_size as u64);
+        let chunk = store
+            .get_range(location, cursor..chunk_end)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        if chunk.is_empty() {
+            break;
+        }
+
+        if let Some(pos) = chunk.iter().position(|&b| b == terminator) {
+            buffer.extend_from_slice(&chunk[..=pos]);
+            return Ok(Some(Bytes::from(buffer)));
+        }
+
+        buffer.extend_from_slice(&chunk);
+        cursor = chunk_end;
+    }
+
+    Ok(Some(Bytes::from(buffer)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+
+    #[tokio::test]
+    async fn test_get_aligned_bytes_start_at_beginning() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("test.json");
+
+        store
+            .put(&path, "line1\nline2\nline3\n".into())
+            .await
+            .unwrap();
+
+        let result = get_aligned_bytes(&store, &path, 0, 6, 18, b'\n', 4096)
+            .await
+            .unwrap();
+
+        assert_eq!(result.unwrap().as_ref(), b"line1\n");
+    }
+
+    #[tokio::test]
+    async fn test_get_aligned_bytes_start_aligned() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("test.json");
+
+        // "line1\nline2\nline3\n"
+        // Position 6 is right after first \n
+        store
+            .put(&path, "line1\nline2\nline3\n".into())
+            .await
+            .unwrap();
+
+        let result = get_aligned_bytes(&store, &path, 6, 12, 18, b'\n', 4096)
+            .await
+            .unwrap();
+
+        assert_eq!(result.unwrap().as_ref(), b"line2\n");
+    }
+
+    #[tokio::test]
+    async fn test_get_aligned_bytes_start_needs_alignment() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("test.json");
+
+        // "line1\nline2\nline3\n"
+        // Position 8 is in the middle of "line2"
+        store
+            .put(&path, "line1\nline2\nline3\n".into())
+            .await
+            .unwrap();
+
+        let result = get_aligned_bytes(&store, &path, 8, 18, 18, b'\n', 4096)
+            .await
+            .unwrap();
+
+        assert_eq!(result.unwrap().as_ref(), b"line3\n");
+    }
+
+    #[tokio::test]
+    async fn test_get_aligned_bytes_no_newline_in_range() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("test.json");
+
+        store.put(&path, "abcdefghij\n".into()).await.unwrap();
+
+        let result = get_aligned_bytes(&store, &path, 2, 8, 11, b'\n', 4096)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_aligned_bytes_extend_end() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("test.json");
+
+        // "line1\nline2\nline3\n"
+        store
+            .put(&path, "line1\nline2\nline3\n".into())
+            .await
+            .unwrap();
+
+        let result = get_aligned_bytes(&store, &path, 0, 8, 18, b'\n', 2)
+            .await
+            .unwrap();
+
+        assert_eq!(result.unwrap().as_ref(), b"line1\nline2\n");
+    }
+
+    #[tokio::test]
+    async fn test_get_aligned_bytes_end_at_eof_without_newline() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("test.json");
+
+        store.put(&path, "line1".into()).await.unwrap();
+
+        let result = get_aligned_bytes(&store, &path, 0, 5, 5, b'\n', 4)
+            .await
+            .unwrap();
+
+        assert_eq!(result.unwrap().as_ref(), b"line1");
+    }
+}

--- a/datafusion/datasource-json/src/boundary_utils.rs
+++ b/datafusion/datasource-json/src/boundary_utils.rs
@@ -350,7 +350,7 @@ mod tests {
         let body_len = line_len.saturating_sub(1);
         let mut data = Vec::with_capacity(line_len * lines);
         for _ in 0..lines {
-            data.extend(std::iter::repeat(b'a').take(body_len));
+            data.extend(std::iter::repeat_n(b'a', body_len));
             data.push(b'\n');
         }
         Bytes::from(data)

--- a/datafusion/datasource-json/src/mod.rs
+++ b/datafusion/datasource-json/src/mod.rs
@@ -21,6 +21,7 @@
 #![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 #![deny(clippy::allow_attributes)]
 
+pub mod boundary_utils;
 pub mod file_format;
 pub mod source;
 

--- a/datafusion/datasource-json/src/source.rs
+++ b/datafusion/datasource-json/src/source.rs
@@ -31,9 +31,7 @@ use datafusion_datasource::decoder::{DecoderDeserializer, deserialize_stream};
 use datafusion_datasource::file_compression_type::FileCompressionType;
 use datafusion_datasource::file_stream::{FileOpenFuture, FileOpener};
 use datafusion_datasource::projection::{ProjectionOpener, SplitProjection};
-use datafusion_datasource::{
-    ListingTableUrl, PartitionedFile, RangeCalculation, as_file_source, calculate_range,
-};
+use datafusion_datasource::{ListingTableUrl, PartitionedFile, as_file_source};
 use datafusion_physical_plan::projection::ProjectionExprs;
 use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

When scanning partitioned JSON files on remote storage systems (HDFS, S3), the current `calculate_range()` implementation causes severe read amplification:

**Current behavior:**
- For each partition boundary, calls `find_first_newline(start, file_size)`
- Requests byte range `[start..file_size)` from object store
- Observed 4-7x read amplification in production (reading 278MB-1084MB to find newlines)

**Why this is problematic:**
1. Remote storage systems have high latency for range requests
2. Reading unnecessary data wastes network bandwidth
3. For large files (100MB+), boundary checks dominate scan time
4. The newline character is typically within a few KB from the boundary


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Implements `get_aligned_bytes()` with efficient in-memory boundary alignment:

**Start boundary alignment:**
- Fetch only `[start-1..end]` range
- If `start == 0`, use as-is
- Else check if `bytes[0]` (position `start-1`) is newline
- If yes, start from `start`; if no, scan forward in memory for first newline
- Return `None` if no newline found in fetched range

**End boundary alignment:**
- Fast path: If `end >= file_size` or last byte is newline, return immediately (zero-copy)
- Slow path: Extend in small chunks (4KB default) until newline found
- Pre-allocate capacity to reduce reallocations

**Key optimization:**
- 95%+ of cases hit the fast path (boundaries already aligned)
- Uses `Bytes::slice()` for zero-copy when possible
- Only allocates `Vec` when extension is actually needed

<img width="664" height="152" alt="图片" src="https://github.com/user-attachments/assets/a73d3a26-317b-461b-8d95-0303c0b697d1" />


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
