### PR TITLE
fix: downgrade spill memory warning from warn to debug (#19846)

### DIFF
--- a/datafusion/physical-plan/src/spill/mod.rs
+++ b/datafusion/physical-plan/src/spill/mod.rs
@@ -49,7 +49,7 @@ use datafusion_common_runtime::SpawnedTask;
 use datafusion_execution::RecordBatchStream;
 use datafusion_execution::disk_manager::RefCountedTempFile;
 use futures::{FutureExt as _, Stream};
-use log::warn;
+use log::debug;
 
 /// Stream that reads spill files from disk where each batch is read in a spawned blocking task
 /// It will read one batch at a time and will not do any buffering, to buffer data use [`crate::common::spawn_buffered`]
@@ -154,7 +154,7 @@ impl SpillReaderStream {
                                         > max_record_batch_memory
                                             + SPILL_BATCH_MEMORY_MARGIN
                                     {
-                                        warn!(
+                                        debug!(
                                             "Record batch memory usage ({actual_size} bytes) exceeds the expected limit ({max_record_batch_memory} bytes) \n\
                                                 by more than the allowed tolerance ({SPILL_BATCH_MEMORY_MARGIN} bytes).\n\
                                                 This likely indicates a bug in memory accounting during spilling.\n\


### PR DESCRIPTION
Downgrade the log level for record batch memory usage warnings from warn! to debug! to reduce production log pollution. This warning was being triggered excessively in production when record batch memory usage exceeded expected limits, creating noise without affecting functional correctness.

The diagnostic information remains available at debug level for development and troubleshooting purposes.

Fixes #19846

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #19846 

## Rationale for this change

The warning message about record batch memory usage exceeding expected limits                                                                                                                                                                      
was being triggered excessively in production environments, creating log                                                                                                                                                                           
pollution without affecting functional correctness.

## What changes are included in this PR?

- Changed log level from `warn!` to `debug!` in `datafusion/physical-plan/src/spill/mod.rs`                                                                                                                                                        - Updated the import from `log::warn` to `log::debug`                                                                                                                                                                                              
                                                                                                                                                                                                                                                     
This reduces production noise while keeping the diagnostic information                                                                                                                                                                             
available at debug level for development and troubleshooting. 

## Are these changes tested?

The change is a simple log level adjustment and doesn't affect the logic.                                                                                                                                                                          
Existing tests continue to validate the functionality. 

## Are there any user-facing changes?

No

