### PR TITLE
Make session state builder clonable

### DIFF
--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -969,6 +969,7 @@ impl SessionState {
 /// be used for all values unless explicitly provided.
 ///
 /// See example on [`SessionState`]
+#[derive(Clone)]
 pub struct SessionStateBuilder {
     session_id: Option<String>,
     analyzer: Option<Analyzer>,


### PR DESCRIPTION

## Rationale for this change

We have the next flow in our DF based project: create a base `SessionStateBuilder` and then, when a new user session is created, it is used to build a session state. As `build(...)` consumes `self`, it would be good to have `Clone` on `SesssionStateBuilder`, what this patch adds.
