### PR TITLE
test: Extend Spark Array functions: `array_repeat `, `shuffle` and `slice` test coverage

### DIFF
--- a/datafusion/sqllogictest/test_files/spark/array/array_repeat.slt
+++ b/datafusion/sqllogictest/test_files/spark/array/array_repeat.slt
@@ -32,6 +32,26 @@ SELECT array_repeat('123', -1);
 []
 
 query ?
+SELECT array_repeat('123', CAST('2' AS INT));
+----
+[123, 123]
+
+query ?
+SELECT array_repeat(123, 3);
+----
+[123, 123, 123]
+
+query ?
+SELECT array_repeat('2001-09-28T01:00:00'::timestamp, 2);
+----
+[2001-09-28T01:00:00, 2001-09-28T01:00:00]
+
+query ?
+SELECT array_repeat(array_repeat('123', CAST('2' AS INT)), CAST('3' AS INT));
+----
+[[123, 123], [123, 123], [123, 123]]
+
+query ?
 SELECT array_repeat(['123'], 2);
 ----
 [[123], [123]]

--- a/datafusion/sqllogictest/test_files/spark/array/shuffle.slt
+++ b/datafusion/sqllogictest/test_files/spark/array/shuffle.slt
@@ -87,6 +87,26 @@ SELECT shuffle(column1, 1) FROM test_shuffle_fixed_size;
 [9, NULL, 8]
 NULL
 
+query ?
+SELECT shuffle(['2001-09-28T01:00:00'::timestamp, '2001-08-28T01:00:00'::timestamp, '2001-07-28T01:00:00'::timestamp, '2001-06-28T01:00:00'::timestamp, '2001-05-28T01:00:00'::timestamp], 1);
+----
+[2001-09-28T01:00:00, 2001-06-28T01:00:00, 2001-07-28T01:00:00, 2001-08-28T01:00:00, 2001-05-28T01:00:00]
+
+query ?
+SELECT shuffle(shuffle([1, 20, NULL, 3, 100, NULL, 98, 99], 1), 1);
+----
+[1, 99, NULL, 98, 100, NULL, 3, 20]
+
+query ?
+SELECT shuffle([' ', NULL, 'abc'], 1);
+----
+[ , NULL, abc]
+
+query ?
+SELECT shuffle([1, 2, 3, 4], CAST('2' AS INT));
+----
+[1, 4, 2, 3]
+
 # Clean up
 statement ok
 DROP TABLE test_shuffle_list_types;

--- a/datafusion/sqllogictest/test_files/spark/array/slice.slt
+++ b/datafusion/sqllogictest/test_files/spark/array/slice.slt
@@ -99,3 +99,18 @@ FROM VALUES
 NULL
 NULL
 NULL
+
+query ?
+SELECT slice(['2001-09-28T01:00:00'::timestamp, '2001-08-28T01:00:00'::timestamp, '2001-07-28T01:00:00'::timestamp, '2001-06-28T01:00:00'::timestamp, '2001-05-28T01:00:00'::timestamp], 1, 3);
+----
+[2001-09-28T01:00:00, 2001-08-28T01:00:00, 2001-07-28T01:00:00]
+
+query ?
+SELECT slice(slice([1, 2, 3, 4], 1, 3), 1, 2);
+----
+[1, 2]
+
+query ?
+SELECT slice([1, 2, 3, 4], CAST('2' AS INT), 4);
+----
+[2, 3, 4]

--- a/docs/source/contributor-guide/testing.md
+++ b/docs/source/contributor-guide/testing.md
@@ -70,7 +70,9 @@ DataFusion's SQL implementation is tested using [sqllogictest](https://github.co
 cargo test --profile=ci --test sqllogictests
 # Run a specific test file
 cargo test --profile=ci --test sqllogictests -- aggregate.slt
-# Run and update expected outputs
+# Run a specific test file and update expected outputs
+cargo test --profile=ci --test sqllogictests -- aggregate.slt --complete
+# Run and update expected outputs for all test files
 cargo test --profile=ci --test sqllogictests -- --complete
 ```
 


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #20419.

## Rationale for this change
This PR adds new positive test cases for `datafusion-spark` array functions: `array_repeat `, `shuffle`, `slice`  for the following use-cases:
```
- nested function execution,
- different datatypes such as timestamp,
- casting before function execution
```
Also, being updated contributor-guide testing documentation with minor addition.

## What changes are included in this PR?
Being added new positive test cases to `datafusion-spark` array functions: `array_repeat `, `shuffle`, `slice`.

## Are these changes tested?
Yes, adding new positive test cases.

## Are there any user-facing changes?
No
