### PR TITLE
Don't allocate to compare string slices

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -399,11 +399,14 @@ impl AdjustedPrintOptions {
 }
 
 fn config_file_type_from_str(ext: &str) -> Option<ConfigFileType> {
-    match ext.to_lowercase().as_str() {
-        "csv" => Some(ConfigFileType::CSV),
-        "json" => Some(ConfigFileType::JSON),
-        "parquet" => Some(ConfigFileType::PARQUET),
-        _ => None,
+    if ext.eq_ignore_ascii_case("csv") {
+        Some(ConfigFileType::CSV)
+    } else if ext.eq_ignore_ascii_case("json") {
+        Some(ConfigFileType::JSON)
+    } else if ext.eq_ignore_ascii_case("parquet") {
+        Some(ConfigFileType::PARQUET)
+    } else {
+        None
     }
 }
 

--- a/datafusion-cli/src/object_storage/instrumented.rs
+++ b/datafusion-cli/src/object_storage/instrumented.rs
@@ -119,11 +119,14 @@ impl FromStr for InstrumentedObjectStoreMode {
     type Err = DataFusionError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "disabled" => Ok(Self::Disabled),
-            "summary" => Ok(Self::Summary),
-            "trace" => Ok(Self::Trace),
-            _ => Err(DataFusionError::Execution(format!("Unrecognized mode {s}"))),
+        if s.eq_ignore_ascii_case("disabled") {
+            Ok(Self::Disabled)
+        } else if s.eq_ignore_ascii_case("summary") {
+            Ok(Self::Summary)
+        } else if s.eq_ignore_ascii_case("trace") {
+            Ok(Self::Trace)
+        } else {
+            Err(DataFusionError::Execution(format!("Unrecognized mode {s}")))
         }
     }
 }

--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -48,9 +48,9 @@ impl FromStr for MaxRows {
     type Err = String;
 
     fn from_str(maxrows: &str) -> Result<Self, Self::Err> {
-        if maxrows.to_lowercase() == "inf"
-            || maxrows.to_lowercase() == "infinite"
-            || maxrows.to_lowercase() == "none"
+        if maxrows.eq_ignore_ascii_case("inf")
+            || maxrows.eq_ignore_ascii_case("infinite")
+            || maxrows.eq_ignore_ascii_case("none")
         {
             Ok(Self::Unlimited)
         } else {

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -56,7 +56,7 @@ use datafusion_macros::user_doc;
     argument(
         name = "part",
         description = r#"Part of the date to return. The following date parts are supported:
-        
+
     - year
     - quarter (emits value in inclusive range [1, 4] based on which quartile of the year the date is in)
     - month
@@ -214,13 +214,20 @@ impl ScalarUDFImpl for DatePartFunc {
             }
         } else {
             // special cases that can be extracted (in postgres) but are not interval units
-            match part_trim.to_lowercase().as_str() {
-                "qtr" | "quarter" => date_part(array.as_ref(), DatePart::Quarter)?,
-                "doy" => date_part(array.as_ref(), DatePart::DayOfYear)?,
-                "dow" => date_part(array.as_ref(), DatePart::DayOfWeekSunday0)?,
-                "isodow" => date_part(array.as_ref(), DatePart::DayOfWeekMonday0)?,
-                "epoch" => epoch(array.as_ref())?,
-                _ => return exec_err!("Date part '{part}' not supported"),
+            if part_trim.eq_ignore_ascii_case("qtr")
+                || part_trim.eq_ignore_ascii_case("quarter")
+            {
+                date_part(array.as_ref(), DatePart::Quarter)?
+            } else if part_trim.eq_ignore_ascii_case("doy") {
+                date_part(array.as_ref(), DatePart::DayOfYear)?
+            } else if part_trim.eq_ignore_ascii_case("dow") {
+                date_part(array.as_ref(), DatePart::DayOfWeekSunday0)?
+            } else if part_trim.eq_ignore_ascii_case("isodow") {
+                date_part(array.as_ref(), DatePart::DayOfWeekMonday0)?
+            } else if part_trim.eq_ignore_ascii_case("epoch") {
+                epoch(array.as_ref())?
+            } else {
+                return exec_err!("Date part '{part}' not supported");
             }
         };
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

Replace usages of `str::to_lowercase().as_str()` + patterm matching with `str::eq_ignore_ascii_case(&str)` to avoid allocating temporary String.

## What changes are included in this PR?

It is a boring change from
```rust
match some_str.to_lowercase().as_str() {
 "one" => ...,
 "two" => ...,
 ...
}
```
to
```rust
if some_str.eq_ignore_ascii_case("one") { 
  ...
} else if some_str.eq_ignore_ascii_case("two") {
  ...
} ...
```

## Are these changes tested?

The logic should be already covered by old tests.

## Are there any user-facing changes?

No.