### PR TITLE
chore: Make memchr a workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ insta = { version = "1.46.3", features = ["glob", "filters"] }
 itertools = "0.14"
 liblzma = { version = "0.4.4", features = ["static"] }
 log = "^0.4"
+memchr = "2.8.0"
 num-traits = { version = "0.2" }
 object_store = { version = "0.12.4", default-features = false }
 parking_lot = "0.12"

--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -82,7 +82,7 @@ hex = { workspace = true, optional = true }
 itertools = { workspace = true }
 log = { workspace = true }
 md-5 = { version = "^0.10.0", optional = true }
-memchr = "2.8.0"
+memchr = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true, optional = true }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Suggested by @alamb.

## What changes are included in this PR?

Moving memchr to be a workspace dependency, instead of a subcrate dependency.

## Are these changes tested?

Yes, no new tests needed.

## Are there any user-facing changes?

No.
