### PR TITLE
feat: support extension planner for `TableScan`

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -161,6 +161,12 @@ pub trait ExtensionPlanner {
     /// Create a physical plan for a [`LogicalPlan::TableScan`].
     ///
     /// This is useful for planning valid [`TableSource`]s that are not [`TableProvider`]s.
+    ///
+    /// Returns:
+    /// * `Ok(Some(plan))` if the planner knows how to plan the `scan`
+    /// * `Ok(None)` if the planner does not know how to plan the `scan` and wants to delegate the planning to another [`ExtensionPlanner`]
+    /// * `Err` if the planner knows how to plan the `scan` but errors while doing so
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -214,10 +220,6 @@ pub trait ExtensionPlanner {
     ///     }
     /// }
     /// ```
-    /// Returns:
-    /// * `Ok(Some(plan))` if the planner knows how to plan the `scan`
-    /// * `Ok(None)` if the planner does not know how to plan the `scan` and wants to delegate the planning to another [`ExtensionPlanner`]
-    /// * `Err` if the planner knows how to plan the `scan` but errors while doing so
     ///
     /// [`TableSource`]: datafusion_expr::TableSource
     /// [`TableProvider`]: datafusion_catalog::TableProvider


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20547.

## Rationale for this change

Please refer to the issue for context. This PR serves as a proof-of-concept and we can consider merging it if we reach consensus on the design discussed in the issue.

## What changes are included in this PR?

The trait method `ExtensionPlanner::plan_table_scan()` is added so that the user can define physical planning logic for custom table sources.

## Are these changes tested?

The changes are accompanied with unit tests.

## Are there any user-facing changes?

Yes, a new trait method is added to `ExtensionPlanner`. This is not a breaking change since the trait method has a default implementation.
