### PR TITLE
chore: Avoid build fails on MinIO rate limits

### DIFF
--- a/datafusion-cli/tests/cli_integration.rs
+++ b/datafusion-cli/tests/cli_integration.rs
@@ -99,13 +99,13 @@ async fn setup_minio_container() -> Result<ContainerAsync<minio::MinIO>, String>
                     let stdout = container.stdout_to_vec().await.unwrap_or_default();
                     let stderr = container.stderr_to_vec().await.unwrap_or_default();
 
-                    panic!(
+                    return Err(format!(
                         "Failed to execute command: {}\nError: {}\nStdout: {:?}\nStderr: {:?}",
                         cmd_ref,
                         e,
                         String::from_utf8_lossy(&stdout),
                         String::from_utf8_lossy(&stderr)
-                    );
+                    ));
                 }
             }
 
@@ -255,7 +255,7 @@ async fn test_cli() {
             eprintln!("Skipping test: Docker pull rate limit reached: {e}");
             return;
         }
-        Err(e) => panic!("{e}"),
+        e @ Err(_) => e.unwrap(),
     };
 
     let settings = make_settings();
@@ -295,7 +295,7 @@ async fn test_aws_options() {
             eprintln!("Skipping test: Docker pull rate limit reached: {e}");
             return;
         }
-        Err(e) => panic!("{e}"),
+        e @ Err(_) => e.unwrap(),
     };
     let port = container.get_host_port_ipv4(9000).await.unwrap();
 
@@ -393,7 +393,7 @@ async fn test_s3_url_fallback() {
             eprintln!("Skipping test: Docker pull rate limit reached: {e}");
             return;
         }
-        Err(e) => panic!("{e}"),
+        e @ Err(_) => e.unwrap(),
     };
 
     let mut settings = make_settings();
@@ -430,7 +430,7 @@ async fn test_object_store_profiling() {
             eprintln!("Skipping test: Docker pull rate limit reached: {e}");
             return;
         }
-        Err(e) => panic!("{e}"),
+        e @ Err(_) => e.unwrap(),
     };
     let mut settings = make_settings();
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change
Sometimes CI failed because of docker rates limits.
```
thread 'test_s3_url_fallback' (11052) panicked at datafusion-cli/tests/cli_integration.rs:116:13:
Failed to start MinIO container. Ensure Docker is running and accessible: failed to pull the image 'minio/minio:RELEASE.2025-02-28T09-55-16Z', error: Docker responded with status code 500: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
stack backtrace:
```
Example https://github.com/apache/datafusion/actions/runs/22262073722/job/64401977127
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Ignore the tests if rates limit hit only

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
