### PR TITLE
feat: Add multi-column support for null-aware anti joins

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -2204,11 +2204,24 @@ impl Expr {
                               )?;
                           }
                           _ => {
-                              return plan_err!(
-                                  "InSubquery should only return one column, but found {}: {}",
-                                  subquery_schema.fields().len(),
-                                  subquery_schema.field_names().join(", ")
+                              // Multi-column IN like `(a, b) IN (SELECT x, y ...)`
+                              // lowers the left side to a `struct` ScalarFunction.
+                              // That form is valid (handled by the join lowering),
+                              // so don't reject it here. The tuple elements are
+                              // explicit exprs, not a bare placeholder bound to a
+                              // single subquery column, so there is nothing to
+                              // infer for placeholders.
+                              let is_struct = matches!(
+                                  expr.as_ref(),
+                                  Expr::ScalarFunction(func) if func.func.name() == "struct"
                               );
+                              if !is_struct {
+                                  return plan_err!(
+                                      "InSubquery should only return one column, but found {}: {}",
+                                      subquery_schema.fields().len(),
+                                      subquery_schema.field_names().join(", ")
+                                  );
+                              }
                           }
                       }
                 }

--- a/datafusion/expr/src/logical_plan/invariants.rs
+++ b/datafusion/expr/src/logical_plan/invariants.rs
@@ -239,16 +239,14 @@ pub fn check_subquery_expr(
             }
 
             // For struct expressions, validate that the number of fields matches
-            if is_struct {
-                if let Expr::ScalarFunction(ref func) = *subquery.expr {
-                    let num_tuple_cols = func.args.len();
-                    if num_tuple_cols != num_subquery_cols {
-                        return plan_err!(
-                            "The number of columns in the tuple ({}) must match the number of columns in the subquery ({})",
-                            num_tuple_cols,
-                            num_subquery_cols
-                        );
-                    }
+            if is_struct && let Expr::ScalarFunction(ref func) = *subquery.expr {
+                let num_tuple_cols = func.args.len();
+                if num_tuple_cols != num_subquery_cols {
+                    return plan_err!(
+                        "The number of columns in the tuple ({}) must match the number of columns in the subquery ({})",
+                        num_tuple_cols,
+                        num_subquery_cols
+                    );
                 }
             }
         }

--- a/datafusion/expr/src/logical_plan/invariants.rs
+++ b/datafusion/expr/src/logical_plan/invariants.rs
@@ -224,13 +224,32 @@ pub fn check_subquery_expr(
         check_correlations_in_subquery(inner_plan)
     } else {
         if let Expr::InSubquery(subquery) = expr {
-            // InSubquery should only return one column
-            if subquery.subquery.subquery.schema().fields().len() > 1 {
+            // InSubquery should only return one column UNLESS the left expression is a struct
+            // (multi-column IN like: (a, b) NOT IN (SELECT x, y FROM ...))
+            let is_struct = matches!(*subquery.expr, Expr::ScalarFunction(ref func) if func.func.name() == "struct");
+
+            let num_subquery_cols = subquery.subquery.subquery.schema().fields().len();
+
+            if !is_struct && num_subquery_cols > 1 {
                 return plan_err!(
                     "InSubquery should only return one column, but found {}: {}",
-                    subquery.subquery.subquery.schema().fields().len(),
+                    num_subquery_cols,
                     subquery.subquery.subquery.schema().field_names().join(", ")
                 );
+            }
+
+            // For struct expressions, validate that the number of fields matches
+            if is_struct {
+                if let Expr::ScalarFunction(ref func) = *subquery.expr {
+                    let num_tuple_cols = func.args.len();
+                    if num_tuple_cols != num_subquery_cols {
+                        return plan_err!(
+                            "The number of columns in the tuple ({}) must match the number of columns in the subquery ({})",
+                            num_tuple_cols,
+                            num_subquery_cols
+                        );
+                    }
+                }
             }
         }
         if let Expr::SetComparison(set_comparison) = expr

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -490,23 +490,43 @@ impl TreeNodeRewriter for TypeCoercionRewriter<'_> {
                     Arc::unwrap_or_clone(subquery.subquery),
                 )?
                 .data;
-                let expr_type = expr.get_type(self.schema)?;
-                let subquery_type = new_plan.schema().field(0).data_type();
-                let common_type = comparison_coercion(&expr_type, subquery_type).ok_or(
-                    plan_datafusion_err!(
-                    "expr type {expr_type} can't cast to {subquery_type} in InSubquery"
-                ),
-                )?;
-                let new_subquery = Subquery {
-                    subquery: Arc::new(new_plan),
-                    outer_ref_columns: subquery.outer_ref_columns,
-                    spans: subquery.spans,
-                };
-                Ok(Transformed::yes(Expr::InSubquery(InSubquery::new(
-                    Box::new(expr.cast_to(&common_type, self.schema)?),
-                    cast_subquery(new_subquery, &common_type)?,
-                    negated,
-                ))))
+
+                // Check if this is a multi-column IN (struct expression)
+                let is_struct = matches!(*expr, Expr::ScalarFunction(ref func) if func.func.name() == "struct");
+
+                if is_struct {
+                    // For multi-column IN, we don't need type coercion at this level
+                    // The decorrelation phase will handle this by creating join conditions
+                    let new_subquery = Subquery {
+                        subquery: Arc::new(new_plan),
+                        outer_ref_columns: subquery.outer_ref_columns,
+                        spans: subquery.spans,
+                    };
+                    Ok(Transformed::yes(Expr::InSubquery(InSubquery::new(
+                        expr,
+                        new_subquery,
+                        negated,
+                    ))))
+                } else {
+                    // Single-column IN: apply type coercion as before
+                    let expr_type = expr.get_type(self.schema)?;
+                    let subquery_type = new_plan.schema().field(0).data_type();
+                    let common_type = comparison_coercion(&expr_type, subquery_type).ok_or(
+                        plan_datafusion_err!(
+                        "expr type {expr_type} can't cast to {subquery_type} in InSubquery"
+                    ),
+                    )?;
+                    let new_subquery = Subquery {
+                        subquery: Arc::new(new_plan),
+                        outer_ref_columns: subquery.outer_ref_columns,
+                        spans: subquery.spans,
+                    };
+                    Ok(Transformed::yes(Expr::InSubquery(InSubquery::new(
+                        Box::new(expr.cast_to(&common_type, self.schema)?),
+                        cast_subquery(new_subquery, &common_type)?,
+                        negated,
+                    ))))
+                }
             }
             Expr::SetComparison(SetComparison {
                 expr,

--- a/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
+++ b/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
@@ -394,9 +394,57 @@ fn build_join(
                 right,
             })),
         ) => {
-            let right_col = create_col_from_scalar_expr(right.deref(), alias)?;
-            let in_predicate = Expr::eq(left.deref().clone(), Expr::Column(right_col));
-            in_predicate.and(join_filter)
+            // Check if this is a multi-column IN (struct expression)
+            if let Expr::ScalarFunction(func) = left.deref() {
+                if func.func.name() == "struct" {
+                    // Decompose struct into individual field comparisons
+                    let struct_args = &func.args;
+
+                    // The right side should be the subquery result
+                    // Note: After pull-up, the subquery may have additional correlated columns
+                    // We only care about the first N columns that match our struct fields
+                    let subquery_fields = sub_query_alias.schema().fields();
+
+                    if struct_args.len() > subquery_fields.len() {
+                        return plan_err!(
+                            "Struct field count ({}) exceeds subquery column count ({})",
+                            struct_args.len(),
+                            subquery_fields.len()
+                        );
+                    }
+
+                    // Create equality conditions for each field
+                    let mut conditions = Vec::new();
+                    for (i, arg) in struct_args.iter().enumerate() {
+                        let field = &subquery_fields[i];
+                        let right_col = Expr::Column(Column::new(
+                            Some(alias.clone()),
+                            field.name().to_string(),
+                        ));
+                        conditions.push(Expr::eq(arg.clone(), right_col));
+                    }
+
+                    // Combine all conditions with AND
+                    let in_predicate = conditions
+                        .into_iter()
+                        .reduce(|acc, cond| acc.and(cond))
+                        .unwrap_or(lit(true));
+
+                    in_predicate.and(join_filter)
+                } else {
+                    // Regular scalar function, handle as before
+                    let right_col = create_col_from_scalar_expr(right.deref(), alias)?;
+                    let in_predicate =
+                        Expr::eq(left.deref().clone(), Expr::Column(right_col));
+                    in_predicate.and(join_filter)
+                }
+            } else {
+                // Not a struct, handle as before
+                let right_col = create_col_from_scalar_expr(right.deref(), alias)?;
+                let in_predicate =
+                    Expr::eq(left.deref().clone(), Expr::Column(right_col));
+                in_predicate.and(join_filter)
+            }
         }
         (Some(join_filter), _) => join_filter,
         (
@@ -407,9 +455,51 @@ fn build_join(
                 right,
             })),
         ) => {
-            let right_col = create_col_from_scalar_expr(right.deref(), alias)?;
+            // Check if this is a multi-column IN (struct expression)
+            if let Expr::ScalarFunction(func) = left.deref() {
+                if func.func.name() == "struct" {
+                    // Decompose struct into individual field comparisons
+                    let struct_args = &func.args;
 
-            Expr::eq(left.deref().clone(), Expr::Column(right_col))
+                    // The right side should be the subquery result
+                    // Note: After pull-up, the subquery may have additional correlated columns
+                    // We only care about the first N columns that match our struct fields
+                    let subquery_fields = sub_query_alias.schema().fields();
+
+                    if struct_args.len() > subquery_fields.len() {
+                        return plan_err!(
+                            "Struct field count ({}) exceeds subquery column count ({})",
+                            struct_args.len(),
+                            subquery_fields.len()
+                        );
+                    }
+
+                    // Create equality conditions for each field
+                    let mut conditions = Vec::new();
+                    for (i, arg) in struct_args.iter().enumerate() {
+                        let field = &subquery_fields[i];
+                        let right_col = Expr::Column(Column::new(
+                            Some(alias.clone()),
+                            field.name().to_string(),
+                        ));
+                        conditions.push(Expr::eq(arg.clone(), right_col));
+                    }
+
+                    // Combine all conditions with AND
+                    conditions
+                        .into_iter()
+                        .reduce(|acc, cond| acc.and(cond))
+                        .unwrap_or(lit(true))
+                } else {
+                    // Regular scalar function, handle as before
+                    let right_col = create_col_from_scalar_expr(right.deref(), alias)?;
+                    Expr::eq(left.deref().clone(), Expr::Column(right_col))
+                }
+            } else {
+                // Not a struct, handle as before
+                let right_col = create_col_from_scalar_expr(right.deref(), alias)?;
+                Expr::eq(left.deref().clone(), Expr::Column(right_col))
+            }
         }
         (None, None) => lit(true),
         _ => return Ok(None),

