### PR TITLE
fix: add parentheses to SchemaDisplay/SqlDisplay for BinaryExpr

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -2847,7 +2847,16 @@ impl Display for SchemaDisplay<'_> {
                 }
             }
             Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
-                write!(f, "{} {op} {}", SchemaDisplay(left), SchemaDisplay(right),)
+                // Add parentheses around nested binary expressions to preserve precedence
+                fn write_child(f: &mut Formatter<'_>, expr: &Expr) -> fmt::Result {
+                    match expr {
+                        Expr::BinaryExpr(_) => write!(f, "({})", SchemaDisplay(expr)),
+                        _ => write!(f, "{}", SchemaDisplay(expr)),
+                    }
+                }
+                write_child(f, left)?;
+                write!(f, " {op} ")?;
+                write_child(f, right)
             }
             Expr::Case(Case {
                 expr,
@@ -3109,7 +3118,18 @@ impl Display for SqlDisplay<'_> {
                 }
             }
             Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
-                write!(f, "{} {op} {}", SqlDisplay(left), SqlDisplay(right),)
+                // Add parentheses around nested binary expressions to preserve precedence
+                fn write_child(f: &mut Formatter<'_>, expr: &Expr) -> fmt::Result {
+                    match expr {
+                        Expr::BinaryExpr(_) => {
+                            write!(f, "({})", SqlDisplay(expr))
+                        }
+                        _ => write!(f, "{}", SqlDisplay(expr)),
+                    }
+                }
+                write_child(f, left)?;
+                write!(f, " {op} ")?;
+                write_child(f, right)
             }
             Expr::Case(Case {
                 expr,

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -888,7 +888,7 @@ mod test {
         assert_optimized_plan_equal!(
             plan,
             @ r"
-        Aggregate: groupBy=[[]], aggr=[[sum(__common_expr_1 AS test.a * Int32(1) - test.b), sum(__common_expr_1 AS test.a * Int32(1) - test.b * (Int32(1) + test.c))]]
+        Aggregate: groupBy=[[]], aggr=[[sum(__common_expr_1 AS test.a * (Int32(1) - test.b)), sum(__common_expr_1 AS test.a * (Int32(1) - test.b) * (Int32(1) + test.c)) AS sum((test.a * (Int32(1) - test.b)) * (Int32(1) + test.c))]]
           Projection: test.a * (Int32(1) - test.b) AS __common_expr_1, test.a, test.b, test.c
             TableScan: test
         "

--- a/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
+++ b/datafusion/optimizer/src/simplify_expressions/simplify_exprs.rs
@@ -491,7 +491,7 @@ mod tests {
             .build()?;
 
         let actual = get_optimized_plan_formatted(plan, &time);
-        let expected = "Projection: NOT test.a AS Boolean(true) OR Boolean(false) != test.a\
+        let expected = "Projection: NOT test.a AS (Boolean(true) OR Boolean(false)) != test.a\
                         \n  TableScan: test";
 
         assert_eq!(expected, actual);

--- a/datafusion/sql/tests/cases/params.rs
+++ b/datafusion/sql/tests/cases/params.rs
@@ -357,7 +357,7 @@ fn test_prepare_statement_to_plan_params_as_constants() {
     assert_snapshot!(
         plan_with_params,
         @r"
-    Projection: Int64(1) + Int32(10) + Float64(10) AS Int64(1) + $1 + $2
+    Projection: Int64(1) + Int32(10) + Float64(10) AS (Int64(1) + $1) + $2
       EmptyRelation: rows=1
     "
     );


### PR DESCRIPTION
## Which issue does this PR close?

Closes #16054

## Rationale for this change

Expression formatting like `(1+2)*3` displays as `Int64(1) + Int64(2) * Int64(3)`, losing parentheses and misrepresenting precedence in column headers and EXPLAIN output.

## What changes are included in this PR?

- `SchemaDisplay` and `SqlDisplay` for `BinaryExpr` now wrap nested `BinaryExpr` children in parentheses (unconditional/DuckDB-style approach as discussed in the issue)
- Updated 3 test snapshots

## Are these changes tested?

Partially. Rust crate tests pass, but 6 SLT tests fail due to `optimize_projections` schema mismatches — when projection merging restructures expression trees, the unconditional parenthesization produces different `schema_name()` strings for semantically equivalent expressions. Opening as draft to get feedback on the right approach.

## Are there any user-facing changes?

Column headers and EXPLAIN output will include parentheses around nested binary sub-expressions.