### PR TITLE
feat: add LazyPartition trait for LazyMemoryExec, migrate generate_series to partitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-plan",
+ "futures",
  "parking_lot",
  "paste",
 ]

--- a/datafusion/functions-table/Cargo.toml
+++ b/datafusion/functions-table/Cargo.toml
@@ -47,6 +47,7 @@ datafusion-catalog = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-physical-plan = { workspace = true }
+futures = { workspace = true }
 parking_lot = { workspace = true }
 paste = { workspace = true }
 

--- a/datafusion/functions-table/src/generate_series.rs
+++ b/datafusion/functions-table/src/generate_series.rs
@@ -244,11 +244,11 @@ impl GenerateSeriesTable {
     }
 
     pub fn as_partition(&self, batch_size: usize) -> Result<Arc<dyn LazyPartition>> {
-        Ok(Arc::new(GenerateSeriesPartition::new(
+        Ok(Arc::new(GenerateSeriesPartition::try_new(
             self.schema(),
             self.args.clone(),
             batch_size,
-        )))
+        )?))
     }
 
     #[deprecated(
@@ -259,20 +259,7 @@ impl GenerateSeriesTable {
         &self,
         batch_size: usize,
     ) -> Result<Arc<RwLock<dyn LazyBatchGenerator>>> {
-        let generator: Arc<RwLock<dyn LazyBatchGenerator>> =
-            match build_generate_series_state(
-                Arc::clone(&self.schema),
-                &self.args,
-                batch_size,
-            )? {
-                GenerateSeriesState::Empty { name } => {
-                    Arc::new(RwLock::new(Empty { name }))
-                }
-                GenerateSeriesState::Int64(state) => Arc::new(RwLock::new(state)),
-                GenerateSeriesState::Timestamp(state) => Arc::new(RwLock::new(state)),
-            };
-
-        Ok(generator)
+        build_generate_series_generator(Arc::clone(&self.schema), &self.args, batch_size)
     }
 }
 
@@ -284,12 +271,20 @@ pub struct GenerateSeriesPartition {
 }
 
 impl GenerateSeriesPartition {
-    pub fn new(schema: SchemaRef, args: GenSeriesArgs, batch_size: usize) -> Self {
-        Self {
+    pub fn try_new(
+        schema: SchemaRef,
+        args: GenSeriesArgs,
+        batch_size: usize,
+    ) -> Result<Self> {
+        if batch_size == 0 {
+            return plan_err!("Batch size cannot be zero");
+        }
+
+        Ok(Self {
             schema,
             args,
             batch_size,
-        }
+        })
     }
 
     pub fn args(&self) -> &GenSeriesArgs {
@@ -427,6 +422,21 @@ fn build_generate_series_state(
     }
 }
 
+#[expect(deprecated)]
+fn build_generate_series_generator(
+    schema: SchemaRef,
+    args: &GenSeriesArgs,
+    batch_size: usize,
+) -> Result<Arc<RwLock<dyn LazyBatchGenerator>>> {
+    let generator: Arc<RwLock<dyn LazyBatchGenerator>> =
+        match build_generate_series_state(schema, args, batch_size)? {
+            GenerateSeriesState::Empty { name } => Arc::new(RwLock::new(Empty { name })),
+            GenerateSeriesState::Int64(state) => Arc::new(RwLock::new(state)),
+            GenerateSeriesState::Timestamp(state) => Arc::new(RwLock::new(state)),
+        };
+
+    Ok(generator)
+}
 impl LazyPartition for GenerateSeriesPartition {
     fn as_any(&self) -> &dyn Any {
         self
@@ -450,6 +460,16 @@ impl LazyPartition for GenerateSeriesPartition {
         });
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+
+    #[expect(deprecated)]
+    fn legacy_generator(&self) -> Option<Arc<RwLock<dyn LazyBatchGenerator>>> {
+        build_generate_series_generator(
+            Arc::clone(&self.schema),
+            &self.args,
+            self.batch_size,
+        )
+        .ok()
     }
 }
 
@@ -904,11 +924,11 @@ mod generate_series_tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::Result;
     #[expect(deprecated)]
-    use datafusion_physical_plan::memory::LazyBatchGenerator;
+    use datafusion_physical_plan::memory::{LazyBatchGenerator, LazyMemoryExec};
     use futures::TryStreamExt;
 
     use crate::generate_series::{
-        GenSeriesArgs, GenerateSeriesTable, GenericSeriesState,
+        GenSeriesArgs, GenerateSeriesPartition, GenerateSeriesTable, GenericSeriesState,
     };
 
     #[test]
@@ -981,5 +1001,69 @@ mod generate_series_tests {
             vec![1, 2, 3, 4, 5]
         );
         Ok(())
+    }
+
+    #[test]
+    #[expect(deprecated)]
+    fn test_generate_series_native_partition_preserves_legacy_generators_accessor()
+    -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int64,
+            false,
+        )]));
+        let table = GenerateSeriesTable::new(
+            Arc::clone(&schema),
+            GenSeriesArgs::Int64Args {
+                start: 1,
+                end: 3,
+                step: 1,
+                include_end: true,
+                name: "generate_series",
+            },
+        );
+        let partition = table.as_partition(2)?;
+        let exec = LazyMemoryExec::try_new_with_partitions(schema, vec![partition])?;
+
+        let generators = exec.generators();
+        assert_eq!(generators.len(), 1);
+
+        let batch = generators[0]
+            .write()
+            .generate_next_batch()?
+            .expect("missing compatibility batch");
+        let values = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("expected int64 batch");
+        assert_eq!(values.values(), &[1, 2]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_series_partition_rejects_zero_batch_size_during_direct_construction()
+    {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int64,
+            false,
+        )]));
+
+        let err = GenerateSeriesPartition::try_new(
+            schema,
+            GenSeriesArgs::Int64Args {
+                start: 0,
+                end: 10,
+                step: 1,
+                include_end: true,
+                name: "generate_series",
+            },
+            0,
+        )
+        .expect_err("zero batch size should fail during direct construction");
+
+        assert!(err.to_string().contains("Batch size cannot be zero"));
     }
 }

