### PR TITLE
fix: Avoid assertion failure on divide-by-zero

### DIFF
--- a/datafusion/physical-expr/src/analysis.rs
+++ b/datafusion/physical-expr/src/analysis.rs
@@ -178,7 +178,7 @@ pub fn analyze(
             "ExprBoundaries has a non-zero distinct count although it represents an empty table"
         );
         assert_or_internal_err!(
-            context.selectivity == Some(0.0),
+            context.selectivity.unwrap_or(0.0) == 0.0,
             "AnalysisContext has a non-zero selectivity although it represents an empty table"
         );
         Ok(context)

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -1926,3 +1926,12 @@ select "current_time" is not null from t_with_current_time;
 true
 false
 true
+
+# https://github.com/apache/datafusion/issues/20215
+statement count 0
+CREATE TABLE t0;
+
+query I
+SELECT COUNT(*) FROM t0 AS tt0 WHERE (4==(3/0));
+----
+0


### PR DESCRIPTION
A WHERE clause like `4==(3/0)` will not be optimized away, but will result in `context.selectivity` being `None`.

## Which issue does this PR close?

- Closes #20215 

## Are these changes tested?

Added test case.