### PR TITLE
perf: Use batched row conversion for `array_has_any`, `array_has_all`

### DIFF
--- a/datafusion/functions-nested/src/array_has.rs
+++ b/datafusion/functions-nested/src/array_has.rs
@@ -1193,7 +1193,7 @@ mod tests {
             })
             .unwrap();
         let output = result.into_array(num_rows).unwrap();
-        assert_eq!(output.as_boolean().iter().collect::<Vec<_>>(), expected,);
+        assert_eq!(output.as_boolean().iter().collect::<Vec<_>>(), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20587 .

## Rationale for this change

`array_has_any` and `array_has_all` called `RowConverter::convert_columns` twice for every input row. `convert_columns` has a lot of per-call overhead: allocating a new `Rows` buffer, doing various schema checking, and so on.

It is more efficient `RowConverter` on multiple rows at once. In this PR, we break the input batch into chunks of 512 rows. We do row conversion for the entire chunk in bulk, and then implement the `has_any` / `has_all` predicate comparison by indexing into the converted rows.

`array_has_any` / `array_has_all` had a special-case for strings, but it had an analogous problem: it iterated over rows, materialized each row's inner list, and then called `string_array_to_vec` twice per row. That does a lot of per-row work; it is significantly faster to call `string_array_to_vec` on many rows at once, and then index into the results to implement the per-row comparisons.

In both cases, we don't convert the entire batch in a single call because benchmarks suggested that it was inefficient to do whole-batch row conversion for large arrays (500 elements per row) on some machines. It seems plausible that this slowdown happens because a large batch full of large arrays results in a large working set, which falls outside the CPU cache. Splitting the batch into smaller chunks avoids this problem.

## What changes are included in this PR?

* Implement optimization
* Improve test coverage for sliced arrays; not strictly related to this PR but more coverage for this codepath made me feel more comfortable

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