--- a/datafusion/physical-plan/src/memory.rs
+++ b/datafusion/physical-plan/src/memory.rs
@@ -25,6 +25,7 @@ use std::task::{Context, Poll};
 use crate::coop::cooperative;
 use crate::execution_plan::{Boundedness, EmissionType, SchedulingType};
 use crate::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use crate::stream::{ObservedStream, RecordBatchStreamAdapter};
 use crate::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     RecordBatchStream, SendableRecordBatchStream,
@@ -39,7 +40,7 @@ use datafusion_execution::memory_pool::MemoryReservation;
 use datafusion_physical_expr::{EquivalenceProperties, PhysicalExpr};
 
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
-use futures::Stream;
+use futures::{Stream, StreamExt, stream};
 use parking_lot::RwLock;
 
 /// Iterator over batches
@@ -134,6 +135,9 @@ impl RecordBatchStream for MemoryStream {
     }
 }
 
+#[deprecated(
+    note = "Use LazyPartition with LazyMemoryExec::try_new_with_partitions instead"
+)]
 pub trait LazyBatchGenerator: Send + Sync + fmt::Debug + fmt::Display {
     /// Returns the generator as [`Any`] so that it can be
     /// downcast to a specific implementation.
@@ -150,6 +154,122 @@ pub trait LazyBatchGenerator: Send + Sync + fmt::Debug + fmt::Display {
     fn reset_state(&self) -> Arc<RwLock<dyn LazyBatchGenerator>>;
 }
 
+/// A partition that lazily produces record batches via [`SendableRecordBatchStream`].
+///
+/// Each call to [`execute`](Self::execute) must return an independent stream
+/// starting from the beginning of the partition's data.  Implementations must
+/// be safe to call `execute` multiple times (replay semantics).
+///
+/// Used with [`LazyMemoryExec::try_new_with_partitions`] to create execution
+/// plans that generate data on-demand without buffering all batches in memory.
+pub trait LazyPartition: fmt::Debug + fmt::Display + Send + Sync {
+    /// Returns the partition as [`Any`] so that it can be
+    /// downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Schema produced by this partition.
+    fn schema(&self) -> &SchemaRef;
+
+    /// Returns the boundedness of this partition.
+    fn boundedness(&self) -> Boundedness {
+        Boundedness::Bounded
+    }
+
+    /// Creates a fresh stream for this partition.
+    fn execute(&self) -> Result<SendableRecordBatchStream>;
+}
+
+/// Compatibility adapter for legacy [`LazyBatchGenerator`].
+#[derive(Debug)]
+#[expect(deprecated)]
+pub struct LazyBatchGeneratorPartition {
+    schema: SchemaRef,
+    generator: Arc<RwLock<dyn LazyBatchGenerator>>,
+}
+
+#[expect(deprecated)]
+impl LazyBatchGeneratorPartition {
+    pub fn new(
+        schema: SchemaRef,
+        generator: Arc<RwLock<dyn LazyBatchGenerator>>,
+    ) -> Self {
+        Self { schema, generator }
+    }
+
+    pub fn generator(&self) -> &Arc<RwLock<dyn LazyBatchGenerator>> {
+        &self.generator
+    }
+}
+
+impl fmt::Display for LazyBatchGeneratorPartition {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.generator.read().fmt(f)
+    }
+}
+
+#[expect(deprecated)]
+impl LazyPartition for LazyBatchGeneratorPartition {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn boundedness(&self) -> Boundedness {
+        self.generator.read().boundedness()
+    }
+
+    fn execute(&self) -> Result<SendableRecordBatchStream> {
+        let schema = Arc::clone(&self.schema);
+        let generator = self.generator.read().reset_state();
+        let stream = stream::try_unfold(generator, |generator| async move {
+            let batch = generator.write().generate_next_batch()?;
+            Ok(batch.map(|batch| (batch, generator)))
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+fn aggregate_boundedness(boundedness: impl Iterator<Item = Boundedness>) -> Boundedness {
+    boundedness
+        .reduce(|acc, b| match acc {
+            Boundedness::Bounded => b,
+            Boundedness::Unbounded {
+                requires_infinite_memory,
+            } => {
+                let acc_infinite_memory = requires_infinite_memory;
+                match b {
+                    Boundedness::Bounded => acc,
+                    Boundedness::Unbounded {
+                        requires_infinite_memory,
+                    } => Boundedness::Unbounded {
+                        requires_infinite_memory: requires_infinite_memory
+                            || acc_infinite_memory,
+                    },
+                }
+            }
+        })
+        .unwrap_or(Boundedness::Bounded)
+}
+
+#[expect(deprecated)]
+fn collect_legacy_generators(
+    partitions: &[Arc<dyn LazyPartition>],
+) -> Vec<Arc<RwLock<dyn LazyBatchGenerator>>> {
+    partitions
+        .iter()
+        .filter_map(|partition| {
+            partition
+                .as_any()
+                .downcast_ref::<LazyBatchGeneratorPartition>()
+                .map(|adapter| Arc::clone(adapter.generator()))
+        })
+        .collect()
+}
+
 /// Execution plan for lazy in-memory batches of data
 ///
 /// This plan generates output batches lazily, it doesn't have to buffer all batches
@@ -159,8 +279,11 @@ pub struct LazyMemoryExec {
     schema: SchemaRef,
     /// Optional projection for which columns to load
     projection: Option<Vec<usize>>,
-    /// Functions to generate batches for each partition
-    batch_generators: Vec<Arc<RwLock<dyn LazyBatchGenerator>>>,
+    /// Partition implementations for each output partition
+    partitions: Vec<Arc<dyn LazyPartition>>,
+    /// Legacy generator compatibility cache for deprecated APIs.
+    #[expect(deprecated)]
+    legacy_generators: Vec<Arc<RwLock<dyn LazyBatchGenerator>>>,
     /// Plan properties cache storing equivalence properties, partitioning, and execution mode
     cache: Arc<PlanProperties>,
     /// Execution metrics
@@ -168,36 +291,26 @@ pub struct LazyMemoryExec {
 }
 
 impl LazyMemoryExec {
-    /// Create a new lazy memory execution plan
-    pub fn try_new(
+    /// Create a new lazy memory execution plan from partition implementations.
+    pub fn try_new_with_partitions(
         schema: SchemaRef,
-        generators: Vec<Arc<RwLock<dyn LazyBatchGenerator>>>,
+        partitions: Vec<Arc<dyn LazyPartition>>,
     ) -> Result<Self> {
-        let boundedness = generators
-            .iter()
-            .map(|g| g.read().boundedness())
-            .reduce(|acc, b| match acc {
-                Boundedness::Bounded => b,
-                Boundedness::Unbounded {
-                    requires_infinite_memory,
-                } => {
-                    let acc_infinite_memory = requires_infinite_memory;
-                    match b {
-                        Boundedness::Bounded => acc,
-                        Boundedness::Unbounded {
-                            requires_infinite_memory,
-                        } => Boundedness::Unbounded {
-                            requires_infinite_memory: requires_infinite_memory
-                                || acc_infinite_memory,
-                        },
-                    }
-                }
-            })
-            .unwrap_or(Boundedness::Bounded);
+        for partition in &partitions {
+            assert_eq_or_internal_err!(
+                partition.schema().as_ref(),
+                schema.as_ref(),
+                "Partition schema must match LazyMemoryExec schema"
+            );
+        }
+
+        let boundedness =
+            aggregate_boundedness(partitions.iter().map(|p| p.boundedness()));
+        let legacy_generators = collect_legacy_generators(&partitions);
 
         let cache = PlanProperties::new(
             EquivalenceProperties::new(Arc::clone(&schema)),
-            Partitioning::RoundRobinBatch(generators.len()),
+            Partitioning::RoundRobinBatch(partitions.len()),
             EmissionType::Incremental,
             boundedness,
         )
@@ -207,10 +320,30 @@ impl LazyMemoryExec {
         Ok(Self {
             schema,
             projection: None,
-            batch_generators: generators,
+            partitions,
+            legacy_generators,
             cache,
             metrics: ExecutionPlanMetricsSet::new(),
         })
+    }
+
+    /// Create a new lazy memory execution plan
+    #[deprecated(note = "Use LazyMemoryExec::try_new_with_partitions instead")]
+    #[expect(deprecated)]
+    pub fn try_new(
+        schema: SchemaRef,
+        generators: Vec<Arc<RwLock<dyn LazyBatchGenerator>>>,
+    ) -> Result<Self> {
+        let partitions = generators
+            .into_iter()
+            .map(|generator| {
+                Arc::new(LazyBatchGeneratorPartition::new(
+                    Arc::clone(&schema),
+                    generator,
+                )) as Arc<dyn LazyPartition>
+            })
+            .collect::<Vec<_>>();
+        Self::try_new_with_partitions(schema, partitions)
     }
 
     pub fn with_projection(mut self, projection: Option<Vec<usize>>) -> Self {
@@ -230,11 +363,11 @@ impl LazyMemoryExec {
 
     pub fn try_set_partitioning(&mut self, partitioning: Partitioning) -> Result<()> {
         let partition_count = partitioning.partition_count();
-        let generator_count = self.batch_generators.len();
+        let generator_count = self.partitions.len();
         assert_eq_or_internal_err!(
             partition_count,
             generator_count,
-            "Partition count must match generator count: {} != {}",
+            "Partitioning count must match number of partitions: {} != {}",
             partition_count,
             generator_count
         );
@@ -248,9 +381,16 @@ impl LazyMemoryExec {
             .add_orderings(std::iter::once(ordering));
     }
 
+    /// Get the partitions.
+    pub fn partitions(&self) -> &[Arc<dyn LazyPartition>] {
+        &self.partitions
+    }
+
     /// Get the batch generators
+    #[deprecated(note = "Use LazyMemoryExec::partitions instead")]
+    #[expect(deprecated)]
     pub fn generators(&self) -> &Vec<Arc<RwLock<dyn LazyBatchGenerator>>> {
-        &self.batch_generators
+        &self.legacy_generators
     }
 }
 
@@ -258,7 +398,7 @@ impl fmt::Debug for LazyMemoryExec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("LazyMemoryExec")
             .field("schema", &self.schema)
-            .field("batch_generators", &self.batch_generators)
+            .field("partitions", &self.partitions)
             .finish()
     }
 }
@@ -270,10 +410,10 @@ impl DisplayAs for LazyMemoryExec {
                 write!(
                     f,
                     "LazyMemoryExec: partitions={}, batch_generators=[{}]",
-                    self.batch_generators.len(),
-                    self.batch_generators
+                    self.partitions.len(),
+                    self.partitions
                         .iter()
-                        .map(|g| g.read().to_string())
+                        .map(|partition| partition.to_string())
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
@@ -283,9 +423,9 @@ impl DisplayAs for LazyMemoryExec {
                 writeln!(
                     f,
                     "batch_generators={}",
-                    self.batch_generators
+                    self.partitions
                         .iter()
-                        .map(|g| g.read().to_string())
+                        .map(|partition| partition.to_string())
                         .collect::<Vec<String>>()
                         .join(", ")
                 )?;
@@ -340,20 +480,29 @@ impl ExecutionPlan for LazyMemoryExec {
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         assert_or_internal_err!(
-            partition < self.batch_generators.len(),
+            partition < self.partitions.len(),
             "Invalid partition {} for LazyMemoryExec with {} partitions",
             partition,
-            self.batch_generators.len()
+            self.partitions.len()
         );
 
         let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
-
-        let stream = LazyMemoryStream {
-            schema: Arc::clone(&self.schema),
-            projection: self.projection.clone(),
-            generator: Arc::clone(&self.batch_generators[partition]),
-            baseline_metrics,
+        let stream = self.partitions[partition].execute()?;
+        let stream = match self.projection.as_ref() {
+            Some(columns) => {
+                let columns = Arc::new(columns.clone());
+                let schema = Arc::clone(&self.schema);
+                let stream = stream.map(move |batch| {
+                    batch.and_then(|batch| {
+                        batch.project(columns.as_ref()).map_err(Into::into)
+                    })
+                });
+                Box::pin(RecordBatchStreamAdapter::new(schema, stream))
+                    as SendableRecordBatchStream
+            }
+            None => stream,
         };
+        let stream = ObservedStream::new(stream, baseline_metrics, None);
         Ok(Box::pin(cooperative(stream)))
     }
 
@@ -361,15 +510,31 @@ impl ExecutionPlan for LazyMemoryExec {
         Some(self.metrics.clone_inner())
     }
 
+    #[expect(deprecated)]
     fn reset_state(self: Arc<Self>) -> Result<Arc<dyn ExecutionPlan>> {
-        let generators = self
-            .generators()
+        let partitions = self
+            .partitions
             .iter()
-            .map(|g| g.read().reset_state())
+            .map(|partition| {
+                partition
+                    .as_any()
+                    .downcast_ref::<LazyBatchGeneratorPartition>()
+                    .map_or_else(
+                        || Arc::clone(partition),
+                        |adapter| {
+                            Arc::new(LazyBatchGeneratorPartition::new(
+                                Arc::clone(adapter.schema()),
+                                adapter.generator().read().reset_state(),
+                            )) as Arc<dyn LazyPartition>
+                        },
+                    )
+            })
             .collect::<Vec<_>>();
+        let legacy_generators = collect_legacy_generators(&partitions);
         Ok(Arc::new(LazyMemoryExec {
             schema: Arc::clone(&self.schema),
-            batch_generators: generators,
+            partitions,
+            legacy_generators,
             cache: Arc::clone(&self.cache),
             metrics: ExecutionPlanMetricsSet::new(),
             projection: self.projection.clone(),
@@ -377,63 +542,15 @@ impl ExecutionPlan for LazyMemoryExec {
     }
 }
 
-/// Stream that generates record batches on demand
-pub struct LazyMemoryStream {
-    schema: SchemaRef,
-    /// Optional projection for which columns to load
-    projection: Option<Vec<usize>>,
-    /// Generator to produce batches
-    ///
-    /// Note: Idiomatically, DataFusion uses plan-time parallelism - each stream
-    /// should have a unique `LazyBatchGenerator`. Use RepartitionExec or
-    /// construct multiple `LazyMemoryStream`s during planning to enable
-    /// parallel execution.
-    /// Sharing generators between streams should be used with caution.
-    generator: Arc<RwLock<dyn LazyBatchGenerator>>,
-    /// Execution metrics
-    baseline_metrics: BaselineMetrics,
-}
-
-impl Stream for LazyMemoryStream {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(
-        self: std::pin::Pin<&mut Self>,
-        _: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        let _timer_guard = self.baseline_metrics.elapsed_compute().timer();
-        let batch = self.generator.write().generate_next_batch();
-
-        let poll = match batch {
-            Ok(Some(batch)) => {
-                // return just the columns requested
-                let batch = match self.projection.as_ref() {
-                    Some(columns) => batch.project(columns)?,
-                    None => batch,
-                };
-                Poll::Ready(Some(Ok(batch)))
-            }
-            Ok(None) => Poll::Ready(None),
-            Err(e) => Poll::Ready(Some(Err(e))),
-        };
-
-        self.baseline_metrics.record_poll(poll)
-    }
-}
-
-impl RecordBatchStream for LazyMemoryStream {
-    fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
-    }
-}
-
 #[cfg(test)]
+#[expect(deprecated)]
 mod lazy_memory_tests {
     use super::*;
     use crate::common::collect;
+    use crate::stream::RecordBatchStreamAdapter;
     use arrow::array::Int64Array;
     use arrow::datatypes::{DataType, Field, Schema};
-    use futures::StreamExt;
+    use futures::{StreamExt, stream};
 
     #[derive(Debug, Clone)]
     struct TestGenerator {
@@ -481,6 +598,57 @@ mod lazy_memory_tests {
                 batch_size: self.batch_size,
                 schema: Arc::clone(&self.schema),
             }))
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct TestPartition {
+        schema: SchemaRef,
+        batches: Arc<Vec<RecordBatch>>,
+        error_at_batch: Option<usize>,
+    }
+
+    impl fmt::Display for TestPartition {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "TestPartition: batches={}, error_at_batch={:?}",
+                self.batches.len(),
+                self.error_at_batch
+            )
+        }
+    }
+
+    impl LazyPartition for TestPartition {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn schema(&self) -> &SchemaRef {
+            &self.schema
+        }
+
+        fn execute(&self) -> Result<SendableRecordBatchStream> {
+            let schema = Arc::clone(&self.schema);
+            let batches = Arc::clone(&self.batches);
+            let error_at_batch = self.error_at_batch;
+            let stream = stream::try_unfold(0usize, move |index| {
+                let batches = Arc::clone(&batches);
+                async move {
+                    if error_at_batch.is_some_and(|fail_at| fail_at == index) {
+                        return Err(datafusion_common::internal_datafusion_err!(
+                            "injected partition error at batch {index}"
+                        ));
+                    }
+
+                    let Some(batch) = batches.get(index).cloned() else {
+                        return Ok(None);
+                    };
+                    Ok(Some((batch, index + 1)))
+                }
+            });
+
+            Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
         }
     }
 
@@ -536,6 +704,137 @@ mod lazy_memory_tests {
     }
 
     #[tokio::test]
+    async fn test_lazy_memory_exec_native_partition_replay_without_reset() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![1, 2, 3]))],
+        )?;
+        let partition = Arc::new(TestPartition {
+            schema: Arc::clone(&schema),
+            batches: Arc::new(vec![batch]),
+            error_at_batch: None,
+        });
+
+        let exec = LazyMemoryExec::try_new_with_partitions(schema, vec![partition])?;
+
+        let batches_first =
+            collect(exec.execute(0, Arc::new(TaskContext::default()))?).await?;
+        let batches_second =
+            collect(exec.execute(0, Arc::new(TaskContext::default()))?).await?;
+
+        assert_eq!(batches_first, batches_second);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lazy_memory_exec_partition_projection() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![10, 20])),
+                Arc::new(Int64Array::from(vec![1, 2])),
+            ],
+        )?;
+        let partition = Arc::new(TestPartition {
+            schema: Arc::clone(&schema),
+            batches: Arc::new(vec![batch]),
+            error_at_batch: None,
+        });
+
+        let exec = LazyMemoryExec::try_new_with_partitions(schema, vec![partition])?
+            .with_projection(Some(vec![1]));
+
+        let batches = collect(exec.execute(0, Arc::new(TaskContext::default()))?).await?;
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].schema().field(0).name(), "b");
+        let values = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(values.values(), &[1, 2]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lazy_memory_exec_deprecated_try_new_replays_on_execute() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let generator = TestGenerator {
+            counter: 0,
+            max_batches: 2,
+            batch_size: 2,
+            schema: Arc::clone(&schema),
+        };
+
+        let exec =
+            LazyMemoryExec::try_new(schema, vec![Arc::new(RwLock::new(generator))])?;
+        let task_ctx = Arc::new(TaskContext::default());
+
+        let first = collect(exec.execute(0, Arc::clone(&task_ctx))?).await?;
+        let second = collect(exec.execute(0, task_ctx)?).await?;
+
+        assert_eq!(first, second);
+        Ok(())
+    }
+
+    #[test]
+    fn test_lazy_memory_exec_generators_compatibility_accessor() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+
+        let legacy_exec = LazyMemoryExec::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(RwLock::new(TestGenerator {
+                counter: 0,
+                max_batches: 1,
+                batch_size: 1,
+                schema: Arc::clone(&schema),
+            }))],
+        )?;
+        assert_eq!(legacy_exec.generators().len(), 1);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![1]))],
+        )?;
+        let native_exec = LazyMemoryExec::try_new_with_partitions(
+            schema,
+            vec![Arc::new(TestPartition {
+                schema: legacy_exec.schema(),
+                batches: Arc::new(vec![batch]),
+                error_at_batch: None,
+            })],
+        )?;
+        assert!(native_exec.generators().is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lazy_memory_exec_error_then_end() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![1]))],
+        )?;
+        let partition = Arc::new(TestPartition {
+            schema: Arc::clone(&schema),
+            batches: Arc::new(vec![batch]),
+            error_at_batch: Some(1),
+        });
+        let exec = LazyMemoryExec::try_new_with_partitions(schema, vec![partition])?;
+
+        let mut stream = exec.execute(0, Arc::new(TaskContext::default()))?;
+        assert!(matches!(stream.next().await, Some(Ok(_))));
+        assert!(matches!(stream.next().await, Some(Err(_))));
+        assert!(stream.next().await.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_lazy_memory_exec_invalid_partition() -> Result<()> {
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
         let generator = TestGenerator {
@@ -561,7 +860,7 @@ mod lazy_memory_tests {
     }
 
     #[tokio::test]
-    async fn test_generate_series_metrics_integration() -> Result<()> {
+    async fn test_lazy_memory_exec_metrics() -> Result<()> {
         // Test LazyMemoryExec metrics with different configurations
         let test_cases = vec![
             (10, 2, 10),    // 10 rows, batch size 2, expected 10 rows
@@ -625,6 +924,70 @@ mod lazy_memory_tests {
         // if the reset_state is not correct, the batches_reset will be empty
         assert_eq!(batches, batches_reset);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lazy_memory_exec_multi_partition() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let batch_a = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![1, 2]))],
+        )?;
+        let batch_b = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![10, 20]))],
+        )?;
+        let p0 = Arc::new(TestPartition {
+            schema: Arc::clone(&schema),
+            batches: Arc::new(vec![batch_a.clone()]),
+            error_at_batch: None,
+        });
+        let p1 = Arc::new(TestPartition {
+            schema: Arc::clone(&schema),
+            batches: Arc::new(vec![batch_b.clone()]),
+            error_at_batch: None,
+        });
+
+        let exec = LazyMemoryExec::try_new_with_partitions(
+            schema,
+            vec![p0 as Arc<dyn LazyPartition>, p1 as Arc<dyn LazyPartition>],
+        )?;
+
+        let ctx = Arc::new(TaskContext::default());
+        let batches_0 = collect(exec.execute(0, Arc::clone(&ctx))?).await?;
+        let batches_1 = collect(exec.execute(1, Arc::clone(&ctx))?).await?;
+
+        assert_eq!(batches_0, vec![batch_a]);
+        assert_eq!(batches_1, vec![batch_b]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lazy_memory_exec_native_partition_reset_state() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![1, 2, 3]))],
+        )?;
+        let partition = Arc::new(TestPartition {
+            schema: Arc::clone(&schema),
+            batches: Arc::new(vec![batch]),
+            error_at_batch: None,
+        });
+
+        let exec = Arc::new(LazyMemoryExec::try_new_with_partitions(
+            schema,
+            vec![partition],
+        )?);
+
+        let ctx = Arc::new(TaskContext::default());
+        let batches_before = collect(exec.execute(0, Arc::clone(&ctx))?).await?;
+
+        let exec_reset = exec.reset_state()?;
+        let batches_after = collect(exec_reset.execute(0, ctx)?).await?;
+
+        assert_eq!(batches_before, batches_after);
         Ok(())
     }
 }

