### PR TITLE
Support non-UTF-8 encoded CSV files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ datafusion-sql = { path = "datafusion/sql", version = "53.1.0" }
 datafusion-substrait = { path = "datafusion/substrait", version = "53.1.0" }
 
 doc-comment = "0.3"
+encoding_rs = "0.8"
 env_logger = "0.11"
 flate2 = "1.1.9"
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Optional features:
 
 - `avro`: support for reading the [Apache Avro] format
 - `backtrace`: include backtrace information in error messages
+- `encoding_rs`: support for reading files with character encodings other than UTF-8
 - `parquet_encryption`: support for using [Parquet Modular Encryption]
 - `serde`: enable arrow-schema's `serde` feature
 

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -3142,6 +3142,7 @@ config_namespace! {
         ///
         /// The default behaviour depends on the `datafusion.catalog.newlines_in_values` setting.
         pub newlines_in_values: Option<bool>, default = None
+        pub encoding: Option<String>, default = None
         pub compression: CompressionTypeVariant, default = CompressionTypeVariant::UNCOMPRESSED
         /// Compression level for the output file. The valid range depends on the
         /// compression algorithm:

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -3142,7 +3142,7 @@ config_namespace! {
         ///
         /// The default behaviour depends on the `datafusion.catalog.newlines_in_values` setting.
         pub newlines_in_values: Option<bool>, default = None
-        pub encoding: Option<String>, default = None
+        pub charset: Option<String>, default = None
         pub compression: CompressionTypeVariant, default = CompressionTypeVariant::UNCOMPRESSED
         /// Compression level for the output file. The valid range depends on the
         /// compression algorithm:
@@ -3276,6 +3276,13 @@ impl CsvOptions {
     /// The default behaviour depends on the `datafusion.catalog.newlines_in_values` setting.
     pub fn with_newlines_in_values(mut self, newlines_in_values: bool) -> Self {
         self.newlines_in_values = Some(newlines_in_values);
+        self
+    }
+
+    /// Specifies the character encoding the file is encoded with.
+    /// - defaults to UTF-8
+    pub fn with_charset(mut self, charset: impl Into<String>) -> Self {
+        self.charset = Some(charset.into());
         self
     }
 

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -68,6 +68,7 @@ default = [
     "recursive_protection",
     "sql",
 ]
+encoding_rs = ["datafusion-datasource-csv/encoding_rs"]
 encoding_expressions = ["datafusion-functions/encoding_expressions"]
 # Used for testing ONLY: causes all values to hash to the same value (test for collisions)
 force_hash_collisions = ["datafusion-physical-plan/force_hash_collisions", "datafusion-common/force_hash_collisions"]
@@ -169,6 +170,7 @@ datafusion-macros = { workspace = true }
 datafusion-physical-optimizer = { workspace = true }
 doc-comment = { workspace = true }
 bytes = { workspace = true }
+encoding_rs = { workspace = true }
 env_logger = { workspace = true }
 glob = { workspace = true }
 insta = { workspace = true }

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -1621,4 +1621,49 @@ mod tests {
 
         Ok(())
     }
+
+    #[cfg(feature = "encoding_rs")]
+    #[tokio::test]
+    async fn test_read_shift_jis_csv() -> Result<()> {
+        use std::io::Write;
+
+        // Encode a test CSV into SHIFT-JIS
+        let data = r#"ID,Name,Price,Description,Notes
+001,山本 大輔,\2945,桜餅と抹茶のセット,数量限定
+002,加藤 由美,\9575,和牛ステーキセット,取り寄せ中
+003,田中 太郎,\1853,抹茶アイスクリーム,ポイント2倍
+004,渡辺 さくら,\9494,和牛ステーキセット,送料無料
+005,加藤 由美,\558,和牛ステーキセット,新商品
+006,渡辺 さくら,\7704,天ぷら盛り合わせ,割引対象外
+007,田中 太郎,\212,桜餅と抹茶のセット,取り寄せ中
+008,中村 陽子,\8847,和牛ステーキセット,期間限定
+009,伊藤 健太,\5997,季節の野菜カレー,お一人様1点限り
+010,高橋 美咲,\6594,季節の野菜カレー,冷凍保存"#;
+        let (data, _, _) = encoding_rs::SHIFT_JIS.encode(data);
+
+        // Write the CSV data to a temp file
+        let mut tmp = tempfile::Builder::new().suffix(".csv").tempfile()?;
+        tmp.write_all(&*data)?;
+        let path = tmp.path().to_str().unwrap().to_string();
+
+        // Read the file
+        let ctx = SessionContext::new();
+        let opts = CsvReadOptions::new().has_header(true);
+        let batches = ctx.read_csv(path, opts).await?.collect().await?;
+
+        // Check
+        let num_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
+        assert_eq!(num_rows, 10);
+
+        let names = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(names.value(0), "山本 大輔");
+        assert_eq!(names.value(1), "加藤 由美");
+        assert_eq!(names.value(2), "田中 太郎");
+
+        Ok(())
+    }
 }

--- a/datafusion/core/src/datasource/file_format/csv.rs
+++ b/datafusion/core/src/datasource/file_format/csv.rs
@@ -1648,7 +1648,7 @@ mod tests {
 
         // Read the file
         let ctx = SessionContext::new();
-        let opts = CsvReadOptions::new().has_header(true);
+        let opts = CsvReadOptions::new().has_header(true).charset("SHIFT-JIS");
         let batches = ctx.read_csv(path, opts).await?.collect().await?;
 
         // Check

--- a/datafusion/core/src/datasource/file_format/options.rs
+++ b/datafusion/core/src/datasource/file_format/options.rs
@@ -85,6 +85,8 @@ pub struct CsvReadOptions<'a> {
     pub file_extension: &'a str,
     /// Partition Columns
     pub table_partition_cols: Vec<(String, DataType)>,
+    /// Character encoding
+    pub charset: Option<&'a str>,
     /// File compression type
     pub file_compression_type: FileCompressionType,
     /// Indicates how the file is sorted
@@ -118,6 +120,7 @@ impl<'a> CsvReadOptions<'a> {
             newlines_in_values: false,
             file_extension: DEFAULT_CSV_EXTENSION,
             table_partition_cols: vec![],
+            charset: None,
             file_compression_type: FileCompressionType::UNCOMPRESSED,
             file_sort_order: vec![],
             comment: None,
@@ -206,6 +209,12 @@ impl<'a> CsvReadOptions<'a> {
     /// Configure number of max records to read for schema inference
     pub fn schema_infer_max_records(mut self, max_records: usize) -> Self {
         self.schema_infer_max_records = max_records;
+        self
+    }
+
+    /// Configure the character set encoding
+    pub fn charset(mut self, charset: &'a str) -> Self {
+        self.charset = Some(charset);
         self
     }
 
@@ -633,6 +642,7 @@ impl ReadOptions<'_> for CsvReadOptions<'_> {
             .with_terminator(self.terminator)
             .with_newlines_in_values(self.newlines_in_values)
             .with_schema_infer_max_rec(self.schema_infer_max_records)
+            .with_charset(self.charset.map(ToOwned::to_owned))
             .with_file_compression_type(self.file_compression_type.to_owned())
             .with_null_regex(self.null_regex.clone())
             .with_truncated_rows(self.truncated_rows);

--- a/datafusion/datasource-csv/Cargo.toml
+++ b/datafusion/datasource-csv/Cargo.toml
@@ -42,6 +42,7 @@ datafusion-expr = { workspace = true }
 datafusion-physical-expr-common = { workspace = true }
 datafusion-physical-plan = { workspace = true }
 datafusion-session = { workspace = true }
+encoding_rs = { workspace = true, optional = true }
 futures = { workspace = true }
 object_store = { workspace = true }
 regex = { workspace = true }

--- a/datafusion/datasource-csv/src/charset.rs
+++ b/datafusion/datasource-csv/src/charset.rs
@@ -41,32 +41,29 @@ pub fn lookup_charset(enc: Option<&str>) -> Result<Option<&'static Encoding>> {
     }
 }
 
-/// A `Decoder` that decodes input bytes from the specified character encoding
-/// to UTF-8 before passing them onto the inner `Decoder`.
-pub struct CharsetDecoder<T> {
+/// A record batch `Decoder` that decodes input bytes from the specified
+/// character encoding to UTF-8 before passing them onto the inner `Decoder`.
+#[derive(Debug)]
+pub struct CharsetBatchDecoder<T> {
     inner: T,
-    charset_decoder: encoding_rs::Decoder,
-    buffer: Buffer,
+    decoder: CharsetDecoder,
 }
 
-impl<T> CharsetDecoder<T> {
+impl<T> CharsetBatchDecoder<T> {
     pub fn new(inner: T, encoding: &'static Encoding) -> Self {
-        Self {
-            inner,
-            charset_decoder: encoding.new_decoder(),
-            buffer: Buffer::with_capacity(DECODE_BUFFER_CAP),
-        }
+        let decoder = CharsetDecoder::new(encoding);
+        Self { inner, decoder }
     }
 }
 
-impl<T: Decoder> Decoder for CharsetDecoder<T> {
+impl<T: Decoder> Decoder for CharsetBatchDecoder<T> {
     fn decode(&mut self, buf: &[u8]) -> Result<usize, ArrowError> {
         let last = buf.is_empty();
         let mut buf_offset = 0;
 
-        if !self.buffer.is_empty() {
-            let decoded = self.inner.decode(self.buffer.read_buf())?;
-            self.buffer.consume(decoded);
+        if !self.decoder.is_empty() {
+            let decoded = self.inner.decode(self.decoder.read())?;
+            self.decoder.consume(decoded);
 
             if decoded == 0 {
                 return Ok(buf_offset);
@@ -74,20 +71,13 @@ impl<T: Decoder> Decoder for CharsetDecoder<T> {
         }
 
         loop {
-            self.buffer.backshift();
-
-            let (res, read, written, _) = self.charset_decoder.decode_to_utf8(
-                &buf[buf_offset..],
-                self.buffer.write_buf(),
-                last,
-            );
+            let (read, input_empty) = self.decoder.fill(&buf[buf_offset..], last);
             buf_offset += read;
-            self.buffer.advance(written);
 
-            let decoded = self.inner.decode(self.buffer.read_buf())?;
-            self.buffer.consume(decoded);
+            let decoded = self.inner.decode(self.decoder.read())?;
+            self.decoder.consume(decoded);
 
-            if res == CoderResult::InputEmpty || decoded == 0 {
+            if input_empty || decoded == 0 {
                 break;
             }
         }
@@ -104,28 +94,18 @@ impl<T: Decoder> Decoder for CharsetDecoder<T> {
     }
 }
 
-impl<T: Debug> Debug for CharsetDecoder<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CharsetDecoder")
-            .field("inner", &self.inner)
-            .field("charset_decoder", self.charset_decoder.encoding())
-            .finish()
-    }
-}
-
+/// A `BufRead` adapter that decodes input bytes from the
+/// specified character encoding to UTF-8.
+#[derive(Debug)]
 pub struct CharsetReader<R> {
     inner: R,
-    charset_decoder: encoding_rs::Decoder,
-    buffer: Buffer,
+    decoder: CharsetDecoder,
 }
 
 impl<R: BufRead> CharsetReader<R> {
     pub fn new(inner: R, encoding: &'static Encoding) -> Self {
-        Self {
-            inner,
-            charset_decoder: encoding.new_decoder(),
-            buffer: Buffer::with_capacity(DECODE_BUFFER_CAP),
-        }
+        let decoder = CharsetDecoder::new(encoding);
+        Self { inner, decoder }
     }
 }
 
@@ -140,24 +120,87 @@ impl<R: BufRead> Read for CharsetReader<R> {
 
 impl<R: BufRead> BufRead for CharsetReader<R> {
     fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
-        if self.buffer.is_empty() {
-            self.buffer.backshift();
-
+        if self.decoder.needs_input() {
             let buf = self.inner.fill_buf()?;
-            let (_, read, written, _) = self.charset_decoder.decode_to_utf8(
-                buf,
-                self.buffer.write_buf(),
-                buf.is_empty(),
-            );
+            let (read, _) = self.decoder.fill(buf, buf.is_empty());
             self.inner.consume(read);
-            self.buffer.advance(written);
         }
 
-        Ok(self.buffer.read_buf())
+        Ok(self.decoder.read())
     }
 
     fn consume(&mut self, amount: usize) {
+        self.decoder.consume(amount);
+    }
+}
+
+/// Converts bytes from some character encoding to UTF-8,
+/// using an internal fixed-size buffer
+pub struct CharsetDecoder {
+    charset_decoder: encoding_rs::Decoder,
+    buffer: Buffer,
+    finished: bool,
+}
+
+impl CharsetDecoder {
+    /// Creates a new `CharsetDecoder`.
+    fn new(encoding: &'static Encoding) -> Self {
+        Self {
+            charset_decoder: encoding.new_decoder(),
+            buffer: Buffer::with_capacity(DECODE_BUFFER_CAP),
+            finished: false,
+        }
+    }
+
+    /// Returns `true` if the internal buffer is empty.
+    fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    /// Returns `true` if the decoder needs more input to make progress.
+    fn needs_input(&self) -> bool {
+        !self.finished && self.buffer.is_empty()
+    }
+
+    /// Fills the internal buffer by decoding the provided bytes, returning
+    /// the number of bytes consumed and whether the input was exhausted.
+    fn fill(&mut self, src: &[u8], last: bool) -> (usize, bool) {
+        if self.finished {
+            return (0, true);
+        }
+
+        self.buffer.backshift();
+
+        let dst = self.buffer.write_buf();
+        let (res, read, written, _) = self.charset_decoder.decode_to_utf8(src, dst, last);
+        self.buffer.advance(written);
+
+        if last && res == CoderResult::InputEmpty {
+            self.finished = true;
+        }
+
+        (read, res == CoderResult::InputEmpty)
+    }
+
+    /// Returns the unread decoded bytes in the internal buffer.
+    fn read(&self) -> &[u8] {
+        self.buffer.read_buf()
+    }
+
+    /// Marks the given amount of bytes from the internal buffer as having been read.
+    /// Subsequent calls to `read` only return bytes that have not been marked as read.
+    fn consume(&mut self, amount: usize) {
         self.buffer.consume(amount);
+    }
+}
+
+impl Debug for CharsetDecoder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CharsetDecoder")
+            .field("charset_decoder", self.charset_decoder.encoding())
+            .field("buffer", &self.buffer)
+            .field("finished", &self.finished)
+            .finish()
     }
 }
 

--- a/datafusion/datasource-csv/src/charset.rs
+++ b/datafusion/datasource-csv/src/charset.rs
@@ -16,17 +16,30 @@
 // under the License.
 
 use std::fmt::Debug;
+use std::io::{BufRead, Read};
 
 use arrow::array::RecordBatch;
 use arrow::error::ArrowError;
-use datafusion_common::Result;
+use datafusion_common::{DataFusionError, Result};
 use datafusion_datasource::decoder::Decoder;
-use encoding_rs::{CoderResult, Encoding};
+use encoding_rs::{CoderResult, Encoding, UTF_8};
 
 use self::buffer::Buffer;
 
 /// Default capacity of the buffer used to decode non-UTF-8 charset streams
 static DECODE_BUFFER_CAP: usize = 8 * 1024;
+
+pub fn lookup_charset(enc: Option<&str>) -> Result<Option<&'static Encoding>> {
+    match enc {
+        Some(enc) => match Encoding::for_label(enc.as_bytes()) {
+            Some(enc) => Ok(Some(enc).filter(|enc| *enc != UTF_8)),
+            None => Err(DataFusionError::Configuration(format!(
+                "Unknown character set '{enc}'"
+            )))?,
+        },
+        None => Ok(None),
+    }
+}
 
 /// A `Decoder` that decodes input bytes from the specified character encoding
 /// to UTF-8 before passing them onto the inner `Decoder`.
@@ -97,6 +110,54 @@ impl<T: Debug> Debug for CharsetDecoder<T> {
             .field("inner", &self.inner)
             .field("charset_decoder", self.charset_decoder.encoding())
             .finish()
+    }
+}
+
+pub struct CharsetReader<R> {
+    inner: R,
+    charset_decoder: encoding_rs::Decoder,
+    buffer: Buffer,
+}
+
+impl<R: BufRead> CharsetReader<R> {
+    pub fn new(inner: R, encoding: &'static Encoding) -> Self {
+        Self {
+            inner,
+            charset_decoder: encoding.new_decoder(),
+            buffer: Buffer::with_capacity(DECODE_BUFFER_CAP),
+        }
+    }
+}
+
+impl<R: BufRead> Read for CharsetReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let src = self.fill_buf()?;
+        let len = src.len().min(buf.len());
+        buf[..len].copy_from_slice(&src[..len]);
+        Ok(len)
+    }
+}
+
+impl<R: BufRead> BufRead for CharsetReader<R> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        if self.buffer.is_empty() {
+            self.buffer.backshift();
+
+            let buf = self.inner.fill_buf()?;
+            let (_, read, written, _) = self.charset_decoder.decode_to_utf8(
+                buf,
+                self.buffer.write_buf(),
+                buf.is_empty(),
+            );
+            self.inner.consume(read);
+            self.buffer.advance(written);
+        }
+
+        Ok(self.buffer.read_buf())
+    }
+
+    fn consume(&mut self, amount: usize) {
+        self.buffer.consume(amount);
     }
 }
 

--- a/datafusion/datasource-csv/src/encoding.rs
+++ b/datafusion/datasource-csv/src/encoding.rs
@@ -1,0 +1,142 @@
+use std::fmt::Debug;
+
+use arrow::array::RecordBatch;
+use arrow::error::ArrowError;
+use datafusion_common::Result;
+use datafusion_datasource::decoder::Decoder;
+use encoding_rs::{CoderResult, Encoding};
+
+use self::buffer::Buffer;
+
+/// Default capacity of the buffer used to decode non-UTF-8 charset streams
+static DECODE_BUFFER_CAP: usize = 8 * 1024;
+
+/// A `Decoder` that decodes input bytes from the specified character encoding
+/// to UTF-8 before passing them onto the inner `Decoder`.
+pub struct CharsetDecoder<T> {
+    inner: T,
+    charset_decoder: encoding_rs::Decoder,
+    buffer: Buffer,
+}
+
+impl<T> CharsetDecoder<T> {
+    pub fn new(inner: T, encoding: &'static Encoding) -> Self {
+        Self {
+            inner,
+            charset_decoder: encoding.new_decoder(),
+            buffer: Buffer::with_capacity(DECODE_BUFFER_CAP),
+        }
+    }
+}
+
+impl<T: Decoder> Decoder for CharsetDecoder<T> {
+    fn decode(&mut self, buf: &[u8]) -> Result<usize, ArrowError> {
+        let last = buf.is_empty();
+        let mut buf_offset = 0;
+
+        if !self.buffer.is_empty() {
+            let decoded = self.inner.decode(self.buffer.read_buf())?;
+            self.buffer.consume(decoded);
+
+            if decoded == 0 {
+                return Ok(buf_offset);
+            }
+        }
+
+        loop {
+            self.buffer.backshift();
+
+            let (res, read, written, _) = self.charset_decoder.decode_to_utf8(
+                &buf[buf_offset..],
+                self.buffer.write_buf(),
+                last,
+            );
+            buf_offset += read;
+            self.buffer.advance(written);
+
+            let decoded = self.inner.decode(self.buffer.read_buf())?;
+            self.buffer.consume(decoded);
+
+            if res == CoderResult::InputEmpty || decoded == 0 {
+                break;
+            }
+        }
+
+        Ok(buf_offset)
+    }
+
+    fn flush(&mut self) -> Result<Option<RecordBatch>, ArrowError> {
+        self.inner.flush()
+    }
+
+    fn can_flush_early(&self) -> bool {
+        self.inner.can_flush_early()
+    }
+}
+
+impl<T: Debug> Debug for CharsetDecoder<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CharsetDecoder")
+            .field("inner", &self.inner)
+            .field("charset_decoder", self.charset_decoder.encoding())
+            .finish()
+    }
+}
+
+mod buffer {
+    /// A fixed-sized buffer that maintains both
+    /// a read position and a write position
+    #[derive(Debug)]
+    pub struct Buffer {
+        buf: Box<[u8]>,
+        read_ptr: usize,
+        write_ptr: usize,
+    }
+
+    impl Buffer {
+        /// Creates a new `Buffer` with the specified capacity
+        #[inline]
+        pub fn with_capacity(capacity: usize) -> Self {
+            Self {
+                buf: vec![0; capacity].into_boxed_slice(),
+                read_ptr: 0,
+                write_ptr: 0,
+            }
+        }
+
+        /// Whether there are no more bytes available to be read
+        pub fn is_empty(&self) -> bool {
+            self.read_ptr == self.write_ptr
+        }
+
+        /// Returns the unread portion of the buffer
+        pub fn read_buf(&self) -> &[u8] {
+            &self.buf[self.read_ptr..self.write_ptr]
+        }
+
+        /// Advances the read position by `amount` bytes
+        pub fn consume(&mut self, amount: usize) {
+            self.read_ptr += amount;
+            debug_assert!(self.read_ptr <= self.write_ptr);
+        }
+
+        /// Returns the portion of the buffer available for writing
+        pub fn write_buf(&mut self) -> &mut [u8] {
+            &mut self.buf[self.write_ptr..]
+        }
+
+        /// Advances the write position by `amount` bytes
+        pub fn advance(&mut self, amount: usize) {
+            self.write_ptr += amount;
+            debug_assert!(self.write_ptr <= self.buf.len())
+        }
+
+        /// Moves any unread bytes to the start of the buffer,
+        /// creating more space for writing new data
+        pub fn backshift(&mut self) {
+            self.buf.copy_within(self.read_ptr..self.write_ptr, 0);
+            self.write_ptr -= self.read_ptr;
+            self.read_ptr = 0;
+        }
+    }
+}

--- a/datafusion/datasource-csv/src/encoding.rs
+++ b/datafusion/datasource-csv/src/encoding.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::fmt::Debug;
 
 use arrow::array::RecordBatch;

--- a/datafusion/datasource-csv/src/file_format.rs
+++ b/datafusion/datasource-csv/src/file_format.rs
@@ -21,6 +21,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug};
 use std::sync::Arc;
 
