### PR TITLE
fix: handle mark joins correctly in optimize_projections

### DIFF
--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -759,12 +759,26 @@ fn split_join_requirements(
         JoinType::Inner
         | JoinType::Left
         | JoinType::Right
-        | JoinType::Full
-        | JoinType::LeftMark
-        | JoinType::RightMark => {
+        | JoinType::Full => {
             // Decrease right side indices by `left_len` so that they point to valid
             // positions within the right child:
             indices.split_off(left_len)
+        }
+        // For LeftMark joins, the schema is [left columns, mark column]
+        // The mark column is at index `left_len` and is not from either child
+        JoinType::LeftMark => {
+            // Filter out the mark column (at index left_len) and route indices to left child only
+            // The right child in a LeftMark join only provides columns for the join condition
+            // and doesn't contribute to the output schema (except the synthetic mark column)
+            let (left_indices, _mark_and_beyond) = indices.split_off(left_len);
+            (left_indices, RequiredIndices::new())
+        }
+        // For RightMark joins, the schema is [right columns, mark column]
+        // The mark column is at the end and is not from either child
+        JoinType::RightMark => {
+            // Filter out the mark column (at the last index) and route indices to right child only
+            let (right_indices, _mark_and_beyond) = indices.split_off(left_len);
+            (RequiredIndices::new(), right_indices)
         }
         // All requirements can be re-routed to left child directly.
         JoinType::LeftAnti | JoinType::LeftSemi => (indices, RequiredIndices::new()),


### PR DESCRIPTION
- Fixes #20083

## Root Cause

For LeftMark/RightMark joins:
- The output schema is `[left columns, mark column]` (for LeftMark) or `[right columns, mark column]` (for RightMark)
- The mark column is synthetic, added by the join itself
- The previous implementation treated LeftMark/RightMark like regular joins
- When `split_join_requirements` split indices at `left_len`, it incorrectly tried to route the mark column requirement to the right child
- This caused a schema mismatch because the mark column doesn't exist in either child

## Solution

Modified `split_join_requirements` to handle LeftMark and RightMark joins specially:
- For LeftMark: Route indices before `left_len` to left child, discard mark column requirement
- For RightMark: Route indices before `left_len` to right child, discard mark column requirement

## Test Plan

Added test `exists_or_exists_with_join` that:
1. Creates a query with `EXISTS(subquery_a) OR EXISTS(subquery_b)` filter
2. Follows it with a LEFT JOIN
3. Runs through full optimizer pipeline
4. Verifies no schema mismatch error occurs

