### PR TITLE
[Minor] Fix error messages for `shrink` and `try_shrink`

### DIFF
--- a/datafusion/execution/src/memory_pool/mod.rs
+++ b/datafusion/execution/src/memory_pool/mod.rs
@@ -388,7 +388,7 @@ impl MemoryReservation {
                 |prev| prev.checked_sub(capacity),
             )
             .unwrap_or_else(|prev| {
-                panic!("capacity {capacity} exceeds reservation size {prev}")
+                panic!("Cannot free the capacity {capacity} out of allocated size {prev}")
             });
         self.registration.pool.shrink(self, capacity);
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
In the following code, when we fetch `prev` again to construct the error message, the value we get may be different from the value that failed `checked_sub` in the first place which would get us out of the fetch_update CAS loop. Instead we should use the prev value that `fetch_update` returned in the error message.

```rust
pub fn try_shrink(&self, capacity: usize) -> Result<usize> {
    let prev = self
        .size
        .fetch_update(
            atomic::Ordering::Relaxed,
            atomic::Ordering::Relaxed,
            |prev| prev.checked_sub(capacity),
        )
        .map_err(|_| {
            let prev = self.size.load(atomic::Ordering::Relaxed);
            internal_datafusion_err!(
                "Cannot free the capacity {capacity} out of allocated size {prev}"
            )
        })?;

    self.registration.pool.shrink(self, capacity);
    Ok(prev - capacity)
}
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes, with existing tests.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No
