### PR TITLE
perf: Optimize scalar fast path of to_hex function

### DIFF
--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -716,6 +716,27 @@ SELECT to_hex(CAST(NULL AS int))
 NULL
 
 query T
+SELECT to_hex(0)
+----
+0
+
+# negative values (two's complement encoding)
+query T
+SELECT to_hex(-1)
+----
+ffffffffffffffff
+
+query T
+SELECT to_hex(CAST(-1 AS INT))
+----
+ffffffffffffffff
+
+query T
+SELECT to_hex(CAST(255 AS TINYINT UNSIGNED))
+----
+ff
+
+query T
 SELECT trim(' tom ')
 ----
 tom


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of https://github.com/apache/datafusion-comet/issues/2986

## Rationale for this change

`to_hex` (used by benchmark items `hex_int` / `hex_long`) previously routed evaluation through `make_scalar_function(..., vec![])`, which converts scalar inputs into size‑1 arrays before execution. This adds avoidable overhead for constant folding / scalar evaluation.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

- Add match-based scalar fast path for integer scalars:
  - `Int8/16/32/64` and `UInt8/16/32/64`
- Remove `make_scalar_function(..., vec![])` usage

| Type | Before | After | Speedup |
|------|--------|-------|---------|
| `to_hex/scalar_i32` | 270.73 ns | 86.676 ns | **3.12x** |
| `to_hex/scalar_i64` | 254.71 ns | 89.254 ns | **2.85x** |

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
