### PR TITLE
chore: enable clippy::clone_on_ref_ptr lint for the whole workspace (#17083)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,7 @@ or_fun_call = "warn"
 unnecessary_lazy_evaluations = "warn"
 uninlined_format_args = "warn"
 inefficient_to_string = "warn"
+clone_on_ref_ptr = "deny"
 # https://github.com/apache/datafusion/issues/18503
 needless_pass_by_value = "warn"
 # https://github.com/apache/datafusion/issues/18881

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -30,6 +30,9 @@ rust-version = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true
+
 [features]
 default = []
 backtrace = ["datafusion/backtrace"]

--- a/datafusion-cli/examples/cli-session-context.rs
+++ b/datafusion-cli/examples/cli-session-context.rs
@@ -73,8 +73,8 @@ impl CliSessionContext for MyUnionerContext {
         &self,
         plan: LogicalPlan,
     ) -> Result<DataFrame, DataFusionError> {
-        let new_plan = LogicalPlanBuilder::from(plan.clone())
-            .union(plan.clone())?
+        let new_plan = LogicalPlanBuilder::from(Arc::clone(&plan))
+            .union(Arc::clone(&plan))?
             .build()?;
 
         self.ctx.execute_logical_plan(new_plan).await

--- a/datafusion-cli/examples/cli-session-context.rs
+++ b/datafusion-cli/examples/cli-session-context.rs
@@ -73,8 +73,8 @@ impl CliSessionContext for MyUnionerContext {
         &self,
         plan: LogicalPlan,
     ) -> Result<DataFrame, DataFusionError> {
-        let new_plan = LogicalPlanBuilder::from(Arc::clone(&plan))
-            .union(Arc::clone(&plan))?
+        let new_plan = LogicalPlanBuilder::from(plan.clone())
+            .union(plan.clone())?
             .build()?;
 
         self.ctx.execute_logical_plan(new_plan).await

--- a/datafusion-cli/src/catalog.rs
+++ b/datafusion-cli/src/catalog.rs
@@ -67,7 +67,7 @@ impl CatalogProviderList for DynamicObjectStoreCatalog {
     }
 
     fn catalog(&self, name: &str) -> Option<Arc<dyn CatalogProvider>> {
-        let state = self.state.clone();
+        let state = Weak::clone(&self.state);
         self.inner.catalog(name).map(|catalog| {
             Arc::new(DynamicObjectStoreCatalogProvider::new(catalog, state)) as _
         })
@@ -100,7 +100,7 @@ impl CatalogProvider for DynamicObjectStoreCatalogProvider {
     }
 
     fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
-        let state = self.state.clone();
+        let state = Weak::clone(&self.state);
         self.inner.schema(name).map(|schema| {
             Arc::new(DynamicObjectStoreSchemaProvider::new(schema, state)) as _
         })
@@ -240,12 +240,12 @@ mod tests {
     fn setup_context() -> (SessionContext, Arc<dyn SchemaProvider>) {
         let ctx = SessionContext::new();
         ctx.register_catalog_list(Arc::new(DynamicObjectStoreCatalog::new(
-            ctx.state().catalog_list().clone(),
+            Arc::clone(ctx.state().catalog_list()),
             ctx.state_weak_ref(),
         )));
 
         let provider = &DynamicObjectStoreCatalog::new(
-            ctx.state().catalog_list().clone(),
+            Arc::clone(ctx.state().catalog_list()),
             ctx.state_weak_ref(),
         ) as &dyn CatalogProviderList;
         let catalog = provider

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -48,6 +48,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::io::prelude::*;
+use std::sync::Arc;
 use tokio::signal;
 
 /// run and execute SQL statements and commands, against a context with the given print options
@@ -281,14 +282,14 @@ impl StatementExecutor {
             }
             // As the input stream comes, we can generate results.
             // However, memory safety is not guaranteed.
-            let stream = execute_stream(physical_plan, task_ctx.clone())?;
+            let stream = execute_stream(physical_plan, Arc::clone(&task_ctx))?;
             print_options
                 .print_stream(stream, now, &options.format)
                 .await?;
         } else {
             // Bounded stream; collected results size is limited by the maxrows option
             let schema = physical_plan.schema();
-            let mut stream = execute_stream(physical_plan, task_ctx.clone())?;
+            let mut stream = execute_stream(physical_plan, Arc::clone(&task_ctx))?;
             let mut results = vec![];
             let mut row_count = 0_usize;
             let max_rows = match print_options.maxrows {

--- a/datafusion-cli/src/functions.rs
+++ b/datafusion-cli/src/functions.rs
@@ -233,8 +233,8 @@ impl TableProvider for ParquetMetadataTable {
         self
     }
 
-    fn schema(&self) -> arrow::datatypes::SchemaRef {
-        self.schema.clone()
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
     }
 
     fn table_type(&self) -> datafusion::logical_expr::TableType {
@@ -436,7 +436,7 @@ impl TableFunctionImpl for ParquetMetadataFunc {
         }
 
         let rb = RecordBatch::try_new(
-            schema.clone(),
+            Arc::clone(&schema),
             vec![
                 Arc::new(StringArray::from(filename_arr)),
                 Arc::new(Int64Array::from(row_group_id_arr)),
@@ -482,8 +482,8 @@ impl TableProvider for MetadataCacheTable {
         self
     }
 
-    fn schema(&self) -> arrow::datatypes::SchemaRef {
-        self.schema.clone()
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
     }
 
     fn table_type(&self) -> datafusion::logical_expr::TableType {
@@ -569,7 +569,7 @@ impl TableFunctionImpl for MetadataCacheFunc {
         }
 
         let batch = RecordBatch::try_new(
-            schema.clone(),
+            Arc::clone(&schema),
             vec![
                 Arc::new(StringArray::from(path_arr)),
                 Arc::new(TimestampMillisecondArray::from(file_modified_arr)),
@@ -600,8 +600,8 @@ impl TableProvider for StatisticsCacheTable {
         self
     }
 
-    fn schema(&self) -> arrow::datatypes::SchemaRef {
-        self.schema.clone()
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
     }
 
     fn table_type(&self) -> datafusion::logical_expr::TableType {
@@ -684,7 +684,7 @@ impl TableFunctionImpl for StatisticsCacheFunc {
         }
 
         let batch = RecordBatch::try_new(
-            schema.clone(),
+            Arc::clone(&schema),
             vec![
                 Arc::new(StringArray::from(path_arr)),
                 Arc::new(TimestampMillisecondArray::from(file_modified_arr)),
@@ -735,8 +735,8 @@ impl TableProvider for ListFilesCacheTable {
         self
     }
 
-    fn schema(&self) -> arrow::datatypes::SchemaRef {
-        self.schema.clone()
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
     }
 
     fn table_type(&self) -> datafusion::logical_expr::TableType {
@@ -862,7 +862,7 @@ impl TableFunctionImpl for ListFilesCacheFunc {
             OffsetBuffer::new(ScalarBuffer::from(Buffer::from_vec(offsets)));
 
         let batch = RecordBatch::try_new(
-            schema.clone(),
+            Arc::clone(&schema),
             vec![
                 Arc::new(StringArray::from(table_arr)),
                 Arc::new(StringArray::from(path_arr)),

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -819,7 +819,7 @@ mod tests {
 
         assert_eq!(
             2,
-            Arc::clone(&df)
+            df.clone()
                 .filter(col("expires_in").is_not_null())?
                 .count()
                 .await?

--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -209,7 +209,7 @@ impl CredentialsFromConfig {
 
 #[derive(Debug)]
 struct S3CredentialProvider {
-    credentials: aws_credential_types::provider::SharedCredentialsProvider,
+    credentials: SharedCredentialsProvider,
 }
 
 #[async_trait]

--- a/datafusion-cli/src/object_storage/instrumented.rs
+++ b/datafusion-cli/src/object_storage/instrumented.rs
@@ -110,7 +110,7 @@ pub enum InstrumentedObjectStoreMode {
 }
 
 impl fmt::Display for InstrumentedObjectStoreMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:?}")
     }
 }
@@ -383,7 +383,7 @@ impl InstrumentedObjectStore {
 }
 
 impl fmt::Display for InstrumentedObjectStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mode: InstrumentedObjectStoreMode =
             self.instrument_mode.load(Ordering::Relaxed).into();
         write!(
@@ -490,7 +490,7 @@ pub enum Operation {
 }
 
 impl fmt::Display for Operation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:?}")
     }
 }
@@ -508,7 +508,7 @@ pub struct RequestDetails {
 }
 
 impl fmt::Display for RequestDetails {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut output_parts = vec![format!(
             "{} operation={:?}",
             self.timestamp.to_rfc3339(),

--- a/datafusion-cli/src/print_format.rs
+++ b/datafusion-cli/src/print_format.rs
@@ -585,7 +585,7 @@ mod tests {
             self.format
                 .print_batches(
                     &mut buffer,
-                    self.schema.clone(),
+                    Arc::clone(&self.schema),
                     &self.batches,
                     self.maxrows,
                     with_header,

--- a/datafusion-cli/src/print_options.rs
+++ b/datafusion-cli/src/print_options.rs
@@ -115,7 +115,7 @@ impl PrintOptions {
         row_count: usize,
         format_options: &FormatOptions,
     ) -> Result<()> {
-        let stdout = std::io::stdout();
+        let stdout = io::stdout();
         let mut writer = stdout.lock();
 
         self.format.print_batches(
@@ -153,7 +153,7 @@ impl PrintOptions {
             ));
         };
 
-        let stdout = std::io::stdout();
+        let stdout = io::stdout();
         let mut writer = stdout.lock();
 
         let mut row_count = 0_usize;

--- a/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_example_table_provider/Cargo.toml
@@ -21,6 +21,9 @@ version = "0.1.0"
 edition = { workspace = true }
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 abi_stable = "0.11.3"
 arrow = { workspace = true }

--- a/datafusion-examples/examples/ffi/ffi_module_interface/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_module_interface/Cargo.toml
@@ -21,6 +21,9 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 abi_stable = "0.11.3"
 datafusion-ffi = { workspace = true }

--- a/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
+++ b/datafusion-examples/examples/ffi/ffi_module_loader/Cargo.toml
@@ -21,6 +21,9 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 abi_stable = "0.11.3"
 datafusion = { workspace = true }

--- a/datafusion/catalog-listing/src/mod.rs
+++ b/datafusion/catalog-listing/src/mod.rs
@@ -21,9 +21,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 
 mod config;
 pub mod helpers;

--- a/datafusion/catalog/src/lib.rs
+++ b/datafusion/catalog/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Interfaces and default implementations of catalogs and schemas.

--- a/datafusion/common-runtime/src/lib.rs
+++ b/datafusion/common-runtime/src/lib.rs
@@ -21,9 +21,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 
 pub mod common;
 mod join_set;

--- a/datafusion/common/benches/with_hashes.rs
+++ b/datafusion/common/benches/with_hashes.rs
@@ -80,14 +80,18 @@ fn criterion_benchmark(c: &mut Criterion) {
             do_hash_test(b, std::slice::from_ref(&nullable_array));
         });
         c.bench_function(&format!("{name}: multiple, no nulls"), |b| {
-            let arrays = vec![array.clone(), array.clone(), array.clone()];
+            let arrays = vec![
+                Arc::clone(&array),
+                Arc::clone(&array),
+                Arc::clone(&array),
+            ];
             do_hash_test(b, &arrays);
         });
         c.bench_function(&format!("{name}: multiple, nulls"), |b| {
             let arrays = vec![
-                nullable_array.clone(),
-                nullable_array.clone(),
-                nullable_array.clone(),
+                Arc::clone(&nullable_array),
+                Arc::clone(&nullable_array),
+                Arc::clone(&nullable_array),
             ];
             do_hash_test(b, &arrays);
         });
@@ -124,8 +128,7 @@ where
 
 // Returns an new array that is the same as array, but with nulls
 fn add_nulls(array: &ArrayRef) -> ArrayRef {
-    let array_data = array
-        .clone()
+    let array_data = Arc::clone(array)
         .into_data()
         .into_builder()
         .nulls(Some(create_null_mask(array.len())))

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 mod column;

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -20,19 +20,12 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-//
 // Eliminate unnecessary function calls(some may be not cheap) due to `xxx_or`
 // for performance. Also avoid abusing `xxx_or_else` for readability:
 // https://github.com/apache/datafusion/issues/15802
 #![cfg_attr(
     not(test),
-    deny(
-        clippy::clone_on_ref_ptr,
-        clippy::or_fun_call,
-        clippy::unnecessary_lazy_evaluations
-    )
+    deny(clippy::or_fun_call, clippy::unnecessary_lazy_evaluations)
 )]
 #![warn(missing_docs, clippy::needless_borrow)]
 // Use `allow` instead of `expect` for test configuration to explicitly

--- a/datafusion/datasource-arrow/src/mod.rs
+++ b/datafusion/datasource-arrow/src/mod.rs
@@ -16,9 +16,6 @@
 // under the License.
 
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 
 //! [`ArrowFormat`]: Apache Arrow file format abstractions
 

--- a/datafusion/datasource-avro/src/mod.rs
+++ b/datafusion/datasource-avro/src/mod.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! An [Avro](https://avro.apache.org/) based [`FileSource`](datafusion_datasource::file::FileSource) implementation and related functionality.

--- a/datafusion/datasource-csv/src/mod.rs
+++ b/datafusion/datasource-csv/src/mod.rs
@@ -16,9 +16,6 @@
 // under the License.
 
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 
 pub mod file_format;
 pub mod source;

--- a/datafusion/datasource-json/src/mod.rs
+++ b/datafusion/datasource-json/src/mod.rs
@@ -16,9 +16,6 @@
 // under the License.
 
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 
 pub mod file_format;
 pub mod source;

--- a/datafusion/datasource-parquet/src/mod.rs
+++ b/datafusion/datasource-parquet/src/mod.rs
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 pub mod access_plan;

--- a/datafusion/datasource/benches/split_groups_by_statistics.rs
+++ b/datafusion/datasource/benches/split_groups_by_statistics.rs
@@ -56,7 +56,7 @@ pub fn compare_split_groups_by_statistics_algorithms(c: &mut Criterion) {
                 ),
                 &(
                     file_groups.clone(),
-                    file_schema.clone(),
+                    Arc::clone(&file_schema),
                     sort_ordering.clone(),
                 ),
                 |b, (fg, schema, order)| {
@@ -79,7 +79,7 @@ pub fn compare_split_groups_by_statistics_algorithms(c: &mut Criterion) {
                     ),
                     &(
                         file_groups.clone(),
-                        file_schema.clone(),
+                        Arc::clone(&file_schema),
                         sort_ordering.clone(),
                         tp,
                     ),

--- a/datafusion/datasource/src/mod.rs
+++ b/datafusion/datasource/src/mod.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! A table that uses the `ObjectStore` listing capability

--- a/datafusion/execution/src/lib.rs
+++ b/datafusion/execution/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! DataFusion execution configuration and runtime structures

--- a/datafusion/expr-common/src/lib.rs
+++ b/datafusion/expr-common/src/lib.rs
@@ -28,9 +28,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 pub mod accumulator;

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! [DataFusion](https://github.com/apache/datafusion)

--- a/datafusion/ffi/src/lib.rs
+++ b/datafusion/ffi/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 pub mod arrow_wrappers;

--- a/datafusion/functions-aggregate-common/src/lib.rs
+++ b/datafusion/functions-aggregate-common/src/lib.rs
@@ -27,9 +27,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 pub mod accumulator;

--- a/datafusion/functions-aggregate/src/lib.rs
+++ b/datafusion/functions-aggregate/src/lib.rs
@@ -21,9 +21,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 
 //! Aggregate Function packages for [DataFusion].
 //!

--- a/datafusion/functions-nested/src/lib.rs
+++ b/datafusion/functions-nested/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Nested type Functions for [DataFusion].

--- a/datafusion/functions-table/src/lib.rs
+++ b/datafusion/functions-table/src/lib.rs
@@ -21,9 +21,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 
 pub mod generate_series;
 

--- a/datafusion/functions-window-common/src/lib.rs
+++ b/datafusion/functions-window-common/src/lib.rs
@@ -21,9 +21,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 
 //! Common user-defined window functionality for [DataFusion]
 //!

--- a/datafusion/functions-window/src/lib.rs
+++ b/datafusion/functions-window/src/lib.rs
@@ -21,9 +21,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 // https://github.com/apache/datafusion/issues/18881
 
 //! Window Function packages for [DataFusion].

--- a/datafusion/functions/benches/encoding.rs
+++ b/datafusion/functions/benches/encoding.rs
@@ -37,7 +37,10 @@ fn criterion_benchmark(c: &mut Criterion) {
             let method = ColumnarValue::Scalar("base64".into());
             let encoded = encoding::encode()
                 .invoke_with_args(ScalarFunctionArgs {
-                    args: vec![ColumnarValue::Array(bin_array.clone()), method.clone()],
+                    args: vec![
+                        ColumnarValue::Array(Arc::clone(&bin_array) as Arc<dyn Array>),
+                        method.clone(),
+                    ],
                     arg_fields: vec![
                         Field::new("a", bin_array.data_type().to_owned(), true).into(),
                         Field::new("b", method.data_type().to_owned(), true).into(),
@@ -79,7 +82,10 @@ fn criterion_benchmark(c: &mut Criterion) {
             ];
             let encoded = encoding::encode()
                 .invoke_with_args(ScalarFunctionArgs {
-                    args: vec![ColumnarValue::Array(bin_array.clone()), method.clone()],
+                    args: vec![
+                        ColumnarValue::Array(Arc::clone(&bin_array) as Arc<dyn Array>),
+                        method.clone(),
+                    ],
                     arg_fields,
                     number_rows: size,
                     return_field: Field::new("f", DataType::Utf8, true).into(),

--- a/datafusion/functions/src/lib.rs
+++ b/datafusion/functions/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Function packages for [DataFusion].

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! # DataFusion Optimizer

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -725,7 +725,7 @@ impl ContextProvider for MyContextProvider {
     fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
         let table_name = name.table();
         if let Some(table) = self.tables.get(table_name) {
-            Ok(table.clone())
+            Ok(Arc::clone(table))
         } else {
             plan_err!("table does not exist")
         }
@@ -786,6 +786,6 @@ impl TableSource for MyTableSource {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+        Arc::clone(&self.schema)
     }
 }

--- a/datafusion/physical-expr-adapter/Cargo.toml
+++ b/datafusion/physical-expr-adapter/Cargo.toml
@@ -11,6 +11,9 @@ license = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 name = "datafusion_physical_expr_adapter"
 path = "src/lib.rs"

--- a/datafusion/physical-expr-common/src/lib.rs
+++ b/datafusion/physical-expr-common/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Physical Expr Common packages for [DataFusion]

--- a/datafusion/physical-expr/benches/binary_op.rs
+++ b/datafusion/physical-expr/benches/binary_op.rs
@@ -163,9 +163,9 @@ fn benchmark_binary_op_in_short_circuit(c: &mut Criterion) {
     let (b_values, c_values) = generate_test_strings(8192);
 
     let batches_and =
-        create_record_batch::<true>(schema.clone(), &b_values, &c_values).unwrap();
+        create_record_batch::<true>(Arc::clone(&schema), &b_values, &c_values).unwrap();
     let batches_or =
-        create_record_batch::<false>(schema.clone(), &b_values, &c_values).unwrap();
+        create_record_batch::<false>(Arc::clone(&schema), &b_values, &c_values).unwrap();
 
     // Build complex string matching conditions
     let right_condition_and = and(
@@ -301,7 +301,7 @@ fn create_record_batch<const TEST_ALL_FALSE: bool>(
         rbs.push((
             name,
             RecordBatch::try_new(
-                schema.clone(),
+                Arc::clone(&schema),
                 vec![Arc::new(a_array), Arc::new(b_array), Arc::new(c_array)],
             )?,
         ));

--- a/datafusion/physical-expr/benches/simplify.rs
+++ b/datafusion/physical-expr/benches/simplify.rs
@@ -169,8 +169,8 @@ pub fn catalog_sales_predicate(num_partitions: usize) -> Arc<dyn PhysicalExpr> {
     let cs_item_sk: Arc<dyn PhysicalExpr> = Arc::new(Column::new("cs_item_sk", 15));
 
     // Use a simple modulo expression as placeholder for hash
-    let item_hash_mod = modulo(cs_item_sk.clone(), lit_i64(num_partitions as i64));
-    let date_hash_mod = modulo(cs_sold_date_sk.clone(), lit_i64(num_partitions as i64));
+    let item_hash_mod = modulo(Arc::clone(&cs_item_sk), lit_i64(num_partitions as i64));
+    let date_hash_mod = modulo(Arc::clone(&cs_sold_date_sk), lit_i64(num_partitions as i64));
 
     // cs_ship_addr_sk IS NULL
     let is_null_expr: Arc<dyn PhysicalExpr> = Arc::new(IsNullExpr::new(cs_ship_addr_sk));
@@ -179,10 +179,10 @@ pub fn catalog_sales_predicate(num_partitions: usize) -> Arc<dyn PhysicalExpr> {
     let item_when_then: Vec<(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)> = (0
         ..num_partitions)
         .map(|partition| {
-            let when_expr = eq(item_hash_mod.clone(), lit_i32(partition as i32));
+            let when_expr = eq(Arc::clone(&item_hash_mod), lit_i32(partition as i32));
             let then_expr = and(
-                gte(cs_item_sk.clone(), lit_i64(partition as i64)),
-                lte(cs_item_sk.clone(), lit_i64(18000)),
+                gte(Arc::clone(&cs_item_sk), lit_i64(partition as i64)),
+                lte(Arc::clone(&cs_item_sk), lit_i64(18000)),
             );
             (when_expr, then_expr)
         })
@@ -195,10 +195,10 @@ pub fn catalog_sales_predicate(num_partitions: usize) -> Arc<dyn PhysicalExpr> {
     let date_when_then: Vec<(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)> = (0
         ..num_partitions)
         .map(|partition| {
-            let when_expr = eq(date_hash_mod.clone(), lit_i32(partition as i32));
+            let when_expr = eq(Arc::clone(&date_hash_mod), lit_i32(partition as i32));
             let then_expr = and(
-                gte(cs_sold_date_sk.clone(), lit_i64(2415000 + partition as i64)),
-                lte(cs_sold_date_sk.clone(), lit_i64(2488070)),
+                gte(Arc::clone(&cs_sold_date_sk), lit_i64(2415000 + partition as i64)),
+                lte(Arc::clone(&cs_sold_date_sk), lit_i64(2488070)),
             );
             (when_expr, then_expr)
         })
@@ -220,8 +220,8 @@ fn web_sales_predicate(num_partitions: usize) -> Arc<dyn PhysicalExpr> {
         Arc::new(Column::new("ws_ship_customer_sk", 8));
 
     // Use simple modulo expression as placeholder for hash
-    let item_hash_mod = modulo(ws_item_sk.clone(), lit_i64(num_partitions as i64));
-    let date_hash_mod = modulo(ws_sold_date_sk.clone(), lit_i64(num_partitions as i64));
+    let item_hash_mod = modulo(Arc::clone(&ws_item_sk), lit_i64(num_partitions as i64));
+    let date_hash_mod = modulo(Arc::clone(&ws_sold_date_sk), lit_i64(num_partitions as i64));
 
     // ws_ship_customer_sk IS NULL
     let is_null_expr: Arc<dyn PhysicalExpr> =
@@ -231,10 +231,10 @@ fn web_sales_predicate(num_partitions: usize) -> Arc<dyn PhysicalExpr> {
     let item_when_then: Vec<(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)> = (0
         ..num_partitions)
         .map(|partition| {
-            let when_expr = eq(item_hash_mod.clone(), lit_i32(partition as i32));
+            let when_expr = eq(Arc::clone(&item_hash_mod), lit_i32(partition as i32));
             let then_expr = and(
-                gte(ws_item_sk.clone(), lit_i64(partition as i64)),
-                lte(ws_item_sk.clone(), lit_i64(18000)),
+                gte(Arc::clone(&ws_item_sk), lit_i64(partition as i64)),
+                lte(Arc::clone(&ws_item_sk), lit_i64(18000)),
             );
             (when_expr, then_expr)
         })
@@ -247,10 +247,10 @@ fn web_sales_predicate(num_partitions: usize) -> Arc<dyn PhysicalExpr> {
     let date_when_then: Vec<(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)> = (0
         ..num_partitions)
         .map(|partition| {
-            let when_expr = eq(date_hash_mod.clone(), lit_i32(partition as i32));
+            let when_expr = eq(Arc::clone(&date_hash_mod), lit_i32(partition as i32));
             let then_expr = and(
-                gte(ws_sold_date_sk.clone(), lit_i64(2415000 + partition as i64)),
-                lte(ws_sold_date_sk.clone(), lit_i64(2488070)),
+                gte(Arc::clone(&ws_sold_date_sk), lit_i64(2415000 + partition as i64)),
+                lte(Arc::clone(&ws_sold_date_sk), lit_i64(2488070)),
             );
             (when_expr, then_expr)
         })

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 // Backward compatibility

--- a/datafusion/physical-optimizer/src/lib.rs
+++ b/datafusion/physical-optimizer/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 pub mod aggregate_statistics;

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Traits for physical query plan, supporting parallel execution for partitioned relations.

--- a/datafusion/proto-common/Cargo.toml
+++ b/datafusion/proto-common/Cargo.toml
@@ -34,6 +34,9 @@ exclude = ["*.proto"]
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true
+
 [lib]
 name = "datafusion_proto_common"
 

--- a/datafusion/proto-common/src/from_proto/mod.rs
+++ b/datafusion/proto-common/src/from_proto/mod.rs
@@ -1205,7 +1205,7 @@ fn vec_to_array<T, const N: usize>(v: Vec<T>) -> [T; N] {
 /// Converts a vector of `protobuf::Field`s to `Arc<arrow::Field>`s.
 pub fn parse_proto_fields_to_fields<'a, I>(
     fields: I,
-) -> std::result::Result<Vec<Field>, Error>
+) -> Result<Vec<Field>, Error>
 where
     I: IntoIterator<Item = &'a protobuf::Field>,
 {

--- a/datafusion/proto-common/src/lib.rs
+++ b/datafusion/proto-common/src/lib.rs
@@ -21,9 +21,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 
 //! Serialize / Deserialize DataFusion Primitive Types to bytes
 //!

--- a/datafusion/proto-common/src/to_proto/mod.rs
+++ b/datafusion/proto-common/src/to_proto/mod.rs
@@ -114,7 +114,7 @@ impl TryFrom<&DataType> for protobuf::ArrowType {
     }
 }
 
-impl TryFrom<&DataType> for protobuf::arrow_type::ArrowTypeEnum {
+impl TryFrom<&DataType> for ArrowTypeEnum {
     type Error = Error;
 
     fn try_from(val: &DataType) -> Result<Self, Self::Error> {
@@ -429,7 +429,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     })
                 }
                 None => Ok(protobuf::ScalarValue {
-                    value: Some(protobuf::scalar_value::Value::NullValue(
+                    value: Some(Value::NullValue(
                         (&data_type).try_into()?,
                     )),
                 }),
@@ -447,7 +447,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     })
                 }
                 None => Ok(protobuf::ScalarValue {
-                    value: Some(protobuf::scalar_value::Value::NullValue(
+                    value: Some(Value::NullValue(
                         (&data_type).try_into()?,
                     )),
                 }),
@@ -465,7 +465,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     })
                 }
                 None => Ok(protobuf::ScalarValue {
-                    value: Some(protobuf::scalar_value::Value::NullValue(
+                    value: Some(Value::NullValue(
                         (&data_type).try_into()?,
                     )),
                 }),
@@ -483,7 +483,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     })
                 }
                 None => Ok(protobuf::ScalarValue {
-                    value: Some(protobuf::scalar_value::Value::NullValue(
+                    value: Some(Value::NullValue(
                         (&data_type).try_into()?,
                     )),
                 }),
@@ -778,8 +778,8 @@ impl From<&Precision<usize>> for protobuf::Precision {
     }
 }
 
-impl From<&Precision<datafusion_common::ScalarValue>> for protobuf::Precision {
-    fn from(s: &Precision<datafusion_common::ScalarValue>) -> protobuf::Precision {
+impl From<&Precision<ScalarValue>> for protobuf::Precision {
+    fn from(s: &Precision<ScalarValue>) -> protobuf::Precision {
         match s {
             Precision::Exact(val) => protobuf::Precision {
                 precision_info: protobuf::PrecisionInfo::Exact.into(),
@@ -1017,14 +1017,14 @@ impl TryFrom<&JsonOptions> for protobuf::JsonOptions {
 
 /// Creates a scalar protobuf value from an optional value (T), and
 /// encoding None as the appropriate datatype
-fn create_proto_scalar<I, T: FnOnce(&I) -> protobuf::scalar_value::Value>(
+fn create_proto_scalar<I, T: FnOnce(&I) -> Value>(
     v: Option<&I>,
     null_arrow_type: &DataType,
     constructor: T,
 ) -> Result<protobuf::ScalarValue, Error> {
     let value = v
         .map(constructor)
-        .unwrap_or(protobuf::scalar_value::Value::NullValue(
+        .unwrap_or(Value::NullValue(
             null_arrow_type.try_into()?,
         ));
 
@@ -1082,25 +1082,25 @@ fn encode_scalar_nested_value(
 
     match val {
         ScalarValue::List(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::ListValue(scalar_list_value)),
+            value: Some(Value::ListValue(scalar_list_value)),
         }),
         ScalarValue::LargeList(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::LargeListValue(
+            value: Some(Value::LargeListValue(
                 scalar_list_value,
             )),
         }),
         ScalarValue::FixedSizeList(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::FixedSizeListValue(
+            value: Some(Value::FixedSizeListValue(
                 scalar_list_value,
             )),
         }),
         ScalarValue::Struct(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::StructValue(
+            value: Some(Value::StructValue(
                 scalar_list_value,
             )),
         }),
         ScalarValue::Map(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::MapValue(scalar_list_value)),
+            value: Some(Value::MapValue(scalar_list_value)),
         }),
         _ => unreachable!(),
     }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -31,6 +31,9 @@ rust-version = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true
+
 [lib]
 name = "datafusion_proto"
 

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Serialize / Deserialize DataFusion Plans to bytes

--- a/datafusion/proto/src/logical_plan/file_formats.rs
+++ b/datafusion/proto/src/logical_plan/file_formats.rs
@@ -639,11 +639,9 @@ mod parquet {
                 exec_datafusion_err!("Failed to decode TableParquetOptionsProto: {e:?}")
             })?;
             let options: TableParquetOptions = (&proto).into();
-            Ok(Arc::new(
-                datafusion_datasource_parquet::file_format::ParquetFormatFactory {
-                    options: Some(options),
-                },
-            ))
+            Ok(Arc::new(ParquetFormatFactory {
+                options: Some(options),
+            }))
         }
 
         fn try_encode_file_format(

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -498,7 +498,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                 )?
                 .build()
             }
-            LogicalPlanType::CustomScan(scan) => {
+            CustomScan(scan) => {
                 let schema: Schema = convert_required!(scan.schema)?;
                 let schema = Arc::new(schema);
                 let mut projection = None;
@@ -975,7 +975,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                 .build()
             }
             LogicalPlanType::Dml(dml_node) => {
-                Ok(LogicalPlan::Dml(datafusion_expr::DmlStatement::new(
+                Ok(LogicalPlan::Dml(DmlStatement::new(
                     from_table_reference(dml_node.table_name.as_ref(), "DML ")?,
                     to_table_source(&dml_node.target, ctx, extension_codec)?,
                     dml_node.dml_type().into(),
@@ -1180,7 +1180,7 @@ impl AsLogicalPlan for LogicalPlanNode {
 
                     Ok(LogicalPlanNode {
                         logical_plan_type: Some(LogicalPlanType::CteWorkTableScan(
-                            protobuf::CteWorkTableScanNode {
+                            CteWorkTableScanNode {
                                 name,
                                 schema: Some(schema),
                             },

--- a/datafusion/pruning/src/file_pruner.rs
+++ b/datafusion/pruning/src/file_pruner.rs
@@ -78,8 +78,10 @@ impl FilePruner {
         predicate_creation_errors: Count,
     ) -> Option<Self> {
         let file_stats = partitioned_file.statistics.as_ref()?;
-        let file_stats_pruning =
-            PrunableStatistics::new(vec![file_stats.clone()], Arc::clone(file_schema));
+        let file_stats_pruning = PrunableStatistics::new(
+            vec![Arc::clone(file_stats)],
+            Arc::clone(file_schema),
+        );
         Some(Self {
             predicate_generation: None,
             predicate,

--- a/datafusion/spark/src/lib.rs
+++ b/datafusion/spark/src/lib.rs
@@ -20,8 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make cheap clones clear: https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Spark Expression packages for [DataFusion].

--- a/datafusion/sql/src/lib.rs
+++ b/datafusion/sql/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![deny(clippy::clone_on_ref_ptr)]
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! This crate provides:

--- a/datafusion/sqllogictest/src/lib.rs
+++ b/datafusion/sqllogictest/src/lib.rs
@@ -20,9 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 
 //! DataFusion sqllogictest driver
 

--- a/datafusion/substrait/src/lib.rs
+++ b/datafusion/substrait/src/lib.rs
@@ -20,10 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Make sure fast / cheap clones on Arc are explicit:
-// https://github.com/apache/datafusion/issues/11143
-#![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
-#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Serialize / Deserialize DataFusion Plans to [Substrait.io]
 //!

--- a/datafusion/substrait/src/lib.rs
+++ b/datafusion/substrait/src/lib.rs
@@ -20,6 +20,8 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// In tests, allow needless_pass_by_value so test code can pass owned values without cloning
+#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 
 //! Serialize / Deserialize DataFusion Plans to [Substrait.io]
 //!

--- a/dev/depcheck/Cargo.toml
+++ b/dev/depcheck/Cargo.toml
@@ -20,7 +20,7 @@
 name = "depcheck"
 edition = "2024"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]\nworkspace = true\n\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 cargo = "0.92.0"

--- a/dev/depcheck/Cargo.toml
+++ b/dev/depcheck/Cargo.toml
@@ -20,7 +20,10 @@
 name = "depcheck"
 edition = "2024"
 
-[lints]\nworkspace = true\n\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 cargo = "0.92.0"

--- a/test-utils/src/data_gen.rs
+++ b/test-utils/src/data_gen.rs
@@ -298,7 +298,7 @@ impl AccessLogGenerator {
 
     /// Return the schema of the [`RecordBatch`]es  created
     pub fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+        Arc::clone(&self.schema)
     }
 
     /// Limit the maximum batch size

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 //! Common functions used for testing
+use std::sync::Arc;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use datafusion_common::cast::as_int32_array;
@@ -66,7 +67,7 @@ pub fn add_empty_batches(
         .into_iter()
         .flat_map(|batch| {
             // insert 0, or 1 empty batches before and after the current batch
-            let empty_batch = RecordBatch::new_empty(schema.clone());
+            let empty_batch = RecordBatch::new_empty(Arc::clone(&schema));
             std::iter::repeat_n(empty_batch.clone(), rng.random_range(0..2))
                 .chain(std::iter::once(batch))
                 .chain(std::iter::repeat_n(empty_batch, rng.random_range(0..2)))


### PR DESCRIPTION
## Which issue does this PR close?
Closes #17083

## Rationale for this change:
Standardizes the use of Arc::clone(&ptr) over ptr.clone() across the workspace to make reference counting increments explicit and distinguishable from deep copies. This improves code readability and maintainability.

## What changes are included in this PR?
- Added clippy::clone_on_ref_ptr = "deny" to workspace lints in root Cargo.toml.
- Enabled lint inheritance in all sub-crates by adding [lints] workspace = true.
- Removed redundant manual #![deny(clippy::clone_on_ref_ptr)] attributes from source files.
- Refactored .clone() calls on Arc and Weak pointers to Arc::clone() / Weak::clone() across the workspace.
- Fixed trait object coercion and missing imports (std::sync::Arc) resulting from the refactoring.

## Are these changes tested?
Yes. Verified via:
- cargo clippy --workspace --all-targets --all-features
- cargo check --benches --examples
- cargo fmt --all --check
- Manual grep audit for remaining manual attributes and double-clones.

## Are there any user-facing changes?
No.