### PR TITLE
perf: Optimize `initcap()`

### DIFF
--- a/datafusion/functions/benches/initcap.rs
+++ b/datafusion/functions/benches/initcap.rs
@@ -49,10 +49,10 @@ fn create_args<O: OffsetSizeTrait>(
 
 /// Create a Utf8 array where every value contains non-ASCII Unicode text.
 fn create_unicode_utf8_args(size: usize) -> Vec<ColumnarValue> {
-    let items: Vec<String> = (0..size)
-        .map(|_| "ñAnDÚ ÁrBOL ОлЕГ ÍslENsku".to_string())
-        .collect();
-    let array = Arc::new(StringArray::from(items)) as ArrayRef;
+    let array = Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+        "ñAnDÚ ÁrBOL ОлЕГ ÍslENsku",
+        size,
+    ))) as ArrayRef;
     vec![ColumnarValue::Array(array)]
 }
 

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -22,7 +22,7 @@ use arrow::array::{
     Array, ArrayRef, GenericStringArray, GenericStringBuilder, OffsetSizeTrait,
     StringViewBuilder,
 };
-use arrow::buffer::Buffer;
+use arrow::buffer::{Buffer, OffsetBuffer};
 use arrow::datatypes::DataType;
 
 use crate::utils::{make_scalar_function, utf8_to_str_type};
@@ -161,7 +161,7 @@ impl ScalarUDFImpl for InitcapFunc {
 fn initcap<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     let string_array = as_generic_string_array::<T>(&args[0])?;
 
-    if string_array.value_data().is_ascii() {
+    if string_array.is_ascii() {
         return Ok(initcap_ascii_array(string_array));
     }
 
@@ -182,10 +182,8 @@ fn initcap<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     Ok(Arc::new(builder.finish()) as ArrayRef)
 }
 
-/// Fast path for initcap of `Utf8` or `LargeUtf8` arrays that are
-/// ASCII-only. We can operate on the entire buffer in a single pass, and
-/// operate on bytes directly. Since ASCII case conversion preserves byte
-/// length, the original offsets and nulls also don't need to be recomputed.
+/// Fast path for `Utf8` or `LargeUtf8` arrays that are ASCII-only. We can use a
+/// single pass over the buffer and operate directly on bytes.
 fn initcap_ascii_array<T: OffsetSizeTrait>(
     string_array: &GenericStringArray<T>,
 ) -> ArrayRef {
@@ -193,10 +191,10 @@ fn initcap_ascii_array<T: OffsetSizeTrait>(
     let src = string_array.value_data();
     let first_offset = offsets.first().unwrap().as_usize();
     let last_offset = offsets.last().unwrap().as_usize();
-    let mut out = Vec::with_capacity(src.len());
 
-    // Preserve bytes before the first offset unchanged.
-    out.extend_from_slice(&src[..first_offset]);
+    // For sliced arrays, only convert the visible bytes, not the entire input
+    // buffer.
+    let mut out = Vec::with_capacity(last_offset - first_offset);
 
     for window in offsets.windows(2) {
         let start = window[0].as_usize();
@@ -214,15 +212,26 @@ fn initcap_ascii_array<T: OffsetSizeTrait>(
         }
     }
 
-    // Preserve bytes after the last offset unchanged.
-    out.extend_from_slice(&src[last_offset..]);
-
     let values = Buffer::from_vec(out);
+    let out_offsets = if first_offset == 0 {
+        offsets.clone()
+    } else {
+        // For sliced arrays, we need to rebase the offsets to reflect that the
+        // output only contains the bytes in the visible slice.
+        let rebased_offsets = offsets
+            .iter()
+            .map(|offset| T::usize_as(offset.as_usize() - first_offset))
+            .collect::<Vec<_>>();
+        OffsetBuffer::<T>::new(rebased_offsets.into())
+    };
+
     // SAFETY: ASCII case conversion preserves byte length, so the original
-    // offsets and nulls remain valid.
+    // string boundaries are preserved. `out_offsets` is either identical to
+    // the input offsets or a rebased version relative to the compacted values
+    // buffer.
     Arc::new(unsafe {
         GenericStringArray::<T>::new_unchecked(
-            offsets.clone(),
+            out_offsets,
             values,
             string_array.nulls().cloned(),
         )
@@ -457,6 +466,13 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result.value(0), "Foo Bar");
         assert_eq!(result.value(1), "Baz Qux");
+
+        // The output values buffer should be compact
+        assert_eq!(*result.offsets().first().unwrap(), 0);
+        assert_eq!(
+            result.value_data().len(),
+            *result.offsets().last().unwrap() as usize
+        );
         Ok(())
     }
 
@@ -479,6 +495,13 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result.value(0), "Foo Bar");
         assert_eq!(result.value(1), "Baz Qux");
+
+        // The output values buffer should be compact
+        assert_eq!(*result.offsets().first().unwrap(), 0);
+        assert_eq!(
+            result.value_data().len(),
+            *result.offsets().last().unwrap() as usize
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20351.

## Rationale for this change

When all values in a `Utf8`/`LargeUtf8` array are ASCII, we can skip using `GenericStringBuilder` and instead process the entire input buffer in a single pass using byte-level operations. This also avoids recomputing the offsets and nulls arrays. A similar optimization is already used for lower() and upper().

Along the way, optimize `initcap_string()` for ASCII-only inputs. It already had an ASCII-only fastpath but there was room for further optimization, by iterating over bytes rather than characters.

## What changes are included in this PR?

* Cleanup benchmarks: we ran the scalar benchmark for different array sizes, despite the fact that it is invariant to the array size
* Add benchmark for different string lengths
* Add benchmark for Unicode array input
* Optimize for ASCII-only inputs as described above
* Add test case for ASCII-only input that is a sliced array
* Add test case variants for `LargeStringArray`

## Are these changes tested?

Yes, plus an additional test added.

## Are there any user-facing changes?

No.
