### PR TITLE
fix(datafusion-cli): solve row count bug adding`saturating_add` to prevent potential overflow

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -300,7 +300,7 @@ impl StatementExecutor {
                 let curr_num_rows = batch.num_rows();
                 // Stop collecting results if the number of rows exceeds the limit
                 // results batch should include the last batch that exceeds the limit
-                if row_count < max_rows + curr_num_rows {
+                if row_count < max_rows.saturating_add(curr_num_rows) {
                     // Try to grow the reservation to accommodate the batch in memory
                     reservation.try_grow(get_record_batch_memory_size(&batch))?;
                     results.push(batch);


### PR DESCRIPTION
Currently `print_options::MaxRows::Unlimited` basically always panics with `attempt to add with overflow`, because we are summing `usize::MAX` with a positive number.

`saturating_add` solves this issue

# MRE

```rs
fn main() {
    let max = usize::MAX;
    println!("max: {}", max);
    let max = max + 1;
    println!("max: {}", max);
}
```

