### PR TITLE
fix: maintain inner list nullability for `array_sort`

### DIFF
--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -2579,16 +2579,16 @@ NULL NULL
 
 # maintains inner nullability
 query ?T
-select column1, arrow_typeof(column1)
-from values (array_sort(arrow_cast([1, 3, 5, -5], 'List(non-null Int32)')));
-----
-[-5, 1, 3, 5] List(non-null Int32)
-
-query ?T
-select column1, arrow_typeof(column1)
-from values (array_sort(arrow_cast([], 'List(non-null Int32)')));
+select array_sort(column1), arrow_typeof(array_sort(column1))
+from values
+  (arrow_cast([], 'List(non-null Int32)')),
+  (arrow_cast(NULL, 'List(non-null Int32)')),
+  (arrow_cast([1, 3, 5, -5], 'List(non-null Int32)'))
+;
 ----
 [] List(non-null Int32)
+NULL List(non-null Int32)
+[-5, 1, 3, 5] List(non-null Int32)
 
 query ?T
 select column1, arrow_typeof(column1)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #19947

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

#17657 introduced a regression since it cloned the inner field in the execution path but in the `return_type` function it still set nullability to true. Fix to ensure we maintain the field of the inner field as is.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change `return_type` to just pass through the input datatype as is.

Also refactor away usage of a null buffer builder in favour of copying the input array null buffer.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added tests.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
