### PR TITLE
Fix custom metric display

### DIFF
--- a/datafusion/physical-expr-common/src/metrics/value.rs
+++ b/datafusion/physical-expr-common/src/metrics/value.rs
@@ -1050,8 +1050,8 @@ impl Display for MetricValue {
                 write!(f, "{pruning_metrics}")
             }
             Self::Ratio { ratio_metrics, .. } => write!(f, "{ratio_metrics}"),
-            Self::Custom { name, value } => {
-                write!(f, "name:{name} {value}")
+            Self::Custom { value, .. } => {
+                write!(f, "{value}")
             }
         }
     }
@@ -1144,6 +1144,12 @@ mod tests {
         } else {
             panic!("Unexpected value");
         }
+    }
+
+    #[test]
+    fn test_display_custom_metric() {
+        let custom_val = new_custom_counter("hi", 11);
+        assert_eq!(custom_val.to_string(), "count: 11");
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes part of https://github.com/datafusion-contrib/datafusion-distributed/issues/361.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The custom metrics display is unnecessarily prepending the name of the metric during the display:

```
network_latency_min_2=name:network_latency_min 274.88µs
```

When it should just be:
```
network_latency_min_2=274.88µs
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix to the display

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

yes, by a new test

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
