### PR TITLE
feat: replace `ScalarValue` with `DynComparator` for RANGE calculation

### DIFF
--- a/datafusion/core/benches/window_query_sql.rs
+++ b/datafusion/core/benches/window_query_sql.rs
@@ -92,6 +92,20 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
+    c.bench_function("window order by and range offsets, aggregate functions", |b| {
+        b.iter(|| {
+            query(
+                ctx.clone(),
+                &rt,
+                "SELECT \
+                    MAX(f64) OVER (ORDER BY u64_narrow RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING), \
+                    MIN(f32) OVER (ORDER BY u64_narrow DESC RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING), \
+                    SUM(u64_narrow) OVER (ORDER BY u64_narrow ASC RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) \
+                FROM t",
+            )
+        })
+    });
+
     c.bench_function("window order by, built-in functions", |b| {
         b.iter(|| {
             query(
@@ -183,6 +197,23 @@ fn criterion_benchmark(c: &mut Criterion) {
     );
 
     c.bench_function(
+        "window partition and order by and range offsets, u64_wide, aggregate functions",
+        |b| {
+            b.iter(|| {
+                query(
+                    ctx.clone(),
+                    &rt,
+                    "SELECT \
+                        MAX(f64) OVER (PARTITION BY u64_wide ORDER by f64 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING), \
+                        MIN(f32) OVER (PARTITION BY u64_wide ORDER by f64 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING), \
+                        SUM(u64_narrow) OVER (PARTITION BY u64_wide ORDER by f64 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) \
+                    FROM t",
+                )
+            })
+        },
+    );
+
+    c.bench_function(
         "window partition and order by, u64_narrow, aggregate functions",
         |b| {
             b.iter(|| {
@@ -193,6 +224,23 @@ fn criterion_benchmark(c: &mut Criterion) {
                         MAX(f64) OVER (PARTITION BY u64_narrow ORDER by f64), \
                         MIN(f32) OVER (PARTITION BY u64_narrow ORDER by f64), \
                         SUM(u64_narrow) OVER (PARTITION BY u64_narrow ORDER by f64) \
+                    FROM t",
+                )
+            })
+        },
+    );
+
+    c.bench_function(
+        "window partition and order by and range offsets, u64_narrow, aggregate functions",
+        |b| {
+            b.iter(|| {
+                query(
+                    ctx.clone(),
+                    &rt,
+                    "SELECT \
+                        MAX(f64) OVER (PARTITION BY u64_narrow ORDER by f64 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING), \
+                        MIN(f32) OVER (PARTITION BY u64_narrow ORDER by f64 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING), \
+                        SUM(u64_narrow) OVER (PARTITION BY u64_narrow ORDER by f64 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) \
                     FROM t",
                 )
             })
@@ -227,6 +275,23 @@ fn criterion_benchmark(c: &mut Criterion) {
                         FIRST_VALUE(f64) OVER (PARTITION BY u64_narrow ORDER by f64), \
                         LAST_VALUE(f32) OVER (PARTITION BY u64_narrow ORDER by f64), \
                         NTH_VALUE(u64_narrow, 50) OVER (PARTITION BY u64_narrow ORDER by f64) \
+                    FROM t",
+                )
+            })
+        },
+    );
+
+    c.bench_function(
+        "window partition and order by and range offsets, u64_wide, aggregate functions",
+        |b| {
+            b.iter(|| {
+                query(
+                    ctx.clone(),
+                    &rt,
+                    "SELECT \
+                        MAX(f64) OVER (PARTITION BY u64_wide ORDER by f64 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING), \
+                        MIN(f32) OVER (PARTITION BY u64_wide ORDER by f64 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING), \
+                        SUM(u64_narrow) OVER (PARTITION BY u64_wide ORDER by f64 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) \
                     FROM t",
                 )
             })

--- a/datafusion/expr/src/window_state.rs
+++ b/datafusion/expr/src/window_state.rs
@@ -155,6 +155,11 @@ impl WindowFrameContext {
         }
     }
 
+    /// Refreshes any cached frame comparators for the current batch.
+    ///
+    /// This is a no-op for `ROWS` and `GROUPS` frames. For `RANGE` frames,
+    /// callers should invoke this before `calculate_range` when the ORDER BY
+    /// columns change, such as when evaluating a new batch or partition.
     pub fn update_comparators(&mut self, range_columns: &[ArrayRef]) -> Result<()> {
         match self {
             WindowFrameContext::Range {
@@ -506,6 +511,7 @@ impl WindowRangeComparator {
 /// ranges of data while processing RANGE frames.
 /// Attribute `sort_options` stores the column ordering specified by the ORDER
 /// BY clause. This information is used to calculate the range.
+/// Attributes `start_bound_comparator` and `end_bound_comparator` store the cached comparators for calculating ranges.
 #[derive(Debug, Default, Clone)]
 pub struct WindowFrameStateRange {
     sort_options: Vec<SortOptions>,

--- a/datafusion/expr/src/window_state.rs
+++ b/datafusion/expr/src/window_state.rs
@@ -155,12 +155,12 @@ impl WindowFrameContext {
         }
     }
 
-    pub fn calculate_bounds(&mut self, range_columns: &[ArrayRef]) -> Result<()> {
+    pub fn update_comparators(&mut self, range_columns: &[ArrayRef]) -> Result<()> {
         match self {
             WindowFrameContext::Range {
                 window_frame,
                 state,
-            } => state.calculate_bounds(window_frame, range_columns),
+            } => state.update_comparators(window_frame, range_columns),
             _ => Ok(()),
         }
     }
@@ -298,62 +298,28 @@ impl PartitionBatchState {
     }
 }
 
+
 type SharedDynComparator = Arc<dyn Fn(usize, usize) -> std::cmp::Ordering + Send + Sync>;
 
 /// Holds pre-computed comparators for finding RANGE window frame boundaries for all rows in the batch.
 #[derive(Clone)]
-pub struct WindowBoundStateRange {
-    start_bound_comparators: Option<Vec<SharedDynComparator>>,
-    end_bound_comparators: Option<Vec<SharedDynComparator>>,
+struct WindowRangeComparator {
+    comparators: Vec<SharedDynComparator>,
 }
 
-impl std::fmt::Debug for WindowBoundStateRange {
+impl std::fmt::Debug for WindowRangeComparator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WindowBoundStateRange")
-            .field(
-                "start_bound_comparators",
-                &self.start_bound_comparators.as_ref().map(|c| c.len()),
-            )
-            .field(
-                "end_bound_comparators",
-                &self.end_bound_comparators.as_ref().map(|c| c.len()),
-            )
-            .finish()
+        f.debug_struct("WindowRangeComparator").field("comparators", &self.comparators.len()).finish()
     }
 }
 
-impl WindowBoundStateRange {
-    pub fn try_new(
-        window_frame: &Arc<WindowFrame>,
-        range_columns: &[ArrayRef],
-        sort_options: &[SortOptions],
-    ) -> Result<Self> {
-        let sort_descending = sort_options.first().map(|o| o.descending).unwrap_or(false);
-
-        let start_bound_comparators = Self::build_bound_comparators(
-            &window_frame.start_bound,
-            range_columns,
-            sort_options,
-            sort_descending,
-        )?;
-        let end_bound_comparators = Self::build_bound_comparators(
-            &window_frame.end_bound,
-            range_columns,
-            sort_options,
-            sort_descending,
-        )?;
-        Ok(Self {
-            start_bound_comparators,
-            end_bound_comparators,
-        })
-    }
-
-    fn build_bound_comparators(
+impl WindowRangeComparator {
+    fn try_build(
         bound: &WindowFrameBound,
         range_columns: &[ArrayRef],
         sort_options: &[SortOptions],
-        sort_descending: bool,
-    ) -> Result<Option<Vec<SharedDynComparator>>> {
+    ) -> Result<Option<Self>> {
+        let sort_descending = sort_options.first().map(|o| o.descending).unwrap_or(false);
         match bound {
             WindowFrameBound::Preceding(delta) if delta.is_null() => {
                 // UNBOUNDED PRECEDING
@@ -364,7 +330,7 @@ impl WindowBoundStateRange {
                 Ok(None)
             }
             WindowFrameBound::Preceding(delta) => {
-                let comparators = Self::build_comparators(
+                let comparators = Self::build_comparator(
                     range_columns,
                     Some(delta),
                     true,
@@ -374,7 +340,7 @@ impl WindowBoundStateRange {
                 Ok(Some(comparators))
             }
             WindowFrameBound::Following(delta) => {
-                let comparators = Self::build_comparators(
+                let comparators = Self::build_comparator(
                     range_columns,
                     Some(delta),
                     false,
@@ -384,7 +350,7 @@ impl WindowBoundStateRange {
                 Ok(Some(comparators))
             }
             WindowFrameBound::CurrentRow => {
-                let comparators = Self::build_comparators(
+                let comparators = Self::build_comparator(
                     range_columns,
                     None,
                     false,
@@ -396,13 +362,13 @@ impl WindowBoundStateRange {
         }
     }
 
-    fn build_comparators(
+    fn build_comparator(
         range_columns: &[ArrayRef],
         delta: Option<&ScalarValue>,
         preceding: bool,
         sort_descending: bool,
         sort_options: &[SortOptions],
-    ) -> Result<Vec<SharedDynComparator>> {
+    ) -> Result<Self> {
         let mut comparators: Vec<SharedDynComparator> =
             Vec::with_capacity(range_columns.len());
         for (col, opt) in range_columns.iter().zip(sort_options.iter()) {
@@ -418,7 +384,7 @@ impl WindowBoundStateRange {
 
             comparators.push(Arc::from(cmp));
         }
-        Ok(comparators)
+        Ok(WindowRangeComparator { comparators })
     }
 
     /// Computes array for a given bound.
@@ -443,6 +409,16 @@ impl WindowBoundStateRange {
         };
         result.map_err(|e| internal_datafusion_err!("Failed to compute bound array: {e}"))
     }
+
+    fn compare(&self, search_idx: usize, current_idx: usize) -> std::cmp::Ordering {
+        for comparator in &self.comparators {
+            let cmp = comparator(search_idx, current_idx);
+            if cmp != std::cmp::Ordering::Equal {
+                return cmp;
+            }
+        }
+        std::cmp::Ordering::Equal
+    }
 }
 
 /// This structure encapsulates all the state information we require as we scan
@@ -452,7 +428,8 @@ impl WindowBoundStateRange {
 #[derive(Debug, Default, Clone)]
 pub struct WindowFrameStateRange {
     sort_options: Vec<SortOptions>,
-    bound_state: Option<WindowBoundStateRange>,
+    start_bound_comparator: Option<WindowRangeComparator>,
+    end_bound_comparator: Option<WindowRangeComparator>,
 }
 
 impl WindowFrameStateRange {
@@ -460,21 +437,18 @@ impl WindowFrameStateRange {
     fn new(sort_options: Vec<SortOptions>) -> Self {
         Self {
             sort_options,
-            bound_state: None,
+            start_bound_comparator: None,
+            end_bound_comparator: None,
         }
     }
 
-    fn calculate_bounds(
+    fn update_comparators(
         &mut self,
         window_frame: &Arc<WindowFrame>,
         range_columns: &[ArrayRef],
     ) -> Result<()> {
-        let bound_state = WindowBoundStateRange::try_new(
-            window_frame,
-            range_columns,
-            &self.sort_options,
-        )?;
-        self.bound_state = Some(bound_state);
+        self.start_bound_comparator = WindowRangeComparator::try_build(&window_frame.start_bound, range_columns, &self.sort_options)?;
+        self.end_bound_comparator = WindowRangeComparator::try_build(&window_frame.end_bound, range_columns, &self.sort_options)?;
         Ok(())
     }
 
@@ -485,23 +459,19 @@ impl WindowFrameStateRange {
         length: usize,
         idx: usize,
     ) -> Result<Range<usize>> {
-        let bound_state = self.bound_state.as_ref().ok_or_else(|| {
-            internal_datafusion_err!("Missing precalculated WindowBoundStateRange")
-        })?;
-
         let start = match window_frame.start_bound {
             WindowFrameBound::Preceding(ref n) if n.is_null() => 0,
             WindowFrameBound::Preceding(_)
             | WindowFrameBound::CurrentRow
             | WindowFrameBound::Following(_) => {
-                let comparators = bound_state
-                    .start_bound_comparators
+                let comparator = self
+                    .start_bound_comparator
                     .as_ref()
                     .ok_or_else(|| {
-                        internal_datafusion_err!("Missing start_bound comparators")
+                        internal_datafusion_err!("Missing start_bound comparator")
                     })?;
                 self.search_index_of_row::<true>(
-                    comparators,
+                    comparator,
                     last_range.start,
                     length,
                     idx,
@@ -514,12 +484,14 @@ impl WindowFrameStateRange {
             WindowFrameBound::Preceding(_)
             | WindowFrameBound::CurrentRow
             | WindowFrameBound::Following(_) => {
-                let comparators =
-                    bound_state.end_bound_comparators.as_ref().ok_or_else(|| {
-                        internal_datafusion_err!("Missing end_bound comparators")
+                let comparator = self
+                    .end_bound_comparator
+                    .as_ref()
+                    .ok_or_else(|| {
+                        internal_datafusion_err!("Missing end_bound comparator")
                     })?;
                 self.search_index_of_row::<false>(
-                    comparators,
+                    comparator,
                     last_range.end,
                     length,
                     idx,
@@ -531,13 +503,13 @@ impl WindowFrameStateRange {
 
     fn search_index_of_row<const SIDE: bool>(
         &self,
-        comparators: &[SharedDynComparator],
+        comparator: &WindowRangeComparator,
         mut search_start: usize,
         length: usize,
         current_idx: usize,
     ) -> usize {
         while search_start < length {
-            let cmp = self.compare_indexes(comparators, search_start, current_idx);
+            let cmp = comparator.compare(search_start, current_idx);
             let stop = if SIDE { !cmp.is_lt() } else { !cmp.is_le() };
             if stop {
                 break;
@@ -545,21 +517,6 @@ impl WindowFrameStateRange {
             search_start += 1;
         }
         search_start
-    }
-
-    fn compare_indexes(
-        &self,
-        comparators: &[SharedDynComparator],
-        search_idx: usize,
-        current_idx: usize,
-    ) -> std::cmp::Ordering {
-        for comparator in comparators {
-            let cmp = comparator(search_idx, current_idx);
-            if cmp != std::cmp::Ordering::Equal {
-                return cmp;
-            }
-        }
-        std::cmp::Ordering::Equal
     }
 }
 
@@ -839,7 +796,7 @@ mod tests {
         let (range_columns, _) = get_test_data();
         let n_row = range_columns[0].len();
         let mut last_range = Range { start: 0, end: 0 };
-        window_frame_context.calculate_bounds(&range_columns)?;
+        window_frame_context.update_comparators(&range_columns)?;
         for (idx, expected_range) in expected_results.into_iter().enumerate() {
             let range = window_frame_context.calculate_range(
                 &range_columns,

--- a/datafusion/expr/src/window_state.rs
+++ b/datafusion/expr/src/window_state.rs
@@ -22,12 +22,12 @@ use std::{collections::VecDeque, ops::Range, sync::Arc};
 use crate::{WindowFrame, WindowFrameBound, WindowFrameUnits};
 
 use arrow::{
-    array::{ArrayRef, make_comparator},
+    array::{ArrayRef, AsArray, PrimitiveArray, make_comparator},
     compute::{
         SortOptions, concat, concat_batches,
         kernels::numeric::{add_wrapping, sub_wrapping},
     },
-    datatypes::{DataType, SchemaRef},
+    datatypes::{DataType, SchemaRef, UInt8Type, UInt16Type, UInt32Type, UInt64Type},
     record_batch::RecordBatch,
 };
 use datafusion_common::{
@@ -298,7 +298,6 @@ impl PartitionBatchState {
     }
 }
 
-
 type SharedDynComparator = Arc<dyn Fn(usize, usize) -> std::cmp::Ordering + Send + Sync>;
 
 /// Holds pre-computed comparators for finding RANGE window frame boundaries for all rows in the batch.
@@ -309,7 +308,9 @@ struct WindowRangeComparator {
 
 impl std::fmt::Debug for WindowRangeComparator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WindowRangeComparator").field("comparators", &self.comparators.len()).finish()
+        f.debug_struct("WindowRangeComparator")
+            .field("comparators", &self.comparators.len())
+            .finish()
     }
 }
 
@@ -388,9 +389,9 @@ impl WindowRangeComparator {
     }
 
     /// Computes array for a given bound.
-    /// For PRECEDING with descending=false: bound = value + delta
-    /// For PRECEDING with descending=true: bound = value - delta
-    /// For FOLLOWING with descending=false: bound = value + delta  
+    /// For PRECEDING with descending=false: bound = value - delta
+    /// For PRECEDING with descending=true: bound = value + delta
+    /// For FOLLOWING with descending=false: bound = value + delta
     /// For FOLLOWING with descending=true: bound = value - delta
     fn compute_bound_array(
         range_column: &ArrayRef,
@@ -405,9 +406,89 @@ impl WindowRangeComparator {
         let result = if add {
             add_wrapping(range_column, &delta_scalar)
         } else {
-            sub_wrapping(range_column, &delta_scalar)
+            if let Some(result) = Self::saturating_sub_unsigned_array(range_column, delta)
+            {
+                Ok(result)
+            } else {
+                sub_wrapping(range_column, &delta_scalar)
+            }
         };
         result.map_err(|e| internal_datafusion_err!("Failed to compute bound array: {e}"))
+    }
+
+    fn saturating_sub_unsigned_array(
+        range_column: &ArrayRef,
+        delta: &ScalarValue,
+    ) -> Option<ArrayRef> {
+        match (range_column.data_type(), delta) {
+            (DataType::UInt8, ScalarValue::UInt8(Some(delta))) => {
+                let result: PrimitiveArray<UInt8Type> = range_column
+                    .as_primitive::<UInt8Type>()
+                    .unary(|value| value.saturating_sub(*delta));
+                Some(Arc::new(result))
+            }
+            (DataType::UInt16, ScalarValue::UInt16(Some(delta))) => {
+                let result: PrimitiveArray<UInt16Type> = range_column
+                    .as_primitive::<UInt16Type>()
+                    .unary(|value| value.saturating_sub(*delta));
+                Some(Arc::new(result))
+            }
+            (DataType::UInt16, ScalarValue::UInt8(Some(delta))) => {
+                let delta = *delta as u16;
+                let result: PrimitiveArray<UInt16Type> = range_column
+                    .as_primitive::<UInt16Type>()
+                    .unary(|value| value.saturating_sub(delta));
+                Some(Arc::new(result))
+            }
+            (DataType::UInt32, ScalarValue::UInt32(Some(delta))) => {
+                let result: PrimitiveArray<UInt32Type> = range_column
+                    .as_primitive::<UInt32Type>()
+                    .unary(|value| value.saturating_sub(*delta));
+                Some(Arc::new(result))
+            }
+            (DataType::UInt32, ScalarValue::UInt16(Some(delta))) => {
+                let delta = *delta as u32;
+                let result: PrimitiveArray<UInt32Type> = range_column
+                    .as_primitive::<UInt32Type>()
+                    .unary(|value| value.saturating_sub(delta));
+                Some(Arc::new(result))
+            }
+            (DataType::UInt32, ScalarValue::UInt8(Some(delta))) => {
+                let delta = *delta as u32;
+                let result: PrimitiveArray<UInt32Type> = range_column
+                    .as_primitive::<UInt32Type>()
+                    .unary(|value| value.saturating_sub(delta));
+                Some(Arc::new(result))
+            }
+            (DataType::UInt64, ScalarValue::UInt64(Some(delta))) => {
+                let result: PrimitiveArray<UInt64Type> = range_column
+                    .as_primitive::<UInt64Type>()
+                    .unary(|value| value.saturating_sub(*delta));
+                Some(Arc::new(result))
+            }
+            (DataType::UInt64, ScalarValue::UInt32(Some(delta))) => {
+                let delta = *delta as u64;
+                let result: PrimitiveArray<UInt64Type> = range_column
+                    .as_primitive::<UInt64Type>()
+                    .unary(|value| value.saturating_sub(delta));
+                Some(Arc::new(result))
+            }
+            (DataType::UInt64, ScalarValue::UInt16(Some(delta))) => {
+                let delta = *delta as u64;
+                let result: PrimitiveArray<UInt64Type> = range_column
+                    .as_primitive::<UInt64Type>()
+                    .unary(|value| value.saturating_sub(delta));
+                Some(Arc::new(result))
+            }
+            (DataType::UInt64, ScalarValue::UInt8(Some(delta))) => {
+                let delta = *delta as u64;
+                let result: PrimitiveArray<UInt64Type> = range_column
+                    .as_primitive::<UInt64Type>()
+                    .unary(|value| value.saturating_sub(delta));
+                Some(Arc::new(result))
+            }
+            _ => None,
+        }
     }
 
     fn compare(&self, search_idx: usize, current_idx: usize) -> std::cmp::Ordering {
@@ -447,8 +528,16 @@ impl WindowFrameStateRange {
         window_frame: &Arc<WindowFrame>,
         range_columns: &[ArrayRef],
     ) -> Result<()> {
-        self.start_bound_comparator = WindowRangeComparator::try_build(&window_frame.start_bound, range_columns, &self.sort_options)?;
-        self.end_bound_comparator = WindowRangeComparator::try_build(&window_frame.end_bound, range_columns, &self.sort_options)?;
+        self.start_bound_comparator = WindowRangeComparator::try_build(
+            &window_frame.start_bound,
+            range_columns,
+            &self.sort_options,
+        )?;
+        self.end_bound_comparator = WindowRangeComparator::try_build(
+            &window_frame.end_bound,
+            range_columns,
+            &self.sort_options,
+        )?;
         Ok(())
     }
 
@@ -464,10 +553,8 @@ impl WindowFrameStateRange {
             WindowFrameBound::Preceding(_)
             | WindowFrameBound::CurrentRow
             | WindowFrameBound::Following(_) => {
-                let comparator = self
-                    .start_bound_comparator
-                    .as_ref()
-                    .ok_or_else(|| {
+                let comparator =
+                    self.start_bound_comparator.as_ref().ok_or_else(|| {
                         internal_datafusion_err!("Missing start_bound comparator")
                     })?;
                 self.search_index_of_row::<true>(
@@ -484,18 +571,10 @@ impl WindowFrameStateRange {
             WindowFrameBound::Preceding(_)
             | WindowFrameBound::CurrentRow
             | WindowFrameBound::Following(_) => {
-                let comparator = self
-                    .end_bound_comparator
-                    .as_ref()
-                    .ok_or_else(|| {
-                        internal_datafusion_err!("Missing end_bound comparator")
-                    })?;
-                self.search_index_of_row::<false>(
-                    comparator,
-                    last_range.end,
-                    length,
-                    idx,
-                )
+                let comparator = self.end_bound_comparator.as_ref().ok_or_else(|| {
+                    internal_datafusion_err!("Missing end_bound comparator")
+                })?;
+                self.search_index_of_row::<false>(comparator, last_range.end, length, idx)
             }
         };
         Ok(Range { start, end })

--- a/datafusion/physical-expr/src/window/standard.rs
+++ b/datafusion/physical-expr/src/window/standard.rs
@@ -129,7 +129,7 @@ impl WindowExpr for StandardWindowExpr {
                 WindowFrameContext::new(Arc::clone(&self.window_frame), sort_options);
             let mut last_range = Range { start: 0, end: 0 };
 
-            window_frame_ctx.calculate_bounds(order_bys_ref)?;
+            window_frame_ctx.update_comparators(order_bys_ref)?;
 
             // We iterate on each row to calculate window frame range and and window function result
             for idx in 0..num_rows {
@@ -216,7 +216,7 @@ impl WindowExpr for StandardWindowExpr {
                             sort_options.clone(),
                         )
                     })
-                    .calculate_bounds(order_bys_ref)?;
+                    .update_comparators(order_bys_ref)?;
             }
 
             for idx in state.last_calculated_index..num_rows {

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -335,6 +335,9 @@ pub trait AggregateWindowExpr: WindowExpr {
         let length = values[0].len();
         let mut row_wise_results: Vec<ScalarValue> = vec![];
         let is_causal = self.get_window_frame().is_causal();
+
+        window_frame_ctx.calculate_bounds(&order_bys)?;
+
         while idx < length {
             // Start search from the last_range. This squeezes searched range.
             let cur_range =

--- a/datafusion/physical-expr/src/window/window_expr.rs
+++ b/datafusion/physical-expr/src/window/window_expr.rs
@@ -336,7 +336,7 @@ pub trait AggregateWindowExpr: WindowExpr {
         let mut row_wise_results: Vec<ScalarValue> = vec![];
         let is_causal = self.get_window_frame().is_causal();
 
-        window_frame_ctx.calculate_bounds(&order_bys)?;
+        window_frame_ctx.update_comparators(&order_bys)?;
 
         while idx < length {
             // Start search from the last_range. This squeezes searched range.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related #15607 .

## Rationale for this change
As discussed in #15607, range calculation is one of the bottlenecks in window processing because of lots `ScalarValue` allocations/operations in the inner loop. The changes in the PR are replacing `ScalarValue` with arrow's `DynComparator` for each frame bound, which are precalculated per batch.

The change gains about 70-80% performance improve in queries with `PARTITION BY` on low-cardinality columns, however on queries with high-cardinality partition columns there is a 20% regression because of the overhead of precomputing comparators on small batches.


### Benchmark results (ryzen 9900x, ubuntu 25.10)

window_query_sql.rs
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query                                                         ┃      main ┃ 15607-260125-window-range-calculation-optimization ┃        Change ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ window empty over, aggregate functions                        │   6.01 ms │                                           6.19 ms  │  1.03x slower │
│ window empty over, built-in functions                         │ 107.45 ms │                                         107.52 ms  │     no change │
│ window order by, aggregate functions                          │ 692.38 ms │                                         244.96 ms  │ +2.83x faster │
│ window order by, built-in functions                           │ 600.14 ms │                                         143.65 ms  │ +4.18x faster │
│ window partition by, u64_wide, aggregate functions            │ 323.13 ms │                                         328.65 ms  │     no change │
│ window partition by, u64_narrow, aggregate functions          │   9.09 ms │                                           9.36 ms  │  1.03x slower │
│ window partition by, u64_wide, built-in functions             │ 349.49 ms │                                         359.59 ms  │  1.03x slower │
│ window partition by, u64_narrow, built-in functions           │  30.76 ms │                                          31.95 ms  │  1.04x slower │
│ window partition and order by, u64_wide, aggregate functions  │ 495.89 ms │                                         585.72 ms  │  1.18x slower │
│ window partition and order by, u64_narrow, aggregate functions│133.34 ms  │                                          63.84 ms  │ +2.09x faster │
│ window partition and order by, u64_wide, built-in functions   │ 490.42 ms │                                         601.34 ms  │  1.23x slower │
│ window partition and order by, u64_narrow, built-in functions │107.62 ms  │                                          37.80 ms  │ +2.85x faster │
└────────────────────────────────────────────────────────────── ┴───────────┴────────────────────────────────────────────────────┴───────────────┘
```

h2o_medium_window_parquet
```
┏━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query     ┃         main ┃ 15607-260125-window-range-calculation-optimization ┃        Change ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ QQuery 1  │    600.78 ms │                                          634.67 ms │  1.06x slower │
│ QQuery 2  │  19674.64 ms │                                         8248.85 ms │ +2.39x faster │
│ QQuery 3  │  13663.79 ms │                                        13705.98 ms │     no change │
│ QQuery 4  │   2706.63 ms │                                         2204.70 ms │ +1.23x faster │
│ QQuery 5  │   9174.88 ms │                                         9359.88 ms │     no change │
│ QQuery 6  │  16570.43 ms │                                        16269.44 ms │     no change │
│ QQuery 7  │  14184.85 ms │                                        14667.06 ms │     no change │
│ QQuery 8  │ 106938.60 ms │                                        81663.04 ms │ +1.31x faster │
│ QQuery 9  │   2332.07 ms │                                         2395.36 ms │     no change │
│ QQuery 10 │   2402.58 ms │                                         2506.51 ms │     no change │
│ QQuery 11 │   2444.16 ms │                                         2377.45 ms │     no change │
│ QQuery 12 │   4985.60 ms │                                         2696.91 ms │ +1.85x faster │
└───────────┴──────────────┴────────────────────────────────────────────────────┴───────────────┘
```
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Covered by existing tests.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
