### PR TITLE
Fix dynamic filter pushdown to wrong table with same-named columns

### DIFF
--- a/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
@@ -401,7 +401,8 @@ async fn test_static_filter_pushdown_through_hash_join() {
     "
     );
 
-    // Test left join - filters should NOT be pushed down
+    // Test left join: filter on preserved (build) side is pushed down,
+    // filter on non-preserved (probe) side is NOT pushed down.
     let join = Arc::new(
         HashJoinExec::try_new(
             TestScanBuilder::new(Arc::clone(&build_side_schema))
@@ -429,7 +430,6 @@ async fn test_static_filter_pushdown_through_hash_join() {
     let plan =
         Arc::new(FilterExec::try_new(filter, join).unwrap()) as Arc<dyn ExecutionPlan>;
 
-    // Test that filters are NOT pushed down for left join
     insta::assert_snapshot!(
         OptimizationTest::new(plan, FilterPushdown::new(), true),
         @r"
@@ -441,10 +441,9 @@ async fn test_static_filter_pushdown_through_hash_join() {
         -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[d, e, f], file_type=test, pushdown_supported=true
       output:
         Ok:
-          - FilterExec: a@0 = aa
-          -   HashJoinExec: mode=Partitioned, join_type=Left, on=[(a@0, d@0)]
-          -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=true
-          -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[d, e, f], file_type=test, pushdown_supported=true
+          - HashJoinExec: mode=Partitioned, join_type=Left, on=[(a@0, d@0)]
+          -   DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=true, predicate=a@0 = aa
+          -   DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[d, e, f], file_type=test, pushdown_supported=true
     "
     );
 }

--- a/datafusion/physical-plan/src/filter_pushdown.rs
+++ b/datafusion/physical-plan/src/filter_pushdown.rs
@@ -44,7 +44,6 @@ use datafusion_common::{
 };
 use datafusion_physical_expr::{expressions::Column, utils::reassign_expr_columns};
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
-use itertools::Itertools;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FilterPushdownPhase {
@@ -317,21 +316,33 @@ pub struct ChildFilterDescription {
 /// exist in the target schema. If any column in the filter is not present
 /// in the schema, the filter cannot be pushed down to that child.
 pub(crate) struct FilterColumnChecker<'a> {
-    column_names: HashSet<&'a str>,
+    /// The set of `(column_name, column_index)` pairs that are allowed.
+    allowed_columns: HashSet<(&'a str, usize)>,
 }
 
 impl<'a> FilterColumnChecker<'a> {
     /// Creates a new [`FilterColumnChecker`] from the given schema.
     ///
-    /// Extracts all column names from the schema's fields to build
+    /// Extracts all column `(name, index)` pairs from the schema's fields to build
     /// a lookup set for efficient column existence checks.
-    pub(crate) fn new(input_schema: &'a Schema) -> Self {
-        let column_names: HashSet<&str> = input_schema
+    pub(crate) fn new_schema(input_schema: &'a Schema) -> Self {
+        let allowed_columns: HashSet<(&str, usize)> = input_schema
             .fields()
             .iter()
-            .map(|f| f.name().as_str())
+            .enumerate()
+            .map(|(i, f)| (f.name().as_str(), i))
             .collect();
-        Self { column_names }
+        Self { allowed_columns }
+    }
+
+    /// Creates a new [`FilterColumnChecker`] from an explicit set of
+    /// allowed `(name, index)` pairs.
+    ///
+    /// This is used by join nodes that need to restrict pushdown to columns
+    /// belonging to a specific side of the join, even when different sides
+    /// have columns with the same name.
+    pub(crate) fn new_columns(allowed_columns: HashSet<(&'a str, usize)>) -> Self {
+        Self { allowed_columns }
     }
 
     /// Checks whether a filter expression can be pushed down to the child
@@ -347,7 +358,9 @@ impl<'a> FilterColumnChecker<'a> {
         filter
             .apply(|expr| {
                 if let Some(column) = expr.as_any().downcast_ref::<Column>()
-                    && !self.column_names.contains(column.name())
+                    && !self
+                        .allowed_columns
+                        .contains(&(column.name(), column.index()))
                 {
                     can_apply = false;
                     return Ok(TreeNodeRecursion::Stop);
@@ -375,7 +388,7 @@ impl ChildFilterDescription {
         let child_schema = child.schema();
 
         // Build a set of column names in the child schema for quick lookup
-        let checker = FilterColumnChecker::new(&child_schema);
+        let checker = FilterColumnChecker::new_schema(&child_schema);
 
         // Analyze each parent filter
         let mut child_parent_filters = Vec::with_capacity(parent_filters.len());
@@ -399,6 +412,52 @@ impl ChildFilterDescription {
             parent_filters: child_parent_filters,
             self_filters: vec![],
         })
+    }
+
+    /// Like [`Self::from_child`], but restricts which parent-level columns are
+    /// considered reachable through this child.
+    ///
+    /// `allowed_columns` is a set of `(column_name, column_index)` pairs
+    /// (in the *parent* schema) that map to this child's side of a join.
+    /// A filter is only eligible for pushdown when **every** column it
+    /// references appears in `allowed_columns`. This prevents incorrect
+    /// pushdown when different join sides have columns with the same name.
+    pub fn from_child_with_allowed_columns(
+        parent_filters: &[Arc<dyn PhysicalExpr>],
+        allowed_columns: HashSet<(&str, usize)>,
+        child: &Arc<dyn crate::ExecutionPlan>,
+    ) -> Result<Self> {
+        let child_schema = child.schema();
+        let checker = FilterColumnChecker::new_columns(allowed_columns);
+
+        let mut child_parent_filters = Vec::with_capacity(parent_filters.len());
+        for filter in parent_filters {
+            if checker.can_pushdown(filter) {
+                let reassigned_filter =
+                    reassign_expr_columns(Arc::clone(filter), &child_schema)?;
+                child_parent_filters
+                    .push(PushedDownPredicate::supported(reassigned_filter));
+            } else {
+                child_parent_filters
+                    .push(PushedDownPredicate::unsupported(Arc::clone(filter)));
+            }
+        }
+
+        Ok(Self {
+            parent_filters: child_parent_filters,
+            self_filters: vec![],
+        })
+    }
+
+    /// Mark all parent filters as unsupported for this child.
+    pub fn all_unsupported(parent_filters: &[Arc<dyn PhysicalExpr>]) -> Self {
+        Self {
+            parent_filters: parent_filters
+                .iter()
+                .map(|f| PushedDownPredicate::unsupported(Arc::clone(f)))
+                .collect(),
+            self_filters: vec![],
+        }
     }
 
     /// Add a self filter (from the current node) to be pushed down to this child.
@@ -476,15 +535,9 @@ impl FilterDescription {
         children: &[&Arc<dyn crate::ExecutionPlan>],
     ) -> Self {
         let mut desc = Self::new();
-        let child_filters = parent_filters
-            .iter()
-            .map(|f| PushedDownPredicate::unsupported(Arc::clone(f)))
-            .collect_vec();
         for _ in 0..children.len() {
-            desc = desc.with_child(ChildFilterDescription {
-                parent_filters: child_filters.clone(),
-                self_filters: vec![],
-            });
+            desc =
+                desc.with_child(ChildFilterDescription::all_unsupported(parent_filters));
         }
         desc
     }

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -384,7 +384,7 @@ impl ExecutionPlan for ProjectionExec {
         // expand alias column to original expr in parent filters
         let invert_alias_map = self.collect_reverse_alias()?;
         let output_schema = self.schema();
-        let checker = FilterColumnChecker::new(&output_schema);
+        let checker = FilterColumnChecker::new_schema(&output_schema);
         let mut child_parent_filters = Vec::with_capacity(parent_filters.len());
 
         for filter in parent_filters {

--- a/datafusion/sqllogictest/test_files/dynamic_filter_pushdown_config.slt
+++ b/datafusion/sqllogictest/test_files/dynamic_filter_pushdown_config.slt
@@ -419,6 +419,97 @@ physical_plan
 03)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/dynamic_filter_pushdown_config/join_right.parquet]]}, projection=[id, info], file_type=parquet
 04)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/dynamic_filter_pushdown_config/join_left.parquet]]}, projection=[id, data], file_type=parquet, predicate=DynamicFilter [ empty ]
 
+# Test 6: Regression test for issue #20213 - dynamic filter applied to wrong table
+# when subquery join has same column names on both sides.
+#
+# The bug: when an outer join pushes a DynamicFilter for column "k" through an
+# inner join where both sides have a column named "k", the name-based routing
+# incorrectly pushed the filter to BOTH sides instead of only the correct one.
+# With small row groups this caused wrong results (0 rows instead of expected).
+
+# Create tables with same column names (k, v) on both sides
+statement ok
+CREATE TABLE issue_20213_t1(k INT, v INT) AS
+SELECT i as k, i as v FROM generate_series(1, 1000) t(i);
+
+statement ok
+CREATE TABLE issue_20213_t2(k INT, v INT) AS
+SELECT i + 100 as k, i as v FROM generate_series(1, 100) t(i);
+
+# Use small row groups to trigger statistics-based pruning
+statement ok
+SET datafusion.execution.parquet.max_row_group_size = 10;
+
+query I
+COPY issue_20213_t1 TO 'test_files/scratch/dynamic_filter_pushdown_config/issue_20213_t1.parquet' STORED AS PARQUET;
+----
+1000
+
+query I
+COPY issue_20213_t2 TO 'test_files/scratch/dynamic_filter_pushdown_config/issue_20213_t2.parquet' STORED AS PARQUET;
+----
+100
+
+# Reset row group size
+statement ok
+SET datafusion.execution.parquet.max_row_group_size = 1000000;
+
+statement ok
+CREATE EXTERNAL TABLE t1_20213(k INT, v INT)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/dynamic_filter_pushdown_config/issue_20213_t1.parquet';
+
+statement ok
+CREATE EXTERNAL TABLE t2_20213(k INT, v INT)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/dynamic_filter_pushdown_config/issue_20213_t2.parquet';
+
+# The query from issue #20213: subquery joins t1 and t2 on v, then outer
+# join uses t2's k column. The dynamic filter on k from the outer join
+# must only apply to t2 (k range 101-200), NOT to t1 (k range 1-1000).
+query I
+SELECT count(*) FROM (
+    SELECT t2_20213.k as k, t1_20213.k as k2
+    FROM t1_20213
+    JOIN t2_20213 ON t1_20213.v = t2_20213.v
+) a
+JOIN t2_20213 b ON a.k = b.k
+WHERE b.v < 10;
+----
+9
+
+# Also verify with SELECT * to catch row-level correctness
+query IIII rowsort
+SELECT * FROM (
+    SELECT t2_20213.k as k, t1_20213.k as k2
+    FROM t1_20213
+    JOIN t2_20213 ON t1_20213.v = t2_20213.v
+) a
+JOIN t2_20213 b ON a.k = b.k
+WHERE b.v < 10;
+----
+101 1 101 1
+102 2 102 2
+103 3 103 3
+104 4 104 4
+105 5 105 5
+106 6 106 6
+107 7 107 7
+108 8 108 8
+109 9 109 9
+
+statement ok
+DROP TABLE issue_20213_t1;
+
+statement ok
+DROP TABLE issue_20213_t2;
+
+statement ok
+DROP TABLE t1_20213;
+
+statement ok
+DROP TABLE t2_20213;
+
 # Cleanup
 
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/20213

## Rationale for this change

When both sides of a join have columns with the same name (e.g. `k`), the dynamic filter from an outer join was incorrectly pushed to **both** children instead of only the correct one. With small row groups this caused **wrong results** (0 rows instead of the expected result set).

The root cause was that `FilterColumnChecker` in `filter_pushdown.rs` matched columns by **name only**. When the parent pushed a filter referencing column `k` at index 2 (the right child's `k`), the name-based check found `k` in the left child's schema too, and incorrectly pushed the filter to both sides.

## What changes are included in this PR?

Approach adopted from #20192:

1. **`FilterColumnChecker`** now matches on `(name, index)` pairs instead of just names, preventing incorrect cross-side pushdown when columns share names
2. **`ChildFilterDescription::from_child_with_allowed_columns`** — new method that restricts pushdown to an explicit set of allowed `(name, index)` pairs
3. **`ChildFilterDescription::all_unsupported`** — helper to mark all filters unsupported for a child
4. **`HashJoinExec::gather_filters_for_pushdown`** — builds per-side allowed-column sets from `column_indices` (+ optional `projection`), uses `lr_is_preserved` to gate pushdown eligibility per join type
5. **`lr_is_preserved`** — mirrors the logical optimizer's preserved-side logic, enabling parent filter pushdown for non-inner join types (Left, Right, Semi, Anti, Mark)

## Are these changes tested?

Yes:

- **Unit test** for `lr_is_preserved` covering all join types
- **SLT regression test** reproducing the exact issue #20213 scenario: subquery join with same-named columns, small row groups, verifying both `COUNT(*)` and `SELECT *` correctness
- **Updated snapshot** for existing Left join filter pushdown test (preserved-side filter now correctly pushes down)
- All existing hash join tests (368), filter pushdown tests (47), and SLT tests pass

## Are there any user-facing changes?

- **Bug fix**: Queries with nested joins where both sides have same-named columns now return correct results with dynamic filter pushdown enabled
- **Improvement**: Parent filters on preserved join sides can now push through non-inner joins (Left, Right, Semi, Anti, Mark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)