### PR TITLE
Fix(optimizer): Make `EnsureCooperative` optimizer idempotent under multiple runs

### DIFF
--- a/datafusion/physical-optimizer/src/ensure_coop.rs
+++ b/datafusion/physical-optimizer/src/ensure_coop.rs
@@ -82,7 +82,6 @@ impl PhysicalOptimizerRule for EnsureCooperative {
             },
             // Up phase: Wrap nodes with CooperativeExec if needed
             |plan| {
- 
                 ancestry_stack.borrow_mut().pop();
 
                 let props = plan.properties();


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #19756.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The previous logic of `EnsureCooperative` optimizer lacked context awareness regarding ancestor nodes, making it not idempotent across multiple runs.

Specifically, we need to ensure that:
1.  **Idempotency**: Running the rule multiple times does not produce nested `CooperativeExec` wrappers.
2.  **Context Awareness**: If a subtree is already protected by a `CooperativeExec`, we should skip and not double-wrap its children.

## What changes are included in this PR?

To solve this, we cannot rely solely on `transform_up` (which lacks parent context) or `transform_down` (which makes safe mutation difficult). This PR adopts `transform_down_up` with a depth counter to strictly enforce that nodes are only wrapped when they are not currently under a `CooperativeExec` scope.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

More unit tests coverage

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
