### PR TITLE
Speedup statistics_from_parquet_metadata

### DIFF
--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -488,6 +488,7 @@ fn summarize_min_max_null_counts(
     if let Some(max_acc) = &mut accumulators.max_accs[logical_schema_index] {
         max_acc.update_batch(&[Arc::clone(&max_values)])?;
 
+        // handle the common special case when all row groups have exact statistics
         let exactness = &is_max_value_exact_stat;
         if !exactness.is_empty()
             && exactness.null_count() == 0
@@ -506,6 +507,7 @@ fn summarize_min_max_null_counts(
     if let Some(min_acc) = &mut accumulators.min_accs[logical_schema_index] {
         min_acc.update_batch(&[Arc::clone(&min_values)])?;
 
+        // handle the common special case when all row groups have exact statistics
         let exactness = &is_min_value_exact_stat;
         if !exactness.is_empty()
             && exactness.null_count() == 0


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #20005

PR:
```
SELECT COUNT(*) FROM hits WHERE "AdvEngineID" <> 0;

Query 1 iteration 0 took 30.5 ms and returned 1 rows
Query 1 avg time: 30.48 ms
```

Main:

```
SELECT COUNT(*) FROM hits WHERE "AdvEngineID" <> 0;

Query 1 iteration 0 took 39.6 ms and returned 1 rows
Query 1 avg time: 39.61 ms
```

## Rationale for this change

Improving cold starts.

## What changes are included in this PR?

## Are these changes tested?

Existing tests

## Are there any user-facing changes?

No