### PR TITLE
add redirect for old upgrading.html URL to fix broken changelog links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -134,4 +134,5 @@ suppress_warnings = ["misc.highlighting_failure"]
 redirects = {
     "library-user-guide/adding-udfs": "functions/index.html",
     "user-guide/runtime_configs": "configs.html",
+    "library-user-guide/upgrading": "/library-user-guide/upgrading/index.html",
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20572

## Rationale for this change

When upgrade guides were split into separate pages (#20183), the old `upgrading.html` URL broke. All changelog files still reference this old URL, causing 404 errors for users.

## What changes are included in this PR?

Added a redirect in `docs/source/conf.py` using the existing `sphinx_reredirects` extension to redirect `library-user-guide/upgrading.html` to `library-user-guide/upgrading/index.html`.

This preserves all existing changelog links without needing to update historical files.

## Are these changes tested?

Tested locally - the redirect works correctly, including with anchor links (e.g., `upgrading.html#datafusion-46-0-0`).

## Are there any user-facing changes?

Yes - users clicking old changelog links will now be redirected to the correct page instead of getting a 404.