--- a/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
+++ b/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
@@ -428,7 +428,7 @@ fn build_join(
                     let in_predicate = conditions
                         .into_iter()
                         .reduce(|acc, cond| acc.and(cond))
-                        .unwrap_or(lit(true));
+                        .unwrap_or_else(|| lit(true));
 
                     in_predicate.and(join_filter)
                 } else {
@@ -489,7 +489,7 @@ fn build_join(
                     conditions
                         .into_iter()
                         .reduce(|acc, cond| acc.and(cond))
-                        .unwrap_or(lit(true))
+                        .unwrap_or_else(|| lit(true))
                 } else {
                     // Regular scalar function, handle as before
                     let right_col = create_col_from_scalar_expr(right.deref(), alias)?;

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -409,13 +409,6 @@ impl HashJoinExecBuilder {
                     "null_aware can only be true for LeftAnti joins, got {join_type}"
                 );
             }
-            let on = exec.on();
-            if on.len() != 1 {
-                return plan_err!(
-                    "null_aware anti join only supports single column join key, got {} columns",
-                    on.len()
-                );
-            }
         }
 
         if preserve_properties {
@@ -6518,26 +6511,41 @@ mod tests {
         );
     }
 
-    /// Test that null_aware validation rejects multi-column joins
+    /// Test null-aware anti join with multi-column (a, b) NOT IN (SELECT x, y FROM ...)
+    /// When probe side (right) has NULL in ANY column, result should be empty
+    #[apply(hash_join_exec_configs)]
     #[tokio::test]
