### PR TITLE
Simplify case when all result expressions are identical

### DIFF
--- a/datafusion/sqllogictest/test_files/cse.slt
+++ b/datafusion/sqllogictest/test_files/cse.slt
@@ -188,12 +188,12 @@ EXPLAIN SELECT
 FROM t1
 ----
 logical_plan
-01)Projection: (__common_expr_1 OR random() = Float64(0)) AND __common_expr_2 AS c1, __common_expr_2 AND random() = Float64(0) OR __common_expr_1 AS c2, CASE WHEN __common_expr_3 = Float64(0) THEN __common_expr_3 ELSE Float64(0) END AS c3, CASE WHEN __common_expr_4 = Float64(0) THEN Int64(0) WHEN CAST(__common_expr_4 AS Boolean) THEN Int64(0) ELSE Int64(0) END AS c4, CASE WHEN __common_expr_5 = Float64(0) THEN Float64(0) WHEN random() = Float64(0) THEN __common_expr_5 ELSE Float64(0) END AS c5, CASE WHEN __common_expr_6 = Float64(0) THEN Float64(0) ELSE __common_expr_6 END AS c6
-02)--Projection: t1.a = Float64(1) AS __common_expr_1, t1.a = Float64(2) AS __common_expr_2, t1.a + Float64(3) AS __common_expr_3, t1.a + Float64(4) AS __common_expr_4, t1.a + Float64(5) AS __common_expr_5, t1.a + Float64(6) AS __common_expr_6
+01)Projection: (__common_expr_1 OR random() = Float64(0)) AND __common_expr_2 AS c1, __common_expr_2 AND random() = Float64(0) OR __common_expr_1 AS c2, CASE WHEN __common_expr_3 = Float64(0) THEN __common_expr_3 ELSE Float64(0) END AS c3, Int64(0) AS c4, CASE WHEN __common_expr_4 = Float64(0) THEN Float64(0) WHEN random() = Float64(0) THEN __common_expr_4 ELSE Float64(0) END AS c5, CASE WHEN __common_expr_5 = Float64(0) THEN Float64(0) ELSE __common_expr_5 END AS c6
+02)--Projection: t1.a = Float64(1) AS __common_expr_1, t1.a = Float64(2) AS __common_expr_2, t1.a + Float64(3) AS __common_expr_3, t1.a + Float64(5) AS __common_expr_4, t1.a + Float64(6) AS __common_expr_5
 03)----TableScan: t1 projection=[a]
 physical_plan
-01)ProjectionExec: expr=[(__common_expr_1@0 OR random() = 0) AND __common_expr_2@1 as c1, __common_expr_2@1 AND random() = 0 OR __common_expr_1@0 as c2, CASE WHEN __common_expr_3@2 = 0 THEN __common_expr_3@2 ELSE 0 END as c3, CASE WHEN __common_expr_4@3 = 0 THEN 0 WHEN CAST(__common_expr_4@3 AS Boolean) THEN 0 ELSE 0 END as c4, CASE WHEN __common_expr_5@4 = 0 THEN 0 WHEN random() = 0 THEN __common_expr_5@4 ELSE 0 END as c5, CASE WHEN __common_expr_6@5 = 0 THEN 0 ELSE __common_expr_6@5 END as c6]
-02)--ProjectionExec: expr=[a@0 = 1 as __common_expr_1, a@0 = 2 as __common_expr_2, a@0 + 3 as __common_expr_3, a@0 + 4 as __common_expr_4, a@0 + 5 as __common_expr_5, a@0 + 6 as __common_expr_6]
+01)ProjectionExec: expr=[(__common_expr_1@0 OR random() = 0) AND __common_expr_2@1 as c1, __common_expr_2@1 AND random() = 0 OR __common_expr_1@0 as c2, CASE WHEN __common_expr_3@2 = 0 THEN __common_expr_3@2 ELSE 0 END as c3, 0 as c4, CASE WHEN __common_expr_4@3 = 0 THEN 0 WHEN random() = 0 THEN __common_expr_4@3 ELSE 0 END as c5, CASE WHEN __common_expr_5@4 = 0 THEN 0 ELSE __common_expr_5@4 END as c6]
+02)--ProjectionExec: expr=[a@0 = 1 as __common_expr_1, a@0 = 2 as __common_expr_2, a@0 + 3 as __common_expr_3, a@0 + 5 as __common_expr_4, a@0 + 6 as __common_expr_5]
 03)----DataSourceExec: partitions=1, partition_sizes=[0]
 
 # Surely only once but also conditionally evaluated subexpressions
