### PR TITLE
fix: Fix Spark `slice` function `Null` type to `GenericListArray` casting issue

### DIFF
--- a/datafusion/spark/src/function/array/slice.rs
+++ b/datafusion/spark/src/function/array/slice.rs
@@ -19,7 +19,9 @@ use arrow::array::{Array, ArrayRef, Int64Builder};
 use arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::cast::{as_int64_array, as_list_array};
 use datafusion_common::utils::ListCoercion;
-use datafusion_common::{Result, exec_err, internal_err, utils::take_function_args};
+use datafusion_common::{
+    DataFusionError, Result, exec_err, internal_err, utils::take_function_args,
+};
 use datafusion_expr::{
     ArrayFunctionArgument, ArrayFunctionSignature, ColumnarValue, ReturnFieldArgs,
     ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
@@ -89,6 +91,10 @@ impl ScalarUDFImpl for SparkSlice {
         &self,
         mut func_args: ScalarFunctionArgs,
     ) -> Result<ColumnarValue> {
+        if func_args.args[0].data_type() == DataType::Null {
+            return Ok::<ColumnarValue, DataFusionError>(func_args.args[0].clone());
+        };
+
         let array_len = func_args
             .args
             .iter()
@@ -164,4 +170,41 @@ fn calculate_start_end(args: &[ArrayRef]) -> Result<(ArrayRef, ArrayRef)> {
     }
 
     Ok((Arc::new(adjusted_start.finish()), Arc::new(end.finish())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::NullArray;
+    use arrow::datatypes::DataType::List;
+    use arrow::datatypes::Field;
+    use datafusion_common::ScalarValue;
+
+    #[test]
+    fn test_spark_slice_function_when_input_array_is_null() {
+        let input_args = vec![
+            ColumnarValue::Array(Arc::new(NullArray::new(1))),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(1))),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(3))),
+        ];
+
+        let args = ScalarFunctionArgs {
+            args: input_args.to_owned(),
+            arg_fields: vec![Arc::new(Field::new(
+                "item",
+                List(FieldRef::new(Field::new("", DataType::Int64, true))),
+                false,
+            ))],
+            number_rows: 0,
+            return_field: Arc::new(Field::new(
+                "item",
+                List(FieldRef::new(Field::new_list_field(DataType::Int64, true))),
+                false,
+            )),
+            config_options: Arc::new(Default::default()),
+        };
+        let slice = SparkSlice::new();
+        let result = slice.invoke_with_args(args).unwrap();
+        assert!(result.to_array(1).unwrap() == Arc::new(NullArray::new(1)));
+    }
 }

--- a/datafusion/spark/src/function/array/slice.rs
+++ b/datafusion/spark/src/function/array/slice.rs
@@ -20,7 +20,7 @@ use arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::cast::{as_int64_array, as_list_array};
 use datafusion_common::utils::ListCoercion;
 use datafusion_common::{
-    DataFusionError, Result, exec_err, internal_err, utils::take_function_args,
+    Result, ScalarValue, exec_err, internal_err, utils::take_function_args,
 };
 use datafusion_expr::{
     ArrayFunctionArgument, ArrayFunctionSignature, ColumnarValue, ReturnFieldArgs,
@@ -91,8 +91,10 @@ impl ScalarUDFImpl for SparkSlice {
         &self,
         mut func_args: ScalarFunctionArgs,
     ) -> Result<ColumnarValue> {
-        if func_args.args[0].data_type() == DataType::Null {
-            return Ok(func_args.args[0].clone());
+        if func_args.args[0].data_type() == DataType::Null
+            && let Some(result) = check_null_types(&func_args.args[0])
+        {
+            return Ok(result);
         }
 
         let array_len = func_args
@@ -126,6 +128,16 @@ impl ScalarUDFImpl for SparkSlice {
             return_field: func_args.return_field,
             config_options: func_args.config_options,
         })
+    }
+}
+
+fn check_null_types(cv: &ColumnarValue) -> Option<ColumnarValue> {
+    match cv {
+        ColumnarValue::Scalar(ScalarValue::Null) => {
+            Some(ColumnarValue::create_null_array(1))
+        }
+        ColumnarValue::Array(_) => Some(cv.clone()),
+        _ => None,
     }
 }
 
