### PR TITLE
Refactor `iszero()` and `isnan()` to accept all numeric types

### DIFF
--- a/datafusion/functions/src/math/nans.rs
+++ b/datafusion/functions/src/math/nans.rs
@@ -17,13 +17,21 @@
 
 //! Math function: `isnan()`.
 
-use arrow::datatypes::{DataType, Float16Type, Float32Type, Float64Type};
-use datafusion_common::types::NativeType;
-use datafusion_common::{Result, ScalarValue, exec_err};
-use datafusion_expr::{Coercion, ColumnarValue, ScalarFunctionArgs, TypeSignatureClass};
-
 use arrow::array::{ArrayRef, AsArray, BooleanArray};
-use datafusion_expr::{Documentation, ScalarUDFImpl, Signature, Volatility};
+use arrow::datatypes::DataType::{
+    Decimal32, Decimal64, Decimal128, Decimal256, Float16, Float32, Float64, Int8, Int16,
+    Int32, Int64, Null, UInt8, UInt16, UInt32, UInt64,
+};
+use arrow::datatypes::{
+    DataType, Decimal32Type, Decimal64Type, Decimal128Type, Decimal256Type, Float16Type,
+    Float32Type, Float64Type, Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type,
+    UInt16Type, UInt32Type, UInt64Type,
+};
+use datafusion_common::{Result, ScalarValue, exec_err, utils::take_function_args};
+use datafusion_expr::{
+    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_macros::user_doc;
 use std::any::Any;
 use std::sync::Arc;
@@ -55,14 +63,10 @@ impl Default for IsNanFunc {
 
 impl IsNanFunc {
     pub fn new() -> Self {
-        // Accept any numeric type and coerce to float
-        let float = Coercion::new_implicit(
-            TypeSignatureClass::Float,
-            vec![TypeSignatureClass::Numeric],
-            NativeType::Float64,
-        );
+        // Accept any numeric type (ints, uints, floats, decimals) without implicit casts.
+        let numeric = Coercion::new_exact(TypeSignatureClass::Numeric);
         Self {
-            signature: Signature::coercible(vec![float], Volatility::Immutable),
+            signature: Signature::coercible(vec![numeric], Volatility::Immutable),
         }
     }
 }
@@ -84,36 +88,123 @@ impl ScalarUDFImpl for IsNanFunc {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        // Handle NULL input
-        if args.args[0].data_type().is_null() {
-            return Ok(ColumnarValue::Scalar(ScalarValue::Boolean(None)));
-        }
+        let [arg] = take_function_args(self.name(), args.args)?;
 
-        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        match arg {
+            ColumnarValue::Scalar(scalar) => {
+                if scalar.is_null() {
+                    return Ok(ColumnarValue::Scalar(ScalarValue::Boolean(None)));
+                }
 
-        let arr: ArrayRef = match args[0].data_type() {
-            DataType::Float64 => Arc::new(BooleanArray::from_unary(
-                args[0].as_primitive::<Float64Type>(),
-                f64::is_nan,
-            )) as ArrayRef,
+                let result = match scalar {
+                    ScalarValue::Float64(Some(v)) => Some(v.is_nan()),
+                    ScalarValue::Float32(Some(v)) => Some(v.is_nan()),
+                    ScalarValue::Float16(Some(v)) => Some(v.is_nan()),
 
-            DataType::Float32 => Arc::new(BooleanArray::from_unary(
-                args[0].as_primitive::<Float32Type>(),
-                f32::is_nan,
-            )) as ArrayRef,
+                    // Non-float numeric inputs are never NaN
+                    ScalarValue::Int8(_)
+                    | ScalarValue::Int16(_)
+                    | ScalarValue::Int32(_)
+                    | ScalarValue::Int64(_)
+                    | ScalarValue::UInt8(_)
+                    | ScalarValue::UInt16(_)
+                    | ScalarValue::UInt32(_)
+                    | ScalarValue::UInt64(_)
+                    | ScalarValue::Decimal32(_, _, _)
+                    | ScalarValue::Decimal64(_, _, _)
+                    | ScalarValue::Decimal128(_, _, _)
+                    | ScalarValue::Decimal256(_, _, _) => Some(false),
 
-            DataType::Float16 => Arc::new(BooleanArray::from_unary(
-                args[0].as_primitive::<Float16Type>(),
-                |x| x.is_nan(),
-            )) as ArrayRef,
-            other => {
-                return exec_err!(
-                    "Unsupported data type {other:?} for function {}",
-                    self.name()
-                );
+                    other => {
+                        return exec_err!(
+                            "Unsupported data type {other:?} for function {}",
+                            self.name()
+                        );
+                    }
+                };
+
+                Ok(ColumnarValue::Scalar(ScalarValue::Boolean(result)))
             }
-        };
-        Ok(ColumnarValue::Array(arr))
+            ColumnarValue::Array(array) => {
+                // NOTE: BooleanArray::from_unary preserves nulls.
+                let arr: ArrayRef = match array.data_type() {
+                    Null => Arc::new(BooleanArray::new_null(array.len())) as ArrayRef,
+
+                    Float64 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Float64Type>(),
+                        f64::is_nan,
+                    )) as ArrayRef,
+                    Float32 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Float32Type>(),
+                        f32::is_nan,
+                    )) as ArrayRef,
+                    Float16 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Float16Type>(),
+                        |x| x.is_nan(),
+                    )) as ArrayRef,
+
+                    // Non-float numeric arrays are never NaN
+                    Decimal32(_, _) => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Decimal32Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    Decimal64(_, _) => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Decimal64Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    Decimal128(_, _) => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Decimal128Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    Decimal256(_, _) => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Decimal256Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+
+                    Int8 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Int8Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    Int16 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Int16Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    Int32 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Int32Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    Int64 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<Int64Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    UInt8 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<UInt8Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    UInt16 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<UInt16Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    UInt32 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<UInt32Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+                    UInt64 => Arc::new(BooleanArray::from_unary(
+                        array.as_primitive::<UInt64Type>(),
+                        |_| false,
+                    )) as ArrayRef,
+
+                    other => {
+                        return exec_err!(
+                            "Unsupported data type {other:?} for function {}",
+                            self.name()
+                        );
+                    }
+                };
+
+                Ok(ColumnarValue::Array(arr))
+            }
+        }
     }
 
     fn documentation(&self) -> Option<&Documentation> {

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -111,11 +111,43 @@ SELECT isnan(1.0::FLOAT), isnan('NaN'::FLOAT), isnan(-'NaN'::FLOAT), isnan(NULL:
 ----
 false true true NULL
 
+# isnan: non-float numeric inputs are never NaN
+query BBBB
+SELECT isnan(1::INT), isnan(0::INT), isnan(NULL::INT), isnan(123::BIGINT)
+----
+false false NULL false
+
+query BBBB
+SELECT isnan(1::INT UNSIGNED), isnan(0::INT UNSIGNED), isnan(NULL::INT UNSIGNED), isnan(255::TINYINT UNSIGNED)
+----
+false false NULL false
+
+query BBBB
+SELECT isnan(1::DECIMAL(10,2)), isnan(0::DECIMAL(10,2)), isnan(NULL::DECIMAL(10,2)), isnan(-1::DECIMAL(10,2))
+----
+false false NULL false
+
 # iszero
 query BBBB
 SELECT iszero(1.0), iszero(0.0), iszero(-0.0), iszero(NULL)
 ----
 false true true NULL
+
+# iszero: integers / unsigned / decimals
+query BBBB
+SELECT iszero(1::INT), iszero(0::INT), iszero(NULL::INT), iszero(-1::INT)
+----
+false true NULL false
+
+query BBBB
+SELECT iszero(1::INT UNSIGNED), iszero(0::INT UNSIGNED), iszero(NULL::INT UNSIGNED), iszero(255::TINYINT UNSIGNED)
+----
+false true NULL false
+
+query BBBB
+SELECT iszero(1::DECIMAL(10,2)), iszero(0::DECIMAL(10,2)), iszero(NULL::DECIMAL(10,2)), iszero(-1::DECIMAL(10,2))
+----
+false true NULL false
 
 # abs: empty argument
 statement error


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #20089

## Rationale for this change

iszero() and isnan() previously accepted “numeric” inputs by implicitly coercing them to Float64, adding unnecessary casts and work for integer/decimal inputs.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

 - Updated iszero() and isnan() signatures to accept TypeSignatureClass::Numeric without implicit float coercion.
 - Refactored iszero() implementation to evaluate zero checks directly for integers, unsigned integers, floats, and decimals.
 - Refactored isnan() implementation to compute is_nan only for float types and return false for all other numeric types  and reduced non-float array handling to use unary kernels instead of manual iteration.
 - Added  sqllogictest

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
