### PR TITLE
feat: multiple columns in count distinct

### DIFF
--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -894,7 +894,7 @@ impl MultiColumnDistinctCountAccumulator {
                 .iter()
                 .next()
                 .map(|vals| {
-                    (ScalarValue::size_of_vec(&vals) - std::mem::size_of_val(&vals))
+                    (ScalarValue::size_of_vec(vals) - std::mem::size_of_val(vals))
                         * self.values.capacity()
                 })
                 .unwrap_or(0)
@@ -907,9 +907,7 @@ impl MultiColumnDistinctCountAccumulator {
             + self
                 .values
                 .iter()
-                .map(|vals| {
-                    ScalarValue::size_of_vec(&vals) - std::mem::size_of_val(&vals)
-                })
+                .map(|vals| ScalarValue::size_of_vec(vals) - std::mem::size_of_val(vals))
                 .sum::<usize>()
             + (std::mem::size_of::<DataType>() * self.state_data_types.capacity())
             + self

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -30,7 +30,7 @@ use arrow::{
     },
 };
 use datafusion_common::{
-    HashMap, Result, ScalarValue, downcast_value, internal_err, not_impl_err,
+    DataFusionError, HashMap, Result, ScalarValue, downcast_value, internal_err,
     stats::Precision, utils::expr::COUNT_STAR_EXPANSION,
 };
 use datafusion_expr::{
@@ -293,20 +293,37 @@ impl AggregateUDFImpl for Count {
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
         if args.is_distinct {
-            let dtype: DataType = match &args.input_fields[0].data_type() {
-                DataType::Dictionary(_, values_type) => (**values_type).clone(),
-                &dtype => dtype.clone(),
-            };
+            if args.input_fields.len() > 1 {
+                Ok(args
+                    .input_fields
+                    .iter()
+                    .map(|field| {
+                        Arc::new(Field::new(
+                            format_state_name(args.name, "count distinct"),
+                            DataType::List(Arc::new(Field::new_list_field(
+                                field.data_type().clone(),
+                                true,
+                            ))),
+                            false,
+                        ))
+                    })
+                    .collect::<Vec<_>>())
+            } else {
+                let dtype: DataType = match &args.input_fields[0].data_type() {
+                    DataType::Dictionary(_, values_type) => (**values_type).clone(),
+                    &dtype => dtype.clone(),
+                };
 
-            Ok(vec![
-                Field::new_list(
-                    format_state_name(args.name, "count distinct"),
-                    // See COMMENTS.md to understand why nullable is set to true
-                    Field::new_list_field(dtype, true),
-                    false,
-                )
-                .into(),
-            ])
+                Ok(vec![
+                    Field::new_list(
+                        format_state_name(args.name, "count distinct"),
+                        // See COMMENTS.md to understand why nullable is set to true
+                        Field::new_list_field(dtype, true),
+                        false,
+                    )
+                    .into(),
+                ])
+            }
         } else {
             Ok(vec![
                 Field::new(
@@ -325,7 +342,14 @@ impl AggregateUDFImpl for Count {
         }
 
         if acc_args.exprs.len() > 1 {
-            return not_impl_err!("COUNT DISTINCT with multiple arguments");
+            let data_types: Vec<DataType> = acc_args
+                .expr_fields
+                .iter()
+                .map(|field| field.data_type().clone())
+                .collect();
+            return Ok(Box::new(MultiColumnDistinctCountAccumulator::new(
+                data_types,
+            )));
         }
 
         let data_type = acc_args.expr_fields[0].data_type();
@@ -841,6 +865,158 @@ impl Accumulator for DistinctCountAccumulator {
     }
 }
 
+#[derive(Debug)]
+struct MultiColumnDistinctCountAccumulator {
+    values: HashSet<Vec<ScalarValue>, RandomState>,
+    state_data_types: Vec<DataType>,
+}
+
+impl MultiColumnDistinctCountAccumulator {
+    fn new(state_data_types: Vec<DataType>) -> Self {
+        Self {
+            values: HashSet::default(),
+            state_data_types,
+        }
+    }
+
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
+        if !values.iter().any(|v| v.is_null()) {
+            self.values.insert(values.to_vec());
+        }
+        Ok(())
+    }
+
+    fn fixed_size(&self) -> usize {
+        std::mem::size_of_val(self)
+            + (std::mem::size_of::<Vec<ScalarValue>>() * self.values.capacity())
+            + self
+                .values
+                .iter()
+                .next()
+                .map(|vals| {
+                    (ScalarValue::size_of_vec(&vals) - std::mem::size_of_val(&vals))
+                        * self.values.capacity()
+                })
+                .unwrap_or(0)
+            + (std::mem::size_of::<DataType>() * self.state_data_types.capacity())
+    }
+
+    fn full_size(&self) -> usize {
+        std::mem::size_of_val(self)
+            + (std::mem::size_of::<Vec<ScalarValue>>() * self.values.capacity())
+            + self
+                .values
+                .iter()
+                .map(|vals| {
+                    ScalarValue::size_of_vec(&vals) - std::mem::size_of_val(&vals)
+                })
+                .sum::<usize>()
+            + (std::mem::size_of::<DataType>() * self.state_data_types.capacity())
+            + self
+                .state_data_types
+                .iter()
+                .map(|dt| dt.size() - std::mem::size_of_val(dt))
+                .sum::<usize>()
+    }
+}
+
+impl Accumulator for MultiColumnDistinctCountAccumulator {
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        let mut scalar_values: Vec<Vec<ScalarValue>> =
+            vec![Vec::new(); self.state_data_types.len()];
+
+        self.values.iter().for_each(|distinct_values| {
+            distinct_values
+                .iter()
+                .enumerate()
+                .for_each(|(col_index, distinct_value)| {
+                    scalar_values[col_index].push(distinct_value.clone());
+                });
+        });
+
+        let accumulator_state: Vec<ScalarValue> = self
+            .state_data_types
+            .iter()
+            .enumerate()
+            .map(|(column_index, state_data_type)| {
+                ScalarValue::List(ScalarValue::new_list_nullable(
+                    &scalar_values[column_index],
+                    state_data_type,
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        Ok(accumulator_state)
+    }
+
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        if values.is_empty() {
+            return Ok(());
+        }
+
+        let arr = &values[0];
+
+        (0..arr.len()).try_for_each(|index| {
+            let vals = values
+                .iter()
+                .map(|array| ScalarValue::try_from_array(array, index))
+                .collect::<Result<Vec<_>>>()?;
+
+            self.update(&vals)
+        })
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+        if states.is_empty() {
+            return Ok(());
+        }
+
+        let arr = &states[0];
+        (0..arr.len()).try_for_each(|index| {
+            let vals = states
+                .iter()
+                .map(|array| ScalarValue::try_from_array(array, index))
+                .collect::<Result<Vec<_>>>()?;
+
+            // The accumulator state does not contain nulls so we use a .values here
+            let col_values = vals
+                .iter()
+                .map(|state| match state {
+                    ScalarValue::List(values) => Ok(values.values()),
+                    _ => Err(DataFusionError::Internal(format!(
+                        "Unexpected accumulator state {state:?}"
+                    ))),
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            (0..col_values[0].len()).try_for_each(|row_index| {
+                let row_values = col_values
+                    .iter()
+                    .map(|col| ScalarValue::try_from_array(col, row_index))
+                    .collect::<Result<Vec<_>>>()?;
+                self.update(&row_values)
+            })
+        })
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        Ok(ScalarValue::Int64(Some(self.values.len() as i64)))
+    }
+
+    fn size(&self) -> usize {
+        let is_fixed_length = self.state_data_types.iter().all(|t| match t {
+            DataType::Boolean | DataType::Null => true,
+            d if d.is_primitive() => true,
+            _ => false,
+        });
+        if is_fixed_length {
+            self.fixed_size()
+        } else {
+            self.full_size()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -1036,6 +1212,84 @@ mod tests {
         merged.merge_batch(&state_arr2)?;
         // Expect distinct {1,2,3} → count = 3
         assert_eq!(merged.evaluate()?, ScalarValue::Int64(Some(3)));
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_basic() -> Result<()> {
+        let mut acc = MultiColumnDistinctCountAccumulator::new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ]);
+
+        // (1, a), (1, b), (1, a), (2, b), (3, b)
+        let col1 = Arc::new(Int32Array::from(vec![
+            Some(1),
+            Some(1),
+            Some(1),
+            Some(2),
+            Some(3),
+        ]));
+        let col2 = Arc::new(StringArray::from(vec![
+            Some("a"),
+            Some("b"),
+            Some("a"),
+            Some("b"),
+            Some("b"),
+        ])) as ArrayRef;
+
+        acc.update_batch(&[col1, col2])?;
+        // Expected (1, a), (1, b), (2, b), (3, b)
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(4)));
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_merge() -> Result<()> {
+        let mut acc1 = MultiColumnDistinctCountAccumulator::new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ]);
+
+        // (1, a), (1, b)
+        let col1 = Arc::new(Int32Array::from(vec![Some(1), Some(1)]));
+        let col2 = Arc::new(StringArray::from(vec![Some("a"), Some("b")])) as ArrayRef;
+
+        acc1.update_batch(&[col1, col2])?;
+
+        let mut acc2 = MultiColumnDistinctCountAccumulator::new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ]);
+
+        // (1, a), (2, b), (3, b)
+        let col1 = Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)]));
+        let col2 = Arc::new(StringArray::from(vec![Some("a"), Some("b"), Some("b")]))
+            as ArrayRef;
+
+        acc2.update_batch(&[col1, col2])?;
+
+        let state_sv1 = acc1.state()?;
+        let state_sv2 = acc2.state()?;
+        let state_arr1: Vec<ArrayRef> = state_sv1
+            .into_iter()
+            .map(|sv| sv.to_array())
+            .collect::<Result<_>>()?;
+        let state_arr2: Vec<ArrayRef> = state_sv2
+            .into_iter()
+            .map(|sv| sv.to_array())
+            .collect::<Result<_>>()?;
+
+        let mut merged = MultiColumnDistinctCountAccumulator::new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ]);
+        merged.merge_batch(&state_arr1)?;
+        merged.merge_batch(&state_arr2)?;
+
+        // Expected (1, a), (1, b), (1, a), (2, b), (3, b)
+        assert_eq!(merged.evaluate()?, ScalarValue::Int64(Some(4)));
+
         Ok(())
     }
 }

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -438,6 +438,16 @@ impl AggregateUDFImpl for Count {
         args: AccumulatorArgs,
     ) -> Result<Box<dyn Accumulator>> {
         if args.is_distinct {
+            if args.exprs.len() > 1 {
+                let data_types: Vec<DataType> = args
+                    .expr_fields
+                    .iter()
+                    .map(|field| field.data_type().clone())
+                    .collect();
+                return Ok(Box::new(MultiColumnDistinctCountAccumulator::try_new(
+                    data_types,
+                )?));
+            }
             let acc =
                 SlidingDistinctCountAccumulator::try_new(args.return_field.data_type())?;
             Ok(Box::new(acc))
@@ -873,7 +883,10 @@ impl Accumulator for DistinctCountAccumulator {
 
 #[derive(Debug)]
 struct MultiColumnDistinctCountAccumulator {
-    values: HashSet<OwnedRow, RandomState>,
+    /// Maps each distinct row to its reference count.
+    /// The count is used by `retract_batch` to support sliding windows;
+    /// for non-sliding aggregation the counts are always 1.
+    values: HashMap<OwnedRow, usize, RandomState>,
     row_converter: RowConverter,
     state_data_types: Vec<DataType>,
 }
@@ -886,7 +899,7 @@ impl MultiColumnDistinctCountAccumulator {
             .collect();
         let row_converter = RowConverter::new(sort_fields)?;
         Ok(Self {
-            values: HashSet::default(),
+            values: HashMap::default(),
             row_converter,
             state_data_types,
         })
@@ -911,7 +924,7 @@ impl Accumulator for MultiColumnDistinctCountAccumulator {
                 .collect());
         }
 
-        let rows_iter = self.values.iter().map(|owned| owned.row());
+        let rows_iter = self.values.keys().map(|owned| owned.row());
         let columns = self.row_converter.convert_rows(rows_iter)?;
 
         Ok(columns
@@ -936,10 +949,34 @@ impl Accumulator for MultiColumnDistinctCountAccumulator {
         let rows = self.row_converter.convert_columns(values)?;
         for i in 0..rows.num_rows() {
             if !values.iter().any(|arr| arr.is_null(i)) {
-                self.values.insert(rows.row(i).owned());
+                *self.values.entry(rows.row(i).owned()).or_default() += 1;
             }
         }
         Ok(())
+    }
+
+    fn retract_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        if values.is_empty() {
+            return Ok(());
+        }
+
+        let rows = self.row_converter.convert_columns(values)?;
+        for i in 0..rows.num_rows() {
+            if !values.iter().any(|arr| arr.is_null(i)) {
+                let row = rows.row(i).owned();
+                if let Some(cnt) = self.values.get_mut(&row) {
+                    *cnt -= 1;
+                    if *cnt == 0 {
+                        self.values.remove(&row);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn supports_retract_batch(&self) -> bool {
+        true
     }
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
@@ -971,7 +1008,7 @@ impl Accumulator for MultiColumnDistinctCountAccumulator {
             // `update_batch` already excludes rows with nulls.
             let rows = self.row_converter.convert_columns(&col_values)?;
             for i in 0..rows.num_rows() {
-                self.values.insert(rows.row(i).owned());
+                *self.values.entry(rows.row(i).owned()).or_default() += 1;
             }
         }
 
@@ -987,10 +1024,10 @@ impl Accumulator for MultiColumnDistinctCountAccumulator {
             + self.row_converter.size()
             + self
                 .values
-                .iter()
-                .map(|r| size_of::<OwnedRow>() + r.as_ref().len())
+                .keys()
+                .map(|r| size_of::<OwnedRow>() + r.as_ref().len() + size_of::<usize>())
                 .sum::<usize>()
-            + size_of::<OwnedRow>()
+            + (size_of::<OwnedRow>() + size_of::<usize>())
                 * self.values.capacity().saturating_sub(self.values.len())
             + size_of::<DataType>() * self.state_data_types.capacity()
     }
@@ -1485,6 +1522,91 @@ mod tests {
         ])?;
         merged.merge_batch(&state_arrs)?;
         assert_eq!(merged.evaluate()?, ScalarValue::Int64(Some(0)));
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_sliding_window() -> Result<()> {
+        let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ])?;
+        assert!(acc.supports_retract_batch());
+
+        // Window frame 1: (1,"a"), (1,"b"), (2,"a")
+        let col1 =
+            Arc::new(Int32Array::from(vec![Some(1), Some(1), Some(2)])) as ArrayRef;
+        let col2 = Arc::new(StringArray::from(vec![Some("a"), Some("b"), Some("a")]))
+            as ArrayRef;
+        acc.update_batch(&[col1, col2])?;
+        // 3 distinct tuples: (1,a), (1,b), (2,a)
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(3)));
+
+        // Slide: retract (1,"a"), add (2,"b")
+        let retract_c1 = Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef;
+        let retract_c2 = Arc::new(StringArray::from(vec![Some("a")])) as ArrayRef;
+        acc.retract_batch(&[retract_c1, retract_c2])?;
+        // (1,a) had count 1, now removed → {(1,b), (2,a)}
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(2)));
+
+        let add_c1 = Arc::new(Int32Array::from(vec![Some(2)])) as ArrayRef;
+        let add_c2 = Arc::new(StringArray::from(vec![Some("b")])) as ArrayRef;
+        acc.update_batch(&[add_c1, add_c2])?;
+        // {(1,b), (2,a), (2,b)}
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(3)));
+
+        // Retract a duplicate: add (2,"b") again, then retract once
+        acc.update_batch(&[
+            Arc::new(Int32Array::from(vec![Some(2)])) as ArrayRef,
+            Arc::new(StringArray::from(vec![Some("b")])) as ArrayRef,
+        ])?;
+        // (2,b) count is now 2
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(3)));
+        acc.retract_batch(&[
+            Arc::new(Int32Array::from(vec![Some(2)])) as ArrayRef,
+            Arc::new(StringArray::from(vec![Some("b")])) as ArrayRef,
+        ])?;
+        // (2,b) count back to 1, still present
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(3)));
+        acc.retract_batch(&[
+            Arc::new(Int32Array::from(vec![Some(2)])) as ArrayRef,
+            Arc::new(StringArray::from(vec![Some("b")])) as ArrayRef,
+        ])?;
+        // (2,b) count 0, removed → {(1,b), (2,a)}
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(2)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_sliding_window_nulls() -> Result<()> {
+        let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ])?;
+
+        // Rows with nulls should be ignored in both update and retract
+        let col1 = Arc::new(Int32Array::from(vec![Some(1), None, Some(2)])) as ArrayRef;
+        let col2 =
+            Arc::new(StringArray::from(vec![Some("a"), Some("b"), None])) as ArrayRef;
+        acc.update_batch(&[col1, col2])?;
+        // Only (1,"a") is non-null in both columns
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(1)));
+
+        // Retract a row with null — should be a no-op
+        acc.retract_batch(&[
+            Arc::new(Int32Array::from(vec![None])) as ArrayRef,
+            Arc::new(StringArray::from(vec![Some("b")])) as ArrayRef,
+        ])?;
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(1)));
+
+        // Retract the only valid row
+        acc.retract_batch(&[
+            Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef,
+            Arc::new(StringArray::from(vec![Some("a")])) as ArrayRef,
+        ])?;
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(0)));
+
         Ok(())
     }
 }

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -1309,8 +1309,6 @@ mod tests {
 
     #[test]
     fn multi_column_accumulator_different_datatypes() -> Result<()> {
-        // Mix of Int32, Float64, Boolean, Utf8, Date32,
-        // Timestamp(Microsecond, None), and Decimal128(10, 2).
         let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
             DataType::Int32,
             DataType::Float64,
@@ -1321,19 +1319,14 @@ mod tests {
             DataType::Decimal128(10, 2),
         ])?;
 
-        // Row layout: (i32, f64, bool, utf8, date32, ts_us, dec128)
-        //
-        // Decimal128(10,2) stores values as i128 with scale 2:
-        //   100 → 1.00, 200 → 2.00
-        //
         // row 0: (1, 1.0, true,  "a", 19000, 1_000_000, 100)
-        // row 1: (1, 1.0, true,  "a", 19000, 1_000_000, 100)  dup of 0
-        // row 2: (1, 1.0, false, "a", 19000, 1_000_000, 100)  bool
-        // row 3: (1, 1.0, true,  "b", 19000, 1_000_000, 100)  utf8
-        // row 4: (1, 1.0, true,  "a", 19001, 1_000_000, 100)  date
-        // row 5: (1, 1.0, true,  "a", 19000, 2_000_000, 100)  ts
-        // row 6: (2, 2.5, true,  "a", 19000, 1_000_000, 100)  i32+f64
-        // row 7: (1, 1.0, true,  "a", 19000, 1_000_000, 200)  dec128
+        // row 1: (1, 1.0, true,  "a", 19000, 1_000_000, 100)  duplicate of 0
+        // row 2: (1, 1.0, false, "a", 19000, 1_000_000, 100)
+        // row 3: (1, 1.0, true,  "b", 19000, 1_000_000, 100)
+        // row 4: (1, 1.0, true,  "a", 19001, 1_000_000, 100)
+        // row 5: (1, 1.0, true,  "a", 19000, 2_000_000, 100)
+        // row 6: (2, 2.5, true,  "a", 19000, 1_000_000, 100)
+        // row 7: (1, 1.0, true,  "a", 19000, 1_000_000, 200)
         let c_i32 = Arc::new(Int32Array::from(vec![1, 1, 1, 1, 1, 1, 2, 1]));
         let c_f64 = Arc::new(Float64Array::from(vec![
             1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.5, 1.0,
@@ -1368,21 +1361,21 @@ mod tests {
             DataType::Int32,
             DataType::Utf8,
         ])?;
-        let ints = Arc::new(Int32Array::from(vec![1, 2, 1, 2, 3]));
-        let strs = Arc::new(StringArray::from(vec!["x", "x", "y", "y", "x"])) as ArrayRef;
-        acc_ab.update_batch(&[ints.clone(), strs.clone()])?;
+        let ints = Arc::new(Int32Array::from(vec![1, 2, 1, 2, 3])) as _;
+        let strs = Arc::new(StringArray::from(vec!["x", "x", "y", "y", "x"])) as _;
+        acc_ab.update_batch(&[Arc::clone(&ints), Arc::clone(&strs)])?;
         // Tuples (int, str):
         //   (1,x), (2,x), (1,y), (2,y), (3,x) → 5 distinct
         assert_eq!(acc_ab.evaluate()?, ScalarValue::Int64(Some(5)));
 
-        // --- Reversed order: (str, int) — same arrays, swapped ---
+        // (str, int)
         let mut acc_ba = MultiColumnDistinctCountAccumulator::try_new(vec![
             DataType::Utf8,
             DataType::Int32,
         ])?;
-        acc_ba.update_batch(&[strs.clone(), ints.clone()])?;
+        acc_ba.update_batch(&[Arc::clone(&strs), Arc::clone(&ints)])?;
         // Tuples (str, int):
-        //   (x,1), (x,2), (y,1), (y,2), (x,3) → still 5 distinct
+        //   (x,1), (x,2), (y,1), (y,2), (x,3) → 5 distinct
         assert_eq!(acc_ba.evaluate()?, ScalarValue::Int64(Some(5)));
 
         Ok(())
@@ -1405,8 +1398,8 @@ mod tests {
             None,
             Some(3),
             Some(2),
-        ]));
-        acc.update_batch(&[col.clone(), col])?;
+        ])) as _;
+        acc.update_batch(&[Arc::clone(&col), col])?;
         // Null rows (NULL,NULL) are skipped.
         // Non-null: (1,1),(2,2),(1,1),(3,3),(2,2)
         //   → distinct {(1,1),(2,2),(3,3)} = 3