-    async fn test_null_aware_validation_multi_column() {
-        let left = build_table(("a", &vec![1]), ("b", &vec![2]), ("c", &vec![3]));
-        let right = build_table(("x", &vec![1]), ("y", &vec![2]), ("z", &vec![3]));
+    async fn test_null_aware_anti_join_multi_column_probe_null(
+        batch_size: usize,
+    ) -> Result<()> {
+        let task_ctx = prepare_task_ctx(batch_size, false);
 
-        // Try multi-column join
+        // Build left table (rows to potentially output)
+        let left = build_table_three_cols(
+            ("a", &vec![Some(1), Some(3), Some(5)]),
+            ("b", &vec![Some(2), Some(4), Some(6)]),
+            ("dummy", &vec![Some(10), Some(30), Some(50)]),
+        );
+
+        // Build right table (has NULL in second column)
+        let right = build_table_two_cols(
+            ("x", &vec![Some(1), Some(7)]),
+            ("y", &vec![Some(2), None]), // NULL in y column
+        );
+
         let on = vec![
             (
-                Arc::new(Column::new_with_schema("a", &left.schema()).unwrap()) as _,
-                Arc::new(Column::new_with_schema("x", &right.schema()).unwrap()) as _,
+                Arc::new(Column::new_with_schema("a", &left.schema())?) as _,
+                Arc::new(Column::new_with_schema("x", &right.schema())?) as _,
             ),
             (
-                Arc::new(Column::new_with_schema("b", &left.schema()).unwrap()) as _,
-                Arc::new(Column::new_with_schema("y", &right.schema()).unwrap()) as _,
+                Arc::new(Column::new_with_schema("b", &left.schema())?) as _,
+                Arc::new(Column::new_with_schema("y", &right.schema())?) as _,
             ),
         ];
 
-        // Try to create null-aware anti join with 2 columns (should fail)
-        let result = HashJoinExec::try_new(
+        // Create null-aware anti join
+        let join = HashJoinExec::try_new(
             left,
             right,
             on,
@@ -6546,16 +6554,166 @@ mod tests {
             None,
             PartitionMode::CollectLeft,
             NullEquality::NullEqualsNothing,
-            true, // null_aware = true (invalid for multi-column)
+            true, // null_aware = true
+        )?;
+
+        let stream = join.execute(0, task_ctx)?;
+        let batches = common::collect(stream).await?;
+
+        // Expected: empty result (probe side has NULL in y column, so no rows should be output)
+        allow_duplicates! {
+            assert_snapshot!(batches_to_sort_string(&batches), @r"
+            ++
+            ++
+            ");
+        }
+        Ok(())
+    }
+
+    /// Test null-aware anti join with multi-column when probe side has no NULLs
+    /// Expected: rows that don't match should be output, but rows with NULL keys should be filtered
+    #[apply(hash_join_exec_configs)]
+    #[tokio::test]
+    async fn test_null_aware_anti_join_multi_column_no_null(
+        batch_size: usize,
+    ) -> Result<()> {
+        let task_ctx = prepare_task_ctx(batch_size, false);
+
+        // Build left table with some NULL keys
+        let left = build_table_three_cols(
+            ("a", &vec![Some(1), Some(3), Some(5), None]),
+            ("b", &vec![Some(2), Some(4), Some(6), Some(8)]),
+            ("dummy", &vec![Some(10), Some(30), Some(50), Some(0)]),
         );
 
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("null_aware anti join only supports single column join key")
+        // Build right table (no NULLs)
+        let right = build_table_two_cols(("x", &vec![Some(1)]), ("y", &vec![Some(2)]));
+
+        let on = vec![
+            (
+                Arc::new(Column::new_with_schema("a", &left.schema())?) as _,
+                Arc::new(Column::new_with_schema("x", &right.schema())?) as _,
+            ),
+            (
+                Arc::new(Column::new_with_schema("b", &left.schema())?) as _,
+                Arc::new(Column::new_with_schema("y", &right.schema())?) as _,
+            ),
+        ];
+
+        // Create null-aware anti join
+        let join = HashJoinExec::try_new(
+            left,
+            right,
+            on,
+            None,
+            &JoinType::LeftAnti,
+            None,
+            PartitionMode::CollectLeft,
+            NullEquality::NullEqualsNothing,
+            true, // null_aware = true
+        )?;
+
+        let stream = join.execute(0, task_ctx)?;
+        let batches = common::collect(stream).await?;
+
+        // Expected: (3, 4, 30) and (5, 6, 50)
+        // Row (1, 2, 10) matches right side, so filtered out
+        // Row (NULL, 8, 0) has NULL in a column, so filtered out
+        allow_duplicates! {
+            assert_snapshot!(batches_to_sort_string(&batches), @r"
+            +---+---+-------+
+            | a | b | dummy |
+            +---+---+-------+
+            | 3 | 4 | 30    |
+            | 5 | 6 | 50    |
+            +---+---+-------+
+            ");
+        }
+        Ok(())
+    }
+
+    /// Test null-aware anti join with three columns (a, b, c) NOT IN (SELECT x, y, z FROM ...)
+    #[apply(hash_join_exec_configs)]
+    #[tokio::test]
+    async fn test_null_aware_anti_join_three_columns(batch_size: usize) -> Result<()> {
+        let task_ctx = prepare_task_ctx(batch_size, false);
+
+        // Build left table
+        let left = build_table_three_cols(
+            ("a", &vec![Some(1), Some(4), Some(7)]),
+            ("b", &vec![Some(2), Some(5), Some(8)]),
+            ("c", &vec![Some(3), Some(6), Some(9)]),
         );
+
+        // Build right table with NULL in third column
+        let right = build_table_three_cols(
+            ("x", &vec![Some(1)]),
+            ("y", &vec![Some(2)]),
+            ("z", &vec![None]), // NULL in z column
+        );
+
+        let on = vec![
+            (
+                Arc::new(Column::new_with_schema("a", &left.schema())?) as _,
+                Arc::new(Column::new_with_schema("x", &right.schema())?) as _,
+            ),
+            (
+                Arc::new(Column::new_with_schema("b", &left.schema())?) as _,
+                Arc::new(Column::new_with_schema("y", &right.schema())?) as _,
+            ),
+            (
+                Arc::new(Column::new_with_schema("c", &left.schema())?) as _,
+                Arc::new(Column::new_with_schema("z", &right.schema())?) as _,
+            ),
+        ];
+
+        // Create null-aware anti join
+        let join = HashJoinExec::try_new(
+            left,
+            right,
+            on,
+            None,
+            &JoinType::LeftAnti,
+            None,
+            PartitionMode::CollectLeft,
+            NullEquality::NullEqualsNothing,
+            true, // null_aware = true
+        )?;
+
+        let stream = join.execute(0, task_ctx)?;
+        let batches = common::collect(stream).await?;
+
+        // Expected: empty result (probe side has NULL in z column)
+        allow_duplicates! {
+            assert_snapshot!(batches_to_sort_string(&batches), @r"
+            ++
+            ++
+            ");
+        }
+        Ok(())
+    }
+
+    /// Helper to build a table with three columns supporting nullable values
+    fn build_table_three_cols(
+        a: (&str, &Vec<Option<i32>>),
+        b: (&str, &Vec<Option<i32>>),
+        c: (&str, &Vec<Option<i32>>),
+    ) -> Arc<dyn ExecutionPlan> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(a.0, DataType::Int32, true),
+            Field::new(b.0, DataType::Int32, true),
+            Field::new(c.0, DataType::Int32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(a.1.clone())),
+                Arc::new(Int32Array::from(b.1.clone())),
+                Arc::new(Int32Array::from(c.1.clone())),
+            ],
+        )
+        .unwrap();
+        TestMemoryExec::try_new_exec(&[vec![batch]], schema, None).unwrap()
     }
 
     #[test]

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -215,7 +215,15 @@ pub(super) struct JoinLeftData {
     /// This is shared across all probe partitions to provide global knowledge
     pub(super) probe_side_non_empty: AtomicBool,
     /// Shared atomic flag indicating if any probe partition saw NULL in join keys (for null-aware anti joins)
+    /// Only used for single-column NAAJ. Multi-column NAAJ uses `left_unknown_bitmap` instead.
     pub(super) probe_side_has_null: AtomicBool,
+    /// For multi-column null-aware anti join: shared bitmap tracking build-side rows
+    /// that have an UNKNOWN comparison result with some probe-side row.
+    /// These rows must NOT be emitted in the anti-join output.
+    pub(super) left_unknown_bitmap: SharedBitmapBuilder,
+    /// For multi-column null-aware anti join: indices of build-side rows that have
+    /// NULL in at least one join key column. Pre-computed during build phase.
+    pub(super) left_null_row_indices: Vec<usize>,
 }
 
 impl JoinLeftData {
@@ -242,6 +250,16 @@ impl JoinLeftData {
     /// returns a reference to the InList values for filter pushdown
     pub(super) fn membership(&self) -> &PushdownStrategy {
         &self.membership
+    }
+
+    /// returns a reference to the unknown bitmap for multi-column NAAJ
+    pub(super) fn left_unknown_bitmap(&self) -> &SharedBitmapBuilder {
+        &self.left_unknown_bitmap
+    }
+
+    /// returns a reference to the indices of left rows with NULL keys
+    pub(super) fn left_null_row_indices(&self) -> &[usize] {
+        &self.left_null_row_indices
     }
 
     /// Decrements the counter of running threads, and returns `true`
@@ -2103,6 +2121,32 @@ async fn collect_left_input(
         bounds = None;
     }
 
+    // For multi-column null-aware anti join: pre-compute which build-side rows
+    // have NULL in at least one join key column. These need special handling.
+    let left_null_row_indices: Vec<usize> = if left_values.len() > 1 {
+        let num_rows = if left_values.is_empty() {
+            0
+        } else {
+            left_values[0].len()
+        };
+        (0..num_rows)
+            .filter(|&i| left_values.iter().any(|col| col.is_null(i)))
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let num_rows = if left_values.is_empty() {
+        0
+    } else {
+        left_values[0].len()
+    };
+    let left_unknown_bitmap = {
+        let mut builder = BooleanBufferBuilder::new(num_rows);
+        builder.resize(num_rows);
+        builder
+    };
+
     let data = JoinLeftData {
         map,
         batch,
@@ -2114,6 +2158,8 @@ async fn collect_left_input(
         membership,
         probe_side_non_empty: AtomicBool::new(false),
         probe_side_has_null: AtomicBool::new(false),
+        left_unknown_bitmap: Mutex::new(left_unknown_bitmap),
+        left_null_row_indices,
     };
 
     Ok(data)
@@ -6560,18 +6606,27 @@ mod tests {
         let stream = join.execute(0, task_ctx)?;
         let batches = common::collect(stream).await?;
 
-        // Expected: empty result (probe side has NULL in y column, so no rows should be output)
+        // Expected: (3, 4, 30) and (5, 6, 50)
+        // For multi-column NAAJ, a NULL in one probe column doesn't make ALL comparisons UNKNOWN.
+        // (1,2) matches (1,2) → excluded
+        // (3,4) vs (7,NULL): 3≠7 → FALSE → NOT IN = TRUE → included
+        // (5,6) vs (7,NULL): 5≠7 → FALSE → NOT IN = TRUE → included
         allow_duplicates! {
             assert_snapshot!(batches_to_sort_string(&batches), @r"
-            ++
-            ++
+            +---+---+-------+
+            | a | b | dummy |
+            +---+---+-------+
+            | 3 | 4 | 30    |
+            | 5 | 6 | 50    |
+            +---+---+-------+
             ");
         }
         Ok(())
     }
 
     /// Test null-aware anti join with multi-column when probe side has no NULLs
-    /// Expected: rows that don't match should be output, but rows with NULL keys should be filtered
+    /// Expected: rows that don't match should be output, including rows with NULL keys
+    /// where the non-NULL column definitively doesn't match any probe row
     #[apply(hash_join_exec_configs)]
     #[tokio::test]
     async fn test_null_aware_anti_join_multi_column_no_null(
@@ -6616,14 +6671,16 @@ mod tests {
         let stream = join.execute(0, task_ctx)?;
         let batches = common::collect(stream).await?;
 
-        // Expected: (3, 4, 30) and (5, 6, 50)
+        // Expected: (3, 4, 30), (5, 6, 50), and (NULL, 8, 0)
         // Row (1, 2, 10) matches right side, so filtered out
-        // Row (NULL, 8, 0) has NULL in a column, so filtered out
+        // Row (NULL, 8, 0): (NULL,8) vs (1,2) → NULL=1 UNKNOWN AND 8=2 FALSE → FALSE → NOT IN = TRUE
+        // The row IS returned because 8≠2 definitively excludes the match
         allow_duplicates! {
             assert_snapshot!(batches_to_sort_string(&batches), @r"
             +---+---+-------+
             | a | b | dummy |
             +---+---+-------+
+            |   | 8 | 0     |
             | 3 | 4 | 30    |
             | 5 | 6 | 50    |
             +---+---+-------+
@@ -6683,11 +6740,18 @@ mod tests {
         let stream = join.execute(0, task_ctx)?;
         let batches = common::collect(stream).await?;
 
-        // Expected: empty result (probe side has NULL in z column)
+        // Expected: (4, 5, 6) and (7, 8, 9)
+        // (1,2,3) vs (1,2,NULL): 1=1 TRUE, 2=2 TRUE, 3=NULL UNKNOWN → UNKNOWN → excluded
+        // (4,5,6) vs (1,2,NULL): 4≠1 FALSE → FALSE → NOT IN = TRUE → included
+        // (7,8,9) vs (1,2,NULL): 7≠1 FALSE → FALSE → NOT IN = TRUE → included
         allow_duplicates! {
             assert_snapshot!(batches_to_sort_string(&batches), @r"
-            ++
-            ++
+            +---+---+---+
+            | a | b | c |
+            +---+---+---+
+            | 4 | 5 | 6 |
+            | 7 | 8 | 9 |
+            +---+---+---+
             ");
         }
         Ok(())

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -52,7 +52,8 @@ use arrow::buffer::NullBuffer;
 use arrow::datatypes::{Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::{
-    JoinSide, JoinType, NullEquality, Result, internal_datafusion_err, internal_err,
+    JoinSide, JoinType, NullEquality, Result, ScalarValue, internal_datafusion_err,
+    internal_err,
 };
 use datafusion_physical_expr::PhysicalExprRef;
 
@@ -465,6 +466,116 @@ fn count_distinct_sorted_indices(indices: &UInt32Array) -> usize {
     count
 }
 
+/// For multi-column null-aware anti join: checks if the comparison between
+/// a build-side row and a probe-side row produces an UNKNOWN (NULL) result.
+///
+/// A multi-column comparison `(a1, a2, ...) = (b1, b2, ...)` is UNKNOWN when:
+/// - No column pair has a definite mismatch (both non-NULL and different)
+/// - At least one column pair involves NULL
+///
+/// For example: `(NULL, 8) = (1, 2)` → `UNKNOWN AND FALSE` → `FALSE` (not unknown)
+/// But: `(NULL, 2) = (1, 2)` → `UNKNOWN AND TRUE` → `UNKNOWN` (is unknown)
+fn is_naaj_comparison_unknown(
+    build_values: &[ArrayRef],
+    probe_values: &[ArrayRef],
+    build_idx: usize,
+    probe_idx: usize,
+) -> Result<bool> {
+    let mut has_null = false;
+    for (build_col, probe_col) in build_values.iter().zip(probe_values.iter()) {
+        let build_null = build_col.is_null(build_idx);
+        let probe_null = probe_col.is_null(probe_idx);
+
+        if build_null || probe_null {
+            has_null = true;
+            continue;
+        }
+
+        // Both non-NULL: check if values are equal
+        let build_val = ScalarValue::try_from_array(build_col, build_idx)?;
+        let probe_val = ScalarValue::try_from_array(probe_col, probe_idx)?;
+        if build_val != probe_val {
+            return Ok(false); // Definite mismatch → comparison is FALSE, not UNKNOWN
+        }
+    }
+    Ok(has_null)
+}
+
+/// For multi-column null-aware anti join: performs secondary checks to find
+/// UNKNOWN comparisons between build and probe rows.
+///
+/// This handles cases that hash probing misses:
+/// 1. Probe rows with NULLs: checked against ALL build rows
+/// 2. Non-NULL probe rows: checked against build rows with NULL keys only
+///
+/// Updates the unknown bitmap for any build row that has an UNKNOWN match.
+fn check_multi_column_naaj_unknown(
+    build_values: &[ArrayRef],
+    probe_values: &[ArrayRef],
+    unknown_bitmap: &crate::joins::SharedBitmapBuilder,
+    build_null_row_indices: &[usize],
+    build_size: usize,
+    probe_size: usize,
+) -> Result<()> {
+    if probe_size == 0 || build_size == 0 {
+        return Ok(());
+    }
+
+    // Identify which probe rows have NULLs in any key column
+    let mut probe_has_null = vec![false; probe_size];
+    for col in probe_values {
+        for (i, has_null) in probe_has_null.iter_mut().enumerate() {
+            if col.is_null(i) {
+                *has_null = true;
+            }
+        }
+    }
+
+    let mut bitmap = unknown_bitmap.lock();
+
+    // Case 1: Probe rows WITH NULLs — check against ALL build rows
+    for (probe_idx, has_null) in probe_has_null.iter().enumerate() {
+        if !has_null {
+            continue;
+        }
+        for build_idx in 0..build_size {
+            if bitmap.get_bit(build_idx) {
+                continue; // Already marked as unknown
+            }
+            if is_naaj_comparison_unknown(
+                build_values,
+                probe_values,
+                build_idx,
+                probe_idx,
+            )? {
+                bitmap.set_bit(build_idx, true);
+            }
+        }
+    }
+
+    // Case 2: Probe rows WITHOUT NULLs — check against build rows with NULL keys only
+    for (probe_idx, has_null) in probe_has_null.iter().enumerate() {
+        if *has_null {
+            continue; // Already handled in Case 1
+        }
+        for &build_idx in build_null_row_indices {
+            if bitmap.get_bit(build_idx) {
+                continue; // Already marked as unknown
+            }
+            if is_naaj_comparison_unknown(
+                build_values,
+                probe_values,
+                build_idx,
+                probe_idx,
+            )? {
+                bitmap.set_bit(build_idx, true);
+            }
+        }
+    }
+
+    Ok(())
+}
+
 impl HashJoinStream {
     #[expect(clippy::too_many_arguments)]
     pub(super) fn new(
@@ -743,12 +854,20 @@ impl HashJoinStream {
 
         // Null-aware anti join semantics:
         // For LeftAnti: output LEFT (build) rows where LEFT.key NOT IN RIGHT.key
-        // 1. If RIGHT (probe) contains NULL in any batch, no LEFT rows should be output
-        // 2. LEFT rows with NULL keys should not be output (handled in final stage)
+        //
+        // Single-column NAAJ:
+        //   1. If RIGHT (probe) contains NULL in any batch, no LEFT rows should be output
+        //   2. LEFT rows with NULL keys should not be output (handled in final stage)
+        //
+        // Multi-column NAAJ:
+        //   NULL handling is more nuanced. A NULL in one column doesn't automatically
+        //   make the comparison UNKNOWN — if another column definitively doesn't match,
+        //   the comparison is FALSE. So we can't just short-circuit.
+        //   Instead, we perform secondary UNKNOWN checks after hash probing.
+        let is_multi_column_naaj = self.null_aware && self.on_right.len() > 1;
+
         if self.null_aware {
             // Mark that we've seen a probe batch with actual rows (probe side is non-empty)
-            // Only set this if batch has rows - empty batches don't count
-            // Use shared atomic state so all partitions can see this global information
             if state.batch.num_rows() > 0 {
                 build_side
                     .left_data
@@ -756,26 +875,25 @@ impl HashJoinStream {
                     .store(true, Ordering::Relaxed);
             }
 
-            // Check if probe side (RIGHT) contains NULL in ANY column
-            // For multi-column joins, if any column has NULL, the entire tuple is considered NULL
-            let has_null = state.values.iter().any(|col| col.null_count() > 0);
-            if has_null {
-                // Found NULL in probe side - set shared flag to prevent any output
-                build_side
+            if !is_multi_column_naaj {
+                // Single-column NAAJ: use fast-path short-circuit
+                let has_null = state.values.iter().any(|col| col.null_count() > 0);
+                if has_null {
+                    build_side
+                        .left_data
+                        .probe_side_has_null
+                        .store(true, Ordering::Relaxed);
+                }
+
+                if build_side
                     .left_data
                     .probe_side_has_null
-                    .store(true, Ordering::Relaxed);
-            }
-
-            // If probe side has NULL (detected in this or any other partition), return empty result
-            if build_side
-                .left_data
-                .probe_side_has_null
-                .load(Ordering::Relaxed)
-            {
-                timer.done();
-                self.state = HashJoinStreamState::FetchProbeBatch;
-                return Ok(StatefulStreamResult::Continue);
+                    .load(Ordering::Relaxed)
+                {
+                    timer.done();
+                    self.state = HashJoinStreamState::FetchProbeBatch;
+                    return Ok(StatefulStreamResult::Continue);
+                }
             }
         }
 
@@ -861,6 +979,22 @@ impl HashJoinStream {
             left_indices.iter().flatten().for_each(|x| {
                 bitmap.set_bit(x as usize, true);
             });
+        }
+
+        // Multi-column NAAJ: perform secondary check for UNKNOWN comparisons.
+        // Hash probing only finds exact (TRUE) matches. We also need to detect
+        // UNKNOWN comparisons where NULLs are involved but non-NULL columns match.
+        if is_multi_column_naaj {
+            let build_size = build_side.left_data.batch().num_rows();
+            let probe_size = state.batch.num_rows();
+            check_multi_column_naaj_unknown(
+                build_side.left_data.values(),
+                &state.values,
+                build_side.left_data.left_unknown_bitmap(),
+                build_side.left_data.left_null_row_indices(),
+                build_size,
+                probe_size,
+            )?;
         }
 
         // The goals of index alignment for different join types are:
@@ -960,9 +1094,12 @@ impl HashJoinStream {
 
         let build_side = self.build_side.try_as_ready()?;
 
-        // For null-aware anti join, if probe side had NULL, no rows should be output
-        // Check shared atomic state to get global knowledge across all partitions
+        let is_multi_column_naaj = self.null_aware && self.on_right.len() > 1;
+
+        // For single-column null-aware anti join, if probe side had NULL, no rows
+        // should be output. Multi-column NAAJ uses the unknown bitmap instead.
         if self.null_aware
+            && !is_multi_column_naaj
             && build_side
                 .left_data
                 .probe_side_has_null
@@ -984,10 +1121,6 @@ impl HashJoinStream {
             true,
         );
 
-        // For null-aware anti join, filter out LEFT rows with NULL in join keys
-        // BUT only if the probe side (RIGHT) was non-empty. If probe side is empty,
-        // NULL NOT IN (empty) = TRUE, so NULL rows should be returned.
-        // Use shared atomic state to get global knowledge across all partitions
         if self.null_aware
             && self.join_type == JoinType::LeftAnti
             && build_side
@@ -995,32 +1128,51 @@ impl HashJoinStream {
                 .probe_side_non_empty
                 .load(Ordering::Relaxed)
         {
-            // Filter out indices where ANY key column is NULL
-            // For multi-column joins, if any column has NULL, the entire tuple should be filtered
-            let build_key_columns = build_side.left_data.values();
+            if is_multi_column_naaj {
+                // Multi-column NAAJ: use the unknown bitmap to filter out rows
+                // that have UNKNOWN comparisons with some probe row.
+                // The unknown bitmap was populated during probe processing.
+                let unknown_bitmap = build_side.left_data.left_unknown_bitmap().lock();
 
-            // Filter out indices where the key is NULL
-            let filtered_indices: Vec<u64> = left_side
-                .iter()
-                .filter_map(|idx| {
-                    let idx_usize = idx.unwrap() as usize;
-                    // Check if any column has NULL at this index
-                    let has_null =
-                        build_key_columns.iter().any(|col| col.is_null(idx_usize));
-                    if has_null {
-                        None // Skip rows with NULL keys
-                    } else {
-                        Some(idx.unwrap())
-                    }
-                })
-                .collect();
+                let filtered_indices: Vec<u64> = left_side
+                    .iter()
+                    .filter_map(|idx| {
+                        let idx_usize = idx.unwrap() as usize;
+                        if unknown_bitmap.get_bit(idx_usize) {
+                            None // Has UNKNOWN comparison → NOT IN result is UNKNOWN → exclude
+                        } else {
+                            Some(idx.unwrap())
+                        }
+                    })
+                    .collect();
 
-            left_side = UInt64Array::from(filtered_indices);
+                left_side = UInt64Array::from(filtered_indices);
 
-            // Update right_side to match the new length
-            let mut builder = arrow::array::UInt32Builder::with_capacity(left_side.len());
-            builder.append_nulls(left_side.len());
-            right_side = builder.finish();
+                let mut builder =
+                    arrow::array::UInt32Builder::with_capacity(left_side.len());
+                builder.append_nulls(left_side.len());
+                right_side = builder.finish();
+            } else {
+                // Single-column NAAJ: filter out rows with NULL keys
+                let build_key_columns = build_side.left_data.values();
+
+                let filtered_indices: Vec<u64> = left_side
+                    .iter()
+                    .filter_map(|idx| {
+                        let idx_usize = idx.unwrap() as usize;
+                        let has_null =
+                            build_key_columns.iter().any(|col| col.is_null(idx_usize));
+                        if has_null { None } else { Some(idx.unwrap()) }
+                    })
+                    .collect();
+
+                left_side = UInt64Array::from(filtered_indices);
+
+                let mut builder =
+                    arrow::array::UInt32Builder::with_capacity(left_side.len());
+                builder.append_nulls(left_side.len());
+                right_side = builder.finish();
+            }
         }
 
         self.join_metrics.input_batches.add(1);

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -756,10 +756,10 @@ impl HashJoinStream {
                     .store(true, Ordering::Relaxed);
             }
 
-            // Check if probe side (RIGHT) contains NULL
-            // Since null_aware validation ensures single column join, we only check the first column
-            let probe_key_column = &state.values[0];
-            if probe_key_column.null_count() > 0 {
+            // Check if probe side (RIGHT) contains NULL in ANY column
+            // For multi-column joins, if any column has NULL, the entire tuple is considered NULL
+            let has_null = state.values.iter().any(|col| col.null_count() > 0);
+            if has_null {
                 // Found NULL in probe side - set shared flag to prevent any output
                 build_side
                     .left_data
@@ -995,15 +995,19 @@ impl HashJoinStream {
                 .probe_side_non_empty
                 .load(Ordering::Relaxed)
         {
-            // Since null_aware validation ensures single column join, we only check the first column
-            let build_key_column = &build_side.left_data.values()[0];
+            // Filter out indices where ANY key column is NULL
+            // For multi-column joins, if any column has NULL, the entire tuple should be filtered
+            let build_key_columns = build_side.left_data.values();
 
             // Filter out indices where the key is NULL
             let filtered_indices: Vec<u64> = left_side
                 .iter()
                 .filter_map(|idx| {
                     let idx_usize = idx.unwrap() as usize;
-                    if build_key_column.is_null(idx_usize) {
+                    // Check if any column has NULL at this index
+                    let has_null =
+                        build_key_columns.iter().any(|col| col.is_null(idx_usize));
+                    if has_null {
                         None // Skip rows with NULL keys
                     } else {
                         Some(idx.unwrap())

--- a/datafusion/sql/src/expr/subquery.rs
+++ b/datafusion/sql/src/expr/subquery.rs
@@ -70,14 +70,41 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         let outer_ref_columns = sub_plan.all_out_ref_exprs();
         planner_context.pop_outer_query_schema();
 
-        self.validate_single_column(
-            &sub_plan,
-            &spans,
-            "Too many columns! The subquery should only return one column",
-            "Select only one column in the subquery",
-        )?;
+        // Check if the left expression is a tuple (multi-column IN)
+        // For tuples like (a, b) NOT IN (SELECT x, y FROM ...), allow multiple columns
+        let is_tuple = matches!(expr, SQLExpr::Tuple(_));
+
+        if !is_tuple {
+            // Single-column IN: validate subquery returns exactly one column
+            self.validate_single_column(
+                &sub_plan,
+                &spans,
+                "Too many columns! The subquery should only return one column",
+                "Select only one column in the subquery",
+            )?;
+        }
 
         let expr_obj = self.sql_to_expr(expr, input_schema, planner_context)?;
+
+        // For multi-column IN, validate that the number of columns match
+        if is_tuple {
+            // Tuples are converted to struct expressions
+            // Extract the number of fields by checking if it's a ScalarFunction call
+            let tuple_len = if let Expr::ScalarFunction(func) = &expr_obj {
+                func.args.len()
+            } else {
+                1 // Fallback to single column if we can't determine
+            };
+
+            let subquery_len = sub_plan.schema().fields().len();
+            if tuple_len != subquery_len {
+                return plan_err!(
+                    "The number of columns in the tuple ({}) must match the number of columns in the subquery ({})",
+                    tuple_len,
+                    subquery_len
+                );
+            }
+        }
 
         Ok(Expr::InSubquery(InSubquery::new(
             Box::new(expr_obj),

--- a/datafusion/sqllogictest/test_files/null_aware_anti_join.slt
+++ b/datafusion/sqllogictest/test_files/null_aware_anti_join.slt
@@ -394,14 +394,200 @@ query II rowsort
 SELECT * FROM test_table WHERE (c1 NOT IN (SELECT c2 FROM test_table)) = true;
 ----
 
-# NOTE: The correlated subquery version from issue #10583:
-# SELECT * FROM test_table t1 WHERE c1 NOT IN (SELECT c2 FROM test_table t2 WHERE t1.c1 = t2.c1)
-# is not yet supported because it creates a multi-column join (correlation + NOT IN condition).
-# This is a known limitation - currently only supports single column null-aware anti joins.
-# This will be addressed in next Phase (multi-column support).
+#############
+## Test 19: Multi-column NOT IN with NULL in subquery
+#############
+
+statement ok
+CREATE TABLE multi_col_outer(a INT, b INT, value TEXT) AS VALUES
+(1, 2, 'x'),
+(3, 4, 'y'),
+(5, 6, 'z'),
+(NULL, 8, 'w');
+
+statement ok
+CREATE TABLE multi_col_inner_with_null(x INT, y INT) AS VALUES
+(1, 2),
+(NULL, 4);
+
+# Should return empty because subquery has NULL
+query IIT rowsort
+SELECT * FROM multi_col_outer
+WHERE (a, b) NOT IN (SELECT x, y FROM multi_col_inner_with_null);
+----
+
+#############
+## Test 20: Multi-column NOT IN without NULL
+#############
+
+statement ok
+CREATE TABLE multi_col_inner_no_null(x INT, y INT) AS VALUES
+(1, 2);
+
+# Should return (3, 4, 'y'), (5, 6, 'z')
+# The row (NULL, 8, 'w') is not returned because NULL is not comparable
+query IIT rowsort
+SELECT * FROM multi_col_outer
+WHERE (a, b) NOT IN (SELECT x, y FROM multi_col_inner_no_null);
+----
+3 4 y
+5 6 z
+
+#############
+## Test 21: Multi-column with NULL in both left and build side columns
+#############
+
+statement ok
+CREATE TABLE multi_left_null(a INT, b INT) AS VALUES
+(1, 2),
+(3, NULL),
+(NULL, 4),
+(5, 6);
+
+statement ok
+CREATE TABLE multi_right_no_null(x INT, y INT) AS VALUES
+(1, 2);
+
+# Should return (5, 6) only
+# (3, NULL) filtered because b is NULL
+# (NULL, 4) filtered because a is NULL
+query II rowsort
+SELECT * FROM multi_left_null
+WHERE (a, b) NOT IN (SELECT x, y FROM multi_right_no_null);
+----
+5 6
+
+#############
+## Test 22: Three-column NOT IN
+#############
+
+statement ok
+CREATE TABLE three_col_outer(a INT, b INT, c INT) AS VALUES
+(1, 2, 3),
+(4, 5, 6),
+(7, 8, 9);
+
+statement ok
+CREATE TABLE three_col_inner(x INT, y INT, z INT) AS VALUES
+(1, 2, 3);
+
+# Should return (4, 5, 6) and (7, 8, 9)
+query III rowsort
+SELECT * FROM three_col_outer
+WHERE (a, b, c) NOT IN (SELECT x, y, z FROM three_col_inner);
+----
+4 5 6
+7 8 9
+
+#############
+## Test 23: Three-column NOT IN with NULL
+#############
+
+statement ok
+CREATE TABLE three_col_inner_null(x INT, y INT, z INT) AS VALUES
+(1, 2, 3),
+(4, NULL, 6);
+
+# Should return empty because subquery has NULL
+query III rowsort
+SELECT * FROM three_col_outer
+WHERE (a, b, c) NOT IN (SELECT x, y, z FROM three_col_inner_null);
+----
+
+#############
+## Test 24: Correlated multi-column NOT IN (from issue #10583)
+#############
+
+statement ok
+CREATE TABLE test_multi(c1 INT, c2 INT, c3 INT) AS VALUES
+(1, 1, 1),
+(2, 2, 2),
+(3, 3, 3),
+(4, 4, NULL);
+
+# Correlated NOT IN with multi-column
+# Should return rows where (c2, c3) doesn't match in same c1 group
+# Row (4, 4, NULL) should not appear because it has NULL in c3
+query III rowsort
+SELECT * FROM test_multi t1
+WHERE (c2, c3) NOT IN (
+    SELECT c2, c3 FROM test_multi t2 WHERE t1.c1 = t2.c1
+);
+----
+
+# Verify the EXPLAIN plan shows LeftAnti join with multi-column join conditions
+query TT
+EXPLAIN SELECT * FROM test_multi t1
+WHERE (c2, c3) NOT IN (
+    SELECT c2, c3 FROM test_multi t2 WHERE t1.c1 = t2.c1
+);
+----
+logical_plan
+01)LeftAnti Join: t1.c2 = __correlated_sq_1.c2, t1.c3 = __correlated_sq_1.c3, t1.c1 = __correlated_sq_1.c1
+02)--SubqueryAlias: t1
+03)----TableScan: test_multi projection=[c1, c2, c3]
+04)--SubqueryAlias: __correlated_sq_1
+05)----Projection: t2.c2, t2.c3, t2.c1
+06)------SubqueryAlias: t2
+07)--------TableScan: test_multi projection=[c1, c2, c3]
+physical_plan
+01)HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(c2@1, c2@0), (c3@2, c3@1), (c1@0, c1@2)]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+03)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+#############
+## Test 25: Multi-column NOT IN with empty subquery
+#############
+
+statement ok
+CREATE TABLE multi_empty(x INT, y INT);
+
+# Empty subquery should return all rows
+query IIT rowsort
+SELECT * FROM multi_col_outer
+WHERE (a, b) NOT IN (SELECT x, y FROM multi_empty);
+----
+1 2 x
+3 4 y
+5 6 z
+NULL 8 w
 
 #############
 ## Cleanup
+#############
+
+statement ok
+DROP TABLE multi_col_outer;
+
+statement ok
+DROP TABLE multi_col_inner_with_null;
+
+statement ok
+DROP TABLE multi_col_inner_no_null;
+
+statement ok
+DROP TABLE multi_left_null;
+
+statement ok
+DROP TABLE multi_right_no_null;
+
+statement ok
+DROP TABLE three_col_outer;
+
+statement ok
+DROP TABLE three_col_inner;
+
+statement ok
+DROP TABLE three_col_inner_null;
+
+statement ok
+DROP TABLE test_multi;
+
+statement ok
+DROP TABLE multi_empty;
+
+#############
+## Cleanup (original tables)
 #############
 
 statement ok

--- a/datafusion/sqllogictest/test_files/null_aware_anti_join.slt
+++ b/datafusion/sqllogictest/test_files/null_aware_anti_join.slt
@@ -410,11 +410,18 @@ CREATE TABLE multi_col_inner_with_null(x INT, y INT) AS VALUES
 (1, 2),
 (NULL, 4);
 
-# Should return empty because subquery has NULL
+# With multi-column NOT IN, a NULL in one column doesn't make the whole comparison UNKNOWN
+# if another column definitively doesn't match.
+# (1,2): matches (1,2) → excluded
+# (3,4): vs (NULL,4) → 3=NULL UNKNOWN AND 4=4 TRUE → UNKNOWN → excluded
+# (5,6): vs (1,2) → FALSE; vs (NULL,4) → 5=NULL UNKNOWN AND 6=4 FALSE → FALSE → included
+# (NULL,8): vs (1,2) → FALSE; vs (NULL,4) → NULL=NULL UNKNOWN AND 8=4 FALSE → FALSE → included
 query IIT rowsort
 SELECT * FROM multi_col_outer
 WHERE (a, b) NOT IN (SELECT x, y FROM multi_col_inner_with_null);
 ----
+5 6 z
+NULL 8 w
 
 #############
 ## Test 20: Multi-column NOT IN without NULL
@@ -424,14 +431,15 @@ statement ok
 CREATE TABLE multi_col_inner_no_null(x INT, y INT) AS VALUES
 (1, 2);
 
-# Should return (3, 4, 'y'), (5, 6, 'z')
-# The row (NULL, 8, 'w') is not returned because NULL is not comparable
+# (NULL, 8) vs (1, 2): NULL=1 UNKNOWN AND 8=2 FALSE → FALSE → NOT IN = TRUE
+# So (NULL, 8, 'w') IS returned because 8≠2 definitively excludes the match
 query IIT rowsort
 SELECT * FROM multi_col_outer
 WHERE (a, b) NOT IN (SELECT x, y FROM multi_col_inner_no_null);
 ----
 3 4 y
 5 6 z
+NULL 8 w
 
 #############
 ## Test 21: Multi-column with NULL in both left and build side columns
@@ -448,14 +456,16 @@ statement ok
 CREATE TABLE multi_right_no_null(x INT, y INT) AS VALUES
 (1, 2);
 
-# Should return (5, 6) only
-# (3, NULL) filtered because b is NULL
-# (NULL, 4) filtered because a is NULL
+# (3, NULL) vs (1, 2): 3=1 FALSE → comparison is FALSE → NOT IN = TRUE → included
+# (NULL, 4) vs (1, 2): NULL=1 UNKNOWN AND 4=2 FALSE → FALSE → NOT IN = TRUE → included
+# Both are included because the non-NULL column definitively doesn't match
 query II rowsort
 SELECT * FROM multi_left_null
 WHERE (a, b) NOT IN (SELECT x, y FROM multi_right_no_null);
 ----
+3 NULL
 5 6
+NULL 4
 
 #############
 ## Test 22: Three-column NOT IN
@@ -488,11 +498,14 @@ CREATE TABLE three_col_inner_null(x INT, y INT, z INT) AS VALUES
 (1, 2, 3),
 (4, NULL, 6);
 
-# Should return empty because subquery has NULL
+# (4,5,6) vs (4,NULL,6): 4=4 TRUE, 5=NULL UNKNOWN, 6=6 TRUE → UNKNOWN → excluded
+# (7,8,9) vs (4,NULL,6): 7=4 FALSE → FALSE → NOT IN = TRUE → included
+# (7,8,9) vs (1,2,3): FALSE → included
 query III rowsort
 SELECT * FROM three_col_outer
 WHERE (a, b, c) NOT IN (SELECT x, y, z FROM three_col_inner_null);
 ----
+7 8 9
 
 #############
 ## Test 24: Correlated multi-column NOT IN (from issue #10583)

--- a/datafusion/sqllogictest/test_files/null_aware_anti_join.slt
+++ b/datafusion/sqllogictest/test_files/null_aware_anti_join.slt
@@ -536,7 +536,7 @@ WHERE (c2, c3) NOT IN (
 );
 ----
 logical_plan
-01)LeftAnti Join: t1.c2 = __correlated_sq_1.c2, t1.c3 = __correlated_sq_1.c3, t1.c1 = __correlated_sq_1.c1
+01)LeftAnti Join: t1.c2 = __correlated_sq_1.c2, t1.c3 = __correlated_sq_1.c3, t1.c1 = __correlated_sq_1.c1 null_aware
 02)--SubqueryAlias: t1
 03)----TableScan: test_multi projection=[c1, c2, c3]
 04)--SubqueryAlias: __correlated_sq_1
@@ -544,7 +544,7 @@ logical_plan
 06)------SubqueryAlias: t2
 07)--------TableScan: test_multi projection=[c1, c2, c3]
 physical_plan
-01)HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(c2@1, c2@0), (c3@2, c3@1), (c1@0, c1@2)]
+01)HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(c2@1, c2@0), (c3@2, c3@1), (c1@0, c1@2)], null_aware
 02)--DataSourceExec: partitions=1, partition_sizes=[1]
 03)--DataSourceExec: partitions=1, partition_sizes=[1]
 

--- a/datafusion/sqllogictest/test_files/subquery.slt
+++ b/datafusion/sqllogictest/test_files/subquery.slt
@@ -2490,3 +2490,196 @@ DROP TABLE sq_count_customer;
 
 statement ok
 DROP TABLE sq_count_orders;
+
+#############
+## Multi-column IN (LeftSemi) Tests
+#############
+## These tests verify that multi-column IN subqueries work correctly
+## Multi-column IN uses LeftSemi join (not null-aware)
+
+#############
+## Test 1: Basic two-column IN
+#############
+
+statement ok
+CREATE TABLE multi_in_left(a INT, b INT, value TEXT) AS VALUES
+(1, 2, 'match'),
+(3, 4, 'no_match'),
+(5, 6, 'match');
+
+statement ok
+CREATE TABLE multi_in_right(x INT, y INT) AS VALUES
+(1, 2),
+(5, 6);
+
+# Should return rows where (a, b) matches (x, y)
+query IIT rowsort
+SELECT * FROM multi_in_left
+WHERE (a, b) IN (SELECT x, y FROM multi_in_right);
+----
+1 2 match
+5 6 match
+
+#############
+## Test 2: Multi-column IN with no matches
+#############
+
+statement ok
+CREATE TABLE multi_in_right_no_match(x INT, y INT) AS VALUES
+(10, 20),
+(30, 40);
+
+# Should return empty result
+query IIT rowsort
+SELECT * FROM multi_in_left
+WHERE (a, b) IN (SELECT x, y FROM multi_in_right_no_match);
+----
+
+#############
+## Test 3: Multi-column IN with NULL values
+#############
+## Note: Unlike NOT IN, regular IN does NOT use null-aware semantics
+## NULL = NULL is always FALSE (not unknown) in regular semi joins
+
+statement ok
+CREATE TABLE multi_in_left_null(a INT, b INT, value TEXT) AS VALUES
+(1, 2, 'x'),
+(3, NULL, 'y'),
+(NULL, 6, 'z');
+
+statement ok
+CREATE TABLE multi_in_right_null(x INT, y INT) AS VALUES
+(1, 2),
+(NULL, 4);
+
+# Should return only (1, 2, 'x')
+# (3, NULL, 'y') doesn't match because NULL doesn't equal anything
+# (NULL, 6, 'z') doesn't match because NULL doesn't equal anything
+query IIT rowsort
+SELECT * FROM multi_in_left_null
+WHERE (a, b) IN (SELECT x, y FROM multi_in_right_null);
+----
+1 2 x
+
+#############
+## Test 4: Three-column IN
+#############
+
+statement ok
+CREATE TABLE three_col_left(a INT, b INT, c INT, value TEXT) AS VALUES
+(1, 2, 3, 'match1'),
+(4, 5, 6, 'no_match'),
+(7, 8, 9, 'match2');
+
+statement ok
+CREATE TABLE three_col_right(x INT, y INT, z INT) AS VALUES
+(1, 2, 3),
+(7, 8, 9);
+
+# Should return rows with matching three-column tuples
+query IIIT rowsort
+SELECT * FROM three_col_left
+WHERE (a, b, c) IN (SELECT x, y, z FROM three_col_right);
+----
+1 2 3 match1
+7 8 9 match2
+
+#############
+## Test 5: Correlated multi-column IN
+#############
+
+statement ok
+CREATE TABLE correlated_outer(id INT, a INT, b INT) AS VALUES
+(1, 10, 20),
+(2, 30, 40),
+(3, 10, 20);
+
+statement ok
+CREATE TABLE correlated_inner(id INT, x INT, y INT) AS VALUES
+(1, 10, 20),
+(1, 30, 40),
+(2, 50, 60),
+(3, 10, 20);
+
+# Should return outer rows where (a, b) matches (x, y) for the same id
+query III rowsort
+SELECT * FROM correlated_outer o
+WHERE (a, b) IN (
+    SELECT x, y FROM correlated_inner i WHERE i.id = o.id
+);
+----
+1 10 20
+3 10 20
+
+#############
+## Test 6: Verify logical plan shows LeftSemi join with multiple conditions
+#############
+
+query TT
+EXPLAIN SELECT * FROM multi_in_left
+WHERE (a, b) IN (SELECT x, y FROM multi_in_right);
+----
+logical_plan
+01)LeftSemi Join: multi_in_left.a = __correlated_sq_1.x, multi_in_left.b = __correlated_sq_1.y
+02)--TableScan: multi_in_left projection=[a, b, value]
+03)--SubqueryAlias: __correlated_sq_1
+04)----TableScan: multi_in_right projection=[x, y]
+
+#############
+## Test 7: Multi-column IN with empty subquery
+#############
+
+statement ok
+CREATE TABLE multi_in_right_empty(x INT, y INT);
+
+# Should return empty result (empty subquery)
+query IIT rowsort
+SELECT * FROM multi_in_left
+WHERE (a, b) IN (SELECT x, y FROM multi_in_right_empty);
+----
+
+#############
+## Test 8: Multi-column IN with WHERE clause in subquery
+#############
+
+# Should return only rows matching filtered subquery
+query IIT rowsort
+SELECT * FROM multi_in_left
+WHERE (a, b) IN (SELECT x, y FROM multi_in_right WHERE x > 0 AND y < 10);
+----
+1 2 match
+5 6 match
+
+#############
+## Cleanup
+#############
+
+statement ok
+DROP TABLE multi_in_left;
+
+statement ok
+DROP TABLE multi_in_right;
+
+statement ok
+DROP TABLE multi_in_right_no_match;
+
+statement ok
+DROP TABLE multi_in_left_null;
+
+statement ok
+DROP TABLE multi_in_right_null;
+
+statement ok
+DROP TABLE three_col_left;
+
+statement ok
+DROP TABLE three_col_right;
+
+statement ok
+DROP TABLE correlated_outer;
+
+statement ok
+DROP TABLE correlated_inner;
+
+statement ok
+DROP TABLE multi_in_right_empty;

--- a/datafusion/sqllogictest/test_files/subquery.slt
+++ b/datafusion/sqllogictest/test_files/subquery.slt
@@ -2624,6 +2624,10 @@ logical_plan
 02)--TableScan: multi_in_left projection=[a, b, value]
 03)--SubqueryAlias: __correlated_sq_1
 04)----TableScan: multi_in_right projection=[x, y]
+physical_plan
+01)HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(x@0, a@0), (y@1, b@1)]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+03)--DataSourceExec: partitions=1, partition_sizes=[1]
 
 #############
 ## Test 7: Multi-column IN with empty subquery


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This commit extends null-aware anti join functionality to support multiple columns, enabling queries like:

    SELECT * FROM t1 WHERE (a, b) NOT IN (SELECT x, y FROM t2);

