### PR TITLE
Add deterministic per-file timing summary to sqllogictest runner

### DIFF
--- a/datafusion/sqllogictest/README.md
+++ b/datafusion/sqllogictest/README.md
@@ -75,22 +75,24 @@ RUST_LOG=debug cargo test --test sqllogictests -- ddl
 The sqllogictest runner can emit deterministic per-file elapsed timings to help
 identify slow test files.
 
-Timing summary output is disabled by default and enabled with
-`--timing-summary` (or `SLT_TIMING_SUMMARY=1`).
+By default (`--timing-summary auto`), timing summary output is disabled in local
+TTY runs and shows a top-slowest summary in non-TTY/CI runs.
+
+`--timing-top-n` / `SLT_TIMING_TOP_N` must be a positive integer (`>= 1`).
 
 ```shell
-# Show deterministic per-file elapsed timings (sorted slowest first)
-cargo test --test sqllogictests -- --timing-summary
+# Show top 10 slowest files (good for CI)
+cargo test --test sqllogictests -- --timing-summary top --timing-top-n 10
 ```
 
 ```shell
-# Keep only the top 10 lines using standard shell tooling
-cargo test --test sqllogictests -- --timing-summary | head -n 10
+# Show full per-file timing table
+cargo test --test sqllogictests -- --timing-summary full
 ```
 
 ```shell
-# Enable via environment variable
-SLT_TIMING_SUMMARY=1 cargo test --test sqllogictests
+# Same controls via environment variables
+SLT_TIMING_SUMMARY=top SLT_TIMING_TOP_N=15 cargo test --test sqllogictests
 ```
 
 ```shell

--- a/datafusion/sqllogictest/bin/sqllogictests.rs
+++ b/datafusion/sqllogictest/bin/sqllogictests.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use clap::{ColorChoice, Parser};
+use clap::{ColorChoice, Parser, ValueEnum};
 use datafusion::common::instant::Instant;
 use datafusion::common::utils::get_available_parallelism;
 use datafusion::common::{DataFusionError, Result, exec_datafusion_err, exec_err};
@@ -60,6 +60,14 @@ const PG_COMPAT_FILE_PREFIX: &str = "pg_compat_";
 const SQLITE_PREFIX: &str = "sqlite";
 const ERRS_PER_FILE_LIMIT: usize = 10;
 const TIMING_DEBUG_SLOW_FILES_ENV: &str = "SLT_TIMING_DEBUG_SLOW_FILES";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum TimingSummaryMode {
+    Auto,
+    Off,
+    Top,
+    Full,
+}
 
 #[derive(Debug)]
 struct FileTiming {
@@ -313,7 +321,7 @@ async fn run_tests() -> Result<()> {
             .then_with(|| a.relative_path.cmp(&b.relative_path))
     });
 
-    print_timing_summary(&options, &m, &file_timings)?;
+    print_timing_summary(&options, &m, is_ci, &file_timings)?;
 
     let errors: Vec<_> = file_results
         .into_iter()
@@ -376,19 +384,39 @@ async fn run_tests() -> Result<()> {
 fn print_timing_summary(
     options: &Options,
     progress: &MultiProgress,
+    is_ci: bool,
     file_timings: &[FileTiming],
 ) -> Result<()> {
-    if !options.timing_summary || file_timings.is_empty() {
+    let mode = options.timing_summary_mode(is_ci);
+    if mode == TimingSummaryMode::Off || file_timings.is_empty() {
         return Ok(());
     }
 
+    let top_n = options.timing_top_n;
+    debug_assert!(matches!(
+        mode,
+        TimingSummaryMode::Top | TimingSummaryMode::Full
+    ));
+    let count = if mode == TimingSummaryMode::Full {
+        file_timings.len()
+    } else {
+        top_n
+    };
+
     progress.println("Per-file elapsed summary (deterministic):")?;
-    for (idx, timing) in file_timings.iter().enumerate() {
+    for (idx, timing) in file_timings.iter().take(count).enumerate() {
         progress.println(format!(
             "{:>3}. {:>8.3}s  {}",
             idx + 1,
             timing.elapsed.as_secs_f64(),
             timing.relative_path.display()
+        ))?;
+    }
+
+    if mode != TimingSummaryMode::Full && file_timings.len() > count {
+        progress.println(format!(
+            "... {} more files omitted (use --timing-summary full to show all)",
+            file_timings.len() - count
         ))?;
     }
 
@@ -404,6 +432,16 @@ fn is_env_truthy(name: &str) -> bool {
                 "1" | "true" | "yes" | "on"
             )
         })
+}
+
+fn parse_timing_top_n(arg: &str) -> std::result::Result<usize, String> {
+    let parsed = arg
+        .parse::<usize>()
+        .map_err(|error| format!("invalid value '{arg}': {error}"))?;
+    if parsed == 0 {
+        return Err("must be >= 1".to_string());
+    }
+    Ok(parsed)
 }
 
 async fn run_test_file_substrait_round_trip(
@@ -902,10 +940,20 @@ struct Options {
     #[clap(
         long,
         env = "SLT_TIMING_SUMMARY",
-        default_value_t = false,
-        help = "Print deterministic per-file timing summary"
+        value_enum,
+        default_value_t = TimingSummaryMode::Auto,
+        help = "Per-file timing summary mode: auto|off|top|full"
     )]
-    timing_summary: bool,
+    timing_summary: TimingSummaryMode,
+
+    #[clap(
+        long,
+        env = "SLT_TIMING_TOP_N",
+        default_value_t = 10,
+        value_parser = parse_timing_top_n,
+        help = "Number of files to show when timing summary mode is auto/top (must be >= 1)"
+    )]
+    timing_top_n: usize,
 
     #[clap(
         long,
@@ -917,6 +965,19 @@ struct Options {
 }
 
 impl Options {
+    fn timing_summary_mode(&self, is_ci: bool) -> TimingSummaryMode {
+        match self.timing_summary {
+            TimingSummaryMode::Auto => {
+                if is_ci {
+                    TimingSummaryMode::Top
+                } else {
+                    TimingSummaryMode::Off
+                }
+            }
+            mode => mode,
+        }
+    }
+
     /// Because this test can be run as a cargo test, commands like
     ///
     /// ```shell


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #20524.

