### PR TITLE
Rewrite physical expressions in execution plans

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2780,6 +2780,15 @@ impl DefaultPhysicalPlanner {
         // to verify that the plan is executable.
         InvariantChecker(InvariantLevel::Executable).check(&new_plan)?;
 
+        #[cfg(debug_assertions)]
+        {
+            use datafusion_physical_plan::execution_plan::check_physical_expressions;
+            new_plan.apply(|p| {
+                check_physical_expressions(Arc::clone(p))?;
+                Ok(TreeNodeRecursion::Continue)
+            })?;
+        }
+
         debug!(
             "Optimized physical plan:\n{}\n",
             displayable(new_plan.as_ref()).indent(false)

--- a/datafusion/core/tests/physical_optimizer/pushdown_utils.rs
+++ b/datafusion/core/tests/physical_optimizer/pushdown_utils.rs
@@ -156,6 +156,16 @@ impl FileSource for TestSource {
         })
     }
 
+    fn with_filter_and_projection(
+        &self,
+        filter: Option<Arc<dyn PhysicalExpr>>,
+        _projection: ProjectionExprs,
+    ) -> Result<Option<Arc<dyn FileSource>>> {
+        let mut conf = self.clone();
+        conf.predicate = filter;
+        Ok(Some(Arc::new(conf)))
+    }
+
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.metrics
     }

--- a/datafusion/datasource-arrow/src/source.rs
+++ b/datafusion/datasource-arrow/src/source.rs
@@ -38,6 +38,7 @@ use datafusion_datasource::{TableSchema, as_file_source};
 
 use arrow::buffer::Buffer;
 use arrow::ipc::reader::{FileDecoder, FileReader, StreamReader};
+use datafusion_common::assert_or_internal_err;
 use datafusion_common::error::Result;
 use datafusion_common::exec_datafusion_err;
 use datafusion_common::tree_node::TreeNodeRecursion;
@@ -51,6 +52,7 @@ use datafusion_physical_plan::projection::ProjectionExprs;
 
 use datafusion_datasource::file_stream::FileOpenFuture;
 use datafusion_datasource::file_stream::FileOpener;
+use datafusion_physical_plan::PhysicalExpr;
 use futures::StreamExt;
 use itertools::Itertools;
 use object_store::{GetOptions, GetRange, GetResultPayload, ObjectStore, ObjectStoreExt};
@@ -400,9 +402,7 @@ impl FileSource for ArrowSource {
 
     fn apply_expressions(
         &self,
-        f: &mut dyn FnMut(
-            &dyn datafusion_physical_plan::PhysicalExpr,
-        ) -> Result<TreeNodeRecursion>,
+        f: &mut dyn FnMut(&dyn PhysicalExpr) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
         // Visit projection expressions
         let mut tnr = TreeNodeRecursion::Continue;
@@ -410,6 +410,20 @@ impl FileSource for ArrowSource {
             tnr = tnr.visit_sibling(|| f(proj_expr.expr.as_ref()))?;
         }
         Ok(tnr)
+    }
+
+    fn with_filter_and_projection(
+        &self,
+        filter: Option<Arc<dyn PhysicalExpr>>,
+        projection: ProjectionExprs,
+    ) -> Result<Option<Arc<dyn FileSource>>> {
+        assert_or_internal_err!(filter.is_none(), "filter should not be defined");
+
+        let mut conf = self.clone();
+        conf.projection =
+            SplitProjection::new(self.table_schema.file_schema(), &projection);
+
+        Ok(Some(Arc::new(conf)))
     }
 }
 

--- a/datafusion/datasource-avro/src/source.rs
+++ b/datafusion/datasource-avro/src/source.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use crate::avro_to_arrow::Reader as AvroReader;
 
+use datafusion_common::assert_or_internal_err;
 use datafusion_common::error::Result;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_datasource::TableSchema;
@@ -33,6 +34,7 @@ use datafusion_physical_expr_common::sort_expr::LexOrdering;
 use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion_physical_plan::projection::ProjectionExprs;
 
+use datafusion_physical_plan::PhysicalExpr;
 use object_store::ObjectStore;
 
 /// AvroSource holds the extra configuration that is necessary for opening avro files
@@ -123,6 +125,20 @@ impl FileSource for AvroSource {
         Some(&self.projection.source)
     }
 
+    fn with_filter_and_projection(
+        &self,
+        filter: Option<Arc<dyn PhysicalExpr>>,
+        projection: ProjectionExprs,
+    ) -> Result<Option<Arc<dyn FileSource>>> {
+        assert_or_internal_err!(filter.is_none(), "filter should not be defined");
+
+        let mut conf = self.clone();
+        conf.projection =
+            SplitProjection::new(self.table_schema.file_schema(), &projection);
+
+        Ok(Some(Arc::new(conf)))
+    }
+
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.metrics
     }
@@ -143,9 +159,7 @@ impl FileSource for AvroSource {
 
     fn apply_expressions(
         &self,
-        f: &mut dyn FnMut(
-            &dyn datafusion_physical_plan::PhysicalExpr,
-        ) -> Result<TreeNodeRecursion>,
+        f: &mut dyn FnMut(&dyn PhysicalExpr) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
         // Visit projection expressions
         let mut tnr = TreeNodeRecursion::Continue;

--- a/datafusion/datasource-csv/src/source.rs
+++ b/datafusion/datasource-csv/src/source.rs
@@ -36,14 +36,14 @@ use datafusion_datasource::{
 use arrow::csv;
 use datafusion_common::config::CsvOptions;
 use datafusion_common::tree_node::TreeNodeRecursion;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result, assert_or_internal_err};
 use datafusion_common_runtime::JoinSet;
 use datafusion_datasource::file::FileSource;
 use datafusion_datasource::file_scan_config::FileScanConfig;
 use datafusion_execution::TaskContext;
 use datafusion_physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet};
 use datafusion_physical_plan::{
-    DisplayFormatType, ExecutionPlan, ExecutionPlanProperties,
+    DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PhysicalExpr,
 };
 
 use crate::file_format::CsvDecoder;
@@ -293,6 +293,20 @@ impl FileSource for CsvSource {
         Some(&self.projection.source)
     }
 
+    fn with_filter_and_projection(
+        &self,
+        filter: Option<Arc<dyn PhysicalExpr>>,
+        projection: ProjectionExprs,
+    ) -> Result<Option<Arc<dyn FileSource>>> {
+        assert_or_internal_err!(filter.is_none(), "filter should not be defined");
+
+        let mut conf = self.clone();
+        conf.projection =
+            SplitProjection::new(self.table_schema.file_schema(), &projection);
+
+        Ok(Some(Arc::new(conf)))
+    }
+
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.metrics
     }
