### PR TITLE
feat : support spark compatible int to timestamp cast

### DIFF
--- a/datafusion/spark/src/function/conversion/cast.rs
+++ b/datafusion/spark/src/function/conversion/cast.rs
@@ -20,13 +20,12 @@ use arrow::datatypes::{
     ArrowPrimitiveType, DataType, Field, FieldRef, Int8Type, Int16Type, Int32Type,
     Int64Type, TimeUnit,
 };
-use datafusion::logical_expr::{Coercion, TypeSignatureClass};
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::types::logical_string;
-use datafusion_common::{
-    Result as DataFusionResult, ScalarValue, exec_err, internal_err,
+use datafusion_common::types::{
+    logical_int8, logical_int16, logical_int32, logical_int64, logical_string,
 };
-use datafusion_expr::TypeSignatureClass::Integer;
+use datafusion_common::{Result, ScalarValue, exec_err, internal_err};
+use datafusion_expr::{Coercion, TypeSignatureClass};
 use datafusion_expr::{
     ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl,
     Signature, TypeSignature, Volatility,
@@ -81,21 +80,28 @@ impl SparkCast {
     }
 
     pub fn new_with_config(config: &ConfigOptions) -> Self {
-        // First arg: value to cast (only ints for now with potential to add further support later)
+        // First arg: value to cast (only signed ints - Spark doesn't have unsigned integers)
         // Second arg: target datatype as Utf8 string literal (ex : 'timestamp')
-        let int_arg = Coercion::new_exact(Integer);
         let string_arg =
             Coercion::new_exact(TypeSignatureClass::Native(logical_string()));
+
+        // Spark only supports signed integers, so we explicitly list them
+        let signed_int_signatures = [
+            logical_int8(),
+            logical_int16(),
+            logical_int32(),
+            logical_int64(),
+        ]
+        .map(|int_type| {
+            TypeSignature::Coercible(vec![
+                Coercion::new_exact(TypeSignatureClass::Native(int_type)),
+                string_arg.clone(),
+            ])
+        });
+
         Self {
-            signature: Signature::one_of(
-                vec![
-                    TypeSignature::Coercible(vec![int_arg.clone(), string_arg.clone()]),
-                    TypeSignature::Coercible(vec![
-                        int_arg,
-                        string_arg.clone(),
-                        string_arg,
-                    ]),
-                ],
+            signature: Signature::new(
+                TypeSignature::OneOf(Vec::from(signed_int_signatures)),
                 Volatility::Stable,
             ),
             timezone: config
@@ -109,10 +115,7 @@ impl SparkCast {
 }
 
 /// Parse target type string into a DataType
-fn parse_target_type(
-    type_str: &str,
-    timezone: Option<Arc<str>>,
-) -> DataFusionResult<DataType> {
+fn parse_target_type(type_str: &str, timezone: Option<Arc<str>>) -> Result<DataType> {
     match type_str.to_lowercase().as_str() {
         // further data type support in future
         "timestamp" => Ok(DataType::Timestamp(TimeUnit::Microsecond, timezone)),
@@ -127,7 +130,7 @@ fn parse_target_type(
 fn get_target_type_from_scalar_args(
     scalar_args: &[Option<&ScalarValue>],
     timezone: Option<Arc<str>>,
-) -> DataFusionResult<DataType> {
+) -> Result<DataType> {
     let type_arg = scalar_args.get(1).and_then(|opt| *opt);
 
     match type_arg {
@@ -143,7 +146,7 @@ fn get_target_type_from_scalar_args(
 fn cast_int_to_timestamp<T: ArrowPrimitiveType>(
     array: &ArrayRef,
     timezone: Option<Arc<str>>,
-) -> DataFusionResult<ArrayRef>
+) -> Result<ArrayRef>
 where
     T::Native: Into<i64>,
 {
@@ -176,7 +179,7 @@ impl ScalarUDFImpl for SparkCast {
         &self.signature
     }
 
-    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
         internal_err!("return_field_from_args should be used instead")
     }
 
@@ -184,10 +187,7 @@ impl ScalarUDFImpl for SparkCast {
         Some(ScalarUDF::from(Self::new_with_config(config)))
     }
 
-    fn return_field_from_args(
-        &self,
-        args: ReturnFieldArgs,
-    ) -> DataFusionResult<FieldRef> {
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
         let nullable = args.arg_fields.iter().any(|f| f.is_nullable());
         let return_type = get_target_type_from_scalar_args(
             args.scalar_arguments,
@@ -196,10 +196,7 @@ impl ScalarUDFImpl for SparkCast {
         Ok(Arc::new(Field::new(self.name(), return_type, nullable)))
     }
 
-    fn invoke_with_args(
-        &self,
-        args: ScalarFunctionArgs,
-    ) -> DataFusionResult<ColumnarValue> {
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let target_type = args.return_field.data_type();
         match target_type {
             DataType::Timestamp(TimeUnit::Microsecond, tz) => {
@@ -214,7 +211,7 @@ impl ScalarUDFImpl for SparkCast {
 fn cast_to_timestamp(
     input: &ColumnarValue,
     timezone: Option<Arc<str>>,
-) -> DataFusionResult<ColumnarValue> {
+) -> Result<ColumnarValue> {
     match input {
         ColumnarValue::Array(array) => match array.data_type() {
             DataType::Null => Ok(ColumnarValue::Array(Arc::new(

--- a/datafusion/spark/src/function/conversion/mod.rs
+++ b/datafusion/spark/src/function/conversion/mod.rs
@@ -18,10 +18,10 @@
 mod cast;
 
 use datafusion_expr::ScalarUDF;
-use datafusion_functions::make_udf_function;
+use datafusion_functions::make_udf_function_with_config;
 use std::sync::Arc;
 
-make_udf_function!(cast::SparkCast, spark_cast);
+make_udf_function_with_config!(cast::SparkCast, spark_cast);
 
 pub mod expr_fn {
     use datafusion_functions::export_functions;
@@ -29,10 +29,12 @@ pub mod expr_fn {
     export_functions!((
         spark_cast,
         "Casts given value to the specified type following Spark-compatible semantics",
-        arg1 arg2
+        @config arg1 arg2
     ));
 }
 
 pub fn functions() -> Vec<Arc<ScalarUDF>> {
-    vec![spark_cast()]
+    use datafusion_common::config::ConfigOptions;
+    let config = ConfigOptions::default();
+    vec![spark_cast(&config)]
 }

--- a/datafusion/sqllogictest/test_files/spark/conversion/cast_int_to_timestamp.slt
+++ b/datafusion/sqllogictest/test_files/spark/conversion/cast_int_to_timestamp.slt
@@ -192,3 +192,61 @@ SELECT spark_cast(1710057600::bigint, 'timestamp');
 # Reset to default UTC
 statement ok
 SET datafusion.execution.time_zone = 'UTC';
+
+#############################
+# Array Tests
+#############################
+
+# Create test table with 4 int columns: null, min, max, regular value
+statement ok
+CREATE TABLE int_test AS SELECT
+    arrow_cast(column1, 'Int8') as i8_col,
+    arrow_cast(column2, 'Int16') as i16_col,
+    arrow_cast(column3, 'Int32') as i32_col,
+    column4::bigint as i64_col
+FROM (VALUES
+    (NULL, NULL, NULL, NULL),
+    (-128, -32768, -2147483648, -86400),
+    (127, 32767, 2147483647, 86400),
+    (100, 3600, 1710054000, 1710054000)
+);
+
+# Test in UTC
+query PPPP
+SELECT spark_cast(i8_col, 'timestamp'), spark_cast(i16_col, 'timestamp'), spark_cast(i32_col, 'timestamp'), spark_cast(i64_col, 'timestamp') FROM int_test;
+----
+NULL NULL NULL NULL
+1969-12-31T23:57:52Z 1969-12-31T14:53:52Z 1901-12-13T20:45:52Z 1969-12-31T00:00:00Z
+1970-01-01T00:02:07Z 1970-01-01T09:06:07Z 2038-01-19T03:14:07Z 1970-01-02T00:00:00Z
+1970-01-01T00:01:40Z 1970-01-01T01:00:00Z 2024-03-10T07:00:00Z 2024-03-10T07:00:00Z
+
+# Test in America/Los_Angeles (PST - has DST)
+statement ok
+SET datafusion.execution.time_zone = 'America/Los_Angeles';
+
+query PPPP
+SELECT spark_cast(i8_col, 'timestamp'), spark_cast(i16_col, 'timestamp'), spark_cast(i32_col, 'timestamp'), spark_cast(i64_col, 'timestamp') FROM int_test;
+----
+NULL NULL NULL NULL
+1969-12-31T15:57:52-08:00 1969-12-31T06:53:52-08:00 1901-12-13T12:45:52-08:00 1969-12-30T16:00:00-08:00
+1969-12-31T16:02:07-08:00 1970-01-01T01:06:07-08:00 2038-01-18T19:14:07-08:00 1970-01-01T16:00:00-08:00
+1969-12-31T16:01:40-08:00 1969-12-31T17:00:00-08:00 2024-03-09T23:00:00-08:00 2024-03-09T23:00:00-08:00
+
+# Test in America/Phoenix (MST - no DST, always UTC-7)
+statement ok
+SET datafusion.execution.time_zone = 'America/Phoenix';
+
+query PPPP
+SELECT spark_cast(i8_col, 'timestamp'), spark_cast(i16_col, 'timestamp'), spark_cast(i32_col, 'timestamp'), spark_cast(i64_col, 'timestamp') FROM int_test;
+----
+NULL NULL NULL NULL
+1969-12-31T16:57:52-07:00 1969-12-31T07:53:52-07:00 1901-12-13T13:45:52-07:00 1969-12-30T17:00:00-07:00
+1969-12-31T17:02:07-07:00 1970-01-01T02:06:07-07:00 2038-01-18T20:14:07-07:00 1970-01-01T17:00:00-07:00
+1969-12-31T17:01:40-07:00 1969-12-31T18:00:00-07:00 2024-03-10T00:00:00-07:00 2024-03-10T00:00:00-07:00
+
+# Reset and cleanup
+statement ok
+SET datafusion.execution.time_zone = 'UTC';
+
+statement ok
+DROP TABLE int_test;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #20554 

Ref : https://github.com/apache/datafusion/pull/20555

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

1. Created a new cast  scalar UDF to support int to timestamp casts (spark compatible). The goal is to leverage this is as an entry point for all spark compatible / df incompatible casts
 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

1. Yes (through series of unit tests testing various edge cases like overflow , null input etc)

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

1. Yes. We are bringing in ability to leverage spark compatible cast operations in DF through `spark_cast` as a first step. Next step would be to make changes to the planner to leverage spark compatible cast instead of regular cast operations

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
