### PR TITLE
Add files_processed and files_scanned metrics to FileStreamMetrics

### DIFF
--- a/datafusion/datasource/src/file_stream.rs
+++ b/datafusion/datasource/src/file_stream.rs
@@ -187,7 +187,9 @@ impl FileStream {
                                         let done = 1
                                             + self.file_iter.len()
                                             + usize::from(next.is_some());
-                                        self.file_stream_metrics.files_processed.add(done);
+                                        self.file_stream_metrics
+                                            .files_processed
+                                            .add(done);
                                         self.state = FileStreamState::Limit;
                                         *remain = 0;
                                         batch
@@ -464,7 +466,8 @@ impl FileStreamMetrics {
 
         let files_opened = MetricBuilder::new(metrics).counter("files_opened", partition);
 
-        let files_processed = MetricBuilder::new(metrics).counter("files_processed", partition);
+        let files_processed =
+            MetricBuilder::new(metrics).counter("files_processed", partition);
 
         Self {
             time_opening,


### PR DESCRIPTION
## Summary
- Add `files_processed` counter to `FileStreamMetrics`, incremented for every file assigned to the partition — whether it was opened, pruned (returned an empty stream), or skipped due to a LIMIT. When the stream completes, this equals the total number of files in the partition.
- Add `files_opened` counter to `FileStreamMetrics`, incremented as soon as we consider a file for processing (either actually opened, discarded because of a LIMIT or stats, etc.).

## Motivation

These metrics enable **tracking query progress** during long-running scans. Today, there is no way to monitor how far along a file scan is. The existing `FileStreamMetrics` only provide:

- **Timing metrics** (`time_elapsed_opening`, `time_elapsed_scanning_total`, etc.) — these measure duration but don't indicate progress. You can't tell whether a scan is 10% or 90% done from elapsed time alone.
- **Error counters** (`file_open_errors`, `file_scan_errors`) — these only count failures, not successful progress.
- **`output_rows`** or **`bytes_scanned`** (from `BaselineMetrics`) — counts rows emitted, but since we don't know upfront how many rows will be emitted in total this is a poor metric, i.e. it never converges to 100% if there are filters, etc.

In contrast, `files_processed` and `files_opened` combined with the known number of files in `file_groups` give a clear progress indicator: `files_processed / total_files`. This is the most natural and reliable way to track scan progress since the file count is known at plan time. Depending on what users plan to do with the metric they can pick `files_opened / total_files` (leading metric) or `files_processed / total_files` (lagging metric).

## Test plan
- [x] Existing `file_stream` tests pass (8/8)
- [x] `cargo check -p datafusion-datasource` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)