### PR TITLE
export `SessionState::register_catalog_list(...)`

### DIFF
--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -878,11 +878,8 @@ impl SessionState {
         &self.catalog_list
     }
 
-    /// set the catalog list
-    pub(crate) fn register_catalog_list(
-        &mut self,
-        catalog_list: Arc<dyn CatalogProviderList>,
-    ) {
+    /// Set the catalog list
+    pub fn register_catalog_list(&mut self, catalog_list: Arc<dyn CatalogProviderList>) {
         self.catalog_list = catalog_list;
     }
 


### PR DESCRIPTION

## Rationale for this change

In our project we use some base `SessionState` (not managed by `SessionContext`) to implement some DDL operations, dynamically replacing its catalog to an actual one. So it would be good to have this function as a `pub` one. 

## What changes are included in this PR?

Export `SessionState::register_catalog_list(...)` method.
