### PR TITLE
fix: grouping separator for float and decimal

### DIFF
--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -1690,6 +1690,23 @@ impl ConversionSpecifier {
     }
 
     fn format_float(&self, writer: &mut String, value: f64) -> Result<()> {
+        // Java/Spark reject the grouping separator flag with scientific notation
+        if self.grouping_separator
+            && matches!(
+                self.conversion_type,
+                ConversionType::SciFloatLower | ConversionType::SciFloatUpper
+            )
+        {
+            return exec_err!(
+                "Grouping separator ',' flag is not compatible with scientific notation conversion '{}'",
+                if self.conversion_type == ConversionType::SciFloatUpper {
+                    'E'
+                } else {
+                    'e'
+                }
+            );
+        }
+
         let mut prefix = String::new();
         let mut suffix = String::new();
         let mut number = String::new();
@@ -1769,6 +1786,9 @@ impl ConversionSpecifier {
                 number = format!("{abs:.prec$}", prec = precision as usize);
                 if strip_trailing_0s {
                     number = trim_trailing_0s(&number).to_owned();
+                }
+                if self.grouping_separator {
+                    number = insert_thousands_separator(&number);
                 }
             }
             if self.alt_form && !number.contains('.') {
@@ -2000,6 +2020,23 @@ impl ConversionSpecifier {
     }
 
     fn format_decimal(&self, writer: &mut String, value: &str, scale: i64) -> Result<()> {
+        // Java/Spark reject the grouping separator flag with scientific notation
+        if self.grouping_separator
+            && matches!(
+                self.conversion_type,
+                ConversionType::SciFloatLower | ConversionType::SciFloatUpper
+            )
+        {
+            return exec_err!(
+                "Grouping separator ',' flag is not compatible with scientific notation conversion '{}'",
+                if self.conversion_type == ConversionType::SciFloatUpper {
+                    'E'
+                } else {
+                    'e'
+                }
+            );
+        }
+
         let mut prefix = String::new();
         let upper = self.conversion_type.is_upper();
 
@@ -2033,7 +2070,15 @@ impl ConversionSpecifier {
         let number = match self.conversion_type {
             ConversionType::DecFloatLower => {
                 // Format as fixed-point decimal
-                self.format_decimal_fixed(&abs_decimal, precision, strip_trailing_0s)?
+                let mut n = self.format_decimal_fixed(
+                    &abs_decimal,
+                    precision,
+                    strip_trailing_0s,
+                )?;
+                if self.grouping_separator {
+                    n = insert_thousands_separator(&n);
+                }
+                n
             }
             ConversionType::SciFloatLower => self.format_decimal_scientific(
                 &abs_decimal,
@@ -2062,11 +2107,15 @@ impl ConversionSpecifier {
                         strip_trailing_0s,
                     )?
                 } else {
-                    self.format_decimal_fixed(
+                    let mut n = self.format_decimal_fixed(
                         &abs_decimal,
                         precision - 1 - log10_val.floor() as i32,
                         strip_trailing_0s,
-                    )?
+                    )?;
+                    if self.grouping_separator {
+                        n = insert_thousands_separator(&n);
+                    }
+                    n
                 }
             }
             _ => {
@@ -2332,6 +2381,24 @@ impl FloatBits for f64 {
     }
 }
 
+/// Inserts thousands separators (`,`) into the integer part of a numeric string.
+/// For example, `"1234567.89"` becomes `"1,234,567.89"`.
+fn insert_thousands_separator(number: &str) -> String {
+    let (int_part, frac_part) = match number.find('.') {
+        Some(pos) => (&number[..pos], &number[pos..]),
+        None => (number, ""),
+    };
+    let mut result = String::with_capacity(number.len() + number.len() / 3);
+    for (i, c) in int_part.char_indices() {
+        if i > 0 && (int_part.len() - i) % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.push_str(frac_part);
+    result
+}
+
 fn trim_trailing_0s(number: &str) -> &str {
     if number.contains('.') {
         for (i, c) in number.chars().rev().enumerate() {
@@ -2355,6 +2422,8 @@ fn trim_trailing_0s_hex(number: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::function::utils::test::test_scalar_function;
+    use arrow::array::StringArray;
     use arrow::datatypes::DataType::Utf8;
 
     #[test]
@@ -2383,6 +2452,227 @@ mod tests {
             "format_string(fmt, ...) should NOT be nullable when fmt is NOT nullable"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_insert_thousands_separator() {
+        assert_eq!(insert_thousands_separator("1234567.89"), "1,234,567.89");
+        assert_eq!(insert_thousands_separator("123.45"), "123.45");
+        assert_eq!(insert_thousands_separator("1234"), "1,234");
+        assert_eq!(insert_thousands_separator("12"), "12");
+        assert_eq!(insert_thousands_separator("0.5"), "0.5");
+        assert_eq!(
+            insert_thousands_separator("1234567890.1234"),
+            "1,234,567,890.1234"
+        );
+        assert_eq!(insert_thousands_separator("1000"), "1,000");
+        assert_eq!(insert_thousands_separator("100"), "100");
+    }
+
+    #[test]
+    fn test_grouping_separator_float() -> Result<()> {
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,.2f".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Ok(Some("1,234,567.89")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouping_separator_decimal() -> Result<()> {
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,.2f".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Decimal128(Some(123456789), 10, 2)),
+            ],
+            Ok(Some("1,234,567.89")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouping_separator_scientific_float() -> Result<()> {
+        // %,e — Java/Spark reject grouping separator with scientific notation
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,e".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Err(DataFusionError::Execution(
+                "Grouping separator ',' flag is not compatible with scientific notation conversion 'e'".to_string(),
+            )),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %,E — uppercase scientific also rejected
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,E".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Err(DataFusionError::Execution(
+                "Grouping separator ',' flag is not compatible with scientific notation conversion 'E'".to_string(),
+            )),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %,.0e — precision 0 scientific with grouping also rejected
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,.0e".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Err(DataFusionError::Execution(
+                "Grouping separator ',' flag is not compatible with scientific notation conversion 'e'".to_string(),
+            )),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouping_separator_compact_float() -> Result<()> {
+        // %,g with large number — triggers scientific, no commas
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,g".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Ok(Some("1.23457e+06")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %,g with small number — triggers fixed-point, commas in integer part
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,g".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(12345.6))),
+            ],
+            Ok(Some("12,345.6")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %,.0g — precision 0 compact with grouping (large number, scientific)
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,.0g".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Ok(Some("1e+06")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %,G — uppercase compact
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,G".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Ok(Some("1.23457E+06")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouping_separator_scientific_decimal() -> Result<()> {
+        // %,e on decimal — Java/Spark reject grouping separator with scientific notation
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,e".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Decimal128(Some(123456789), 10, 2)),
+            ],
+            Err(DataFusionError::Execution(
+                "Grouping separator ',' flag is not compatible with scientific notation conversion 'e'".to_string(),
+            )),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %,.0e on decimal — also rejected
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,.0e".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Decimal128(Some(123456789), 10, 2)),
+            ],
+            Err(DataFusionError::Execution(
+                "Grouping separator ',' flag is not compatible with scientific notation conversion 'e'".to_string(),
+            )),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouping_separator_compact_decimal() -> Result<()> {
+        // %,g on decimal — large number triggers scientific, no commas
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,g".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Decimal128(Some(123456789), 10, 2)),
+            ],
+            Ok(Some("1.23457e+06")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %,g on decimal — small number triggers fixed-point, commas expected
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,g".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Decimal128(Some(1234560), 10, 2)),
+            ],
+            Ok(Some("12,345.6")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %,.0g on decimal — precision 0 compact with grouping (scientific)
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%,.0g".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Decimal128(Some(123456789), 10, 2)),
+            ],
+            Ok(Some("1e+06")),
+            &str,
+            Utf8,
+            StringArray
+        );
         Ok(())
     }
 }

--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -2030,6 +2030,10 @@ impl ConversionSpecifier {
         let decimal = BigDecimal::from_bigint(decimal, scale);
 
         // Handle sign
+        // TODO: `negative_in_parentheses` (the `(` flag) is not implemented here.
+        // Java/Spark wrap negative values in parentheses when this flag is set
+        // (e.g. `%(,.2f` with -1234.5 → "(1,234.50)"), but this path always
+        // uses a minus sign. See `format_float` for the correct implementation.
         let is_negative = decimal.sign() == Sign::Minus;
         let abs_decimal = decimal.abs();
 
@@ -2722,6 +2726,44 @@ mod tests {
                 ColumnarValue::Scalar(ScalarValue::Decimal128(Some(123456789), 10, 2)),
             ],
             Ok(Some("  +1,234,567.89")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouping_separator_parentheses_float() -> Result<()> {
+        // %(,15.2f with negative — parentheses + grouping + width
+        // Java: String.format("%(,15.2f", -1234.5) → "     (1,234.50)"
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%(,15.2f".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(-1234.5))),
+            ],
+            Ok(Some("     (1,234.50)")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouping_separator_parentheses_decimal() -> Result<()> {
+        // %(,15.2f on negative decimal — format_decimal ignores negative_in_parentheses,
+        // always uses '-'. Check TODO in fn format_decimal
+        // Java: String.format("%(,15.2f", -1234.5) → "     (1,234.50)"
+        // Ours: "      -1,234.50" (minus sign, no parens)
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%(,15.2f".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Decimal128(Some(-123450), 10, 2)),
+            ],
+            Ok(Some("      -1,234.50")),
             &str,
             Utf8,
             StringArray

--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -862,6 +862,28 @@ fn take_numeric_param(s: &str, zero: bool) -> (NumericParam, &str) {
 }
 
 impl ConversionSpecifier {
+    /// Validates that the grouping separator flag is not used with scientific
+    /// notation conversions, matching Java/Spark behavior which throws
+    /// `FormatFlagsConversionMismatchException` for `%,e` / `%,E`.
+    fn validate_grouping_separator(&self) -> Result<()> {
+        if self.grouping_separator
+            && matches!(
+                self.conversion_type,
+                ConversionType::SciFloatLower | ConversionType::SciFloatUpper
+            )
+        {
+            return exec_err!(
+                "Grouping separator ',' flag is not compatible with scientific notation conversion '{}'",
+                if self.conversion_type == ConversionType::SciFloatUpper {
+                    'E'
+                } else {
+                    'e'
+                }
+            );
+        }
+        Ok(())
+    }
+
     pub fn format(&self, string: &mut String, value: &ScalarValue) -> Result<()> {
         match value {
             ScalarValue::Boolean(value) => match self.conversion_type {
@@ -1690,22 +1712,7 @@ impl ConversionSpecifier {
     }
 
     fn format_float(&self, writer: &mut String, value: f64) -> Result<()> {
-        // Java/Spark reject the grouping separator flag with scientific notation
-        if self.grouping_separator
-            && matches!(
-                self.conversion_type,
-                ConversionType::SciFloatLower | ConversionType::SciFloatUpper
-            )
-        {
-            return exec_err!(
-                "Grouping separator ',' flag is not compatible with scientific notation conversion '{}'",
-                if self.conversion_type == ConversionType::SciFloatUpper {
-                    'E'
-                } else {
-                    'e'
-                }
-            );
-        }
+        self.validate_grouping_separator()?;
 
         let mut prefix = String::new();
         let mut suffix = String::new();
@@ -1902,20 +1909,11 @@ impl ConversionSpecifier {
         match self.conversion_type {
             ConversionType::DecInt => {
                 let num_str = format!("{value}");
-                if self.grouping_separator {
-                    // Add thousands separators
-                    let mut result = String::new();
-                    let chars: Vec<char> = num_str.chars().collect();
-                    for (i, c) in chars.iter().enumerate() {
-                        if i > 0 && (chars.len() - i).is_multiple_of(3) {
-                            result.push(',');
-                        }
-                        result.push(*c);
-                    }
-                    s = result;
+                s = if self.grouping_separator {
+                    insert_thousands_separator(&num_str)
                 } else {
-                    s = num_str;
-                }
+                    num_str
+                };
             }
             ConversionType::HexIntLower => {
                 alt_prefix = "0x";
@@ -2020,22 +2018,7 @@ impl ConversionSpecifier {
     }
 
     fn format_decimal(&self, writer: &mut String, value: &str, scale: i64) -> Result<()> {
-        // Java/Spark reject the grouping separator flag with scientific notation
-        if self.grouping_separator
-            && matches!(
-                self.conversion_type,
-                ConversionType::SciFloatLower | ConversionType::SciFloatUpper
-            )
-        {
-            return exec_err!(
-                "Grouping separator ',' flag is not compatible with scientific notation conversion '{}'",
-                if self.conversion_type == ConversionType::SciFloatUpper {
-                    'E'
-                } else {
-                    'e'
-                }
-            );
-        }
+        self.validate_grouping_separator()?;
 
         let mut prefix = String::new();
         let upper = self.conversion_type.is_upper();
@@ -2669,6 +2652,76 @@ mod tests {
                 ColumnarValue::Scalar(ScalarValue::Decimal128(Some(123456789), 10, 2)),
             ],
             Ok(Some("1e+06")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouping_separator_width_sign_float() -> Result<()> {
+        // %0,15.2f — zero-pad + grouping + width
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%0,15.2f".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Ok(Some("0001,234,567.89")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %+,15.2f — force-sign + grouping + width (space-padded)
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%+,15.2f".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Ok(Some("  +1,234,567.89")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %-,15.2f — left-adjust + grouping + width
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%-,15.2f".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(1234567.89))),
+            ],
+            Ok(Some("1,234,567.89   ")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouping_separator_width_sign_decimal() -> Result<()> {
+        // %0,15.2f — zero-pad + grouping + width on decimal
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%0,15.2f".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Decimal128(Some(123456789), 10, 2)),
+            ],
+            Ok(Some("0001,234,567.89")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        // %+,15.2f — force-sign + grouping + width on decimal
+        test_scalar_function!(
+            FormatStringFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("%+,15.2f".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Decimal128(Some(123456789), 10, 2)),
+            ],
+            Ok(Some("  +1,234,567.89")),
             &str,
             Utf8,
             StringArray


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/20266


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Created a new function to insert the separator (,) into the numbers if the flag is enabled
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Tests passed locally 
Added unit tests to verify functionality
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No changes to public api

## Additional Info
Claude was used to assist in identifying the source of the issue.