### PR TITLE
Fix FilterExec converting Absent column stats to Exact(NULL)

### DIFF
--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -740,7 +740,7 @@ impl EmbeddedProjection for FilterExec {
 }
 
 /// Converts an interval bound to a [`Precision`] value. NULL bounds (which
-/// represent "unbounded" in the [`Interval`] type) map to [`Precision::Absent`].
+/// represent "unbounded" in the interval type) map to [`Precision::Absent`].
 fn interval_bound_to_precision(
     bound: ScalarValue,
     is_exact: bool,


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20388.

## Rationale for this change

`collect_new_statistics` in `FilterExec` wraps NULL interval bounds in `Precision::Exact`, converting what should be `Precision::Absent` column statistics into `Precision::Exact(ScalarValue::Int32(None))`. Downstream, `estimate_disjoint_inputs` treats these as real bounds and incorrectly concludes join inputs are disjoint, forcing Partitioned join mode and disabling dynamic filter pushdown for Parquet row group pruning.

## What changes are included in this PR?

Single change to `collect_new_statistics` in `filter.rs`: check `is_null()` on interval bounds before wrapping in `Precision`, mapping NULL bounds back to `Absent`.

## Are these changes tested?

Yes — includes a regression test (`test_filter_statistics_absent_columns_stay_absent`) that fails on current main and passes with the fix.

## Are there any user-facing changes?

No API changes. Corrects statistics propagation for tables/views with absent column statistics.