### PR TITLE
fix: Handle NULL inputs correctly in find_in_set()

### DIFF
--- a/datafusion/functions/src/unicode/find_in_set.rs
+++ b/datafusion/functions/src/unicode/find_in_set.rs
@@ -98,9 +98,8 @@ impl ScalarUDFImpl for FindInSetFunc {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs { args, .. } = args;
-
-        let [string, str_list] = take_function_args(self.name(), args)?;
+        let return_field = args.return_field;
+        let [string, str_list] = take_function_args(self.name(), args.args)?;
 
         match (string, str_list) {
             // both inputs are scalars
@@ -141,7 +140,7 @@ impl ScalarUDFImpl for FindInSetFunc {
             ) => {
                 let result_array = match str_list_literal {
                     // find_in_set(column_a, null) = null
-                    None => new_null_array(str_array.data_type(), str_array.len()),
+                    None => new_null_array(return_field.data_type(), str_array.len()),
                     Some(str_list_literal) => {
                         let str_list = str_list_literal.split(',').collect::<Vec<&str>>();
                         let result = match str_array.data_type() {
@@ -190,7 +189,7 @@ impl ScalarUDFImpl for FindInSetFunc {
                 let res = match string_literal {
                     // find_in_set(null, column_b) = null
                     None => {
-                        new_null_array(str_list_array.data_type(), str_list_array.len())
+                        new_null_array(return_field.data_type(), str_list_array.len())
                     }
                     Some(string) => {
                         let result = match str_list_array.data_type() {

--- a/datafusion/sqllogictest/test_files/string/string_query.slt.part
+++ b/datafusion/sqllogictest/test_files/string/string_query.slt.part
@@ -993,25 +993,27 @@ NULL NULL NULL NULL
 # Test FIND_IN_SET
 # --------------------------------------
 
-query IIII
+query IIIIII
 SELECT
   FIND_IN_SET(ascii_1, 'a,b,c,d'),
   FIND_IN_SET(ascii_1, 'Andrew,Xiangpeng,Raphael'),
   FIND_IN_SET(unicode_1, 'a,b,c,d'),
-  FIND_IN_SET(unicode_1, 'datafusion📊🔥,datafusion数据融合,datafusionДатаФусион')
+  FIND_IN_SET(unicode_1, 'datafusion📊🔥,datafusion数据融合,datafusionДатаФусион'),
+  FIND_IN_SET(NULL, unicode_1),
+  FIND_IN_SET(unicode_1, NULL)
 FROM test_basic_operator;
 ----
-0 1 0 1
-0 2 0 2
-0 3 0 3
-0 0 0 0
-0 0 0 0
-0 0 0 0
-0 0 0 0
-0 0 0 0
-0 0 0 0
-NULL NULL NULL NULL
-NULL NULL NULL NULL
+0 1 0 1 NULL NULL
+0 2 0 2 NULL NULL
+0 3 0 3 NULL NULL
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
+0 0 0 0 NULL NULL
+NULL NULL NULL NULL NULL NULL
+NULL NULL NULL NULL NULL NULL
 
 # --------------------------------------
 # Test || operator


### PR DESCRIPTION
The previous coding returned an array of the wrong type, leading to an assertion failure.

## Rationale for this change

```
create table tt (x string);
insert into tt values ('a'), ('b,a'), ('c'), (null);
select find_in_set(tt.x, null) from tt;
select find_in_set(null, tt.x) from tt;
```

Yields:

```
Internal error: Assertion failed: result_data_type == *expected_type: Function 'find_in_set' returned value of type 'Utf8View' while the following type was promised at planning time and expected: 'Int32'.
This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
Internal error: Assertion failed: result_data_type == *expected_type: Function 'find_in_set' returned value of type 'Utf8View' while the following type was promised at planning time and expected: 'Int32'.
This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
```

## Are these changes tested?

Yes, added an SLT test.
