### PR TITLE
fix: Make `serialize_to_file` test cross platform

### DIFF
--- a/datafusion/substrait/tests/cases/serialize.rs
+++ b/datafusion/substrait/tests/cases/serialize.rs
@@ -48,9 +48,12 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            ["File exists", "os error 80"]
-                .iter()
-                .any(|s| got.contains(s))
+            [
+                "File exists", // unix
+                "os error 80"  // windows
+            ]
+            .iter()
+            .any(|s| got.contains(s))
         );
 
         fs::remove_file(path)?;


### PR DESCRIPTION
## Which issue does this PR close?

- N/A.

## Rationale for this change

Make the `serialize_to_file` substrait test work on different platforms.

## What changes are included in this PR?

- Updated `serialize_to_file`.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.