@@ -205,6 +217,6 @@ mod tests {
         };
         let slice = SparkSlice::new();
         let result = slice.invoke_with_args(args).unwrap();
-        assert_eq!(result.to_array(1).unwrap(), Arc::new(NullArray::new(1)));
+        assert_eq!(*result.to_array(1).unwrap(), *Arc::new(NullArray::new(1)));
     }
 }

--- a/datafusion/spark/src/function/array/slice.rs
+++ b/datafusion/spark/src/function/array/slice.rs
@@ -15,11 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{Array, ArrayData, ArrayRef, Int64Builder, ListArray};
+use arrow::array::{Array, ArrayRef, Int64Builder};
 use arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::cast::{as_int64_array, as_list_array};
 use datafusion_common::utils::ListCoercion;
-use datafusion_common::{Result, exec_err, internal_err, utils::take_function_args};
+use datafusion_common::{
+    Result, ScalarValue, exec_err, internal_err, utils::take_function_args,
+};
 use datafusion_expr::{
     ArrayFunctionArgument, ArrayFunctionSignature, ColumnarValue, ReturnFieldArgs,
     ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
@@ -93,11 +95,11 @@ impl ScalarUDFImpl for SparkSlice {
         mut func_args: ScalarFunctionArgs,
     ) -> Result<ColumnarValue> {
         if func_args.args[0].data_type() == DataType::Null {
-            let len = match &func_args.args[0] {
-                ColumnarValue::Array(a) => a.len(),
-                ColumnarValue::Scalar(_) => func_args.number_rows,
-            };
-            return Ok(ColumnarValue::Array(list_null_array(len)));
+            return Ok(ColumnarValue::Scalar(ScalarValue::new_null_list(
+                DataType::Null,
+                true,
+                1,
+            )));
         }
 
         let array_len = func_args
@@ -132,11 +134,6 @@ impl ScalarUDFImpl for SparkSlice {
             config_options: func_args.config_options,
         })
     }