@@ -226,8 +226,8 @@ EXPLAIN SELECT
 FROM t1
 ----
 logical_plan
-01)Projection: (random() = Float64(0) OR t1.a = Float64(1)) AND t1.a = Float64(2) AS c1, random() = Float64(0) AND t1.a = Float64(2) OR t1.a = Float64(1) AS c2, CASE WHEN random() = Float64(0) THEN t1.a + Float64(3) ELSE t1.a + Float64(3) END AS c3, CASE WHEN random() = Float64(0) THEN Float64(0) WHEN t1.a + Float64(4) = Float64(0) THEN t1.a + Float64(4) ELSE Float64(0) END AS c4, CASE WHEN random() = Float64(0) THEN Float64(0) WHEN t1.a + Float64(5) = Float64(0) THEN Float64(0) ELSE t1.a + Float64(5) END AS c5, CASE WHEN random() = Float64(0) THEN Float64(0) WHEN random() = Float64(0) THEN t1.a + Float64(6) ELSE t1.a + Float64(6) END AS c6
+01)Projection: (random() = Float64(0) OR t1.a = Float64(1)) AND t1.a = Float64(2) AS c1, random() = Float64(0) AND t1.a = Float64(2) OR t1.a = Float64(1) AS c2, t1.a + Float64(3) AS c3, CASE WHEN random() = Float64(0) THEN Float64(0) WHEN t1.a + Float64(4) = Float64(0) THEN t1.a + Float64(4) ELSE Float64(0) END AS c4, CASE WHEN random() = Float64(0) THEN Float64(0) WHEN t1.a + Float64(5) = Float64(0) THEN Float64(0) ELSE t1.a + Float64(5) END AS c5, CASE WHEN random() = Float64(0) THEN Float64(0) WHEN random() = Float64(0) THEN t1.a + Float64(6) ELSE t1.a + Float64(6) END AS c6
 02)--TableScan: t1 projection=[a]
 physical_plan
-01)ProjectionExec: expr=[(random() = 0 OR a@0 = 1) AND a@0 = 2 as c1, random() = 0 AND a@0 = 2 OR a@0 = 1 as c2, CASE WHEN random() = 0 THEN a@0 + 3 ELSE a@0 + 3 END as c3, CASE WHEN random() = 0 THEN 0 WHEN a@0 + 4 = 0 THEN a@0 + 4 ELSE 0 END as c4, CASE WHEN random() = 0 THEN 0 WHEN a@0 + 5 = 0 THEN 0 ELSE a@0 + 5 END as c5, CASE WHEN random() = 0 THEN 0 WHEN random() = 0 THEN a@0 + 6 ELSE a@0 + 6 END as c6]
+01)ProjectionExec: expr=[(random() = 0 OR a@0 = 1) AND a@0 = 2 as c1, random() = 0 AND a@0 = 2 OR a@0 = 1 as c2, a@0 + 3 as c3, CASE WHEN random() = 0 THEN 0 WHEN a@0 + 4 = 0 THEN a@0 + 4 ELSE 0 END as c4, CASE WHEN random() = 0 THEN 0 WHEN a@0 + 5 = 0 THEN 0 ELSE a@0 + 5 END as c5, CASE WHEN random() = 0 THEN 0 WHEN random() = 0 THEN a@0 + 6 ELSE a@0 + 6 END as c6]
 02)--DataSourceExec: partitions=1, partition_sizes=[0]

--- a/datafusion/sqllogictest/test_files/simplify_expr.slt
+++ b/datafusion/sqllogictest/test_files/simplify_expr.slt
@@ -124,10 +124,10 @@ EXPLAIN SELECT
 FROM (VALUES (0), (1), (2)) t(v)
 ----
 logical_plan
