### PR TITLE
chore: bump dependabot PR limit for cargo from 5 to 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       interval: weekly
     target-branch: main
     labels: [auto-dependencies]
+    open-pull-requests-limit: 15
     ignore:
       # major version bumps of arrow* and parquet are handled manually
       - dependency-name: "arrow*"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Occasionally we do PRs to bump a bunch of versions in `Cargo.lock`, recent example:

- https://github.com/apache/datafusion/pull/19667

Ideally this should be handled by dependabot already. I suspect the default limit of 5 is preventing dependabot from creating all the PRs it needs; this causes it to error and those version bumps are "lost".

- I say "lost" but dependabot can pick it up on the next run... if it doesn't error again

See an example from a dependabot run:

<img width="703" height="118" alt="image" src="https://github.com/user-attachments/assets/f8ae6b70-6fe1-4613-8c60-28564c23188b" />

From the logs:

```text
 +-------------------------------------------------------+
|          Changes to Dependabot Pull Requests          |
+---------+---------------------------------------------+
| created | insta ( from 1.45.0 to 1.46.0 )             |
| created | tracing ( from 0.1.43 to 0.1.44 )           |
| created | syn ( from 2.0.111 to 2.0.113 )             |
| created | async-compression ( from 0.4.35 to 0.4.36 ) |
| created | object_store ( from 0.12.4 to 0.13.0 )      |
| created | serde_json ( from 1.0.145 to 1.0.148 )      |
| created | bigdecimal ( from 0.4.9 to 0.4.10 )         |
| created | clap ( from 4.5.53 to 4.5.54 )              |
| created | libc ( from 0.2.177 to 0.2.179 )            |
| created | tokio ( from 1.48.0 to 1.49.0 )             |
| created | tokio-util ( from 0.7.17 to 0.7.18 )        |
| created | sqllogictest ( from 0.28.4 to 0.29.0 )      |
+---------+---------------------------------------------+
```

We expect to have all these PRs created (this was for the run 5 days ago), but only these were created on that day:

- https://github.com/apache/datafusion/pull/19645
- https://github.com/apache/datafusion/pull/19644
- https://github.com/apache/datafusion/pull/19643

And considering these PRs were still open at the time:

- https://github.com/apache/datafusion/pull/19544
- https://github.com/apache/datafusion/pull/19325

We can see it hit the 5 limit.

> Dependabot default behavior:
>
> - If five pull requests with version updates are open, no further pull requests are raised until some of those open requests are merged or closed.
> - Security updates have a separate, internal limit of ten open pull requests which cannot be changed.

- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Bump the limit to 15. We might have an appetite for increasing it more, 15 was chosen arbitrarily.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Dependabot only.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