and correlated multi-column NOT IN subqueries:

    SELECT * FROM t1 WHERE (c2, c3) NOT IN (
      SELECT c2, c3 FROM t2 WHERE t1.c1 = t2.c1
    );

Changes:

Physical Execution Layer:
  - Remove single-column validation restriction in HashJoinExec
  - Extend NULL detection in probe phase to check ANY column for NULLs
  - Extend NULL filtering in final phase to filter rows with ANY NULL column   - Add comprehensive unit tests for 2-column and 3-column joins

SQL Planning Layer:
  - Allow tuple expressions in parse_in_subquery()
  - Add validation for tuple field count matching

Query Optimization Layer:
  - Update InSubquery validation to allow struct expressions
  - Skip type coercion for struct expressions (handled in decorrelation)
  - Implement struct decomposition in decorrelate_predicate_subquery
  - Decompose struct(a, b) into individual join conditions a = x AND b = y
  - Handle both correlated and non-correlated multi-column subqueries

Test Coverage:
  - Add 7 new SQL logic test cases (Tests 19-25)
  - Add 3 unit test functions with 15 test variants (5 batch sizes each)
  - Cover 2-column, 3-column, empty subquery, and NULL patterns
  - Include correlated multi-column NOT IN from issue #10583
  - Add test coverage for multi-column IN subqueries to verify that the
    struct expression support works correctly for both negated (NOT IN)
    and non-negated (IN) cases.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