@@ -1432,7 +1425,7 @@ mod tests {
             Some(1),
             Some(2),
             Some(1),
-        ]));
+        ])) as _;
         let b = Arc::new(StringArray::from(vec![
             Some("x"),
             Some("y"),
@@ -1441,7 +1434,7 @@ mod tests {
             None,
         ])) as ArrayRef;
 
-        acc.update_batch(&[a.clone(), a, b.clone(), b])?;
+        acc.update_batch(&[Arc::clone(&a), a, Arc::clone(&b), b])?;
         // Skipped: row 1 (a=NULL), row 4 (b=NULL)
         // Non-null: (1,1,x,x), (1,1,y,y), (2,2,x,x) → all distinct = 3
         assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(3)));

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -17,8 +17,11 @@
 
 use ahash::RandomState;
 use arrow::{
-    array::{Array, ArrayRef, AsArray, BooleanArray, Int64Array, PrimitiveArray},
-    buffer::BooleanBuffer,
+    array::{
+        Array, ArrayRef, AsArray, BooleanArray, Int64Array, ListArray, PrimitiveArray,
+        new_empty_array,
+    },
+    buffer::{BooleanBuffer, OffsetBuffer},
     compute,
     datatypes::{
         DataType, Date32Type, Date64Type, Decimal128Type, Decimal256Type, Field,
@@ -28,6 +31,7 @@ use arrow::{
         TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType,
         UInt8Type, UInt16Type, UInt32Type, UInt64Type,
     },
+    row::{OwnedRow, RowConverter, SortField},
 };
 use datafusion_common::{
     DataFusionError, HashMap, Result, ScalarValue, downcast_value, internal_err,
@@ -297,10 +301,12 @@ impl AggregateUDFImpl for Count {
                 Ok(args
                     .input_fields
                     .iter()
-                    .map(|field| {
+                    .enumerate()
+                    .map(|(col_idx, field)| {
                         Arc::new(Field::new(
                             format_state_name(args.name, "count distinct"),
-                            DataType::List(Arc::new(Field::new_list_field(
+                            DataType::List(Arc::new(Field::new(
+                                format!("item_{col_idx}"),
                                 field.data_type().clone(),
                                 true,
                             ))),
@@ -347,9 +353,9 @@ impl AggregateUDFImpl for Count {
                 .iter()
                 .map(|field| field.data_type().clone())
                 .collect();
-            return Ok(Box::new(MultiColumnDistinctCountAccumulator::new(
+            return Ok(Box::new(MultiColumnDistinctCountAccumulator::try_new(
                 data_types,
-            )));
+            )?));
         }
 
         let data_type = acc_args.expr_fields[0].data_type();
@@ -867,84 +873,59 @@ impl Accumulator for DistinctCountAccumulator {
 
 #[derive(Debug)]
 struct MultiColumnDistinctCountAccumulator {
-    values: HashSet<Vec<ScalarValue>, RandomState>,
+    values: HashSet<OwnedRow, RandomState>,
+    row_converter: RowConverter,
     state_data_types: Vec<DataType>,
 }
 
 impl MultiColumnDistinctCountAccumulator {
-    fn new(state_data_types: Vec<DataType>) -> Self {
-        Self {
+    fn try_new(state_data_types: Vec<DataType>) -> Result<Self> {
+        let sort_fields: Vec<SortField> = state_data_types
+            .iter()
+            .map(|dt| SortField::new(dt.clone()))
+            .collect();
+        let row_converter = RowConverter::new(sort_fields)?;
+        Ok(Self {
             values: HashSet::default(),
+            row_converter,
             state_data_types,
-        }
-    }
-
-    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
-        if !values.iter().any(|v| v.is_null()) {
-            self.values.insert(values.to_vec());
-        }
-        Ok(())
-    }
-
-    fn fixed_size(&self) -> usize {
-        std::mem::size_of_val(self)
-            + (std::mem::size_of::<Vec<ScalarValue>>() * self.values.capacity())
-            + self
-                .values
-                .iter()
-                .next()
-                .map(|vals| {
-                    (ScalarValue::size_of_vec(vals) - std::mem::size_of_val(vals))
-                        * self.values.capacity()
-                })
-                .unwrap_or(0)
-            + (std::mem::size_of::<DataType>() * self.state_data_types.capacity())
-    }
-
-    fn full_size(&self) -> usize {
-        std::mem::size_of_val(self)
-            + (std::mem::size_of::<Vec<ScalarValue>>() * self.values.capacity())
-            + self
-                .values
-                .iter()
-                .map(|vals| ScalarValue::size_of_vec(vals) - std::mem::size_of_val(vals))
-                .sum::<usize>()
-            + (std::mem::size_of::<DataType>() * self.state_data_types.capacity())
-            + self
-                .state_data_types
-                .iter()
-                .map(|dt| dt.size() - std::mem::size_of_val(dt))
-                .sum::<usize>()
+        })
     }
 }
 
 impl Accumulator for MultiColumnDistinctCountAccumulator {
     fn state(&mut self) -> Result<Vec<ScalarValue>> {
-        let mut scalar_values: Vec<Vec<ScalarValue>> =
-            vec![Vec::new(); self.state_data_types.len()];
-
-        self.values.iter().for_each(|distinct_values| {
-            distinct_values
+        if self.values.is_empty() {
+            return Ok(self
+                .state_data_types
                 .iter()
                 .enumerate()
-                .for_each(|(col_index, distinct_value)| {
-                    scalar_values[col_index].push(distinct_value.clone());
-                });
-        });
+                .map(|(col_idx, dt)| {
+                    let field =
+                        Arc::new(Field::new(format!("item_{col_idx}"), dt.clone(), true));
+                    let offsets = OffsetBuffer::from_lengths([0]);
+                    let empty = new_empty_array(dt);
+                    let list_arr = ListArray::new(field, offsets, empty, None);
+                    ScalarValue::List(Arc::new(list_arr))
+                })
+                .collect());
+        }
 
-        let accumulator_state: Vec<ScalarValue> = self
-            .state_data_types
-            .iter()
+        let rows_iter = self.values.iter().map(|owned| owned.row());
+        let columns = self.row_converter.convert_rows(rows_iter)?;
+
+        Ok(columns
+            .into_iter()
             .enumerate()
-            .map(|(column_index, state_data_type)| {
-                ScalarValue::List(ScalarValue::new_list_nullable(
-                    &scalar_values[column_index],
-                    state_data_type,
-                ))
+            .zip(self.state_data_types.iter())
+            .map(|((col_idx, col), dt)| {
+                let field =
+                    Arc::new(Field::new(format!("item_{col_idx}"), dt.clone(), true));
+                let offsets = OffsetBuffer::from_lengths([col.len()]);
+                let list_arr = ListArray::new(field, offsets, col, None);
+                ScalarValue::List(Arc::new(list_arr))
             })
-            .collect::<Vec<_>>();
-
-        Ok(accumulator_state)
+            .collect())
     }
 
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
@@ -952,16 +933,13 @@ impl Accumulator for MultiColumnDistinctCountAccumulator {
             return Ok(());
         }
 
-        let arr = &values[0];
-
-        (0..arr.len()).try_for_each(|index| {
-            let vals = values
-                .iter()
-                .map(|array| ScalarValue::try_from_array(array, index))
-                .collect::<Result<Vec<_>>>()?;
-
-            self.update(&vals)
-        })
+        let rows = self.row_converter.convert_columns(values)?;
+        for i in 0..rows.num_rows() {
+            if !values.iter().any(|arr| arr.is_null(i)) {
+                self.values.insert(rows.row(i).owned());
+            }
+        }
+        Ok(())
     }
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
@@ -970,31 +948,34 @@ impl Accumulator for MultiColumnDistinctCountAccumulator {
         }
 
         let arr = &states[0];
-        (0..arr.len()).try_for_each(|index| {
-            let vals = states
+        for index in 0..arr.len() {
+            let col_values: Vec<ArrayRef> = states
                 .iter()
-                .map(|array| ScalarValue::try_from_array(array, index))
-                .collect::<Result<Vec<_>>>()?;
-
-            // The accumulator state does not contain nulls so we use a .values here
-            let col_values = vals
-                .iter()
-                .map(|state| match state {
-                    ScalarValue::List(values) => Ok(values.values()),
-                    _ => Err(DataFusionError::Internal(format!(
-                        "Unexpected accumulator state {state:?}"
-                    ))),
+                .map(|array| {
+                    let list_arr = array.as_list_opt::<i32>().ok_or_else(|| {
+                        DataFusionError::Internal(format!(
+                            "Expected ListArray in merge \
+                                 state, got {:?}",
+                            array.data_type()
+                        ))
+                    })?;
+                    Ok(list_arr.value(index))
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            (0..col_values[0].len()).try_for_each(|row_index| {
-                let row_values = col_values
-                    .iter()
-                    .map(|col| ScalarValue::try_from_array(col, row_index))
-                    .collect::<Result<Vec<_>>>()?;
-                self.update(&row_values)
-            })
-        })
+            if col_values[0].is_empty() {
+                continue;
+            }
+
+            // No null filtering needed: state produced by
+            // `update_batch` already excludes rows with nulls.
+            let rows = self.row_converter.convert_columns(&col_values)?;
+            for i in 0..rows.num_rows() {
+                self.values.insert(rows.row(i).owned());
+            }
+        }
+
+        Ok(())
     }
 
     fn evaluate(&mut self) -> Result<ScalarValue> {
@@ -1002,16 +983,16 @@ impl Accumulator for MultiColumnDistinctCountAccumulator {
     }
 
     fn size(&self) -> usize {
-        let is_fixed_length = self.state_data_types.iter().all(|t| match t {
-            DataType::Boolean | DataType::Null => true,
-            d if d.is_primitive() => true,
-            _ => false,
-        });
-        if is_fixed_length {
-            self.fixed_size()
-        } else {
-            self.full_size()
-        }
+        size_of_val(self)
+            + self.row_converter.size()
+            + self
+                .values
+                .iter()
+                .map(|r| size_of::<OwnedRow>() + r.as_ref().len())
+                .sum::<usize>()
+            + size_of::<OwnedRow>()
+                * self.values.capacity().saturating_sub(self.values.len())
+            + size_of::<DataType>() * self.state_data_types.capacity()
     }
 }
 
@@ -1020,8 +1001,11 @@ mod tests {
 
     use super::*;
     use arrow::{
-        array::{DictionaryArray, Int32Array, NullArray, StringArray},
-        datatypes::{DataType, Field, Int32Type, Schema},
+        array::{
+            BooleanArray, Date32Array, Decimal128Array, DictionaryArray, Float64Array,
+            Int32Array, NullArray, StringArray, TimestampMicrosecondArray,
+        },
+        datatypes::{DataType, Field, Int32Type, Schema, TimeUnit},
     };
     use datafusion_expr::function::AccumulatorArgs;
     use datafusion_physical_expr::{PhysicalExpr, expressions::Column};
@@ -1215,10 +1199,10 @@ mod tests {
 
     #[test]
     fn multi_column_accumulator_basic() -> Result<()> {
-        let mut acc = MultiColumnDistinctCountAccumulator::new(vec![
+        let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
             DataType::Int32,
             DataType::Utf8,
-        ]);
+        ])?;
 
         // (1, a), (1, b), (1, a), (2, b), (3, b)
         let col1 = Arc::new(Int32Array::from(vec![
@@ -1244,10 +1228,10 @@ mod tests {
 
     #[test]
     fn multi_column_accumulator_merge() -> Result<()> {
-        let mut acc1 = MultiColumnDistinctCountAccumulator::new(vec![
+        let mut acc1 = MultiColumnDistinctCountAccumulator::try_new(vec![
             DataType::Int32,
             DataType::Utf8,
-        ]);
+        ])?;
 
         // (1, a), (1, b)
         let col1 = Arc::new(Int32Array::from(vec![Some(1), Some(1)]));
@@ -1255,10 +1239,10 @@ mod tests {
 
         acc1.update_batch(&[col1, col2])?;
 
-        let mut acc2 = MultiColumnDistinctCountAccumulator::new(vec![
+        let mut acc2 = MultiColumnDistinctCountAccumulator::try_new(vec![
             DataType::Int32,
             DataType::Utf8,
-        ]);
+        ])?;
 
         // (1, a), (2, b), (3, b)
         let col1 = Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)]));
@@ -1278,16 +1262,236 @@ mod tests {
             .map(|sv| sv.to_array())
             .collect::<Result<_>>()?;
 
-        let mut merged = MultiColumnDistinctCountAccumulator::new(vec![
+        let mut merged = MultiColumnDistinctCountAccumulator::try_new(vec![
             DataType::Int32,
             DataType::Utf8,
-        ]);
+        ])?;
         merged.merge_batch(&state_arr1)?;
         merged.merge_batch(&state_arr2)?;
 
-        // Expected (1, a), (1, b), (1, a), (2, b), (3, b)
+        // Expected (1, a), (1, b), (2, b), (3, b)
         assert_eq!(merged.evaluate()?, ScalarValue::Int64(Some(4)));
 
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_mixed_nulls() -> Result<()> {
+        let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ])?;
+
+        // Rows with any null column should be excluded entirely.
+        // (1, a), (NULL, b), (2, NULL), (NULL, NULL), (1, a), (3, c)
+        let col1 = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            Some(2),
+            None,
+            Some(1),
+            Some(3),
+        ]));
+        let col2 = Arc::new(StringArray::from(vec![
+            Some("a"),
+            Some("b"),
+            None,
+            None,
+            Some("a"),
+            Some("c"),
+        ])) as ArrayRef;
+
+        acc.update_batch(&[col1, col2])?;
+        // Only non-null rows: (1, a), (3, c)
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(2)));
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_different_datatypes() -> Result<()> {
+        // Mix of Int32, Float64, Boolean, Utf8, Date32,
+        // Timestamp(Microsecond, None), and Decimal128(10, 2).
+        let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Float64,
+            DataType::Boolean,
+            DataType::Utf8,
+            DataType::Date32,
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            DataType::Decimal128(10, 2),
+        ])?;
+
+        // Row layout: (i32, f64, bool, utf8, date32, ts_us, dec128)
+        //
+        // Decimal128(10,2) stores values as i128 with scale 2:
+        //   100 → 1.00, 200 → 2.00
+        //
+        // row 0: (1, 1.0, true,  "a", 19000, 1_000_000, 100)
+        // row 1: (1, 1.0, true,  "a", 19000, 1_000_000, 100)  dup of 0
+        // row 2: (1, 1.0, false, "a", 19000, 1_000_000, 100)  bool
+        // row 3: (1, 1.0, true,  "b", 19000, 1_000_000, 100)  utf8
+        // row 4: (1, 1.0, true,  "a", 19001, 1_000_000, 100)  date
+        // row 5: (1, 1.0, true,  "a", 19000, 2_000_000, 100)  ts
+        // row 6: (2, 2.5, true,  "a", 19000, 1_000_000, 100)  i32+f64
+        // row 7: (1, 1.0, true,  "a", 19000, 1_000_000, 200)  dec128
+        let c_i32 = Arc::new(Int32Array::from(vec![1, 1, 1, 1, 1, 1, 2, 1]));
+        let c_f64 = Arc::new(Float64Array::from(vec![
+            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.5, 1.0,
+        ]));
+        let c_bool = Arc::new(BooleanArray::from(vec![
+            true, true, false, true, true, true, true, true,
+        ])) as ArrayRef;
+        let c_utf8 = Arc::new(StringArray::from(vec![
+            "a", "a", "a", "b", "a", "a", "a", "a",
+        ])) as ArrayRef;
+        let c_date = Arc::new(Date32Array::from(vec![
+            19000, 19000, 19000, 19000, 19001, 19000, 19000, 19000,
+        ]));
+        let c_ts = Arc::new(TimestampMicrosecondArray::from(vec![
+            1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 2_000_000, 1_000_000,
+            1_000_000,
+        ])) as ArrayRef;
+        let c_dec = Arc::new(
+            Decimal128Array::from(vec![100, 100, 100, 100, 100, 100, 100, 200])
+                .with_precision_and_scale(10, 2)?,
+        ) as ArrayRef;
+
+        acc.update_batch(&[c_i32, c_f64, c_bool, c_utf8, c_date, c_ts, c_dec])?;
+        // 7 distinct rows (row 1 is a duplicate of row 0)
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(7)));
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_column_order() -> Result<()> {
+        let mut acc_ab = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ])?;
+        let ints = Arc::new(Int32Array::from(vec![1, 2, 1, 2, 3]));
+        let strs = Arc::new(StringArray::from(vec!["x", "x", "y", "y", "x"])) as ArrayRef;
+        acc_ab.update_batch(&[ints.clone(), strs.clone()])?;
+        // Tuples (int, str):
+        //   (1,x), (2,x), (1,y), (2,y), (3,x) → 5 distinct
+        assert_eq!(acc_ab.evaluate()?, ScalarValue::Int64(Some(5)));
+
+        // --- Reversed order: (str, int) — same arrays, swapped ---
+        let mut acc_ba = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Utf8,
+            DataType::Int32,
+        ])?;
+        acc_ba.update_batch(&[strs.clone(), ints.clone()])?;
+        // Tuples (str, int):
+        //   (x,1), (x,2), (y,1), (y,2), (x,3) → still 5 distinct
+        assert_eq!(acc_ba.evaluate()?, ScalarValue::Int64(Some(5)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_duplicate_columns() -> Result<()> {
+        // COUNT(DISTINCT a, a).
+        let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Int32,
+        ])?;
+
+        // a = [1, NULL, 2, 1, NULL, 3, 2]
+        let col = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            Some(2),
+            Some(1),
+            None,
+            Some(3),
+            Some(2),
+        ]));
+        acc.update_batch(&[col.clone(), col])?;
+        // Null rows (NULL,NULL) are skipped.
+        // Non-null: (1,1),(2,2),(1,1),(3,3),(2,2)
+        //   → distinct {(1,1),(2,2),(3,3)} = 3
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(3)));
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_duplicate_columns_mixed() -> Result<()> {
+        // COUNT(DISTINCT a, a, b, b).
+        let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Int32,
+            DataType::Utf8,
+            DataType::Utf8,
+        ])?;
+
+        // a = [1, NULL, 1, 2, 1], b = ["x", "y", "y", "x", NULL]
+        // Null in either column skips the entire row.
+        let a = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            Some(1),
+            Some(2),
+            Some(1),
+        ]));
+        let b = Arc::new(StringArray::from(vec![
+            Some("x"),
+            Some("y"),
+            Some("y"),
+            Some("x"),
+            None,
+        ])) as ArrayRef;
+
+        acc.update_batch(&[a.clone(), a, b.clone(), b])?;
+        // Skipped: row 1 (a=NULL), row 4 (b=NULL)
+        // Non-null: (1,1,x,x), (1,1,y,y), (2,2,x,x) → all distinct = 3
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(3)));
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_all_nulls() -> Result<()> {
+        let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ])?;
+
+        let col1 = Arc::new(Int32Array::from(vec![None, None, None]));
+        let col2 =
+            Arc::new(StringArray::from(vec![None::<&str>, None, None])) as ArrayRef;
+
+        acc.update_batch(&[col1, col2])?;
+        // Every row has a null → count = 0
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(0)));
+        Ok(())
+    }
+
+    #[test]
+    fn multi_column_accumulator_empty_batch() -> Result<()> {
+        let mut acc = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ])?;
+
+        // Empty arrays
+        let col1 = Arc::new(Int32Array::from(vec![] as Vec<i32>));
+        let col2 = Arc::new(StringArray::from(vec![] as Vec<&str>)) as ArrayRef;
+
+        acc.update_batch(&[col1, col2])?;
+        assert_eq!(acc.evaluate()?, ScalarValue::Int64(Some(0)));
+
+        // state() on empty accumulator should round-trip through merge
+        let state = acc.state()?;
+        let state_arrs: Vec<ArrayRef> = state
+            .into_iter()
+            .map(|sv| sv.to_array())
+            .collect::<Result<_>>()?;
+
+        let mut merged = MultiColumnDistinctCountAccumulator::try_new(vec![
+            DataType::Int32,
+            DataType::Utf8,
+        ])?;
+        merged.merge_batch(&state_arrs)?;
+        assert_eq!(merged.evaluate()?, ScalarValue::Int64(Some(0)));
         Ok(())
     }
 }

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -22,9 +22,7 @@ use std::sync::Arc;
 use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 