## Rationale for this change

The sqllogictest runner executes files in parallel, but it was hard to pinpoint which test files dominate wall-clock time. This change adds **deterministic per-file elapsed timing observability** so we can identify long-tail files and prioritize follow-up optimization work, while keeping default output usable for both local development (TTY) and CI (non-TTY).

## What changes are included in this PR?

* Collect per-file elapsed durations in the sqllogictest runner and aggregate them at end-of-run.
* Print a **deterministic timing summary** (stable sort: elapsed desc, path asc; stable formatting) via `MultiProgress` to avoid interleaved progress-bar noise.
* Add CLI flags and environment variables to control output:

  * `--timing-summary auto|off|top|full` (also `SLT_TIMING_SUMMARY`)
  * `--timing-top-n <N>` (also `SLT_TIMING_TOP_N`, must be `>= 1`)
* Default behavior:

  * `auto` maps to `off` for local TTY runs and `top` for CI/non-TTY runs.
* Add optional debug logging for slow files (over 30s) behind `SLT_TIMING_DEBUG_SLOW_FILES=1`.
* Update `datafusion/sqllogictest/README.md` with usage examples.

## Are these changes tested?

* Covered by existing `sqllogictests` integration test execution; no new unit tests were added.
* Manual validation plan (ran locally / in CI as applicable):

  * `cargo test --test sqllogictests -- push_down_filter_ --test-threads 16`
  * `cargo test --test sqllogictests -- --test-threads 16`
  * `cargo test --test sqllogictests -- --timing-summary top --timing-top-n 10`
  * `cargo test --test sqllogictests -- --timing-summary full`
* Verified output properties:

  * Summary ordering is deterministic across repeated runs (elapsed desc, path asc).
  * `auto` mode is quiet on TTY but prints a top-N summary on non-TTY/CI.
  * Pass/fail behavior and error reporting are unchanged.

## Are there any user-facing changes?

Yes (test-runner UX only):

* New optional timing summary output for `sqllogictests`.
* New CLI flags / env vars documented in `datafusion/sqllogictest/README.md`:

  * `--timing-summary auto|off|top|full` / `SLT_TIMING_SUMMARY`
  * `--timing-top-n <N>` / `SLT_TIMING_TOP_N`
  * `SLT_TIMING_DEBUG_SLOW_FILES=1` (optional debug logging for slow files >30s)

No public DataFusion APIs are changed.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