+use crate::charset::lookup_charset;
 use crate::source::CsvSource;
 
 use arrow::array::RecordBatch;
@@ -289,6 +290,13 @@ impl CsvFormat {
         self
     }
 
+    /// Sets the character encoding of the CSV.
+    /// Defaults to UTF-8 if unspecified.
+    pub fn with_charset(mut self, charset: Option<String>) -> Self {
+        self.options.charset = charset;
+        self
+    }
+
     /// Set a `FileCompressionType` of CSV
     /// - defaults to `FileCompressionType::UNCOMPRESSED`
     pub fn with_file_compression_type(
@@ -530,6 +538,8 @@ impl CsvFormat {
 
         pin_mut!(stream);
 
+        let charset = lookup_charset(self.options.charset.as_deref())?;
+
         while let Some(chunk) = stream.next().await.transpose()? {
             record_number += 1;
             let first_chunk = record_number == 0;
@@ -559,8 +569,15 @@ impl CsvFormat {
                 format = format.with_comment(comment);
             }
 
-            let (Schema { fields, .. }, records_read) =
-                format.infer_schema(chunk.reader(), Some(records_to_read))?;
+            let (Schema { fields, .. }, records_read) = match charset {
+                #[cfg(feature = "encoding_rs")]
+                Some(enc) => {
+                    use crate::charset::CharsetReader;
+                    let reader = CharsetReader::new(chunk.reader(), enc);
+                    format.infer_schema(reader, Some(records_to_read))?
+                }
+                None => format.infer_schema(chunk.reader(), Some(records_to_read))?,
+            };
 
             records_to_read -= records_read;
             total_records_read += records_read;

--- a/datafusion/datasource-csv/src/mod.rs
+++ b/datafusion/datasource-csv/src/mod.rs
@@ -20,6 +20,8 @@
 // https://github.com/apache/datafusion/issues/11143
 #![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 
+#[cfg(feature = "encoding_rs")]
+mod encoding;
 pub mod file_format;
 pub mod source;
 

--- a/datafusion/datasource-csv/src/mod.rs
+++ b/datafusion/datasource-csv/src/mod.rs
@@ -21,7 +21,7 @@
 #![cfg_attr(not(test), deny(clippy::clone_on_ref_ptr))]
 
 #[cfg(feature = "encoding_rs")]
-mod encoding;
+mod charset;
 pub mod file_format;
 pub mod source;
 
@@ -32,6 +32,7 @@ use datafusion_datasource::file_groups::FileGroup;
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::{file::FileSource, file_scan_config::FileScanConfig};
 use datafusion_execution::object_store::ObjectStoreUrl;
+
 pub use file_format::*;
 
 /// Returns a [`FileScanConfig`] for given `file_groups`
@@ -44,4 +45,18 @@ pub fn partitioned_csv_config(
             .with_file_groups(file_groups)
             .build(),
     )
+}
+
+#[cfg(not(feature = "encoding_rs"))]
+mod encoding {
+    use datafusion_common::{DataFusionError, Result};
+
+    pub fn find_encoding(enc: Option<&str>) -> Result<Option<core::convert::Infallible>> {
+        match enc {
+            Some(_) => Err(DataFusionError::NotImplemented(format!(
+                "The 'encoding_rs' feature must be enabled to decode non-UTF-8 encodings"
+            )))?,
+            None => Ok(None),
+        }
+    }
 }

--- a/datafusion/datasource-csv/src/mod.rs
+++ b/datafusion/datasource-csv/src/mod.rs
@@ -54,9 +54,10 @@ mod charset {
 
     pub fn lookup_charset(enc: Option<&str>) -> Result<Option<Infallible>> {
         match enc {
-            Some(_) => Err(DataFusionError::NotImplemented(format!(
+            Some(_) => Err(DataFusionError::NotImplemented(
                 "The 'encoding_rs' feature must be enabled to decode non-UTF-8 encodings"
-            )))?,
+                    .to_string(),
+            ))?,
             None => Ok(None),
         }
     }

--- a/datafusion/datasource-csv/src/mod.rs
+++ b/datafusion/datasource-csv/src/mod.rs
@@ -48,10 +48,11 @@ pub fn partitioned_csv_config(
 }
 
 #[cfg(not(feature = "encoding_rs"))]
-mod encoding {
+mod charset {
+    use core::convert::Infallible;
     use datafusion_common::{DataFusionError, Result};
 
-    pub fn find_encoding(enc: Option<&str>) -> Result<Option<core::convert::Infallible>> {
+    pub fn lookup_charset(enc: Option<&str>) -> Result<Option<Infallible>> {
         match enc {
             Some(_) => Err(DataFusionError::NotImplemented(format!(
                 "The 'encoding_rs' feature must be enabled to decode non-UTF-8 encodings"

--- a/datafusion/datasource-csv/src/source.rs
+++ b/datafusion/datasource-csv/src/source.rs
@@ -184,10 +184,6 @@ impl CsvSource {
 }
 
 impl CsvSource {
-    fn open<R: Read>(&self, reader: R) -> Result<csv::Reader<R>> {
-        Ok(self.builder().build(reader)?)
-    }
-
     fn builder(&self) -> csv::ReaderBuilder {
         let mut builder =
             csv::ReaderBuilder::new(Arc::clone(self.table_schema.file_schema()))

--- a/datafusion/datasource-csv/src/source.rs
+++ b/datafusion/datasource-csv/src/source.rs
@@ -46,8 +46,7 @@ use datafusion_physical_plan::{
     DisplayFormatType, ExecutionPlan, ExecutionPlanProperties,
 };
 
-#[cfg(feature = "encoding_rs")]
-use crate::encoding::CharsetDecoder;
+use crate::charset::lookup_charset;
 use crate::file_format::CsvDecoder;
 use futures::{StreamExt, TryStreamExt};
 use object_store::buffered::BufWriter;
@@ -232,30 +231,6 @@ impl CsvOpener {
             partition_index: 0,
         }
     }
-
-    #[cfg(feature = "encoding_rs")]
-    fn encoding(&self) -> Result<Option<&'static encoding_rs::Encoding>> {
-        match self.config.options.encoding.as_ref() {
-            Some(enc) => match encoding_rs::Encoding::for_label(enc.as_bytes()) {
-                Some(enc) => Ok(Some(enc)),
-                None => Err(DataFusionError::Configuration(format!(
-                    "Unknown character set '{enc}'"
-                )))?,
-            },
-            None => Ok(None),
-        }
-    }
-
-    #[cfg(not(feature = "encoding_rs"))]
-    fn encoding(&self) -> Result<Option<core::convert::Infallible>> {
-        match &self.config.options.encoding {
-            Some(_) => Err(DataFusionError::NotImplemented(
-                "The 'encoding_rs' feature must be enabled to decode non-UTF-8 encodings"
-                    .to_owned(),
-            ))?,
-            None => Ok(None),
-        }
-    }
 }
 
 impl From<CsvSource> for Arc<dyn FileSource> {
@@ -389,7 +364,7 @@ impl FileOpener for CsvOpener {
         config.options.truncated_rows = Some(config.truncate_rows());
 
         let file_compression_type = self.file_compression_type.to_owned();
-        let encoding = self.encoding()?;
+        let charset = lookup_charset(self.config.options.charset.as_deref())?;
 
         if partitioned_file.range.is_some() {
             assert!(
@@ -447,9 +422,10 @@ impl FileOpener for CsvOpener {
 
                     let reader = BufReader::new(reader);
 
-                    let mut reader = match encoding {
+                    let mut reader = match charset {
                         #[cfg(feature = "encoding_rs")]
                         Some(enc) => {
+                            use crate::charset::CharsetDecoder;
                             let decoder = CharsetDecoder::new(decoder, enc);
                             deserialize_reader(reader, decoder)
                         }
@@ -471,9 +447,10 @@ impl FileOpener for CsvOpener {
 
                     let stream = file_compression_type.convert_stream(stream)?.fuse();
 
-                    let stream = match encoding {
+                    let stream = match charset {
                         #[cfg(feature = "encoding_rs")]
                         Some(enc) => {
+                            use crate::charset::CharsetDecoder;
                             let decoder = CharsetDecoder::new(decoder, enc);
                             deserialize_stream(stream, DecoderDeserializer::new(decoder))
                         }

--- a/datafusion/datasource-csv/src/source.rs
+++ b/datafusion/datasource-csv/src/source.rs
@@ -425,8 +425,8 @@ impl FileOpener for CsvOpener {
                     let mut reader = match charset {
                         #[cfg(feature = "encoding_rs")]
                         Some(enc) => {
-                            use crate::charset::CharsetDecoder;
-                            let decoder = CharsetDecoder::new(decoder, enc);
+                            use crate::charset::CharsetBatchDecoder;
+                            let decoder = CharsetBatchDecoder::new(decoder, enc);
                             deserialize_reader(reader, decoder)
                         }
                         None => deserialize_reader(reader, decoder),
@@ -450,8 +450,8 @@ impl FileOpener for CsvOpener {
                     let stream = match charset {
                         #[cfg(feature = "encoding_rs")]
                         Some(enc) => {
-                            use crate::charset::CharsetDecoder;
-                            let decoder = CharsetDecoder::new(decoder, enc);
+                            use crate::charset::CharsetBatchDecoder;
+                            let decoder = CharsetBatchDecoder::new(decoder, enc);
                             deserialize_stream(stream, DecoderDeserializer::new(decoder))
                         }
                         None => {

--- a/datafusion/datasource-csv/src/source.rs
+++ b/datafusion/datasource-csv/src/source.rs
@@ -17,10 +17,11 @@
 
 //! Execution plan for reading CSV files
 
+use datafusion_datasource::decoder::deserialize_reader;
 use datafusion_datasource::projection::{ProjectionOpener, SplitProjection};
 use datafusion_physical_plan::projection::ProjectionExprs;
 use std::fmt;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
 use std::task::Poll;
 
@@ -45,6 +46,8 @@ use datafusion_physical_plan::{
     DisplayFormatType, ExecutionPlan, ExecutionPlanProperties,
 };
 
+#[cfg(feature = "encoding_rs")]
+use crate::encoding::CharsetDecoder;
 use crate::file_format::CsvDecoder;
 use futures::{StreamExt, TryStreamExt};
 use object_store::buffered::BufWriter;
@@ -233,6 +236,30 @@ impl CsvOpener {
             partition_index: 0,
         }
     }
+
+    #[cfg(feature = "encoding_rs")]
+    fn encoding(&self) -> Result<Option<&'static encoding_rs::Encoding>> {
+        match self.config.options.encoding.as_ref() {
+            Some(enc) => match encoding_rs::Encoding::for_label(enc.as_bytes()) {
+                Some(enc) => Ok(Some(enc)),
+                None => Err(DataFusionError::Configuration(format!(
+                    "Unknown character set '{enc}'"
+                )))?,
+            },
+            None => Ok(None),
+        }
+    }
+
+    #[cfg(not(feature = "encoding_rs"))]
+    fn encoding(&self) -> Result<Option<core::convert::Infallible>> {
+        match &self.config.options.encoding {
+            Some(_) => Err(DataFusionError::NotImplemented(
+                "The 'encoding_rs' feature must be enabled to decode non-UTF-8 encodings"
+                    .to_owned(),
+            ))?,
+            None => Ok(None),
+        }
+    }
 }
 
 impl From<CsvSource> for Arc<dyn FileSource> {
@@ -366,6 +393,7 @@ impl FileOpener for CsvOpener {
         config.options.truncated_rows = Some(config.truncate_rows());
 
         let file_compression_type = self.file_compression_type.to_owned();
+        let encoding = self.encoding()?;
 
         if partitioned_file.range.is_some() {
             assert!(
@@ -405,43 +433,59 @@ impl FileOpener for CsvOpener {
                 .get_opts(&partitioned_file.object_meta.location, options)
                 .await?;
 
+            let decoder = config.builder().build_decoder();
+            let decoder = CsvDecoder::new(decoder);
+
             match result.payload {
                 #[cfg(not(target_arch = "wasm32"))]
                 GetResultPayload::File(mut file, _) => {
                     let is_whole_file_scanned = partitioned_file.range.is_none();
-                    let decoder = if is_whole_file_scanned {
-                        // Don't seek if no range as breaks FIFO files
+                    let reader = if is_whole_file_scanned {
+                        // Don't seek if no range as that would break FIFO files
                         file_compression_type.convert_read(file)?
                     } else {
-                        file.seek(SeekFrom::Start(result.range.start as _))?;
-                        file_compression_type.convert_read(
-                            file.take((result.range.end - result.range.start) as u64),
-                        )?
+                        let bytes = (result.range.end - result.range.start) as u64;
+                        file.seek(SeekFrom::Start(result.range.start as u64))?;
+                        file_compression_type.convert_read(file.take(bytes))?
                     };
 
-                    let mut reader = config.open(decoder)?;
+                    let reader = BufReader::new(reader);
+
+                    let mut reader = match encoding {
+                        #[cfg(feature = "encoding_rs")]
+                        Some(enc) => {
+                            let decoder = CharsetDecoder::new(decoder, enc);
+                            deserialize_reader(reader, decoder)
+                        }
+                        None => deserialize_reader(reader, decoder),
+                    };
 
                     // Use std::iter::from_fn to wrap execution of iterator's next() method.
                     let iterator = std::iter::from_fn(move || {
                         let mut timer = baseline_metrics.elapsed_compute().timer();
                         let result = reader.next();
                         timer.stop();
-                        result
+                        result.map(|r| r.map_err(Into::into))
                     });
 
-                    Ok(futures::stream::iter(iterator)
-                        .map(|r| r.map_err(Into::into))
-                        .boxed())
+                    Ok(futures::stream::iter(iterator).boxed())
                 }
-                GetResultPayload::Stream(s) => {
-                    let decoder = config.builder().build_decoder();
-                    let s = s.map_err(DataFusionError::from);
-                    let input = file_compression_type.convert_stream(s.boxed())?.fuse();
+                GetResultPayload::Stream(stream) => {
+                    let stream = stream.map_err(DataFusionError::from).boxed();
 
-                    let stream = deserialize_stream(
-                        input,
-                        DecoderDeserializer::new(CsvDecoder::new(decoder)),
-                    );
+                    let stream = file_compression_type.convert_stream(stream)?.fuse();
+
+                    let stream = match encoding {
+                        #[cfg(feature = "encoding_rs")]
+                        Some(enc) => {
+                            let decoder = CharsetDecoder::new(decoder, enc);
+                            deserialize_stream(stream, DecoderDeserializer::new(decoder))
+                        }
+                        None => {
+                            deserialize_stream(stream, DecoderDeserializer::new(decoder))
+                        }
+                    };
+
                     Ok(stream.map_err(Into::into).boxed())
                 }
             }

--- a/datafusion/datasource/src/decoder.rs
+++ b/datafusion/datasource/src/decoder.rs
@@ -174,7 +174,7 @@ pub fn deserialize_stream<'a>(
     futures::stream::poll_fn(move |cx| {
         loop {
             match ready!(input.poll_next_unpin(cx)).transpose()? {
-                Some(b) => _ = deserializer.digest(b),
+                Some(b) => deserializer.digest(b),
                 None => deserializer.finish(),
             };
 
@@ -192,7 +192,7 @@ pub fn deserialize_stream<'a>(
 /// and deserializes them using the provided decoder.
 pub fn deserialize_reader<'a>(
     mut reader: impl BufRead + Send + 'a,
-    mut decoder: impl Decoder + Send + 'a,
+    mut decoder: impl Decoder + 'a,
 ) -> Box<dyn Iterator<Item = Result<RecordBatch, ArrowError>> + Send + 'a> {
     let mut read = move || {
         loop {

--- a/datafusion/proto-common/proto/datafusion_common.proto
+++ b/datafusion/proto-common/proto/datafusion_common.proto
@@ -499,7 +499,7 @@ message CsvOptions {
   bytes ignore_leading_whitespace = 21;
   // Whether to ignore trailing whitespace in string values
   bytes ignore_trailing_whitespace = 22;
-  string encoding = 23; // Optional character encoding
+  string charset = 23; // Optional character encoding
 }
 
 // Options controlling CSV format

--- a/datafusion/proto-common/proto/datafusion_common.proto
+++ b/datafusion/proto-common/proto/datafusion_common.proto
@@ -499,6 +499,7 @@ message CsvOptions {
   bytes ignore_leading_whitespace = 21;
   // Whether to ignore trailing whitespace in string values
   bytes ignore_trailing_whitespace = 22;
+  string encoding = 23; // Optional character encoding
 }
 
 // Options controlling CSV format

--- a/datafusion/proto-common/src/from_proto/mod.rs
+++ b/datafusion/proto-common/src/from_proto/mod.rs
@@ -1012,7 +1012,7 @@ impl TryFrom<&protobuf::CsvOptions> for CsvOptions {
             escape: proto_opts.escape.first().copied(),
             double_quote: proto_opts.double_quote.first().map(|h| *h != 0),
             newlines_in_values: proto_opts.newlines_in_values.first().map(|h| *h != 0),
-            encoding: (!proto_opts.encoding.is_empty())
+            charset: (!proto_opts.encoding.is_empty())
                 .then(|| proto_opts.encoding.clone()),
             compression: proto_opts.compression().into(),
             compression_level: proto_opts.compression_level,

--- a/datafusion/proto-common/src/from_proto/mod.rs
+++ b/datafusion/proto-common/src/from_proto/mod.rs
@@ -1012,8 +1012,7 @@ impl TryFrom<&protobuf::CsvOptions> for CsvOptions {
             escape: proto_opts.escape.first().copied(),
             double_quote: proto_opts.double_quote.first().map(|h| *h != 0),
             newlines_in_values: proto_opts.newlines_in_values.first().map(|h| *h != 0),
-            charset: (!proto_opts.encoding.is_empty())
-                .then(|| proto_opts.encoding.clone()),
+            charset: (!proto_opts.charset.is_empty()).then(|| proto_opts.charset.clone()),
             compression: proto_opts.compression().into(),
             compression_level: proto_opts.compression_level,
             schema_infer_max_rec: proto_opts.schema_infer_max_rec.map(|h| h as usize),

--- a/datafusion/proto-common/src/from_proto/mod.rs
+++ b/datafusion/proto-common/src/from_proto/mod.rs
@@ -1012,6 +1012,8 @@ impl TryFrom<&protobuf::CsvOptions> for CsvOptions {
             escape: proto_opts.escape.first().copied(),
             double_quote: proto_opts.double_quote.first().map(|h| *h != 0),
             newlines_in_values: proto_opts.newlines_in_values.first().map(|h| *h != 0),
+            encoding: (!proto_opts.encoding.is_empty())
+                .then(|| proto_opts.encoding.clone()),
             compression: proto_opts.compression().into(),
             compression_level: proto_opts.compression_level,
             schema_infer_max_rec: proto_opts.schema_infer_max_rec.map(|h| h as usize),

--- a/datafusion/proto-common/src/generated/pbjson.rs
+++ b/datafusion/proto-common/src/generated/pbjson.rs
@@ -1876,6 +1876,9 @@ impl serde::Serialize for CsvOptions {
         if !self.ignore_trailing_whitespace.is_empty() {
             len += 1;
         }
+        if !self.encoding.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion_common.CsvOptions", len)?;
         if !self.has_header.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -1971,6 +1974,9 @@ impl serde::Serialize for CsvOptions {
             #[allow(clippy::needless_borrows_for_generic_args)]
             struct_ser.serialize_field("ignoreTrailingWhitespace", pbjson::private::base64::encode(&self.ignore_trailing_whitespace).as_str())?;
         }
+        if !self.encoding.is_empty() {
+            struct_ser.serialize_field("encoding", &self.encoding)?;
+        }
         struct_ser.end()
     }
 }
@@ -2019,6 +2025,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
             "ignoreLeadingWhitespace",
             "ignore_trailing_whitespace",
             "ignoreTrailingWhitespace",
+            "encoding",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -2045,6 +2052,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
             QuoteStyle,
             IgnoreLeadingWhitespace,
             IgnoreTrailingWhitespace,
+            Encoding,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2088,6 +2096,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
                             "quoteStyle" | "quote_style" => Ok(GeneratedField::QuoteStyle),
                             "ignoreLeadingWhitespace" | "ignore_leading_whitespace" => Ok(GeneratedField::IgnoreLeadingWhitespace),
                             "ignoreTrailingWhitespace" | "ignore_trailing_whitespace" => Ok(GeneratedField::IgnoreTrailingWhitespace),
+                            "encoding" => Ok(GeneratedField::Encoding),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -2129,6 +2138,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
                 let mut quote_style__ = None;
                 let mut ignore_leading_whitespace__ = None;
                 let mut ignore_trailing_whitespace__ = None;
+                let mut encoding__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::HasHeader => {
@@ -2289,6 +2299,12 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::Encoding => {
+                            if encoding__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("encoding"));
+                            }
+                            encoding__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(CsvOptions {
@@ -2314,6 +2330,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
                     quote_style: quote_style__.unwrap_or_default(),
                     ignore_leading_whitespace: ignore_leading_whitespace__.unwrap_or_default(),
                     ignore_trailing_whitespace: ignore_trailing_whitespace__.unwrap_or_default(),
+                    encoding: encoding__.unwrap_or_default(),
                 })
             }
         }

--- a/datafusion/proto-common/src/generated/pbjson.rs
+++ b/datafusion/proto-common/src/generated/pbjson.rs
@@ -1876,7 +1876,7 @@ impl serde::Serialize for CsvOptions {
         if !self.ignore_trailing_whitespace.is_empty() {
             len += 1;
         }
-        if !self.encoding.is_empty() {
+        if !self.charset.is_empty() {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("datafusion_common.CsvOptions", len)?;
@@ -1974,8 +1974,8 @@ impl serde::Serialize for CsvOptions {
             #[allow(clippy::needless_borrows_for_generic_args)]
             struct_ser.serialize_field("ignoreTrailingWhitespace", pbjson::private::base64::encode(&self.ignore_trailing_whitespace).as_str())?;
         }
-        if !self.encoding.is_empty() {
-            struct_ser.serialize_field("encoding", &self.encoding)?;
+        if !self.charset.is_empty() {
+            struct_ser.serialize_field("charset", &self.charset)?;
         }
         struct_ser.end()
     }
@@ -2025,7 +2025,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
             "ignoreLeadingWhitespace",
             "ignore_trailing_whitespace",
             "ignoreTrailingWhitespace",
-            "encoding",
+            "charset",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -2052,7 +2052,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
             QuoteStyle,
             IgnoreLeadingWhitespace,
             IgnoreTrailingWhitespace,
-            Encoding,
+            Charset,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2096,7 +2096,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
                             "quoteStyle" | "quote_style" => Ok(GeneratedField::QuoteStyle),
                             "ignoreLeadingWhitespace" | "ignore_leading_whitespace" => Ok(GeneratedField::IgnoreLeadingWhitespace),
                             "ignoreTrailingWhitespace" | "ignore_trailing_whitespace" => Ok(GeneratedField::IgnoreTrailingWhitespace),
-                            "encoding" => Ok(GeneratedField::Encoding),
+                            "charset" => Ok(GeneratedField::Charset),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -2138,7 +2138,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
                 let mut quote_style__ = None;
                 let mut ignore_leading_whitespace__ = None;
                 let mut ignore_trailing_whitespace__ = None;
-                let mut encoding__ = None;
+                let mut charset__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::HasHeader => {
@@ -2299,11 +2299,11 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
-                        GeneratedField::Encoding => {
-                            if encoding__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("encoding"));
+                        GeneratedField::Charset => {
+                            if charset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("charset"));
                             }
-                            encoding__ = Some(map_.next_value()?);
+                            charset__ = Some(map_.next_value()?);
                         }
                     }
                 }
@@ -2330,7 +2330,7 @@ impl<'de> serde::Deserialize<'de> for CsvOptions {
                     quote_style: quote_style__.unwrap_or_default(),
                     ignore_leading_whitespace: ignore_leading_whitespace__.unwrap_or_default(),
                     ignore_trailing_whitespace: ignore_trailing_whitespace__.unwrap_or_default(),
-                    encoding: encoding__.unwrap_or_default(),
+                    charset: charset__.unwrap_or_default(),
                 })
             }
         }

--- a/datafusion/proto-common/src/generated/prost.rs
+++ b/datafusion/proto-common/src/generated/prost.rs
@@ -698,6 +698,9 @@ pub struct CsvOptions {
     /// Whether to ignore trailing whitespace in string values
     #[prost(bytes = "vec", tag = "22")]
     pub ignore_trailing_whitespace: ::prost::alloc::vec::Vec<u8>,
+    /// Optional character encoding
+    #[prost(string, tag = "23")]
+    pub encoding: ::prost::alloc::string::String,
 }
 /// Options controlling CSV format
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/datafusion/proto-common/src/generated/prost.rs
+++ b/datafusion/proto-common/src/generated/prost.rs
@@ -700,7 +700,7 @@ pub struct CsvOptions {
     pub ignore_trailing_whitespace: ::prost::alloc::vec::Vec<u8>,
     /// Optional character encoding
     #[prost(string, tag = "23")]
-    pub encoding: ::prost::alloc::string::String,
+    pub charset: ::prost::alloc::string::String,
 }
 /// Options controlling CSV format
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/datafusion/proto-common/src/to_proto/mod.rs
+++ b/datafusion/proto-common/src/to_proto/mod.rs
@@ -1030,7 +1030,7 @@ impl TryFrom<&CsvOptions> for protobuf::CsvOptions {
             newlines_in_values: opts
                 .newlines_in_values
                 .map_or_else(Vec::new, |h| vec![h as u8]),
-            encoding: opts.charset.clone().unwrap_or_default(),
+            charset: opts.charset.clone().unwrap_or_default(),
             compression: compression.into(),
             schema_infer_max_rec: opts.schema_infer_max_rec.map(|h| h as u64),
             date_format: opts.date_format.clone().unwrap_or_default(),

--- a/datafusion/proto-common/src/to_proto/mod.rs
+++ b/datafusion/proto-common/src/to_proto/mod.rs
@@ -1030,6 +1030,7 @@ impl TryFrom<&CsvOptions> for protobuf::CsvOptions {
             newlines_in_values: opts
                 .newlines_in_values
                 .map_or_else(Vec::new, |h| vec![h as u8]),
+            encoding: opts.encoding.clone().unwrap_or_default(),
             compression: compression.into(),
             schema_infer_max_rec: opts.schema_infer_max_rec.map(|h| h as u64),
             date_format: opts.date_format.clone().unwrap_or_default(),

--- a/datafusion/proto-common/src/to_proto/mod.rs
+++ b/datafusion/proto-common/src/to_proto/mod.rs
@@ -1030,7 +1030,7 @@ impl TryFrom<&CsvOptions> for protobuf::CsvOptions {
             newlines_in_values: opts
                 .newlines_in_values
                 .map_or_else(Vec::new, |h| vec![h as u8]),
-            encoding: opts.encoding.clone().unwrap_or_default(),
+            encoding: opts.charset.clone().unwrap_or_default(),
             compression: compression.into(),
             schema_infer_max_rec: opts.schema_infer_max_rec.map(|h| h as u64),
             date_format: opts.date_format.clone().unwrap_or_default(),

--- a/datafusion/proto/src/generated/datafusion_proto_common.rs
+++ b/datafusion/proto/src/generated/datafusion_proto_common.rs
@@ -698,6 +698,9 @@ pub struct CsvOptions {
     /// Whether to ignore trailing whitespace in string values
     #[prost(bytes = "vec", tag = "22")]
     pub ignore_trailing_whitespace: ::prost::alloc::vec::Vec<u8>,
+    /// Optional character encoding
+    #[prost(string, tag = "23")]
+    pub encoding: ::prost::alloc::string::String,
 }
 /// Options controlling CSV format
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/datafusion/proto/src/generated/datafusion_proto_common.rs
+++ b/datafusion/proto/src/generated/datafusion_proto_common.rs
@@ -700,7 +700,7 @@ pub struct CsvOptions {
     pub ignore_trailing_whitespace: ::prost::alloc::vec::Vec<u8>,
     /// Optional character encoding
     #[prost(string, tag = "23")]
-    pub encoding: ::prost::alloc::string::String,
+    pub charset: ::prost::alloc::string::String,
 }
 /// Options controlling CSV format
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/datafusion/proto/src/logical_plan/file_formats.rs
+++ b/datafusion/proto/src/logical_plan/file_formats.rs
@@ -47,6 +47,7 @@ impl CsvOptionsProto {
                 terminator: options.terminator.map_or(vec![], |v| vec![v]),
                 escape: options.escape.map_or(vec![], |v| vec![v]),
                 double_quote: options.double_quote.map_or(vec![], |v| vec![v as u8]),
+                encoding: options.encoding.clone().unwrap_or_default(),
                 compression: options.compression as i32,
                 schema_infer_max_rec: options.schema_infer_max_rec.map(|v| v as u64),
                 date_format: options.date_format.clone().unwrap_or_default(),
@@ -101,6 +102,11 @@ impl From<&CsvOptionsProto> for CsvOptions {
             },
             double_quote: if !proto.double_quote.is_empty() {
                 Some(proto.double_quote[0] != 0)
+            } else {
+                None
+            },
+            encoding: if !proto.encoding.is_empty() {
+                Some(proto.encoding.clone())
             } else {
                 None
             },

--- a/datafusion/proto/src/logical_plan/file_formats.rs
+++ b/datafusion/proto/src/logical_plan/file_formats.rs
@@ -47,7 +47,7 @@ impl CsvOptionsProto {
                 terminator: options.terminator.map_or(vec![], |v| vec![v]),
                 escape: options.escape.map_or(vec![], |v| vec![v]),
                 double_quote: options.double_quote.map_or(vec![], |v| vec![v as u8]),
-                encoding: options.encoding.clone().unwrap_or_default(),
+                charset: options.charset.clone().unwrap_or_default(),
                 compression: options.compression as i32,
                 schema_infer_max_rec: options.schema_infer_max_rec.map(|v| v as u64),
                 date_format: options.date_format.clone().unwrap_or_default(),
@@ -105,8 +105,8 @@ impl From<&CsvOptionsProto> for CsvOptions {
             } else {
                 None
             },
-            encoding: if !proto.encoding.is_empty() {
-                Some(proto.encoding.clone())
+            charset: if !proto.charset.is_empty() {
+                Some(proto.charset.clone())
             } else {
                 None
             },


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/20473

## Rationale for this change

CSV is a ubiquitous file format, and many are encoded in Windows-1252 and other encodings. It would be useful to have the option to read them in datafusion.

## What changes are included in this PR?

* Adds a configuration option to the CSV reader to specify an encoding
* Adds an optional dependency on `encoding_rs` to do the actual decoding
* Refactored `CsvSource` somewhat to aid the implementation
* Removed the return value from `DecoderDeserializer::digest` as it was misleading (call sites were ignoring it)

## Are these changes tested?

I have added one unit test that attempts to read a SHIFT-JIS encoded CSV file. More tests are probably needed, but I may need some guidance on this. I'm also running into issues getting the test suite to run locally on my Windows machine.

## Are there any user-facing changes?

Adds a new field to `CsvOptions`.