### PR TITLE
docs: update data_types.md to reflect current Arrow type mappings

### DIFF
--- a/docs/source/user-guide/sql/data_types.md
+++ b/docs/source/user-guide/sql/data_types.md
@@ -78,19 +78,19 @@ By default, string types are mapped to `Utf8View`. This can be configured using 
 
 ## Numeric Types
 
-| SQL DataType                         | Arrow DataType                 |
-| ------------------------------------ | :----------------------------- |
-| `TINYINT`                            | `Int8`                         |
-| `SMALLINT`                           | `Int16`                        |
-| `INT` or `INTEGER`                   | `Int32`                        |
-| `BIGINT`                             | `Int64`                        |
-| `TINYINT UNSIGNED`                   | `UInt8`                        |
-| `SMALLINT UNSIGNED`                  | `UInt16`                       |
-| `INT UNSIGNED` or `INTEGER UNSIGNED` | `UInt32`                       |
-| `BIGINT UNSIGNED`                    | `UInt64`                       |
-| `FLOAT`                              | `Float32`                      |
-| `REAL`                               | `Float32`                      |
-| `DOUBLE`                             | `Float64`                      |
+| SQL DataType                                     | Arrow DataType                 |
+| ------------------------------------------------ | :----------------------------- |
+| `TINYINT`                                        | `Int8`                         |
+| `SMALLINT`                                       | `Int16`                        |
+| `INT` or `INTEGER`                               | `Int32`                        |
+| `BIGINT`                                         | `Int64`                        |
+| `TINYINT UNSIGNED`                               | `UInt8`                        |
+| `SMALLINT UNSIGNED`                              | `UInt16`                       |
+| `INT UNSIGNED` or `INTEGER UNSIGNED`             | `UInt32`                       |
+| `BIGINT UNSIGNED`                                | `UInt64`                       |
+| `FLOAT`                                          | `Float32`                      |
+| `REAL`                                           | `Float32`                      |
+| `DOUBLE`                                         | `Float64`                      |
 | `DECIMAL(precision, scale)` where precision ≤ 38 | `Decimal128(precision, scale)` |
 | `DECIMAL(precision, scale)` where precision > 38 | `Decimal256(precision, scale)` |
 


### PR DESCRIPTION
## Which issue does this PR close?                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                     
  - Closes #18314                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                     
  ## Rationale for this change                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                     
  The documentation in `data_types.md` was outdated and showed `Utf8` as the default mapping for character types (CHAR, VARCHAR, TEXT, STRING), but the current implementation defaults to `Utf8View`. This caused confusion for users reading the   
  documentation as it didn't match the actual behavior.                                                                                                                                                                                              
                                                                                                                                                                                                                                                     
  Additionally, the "Supported Arrow Types" section at the end was redundant since `arrow_typeof` now supports all Arrow types, making the comprehensive list unnecessary.                                                                           
                                                                                                                                                                                                                                                     
  ## What changes are included in this PR?                                                                                                                                                                                                           
                                                                                                                                                                                                                                                     
  1. **Updated Character Types table**: Changed the Arrow DataType column from `Utf8` to `Utf8View` for CHAR, VARCHAR, TEXT, and STRING types                                                                                                        
  2. **Added configuration note**: Documented the `datafusion.sql_parser.map_string_types_to_utf8view` setting that allows users to switch back to `Utf8` if needed                                                                                  
  3. **Removed outdated section**: Deleted the "Supported Arrow Types" section (39 lines) as it's no longer necessary                                                                                                                                
                                                                                                                                                                                                                                                     
  ## Are these changes tested?                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                     
  This is a documentation-only change. The documentation accurately reflects the current behavior of DataFusion:                                                                                                                                     
  - The default mapping to `Utf8View` is the current implementation behavior                                                                                                                                                                         
  - The `datafusion.sql_parser.map_string_types_to_utf8view` configuration option exists and works as documented                                                                                                                                     
                                                                                                                                                                                                                                                     
  ## Are there any user-facing changes?                                                                                                                                                                                                              
                                                                                                                                                                                                                                                     
  Yes, documentation changes only. Users will now see accurate information about:                                                                                                                                                                    
  - The correct default Arrow type mappings for character types                                                                                                                                                                                      
  - How to configure the string type mapping behavior if they need the old `Utf8` behavior 