### PR TITLE
[Minor] Reuse indices buffer in RepartitionExec

### DIFF
--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -48,7 +48,8 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::stats::Precision;
 use datafusion_common::utils::transpose;
 use datafusion_common::{
-    ColumnStatistics, DataFusionError, HashMap, assert_or_internal_err, internal_err,
+    ColumnStatistics, DataFusionError, HashMap, assert_or_internal_err,
+    internal_datafusion_err, internal_err,
 };
 use datafusion_common::{Result, not_impl_err};
 use datafusion_common_runtime::SpawnedTask;
@@ -622,9 +623,9 @@ impl BatchPartitioner {
                             let (_, buffer, _) = indices_array.into_parts();
                             let mut vec =
                                 buffer.into_inner().into_vec::<u32>().map_err(|e| {
-                                    DataFusionError::Internal(format!(
+                                    internal_datafusion_err!(
                                         "Could not convert buffer to vec: {e:?}"
-                                    ))
+                                    )
                                 })?;
                             vec.clear();
                             *p_indices = vec;


### PR DESCRIPTION
This commit optimizes the `RepartitionExec` operator by reusing the `Vec` allocations for indices in the `BatchPartitioner`. Instead of reallocating the `indices` vector for every `RecordBatch` it processes in hash partitioning mode, this change modifies the `BatchPartitioner` to reuse these allocations across batches.

This is achieved by:
- Storing the `indices` vectors in the `BatchPartitionerState`.
- Clearing the vectors for each new batch.
- Using `std::mem::take` to move the data out for processing.
- Reclaiming the underlying `Vec` from the Arrow array using `into_parts` after processing, clearing it, and placing it back into the state for the next iteration.

This avoids repeated allocations and improves performance, especially when dealing with many small batches.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