-use datafusion_common::{
-    DataFusionError, HashSet, Result, assert_eq_or_internal_err, tree_node::Transformed,
-};
+use datafusion_common::{DataFusionError, HashSet, Result, tree_node::Transformed};
 use datafusion_expr::builder::project;
 use datafusion_expr::expr::AggregateFunctionParams;
 use datafusion_expr::{
@@ -192,11 +190,15 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                                 },
                         }) => {
                             if distinct {
-                                assert_eq_or_internal_err!(
-                                    args.len(),
-                                    1,
-                                    "DISTINCT aggregate should have exactly one argument"
-                                );
+                                // De-duplicate args so that e.g. count(distinct c, c)
+                                // is treated as count(distinct c).
+                                // is_single_distinct_agg already verified that all
+                                // unique distinct args across aggregates refer to the
+                                // same single field.
+                                let mut seen = HashSet::new();
+                                args.retain(|arg| {
+                                    seen.insert(arg.schema_name().to_string())
+                                });
                                 let arg = args.swap_remove(0);
 
                                 if group_fields_set.insert(arg.schema_name().to_string())
@@ -749,6 +751,35 @@ mod tests {
             @r"
         Aggregate: groupBy=[[test.c]], aggr=[[sum(test.a), count(DISTINCT test.a) FILTER (WHERE test.a > Int32(5)) ORDER BY [test.a ASC NULLS LAST]]] [c:UInt32, sum(test.a):UInt64;N, count(DISTINCT test.a) FILTER (WHERE test.a > Int32(5)) ORDER BY [test.a ASC NULLS LAST]:Int64]
           TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        "
+        )
+    }
+
+    #[test]
+    fn single_distinct_with_duplicate_args() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        // count(DISTINCT b, b) — duplicate args de-duplicated to count(DISTINCT b)
+        let expr = Expr::AggregateFunction(AggregateFunction::new_udf(
+            count_udaf(),
+            vec![col("b"), col("b")],
+            true,
+            None,
+            vec![],
+            None,
+        ));
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(vec![col("a")], vec![expr])?
+            .build()?;
+
+        // Should work — duplicate args are de-duplicated
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: test.a, count(alias1) AS count(DISTINCT test.b,test.b) [a:UInt32, count(DISTINCT test.b,test.b):Int64]
+          Aggregate: groupBy=[[test.a]], aggr=[[count(alias1)]] [a:UInt32, count(alias1):Int64]
+            Aggregate: groupBy=[[test.a, test.b AS alias1]], aggr=[[]] [a:UInt32, alias1:UInt32]
+              TableScan: test [a:UInt32, b:UInt32, c:UInt32]
         "
         )
     }

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -2980,6 +2980,7 @@ SELECT count(c1, c2) FROM test
 3
 
 # count(distinct) with multiple arguments
