### PR TITLE
perf: Optimize compare_element_to_list

### DIFF
--- a/datafusion/functions-nested/src/position.rs
+++ b/datafusion/functions-nested/src/position.rs
@@ -164,7 +164,6 @@ fn general_position_dispatch<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<Ar
     let arr_from = if args.len() == 3 {
         as_int64_array(&args[2])?
             .values()
-            .to_vec()
             .iter()
             .map(|&x| x - 1)
             .collect::<Vec<_>>()

--- a/datafusion/functions-nested/src/utils.rs
+++ b/datafusion/functions-nested/src/utils.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use arrow::datatypes::{DataType, Field, Fields};
 
 use arrow::array::{
-    Array, ArrayRef, BooleanArray, GenericListArray, OffsetSizeTrait, Scalar, UInt32Array,
+    Array, ArrayRef, BooleanArray, GenericListArray, OffsetSizeTrait, Scalar,
 };
 use arrow::buffer::OffsetBuffer;
 use datafusion_common::cast::{
@@ -161,8 +161,7 @@ pub(crate) fn compare_element_to_list(
         );
     }
 
-    let indices = UInt32Array::from(vec![row_index as u32]);
-    let element_array_row = arrow::compute::take(element_array, &indices, None)?;
+    let element_array_row = element_array.slice(row_index, 1);
 
     // Compute all positions in list_row_array (that is itself an
     // array) that are equal to `from_array_row`


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20322 

## Rationale for this change

`compare_element_to_list` is a utility function used by several of the array-related UDFs (e.g., array_position, array_positions, array_remove, and array_replace).

The current implementation extracts a scalar from an array using `arrow::compute::take()`. This is slow; we can just use `slice` directly, which also avoids allocating an intermediate array of indices.

## What changes are included in this PR?

## Are these changes tested?

Yes; microbenchmarks indicate 15-50% performance improvement for `array_remove`.

## Are there any user-facing changes?

No.
