### PR TITLE
Change GitHub actions dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,7 +48,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 10
     labels: [auto-dependencies]
   - package-ecosystem: "pip"


### PR DESCRIPTION
Main motivator for this is the `taiki-e` action which has lots of version bumps and subsequently lots of PRs; but also the other actions are weekly only so might as well make them consistent.