### PR TITLE
Changed clippy.toml and added std hashmap and hashset to disallowed t…

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -5,6 +5,8 @@ disallowed-methods = [
 
 disallowed-types = [
     { path = "std::time::Instant", reason = "Use `datafusion_common::instant::Instant` instead for WASM compatibility" },
+    { path = "std::collections::HashMap", reason = "Use `datafusion_common::HashMap` instead to ensure a single, uniform HashMap implementation (re-exported from hashbrown)" },
+    { path = "std::collections::HashSet", reason = "Use `datafusion_common::HashSet` instead to ensure a single, uniform HashSet implementation (re-exported from hashbrown)" },
 ]
 
 # Lowering the threshold to help prevent stack overflows (default is 16384)


### PR DESCRIPTION
- Closes #19869

This PR updates the Clippy configuration to disallow usage of std::collections::HashMap and std::collections::HashSet across the DataFusion codebase.

The change helps enforce consistent usage of project-preferred HashMap/set implementations, avoiding accidental use of the standard library types.

What changed

Updated clippy. toml to add std::collections::HashMap and std::collections::HashSet to the list of disallowed types.

Ensures new code follows the project’s hashing and performance conventions.

Why

The default Rust HashMap / HashSet use randomized hashing, which may be:

non-deterministic,

sub-optimal for performance-critical paths,

inconsistent with DataFusion’s existing design choices.

Enforcing this at the lint level prevents regressions and improves code consistency for contributors.

Testing

No functional code changes.

CI / Clippy will fail if std::HashMap or std::HashSet are newly introduced.