### PR TITLE
fix: Fix panic in regexp_like()

### DIFF
--- a/datafusion/functions/src/regex/regexplike.rs
+++ b/datafusion/functions/src/regex/regexplike.rs
@@ -356,7 +356,7 @@ fn handle_regexp_like(
                 .map_err(|e| arrow_datafusion_err!(e))?
         }
         (Utf8, LargeUtf8) => {
-            let value = values.as_string_view();
+            let value = values.as_string::<i32>();
             let pattern = patterns.as_string::<i64>();
 
             regexp::regexp_is_match(value, pattern, flags)

--- a/datafusion/sqllogictest/test_files/regexp/regexp_like.slt
+++ b/datafusion/sqllogictest/test_files/regexp/regexp_like.slt
@@ -334,5 +334,10 @@ true true
 false false
 false false
 
+query TT
+select * from regexp_test where regexp_like('f', regexp_replace((('v\r') like ('f_*sP6H1*')), '339629555', '-1459539013'));
+----
+
+
 statement ok
 drop table if exists dict_table;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

Evaluating
```
CREATE TABLE t0(v0 BOOLEAN, v1 BOOLEAN, v2 BIGINT);
INSERT INTO t0(v2) VALUES (680485277);
SELECT 'NaN'::Double FROM t0 AS tt0 WHERE REGEXP_LIKE('f', REGEXP_REPLACE((('v\r') LIKE ('f_*sP6H1*')), '339629555', '-1459539013'));
```

Yields a panic:

```
DataFusion CLI v52.1.0
0 row(s) fetched.
Elapsed 0.010 seconds.

+-------+
| count |
+-------+
| 1     |
+-------+
1 row(s) fetched.
Elapsed 0.008 seconds.


thread 'main' (41417869) panicked at /Users/neilconway/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-array-57.2.0/src/cast.rs:878:33:
string view array
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/std/src/panicking.rs:698:5
   1: core::panicking::panic_fmt
             at /rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/panicking.rs:80:14
   2: core::panicking::panic_display
             at /rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/panicking.rs:264:5
   3: core::option::expect_failed
             at /rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/option.rs:2183:5
   4: core::option::Option<T>::expect
             at /Users/neilconway/.rustup/toolchains/1.92.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/option.rs:970:21
   5: arrow_array::cast::AsArray::as_string_view
             at /Users/neilconway/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-array-57.2.0/src/cast.rs:878:33
   6: datafusion_functions::regex::regexplike::handle_regexp_like
             at ./datafusion/functions/src/regex/regexplike.rs:359:32
   7: datafusion_functions::regex::regexplike::regexp_like
             at ./datafusion/functions/src/regex/regexplike.rs:272:14
```

## Are these changes tested?

Tested manually. It seemed a bit arbitrary to add a unit test for this case specifically, but I'm happy to do so if folks think it would be useful.