@@ -318,9 +332,7 @@ impl FileSource for CsvSource {
 
     fn apply_expressions(
         &self,
-        f: &mut dyn FnMut(
-            &dyn datafusion_physical_plan::PhysicalExpr,
-        ) -> Result<TreeNodeRecursion>,
+        f: &mut dyn FnMut(&dyn PhysicalExpr) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
         // Visit projection expressions
         let mut tnr = TreeNodeRecursion::Continue;

--- a/datafusion/datasource-json/src/source.rs
+++ b/datafusion/datasource-json/src/source.rs
@@ -26,6 +26,7 @@ use std::task::{Context, Poll};
 use crate::file_format::JsonDecoder;
 use crate::utils::{ChannelReader, JsonArrayToNdjsonReader};
 
+use datafusion_common::assert_or_internal_err;
 use datafusion_common::error::{DataFusionError, Result};
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common_runtime::{JoinSet, SpawnedTask};
@@ -37,7 +38,7 @@ use datafusion_datasource::{
     ListingTableUrl, PartitionedFile, RangeCalculation, as_file_source, calculate_range,
 };
 use datafusion_physical_plan::projection::ProjectionExprs;
-use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties, PhysicalExpr};
 
 use arrow::array::RecordBatch;
 use arrow::json::ReaderBuilder;
@@ -230,6 +231,20 @@ impl FileSource for JsonSource {
         Some(&self.projection.source)
     }
 
+    fn with_filter_and_projection(
+        &self,
+        filter: Option<Arc<dyn PhysicalExpr>>,
+        projection: ProjectionExprs,
+    ) -> Result<Option<Arc<dyn FileSource>>> {
+        assert_or_internal_err!(filter.is_none(), "filter should not be defined");
+
+        let mut conf = self.clone();
+        conf.projection =
+            SplitProjection::new(self.table_schema.file_schema(), &projection);
+
+        Ok(Some(Arc::new(conf)))
+    }
+
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.metrics
     }
