### PR TITLE
Document the relationship between FileFormat::projection / FileFormat::filter and FileScanConfig::output_ordering

### DIFF
--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -158,7 +158,7 @@ pub struct FileScanConfig {
     /// DataFusion may reorder file processing for optimization without affecting correctness.
     pub preserve_order: bool,
     /// All equivalent lexicographical output orderings of this file scan, in terms of
-    /// [`Self::table_schema`]. See [`FileScanConfigBuilder::with_output_ordering`] for more
+    /// [`FileSource::table_schema`]. See [`FileScanConfigBuilder::with_output_ordering`] for more
     /// details.
     ///
     /// [`Self::eq_properties`] uses this information along with projection


### PR DESCRIPTION

## Which issue does this PR close?

- closes https://github.com/apache/datafusion/issues/20173
- Similar to https://github.com/apache/datafusion/pull/20188

## Rationale for this change

I spent a long time trying to figure out what was going on in our fork after
a DataFusion 52 upgrade, and the root cause was that the output_ordering in DataFusion
52 does *NOT* include the projection (more details here https://github.com/apache/datafusion/issues/20173#issuecomment-3862089306)

This was not clear to me from the DataFusion code or documentation, and I think
it would be helpful to clarify this in the documentation.


## What changes are included in this PR?

1. Document FileScanConfig::output_ordering better


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
