### PR TITLE
perf: Optimize factorial scalar path

### DIFF
--- a/datafusion/functions/src/math/factorial.rs
+++ b/datafusion/functions/src/math/factorial.rs
@@ -144,7 +144,7 @@ const FACTORIALS: [i64; 21] = [
     6402373705728000,
     121645100408832000,
     2432902008176640000,
-];
+]; // if return type changes, this constant needs to be updated accordingly
 
 fn compute_factorial(n: i64) -> Result<i64> {
     if n < 0 {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of https://github.com/apache/datafusion-comet/issues/2986.

## Rationale for this change

The `factorial` function currently converts scalar inputs to arrays before processing. Adding a scalar fast path avoids this overhead and improves performance.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

1. Refactored `invoke_with_args` to use `match` statement for handling both scalar and array inputs
2. Inlined array processing logic, removing `make_scalar_function` usage.

| Type | Before | After | Speedup |
|------|--------|-------|---------|
| **factorial_scalar** | 244 ns | 102 ns | **2.4x** |

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes, covered by existing SLT tests:
- `scalar.slt` lines 461-477
- `math.slt` line 797

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