@@ -240,9 +255,7 @@ impl FileSource for JsonSource {
 
     fn apply_expressions(
         &self,
-        f: &mut dyn FnMut(
-            &dyn datafusion_physical_plan::PhysicalExpr,
-        ) -> Result<TreeNodeRecursion>,
+        f: &mut dyn FnMut(&dyn PhysicalExpr) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
         // Visit projection expressions
         let mut tnr = TreeNodeRecursion::Continue;

--- a/datafusion/datasource-parquet/src/source.rs
+++ b/datafusion/datasource-parquet/src/source.rs
@@ -604,6 +604,17 @@ impl FileSource for ParquetSource {
         Some(&self.projection)
     }
 
+    fn with_filter_and_projection(
+        &self,
+        filter: Option<Arc<dyn PhysicalExpr>>,
+        projection: ProjectionExprs,
+    ) -> datafusion_common::Result<Option<Arc<dyn FileSource>>> {
+        let mut conf = self.clone();
+        conf.predicate = filter;
+        conf.projection = projection;
+        Ok(Some(Arc::new(conf)))
+    }
+
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.metrics
     }

--- a/datafusion/datasource/src/file.rs
+++ b/datafusion/datasource/src/file.rs
@@ -104,6 +104,21 @@ pub trait FileSource: Send + Sync {
         None
     }
 
+    /// Returns new file source with given filter and projection.
+    ///
+    /// This method is primarily used during physical plan rewriting (in
+    /// `ExecutionPlan::with_physical_expressions`) to update the expressions within a file source.
+    ///
+    /// It should NOT be used to pass in projections or filters. That pushdown is handled by
+    /// optimizer rules.
+    fn with_filter_and_projection(
+        &self,
+        _filter: Option<Arc<dyn PhysicalExpr>>,
+        _projection: ProjectionExprs,
+    ) -> Result<Option<Arc<dyn FileSource>>> {
+        Ok(None)
+    }
+
     /// Return execution plan metrics
     fn metrics(&self) -> &ExecutionPlanMetricsSet;
 

--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -29,7 +29,8 @@ use arrow::datatypes::{DataType, Schema, SchemaRef};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{
-    Constraints, Result, ScalarValue, Statistics, internal_datafusion_err, internal_err,
+    Constraints, Result, ScalarValue, Statistics, assert_eq_or_internal_err,
+    internal_datafusion_err, internal_err,
 };
 use datafusion_execution::{
     SendableRecordBatchStream, TaskContext, object_store::ObjectStoreUrl,
@@ -38,7 +39,7 @@ use datafusion_expr::Operator;
 
 use datafusion_physical_expr::equivalence::project_orderings;
 use datafusion_physical_expr::expressions::{BinaryExpr, Column};
-use datafusion_physical_expr::projection::ProjectionExprs;
+use datafusion_physical_expr::projection::{ProjectionExpr, ProjectionExprs};
 use datafusion_physical_expr::utils::reassign_expr_columns;
 use datafusion_physical_expr::{EquivalenceProperties, Partitioning, split_conjunction};
 use datafusion_physical_expr_adapter::PhysicalExprAdapterFactory;
@@ -46,7 +47,7 @@ use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
 use datafusion_physical_plan::SortOrderPushdownResult;
 use datafusion_physical_plan::coop::cooperative;
-use datafusion_physical_plan::execution_plan::SchedulingType;
+use datafusion_physical_plan::execution_plan::{ReplacePhysicalExpr, SchedulingType};
 use datafusion_physical_plan::{
     DisplayAs, DisplayFormatType,
     display::{ProjectSchemaDisplay, display_orderings},
@@ -940,6 +941,75 @@ impl DataSource for FileScanConfig {
     ) -> Result<TreeNodeRecursion> {
         // Delegate to the file source
         self.file_source.apply_expressions(f)
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        let filter = self.file_source.filter().into_iter();
+        let projection = self
+            .file_source
+            .projection()
+            .into_iter()
+            .flat_map(|p| p.expr_iter());
+
+        Some(Box::new(filter.chain(projection)))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn DataSource>>> {
+        let filter_count = self.file_source.filter().iter().len();
+        let projection_count = self
+            .file_source
+            .projection()
+            .map(|p| p.expr_iter().count())
+            .unwrap_or(0);
+
+        let expected_count = filter_count + projection_count;
+        let exprs_count = params.exprs.len();
+
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for FileScanConfig",
+        );
+
+        let mut filter = None;
+        let mut projection = vec![];
+        let mut expr_iter = params.exprs.into_iter();
+
+        if filter_count > 0 {
+            filter = expr_iter.next();
+        }
+
+        if projection_count > 0 {
+            projection = self
+                .file_source
+                .projection()
+                .expect("should have expressions")
+                .iter()
+                .zip(expr_iter)
+                .map(|(p, expr)| ProjectionExpr::new(expr, p.alias.clone()))
+                .collect();
+        }
+
+        let file_source = self
+            .file_source
+            .with_filter_and_projection(filter, projection.into())?;
+
+        match file_source {
+            Some(file_source) => {
+                let conf_builder: FileScanConfigBuilder = self.clone().into();
+                Ok(Some(Arc::new(
+                    conf_builder.with_source(file_source).build(),
+                )))
+            }
+            None => {
+                internal_err!("file source is not rebuilt")
+            }
+        }
     }
 }
 

--- a/datafusion/datasource/src/source.rs
+++ b/datafusion/datasource/src/source.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use datafusion_physical_expr::projection::ProjectionExprs;
 use datafusion_physical_plan::execution_plan::{
-    Boundedness, EmissionType, SchedulingType,
+    Boundedness, EmissionType, ReplacePhysicalExpr, SchedulingType,
 };
 use datafusion_physical_plan::metrics::SplitMetrics;
 use datafusion_physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
@@ -244,6 +244,39 @@ pub trait DataSource: Send + Sync + Debug {
     ) -> Option<Arc<dyn DataSource>> {
         None
     }
+
+    /// Returns an iterator over a subset of [`PhysicalExpr`]s that are used by this [`DataSource`].
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        None
+    }
+
+    /// Returns a new [`DataSource`] with its physical expressions replaced by the provided
+    /// `exprs`.
+    ///
+    /// By default, this method creates a full clone except for physical expressions, and
+    /// does not recompute properties.
+    ///
+    /// # Constraints
+    ///
+    /// * The number of expressions in `exprs` must match the number of expressions returned by
+    ///   [`DataSource::physical_expressions`].
+    /// * The order of expressions in `exprs` must match the order they were yielded by the
+    ///   iterator from [`DataSource::physical_expressions`].
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(new_source))` if the expressions were successfully replaced.
+    /// * `Ok(None)` if the source does not support replacing its expressions (the default).
+    /// * `Err` if the number of expressions is incorrect or if another error occurs during
+    ///   replacement.
+    fn with_physical_expressions(
+        &self,
+        _params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn DataSource>>> {
+        Ok(None)
+    }
 }
 
 /// [`ExecutionPlan`] that reads one or more files
@@ -459,6 +492,23 @@ impl ExecutionPlan for DataSourceExec {
                 Arc::new(self.clone().with_data_source(new_data_source))
                     as Arc<dyn ExecutionPlan>
             })
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        self.data_source.physical_expressions()
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        if let Some(source) = self.data_source.with_physical_expressions(params)? {
+            Ok(Some(Arc::new(self.clone().with_data_source(source))))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/datafusion/datasource/src/test_util.rs
+++ b/datafusion/datasource/src/test_util.rs
@@ -84,6 +84,21 @@ impl FileSource for MockSource {
         self.filter.clone()
     }
 
+    fn with_filter_and_projection(
+        &self,
+        filter: Option<Arc<dyn PhysicalExpr>>,
+        projection: datafusion_physical_plan::projection::ProjectionExprs,
+    ) -> Result<Option<Arc<dyn FileSource>>> {
+        let mut conf = self.clone();
+        conf.filter = filter;
+        conf.projection = crate::projection::SplitProjection::new(
+            self.table_schema.file_schema(),
+            &projection,
+        );
+
+        Ok(Some(Arc::new(conf)))
+    }
+
     fn with_batch_size(&self, _batch_size: usize) -> Arc<dyn FileSource> {
         Arc::new(Self { ..self.clone() })
     }

--- a/datafusion/physical-expr/src/aggregate.rs
+++ b/datafusion/physical-expr/src/aggregate.rs
@@ -662,7 +662,7 @@ impl AggregateFunctionExpr {
             ignore_nulls: self.ignore_nulls,
             ordering_fields: self.ordering_fields.clone(),
             is_distinct: self.is_distinct,
-            is_reversed: false,
+            is_reversed: self.is_reversed,
             input_fields: self.input_fields.clone(),
             is_nullable: self.is_nullable,
         })

--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -531,9 +531,21 @@ impl ProjectionExprs {
     /// with the given projection expressions.
     /// For example, if an expression only works with integer columns but the input schema has a string column at that index.
     pub fn make_projector(&self, input_schema: &Schema) -> Result<Projector> {
+        self.clone().into_projector(input_schema)
+    }
+
+    /// Create a new [`Projector`] by consuming projection expressions.
+    ///
+    /// A [`Projector`] can be used to apply this projection to record batches.
+    ///
+    /// # Errors
+    /// This function returns an error if the output schema cannot be constructed from the input schema
+    /// with the given projection expressions.
+    /// For example, if an expression only works with integer columns but the input schema has a string column at that index.
+    pub fn into_projector(self, input_schema: &Schema) -> Result<Projector> {
         let output_schema = Arc::new(self.project_schema(input_schema)?);
         Ok(Projector {
-            projection: self.clone(),
+            projection: self,
             output_schema,
             expression_metrics: None,
         })

--- a/datafusion/physical-expr/src/window/sliding_aggregate.rs
+++ b/datafusion/physical-expr/src/window/sliding_aggregate.rs
@@ -31,7 +31,7 @@ use crate::{PhysicalExpr, expressions::PhysicalSortExpr};
 use arrow::array::{ArrayRef, BooleanArray};
 use arrow::datatypes::FieldRef;
 use arrow::record_batch::RecordBatch;
-use datafusion_common::{Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue, assert_eq_or_internal_err};
 use datafusion_expr::{Accumulator, WindowFrame};
 
 /// A window expr that takes the form of an aggregate function that
@@ -184,6 +184,95 @@ impl WindowExpr for SlidingAggregateWindowExpr {
 
     fn create_window_fn(&self) -> Result<WindowFn> {
         Ok(WindowFn::Aggregate(self.get_accumulator()?))
+    }
+
+    fn inner_expressions_count(&self) -> usize {
+        let aggregate_args_count = self.aggregate.expressions().len();
+        let aggregate_order_by_count = self.aggregate.order_bys().len();
+        let partition_by_count = self.partition_by.len();
+        let order_by_count = self.order_by.len();
+        let filter_count = self.filter.iter().len();
+
+        aggregate_args_count
+            + aggregate_order_by_count
+            + partition_by_count
+            + order_by_count
+            + filter_count
+    }
+
+    fn inner_expressions_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a> {
+        let aggregate_args = self.aggregate.expressions().into_iter();
+        let aggregate_order_by = self
+            .aggregate
+            .order_bys()
+            .iter()
+            .map(|sort| Arc::clone(&sort.expr));
+
+        let partition_by = self.partition_by.iter().cloned();
+        let order_by = self.order_by.iter().map(|sort| Arc::clone(&sort.expr));
+        let filter = self.filter.iter().cloned();
+
+        Box::new(
+            aggregate_args
+                .chain(aggregate_order_by)
+                .chain(partition_by)
+                .chain(order_by)
+                .chain(filter),
+        )
+    }
+
+    fn with_inner_expressions(
+        &self,
+        exprs: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn WindowExpr>> {
+        let aggregate_args_count = self.aggregate.expressions().len();
+        let aggregate_order_by_count = self.aggregate.order_bys().len();
+        let partition_by_count = self.partition_by.len();
+        let order_by_count = self.order_by.len();
+        let filter_count = self.filter.iter().len();
+
+        let expected_count = aggregate_args_count
+            + aggregate_order_by_count
+            + partition_by_count
+            + order_by_count
+            + filter_count;
+
+        let exprs_count = exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for SlidingAggregateWindowExpr",
+        );
+
+        let mut exprs_iter = exprs.into_iter();
+        let aggregate_args = exprs_iter.by_ref().take(aggregate_args_count).collect();
+        let aggregate_order_by =
+            exprs_iter.by_ref().take(aggregate_order_by_count).collect();
+        let aggregate = Arc::new(
+            self.aggregate
+                .with_new_expressions(aggregate_args, aggregate_order_by)
+                .expect("should rewrite"),
+        );
+
+        let partition_by = exprs_iter.by_ref().take(partition_by_count).collect();
+        let order_by = self
+            .order_by
+            .iter()
+            .zip(&mut exprs_iter)
+            .map(|(sort, expr)| PhysicalSortExpr::new(expr, sort.options))
+            .collect::<Vec<_>>();
+
+        let filter = exprs_iter.next();
+
+        Ok(Arc::new(Self {
+            aggregate,
+            partition_by,
+            order_by,
+            window_frame: Arc::clone(&self.window_frame),
+            filter,
+        }))
     }
 }
 

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -164,6 +164,38 @@ pub trait WindowExpr: Send + Sync + Debug {
     ) -> Option<Arc<dyn WindowExpr>> {
         None
     }
+
+    /// Returns the total count of a subset of inner expressions used in this window expression.
+    ///
+    /// This count corresponds to the number of expressions that would be returned by
+    /// [`WindowExpr::inner_expressions_iter`].
+    ///
+    /// Note: This count may differ from the count of expressions returned by
+    /// [`WindowExpr::all_expressions`].
+    fn inner_expressions_count(&self) -> usize {
+        self.inner_expressions_iter().count()
+    }
+
+    /// Returns an iterator over a subset of inner expressions used in this window expression.
+    ///
+    /// Note: Implementations may return a different set of expressions than those returned by
+    /// [`WindowExpr::all_expressions`]. This method must be consistent with
+    /// [`WindowExpr::with_inner_expressions`] in that
+    /// `expr.with_inner_expressions(&expr.inner_expressions_iter().collect())` should return an
+    /// instance with the same expressions as the initial one.
+    fn inner_expressions_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>;
+
+    /// Replaces the expressions in this window expression with new ones.
+    ///
+    /// This method allows for rewriting the window expression with different physical expressions.
+    /// The number of expressions provided should match the count returned by
+    /// [`WindowExpr::inner_expressions_count`].
+    fn with_inner_expressions(
+        &self,
+        _exprs: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn WindowExpr>>;
 }
 
 /// Stores the physical expressions used inside the `WindowExpr`.

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -25,7 +25,7 @@ use crate::aggregates::{
     no_grouping::AggregateStream, row_hash::GroupedHashAggregateStream,
     topk_stream::GroupedTopKAggregateStream,
 };
-use crate::execution_plan::{CardinalityEffect, EmissionType};
+use crate::execution_plan::{CardinalityEffect, EmissionType, ReplacePhysicalExpr};
 use crate::filter_pushdown::{
     ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
     FilterPushdownPropagation, PushedDownPredicate,
@@ -1596,6 +1596,110 @@ impl ExecutionPlan for AggregateExec {
         }
 
         Ok(result)
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        let group_by_expr = self.group_by.expr.iter().map(|pair| Arc::clone(&pair.0));
+        let group_by_null_expr = self
+            .group_by
+            .null_expr
+            .iter()
+            .map(|pair| Arc::clone(&pair.0));
+        let aggr_expr = self.aggr_expr.iter().flat_map(|expr| {
+            expr.expressions()
+                .into_iter()
+                .chain(expr.order_bys().iter().map(|sort| Arc::clone(&sort.expr)))
+        });
+        let filter_exprs = self.filter_expr.iter().flatten().cloned();
+
+        Some(Box::new(
+            group_by_expr
+                .chain(group_by_null_expr)
+                .chain(aggr_expr)
+                .chain(filter_exprs),
+        ))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let group_by_expr_count = self.group_by.expr.len();
+        let group_by_null_expr_count = self.group_by.null_expr.len();
+        let aggr_expr_count = self
+            .aggr_expr
+            .iter()
+            .map(|aggr| aggr.order_bys().len() + aggr.expressions().len())
+            .sum::<usize>();
+        let filter_expr_count = self.filter_expr.iter().filter(|f| f.is_some()).count();
+
+        let expected_count = group_by_expr_count
+            + group_by_null_expr_count
+            + aggr_expr_count
+            + filter_expr_count;
+
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let mut exprs_iter = params.exprs.into_iter();
+        let group_by_expr = self
+            .group_by
+            .expr
+            .iter()
+            .zip(&mut exprs_iter)
+            .map(|(group_by, expr)| (expr, group_by.1.clone()))
+            .collect();
+
+        let group_by_null_expr = self
+            .group_by
+            .null_expr
+            .iter()
+            .zip(&mut exprs_iter)
+            .map(|(group_by, expr)| (expr, group_by.1.clone()))
+            .collect();
+
+        let group_by = PhysicalGroupBy::new(
+            group_by_expr,
+            group_by_null_expr,
+            self.group_by.groups.clone(),
+            self.group_by.has_grouping_set,
+        );
+
+        let mut aggr_expr = Vec::with_capacity(self.aggr_expr.len());
+        for expr in self.aggr_expr.iter() {
+            let args_count = expr.expressions().len();
+            let order_by_count = expr.order_bys().len();
+            let args = exprs_iter.by_ref().take(args_count).collect();
+            let order_by = exprs_iter.by_ref().take(order_by_count).collect();
+
+            let new_expr = expr
+                .with_new_expressions(args, order_by)
+                .expect("should rewrite");
+
+            aggr_expr.push(Arc::new(new_expr));
+        }
+
+        let mut filter_expr = Vec::with_capacity(self.filter_expr.len());
+        for expr in self.filter_expr.iter() {
+            let new_filter_expr = expr.as_ref().and_then(|_| exprs_iter.next());
+            filter_expr.push(new_filter_expr);
+        }
+
+        Ok(Some(Arc::new(Self {
+            group_by: Arc::new(group_by),
+            aggr_expr: aggr_expr.into(),
+            filter_expr: filter_expr.into(),
+            dynamic_filter: None,
+            metrics: ExecutionPlanMetricsSet::new(),
+            ..self.clone()
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -279,7 +279,13 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
     fn apply_expressions(
         &self,
         f: &mut dyn FnMut(&dyn PhysicalExpr) -> Result<TreeNodeRecursion>,
-    ) -> Result<TreeNodeRecursion>;
+    ) -> Result<TreeNodeRecursion> {
+        let mut tnr = TreeNodeRecursion::Continue;
+        for expr in self.physical_expressions().unwrap() {
+            tnr = tnr.visit_sibling(|| f(expr.as_ref()))?;
+        }
+        Ok(tnr)
+    }
 
     /// Returns a new `ExecutionPlan` where all existing children were replaced
     /// by the `children`, in order
@@ -793,6 +799,51 @@ pub trait ExecutionPlan: Debug + DisplayAs + Send + Sync {
     ) -> Option<Arc<dyn ExecutionPlan>> {
         None
     }
+
+    /// Returns an iterator over a subset of [`PhysicalExpr`]s that are used by this
+    /// [`ExecutionPlan`].
+    ///
+    /// This method provides a way to inspect the physical expressions within a node without
+    /// knowing its specific type. These expressions could be predicates in a filter, projection
+    /// expressions, or join conditions, etc.
+    ///
+    /// The default implementation returns `None`, indicating that the node either has no physical
+    /// expressions or does not support exposing them.
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        None
+    }
+
+    /// Returns a new `ExecutionPlan` with its physical expressions replaced by the provided
+    /// `exprs`.
+    ///
+    /// This method is the counterpart to [`ExecutionPlan::physical_expressions`]. It allows
+    /// transforming the expressions within a node while preserving the node itself and its
+    /// children.
+    ///
+    /// By default, the behavior of this method is similar to [`ExecutionPlan::reset_state`] in the
+    /// sense that it also resets the internal state of [`ExecutionPlan`].
+    ///
+    /// # Constraints
+    ///
+    /// * The number of expressions in `params.exprs` must match the number of expressions returned
+    ///   by [`ExecutionPlan::physical_expressions`].
+    /// * The order of expressions in `params.exprs` must match the order they were yielded by the
+    ///   iterator from [`ExecutionPlan::physical_expressions`].
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(new_plan))` if the expressions were successfully replaced.
+    /// * `Ok(None)` if the node does not support replacing its expressions (the default).
+    /// * `Err` if the number of expressions is incorrect or if another error occurs during
+    ///   replacement.
+    fn with_physical_expressions(
+        &self,
+        _params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
 }
 
 /// [`ExecutionPlan`] Invariant Level