-01)Projection: CASE t.v WHEN Int64(100) THEN Int64(1) ELSE Int64(1) END AS opt1, CASE t.v WHEN Int64(200) THEN Int64(2) WHEN Int64(201) THEN Int64(2) ELSE Int64(2) END AS opt2, CASE t.v WHEN Int64(300) THEN Int64(3) WHEN Int64(301) THEN Int64(3) ELSE Int64(4) END AS noopt1, CASE t.v WHEN Int64(400) THEN Int64(4) WHEN Int64(401) THEN Int64(4) END AS noopt2
+01)Projection: Int64(1) AS opt1, Int64(2) AS opt2, CASE t.v WHEN Int64(300) THEN Int64(3) WHEN Int64(301) THEN Int64(3) ELSE Int64(4) END AS noopt1, CASE t.v WHEN Int64(400) THEN Int64(4) WHEN Int64(401) THEN Int64(4) END AS noopt2
 02)--SubqueryAlias: t
 03)----Projection: column1 AS v
 04)------Values: (Int64(0)), (Int64(1)), (Int64(2))
 physical_plan
-01)ProjectionExec: expr=[CASE column1@0 WHEN 100 THEN 1 ELSE 1 END as opt1, CASE column1@0 WHEN 200 THEN 2 WHEN 201 THEN 2 ELSE 2 END as opt2, CASE column1@0 WHEN 300 THEN 3 WHEN 301 THEN 3 ELSE 4 END as noopt1, CASE column1@0 WHEN 400 THEN 4 WHEN 401 THEN 4 END as noopt2]
+01)ProjectionExec: expr=[1 as opt1, 2 as opt2, CASE column1@0 WHEN 300 THEN 3 WHEN 301 THEN 3 ELSE 4 END as noopt1, CASE column1@0 WHEN 400 THEN 4 WHEN 401 THEN 4 END as noopt2]
 02)--DataSourceExec: partitions=1, partition_sizes=[1]

--- a/datafusion/sqllogictest/test_files/simplify_expr.slt
+++ b/datafusion/sqllogictest/test_files/simplify_expr.slt
@@ -113,3 +113,21 @@ logical_plan
 physical_plan
 01)ProjectionExec: expr=[[{x:100}] as a]
 02)--PlaceholderRowExec
+
+# Simplify cases where the end expressions are the same to that expression
+query TT
+EXPLAIN SELECT
+    CASE v when 100 then 1 else 1 end as opt1,
+    CASE v when 200 then 2 when 201 then 2 else 2 end as opt2,
+    CASE v when 300 then 3 when 301 then 3 else 4 end as noopt1,
+    CASE v when 400 then 4 when 401 then 4 end as noopt2
+FROM (VALUES (0), (1), (2)) t(v)
+----
+logical_plan
+01)Projection: CASE t.v WHEN Int64(100) THEN Int64(1) ELSE Int64(1) END AS opt1, CASE t.v WHEN Int64(200) THEN Int64(2) WHEN Int64(201) THEN Int64(2) ELSE Int64(2) END AS opt2, CASE t.v WHEN Int64(300) THEN Int64(3) WHEN Int64(301) THEN Int64(3) ELSE Int64(4) END AS noopt1, CASE t.v WHEN Int64(400) THEN Int64(4) WHEN Int64(401) THEN Int64(4) END AS noopt2
+02)--SubqueryAlias: t
+03)----Projection: column1 AS v
+04)------Values: (Int64(0)), (Int64(1)), (Int64(2))
+physical_plan
+01)ProjectionExec: expr=[CASE column1@0 WHEN 100 THEN 1 ELSE 1 END as opt1, CASE column1@0 WHEN 200 THEN 2 WHEN 201 THEN 2 ELSE 2 END as opt2, CASE column1@0 WHEN 300 THEN 3 WHEN 301 THEN 3 ELSE 4 END as noopt1, CASE column1@0 WHEN 400 THEN 4 WHEN 401 THEN 4 END as noopt2]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When a case expression has identical result expressions, we can remove the case, replacing it with the expression.
It's unlikely that a human would write such an expression, but a generated query may lead to such an expression.

Example where this optimization applies:
```sql
CASE v when 100 then 1 else 1 end
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Extend the expression simplifier to detect the case.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, added SLT.
The first commit shows the plan before the optimization.

## Are there any user-facing changes?

Slightly better plan so fewer runtime ops

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
