### PR TITLE
Tweak `adapter serialization` example

### DIFF
--- a/datafusion-examples/examples/custom_data_source/adapter_serialization.rs
+++ b/datafusion-examples/examples/custom_data_source/adapter_serialization.rs
@@ -234,10 +234,10 @@ impl PhysicalExprAdapterFactory for MetadataAdapterFactory {
         &self,
         logical_file_schema: SchemaRef,
         physical_file_schema: SchemaRef,
-    ) -> Arc<dyn PhysicalExprAdapter> {
+    ) -> Result<Arc<dyn PhysicalExprAdapter>> {
         let inner = DefaultPhysicalExprAdapterFactory
-            .create(logical_file_schema, physical_file_schema);
-        Arc::new(MetadataAdapter { inner })
+            .create(logical_file_schema, physical_file_schema)?;
+        Ok(Arc::new(MetadataAdapter { inner }))
     }
 }
 


### PR DESCRIPTION
Followup to #19437

The main changes made here are:
-  Remove inner_plan_bytes from ExtensionPayload and store inner plan as protobuf child in extension.inputs instead of encoded bytes
- No need to manually strip the adapter before serializing, that will happen regardless

The end result is a slightly smaller line count and I think slightly better approach.