@@ -1202,6 +1253,28 @@ impl PlanProperties {
     }
 }
 
+/// Parameters for [`ExecutionPlan::with_physical_expressions`]
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct ReplacePhysicalExpr {
+    /// Input physical expressisons
+    pub exprs: Vec<Arc<dyn PhysicalExpr>>,
+    // We can add recompute_properties: bool here in the future
+}
+
+impl ReplacePhysicalExpr {
+    /// Create a new [`ReplacePhysicalExpr`]
+    pub fn new(exprs: Vec<Arc<dyn PhysicalExpr>>) -> Self {
+        Self { exprs }
+    }
+}
+
+impl From<Vec<Arc<dyn PhysicalExpr>>> for ReplacePhysicalExpr {
+    fn from(exprs: Vec<Arc<dyn PhysicalExpr>>) -> Self {
+        Self::new(exprs)
+    }
+}
+
 macro_rules! check_len {
     ($target:expr, $func_name:ident, $expected_len:expr) => {
         let actual_len = $target.$func_name().len();
@@ -1231,6 +1304,73 @@ pub fn check_default_invariants<P: ExecutionPlan + ?Sized>(
     check_len!(plan, benefits_from_input_partitioning, children_len);
 
     Ok(())
+}
+
+/// Verifies that the [`ExecutionPlan::physical_expressions`] and
+/// [`ExecutionPlan::with_physical_expressions`] implementations are consistent.
+///
+/// It verifies:
+/// 1. `with_physical_expressions` with the same expressions returns a plan with the same expressions.
+/// 2. `with_physical_expressions` with a different number of expressions returns an error.
+///
+/// Returns rewritten plan if it supported expression replacement.
+pub fn check_physical_expressions(
+    plan: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let Some(exprs) = plan.physical_expressions() else {
+        if let Some(new_plan) = plan.with_physical_expressions(vec![].into())? {
+            assert_or_internal_err!(
+                plan.physical_expressions().is_none(),
+                "plan.physical_expressions() should return None if it initially returned None, \
+                and we try to rebuild the plan with an empty list of physical expressions"
+            );
+
+            let new_expr = Arc::new(expressions::Column::new("", 0)) as Arc<_>;
+            let result = plan.with_physical_expressions(vec![new_expr].into());
+            assert_or_internal_err!(
+                result.is_err(),
+                "plan.with_physical_expressions() should return error if expressions length doesn't match"
+            );
+
+            return Ok(new_plan);
+        };
+
+        return Ok(plan);
+    };
+
+    let mut exprs = exprs.collect::<Vec<_>>();
+
+    let new_plan = plan
+        .with_physical_expressions(exprs.clone().into())?
+        .unwrap();
+    let new_plan_exprs = new_plan.physical_expressions().unwrap();
+
+    assert_or_internal_err!(
+        exprs.iter().cloned().eq(new_plan_exprs),
+        "plan.with_physical_expressions() should return plan with same expressions"
+    );
+
+    let new_expr = Arc::new(expressions::Column::new("", 0));
+    exprs.push(new_expr);
+
+    let result = new_plan.with_physical_expressions(exprs.clone().into());
+    assert_or_internal_err!(
+        result.is_err(),
+        "plan.with_physical_expressions() should return error if expressions length doesn't match"
+    );
+
+    if exprs.len() > 2 {
+        exprs.pop().unwrap();
+        exprs.pop().unwrap();
+
+        let result = new_plan.with_physical_expressions(exprs.into());
+        assert_or_internal_err!(
+            result.is_err(),
+            "plan.with_physical_expressions() should return error if expressions length doesn't match"
+        );
+    }
+
+    Ok(new_plan)
 }
 
 /// Indicate whether a data exchange is needed for the input of `plan`, which will be very helpful

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -30,7 +30,7 @@ use super::{
 use crate::check_if_same_properties;
 use crate::coalesce::{LimitedBatchCoalescer, PushBatchStatus};
 use crate::common::can_project;
-use crate::execution_plan::CardinalityEffect;
+use crate::execution_plan::{CardinalityEffect, ReplacePhysicalExpr};
 use crate::filter_pushdown::{
     ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
     FilterPushdownPropagation, PushedDown,
@@ -53,7 +53,8 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::stats::Precision;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{
-    DataFusionError, Result, ScalarValue, internal_err, plan_err, project_schema,
+    DataFusionError, Result, ScalarValue, assert_eq_or_internal_err, internal_err,
+    plan_err, project_schema,
 };
 use datafusion_execution::TaskContext;
 use datafusion_expr::Operator;
@@ -775,6 +776,32 @@ impl ExecutionPlan for FilterExec {
                     .with_new_children(vec![new_input])
                     .ok()
             })
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        Some(Box::new(std::iter::once(Arc::clone(&self.predicate))))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        mut params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            exprs_count,
+            1,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let predicate = params.exprs.pop().unwrap();
+        Ok(Some(Arc::new(Self {
+            predicate,
+            metrics: ExecutionPlanMetricsSet::new(),
+            ..self.clone()
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -23,7 +23,9 @@ use std::sync::{Arc, OnceLock};
 use std::{any::Any, vec};
 
 use crate::ExecutionPlanProperties;
-use crate::execution_plan::{EmissionType, boundedness_from_children, stub_properties};
+use crate::execution_plan::{
+    EmissionType, ReplacePhysicalExpr, boundedness_from_children, stub_properties,
+};
 use crate::filter_pushdown::{
     ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
     FilterPushdownPropagation,
@@ -72,8 +74,8 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::utils::memory::estimate_memory_size;
 use datafusion_common::{
-    JoinSide, JoinType, NullEquality, Result, assert_or_internal_err, internal_err,
-    plan_err, project_schema,
+    JoinSide, JoinType, NullEquality, Result, assert_eq_or_internal_err,
+    assert_or_internal_err, internal_err, plan_err, project_schema,
 };
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
@@ -1709,6 +1711,58 @@ impl ExecutionPlan for HashJoinExec {
             .build()
             .ok()
             .map(|exec| Arc::new(exec) as _)
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        self.filter
+            .as_ref()
+            .map(|f| Box::new(std::iter::once(Arc::clone(&f.expression))) as Box<_>)
+    }
+
+    fn with_physical_expressions(
+        &self,
+        mut params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let expected_count = self.filter.iter().len();
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let filter = self
+            .filter
+            .as_ref()
+            .zip(params.exprs.pop())
+            .map(|(f, expr)| {
+                JoinFilter::new(expr, f.column_indices.clone(), Arc::clone(&f.schema))
+            });
+
+        Ok(Some(Arc::new(Self {
+            left: Arc::clone(&self.left),
+            right: Arc::clone(&self.right),
+            on: self.on.clone(),
+            filter,
+            join_type: self.join_type,
+            join_schema: Arc::clone(&self.join_schema),
+            // Reset the left_fut to allow re-execution
+            left_fut: Arc::new(OnceAsync::default()),
+            random_state: self.random_state.clone(),
+            mode: self.mode,
+            metrics: ExecutionPlanMetricsSet::new(),
+            projection: self.projection.clone(),
+            column_indices: self.column_indices.clone(),
+            null_equality: self.null_equality,
+            null_aware: self.null_aware,
+            cache: Arc::clone(&self.cache),
+            fetch: self.fetch,
+            // Reset dynamic filter and bounds accumulator to initial state
+            dynamic_filter: None,
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -29,7 +29,9 @@ use super::utils::{
     reorder_output_after_swap, swap_join_projection,
 };
 use crate::common::can_project;
-use crate::execution_plan::{EmissionType, boundedness_from_children};
+use crate::execution_plan::{
+    EmissionType, ReplacePhysicalExpr, boundedness_from_children,
+};
 use crate::joins::SharedBitmapBuilder;
 use crate::joins::utils::{
     BuildProbeJoinMetrics, ColumnIndex, JoinFilter, OnceAsync, OnceFut,
@@ -73,7 +75,10 @@ use datafusion_physical_expr::equivalence::{
     ProjectionMapping, join_equivalence_properties,
 };
 
-use datafusion_physical_expr::projection::{ProjectionRef, combine_projections};
+use datafusion_physical_expr::{
+    PhysicalExpr,
+    projection::{ProjectionRef, combine_projections},
+};
 use futures::{Stream, StreamExt, TryStreamExt};
 use log::debug;
 use parking_lot::Mutex;
@@ -560,7 +565,7 @@ impl ExecutionPlan for NestedLoopJoinExec {
 
     fn apply_expressions(
         &self,
-        f: &mut dyn FnMut(&dyn crate::PhysicalExpr) -> Result<TreeNodeRecursion>,
+        f: &mut dyn FnMut(&dyn PhysicalExpr) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
         // Apply to join filter expressions if present
         if let Some(filter) = &self.filter {
@@ -714,6 +719,49 @@ impl ExecutionPlan for NestedLoopJoinExec {
         } else {
             try_embed_projection(projection, self)
         }
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        self.filter
+            .as_ref()
+            .map(|f| Box::new(std::iter::once(Arc::clone(&f.expression))) as Box<_>)
+    }
+
+    fn with_physical_expressions(
+        &self,
+        mut params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let expected_count = self.filter.iter().len();
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let filter = self
+            .filter
+            .as_ref()
+            .zip(params.exprs.pop())
+            .map(|(f, expr)| {
+                JoinFilter::new(expr, f.column_indices.clone(), Arc::clone(&f.schema))
+            });
+
+        Ok(Some(Arc::new(Self {
+            left: Arc::clone(&self.left),
+            right: Arc::clone(&self.right),
+            filter,
+            join_type: self.join_type,
+            join_schema: Arc::clone(&self.join_schema),
+            build_side_data: Default::default(),
+            column_indices: self.column_indices.clone(),
+            projection: self.projection.clone(),
+            metrics: Default::default(),
+            cache: Arc::clone(&self.cache),
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
@@ -23,7 +23,9 @@ use std::any::Any;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use crate::execution_plan::{EmissionType, boundedness_from_children};
+use crate::execution_plan::{
+    EmissionType, ReplacePhysicalExpr, boundedness_from_children,
+};
 use crate::expressions::PhysicalSortExpr;
 use crate::joins::sort_merge_join::metrics::SortMergeJoinMetrics;
 use crate::joins::sort_merge_join::stream::SortMergeJoinStream;
@@ -51,6 +53,7 @@ use datafusion_common::{
 };
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::MemoryConsumer;
+use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_expr::equivalence::join_equivalence_properties;
 use datafusion_physical_expr_common::physical_expr::{PhysicalExprRef, fmt_sql};
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, OrderingRequirements};
@@ -453,7 +456,7 @@ impl ExecutionPlan for SortMergeJoinExec {
 
     fn apply_expressions(
         &self,
-        f: &mut dyn FnMut(&dyn crate::PhysicalExpr) -> Result<TreeNodeRecursion>,
+        f: &mut dyn FnMut(&dyn PhysicalExpr) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
         // Apply to join keys from both sides
         let mut tnr = TreeNodeRecursion::Continue;
@@ -629,5 +632,67 @@ impl ExecutionPlan for SortMergeJoinExec {
             self.sort_options.clone(),
             self.null_equality,
         )?)))
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        let left_sort_iter = self
+            .left_sort_exprs
+            .iter()
+            .map(|sort| Arc::clone(&sort.expr));
+
+        let right_sort_iter = self
+            .right_sort_exprs
+            .iter()
+            .map(|sort| Arc::clone(&sort.expr));
+
+        let filter = self
+            .filter
+            .as_ref()
+            .map(|f| Arc::clone(&f.expression))
+            .into_iter();
+
+        Some(Box::new(
+            left_sort_iter.chain(right_sort_iter).chain(filter),
+        ))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let expected_count = self.left_sort_exprs.len()
+            + self.right_sort_exprs.len()
+            + self.filter.iter().len();
+
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let mut exprs = params.exprs.into_iter();
+        let left_sort_exprs = self
+            .left_sort_exprs
+            .try_with_new_expressions(exprs.by_ref().take(self.left_sort_exprs.len()))?;
+
+        let right_sort_exprs = self
+            .right_sort_exprs
+            .try_with_new_expressions(exprs.by_ref().take(self.right_sort_exprs.len()))?;
+
+        let filter = self.filter.as_ref().zip(exprs.next()).map(|(f, expr)| {
+            JoinFilter::new(expr, f.column_indices.clone(), Arc::clone(&f.schema))
+        });
+
+        Ok(Some(Arc::new(Self {
+            filter,
+            metrics: ExecutionPlanMetricsSet::new(),
+            left_sort_exprs,
+            right_sort_exprs,
+            ..self.clone()
+        })))
     }
 }

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -34,7 +34,9 @@ use std::vec;
 
 use crate::check_if_same_properties;
 use crate::common::SharedMemoryReservation;
-use crate::execution_plan::{boundedness_from_children, emission_type_from_children};
+use crate::execution_plan::{
+    ReplacePhysicalExpr, boundedness_from_children, emission_type_from_children,
+};
 use crate::joins::stream_join_utils::{
     PruningJoinHashMap, SortedFilterExpr, StreamJoinMetrics,
     calculate_filter_expr_intervals, combine_two_batches,
@@ -75,6 +77,7 @@ use datafusion_common::{
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_expr::interval_arithmetic::Interval;
+use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_expr::equivalence::join_equivalence_properties;
 use datafusion_physical_expr::intervals::cp_solver::ExprIntervalGraph;
 use datafusion_physical_expr_common::physical_expr::{PhysicalExprRef, fmt_sql};
@@ -467,7 +470,7 @@ impl ExecutionPlan for SymmetricHashJoinExec {
 
     fn apply_expressions(
         &self,
-        f: &mut dyn FnMut(&dyn crate::PhysicalExpr) -> Result<TreeNodeRecursion>,
+        f: &mut dyn FnMut(&dyn PhysicalExpr) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
         // Apply to join keys from both sides
         let mut tnr = TreeNodeRecursion::Continue;
@@ -675,6 +678,84 @@ impl ExecutionPlan for SymmetricHashJoinExec {
             self.partition_mode(),
         )
         .map(|e| Some(Arc::new(e) as _))
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        let left_sort_iter = self
+            .left_sort_exprs
+            .as_ref()
+            .map(|lex| lex.iter().map(|sort| Arc::clone(&sort.expr)))
+            .into_iter()
+            .flatten();
+
+        let right_sort_iter = self
+            .right_sort_exprs
+            .as_ref()
+            .map(|lex| lex.iter().map(|sort| Arc::clone(&sort.expr)))
+            .into_iter()
+            .flatten();
+
+        let filter = self
+            .filter
+            .as_ref()
+            .map(|f| Arc::clone(&f.expression))
+            .into_iter();
+
+        Some(Box::new(
+            left_sort_iter.chain(right_sort_iter).chain(filter),
+        ))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let filter_exprs_count = self.filter.iter().len();
+        let left_sort_exprs_count =
+            self.left_sort_exprs.as_ref().map(|e| e.len()).unwrap_or(0);
+
+        let right_sort_exprs_count =
+            self.right_sort_exprs.as_ref().map(|e| e.len()).unwrap_or(0);
+
+        let expected_count =
+            filter_exprs_count + left_sort_exprs_count + right_sort_exprs_count;
+
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let mut exprs = params.exprs.into_iter();
+        let left_sort_exprs = self
+            .left_sort_exprs
+            .as_ref()
+            .map(|l| l.try_with_new_expressions(exprs.by_ref().take(l.len())))
+            .transpose()?;
+
+        let right_sort_exprs = self
+            .right_sort_exprs
+            .as_ref()
+            .map(|r| r.try_with_new_expressions(exprs.by_ref().take(r.len())))
+            .transpose()?;
+
+        let filter = self.filter.as_ref().zip(exprs.next()).map(|(f, expr)| {
+            JoinFilter::new(expr, f.column_indices.clone(), Arc::clone(&f.schema))
+        });
+
+        let random_state = RandomState::with_seeds(0, 0, 0, 0);
+        Ok(Some(Arc::new(Self {
+            filter,
+            random_state,
+            metrics: ExecutionPlanMetricsSet::new(),
+            left_sort_exprs,
+            right_sort_exprs,
+            ..self.clone()
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -27,7 +27,7 @@ use super::{
     SendableRecordBatchStream, SortOrderPushdownResult, Statistics,
 };
 use crate::column_rewriter::PhysicalColumnRewriter;
-use crate::execution_plan::CardinalityEffect;
+use crate::execution_plan::{CardinalityEffect, ReplacePhysicalExpr};
 use crate::filter_pushdown::{
     ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
     FilterPushdownPropagation, FilterRemapper, PushedDownPredicate,
@@ -46,7 +46,9 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
 };
-use datafusion_common::{DataFusionError, JoinSide, Result, internal_err};
+use datafusion_common::{
+    DataFusionError, JoinSide, Result, assert_eq_or_internal_err, internal_err,
+};
 use datafusion_execution::TaskContext;
 use datafusion_expr::ExpressionPlacement;
 use datafusion_physical_expr::equivalence::ProjectionMapping;
@@ -513,6 +515,43 @@ impl ExecutionPlan for ProjectionExec {
                     .with_new_children(vec![new_input])
                     .ok()
             })
+    }
+
+    fn physical_expressions(
+        &self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + '_>> {
+        Some(Box::new(self.projector.projection().expr_iter()))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let expected_count = self.expr().len();
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let projection_exprs = self
+            .expr()
+            .iter()
+            .zip(params.exprs)
+            .map(|(p, expr)| ProjectionExpr::new(expr, p.alias.clone()))
+            .collect::<Vec<_>>();
+
+        let projection = ProjectionExprs::from(projection_exprs);
+        let input_schema = self.input.schema();
+        let projector = projection.into_projector(&input_schema)?;
+
+        Ok(Some(Arc::new(Self {
+            projector,
+            metrics: ExecutionPlanMetricsSet::new(),
+            ..self.clone()
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/sorts/partial_sort.rs
+++ b/datafusion/physical-plan/src/sorts/partial_sort.rs
@@ -57,6 +57,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use crate::execution_plan::ReplacePhysicalExpr;
 use crate::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use crate::sorts::sort::sort_batch;
 use crate::{
@@ -68,9 +69,9 @@ use crate::{
 use arrow::compute::concat_batches;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
-use datafusion_common::Result;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::utils::evaluate_partition_ranges;
+use datafusion_common::{Result, assert_eq_or_internal_err};
 use datafusion_execution::{RecordBatchStream, TaskContext};
 use datafusion_physical_expr::{LexOrdering, PhysicalExpr};
 
@@ -352,6 +353,35 @@ impl ExecutionPlan for PartialSortExec {
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
         self.input.partition_statistics(partition)
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        Some(Box::new(
+            self.expr.iter().map(|sort| Arc::clone(&sort.expr)),
+        ))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let expected_count = self.expr.len();
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let expr = self.expr.try_with_new_expressions(params.exprs)?;
+        Ok(Some(Arc::new(Self {
+            expr,
+            metrics_set: ExecutionPlanMetricsSet::new(),
+            ..self.clone()
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -28,7 +28,8 @@ use parking_lot::RwLock;
 
 use crate::common::spawn_buffered;
 use crate::execution_plan::{
-    Boundedness, CardinalityEffect, EmissionType, has_same_children_properties,
+    Boundedness, CardinalityEffect, EmissionType, ReplacePhysicalExpr,
+    has_same_children_properties,
 };
 use crate::expressions::PhysicalSortExpr;
 use crate::filter_pushdown::{
@@ -60,8 +61,8 @@ use arrow::datatypes::SchemaRef;
 use datafusion_common::config::SpillCompression;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{
-    DataFusionError, Result, assert_or_internal_err, internal_datafusion_err,
-    unwrap_or_internal_err,
+    DataFusionError, Result, assert_eq_or_internal_err, assert_or_internal_err,
+    internal_datafusion_err, unwrap_or_internal_err,
 };
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
@@ -1405,6 +1406,55 @@ impl ExecutionPlan for SortExec {
         }
 
         Ok(FilterDescription::new().with_child(child))
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        Some(Box::new(
+            self.expr.iter().map(|sort| Arc::clone(&sort.expr)),
+        ))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let expected_count = self.expr.len();
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let expr = self.expr.try_with_new_expressions(params.exprs)?;
+        let filter = self.filter.as_ref().map(|_| {
+            let children = expr
+                .iter()
+                .map(|sort_expr| Arc::clone(&sort_expr.expr))
+                .collect::<Vec<_>>();
+
+            Arc::new(RwLock::new(TopKDynamicFilters::new(Arc::new(
+                DynamicFilterPhysicalExpr::new(children, lit(true)),
+            ))))
+        });
+
+        let (cache, sort_prefix) = Self::compute_properties(
+            &self.input,
+            expr.clone(),
+            self.preserve_partitioning,
+        )?;
+
+        Ok(Some(Arc::new(Self {
+            expr,
+            filter,
+            metrics_set: ExecutionPlanMetricsSet::new(),
+            cache: Arc::new(cache),
+            common_sort_prefix: sort_prefix,
+            ..self.clone()
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -38,7 +38,7 @@ use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, OrderingRequirements};
 
-use crate::execution_plan::{EvaluationType, SchedulingType};
+use crate::execution_plan::{EvaluationType, ReplacePhysicalExpr, SchedulingType};
 use log::{debug, trace};
 
 /// Sort preserving merge execution plan
@@ -430,6 +430,35 @@ impl ExecutionPlan for SortPreservingMergeExec {
             )
             .with_fetch(self.fetch()),
         )))
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        Some(Box::new(
+            self.expr.iter().map(|sort| Arc::clone(&sort.expr)),
+        ))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let expected_count = self.expr.len();
+        let exprs_count = params.exprs.len();
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        let expr = self.expr.try_with_new_expressions(params.exprs)?;
+        Ok(Some(Arc::new(Self {
+            expr,
+            metrics: ExecutionPlanMetricsSet::new(),
+            ..self.clone()
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
+++ b/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use super::utils::create_schema;
+use crate::execution_plan::ReplacePhysicalExpr;
 use crate::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use crate::windows::{
     calc_requirements, get_ordered_partition_by_indices, get_partition_by_sort_exprs,
@@ -53,7 +54,8 @@ use datafusion_common::utils::{
     evaluate_partition_ranges, get_at_indices, get_row_at_idx,
 };
 use datafusion_common::{
-    HashMap, Result, arrow_datafusion_err, exec_datafusion_err, exec_err,
+    HashMap, Result, arrow_datafusion_err, assert_eq_or_internal_err,
+    exec_datafusion_err, exec_err,
 };
 use datafusion_execution::TaskContext;
 use datafusion_expr::ColumnarValue;
@@ -403,6 +405,49 @@ impl ExecutionPlan for BoundedWindowAggExec {
 
     fn cardinality_effect(&self) -> CardinalityEffect {
         CardinalityEffect::Equal
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        Some(Box::new(
+            self.window_expr
+                .iter()
+                .flat_map(|expr| expr.inner_expressions_iter()),
+        ))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let exprs_count = params.exprs.len();
+        let mut expected_count = 0;
+
+        let mut exprs_iter = params.exprs.into_iter();
+        let mut window_exprs = Vec::with_capacity(self.window_expr.len());
+
+        for expr in self.window_expr.iter() {
+            let window_expr_count = expr.inner_expressions_count();
+            let new_exprs = exprs_iter.by_ref().take(window_expr_count).collect();
+            let window_expr = expr.with_inner_expressions(new_exprs)?;
+
+            expected_count += window_expr_count;
+            window_exprs.push(window_expr);
+        }
+
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        Ok(Some(Arc::new(Self {
+            window_expr: window_exprs,
+            metrics: ExecutionPlanMetricsSet::new(),
+            ..self.clone()
+        })))
     }
 }
 

--- a/datafusion/physical-plan/src/windows/window_agg_exec.rs
+++ b/datafusion/physical-plan/src/windows/window_agg_exec.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use super::utils::create_schema;
-use crate::execution_plan::{CardinalityEffect, EmissionType};
+use crate::execution_plan::{CardinalityEffect, EmissionType, ReplacePhysicalExpr};
 use crate::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use crate::windows::{
     calc_requirements, get_ordered_partition_by_indices, get_partition_by_sort_exprs,
@@ -319,6 +319,49 @@ impl ExecutionPlan for WindowAggExec {
 
     fn cardinality_effect(&self) -> CardinalityEffect {
         CardinalityEffect::Equal
+    }
+
+    fn physical_expressions<'a>(
+        &'a self,
+    ) -> Option<Box<dyn Iterator<Item = Arc<dyn PhysicalExpr>> + 'a>> {
+        Some(Box::new(
+            self.window_expr
+                .iter()
+                .flat_map(|expr| expr.inner_expressions_iter()),
+        ))
+    }
+
+    fn with_physical_expressions(
+        &self,
+        params: ReplacePhysicalExpr,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let exprs_count = params.exprs.len();
+        let mut expected_count = 0;
+
+        let mut exprs_iter = params.exprs.into_iter();
+        let mut window_exprs = Vec::with_capacity(self.window_expr.len());
+
+        for expr in self.window_expr.iter() {
+            let window_expr_count = expr.inner_expressions_count();
+            let new_exprs = exprs_iter.by_ref().take(window_expr_count).collect();
+            let window_expr = expr.with_inner_expressions(new_exprs)?;
+
+            expected_count += window_expr_count;
+            window_exprs.push(window_expr);
+        }
+
+        assert_eq_or_internal_err!(
+            expected_count,
+            exprs_count,
+            "Inconsistent number of physical expressions for {}",
+            self.name()
+        );
+
+        Ok(Some(Arc::new(Self {
+            window_expr: window_exprs,
+            metrics: ExecutionPlanMetricsSet::new(),
+            ..self.clone()
+        })))
     }
 }
 


### PR DESCRIPTION
## Rationale for this change

This PR covers a part of #14342.

This PR introduces methods for replacing physical expressions in execution plan nodes. This is an intermediate step in the development of physical-level placeholders. Later, these methods will be used to resolve placeholders in physical plans.

## What changes are included in this PR?

- **Expression Rewriting Interface**: Added `physical_expressions` and `with_physical_expressions` to the `ExecutionPlan` trait to allow inspection and replacement of expressions within plan nodes.
- **FileSource Update**: Added `with_filter_and_projection` to the `FileSource` trait. This method is required to implement `with_physical_expressions` for `DataSourceExec`. Since file-based scans store their physical expressions (pushed-down filters and projections) within the `FileSource` implementation, we need a way to reconstruct the `FileSource` with updated expressions during plan rewriting.
- **Window Function Rewriting**: Added `inner_expressions_iter` and `with_inner_expressions` to the `WindowExpr` trait and its implementations to enable expression replacement within window functions. `WindowAggExec` and `BoundedWindowAggExec` now use these methods to support the `ExecutionPlan` rewriting interface. 

## Are these changes tested?

- The new `physical_expressions` and `with_physical_expressions` methods are verified using the [`check_physical_expressions`](https://github.com/LLDay/datafusion/blob/feat/physical-placeholders/datafusion/core/src/physical_planner.rs#L2550-L2557) invariant.

## Are there any user-facing changes?

Yes, a user can rewrite physical expressions in some execution plans.