### PR TITLE
Introduce OwnedCastOptions and OwnedFormatOptions; strengthen CastColumnExpr validation and schema-aware construction

### DIFF
--- a/datafusion/common/src/format.rs
+++ b/datafusion/common/src/format.rs
@@ -35,6 +35,167 @@ pub const DEFAULT_CAST_OPTIONS: CastOptions<'static> = CastOptions {
     format_options: DEFAULT_FORMAT_OPTIONS,
 };
 
+/// Owned version of Arrow's `FormatOptions` with all `String` values instead of `&str`.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct OwnedFormatOptions {
+    /// String representation of null values
+    pub null: String,
+    /// Date format string
+    pub date_format: Option<String>,
+    /// Datetime format string
+    pub datetime_format: Option<String>,
+    /// Timestamp format string
+    pub timestamp_format: Option<String>,
+    /// Timestamp with timezone format string
+    pub timestamp_tz_format: Option<String>,
+    /// Time format string
+    pub time_format: Option<String>,
+    /// Duration format
+    pub duration_format: DurationFormat,
+    /// Include type information in formatted output
+    pub types_info: bool,
+}
+
+impl OwnedFormatOptions {
+    /// Create a new `OwnedFormatOptions` with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the null string.
+    pub fn with_null(mut self, null: String) -> Self {
+        self.null = null;
+        self
+    }
+
+    /// Set the date format.
+    pub fn with_date_format(mut self, date_format: Option<String>) -> Self {
+        self.date_format = date_format;
+        self
+    }
+
+    /// Set the datetime format.
+    pub fn with_datetime_format(mut self, datetime_format: Option<String>) -> Self {
+        self.datetime_format = datetime_format;
+        self
+    }
+
+    /// Set the timestamp format.
+    pub fn with_timestamp_format(mut self, timestamp_format: Option<String>) -> Self {
+        self.timestamp_format = timestamp_format;
+        self
+    }
+
+    /// Set the timestamp with timezone format.
+    pub fn with_timestamp_tz_format(
+        mut self,
+        timestamp_tz_format: Option<String>,
+    ) -> Self {
+        self.timestamp_tz_format = timestamp_tz_format;
+        self
+    }
+
+    /// Set the time format.
+    pub fn with_time_format(mut self, time_format: Option<String>) -> Self {
+        self.time_format = time_format;
+        self
+    }
+
+    /// Set the duration format.
+    pub fn with_duration_format(mut self, duration_format: DurationFormat) -> Self {
+        self.duration_format = duration_format;
+        self
+    }
+
+    /// Set whether to include type information in formatted output.
+    pub fn with_types_info(mut self, types_info: bool) -> Self {
+        self.types_info = types_info;
+        self
+    }
+
+    /// Convert to Arrow's `FormatOptions<'a>` with borrowed references.
+    pub fn as_arrow_options<'a>(&'a self) -> FormatOptions<'a> {
+        FormatOptions::new()
+            .with_null(self.null.as_str())
+            .with_date_format(self.date_format.as_deref())
+            .with_datetime_format(self.datetime_format.as_deref())
+            .with_timestamp_format(self.timestamp_format.as_deref())
+            .with_timestamp_tz_format(self.timestamp_tz_format.as_deref())
+            .with_time_format(self.time_format.as_deref())
+            .with_duration_format(self.duration_format)
+            .with_display_error(false)
+            .with_types_info(self.types_info)
+    }
+}
+
+impl Default for OwnedFormatOptions {
+    fn default() -> Self {
+        Self {
+            null: "NULL".to_string(),
+            date_format: None,
+            datetime_format: None,
+            timestamp_format: None,
+            timestamp_tz_format: None,
+            time_format: None,
+            duration_format: DurationFormat::Pretty,
+            types_info: false,
+        }
+    }
+}
+
+/// Owned version of Arrow's `CastOptions` with `OwnedFormatOptions`.
+#[derive(Debug, Clone, Default, Eq, PartialEq, Hash)]
+pub struct OwnedCastOptions {
+    /// Whether to use safe casting (return errors instead of overflowing)
+    pub safe: bool,
+    /// Format options for string output
+    pub format_options: OwnedFormatOptions,
+}
+
+impl OwnedCastOptions {
+    /// Create a new `OwnedCastOptions` with default values.
+    pub fn new(safe: bool) -> Self {
+        Self {
+            safe,
+            format_options: OwnedFormatOptions::default(),
+        }
+    }
+
+    /// Create a new `OwnedCastOptions` from Arrow `CastOptions`.
+    pub fn from_arrow_options(options: &CastOptions<'_>) -> Self {
+        Self {
+            safe: options.safe,
+            format_options: OwnedFormatOptions {
+                null: options.format_options.null().to_string(),
+                date_format: options.format_options.date_format().map(|s| s.to_string()),
+                datetime_format: options
+                    .format_options
+                    .datetime_format()
+                    .map(|s| s.to_string()),
+                timestamp_format: options
+                    .format_options
+                    .timestamp_format()
+                    .map(|s| s.to_string()),
+                timestamp_tz_format: options
+                    .format_options
+                    .timestamp_tz_format()
+                    .map(|s| s.to_string()),
+                time_format: options.format_options.time_format().map(|s| s.to_string()),
+                duration_format: options.format_options.duration_format(),
+                types_info: options.format_options.types_info(),
+            },
+        }
+    }
+
+    /// Convert to Arrow's `CastOptions<'a>` with borrowed references.
+    pub fn as_arrow_options<'a>(&'a self) -> CastOptions<'a> {
+        CastOptions {
+            safe: self.safe,
+            format_options: self.format_options.as_arrow_options(),
+        }
+    }
+}
+
 /// Output formats for controlling for Explain plans
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ExplainFormat {

--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -79,6 +79,7 @@ pub use file_options::file_type::{
     DEFAULT_ARROW_EXTENSION, DEFAULT_AVRO_EXTENSION, DEFAULT_CSV_EXTENSION,
     DEFAULT_JSON_EXTENSION, DEFAULT_PARQUET_EXTENSION, GetExt,
 };
+pub use format::{OwnedCastOptions, OwnedFormatOptions};
 pub use functional_dependencies::{
     Constraint, Constraints, Dependency, FunctionalDependence, FunctionalDependencies,
     aggregate_functional_dependencies, get_required_group_by_exprs_indices,
@@ -86,7 +87,7 @@ pub use functional_dependencies::{
 };
 use hashbrown::DefaultHashBuilder;
 pub use join_type::{JoinConstraint, JoinSide, JoinType};
-pub use nested_struct::cast_column;
+pub use nested_struct::{cast_column, validate_field_compatibility};
 pub use null_equality::NullEquality;
 pub use param_value::ParamValues;
 pub use scalar::{ScalarType, ScalarValue};

--- a/datafusion/common/src/nested_struct.rs
+++ b/datafusion/common/src/nested_struct.rs
@@ -254,7 +254,9 @@ pub fn validate_struct_compatibility(
     Ok(())
 }
 
-fn validate_field_compatibility(
+/// Validates that a source field can be cast to a target field, including
+/// nullability checks and nested struct compatibility.
+pub fn validate_field_compatibility(
     source_field: &Field,
     target_field: &Field,
 ) -> Result<()> {

--- a/datafusion/core/src/datasource/physical_plan/parquet.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet.rs
@@ -880,7 +880,7 @@ mod tests {
 
         // Table schema is Utf8 but file schema is StringView
         let table_schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, true)]));
 
         // Predicate should prune all row groups
         let filter = col("c1").eq(lit(ScalarValue::Utf8(Some("aaa".to_string()))));
@@ -922,7 +922,7 @@ mod tests {
         let batch = create_batch(vec![("c1", c1.clone())]);
 
         let table_schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt64, false)]));
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt64, true)]));
 
         // Predicate should prune all row groups
         let filter = col("c1").eq(lit(ScalarValue::UInt64(Some(5))));
