### PR TITLE
add more projection pushdown slt tests

### DIFF
--- a/datafusion/sqllogictest/test_files/projection_pushdown.slt
+++ b/datafusion/sqllogictest/test_files/projection_pushdown.slt
@@ -363,8 +363,7 @@ SELECT id, s['value'] FROM simple_struct ORDER BY s['value'];
 
 ###
 # Test 4.4: Projection with duplicate column through Sort
-# The projection expands the logical output (3→4 columns) but reduces physical columns
-# since the duplicate column reuses an existing source column.
+# The projection expands the number of columns from 3 to 4 by introducing `col_b_dup`
 ###
 
 statement ok
@@ -397,11 +396,11 @@ physical_plan
 
 # Verify correctness
 query IIII
-SELECT col_a, col_b, col_c, col_b as col_b_dup FROM three_cols ORDER BY col_a;
+SELECT col_a, col_b, col_c, col_b as col_b_dup FROM three_cols ORDER BY col_a DESC;
 ----
-1 2 3 2
-4 5 6 5
 7 8 9 8
+4 5 6 5
+1 2 3 2
 
 statement ok
 DROP TABLE three_cols;


### PR DESCRIPTION
Adds more interesting test cases extracted from https://github.com/apache/datafusion/pull/19538

The reasoning is that it's (1) better to split the additional tests out from that PR to make that PR easier to review and (2) it's a good thing to document current behavior with complex edge cases like these, so even if that PR doesn't get merged there is still value in having these as regression tests.