### PR TITLE
fix: make the `sql` feature truly optional

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -88,8 +88,8 @@ recursive_protection = [
     "datafusion-optimizer/recursive_protection",
     "datafusion-physical-optimizer/recursive_protection",
     "datafusion-physical-expr/recursive_protection",
-    "datafusion-sql/recursive_protection",
-    "sqlparser/recursive-protection",
+    "datafusion-sql?/recursive_protection",
+    "sqlparser?/recursive-protection",
 ]
 serde = [
     "dep:serde",


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

When enabling the `recursive_protection` feature for the `datafusion` crate, the `sql` feature is enabled. This is undesirable if the downstream project would like the `sql` feature to be off.

## What changes are included in this PR?

Use the `?` syntax for features of dependencies for `recursive_protection`. This was already correctly done for other features such as `unicode_expressions`.

<https://doc.rust-lang.org/cargo/reference/features.html>

## Are these changes tested?

N/A

## Are there any user-facing changes?

This makes dependency management better for downstream projects and is not a breaking change.