@@ -969,7 +969,7 @@ mod tests {
         let table_schema = Arc::new(Schema::new(vec![Field::new(
             "c1",
             DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
-            false,
+            true,
         )]));
         // One row should match, 2 pruned via page index, 1 pruned via filter pushdown
         let filter = col("c1").eq(lit(ScalarValue::TimestampMillisecond(

--- a/datafusion/core/tests/parquet/expr_adapter.rs
+++ b/datafusion/core/tests/parquet/expr_adapter.rs
@@ -136,7 +136,7 @@ async fn test_custom_schema_adapter_and_custom_expression_adapter() {
     write_parquet(batch, store.clone(), path).await;
 
     let table_schema = Arc::new(Schema::new(vec![
-        Field::new("c1", DataType::Int64, false),
+        Field::new("c1", DataType::Int64, true),
         Field::new("c2", DataType::Utf8, true),
     ]));
 
@@ -234,9 +234,9 @@ async fn test_physical_expr_adapter_with_non_null_defaults() {
 
     // Table schema has additional columns c2 (Utf8) and c3 (Int64) that don't exist in file
     let table_schema = Arc::new(Schema::new(vec![
-        Field::new("c1", DataType::Int64, false), // type differs from file (Int32 vs Int64)
-        Field::new("c2", DataType::Utf8, true),   // missing from file
-        Field::new("c3", DataType::Int64, true),  // missing from file
+        Field::new("c1", DataType::Int64, true), // type differs from file (Int32 vs Int64)
+        Field::new("c2", DataType::Utf8, true),  // missing from file
+        Field::new("c3", DataType::Int64, true), // missing from file
     ]));
 
     let mut cfg = SessionConfig::new()
@@ -343,7 +343,7 @@ async fn test_physical_expr_adapter_factory_reuse_across_tables() {
 
     // Table schema has additional columns that don't exist in files
     let table_schema = Arc::new(Schema::new(vec![
-        Field::new("c1", DataType::Int64, false),
+        Field::new("c1", DataType::Int64, true),
         Field::new("c2", DataType::Utf8, true), // missing from files
     ]));
 

--- a/datafusion/physical-expr-adapter/src/schema_rewriter.rs
+++ b/datafusion/physical-expr-adapter/src/schema_rewriter.rs
@@ -498,12 +498,13 @@ impl DefaultPhysicalExprAdapterRewriter {
             }
         }
 
-        let cast_expr = Arc::new(CastColumnExpr::new(
+        let cast_expr = Arc::new(CastColumnExpr::new_with_schema(
             Arc::new(column),
             Arc::new(actual_physical_field.clone()),
             Arc::new(logical_field.clone()),
             None,
-        ));
+            Arc::clone(&self.physical_file_schema),
+        )?);
 
         Ok(Transformed::yes(cast_expr))
     }
@@ -720,12 +721,15 @@ mod tests {
         println!("Rewritten expression: {result}");
 
         let expected = expressions::BinaryExpr::new(
-            Arc::new(CastColumnExpr::new(
-                Arc::new(Column::new("a", 0)),
-                Arc::new(Field::new("a", DataType::Int32, false)),
-                Arc::new(Field::new("a", DataType::Int64, false)),
-                None,
-            )),
+            Arc::new(
+                CastColumnExpr::new(
+                    Arc::new(Column::new("a", 0)),
+                    Arc::new(Field::new("a", DataType::Int32, false)),
+                    Arc::new(Field::new("a", DataType::Int64, false)),
+                    None,
+                )
+                .unwrap(),
+            ),
             Operator::Plus,
             Arc::new(expressions::Literal::new(ScalarValue::Int64(Some(5)))),
         );
@@ -830,12 +834,15 @@ mod tests {
             false,
         ));
 
-        let expected = Arc::new(CastColumnExpr::new(
-            Arc::new(Column::new("data", 0)),
-            physical_field,
-            logical_field,
-            None,
-        )) as Arc<dyn PhysicalExpr>;
+        let expected = Arc::new(
+            CastColumnExpr::new(
+                Arc::new(Column::new("data", 0)),
+                physical_field,
+                logical_field,
+                None,
+            )
+            .unwrap(),
+        ) as Arc<dyn PhysicalExpr>;
 
         assert_eq!(result.to_string(), expected.to_string());
     }

--- a/datafusion/physical-expr/src/expressions/cast_column.rs
+++ b/datafusion/physical-expr/src/expressions/cast_column.rs
@@ -17,14 +17,19 @@
 
 //! Physical expression for struct-aware casting of columns.
 
-use crate::physical_expr::PhysicalExpr;
+use crate::{expressions::Column, physical_expr::PhysicalExpr};
 use arrow::{
-    compute::CastOptions,
+    compute::can_cast_types,
     datatypes::{DataType, FieldRef, Schema},
     record_batch::RecordBatch,
 };
 use datafusion_common::{
-    Result, ScalarValue, format::DEFAULT_CAST_OPTIONS, nested_struct::cast_column,
+    Result, ScalarValue,
+    format::OwnedCastOptions,
+    nested_struct::{
+        cast_column, validate_field_compatibility, validate_struct_compatibility,
+    },
+    plan_err,
 };
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use std::{
@@ -54,18 +59,19 @@ pub struct CastColumnExpr {
     input_field: FieldRef,
     /// The field metadata describing the desired output column.
     target_field: FieldRef,
-    /// Options forwarded to [`cast_column`].
-    cast_options: CastOptions<'static>,
+    /// Options forwarded to [`cast_column`] (owned, allowing dynamic format strings).
+    cast_options: OwnedCastOptions,
+    /// Schema used to resolve expression data types during construction.
+    input_schema: Arc<Schema>,
 }
 
-// Manually derive `PartialEq`/`Hash` as `Arc<dyn PhysicalExpr>` does not
-// implement these traits by default for the trait object.
 impl PartialEq for CastColumnExpr {
     fn eq(&self, other: &Self) -> bool {
         self.expr.eq(&other.expr)
             && self.input_field.eq(&other.input_field)
             && self.target_field.eq(&other.target_field)
             && self.cast_options.eq(&other.cast_options)
+            && self.input_schema.eq(&other.input_schema)
     }
 }
 
@@ -75,23 +81,146 @@ impl Hash for CastColumnExpr {
         self.input_field.hash(state);
         self.target_field.hash(state);
         self.cast_options.hash(state);
+        self.input_schema.hash(state);
     }
 }
 
+fn normalize_cast_options(cast_options: Option<OwnedCastOptions>) -> OwnedCastOptions {
+    cast_options.unwrap_or_default()
+}
+
+fn validate_column_expr(
+    column: &Column,
+    input_field: &FieldRef,
+    input_schema: &Schema,
+) -> Result<()> {
+    let fields = input_schema.fields();
+    if column.index() >= fields.len() {
+        return plan_err!(
+            "CastColumnExpr column index {} is out of bounds for input schema with {} fields",
+            column.index(),
+            fields.len()
+        );
+    }
+
+    let schema_field = &fields[column.index()];
+    if schema_field.data_type() != input_field.data_type()
+        && !can_cast_types(schema_field.data_type(), input_field.data_type())
+    {
+        return plan_err!(
+            "CastColumnExpr column '{}' at index {} has data type '{}' which cannot be cast to input field type '{}'",
+            column.name(),
+            column.index(),
+            schema_field.data_type(),
+            input_field.data_type()
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_expression_field(
+    expr: &Arc<dyn PhysicalExpr>,
+    input_field: &FieldRef,
+    input_schema: &Schema,
+) -> Result<()> {
+    let expr_field = expr.return_field(input_schema)?;
+
+    if expr_field.data_type() != input_field.data_type() {
+        return plan_err!(
+            "CastColumnExpr expression field type '{}' does not match input field type '{}'",
+            expr_field.data_type(),
+            input_field.data_type()
+        );
+    }
+
+    if expr_field.is_nullable() && !input_field.is_nullable() {
+        return plan_err!(
+            "CastColumnExpr cannot cast nullable expression to non-nullable input field '{}'",
+            input_field.name()
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_input_to_target_cast(
+    input_field: &FieldRef,
+    target_field: &FieldRef,
+) -> Result<()> {
+    match (input_field.data_type(), target_field.data_type()) {
+        (DataType::Struct(source_fields), DataType::Struct(target_fields)) => {
+            validate_struct_compatibility(source_fields, target_fields)
+        }
+        (_, DataType::Struct(_)) => {
+            plan_err!(
+                "CastColumnExpr cannot cast non-struct type '{}' to struct type '{}'",
+                input_field.data_type(),
+                target_field.data_type()
+            )
+        }
+        _ => validate_field_compatibility(input_field, target_field),
+    }
+}
+
+fn validate_cast_compatibility(
+    expr: &Arc<dyn PhysicalExpr>,
+    input_field: &FieldRef,
+    target_field: &FieldRef,
+    input_schema: &Schema,
+) -> Result<()> {
+    if let Some(column) = expr.as_any().downcast_ref::<Column>() {
+        validate_column_expr(column, input_field, input_schema)?;
+    } else {
+        validate_expression_field(expr, input_field, input_schema)?;
+    }
+
+    validate_input_to_target_cast(input_field, target_field)
+}
+
 impl CastColumnExpr {
+    fn build(
+        expr: Arc<dyn PhysicalExpr>,
+        input_field: FieldRef,
+        target_field: FieldRef,
+        cast_options: Option<OwnedCastOptions>,
+        input_schema: Arc<Schema>,
+    ) -> Result<Self> {
+        let cast_options = normalize_cast_options(cast_options);
+
+        validate_cast_compatibility(&expr, &input_field, &target_field, &input_schema)?;
+
+        Ok(Self {
+            expr,
+            input_field,
+            target_field,
+            cast_options,
+            input_schema,
+        })
+    }
+
     /// Create a new [`CastColumnExpr`].
     pub fn new(
         expr: Arc<dyn PhysicalExpr>,
         input_field: FieldRef,
         target_field: FieldRef,
-        cast_options: Option<CastOptions<'static>>,
-    ) -> Self {
-        Self {
-            expr,
-            input_field,
-            target_field,
-            cast_options: cast_options.unwrap_or(DEFAULT_CAST_OPTIONS),
-        }
+        cast_options: Option<OwnedCastOptions>,
+    ) -> Result<Self> {
+        let input_schema = Arc::new(Schema::new(vec![Arc::unwrap_or_clone(Arc::clone(
+            &input_field,
+        ))]));
+        Self::build(expr, input_field, target_field, cast_options, input_schema)
+    }
+
+    /// Create a new [`CastColumnExpr`] with an explicit input schema.
+    pub fn new_with_schema(
+        expr: Arc<dyn PhysicalExpr>,
+        input_field: FieldRef,
+        target_field: FieldRef,
+        cast_options: Option<OwnedCastOptions>,
+        input_schema: Arc<Schema>,
+    ) -> Result<Self> {
+        Self::build(expr, input_field, target_field, cast_options, input_schema)
     }
 
     /// The expression that produces the value to be cast.
@@ -107,6 +236,11 @@ impl CastColumnExpr {
     /// Field metadata describing the output column after casting.
     pub fn target_field(&self) -> &FieldRef {
         &self.target_field
+    }
+
+    /// Casting options forwarded to [`cast_column`].
+    pub fn cast_options(&self) -> &OwnedCastOptions {
+        &self.cast_options
     }
 }
 
@@ -136,19 +270,17 @@ impl PhysicalExpr for CastColumnExpr {
 
     fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
         let value = self.expr.evaluate(batch)?;
+        let arrow_options = self.cast_options.as_arrow_options();
         match value {
             ColumnarValue::Array(array) => {
                 let casted =
-                    cast_column(&array, self.target_field.as_ref(), &self.cast_options)?;
+                    cast_column(&array, self.target_field.as_ref(), &arrow_options)?;
                 Ok(ColumnarValue::Array(casted))
             }
             ColumnarValue::Scalar(scalar) => {
                 let as_array = scalar.to_array_of_size(1)?;
-                let casted = cast_column(
-                    &as_array,
-                    self.target_field.as_ref(),
-                    &self.cast_options,
-                )?;
+                let casted =
+                    cast_column(&as_array, self.target_field.as_ref(), &arrow_options)?;
                 let result = ScalarValue::try_from_array(casted.as_ref(), 0)?;
                 Ok(ColumnarValue::Scalar(result))
             }
@@ -169,12 +301,13 @@ impl PhysicalExpr for CastColumnExpr {
     ) -> Result<Arc<dyn PhysicalExpr>> {
         assert_eq!(children.len(), 1);
         let child = children.pop().expect("CastColumnExpr child");
-        Ok(Arc::new(Self::new(
+        Ok(Arc::new(Self::new_with_schema(
             child,
             Arc::clone(&self.input_field),
             Arc::clone(&self.target_field),
             Some(self.cast_options.clone()),
-        )))
+            Arc::clone(&self.input_schema),
+        )?))
     }
 
     fn fmt_sql(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -192,7 +325,7 @@ mod tests {
         datatypes::{DataType, Field, Fields, SchemaRef},
     };
     use datafusion_common::{
-        Result as DFResult, ScalarValue,
+        Result as DFResult, ScalarValue, assert_contains,
         cast::{as_int64_array, as_string_array, as_struct_array, as_uint8_array},
     };
 
@@ -214,12 +347,13 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::clone(&schema), vec![values])?;
 
         let column = Arc::new(Column::new_with_schema("a", schema.as_ref())?);
-        let expr = CastColumnExpr::new(
+        let expr = CastColumnExpr::new_with_schema(
             column,
             Arc::new(input_field.clone()),
             Arc::new(target_field.clone()),
             None,
-        );
+            Arc::clone(&schema),
+        )?;
 
         let result = expr.evaluate(&batch)?;
         let ColumnarValue::Array(array) = result else {
@@ -268,12 +402,13 @@ mod tests {
         )?;
 
         let column = Arc::new(Column::new_with_schema("s", schema.as_ref())?);
-        let expr = CastColumnExpr::new(
+        let expr = CastColumnExpr::new_with_schema(
             column,
             Arc::new(input_field.clone()),
             Arc::new(target_field.clone()),
             None,
-        );
+            Arc::clone(&schema),
+        )?;
 
         let result = expr.evaluate(&batch)?;
         let ColumnarValue::Array(array) = result else {
@@ -338,12 +473,13 @@ mod tests {
         )?;
 
         let column = Arc::new(Column::new_with_schema("root", schema.as_ref())?);
-        let expr = CastColumnExpr::new(
+        let expr = CastColumnExpr::new_with_schema(
             column,
             Arc::new(outer_field.clone()),
             Arc::new(target_field.clone()),
             None,
-        );
+            Arc::clone(&schema),
+        )?;
 
         let result = expr.evaluate(&batch)?;
         let ColumnarValue::Array(array) = result else {
@@ -389,12 +525,13 @@ mod tests {
         );
         let literal =
             Arc::new(Literal::new(ScalarValue::Struct(Arc::new(scalar_struct))));
-        let expr = CastColumnExpr::new(
+        let expr = CastColumnExpr::new_with_schema(
             literal,
             Arc::new(input_field.clone()),
             Arc::new(target_field.clone()),
             None,
-        );
+            Arc::clone(&schema),
+        )?;
 
         let batch = RecordBatch::new_empty(Arc::clone(&schema));
         let result = expr.evaluate(&batch)?;
@@ -405,5 +542,38 @@ mod tests {
         let casted = as_uint8_array(casted.as_ref())?;
         assert_eq!(casted.value(0), 9);
         Ok(())
+    }
+
+    #[test]
+    fn reject_nullable_to_non_nullable_field_cast() {
+        let err = CastColumnExpr::new(
+            Arc::new(Literal::new(ScalarValue::Int32(None))),
+            Arc::new(Field::new("a", DataType::Int32, true)),
+            Arc::new(Field::new("a", DataType::Int64, false)),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert_contains!(
+            err,
+            "Cannot cast nullable struct field 'a' to non-nullable field"
+        );
+    }
+
+    #[test]
+    fn reject_column_index_out_of_bounds() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let err = CastColumnExpr::new_with_schema(
+            Arc::new(Column::new("missing", 1)),
+            Arc::new(Field::new("a", DataType::Int32, true)),
+            Arc::new(Field::new("a", DataType::Int64, true)),
+            None,
+            schema,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert_contains!(err, "column index 1 is out of bounds");
     }
 }


### PR DESCRIPTION


## Which issue does this PR close?

* [Comment](https://github.com/apache/datafusion/pull/20202#discussion_r2804851175) on #20202

---

## Rationale for this change

This PR improves the flexibility and safety of casting behavior in DataFusion by:

1. Introducing owned variants of `FormatOptions` and `CastOptions` to allow dynamic and runtime-configurable format strings without lifetime constraints.
2. Strengthening validation logic in `CastColumnExpr` to catch schema mismatches, invalid casts, and nullability violations earlier in the planning phase.
3. Making struct and nested field compatibility checks reusable across modules.

These changes help prevent subtle runtime errors, improve error messages, and make casting behavior more robust and predictable, especially in schema adaptation scenarios (e.g., Parquet file schema vs. table schema mismatches).

---

## What changes are included in this PR?

### 1. Owned Format and Cast Options

* Added `OwnedFormatOptions` as an owned version of Arrow's `FormatOptions` (using `String` instead of `&str`).
* Added `OwnedCastOptions` as an owned version of Arrow's `CastOptions`, embedding `OwnedFormatOptions`.
* Implemented conversions:

  * `OwnedCastOptions::from_arrow_options`
  * `OwnedCastOptions::as_arrow_options`
  * `OwnedFormatOptions::as_arrow_options`
* Re-exported `OwnedCastOptions` and `OwnedFormatOptions` from `datafusion_common`.

This enables dynamic formatting configuration without requiring `'static` lifetimes.

---

### 2. CastColumnExpr Refactor and Validation

* Replaced `CastOptions<'static>` with `OwnedCastOptions` in `CastColumnExpr`.
* Added `input_schema` to `CastColumnExpr` to enable schema-aware validation.
* Introduced:

  * `new_with_schema` constructor (returns `Result<Self>`)
  * Internal `build` constructor with centralized validation
* Added validation helpers:

  * Column index bounds checking
  * Expression return type validation
  * Nullability checks (reject nullable → non-nullable casts)
  * Struct compatibility validation via `validate_struct_compatibility`
  * Field compatibility validation via newly public `validate_field_compatibility`
* Improved error reporting using `plan_err!`.

These changes ensure invalid casts are rejected during expression construction rather than failing later during evaluation.

---

### 3. Nested Struct Validation Improvements

* Made `validate_field_compatibility` public.
* Reused struct validation logic inside `CastColumnExpr`.

---

### 4. Physical Expr Adapter Updates

* Updated schema rewriter to use `CastColumnExpr::new_with_schema`.
* Adjusted tests to handle fallible constructors.

---

### 5. Test Updates and Additions

* Updated existing tests to use the new fallible constructors.
* Added tests for:

  * Rejecting nullable → non-nullable casts
  * Rejecting column index out-of-bounds
* Updated several Parquet-related tests to align nullability expectations.

---

## Are these changes tested?

Yes.

* Existing tests were updated to use the new fallible constructors.
* New unit tests were added to verify:

  * Column index bounds validation
  * Nullable-to-non-nullable cast rejection
  * Struct and nested casting behavior
* Parquet schema adapter tests were updated to reflect nullability handling changes.

These tests help ensure casting correctness, schema safety, and error reporting behavior.

---

## Are there any user-facing changes?

Yes, but limited:

* Invalid casts (e.g., nullable → non-nullable, incompatible struct casts, or out-of-bounds column references) now fail earlier during expression construction with clearer error messages.
* New public APIs:

  * `OwnedCastOptions`
  * `OwnedFormatOptions`
  * `validate_field_compatibility`

There are no breaking changes to existing public APIs, but behavior is stricter and more defensive. If considered API-impacting, the `api change` label may be appropriate due to new exported types and validation semantics.
