### PR TITLE
fix(core): Correctly handle nested async UDF execution

### DIFF
--- a/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs
@@ -75,7 +75,7 @@ async fn test_async_udf_with_non_modular_batch_size() -> Result<()> {
     let result: Vec<RecordBatch> = df.collect().await?;
 
     let result_str = format_batches(&result)?.to_string();
-    let expected = vec![
+    let expected = [
         "+----+---------+",
         "| id | result  |",
         "+----+---------+",
@@ -132,7 +132,7 @@ async fn test_nested_async_udf() -> Result<()> {
         Ok(batches) => {
             // Check results
             let result_str = format_batches(batches)?.to_string();
-            let expected = vec![
+            let expected = [
                 "+----+---------+",
                 "| id | result  |",
                 "+----+---------+",

--- a/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs
@@ -20,6 +20,8 @@ use std::sync::Arc;
 use arrow::array::{Int32Array, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use async_trait::async_trait;
+use datafusion::dataframe::DataFrame;
+use datafusion::execution::context::SessionContext;
 use datafusion::prelude::*;
 use datafusion_common::test_util::format_batches;
 use datafusion_common::{Result, assert_batches_eq};
@@ -66,24 +68,24 @@ fn register_table_and_udf() -> Result<SessionContext> {
 async fn test_async_udf_with_non_modular_batch_size() -> Result<()> {
     let ctx = register_table_and_udf()?;
 
-    let df = ctx
+    let df: DataFrame = ctx
         .sql("SELECT id, test_async_udf(prompt) as result FROM test_table")
         .await?;
 
-    let result = df.collect().await?;
+    let result: Vec<RecordBatch> = df.collect().await?;
 
-    assert_batches_eq!(
-        &[
-            "+----+---------+",
-            "| id | result  |",
-            "+----+---------+",
-            "| 0  | prompt0 |",
-            "| 1  | prompt1 |",
-            "| 2  | prompt2 |",
-            "+----+---------+"
-        ],
-        &result
-    );
+    let result_str = format_batches(&result)?.to_string();
+    let expected = vec![
+        "+----+---------+",
+        "| id | result  |",
+        "+----+---------+",
+        "| 0  | prompt0 |",
+        "| 1  | prompt1 |",
+        "| 2  | prompt2 |",
+        "+----+---------+",
+    ]
+    .join("\n");
+    assert_eq!(result_str.trim(), expected.trim());
 
     Ok(())
 }
@@ -93,13 +95,13 @@ async fn test_async_udf_with_non_modular_batch_size() -> Result<()> {
 async fn test_async_udf_metrics() -> Result<()> {
     let ctx = register_table_and_udf()?;
 
-    let df = ctx
+    let df: DataFrame = ctx
         .sql(
             "EXPLAIN ANALYZE SELECT id, test_async_udf(prompt) as result FROM test_table",
         )
         .await?;
 
-    let result = df.collect().await?;
+    let result: Vec<RecordBatch> = df.collect().await?;
 
     let explain_analyze_str = format_batches(&result)?.to_string();
     let async_func_exec_without_metrics =
@@ -109,6 +111,43 @@ async fn test_async_udf_metrics() -> Result<()> {
         });
 
     assert!(!async_func_exec_without_metrics);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_nested_async_udf() -> Result<()> {
+    let ctx = register_table_and_udf()?;
+
+    let df: DataFrame = ctx
+        .sql(
+            "SELECT id, test_async_udf(test_async_udf(prompt)) as result FROM test_table",
+        )
+        .await?;
+
+    let result: Result<Vec<RecordBatch>> = df.collect().await;
+
+    // This is expected to succeed now
+    match &result {
+        Ok(batches) => {
+            // Check results
+            let result_str = format_batches(batches)?.to_string();
+            let expected = vec![
+                "+----+---------+",
+                "| id | result  |",
+                "+----+---------+",
+                "| 0  | prompt0 |",
+                "| 1  | prompt1 |",
+                "| 2  | prompt2 |",
+                "+----+---------+",
+            ]
+            .join("\n");
+            assert_eq!(result_str.trim(), expected.trim());
+        }
+        Err(e) => {
+            panic!("Nested async UDF failed: {}", e);
+        }
+    }
 
     Ok(())
 }

--- a/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs
@@ -22,9 +22,8 @@ use arrow::datatypes::{DataType, Field, Schema};
 use async_trait::async_trait;
 use datafusion::dataframe::DataFrame;
 use datafusion::execution::context::SessionContext;
-use datafusion::prelude::*;
 use datafusion_common::test_util::format_batches;
-use datafusion_common::{Result, assert_batches_eq};
+use datafusion_common::Result;
 use datafusion_expr::async_udf::{AsyncScalarUDF, AsyncScalarUDFImpl};
 use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
@@ -145,7 +144,7 @@ async fn test_nested_async_udf() -> Result<()> {
             assert_eq!(result_str.trim(), expected.trim());
         }
         Err(e) => {
-            panic!("Nested async UDF failed: {}", e);
+            panic!("Nested async UDF failed: {e}");
         }
     }
 

--- a/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs
@@ -22,8 +22,8 @@ use arrow::datatypes::{DataType, Field, Schema};
 use async_trait::async_trait;
 use datafusion::dataframe::DataFrame;
 use datafusion::execution::context::SessionContext;
-use datafusion_common::test_util::format_batches;
 use datafusion_common::Result;
+use datafusion_common::test_util::format_batches;
 use datafusion_expr::async_udf::{AsyncScalarUDF, AsyncScalarUDFImpl};
 use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,

--- a/datafusion/sqllogictest/test_files/async_udf.slt
+++ b/datafusion/sqllogictest/test_files/async_udf.slt
@@ -99,3 +99,11 @@ physical_plan
 01)ProjectionExec: expr=[__async_fn_0@1 as async_abs(data.x)]
 02)--AsyncFuncExec: async_expr=[async_expr(name=__async_fn_0, expr=async_abs(x@0))]
 03)----DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Async udf with nesting
+query I rowsort
+select async_abs(async_abs(x)) from data;
+----
+10
+2
+


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #20031

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, nesting asynchronous User-Defined Functions (e.g., `my_async_udf(my_async_udf(col))`) causes an internal error: `"async functions should not be called directly"`. This happens because [AsyncFuncExec](cci:2://file:///d:/Agentic_AI/Gssoc_Apache/datafusion/datafusion/physical-plan/src/async_func.rs:50:0-56:1) and the physical planner treat all async expressions as independent and parallelizable against the initial input batch. When one async UDF depends on the output of another, the dependency chain is invalid, and the inner UDF's output is not available when the outer UDF tries to execute.

This PR updates the planning and execution logic to correctly handle these dependencies by processing async expressions sequentially when necessary and ensuring intermediate results are available for subsequent expressions.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- **`AsyncMapper::find_and_map`**: Updated to perform a bottom-up transformation. It now dynamically extends a temporary schema with the output fields of inner async functions, allowing outer functions to be correctly planned against those intermediate columns.
- **`AsyncFuncExec::execute`**: Modified to process async expressions incrementally. The record batch is updated with the results of each async call before being passed to the next one, ensuring that subsequent expressions can access the results of previous ones.
- **`AsyncFuncExec::try_new`**: Updated schema validation logic to mirror the execution path. It now verifies expressions against an incrementally built schema rather than validating all expressions against the static input schema.
- **`ProjectionMapping`**: Logic added to exclude columns created by inner async UDFs from the `ProjectionMapping` validation, as these columns do not exist in the original input schema.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. I added a new regression test [test_nested_async_udf](cci:1://file:///d:/Agentic_AI/Gssoc_Apache/datafusion/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs:116:0-148:1) in [datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs](cci:7://file:///d:/Agentic_AI/Gssoc_Apache/datafusion/datafusion/core/tests/user_defined/user_defined_async_scalar_functions.rs:0:0-0:0).
- The test defines a mock async UDF.
- It executes a query with nested calls: `SELECT test_async_udf(test_async_udf(prompt)) ...`.
- It asserts that the query executes successfully and produces the correct result (previously it panicked).

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

- **No breaking API changes.**
- **Bug Fix:** Users can now nest asynchronous UDFs in their SQL queries without encountering internal errors.