--- a/datafusion/physical-plan/src/memory.rs
+++ b/datafusion/physical-plan/src/memory.rs
@@ -177,6 +177,13 @@ pub trait LazyPartition: fmt::Debug + fmt::Display + Send + Sync {
 
     /// Creates a fresh stream for this partition.
     fn execute(&self) -> Result<SendableRecordBatchStream>;
+
+    /// Compatibility hook for the deprecated [`LazyMemoryExec::generators`] API.
+    #[doc(hidden)]
+    #[expect(deprecated)]
+    fn legacy_generator(&self) -> Option<Arc<RwLock<dyn LazyBatchGenerator>>> {
+        None
+    }
 }
 
 /// Compatibility adapter for legacy [`LazyBatchGenerator`].
@@ -231,6 +238,10 @@ impl LazyPartition for LazyBatchGeneratorPartition {
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
     }
+
+    fn legacy_generator(&self) -> Option<Arc<RwLock<dyn LazyBatchGenerator>>> {
+        Some(Arc::clone(&self.generator))
+    }
 }
 
 fn aggregate_boundedness(boundedness: impl Iterator<Item = Boundedness>) -> Boundedness {
@@ -261,12 +272,7 @@ fn collect_legacy_generators(
 ) -> Vec<Arc<RwLock<dyn LazyBatchGenerator>>> {
     partitions
         .iter()
-        .filter_map(|partition| {
-            partition
-                .as_any()
-                .downcast_ref::<LazyBatchGeneratorPartition>()
-                .map(|adapter| Arc::clone(adapter.generator()))
-        })
+        .filter_map(|partition| partition.legacy_generator())
         .collect()
 }
 

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -2169,11 +2169,11 @@ impl protobuf::PhysicalPlanNode {
             None => return internal_err!("Missing args in GenerateSeriesNode"),
         };
 
-        let partition = Arc::new(GenerateSeriesPartition::new(
+        let partition = Arc::new(GenerateSeriesPartition::try_new(
             Arc::clone(&schema),
             args,
             generate_series.target_batch_size as usize,
-        ));
+        )?);
 
         Ok(Arc::new(LazyMemoryExec::try_new_with_partitions(
             schema,

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -52,7 +52,7 @@ use datafusion_execution::object_store::ObjectStoreUrl;
 use datafusion_execution::{FunctionRegistry, TaskContext};
 use datafusion_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 use datafusion_functions_table::generate_series::{
-    Empty, GenSeriesArgs, GenerateSeriesTable, GenericSeriesState, TimestampValue,
+    Empty, GenSeriesArgs, GenerateSeriesPartition, GenericSeriesState, TimestampValue,
 };
 use datafusion_physical_expr::aggregate::{AggregateExprBuilder, AggregateFunctionExpr};
 use datafusion_physical_expr::async_scalar_function::AsyncFuncExpr;
@@ -77,7 +77,7 @@ use datafusion_physical_plan::joins::{
     StreamJoinPartitionMode, SymmetricHashJoinExec,
 };
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
-use datafusion_physical_plan::memory::LazyMemoryExec;
+use datafusion_physical_plan::memory::{LazyBatchGeneratorPartition, LazyMemoryExec};
 use datafusion_physical_plan::metrics::MetricType;
 use datafusion_physical_plan::placeholder_row::PlaceholderRowExec;
 use datafusion_physical_plan::projection::{ProjectionExec, ProjectionExpr};
@@ -2169,10 +2169,16 @@ impl protobuf::PhysicalPlanNode {
             None => return internal_err!("Missing args in GenerateSeriesNode"),
         };
 
-        let table = GenerateSeriesTable::new(Arc::clone(&schema), args);
-        let generator = table.as_generator(generate_series.target_batch_size as usize)?;
+        let partition = Arc::new(GenerateSeriesPartition::new(
+            Arc::clone(&schema),
+            args,
+            generate_series.target_batch_size as usize,
+        ));
 
-        Ok(Arc::new(LazyMemoryExec::try_new(schema, vec![generator])?))
+        Ok(Arc::new(LazyMemoryExec::try_new_with_partitions(
+            schema,
+            vec![partition],
+        )?))
     }
 
     fn try_into_cooperative_physical_plan(
@@ -3469,22 +3475,118 @@ impl protobuf::PhysicalPlanNode {
         }
     }
 
-    fn try_from_lazy_memory_exec(exec: &LazyMemoryExec) -> Result<Option<Self>> {
-        let generators = exec.generators();
+    fn serialize_generate_series_args(
+        args: &GenSeriesArgs,
+    ) -> Result<protobuf::generate_series_node::Args> {
+        match args {
+            GenSeriesArgs::ContainsNull { name } => {
+                Ok(protobuf::generate_series_node::Args::ContainsNull(
+                    protobuf::GenerateSeriesArgsContainsNull {
+                        name: Self::str_to_generate_series_name(name)? as i32,
+                    },
+                ))
+            }
+            GenSeriesArgs::Int64Args {
+                start,
+                end,
+                step,
+                include_end,
+                name,
+            } => Ok(protobuf::generate_series_node::Args::Int64Args(
+                protobuf::GenerateSeriesArgsInt64 {
+                    start: *start,
+                    end: *end,
+                    step: *step,
+                    include_end: *include_end,
+                    name: Self::str_to_generate_series_name(name)? as i32,
+                },
+            )),
+            GenSeriesArgs::TimestampArgs {
+                start,
+                end,
+                step,
+                tz,
+                include_end,
+                name,
+            } => Ok(protobuf::generate_series_node::Args::TimestampArgs(
+                protobuf::GenerateSeriesArgsTimestamp {
+                    start: *start,
+                    end: *end,
+                    step: Some(datafusion_proto_common::IntervalMonthDayNanoValue {
+                        months: step.months,
+                        days: step.days,
+                        nanos: step.nanoseconds,
+                    }),
+                    include_end: *include_end,
+                    name: Self::str_to_generate_series_name(name)? as i32,
+                    tz: tz.as_ref().map(ToString::to_string),
+                },
+            )),
+            GenSeriesArgs::DateArgs {
+                start,
+                end,
+                step,
+                include_end,
+                name,
+            } => Ok(protobuf::generate_series_node::Args::DateArgs(
+                protobuf::GenerateSeriesArgsDate {
+                    start: *start,
+                    end: *end,
+                    step: Some(datafusion_proto_common::IntervalMonthDayNanoValue {
+                        months: step.months,
+                        days: step.days,
+                        nanos: step.nanoseconds,
+                    }),
+                    include_end: *include_end,
+                    name: Self::str_to_generate_series_name(name)? as i32,
+                },
+            )),
+        }
+    }
 
-        // ensure we only have one generator
-        let [generator] = generators.as_slice() else {
+    #[allow(deprecated)]
+    fn try_from_lazy_memory_exec(exec: &LazyMemoryExec) -> Result<Option<Self>> {
+        let partitions = exec.partitions();
+
+        // ensure we only have one partition
+        let [partition] = partitions else {
             return Ok(None);
         };
 
-        let generator_guard = generator.read();
+        if let Some(generate_series_partition) =
+            partition.as_any().downcast_ref::<GenerateSeriesPartition>()
+        {
+            let schema = exec.schema();
+            let node = protobuf::GenerateSeriesNode {
+                schema: Some(schema.as_ref().try_into()?),
+                target_batch_size: generate_series_partition.batch_size() as u32,
+                args: Some(Self::serialize_generate_series_args(
+                    generate_series_partition.args(),
+                )?),
+            };
+
+            return Ok(Some(protobuf::PhysicalPlanNode {
+                physical_plan_type: Some(PhysicalPlanType::GenerateSeries(node)),
+            }));
+        }
+
+        let Some(adapter) = partition
+            .as_any()
+            .downcast_ref::<LazyBatchGeneratorPartition>()
+        else {
+            return Ok(None);
+        };
+
+        let generator_guard = adapter.generator().read();
 
         // Try to downcast to different generate_series types
         if let Some(empty_gen) = generator_guard.as_any().downcast_ref::<Empty>() {
             let schema = exec.schema();
             let node = protobuf::GenerateSeriesNode {
                 schema: Some(schema.as_ref().try_into()?),
-                target_batch_size: 8192, // Default batch size
+                // Empty generator produces no rows, so batch_size is irrelevant.
+                // The legacy Empty type doesn't expose batch_size(), so use a default.
+                target_batch_size: 8192,
                 args: Some(protobuf::generate_series_node::Args::ContainsNull(
                     protobuf::GenerateSeriesArgsContainsNull {
                         name: Self::str_to_generate_series_name(empty_gen.name())? as i32,

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -1947,6 +1947,41 @@ async fn roundtrip_generate_series() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn generate_series_zero_batch_size_fails_during_plan_construction() -> Result<()> {
+    let schema = Arc::new(Schema::new(Fields::from([Arc::new(Field::new(
+        "value",
+        DataType::Int64,
+        false,
+    ))])));
+    let node = PhysicalPlanNode {
+        physical_plan_type: Some(
+            protobuf::physical_plan_node::PhysicalPlanType::GenerateSeries(
+                protobuf::GenerateSeriesNode {
+                    schema: Some(schema.as_ref().try_into()?),
+                    target_batch_size: 0,
+                    args: Some(protobuf::generate_series_node::Args::Int64Args(
+                        protobuf::GenerateSeriesArgsInt64 {
+                            start: 0,
+                            end: 10,
+                            step: 1,
+                            include_end: true,
+                            name: protobuf::GenerateSeriesName::GsGenerateSeries as i32,
+                        },
+                    )),
+                },
+            ),
+        ),
+    };
+
+    let ctx = SessionContext::new();
+    let err = node
+        .try_into_physical_plan(&ctx.task_ctx(), &DefaultPhysicalExtensionCodec {})
+        .expect_err("zero batch size should fail during plan construction");
+    assert!(err.to_string().contains("Batch size cannot be zero"));
+
+    Ok(())
+}
 #[tokio::test]
 #[expect(deprecated)]
 async fn roundtrip_generate_series_legacy_generator_adapter() -> Result<()> {

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -1948,6 +1948,69 @@ async fn roundtrip_generate_series() -> Result<()> {
 }
 
 #[tokio::test]
+#[expect(deprecated)]
+async fn roundtrip_generate_series_legacy_generator_adapter() -> Result<()> {
+    use datafusion_functions_table::generate_series::{
+        GenSeriesArgs, GenerateSeriesPartition, GenerateSeriesTable,
+    };
+    use datafusion_physical_plan::memory::LazyMemoryExec;
+
+    let schema = Arc::new(Schema::new(Fields::from([Arc::new(Field::new(
+        "value",
+        DataType::Int64,
+        false,
+    ))])));
+    let table = GenerateSeriesTable::new(
+        Arc::clone(&schema),
+        GenSeriesArgs::Int64Args {
+            start: 1,
+            end: 10,
+            step: 1,
+            include_end: true,
+            name: "generate_series",
+        },
+    );
+    let generator = table.as_generator(4)?;
+    let plan = Arc::new(LazyMemoryExec::try_new(schema, vec![generator])?);
+
+    let node = PhysicalPlanNode::try_from_physical_plan(
+        plan.clone(),
+        &DefaultPhysicalExtensionCodec {},
+    )?;
+    let Some(protobuf::physical_plan_node::PhysicalPlanType::GenerateSeries(
+        generate_series_node,
+    )) = &node.physical_plan_type
+    else {
+        return internal_err!("Expected GenerateSeries physical plan node");
+    };
+    assert_eq!(generate_series_node.target_batch_size, 4);
+
+    let encoded = node.encode_to_vec();
+    let decoded = PhysicalPlanNode::decode(encoded.as_slice())
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+    let ctx = SessionContext::new();
+    let restored = decoded
+        .try_into_physical_plan(&ctx.task_ctx(), &DefaultPhysicalExtensionCodec {})?;
+
+    assert_eq!(plan.schema(), restored.schema());
+
+    let Some(lazy_exec) = restored.as_any().downcast_ref::<LazyMemoryExec>() else {
+        return internal_err!("Expected LazyMemoryExec after roundtrip");
+    };
+    assert_eq!(lazy_exec.partitions().len(), 1);
+
+    let Some(partition) = lazy_exec.partitions()[0]
+        .as_any()
+        .downcast_ref::<GenerateSeriesPartition>()
+    else {
+        return internal_err!("Expected GenerateSeriesPartition after roundtrip");
+    };
+    assert_eq!(partition.batch_size(), 4);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn roundtrip_projection_source() -> Result<()> {
     let schema = Arc::new(Schema::new(Fields::from([
         Arc::new(Field::new("a", DataType::Utf8, false)),


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #13614

## Rationale for this change

`LazyMemoryExec` currently uses generator closures (`LazyBatchGenerator`) as its partition interface. This replaces with a `LazyPartition` trait that gives partitions a proper abstraction while keeping the old generator path working through a legacy adapter.

`generate_series`/`range` are migrated to native `LazyPartition` as the first consumer. Proto roundtrip is updated to handle both native and legacy forms.

## What changes are included in this PR?

- `LazyPartition` trait as the native partition interface for `LazyMemoryExec`
- `LazyBatchGeneratorPartition` adapter allowing existing generator to work
- Deprecated compatibility APIs preserved: `LazyMemoryExec::try_new`, `LazyMemoryExec::generators`, `GenerateSeriesTable::as_generator`.
- `generate_series`/`range` migrated to native `GenerateSeriesPartition`
- Shared helper for generate series state construction (dedupes native and deprecated paths)
- Proto roundtrip updated for native `GenerateSeriesPartition` with legacy adapter fallback
- Core coop test helper updated to use `LazyPartition`
- Proto regression test coverage added

## Are these changes tested?

yes

- `cargo test -p datafusion-physical-plan lazy_memory_tests --lib`
- `cargo test -p datafusion-functions-table generate_series_tests --lib`
- `cargo test -p datafusion-proto roundtrip_generate_series --test proto_integration`
- `cargo test -p datafusion execution::coop --test core_integration`
- `cargo check -p datafusion-physical-plan -p datafusion-functions-table -p datafusion-proto -p datafusion`

## Are there any user-facing changes?

No. `LazyBatchGenerator` and existing public APIs remain available (deprecated)