### PR TITLE
test(wasmtest): enable compression feature for wasm build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,7 @@ dependencies = [
 name = "datafusion-wasmtest"
 version = "52.0.0"
 dependencies = [
+ "bytes",
  "chrono",
  "console_error_panic_hook",
  "datafusion",
@@ -2673,6 +2674,7 @@ dependencies = [
  "datafusion-optimizer",
  "datafusion-physical-plan",
  "datafusion-sql",
+ "futures",
  "getrandom 0.3.4",
  "object_store",
  "tokio",

--- a/datafusion/wasmtest/Cargo.toml
+++ b/datafusion/wasmtest/Cargo.toml
@@ -59,6 +59,8 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 wasm-bindgen = "0.2.99"
 
 [dev-dependencies]
+bytes = { workspace = true }
+futures = { workspace = true }
 object_store = { workspace = true }
 # needs to be compiled
 tokio = { workspace = true }


### PR DESCRIPTION
  ## Which issue does this PR close?

  - Refs #17509 (Switch from xz2 to liblzma to reduce duplicate dependencies)

  ## Rationale for this change

  Switching from `xz2` to `liblzma` enabled wasm builds (liblzma supports wasm),
  so we can now enable the `compression` feature in wasm tests.

  ## What changes are included in this PR?

  - Add the `compression` feature to the `datafusion` dependency in `datafusion/wasmtest/Cargo.toml`.

  ## Are these changes tested?

  - Verified by CI in this PR.

  ## Are there any user-facing changes?

  - No. (test configuration change only)