+query I
 SELECT count(distinct c1, c2) FROM test
 ----
 2

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -2980,8 +2980,9 @@ SELECT count(c1, c2) FROM test
 3
 
 # count(distinct) with multiple arguments
-query error DataFusion error: This feature is not implemented: COUNT DISTINCT with multiple arguments
 SELECT count(distinct c1, c2) FROM test
+----
+2
 
 # count_null
 query III

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -2985,6 +2985,53 @@ SELECT count(distinct c1, c2) FROM test
 ----
 2
 
+# test count(distinct) multi column
+statement ok
+CREATE TABLE count_distinct_multi (
+    grp INT,
+    a INT,
+    b VARCHAR,
+    c INT
+) AS VALUES
+    (1, 1, 'x', 10),
+    (1, 1, 'x', 10),
+    (1, 1, 'y', 10),
+    (1, 2, 'x', 20),
+    (1, NULL, 'x', 10),
+    (2, 1, 'x', 10),
+    (2, 1, 'x', 30),
+    (2, NULL, NULL, NULL),
+    (2, 3, 'z', 10);
+
+query I
+SELECT count(distinct a, b, c) FROM count_distinct_multi
+----
+5
+
+query I
+SELECT count(distinct grp, a, b, c) FROM count_distinct_multi
+----
+6
+
+# count(distinct a, a) — duplicate column hits optimizer bug
+statement error
+SELECT count(distinct a, a) FROM count_distinct_multi
+
+query II
+SELECT grp, count(distinct a, b) FROM count_distinct_multi GROUP BY grp ORDER BY grp
+----
+1 3
+2 2
+
+query III
+SELECT grp, count(distinct a, b), count(distinct a, b, c) FROM count_distinct_multi GROUP BY grp ORDER BY grp
+----
+1 3 3
+2 2 3
+
+statement ok
+DROP TABLE count_distinct_multi;
+
 # count_null
 query III
 SELECT count(null), count(null, null), count(distinct null) FROM test

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3035,6 +3035,20 @@ SELECT grp, count(distinct a, b), count(distinct a, b, c) FROM count_distinct_mu
 1 3 3
 2 2 3
 
