### PR TITLE
[Minor] Use buffer_unordered

### DIFF
--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -401,11 +401,10 @@ impl FileFormat for ParquetFormat {
         // is not deterministic. Thus, to ensure deterministic schema inference
         // sort the files first.
         // https://github.com/apache/datafusion/pull/6629
-        schemas.sort_unstable_by(|(location1, _), (location2, _)| location1.cmp(location2));
+        schemas
+            .sort_unstable_by(|(location1, _), (location2, _)| location1.cmp(location2));
 
-        let schemas = schemas
-            .into_iter()
-            .map(|(_, schema)| schema);
+        let schemas = schemas.into_iter().map(|(_, schema)| schema);
 
         let schema = if self.skip_metadata() {
             Schema::try_merge(clear_metadata(schemas))


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #.

## Rationale for this change

`buffer_unordered` should be slightly better here - as we sort by the paths anyway (perhaps we can reduce the default concurrency).

Also remove some unnecessary allocations.

## What changes are included in this PR?


## Are these changes tested?

## Are there any user-facing changes?

