### PR TITLE
Make `custom_file_casts` example schema nullable to allow null `id` values during casting

### DIFF
--- a/datafusion-examples/examples/custom_data_source/custom_file_casts.rs
+++ b/datafusion-examples/examples/custom_data_source/custom_file_casts.rs
@@ -49,9 +49,9 @@ use object_store::{ObjectStore, PutPayload};
 pub async fn custom_file_casts() -> Result<()> {
     println!("=== Creating example data ===");
 
-    // Create a logical / table schema with an Int32 column
+    // Create a logical / table schema with an Int32 column (nullable)
     let logical_schema =
-        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, true)]));
 
     // Create some data that can be cast (Int16 -> Int32 is widening) and some that cannot (Int64 -> Int32 is narrowing)
     let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;


### PR DESCRIPTION
## Which issue does this PR close?

* [Comment](https://github.com/apache/datafusion/pull/20202#discussion_r2804841561) on #20202

---

## Rationale for this change

The `custom_file_casts` example defines a *logical/table* schema that uses `id: Int32` as the target type. In practice, casting and projection paths in DataFusion can produce **nulls** (e.g. failed casts, missing values, or intermediate expressions), and examples should avoid implying that nulls are impossible when demonstrating casting behavior.

Marking the `id` field as **nullable** makes the example more realistic and prevents confusion when users follow or adapt the example to scenarios where nulls may appear.

---

## What changes are included in this PR?

* Update the logical/table schema in `custom_file_casts.rs` to define `id` as **nullable** (`Field::new("id", DataType::Int32, true)`).
* Adjust the inline comment to reflect the nullable schema.

---

## Are these changes tested?

No new tests were added.

This is a documentation/example-only change that updates a schema definition and comment. The example continues to compile and can be exercised by running the `custom_file_casts` example as before.

---

## Are there any user-facing changes?

Yes (example behavior/expectations):

* The `custom_file_casts` example now documents `id` as nullable, aligning the example schema with situations where cast/projection may yield null values.
* No public APIs are changed and no breaking behavior is introduced.
