### PR TITLE
Improve memory accounting for ArrowBytesViewMap

### DIFF
--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -437,7 +437,7 @@ where
         let views_size = self.views.len() * size_of::<u128>();
         let in_progress_size = self.in_progress.capacity();
         let completed_size: usize = self.completed.iter().map(|b| b.len()).sum();
-        let nulls_size = self.nulls.allocated_size() / 8;
+        let nulls_size = self.nulls.allocated_size();
 
         self.map_size
             + views_size


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20074

## Rationale for this change

ArrowBytesViewMap was previously accounting for the logical number of null bits when reporting memory usage. This under-reported memory consumption is because NullBufferBuilder may allocate more memory than is currently used.

Memory accounting in DataFusion is expected to reflect allocated memory rather than logical usage to ensure accurate memory tracking.

## What changes are included in this PR?

- Update ArrowBytesViewMap::size to use NullBufferBuilder::allocated_size instead of calculating size from the number of used null bits.

## Are these changes tested?

- Yes. Existing tests were run:
  - cargo test -p datafusion-physical-expr-common

## Are there any user-facing changes?

- No. This change only affects internal memory accounting and does not alter query behavior or public APIs.
