### PR TITLE
feat: add coerce_arguments flag to UDTFs to allow skipping automatic …

### DIFF
--- a/datafusion/catalog/src/table.rs
+++ b/datafusion/catalog/src/table.rs
@@ -489,6 +489,12 @@ pub trait TableProviderFactory: Debug + Sync + Send {
 pub trait TableFunctionImpl: Debug + Sync + Send {
     /// Create a table provider
     fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>>;
+
+    /// Returns true if the arguments should be coerced and simplified.
+    /// Defaults to true for backward compatibility.
+    fn coerce_arguments(&self) -> bool {
+        true
+    }
 }
 
 /// A table that uses a function to generate data
@@ -519,5 +525,10 @@ impl TableFunction {
     /// Get the function implementation and generate a table
     pub fn create_table_provider(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
         self.fun.call(args)
+    }
+
+    /// Returns true if the arguments should be coerced and simplified
+    pub fn coerce_arguments(&self) -> bool {
+        self.fun.coerce_arguments()
     }
 }

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -1842,14 +1842,17 @@ impl ContextProvider for SessionContextProvider<'_> {
             );
         let simplifier = ExprSimplifier::new(simplify_context);
         let schema = DFSchema::empty();
-        let args = args
-            .into_iter()
-            .map(|arg| {
-                simplifier
-                    .coerce(arg, &schema)
-                    .and_then(|e| simplifier.simplify(e))
-            })
-            .collect::<datafusion_common::Result<Vec<_>>>()?;
+        let args = if tbl_func.coerce_arguments() {
+            args.into_iter()
+                .map(|arg| {
+                    simplifier
+                        .coerce(arg, &schema)
+                        .and_then(|e| simplifier.simplify(e))
+                })
+                .collect::<datafusion_common::Result<Vec<_>>>()?
+        } else {
+            args
+        };
         let provider = tbl_func.create_table_provider(&args)?;
 
         Ok(provider_as_source(provider))
