### PR TITLE
fix: datatype_is_logically_equal for dictionaries

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -1801,7 +1801,7 @@ mod tests {
             &DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8))
         ));
 
-        // Dictionary is logically equal to logically equivalent value type
+        // Dictionary is logically equal to the logically equivalent value type
         assert!(DFSchema::datatype_is_logically_equal(
             &DataType::Utf8View,
             &DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8))


### PR DESCRIPTION
## Which issue does this PR close?

When checking logical equivalence with `Dictionary<_, Utf8>` and `Utf8View`, the response was `false` which is not what we expect (logical equivalence should be a transitive property).

## What changes are included in this PR?

This PR introduces a test and a fix. The test fails without the fix. The fix is simply calling `datatype_is_logically_equal` again on the `v1` and `othertype` when called with `Dictionary<K1, V1>` and `othertype`.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.