-}
-
-fn list_null_array(len: usize) -> ArrayRef {
-    let list_type = DataType::List(Arc::new(Field::new_list_field(DataType::Null, true)));
-    Arc::new(ListArray::from(ArrayData::new_null(&list_type, len)))
 }
 
 fn calculate_start_end(args: &[ArrayRef]) -> Result<(ArrayRef, ArrayRef)> {

--- a/datafusion/spark/src/function/array/slice.rs
+++ b/datafusion/spark/src/function/array/slice.rs
@@ -15,13 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{Array, ArrayRef, Int64Builder};
+use arrow::array::{Array, ArrayData, ArrayRef, Int64Builder, ListArray};
 use arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::cast::{as_int64_array, as_list_array};
 use datafusion_common::utils::ListCoercion;
-use datafusion_common::{
-    Result, ScalarValue, exec_err, internal_err, utils::take_function_args,
-};
+use datafusion_common::{Result, exec_err, internal_err, utils::take_function_args};
 use datafusion_expr::{
     ArrayFunctionArgument, ArrayFunctionSignature, ColumnarValue, ReturnFieldArgs,
     ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
@@ -80,21 +78,26 @@ impl ScalarUDFImpl for SparkSlice {
     fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
         let nullable = args.arg_fields.iter().any(|f| f.is_nullable());
 
-        Ok(Arc::new(Field::new(
-            "slice",
-            args.arg_fields[0].data_type().clone(),
-            nullable,
-        )))
+        let data_type = match args.arg_fields[0].data_type() {
+            DataType::Null => {
+                DataType::List(Arc::new(Field::new_list_field(DataType::Null, true)))
+            }
+            dt => dt.clone(),
+        };
+
+        Ok(Arc::new(Field::new("slice", data_type, nullable)))
     }
 
     fn invoke_with_args(
         &self,
         mut func_args: ScalarFunctionArgs,
     ) -> Result<ColumnarValue> {
-        if func_args.args[0].data_type() == DataType::Null
-            && let Some(result) = check_null_types(&func_args.args[0])
-        {
-            return Ok(result);
+        if func_args.args[0].data_type() == DataType::Null {
+            let len = match &func_args.args[0] {
+                ColumnarValue::Array(a) => a.len(),
+                ColumnarValue::Scalar(_) => func_args.number_rows,
+            };
+            return Ok(ColumnarValue::Array(list_null_array(len)));
         }
 
         let array_len = func_args
@@ -131,14 +134,9 @@ impl ScalarUDFImpl for SparkSlice {
     }
 }
 
-fn check_null_types(cv: &ColumnarValue) -> Option<ColumnarValue> {
-    match cv {
-        ColumnarValue::Scalar(ScalarValue::Null) => {
-            Some(ColumnarValue::create_null_array(1))
-        }
-        ColumnarValue::Array(_) => Some(cv.clone()),
-        _ => None,
-    }
+fn list_null_array(len: usize) -> ArrayRef {
+    let list_type = DataType::List(Arc::new(Field::new_list_field(DataType::Null, true)));
+    Arc::new(ListArray::from(ArrayData::new_null(&list_type, len)))
 }
 
 fn calculate_start_end(args: &[ArrayRef]) -> Result<(ArrayRef, ArrayRef)> {
@@ -188,9 +186,30 @@ fn calculate_start_end(args: &[ArrayRef]) -> Result<(ArrayRef, ArrayRef)> {
 mod tests {
     use super::*;
     use arrow::array::NullArray;
-    use arrow::datatypes::DataType::List;
     use arrow::datatypes::Field;
     use datafusion_common::ScalarValue;
+    use datafusion_common::cast::as_list_array;
+    use datafusion_expr::ReturnFieldArgs;
+
+    #[test]
+    fn test_spark_slice_function_when_input_is_null() {
+        let slice = SparkSlice::new();
+        let arg_fields: Vec<Arc<Field>> = vec![
+            Arc::new(Field::new("a", DataType::Null, true)),
+            Arc::new(Field::new("s", DataType::Int64, true)),
+            Arc::new(Field::new("l", DataType::Int64, true)),
+        ];
+        let out = slice
+            .return_field_from_args(ReturnFieldArgs {
+                arg_fields: &arg_fields,
+                scalar_arguments: &[],
+            })
+            .unwrap();
+        assert_eq!(
+            out.data_type(),
+            &DataType::List(Arc::new(Field::new_list_field(DataType::Null, true)))
+        );
+    }
 
     #[test]
     fn test_spark_slice_function_when_input_array_is_null() {
@@ -202,21 +221,23 @@ mod tests {
 
         let args = ScalarFunctionArgs {
             args: input_args,
-            arg_fields: vec![Arc::new(Field::new(
-                "item",
-                List(FieldRef::new(Field::new("f", DataType::Int64, true))),
-                false,
-            ))],
+            arg_fields: vec![Arc::new(Field::new("item", DataType::Null, true))],
             number_rows: 1,
             return_field: Arc::new(Field::new(
-                "item",
-                List(FieldRef::new(Field::new_list_field(DataType::Int64, true))),
-                false,
+                "slice",
+                DataType::List(Arc::new(Field::new_list_field(DataType::Null, true))),
+                true,
             )),
             config_options: Arc::new(Default::default()),
         };
         let slice = SparkSlice::new();
         let result = slice.invoke_with_args(args).unwrap();
-        assert_eq!(*result.to_array(1).unwrap(), *Arc::new(NullArray::new(1)));
+        let arr = result.to_array(1).unwrap();
+        let list = as_list_array(&arr).unwrap();
+        assert_eq!(
+            arr.data_type(),
+            &DataType::List(Arc::new(Field::new_list_field(DataType::Null, true)))
+        );
+        assert!(list.is_null(0));
     }
 }

--- a/datafusion/spark/src/function/array/slice.rs
+++ b/datafusion/spark/src/function/array/slice.rs
@@ -92,8 +92,8 @@ impl ScalarUDFImpl for SparkSlice {
         mut func_args: ScalarFunctionArgs,
     ) -> Result<ColumnarValue> {
         if func_args.args[0].data_type() == DataType::Null {
-            return Ok::<ColumnarValue, DataFusionError>(func_args.args[0].clone());
-        };
+            return Ok(func_args.args[0].clone());
+        }
 
         let array_len = func_args
             .args
@@ -189,13 +189,13 @@ mod tests {
         ];
 
         let args = ScalarFunctionArgs {
-            args: input_args.to_owned(),
+            args: input_args,
             arg_fields: vec![Arc::new(Field::new(
                 "item",
-                List(FieldRef::new(Field::new("", DataType::Int64, true))),
+                List(FieldRef::new(Field::new("f", DataType::Int64, true))),
                 false,
             ))],
-            number_rows: 0,
+            number_rows: 1,
             return_field: Arc::new(Field::new(
                 "item",
                 List(FieldRef::new(Field::new_list_field(DataType::Int64, true))),
@@ -205,6 +205,6 @@ mod tests {
         };
         let slice = SparkSlice::new();
         let result = slice.invoke_with_args(args).unwrap();
-        assert!(result.to_array(1).unwrap() == Arc::new(NullArray::new(1)));
+        assert_eq!(result.to_array(1).unwrap(), Arc::new(NullArray::new(1)));
     }
 }

--- a/datafusion/sqllogictest/test_files/spark/array/slice.slt
+++ b/datafusion/sqllogictest/test_files/spark/array/slice.slt
@@ -114,3 +114,21 @@ query ?
 SELECT slice([1, 2, 3, 4], CAST('2' AS INT), 4);
 ----
 [2, 3, 4]
+
+query ?
+SELECT slice(column1, column2, column3)
+FROM VALUES
+(NULL, 1, 2),
+(NULL, 1, -2),
+(NULL, -1, 2),
+(NULL, 0, 2);
+----
+NULL
+NULL
+NULL
+NULL
+
+query ?
+SELECT slice(slice(NULL, 1, 2), 1, 2)
+----
+NULL

--- a/datafusion/sqllogictest/test_files/spark/array/slice.slt
+++ b/datafusion/sqllogictest/test_files/spark/array/slice.slt
@@ -132,3 +132,8 @@ query ?
 SELECT slice(slice(NULL, 1, 2), 1, 2)
 ----
 NULL
+
+query ?
+SELECT slice(slice(make_array(NULL), 1, 2), 1, 2)
+----
+[NULL]


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #20466.

## Rationale for this change
Currently, Spark `slice` function accepts Null Arrays and return `Null` for this particular queries. DataFusion-Spark `slice` function also needs to return `NULL` when Null Array is set.
**Spark Behavior** (tested with latest Spark master):
```
> SELECT slice(NULL, 1, 2);
+-----------------+
|slice(NULL, 1, 2)|
+-----------------+
|             null|
+-----------------+
```

**DF Behaviour:**
Current:
```
query error
SELECT slice(NULL, 1, 2);
----
DataFusion error: Internal error: could not cast array of type Null to arrow_array::array::list_array::GenericListArray<i32>.
This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
```
New:
```
query ?
SELECT slice(NULL, 1, 2);
----
NULL
```

## What changes are included in this PR?
Explained under first section.

## Are these changes tested?
Added new UT cases for both `slice.rs` and `slice.slt`.

## Are there any user-facing changes?
Yes, currently, `slice` function returns error message for `Null` Array inputs, however, expected behavior is to be returned `NULL` so end-user will get expected result instead of error message.
