### PR TITLE
Fix dynamic filter is_used function

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -631,10 +631,8 @@ impl HashJoinExec {
     ///
     /// This method is intended for testing only and should not be used in production code.
     #[doc(hidden)]
-    pub fn dynamic_filter_for_test(&self) -> Option<Arc<DynamicFilterPhysicalExpr>> {
-        self.dynamic_filter
-            .as_ref()
-            .map(|df| Arc::clone(&df.filter))
+    pub fn dynamic_filter_for_test(&self) -> Option<&Arc<DynamicFilterPhysicalExpr>> {
+        self.dynamic_filter.as_ref().map(|df| &df.filter)
     }
 
     /// Calculate order preservation flags for this hash join.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/19715.

## Rationale for this change

The:is_used() API incorrectly returned false for custom `DataSource` implementations that didn't call  reassign_expr_columns() ->  with_new_children() . This caused `HashJoinExec` to skip computing dynamic filters even when they were actually being used.

## What changes are included in this PR?


Updated is_used() to check both outer and inner Arc counts

## Are these changes tested?

Functionality is covered by existing test `test_hashjoin_dynamic_filter_pushdown_is_used`. I was not sure if to add a repro since it would require adding a custom `DataSource`, the current tests in datafusion/core/tests/physical_optimizer/filter_pushdown/mod.rs use `FileScanConfig` 

## Are there any user-facing changes?

no
