### PR TITLE
fix(expr): coerce literal arguments in return_field_from_args for UDFs

### DIFF
--- a/datafusion-examples/examples/builtin_functions/date_time.rs
+++ b/datafusion-examples/examples/builtin_functions/date_time.rs
@@ -179,12 +179,8 @@ async fn query_make_date() -> Result<()> {
 
     assert_batches_eq!(expected, &df.collect().await?);
 
-    // invalid column values will result in an error
-    let result = ctx
-        .sql("select make_date(2024, '', 23)")
-        .await?
-        .collect()
-        .await;
+    // invalid column values will result in an error during planning phase
+    let result = ctx.sql("select make_date(2024, '', 23)").await;
 
     let expected =
         "Arrow error: Cast error: Cannot cast string '' to value of Int32 type";

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -598,13 +598,32 @@ impl ExprSchemable for Expr {
                         )
                     })?;
 
-                let arguments = args
+                let coerced_values: Vec<Option<ScalarValue>> = args
                     .iter()
-                    .map(|e| match e {
-                        Expr::Literal(sv, _) => Some(sv),
-                        _ => None,
+                    .zip(new_fields.iter())
+                    .map(|(expr, field)| {
+                        let mut current_expr = expr;
+
+                        // Loop to remove all casting layers
+                        loop {
+                            match current_expr {
+                                Expr::Cast(cast) => current_expr = &cast.expr,
+                                Expr::TryCast(cast) => current_expr = &cast.expr,
+                                _ => break,
+                            }
+                        }
+
+                        let literal = if let Expr::Literal(sv, _) = current_expr {
+                            Some(sv)
+                        } else {
+                            None
+                        };
+
+                        literal.map(|sv| sv.cast_to(field.data_type())).transpose()
                     })
-                    .collect::<Vec<_>>();
+                    .collect::<Result<Vec<_>>>()?;
+                let arguments: Vec<Option<&ScalarValue>> =
+                    coerced_values.iter().map(|opt| opt.as_ref()).collect();
                 let args = ReturnFieldArgs {
                     arg_fields: &new_fields,
                     scalar_arguments: &arguments,

--- a/datafusion/sqllogictest/test_files/arrow_typeof.slt
+++ b/datafusion/sqllogictest/test_files/arrow_typeof.slt
@@ -319,7 +319,7 @@ select arrow_cast(interval '30 minutes', 'Duration(Second)');
 ----
 0 days 0 hours 30 mins 0 secs
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*This feature is not implemented: Unsupported CAST from Utf8 to Duration\(s\)
+query error This feature is not implemented: Unsupported CAST from Utf8 to Duration\(s\)
 select arrow_cast('30 minutes', 'Duration(Second)');
 
 
@@ -340,7 +340,7 @@ select arrow_cast(timestamp '2000-01-01T00:00:00Z', 'Timestamp(Nanosecond, Some(
 ----
 2000-01-01T00:00:00+08:00
 
-statement error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Parser error: Invalid timezone "\+25:00": failed to parse timezone
+statement error Arrow error: Parser error: Invalid timezone "\+25:00": failed to parse timezone
 select arrow_cast(timestamp '2000-01-01T00:00:00', 'Timestamp(Nanosecond, Some( "+25:00" ))');
 
 
@@ -409,7 +409,7 @@ select arrow_cast([1], 'FixedSizeList(1, Int64)');
 ----
 [1]
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast to FixedSizeList\(4\): value at index 0 has length 3
+query error Arrow error: Cast error: Cannot cast to FixedSizeList\(4\): value at index 0 has length 3
 select arrow_cast(make_array(1, 2, 3), 'FixedSizeList(4, Int64)');
 
 query ?

--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -871,7 +871,7 @@ WITH RECURSIVE my_cte AS (
 
 # Test issue: https://github.com/apache/datafusion/issues/9794
 # Non-recursive term and recursive term have different types, and cannot be casted
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'abc' to value of Int64 type
+query error Arrow error: Cast error: Cannot cast string 'abc' to value of Int64 type
 WITH RECURSIVE my_cte AS (
     SELECT 1 AS a
     UNION ALL

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -696,11 +696,11 @@ select
 ----
 08:09:10.123456789 13:14:15.123456 13:14:15.123 13:14:15
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'not a time' to value of Time64\(ns\) type
+query error Arrow error: Cast error: Cannot cast string 'not a time' to value of Time64\(ns\) type
 SELECT TIME 'not a time' as time;
 
 # invalid time
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string '24:01:02' to value of Time64\(ns\) type
+query error Arrow error: Cast error: Cannot cast string '24:01:02' to value of Time64\(ns\) type
 SELECT TIME '24:01:02' as time;
 
 # invalid timezone
@@ -3956,7 +3956,7 @@ statement error DataFusion error: Error during planning: Function 'to_local_time
 select to_local_time('2024-04-01T00:00:20Z');
 
 # invalid timezone
-statement error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Parser error: Invalid timezone "Europe/timezone": failed to parse timezone
+statement error Arrow error: Parser error: Invalid timezone "Europe/timezone": failed to parse timezone
 select to_local_time('2024-04-01T00:00:20Z'::timestamp AT TIME ZONE 'Europe/timezone');
 
 # valid query

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -150,7 +150,7 @@ SELECT
    LIMIT 5;
 
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'foo' to value of Int64 type
+query error Arrow error: Cast error: Cannot cast string 'foo' to value of Int64 type
 create table foo as values (1), ('foo');
 
 query error DataFusion error: Error during planning: Substring without for/from is not valid

--- a/datafusion/sqllogictest/test_files/map.slt
+++ b/datafusion/sqllogictest/test_files/map.slt
@@ -154,7 +154,7 @@ SELECT MAKE_MAP('POST', 41, 'HEAD', 53, 'PATCH', 30);
 ----
 {POST: 41, HEAD: 53, PATCH: 30}
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'ab' to value of Int64 type
+query error Arrow error: Cast error: Cannot cast string 'ab' to value of Int64 type
 SELECT MAKE_MAP('POST', 41, 'HEAD', 'ab', 'PATCH', 30);
 
 # Map keys can not be NULL
@@ -536,7 +536,7 @@ SELECT MAP { 'a': 1, 'b': 3 };
 ----
 {a: 1, b: 3}
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
+query error Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
 SELECT MAP { 'a': 1, 2: 3 };
 
 # accessing map with non-string key
@@ -553,7 +553,7 @@ SELECT MAP { 'a': 1, 'b': 2, 'c': 3 }['a'];
 
 # accessing map with non-string key in case expression
 query I
-SELECT (CASE WHEN 1 > 0 THEN MAP {'x': 100} ELSE MAP {'y': 200} END)['x']; 
+SELECT (CASE WHEN 1 > 0 THEN MAP {'x': 100} ELSE MAP {'y': 200} END)['x'];
 ----
 100
 
@@ -691,7 +691,7 @@ SELECT map_entries(MAP { 'a': 1, 'b': 3 });
 ----
 [{key: a, value: 1}, {key: b, value: 3}]
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
+query error Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
 SELECT map_entries(MAP { 'a': 1, 2: 3 });
 
 query ?
@@ -742,7 +742,7 @@ SELECT map_keys(MAP { 'a': 1, 'b': 3 });
 ----
 [a, b]
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
+query error Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
 SELECT map_keys(MAP { 'a': 1, 2: 3 });
 
 query ?
@@ -789,7 +789,7 @@ NULL
 
 # Tests for map_values
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
+query error Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
 SELECT map_values(MAP { 'a': 1, 2: 3 });
 
 query ?

--- a/datafusion/sqllogictest/test_files/nullif.slt
+++ b/datafusion/sqllogictest/test_files/nullif.slt
@@ -112,7 +112,7 @@ select nullif(1.0, 2);
 ----
 1
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
+query error Arrow error: Cast error: Cannot cast string 'a' to value of Int64 type
 select nullif(2, 'a');
 
 query T

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -1766,7 +1766,7 @@ DROP TABLE test;
 query error DataFusion error: Arrow error: Parser error: Error parsing timestamp from 'I AM NOT A TIMESTAMP': error parsing date
 SELECT to_timestamp('I AM NOT A TIMESTAMP');
 
-query error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string '' to value of Int32 type
+query error Arrow error: Cast error: Cannot cast string '' to value of Int32 type
 SELECT CAST('' AS int);
 
 # See issue: https://github.com/apache/datafusion/issues/8978

--- a/datafusion/sqllogictest/test_files/struct.slt
+++ b/datafusion/sqllogictest/test_files/struct.slt
@@ -551,7 +551,7 @@ statement ok
 drop table t;
 
 # row() with incorrect order - row() is positional, not name-based
-statement error DataFusion error: Optimizer rule 'simplify_expressions' failed[\s\S]*Arrow error: Cast error: Cannot cast string 'blue' to value of Float32 type
+statement error Arrow error: Cast error: Cannot cast string 'blue' to value of Float32 type
 create table t(a struct(r varchar, c int), b struct(r varchar, c float)) as values
     (row('red', 1), row(2.3, 'blue')),
     (row('purple', 1), row('green', 2.3));


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #19982.

## What changes are included in this PR?

- Coercion of `ScalarValue`s: `scalar_arguments` now match the types of `arg_fields`.
- Recursive extraction of `ScalarValue`s: Loop through nested `Cast` and `TryCast` expressions to find if there is a `Literal` expression. 
- Early Validation: Errors are now caught during the Logical Planning phase instead of during Execution.

## Are these changes tested?

- Yes, in `user_defined_integration.rs`.
- Updated several .slt files to reflect the shift.
- Updated `date_time` example to handle earlier error reporting.


## Are there any user-facing changes?

No.
