### PR TITLE
[branch-53] fix: make the `sql` feature truly optional (#20625)

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -88,8 +88,8 @@ recursive_protection = [
     "datafusion-optimizer/recursive_protection",
     "datafusion-physical-optimizer/recursive_protection",
     "datafusion-physical-expr/recursive_protection",
-    "datafusion-sql/recursive_protection",
-    "sqlparser/recursive-protection",
+    "datafusion-sql?/recursive_protection",
+    "sqlparser?/recursive-protection",
 ]
 serde = [
     "dep:serde",


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Backport for https://github.com/apache/datafusion/pull/20625

When enabling the `recursive_protection` feature for the `datafusion` crate, the `sql` feature is enabled. This is undesirable if the downstream project would like the `sql` feature to be off.

## What changes are included in this PR?

Use the `?` syntax for features of dependencies for `recursive_protection`. This was already correctly done for other features such as `unicode_expressions`.

<https://doc.rust-lang.org/cargo/reference/features.html>

## Are these changes tested?

N/A

## Are there any user-facing changes?

This makes dependency management better for downstream projects and is not a breaking change.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
