### PR TITLE
fix: select array_union([[null]], []) failing

### DIFF
--- a/datafusion/functions-nested/src/set_ops.rs
+++ b/datafusion/functions-nested/src/set_ops.rs
@@ -355,6 +355,15 @@ fn generic_set_lists<OffsetSize: OffsetSizeTrait>(
         return general_array_distinct::<OffsetSize>(l, &field);
     }
 
+    // Check if value type contains nested nulls (e.g., List(Null))
+    // RowConverter cannot handle these types, so we use a specialized path
+    if contains_nested_null(&l.value_type()) {
+        // For nested null types, we cannot use RowConverter's convert_rows
+        // For Union: combine arrays and deduplicate using length-based equality
+        // For Intersect: find common elements based on length
+        return generic_set_lists_for_nested_null::<OffsetSize>(l, r, field, set_op);
+    }
+
     assert_eq_or_internal_err!(
         l.value_type(),
         r.value_type(),
@@ -521,6 +530,170 @@ fn array_intersect_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     general_set_op(array1, array2, SetOp::Intersect)
 }
 
+/// Checks if a data type contains Null in a nested structure that would cause
+/// RowConverter to fail. This includes List(Null), List(List(Null)), etc.
+fn contains_nested_null(dt: &DataType) -> bool {
+    match dt {
+        Null => true,
+        List(field) | LargeList(field) => contains_nested_null(field.data_type()),
+        _ => false,
+    }
+}
+
+/// Specialized set operation for List(Null) or types containing nested nulls.
+/// Since RowConverter cannot handle these types and all null values are
+/// indistinguishable, we handle union/intersect specially.
+fn generic_set_lists_for_nested_null<OffsetSize: OffsetSizeTrait>(
+    l: &GenericListArray<OffsetSize>,
+    r: &GenericListArray<OffsetSize>,
+    field: Arc<Field>,
+    set_op: SetOp,
+) -> Result<ArrayRef> {
+    match set_op {
+        SetOp::Union => {
+            // For union with List(Null) types:
+            // After distinct/dedup, inner lists of nulls become empty lists.
+            // Return structure with one empty inner list per row.
+            let mut new_offsets = vec![OffsetSize::usize_as(0)];
+            let mut new_null_buf = Vec::new();
+
+            for (l_elem, r_elem) in l.iter().zip(r.iter()) {
+                let last_offset = new_offsets.last().copied().unwrap();
+
+                if l_elem.is_none() && r_elem.is_none() {
+                    new_offsets.push(last_offset);
+                    new_null_buf.push(false);
+                    continue;
+                }
+
+                // Add one empty inner list to the result
+                new_offsets.push(last_offset + OffsetSize::usize_as(1));
+                new_null_buf.push(true);
+            }
+
+            // Create inner values: one empty list for each non-null outer element
+            let num_inner_lists = new_null_buf.iter().filter(|&&b| b).count();
+            let inner_field = Arc::new(Field::new_list_field(Null, true));
+            let inner_offsets: Vec<OffsetSize> = (0..=num_inner_lists)
+                .map(|_| OffsetSize::usize_as(0))
+                .collect();
+
+            let inner_values = new_null_array(&Null, 0);
+            let inner_list = GenericListArray::<OffsetSize>::try_new(
+                inner_field,
+                OffsetBuffer::new(inner_offsets.into()),
+                inner_values,
+                None,
+            )?;
+
+            Ok(Arc::new(GenericListArray::<OffsetSize>::try_new(
+                field,
+                OffsetBuffer::new(new_offsets.into()),
+                Arc::new(inner_list),
+                Some(NullBuffer::new(new_null_buf.into())),
+            )?))
+        }
+        SetOp::Intersect => {
+            // For intersect with List(Null) types:
+            // Since different List(Null) elements (with different lengths or null counts)
+            // are not considered equal, intersection returns empty lists.
+            let mut new_offsets = vec![OffsetSize::usize_as(0)];
+            let mut new_null_buf = Vec::new();
+
+            for _ in 0..l.len() {
+                new_offsets.push(new_offsets.last().copied().unwrap());
+                new_null_buf.push(true);
+            }
+
+            Ok(Arc::new(GenericListArray::<OffsetSize>::try_new(
+                field,
+                OffsetBuffer::new(new_offsets.into()),
+                new_null_array(&l.value_type(), 0),
+                Some(NullBuffer::new(new_null_buf.into())),
+            )?))
+        }
+    }
+}
+
+/// Specialized distinct for List(Null) or types containing nested nulls where
+/// RowConverter fails. Since all null values are indistinguishable, we treat
+/// elements as equal if they have the same length (for lists) or if they're both null.
+fn general_array_distinct_for_nested_null<OffsetSize: OffsetSizeTrait>(
+    array: &GenericListArray<OffsetSize>,
+    field: &FieldRef,
+) -> Result<ArrayRef> {
+    let mut offsets = Vec::with_capacity(array.len());
+    offsets.push(OffsetSize::usize_as(0));
+    let mut new_arrays = Vec::with_capacity(array.len());
+
+    // For each list in the array, deduplicate elements by their length
+    for arr in array.iter() {
+        let last_offset: OffsetSize = offsets.last().copied().unwrap();
+        let Some(arr) = arr else {
+            // Null list element - just push same offset
+            offsets.push(last_offset);
+            continue;
+        };
+
+        // For List(Null), the only distinguishing feature is length
+        // Track seen lengths to implement distinct
+        let list_arr = arr.as_any().downcast_ref::<GenericListArray<OffsetSize>>();
+        if let Some(list) = list_arr {
+            let mut seen_lengths = HashSet::new();
+            let mut seen_null = false;
+            let mut indices = Vec::new();
+
+            for i in 0..list.len() {
+                if list.is_null(i) {
+                    if !seen_null {
+                        seen_null = true;
+                        indices.push(i);
+                    }
+                } else {
+                    let len = list.value_length(i).as_usize();
+                    if seen_lengths.insert(len) {
+                        indices.push(i);
+                    }
+                }
+            }
+
+            let distinct_count = indices.len();
+            offsets.push(last_offset + OffsetSize::usize_as(distinct_count));
+
+            // Take only the distinct elements
+            let index_array = arrow::array::UInt32Array::from(
+                indices.into_iter().map(|i| i as u32).collect::<Vec<_>>(),
+            );
+            let taken = compute::take(list, &index_array, None)?;
+            new_arrays.push(taken);
+        } else {
+            // For non-list nested types, just use first element as representative
+            // Since they're all null, they're all equal
+            if !arr.is_empty() {
+                offsets.push(last_offset + OffsetSize::usize_as(1));
+                let first = arr.slice(0, 1);
+                new_arrays.push(first);
+            } else {
+                offsets.push(last_offset);
+            }
+        }
+    }
+
+    if new_arrays.is_empty() {
+        return Ok(Arc::new(array.clone()) as ArrayRef);
+    }
+
+    let offsets = OffsetBuffer::new(offsets.into());
+    let new_arrays_ref = new_arrays.iter().map(|v| v.as_ref()).collect::<Vec<_>>();
+    let values = compute::concat(&new_arrays_ref)?;
+    Ok(Arc::new(GenericListArray::<OffsetSize>::try_new(
+        Arc::clone(field),
+        offsets,
+        values,
+        array.nulls().cloned(),
+    )?))
+}
+
 fn general_array_distinct<OffsetSize: OffsetSizeTrait>(
     array: &GenericListArray<OffsetSize>,
     field: &FieldRef,
@@ -529,6 +702,12 @@ fn general_array_distinct<OffsetSize: OffsetSizeTrait>(
         return Ok(Arc::new(array.clone()) as ArrayRef);
     }
     let dt = array.value_type();
+    // RowConverter cannot handle List(Null) or similar nested null types.
+    // In this case, use a specialized distinct that considers elements equal
+    // based on their length (since all null values are indistinguishable).
+    if contains_nested_null(&dt) {
+        return general_array_distinct_for_nested_null::<OffsetSize>(array, field);
+    }
     let mut offsets = Vec::with_capacity(array.len());
     offsets.push(OffsetSize::usize_as(0));
     let mut new_arrays = Vec::with_capacity(array.len());


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #19798 

## Rationale for this change

The array_union function fails with an error when one of the input arrays contains nested null types (e.g., [[null]]) and the other is empty.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

- Helper function to detect if a data type contains Null in a nested structure
-  Specialized set operation for List(Null) types that avoids using RowConverter.convert_rows()
- Specialized distinct operation for List(Null) types that uses length-based comparison instead of RowConverter

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes, existing sqllogictests cover these cases

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
