### PR TITLE
Do not reset `HashJoinExec` state when calling `HashJoinExec::with_projection`

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -867,6 +867,7 @@ impl HashJoinExec {
             null_aware: self.null_aware,
             cache,
             dynamic_filter: self.dynamic_filter.clone(),
+            fetch: self.fetch,
         })
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Follow on to https://github.com/apache/datafusion/pull/19893 from @askalt 

## Rationale for this change

@2010YOUY01 noted in https://github.com/apache/datafusion/pull/19893/changes#r2787434025 that the change to `HashJoinExec::with_projection` resulting in non obviously resetting the plan state (like dynamic filters). This could potentially lead to bugs in the future so let's be explicit

## What changes are included in this PR?

Remove use of HashJoinExecBuilder

## Are these changes tested?

Yes, by existing CI

## Are there any user-facing changes?

No