@@ -2507,5 +2510,147 @@ mod tests {
         fn udwf_names(&self) -> Vec<String> {
             self.state.window_functions().keys().cloned().collect()
         }
+    }
+}
+
+#[cfg(test)]
+mod udtf_tests {
+    use super::*;
+    use datafusion_catalog::{TableFunctionImpl, TableProvider, TableFunction};
+    use datafusion_expr::{Expr, TableType};
+    use std::sync::Arc;
+    use std::any::Any;
+    use arrow::datatypes::{SchemaRef, Schema, Field, DataType};
+    use datafusion_physical_plan::ExecutionPlan;
+    use async_trait::async_trait;
+    use datafusion_catalog::Session;
+    use datafusion_common::{Result, plan_err};
+
+    #[derive(Debug)]
+    struct MockTableProvider {
+        schema: SchemaRef,
+    }
+
+    #[async_trait]
+    impl TableProvider for MockTableProvider {
+        fn as_any(&self) -> &dyn Any { self }
+        fn schema(&self) -> SchemaRef { self.schema.clone() }
+        fn table_type(&self) -> TableType { TableType::Base }
+        async fn scan(
+            &self,
+            _state: &dyn Session,
+            _projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            let schema = self.schema.clone();
+            Ok(Arc::new(datafusion_physical_plan::empty::EmptyExec::new(schema)))
+        }
+    }
+
+    #[derive(Debug)]
+    struct NoCoerceUDTF {}
+
+    impl TableFunctionImpl for NoCoerceUDTF {
+        fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+            // Verify that the argument 'index' (which is technically a column reference in SQL)
+            // survives as an identifier instead of failing coercion because it's missing from the empty schema.
+            match &args[0] {
+                Expr::BinaryExpr(be) => {
+                    match be.left.as_ref() {
+                        Expr::Column(c) if c.name == "index" => {
+                            // Success!
+                        }
+                        _ => return plan_err!("Expected Column('index') on left side, got {:?}", be.left),
+                    }
+                }
+                _ => return plan_err!("Expected BinaryExpr, got {:?}", args[0]),
+            }
+
+            let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+            Ok(Arc::new(MockTableProvider { schema }))
+        }
+
+        fn coerce_arguments(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn test_udtf_no_coercion() -> Result<()> {
+        let udtf = Arc::new(TableFunction::new(
+            "scan_with".to_string(),
+            Arc::new(NoCoerceUDTF {}),
+        ));
+        
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_table_function_list(vec![udtf])
+            .build();
+            
+        let provider = SessionContextProvider {
+            state: &state,
+            tables: HashMap::new(),
+        };
+
+        // SQL: SELECT * FROM scan_with(index=1)
+        let args = vec![
+            Expr::BinaryExpr(datafusion_expr::BinaryExpr {
+                left: Box::new(Expr::Column(datafusion_common::Column::from_name("index"))),
+                op: datafusion_expr::Operator::Eq,
+                right: Box::new(Expr::Literal(datafusion_common::ScalarValue::Int32(Some(1)), None)),
+            })
+        ];
+
+        let source = provider.get_table_function_source("scan_with", args)?;
+        assert_eq!(source.schema().fields().len(), 1);
+        assert_eq!(source.schema().field(0).name(), "a");
+        
+        Ok(())
+    }
+
+    #[test]
+    fn test_udtf_default_coercion() -> Result<()> {
+        #[derive(Debug)]
+        struct CoerceUDTF {}
+        impl TableFunctionImpl for CoerceUDTF {
+            fn call(&self, _args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+                let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+                Ok(Arc::new(MockTableProvider { schema }))
+            }
+        }
+
+        let udtf = Arc::new(TableFunction::new(
+            "scan_with".to_string(),
+            Arc::new(CoerceUDTF {}),
+        ));
+        
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_table_function_list(vec![udtf])
+            .build();
+            
+        let provider = SessionContextProvider {
+            state: &state,
+            tables: HashMap::new(),
+        };
+
+        // In SQL: SELECT * FROM scan_with(unknown_col=1)
+        let args = vec![
+            Expr::BinaryExpr(datafusion_expr::BinaryExpr {
+                left: Box::new(Expr::Column(datafusion_common::Column::from_name("unknown_col"))),
+                op: datafusion_expr::Operator::Eq,
+                right: Box::new(Expr::Literal(datafusion_common::ScalarValue::Int32(Some(1)), None)),
+            })
+        ];
+
+        // Should fail because coercion is ON and "unknown_col" is not in the empty schema.
+        let res = provider.get_table_function_source("scan_with", args);
+        match res {
+            Ok(_) => panic!("Expected error, but got success"),
+            Err(e) => assert!(e.to_string().contains("Schema error: No field named unknown_col")),
+        }
+        
+        Ok(())
     }
 }


### PR DESCRIPTION
# UDTF Argument Coercion Suppression

## Which issue does this PR close?

Closes #20293.

## Rationale for this change

Currently, User-Defined Table Functions (UDTFs) in DataFusion automatically undergo argument coercion and simplification before being passed to the function creator. This process happens against an empty schema (`DFSchema::empty()`). 

If a UDTF uses arguments that contain identifiers (e.g., [scan_with(index=['a', 'b'])](cci:1://file:///Users/evangelisilva/Documents/datafusion/datafusion/catalog/src/table.rs:173:4-202:5)), the simplifier fails with a `Schema error: No field named index` because it attempts to resolve [index](cci:1://file:///Users/evangelisilva/Documents/datafusion/datafusion/datasource-parquet/src/opener.rs:971:0-1000:1) as a column reference. This prevents UDTFs from implementing custom argument parsing logic that relies on identifiers or complex expressions.

## What changes are included in this PR?

1.  **Modified [TableFunctionImpl](cci:2://file:///Users/evangelisilva/Documents/datafusion/datafusion/catalog/src/table.rs:488:0-497:1) trait**: Added a new method [coerce_arguments(&self) -> bool](cci:1://file:///Users/evangelisilva/Documents/datafusion/datafusion/catalog/src/table.rs:529:4-532:5) that defaults to [true](cci:1://file:///Users/evangelisilva/Documents/datafusion/datafusion/physical-expr/src/expressions/binary.rs:5218:4-5240:5). This allows UDTF authors to opt-out of automatic coercion.
2.  **Updated [TableFunction](cci:2://file:///Users/evangelisilva/Documents/datafusion/datafusion/catalog/src/table.rs:501:0-506:1) struct**: Exposed [coerce_arguments](cci:1://file:///Users/evangelisilva/Documents/datafusion/datafusion/catalog/src/table.rs:529:4-532:5) on the wrapper struct.
3.  **Updated [SessionContextProvider](cci:2://file:///Users/evangelisilva/Documents/datafusion/datafusion/core/src/execution/session_state.rs:1792:0-1795:1)**: Modified the SQL planner integration in [session_state.rs](cci:7://file:///Users/evangelisilva/Documents/datafusion/datafusion/core/src/execution/session_state.rs:0:0-0:0) to check the [coerce_arguments](cci:1://file:///Users/evangelisilva/Documents/datafusion/datafusion/catalog/src/table.rs:529:4-532:5) flag. If `false`, the raw [Expr](cci:2://file:///Users/evangelisilva/Documents/datafusion/datafusion/physical-expr/src/expressions/cast.rs:62:0-69:1) arguments are passed directly to the UDTF creator without modification.
4.  **Unit Tests**: Added comprehensive tests in [session_state.rs](cci:7://file:///Users/evangelisilva/Documents/datafusion/datafusion/core/src/execution/session_state.rs:0:0-0:0) to verify both the default behavior (automatic coercion/failure on identifiers) and the new suppressed behavior (allowing identifiers).

## Are these changes tested?

Yes. I've added a new test module `udtf_tests` in [datafusion/core/src/execution/session_state.rs](cci:7://file:///Users/evangelisilva/Documents/datafusion/datafusion/core/src/execution/session_state.rs:0:0-0:0) containing:
- [test_udtf_no_coercion](cci:1://file:///Users/evangelisilva/Documents/datafusion/datafusion/core/src/execution/session_state.rs:2578:4-2609:5): Verifies that identifiers survive when coercion is disabled.
- [test_udtf_default_coercion](cci:1://file:///Users/evangelisilva/Documents/datafusion/datafusion/core/src/execution/session_state.rs:2611:4-2654:5): Verifies that the existing behavior (failing on identifiers) is preserved by default to ensure no regressions.

## Are there any user-facing changes?

Yes. There is a new method on the [TableFunctionImpl](cci:2://file:///Users/evangelisilva/Documents/datafusion/datafusion/catalog/src/table.rs:488:0-497:1) trait. However, because it has a default implementation that returns [true](cci:1://file:///Users/evangelisilva/Documents/datafusion/datafusion/physical-expr/src/expressions/binary.rs:5218:4-5240:5), it is **backward compatible** and will not break existing UDTF implementations. UDTF authors who need the new behavior simply need to override this method.

cc: @askalt @alamb 