### PR TITLE
cli: Fix datafusion-cli hint edge cases

### DIFF
--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -196,6 +196,7 @@ pub async fn exec_from_repl(
             }
             Err(ReadlineError::Interrupted) => {
                 println!("^C");
+                rl.helper().unwrap().reset_hint();
                 continue;
             }
             Err(ReadlineError::Eof) => {

--- a/datafusion-cli/src/helper.rs
+++ b/datafusion-cli/src/helper.rs
@@ -19,6 +19,7 @@
 //! and auto-completion for file name during creating external table.
 
 use std::borrow::Cow;
+use std::cell::Cell;
 
 use crate::highlighter::{Color, NoSyntaxHighlighter, SyntaxHighlighter};
 
@@ -40,6 +41,10 @@ pub struct CliHelper {
     completer: FilenameCompleter,
     dialect: Dialect,
     highlighter: Box<dyn Highlighter>,
+    /// Tracks whether to show the default hint. Set to `false` once the user
+    /// types anything, so the hint doesn't reappear after deleting back to
+    /// an empty line. Reset to `true` when the line is submitted.
+    show_hint: Cell<bool>,
 }
 
 impl CliHelper {
@@ -53,6 +58,7 @@ impl CliHelper {
             completer: FilenameCompleter::new(),
             dialect: *dialect,
             highlighter,
+            show_hint: Cell::new(true),
         }
     }
 
@@ -60,6 +66,11 @@ impl CliHelper {
         if *dialect != self.dialect {
             self.dialect = *dialect;
         }
+    }
+
+    /// Re-enable the default hint for the next prompt.
+    pub fn reset_hint(&self) {
+        self.show_hint.set(true);
     }
 
     fn validate_input(&self, input: &str) -> Result<ValidationResult> {
@@ -119,12 +130,11 @@ impl Hinter for CliHelper {
     type Hint = String;
 
     fn hint(&self, line: &str, _pos: usize, _ctx: &Context<'_>) -> Option<String> {
-        if line.trim().is_empty() {
-            let suggestion = Color::gray(DEFAULT_HINT_SUGGESTION);
-            Some(suggestion)
-        } else {
-            None
+        if !line.is_empty() {
+            self.show_hint.set(false);
         }
+        (self.show_hint.get() && line.trim().is_empty())
+            .then(|| Color::gray(DEFAULT_HINT_SUGGESTION))
     }
 }
 
@@ -133,12 +143,9 @@ impl Hinter for CliHelper {
 fn is_open_quote_for_location(line: &str, pos: usize) -> bool {
     let mut sql = line[..pos].to_string();
     sql.push('\'');
-    if let Ok(stmts) = DFParser::parse_sql(&sql)
-        && let Some(Statement::CreateExternalTable(_)) = stmts.back()
-    {
-        return true;
-    }
-    false
+    DFParser::parse_sql(&sql).is_ok_and(|stmts| {
+        matches!(stmts.back(), Some(Statement::CreateExternalTable(_)))
+    })
 }
 
 impl Completer for CliHelper {
@@ -161,7 +168,9 @@ impl Completer for CliHelper {
 impl Validator for CliHelper {
     fn validate(&self, ctx: &mut ValidationContext<'_>) -> Result<ValidationResult> {
         let input = ctx.input().trim_end();
-        self.validate_input(input)
+        let result = self.validate_input(input);
+        self.reset_hint();
+        result
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

The hint show condition relied on just checking if the input string is empty which caused visual issues like 

<img width="428" height="236" alt="image" src="https://github.com/user-attachments/assets/2b3a5c61-f910-4313-8844-35e1b0475692" />



<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

```
  helper.rs:                                                
  - Added a show_hint: Cell<bool> field to CliHelper. Uses Cell for interior mutability since hint() takes &self.                                                                                          
  - hint() now sets show_hint to false the moment line is non-empty. The hint only displays when show_hint is still true and the line is empty — i.e., only on the fresh prompt before any key is pressed. 
  - validate() calls reset_hint() after validation so the hint reappears on the next prompt after submission.                                                                                              
  - Added pub fn reset_hint(&self) for external reset.                                                                                                                                                     
                                                            
  exec.rs:
  - On Ctrl+C (ReadlineError::Interrupted), calls rl.helper().unwrap().reset_hint() so the next prompt still shows the hint.
```

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
