### PR TITLE
Make repeat emit Utf8View for Utf8View input

### DIFF
--- a/datafusion/sqllogictest/test_files/string/string_literal.slt
+++ b/datafusion/sqllogictest/test_files/string/string_literal.slt
@@ -352,6 +352,21 @@ SELECT repeat(arrow_cast('foo', 'Dictionary(Int32, Utf8)'), 3)
 ----
 foofoofoo
 
+query T
+SELECT arrow_typeof(repeat('foo', 3))
+----
+Utf8
+
+query T
+SELECT arrow_typeof(repeat(arrow_cast('foo', 'LargeUtf8'), 3))
+----
+LargeUtf8
+
+query T
+SELECT arrow_typeof(repeat(arrow_cast('foo', 'Utf8View'), 3))
+----
+Utf8View
+
 
 query T
 SELECT replace('foobar', 'bar', 'hello')


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion/issues/20585

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


## Rationale for this change

String UDFs should preserve string representation where feasible. repeat previously accepted Utf8View input but emitted Utf8, causing an unnecessary type downgrade. This aligns repeat with the expected behavior of returning the same string type as its primary input.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

1. Updated repeat return type inference to emit Utf8View when input is Utf8View, while preserving existing behavior for Utf8 and LargeUtf8.
2. Added tests

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