+# count(distinct) multi-column with sliding window
+query IITI
+SELECT grp, a, b, count(distinct a, b) OVER (PARTITION BY grp ORDER BY a NULLS LAST ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) as cd FROM count_distinct_multi ORDER BY grp, a NULLS LAST, b
+----
+1 1 x 1
+1 1 x 1
+1 1 y 2
+1 2 x 2
+1 NULL x 1
+2 1 x 1
+2 1 x 1
+2 3 z 2
+2 NULL NULL 1
+
 statement ok
 DROP TABLE count_distinct_multi;
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3013,9 +3013,15 @@ SELECT count(distinct grp, a, b, c) FROM count_distinct_multi
 ----
 6
 
-# count(distinct a, a) — duplicate column hits optimizer bug
-statement error
+query I
 SELECT count(distinct a, a) FROM count_distinct_multi
+----
+3
+
+query I
+SELECT count(distinct a, a, b, b) FROM count_distinct_multi
+----
+4
 
 query II
 SELECT grp, count(distinct a, b) FROM count_distinct_multi GROUP BY grp ORDER BY grp


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5619

## What changes are included in this PR?

1. Introduce a separate accumulator for multi column distinct count `MultiColumnDistinctCountAccumulator`
2. I used some parts of #5939 for reference, however it was old so I had to reimplement this

## Are these changes tested?

1. Unit tests have been added
2. I've tested this with a couple of queries in the cli
```
with data AS (
  select * from (values
    ('a', 1, 'x'),
    ('a', 2, 'x'),
    ('b', 2, 'y'),
    ('b', 2, 'z'),
    ('c', 3, 'z')
  ) AS t(col1, col2, col3)
)
select count(distinct (col1, col2)) FROM data;
```
