### PR TITLE
fix: union should retrun error instead of panic when input schema's len different

### DIFF
--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -1091,7 +1091,7 @@ mod tests {
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains(
-                "UnionExec requires all inputs to have the same number of fields"
+                "UnionExec/InterleaveExec requires all inputs to have the same number of fields"
             )
         );
     }


### PR DESCRIPTION

## Which issue does this PR close?

None

## Rationale for this change

current when user self construct a UnionExec that with different schema len, it will panic instead of error

## What changes are included in this PR?

if the input for UnionExec have diffent schema len, return error instead of panic

## Are these changes tested?

yes, add one test case

## Are there any user-facing changes?

