### PR TITLE
Refactor schema rewriter: remove lifetimes, extract column/cast helpers, add mismatch coverage

### DIFF
--- a/datafusion/physical-expr-adapter/src/schema_rewriter.rs
+++ b/datafusion/physical-expr-adapter/src/schema_rewriter.rs
@@ -427,10 +427,7 @@ impl DefaultPhysicalExprAdapterRewriter {
             return Ok(Transformed::no(expr));
         }
 
-        let column = self.resolve_column(
-            column,
-            physical_column_index,
-        )?;
+        let column = self.resolve_column(column, physical_column_index)?;
 
         if logical_field.data_type() == physical_field.data_type() {
             // If the data types match, we can use the column as is
@@ -457,10 +454,7 @@ impl DefaultPhysicalExprAdapterRewriter {
         if column.index() == physical_column_index {
             Ok(column.clone())
         } else {
-            Column::new_with_schema(
-                column.name(),
-                self.physical_file_schema.as_ref(),
-            )
+            Column::new_with_schema(column.name(), self.physical_file_schema.as_ref())
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #20161.

## Rationale for this change

This change is a focused refactor of the `PhysicalExprAdapter` schema rewriter to improve readability and maintainability while preserving behavior.

Key motivations:

* Reduce complexity from explicit lifetimes by storing schema references as `SchemaRef`.
* Make column/index/type handling easier to follow by extracting helper functions.
* Strengthen the test suite to ensure refactors do not alter adapter output.

## What changes are included in this PR?

* Refactored `DefaultPhysicalExprAdapterRewriter` to own `SchemaRef` values instead of borrowing `&Schema`.

  * Simplifies construction and avoids lifetime plumbing.
* Simplified column rewrite logic by:

  * Early-exiting when both the physical index and data type already match.
  * Extracting `resolve_column` to handle physical index/name resolution.
  * Extracting `create_cast_column_expr` to validate cast compatibility (including nested structs) and build `CastColumnExpr`.
* Minor cleanups in struct compatibility validation and field selection to ensure the cast checks are performed against the *actual* physical field resolved by the final column index.
* Test updates and additions:

  * Simplified construction of expected struct `Field`s in tests for clarity.
  * Added `test_rewrite_column_index_and_type_mismatch` to validate the combined case where the logical column index differs from the physical schema *and* the data type requires casting.

## Are these changes tested?

Yes.

* Existing unit tests continue to pass.
* Added a new unit test to cover the index-and-type mismatch scenario for column rewriting, asserting:

  * The inner `Column` points to the correct physical index.
  * The resulting expression is a `CastColumnExpr` producing the expected logical type.

## Are there any user-facing changes?

No.

* This is a refactor/cleanup intended to preserve existing behavior.
* No public API changes, no behavioral changes expected in query results.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
