### PR TITLE
perf: short-circuit and collect_bool for IN list with column references

### DIFF
--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -853,7 +853,7 @@ impl PhysicalExpr for InListExpr {
                 for expr in self.list.iter().skip(1) {
                     // Short-circuit: if every non-null row is already true,
                     // no further list items can change the result.
-                    if found.true_count() == num_rows {
+                    if found.null_count() == 0 && found.true_count() == num_rows {
                         break;
                     }
                     found = or_kleene(&found, &compare_one(expr)?)?;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #20428 .

## Rationale for this change

  Third PR in the IN list optimization series (split from #20428):
  - PR1: benchmarks (#20444, merged)
  - PR2: Arrow vectorized eq kernel (#20528, merged)
  - **PR3 (this): short-circuit, collect_bool, and first-expr initialization**

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
  - **Short-circuit break**: convert `try_fold` to `for` loop; when all non-null rows are already `true`, skip remaining list items (up to 27x faster for match=100%/nulls=0%)
  - **`BooleanBuffer::collect_bool`**: use in `make_comparator` fallback path for nested types instead `(0..n).map().collect()` (suggested by @Dandandan in #20428 )
  - **First-expr initialization**: evaluate the first list expression directly as the accumulator, avoiding a redundant `or_kleene(all_false, rhs)` (suggested by @Dandandan in #20428 )
  - **Tests**: added 3 new tests covering short-circuit, short-circuit with nulls, and struct column references (make_comparator fallback path)

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested? 
Yes, and add test to cover short-circuit, short-circuit with nulls, and struct column references (make_comparator fallback path)

Benchmark result:
```
(zhangxffff) zhangxffff@95d3d60664da ~/W/datafusion ((bcc52cd4))> critcmp after before
group                                              after                                  before
-----                                              -----                                  ------
in_list_cols/Int32/list=28/match=0%/nulls=0%       1.02     93.8±1.80µs        ? ?/sec    1.00     91.8±1.52µs        ? ?/sec
in_list_cols/Int32/list=28/match=0%/nulls=20%      1.03    105.3±1.95µs        ? ?/sec    1.00    102.2±1.59µs        ? ?/sec
in_list_cols/Int32/list=28/match=100%/nulls=0%     1.00      3.4±0.07µs        ? ?/sec    27.14    91.7±1.52µs        ? ?/sec
in_list_cols/Int32/list=28/match=100%/nulls=20%    1.07    107.7±1.91µs        ? ?/sec    1.00    100.4±1.33µs        ? ?/sec
in_list_cols/Int32/list=28/match=50%/nulls=0%      1.00     50.1±1.15µs        ? ?/sec    1.84     92.4±1.36µs        ? ?/sec
in_list_cols/Int32/list=28/match=50%/nulls=20%     1.05    105.1±1.49µs        ? ?/sec    1.00    100.0±0.84µs        ? ?/sec
in_list_cols/Int32/list=3/match=0%/nulls=0%        1.00      9.9±0.17µs        ? ?/sec    1.01     10.1±0.19µs        ? ?/sec
in_list_cols/Int32/list=3/match=0%/nulls=20%       1.02     11.0±0.18µs        ? ?/sec    1.00     10.8±0.16µs        ? ?/sec
in_list_cols/Int32/list=3/match=100%/nulls=0%      1.00      3.3±0.06µs        ? ?/sec    2.95      9.9±0.16µs        ? ?/sec
in_list_cols/Int32/list=3/match=100%/nulls=20%     1.01     10.9±0.19µs        ? ?/sec    1.00     10.8±0.09µs        ? ?/sec
in_list_cols/Int32/list=3/match=50%/nulls=0%       1.00     10.0±0.17µs        ? ?/sec    1.00      9.9±0.18µs        ? ?/sec
in_list_cols/Int32/list=3/match=50%/nulls=20%      1.05     11.3±0.24µs        ? ?/sec    1.00     10.8±0.11µs        ? ?/sec
in_list_cols/Int32/list=8/match=0%/nulls=0%        1.02     26.7±0.58µs        ? ?/sec    1.00     26.2±0.50µs        ? ?/sec
in_list_cols/Int32/list=8/match=0%/nulls=20%       1.04     29.6±0.57µs        ? ?/sec    1.00     28.5±0.45µs        ? ?/sec
in_list_cols/Int32/list=8/match=100%/nulls=0%      1.00      3.4±0.05µs        ? ?/sec    7.78     26.2±0.36µs        ? ?/sec
in_list_cols/Int32/list=8/match=100%/nulls=20%     1.05     30.0±0.65µs        ? ?/sec    1.00     28.7±0.55µs        ? ?/sec
in_list_cols/Int32/list=8/match=50%/nulls=0%       1.03     26.7±0.59µs        ? ?/sec    1.00     26.0±0.37µs        ? ?/sec
in_list_cols/Int32/list=8/match=50%/nulls=20%      1.04     29.9±0.57µs        ? ?/sec    1.00     28.7±0.46µs        ? ?/sec
in_list_cols/Utf8/list=28/match=0%                 1.17    155.0±2.44µs        ? ?/sec    1.00    132.8±2.97µs        ? ?/sec
in_list_cols/Utf8/list=28/match=100%               1.02   726.6±14.54µs        ? ?/sec    1.00    712.4±9.09µs        ? ?/sec
in_list_cols/Utf8/list=28/match=50%                1.02  1070.1±13.06µs        ? ?/sec    1.00   1051.8±8.17µs        ? ?/sec
in_list_cols/Utf8/list=3/match=0%                  1.14     16.4±0.37µs        ? ?/sec    1.00     14.4±0.22µs        ? ?/sec
in_list_cols/Utf8/list=3/match=100%                1.02     68.0±1.29µs        ? ?/sec    1.00     66.5±0.99µs        ? ?/sec
in_list_cols/Utf8/list=3/match=50%                 1.15    107.6±2.05µs        ? ?/sec    1.00     93.6±1.88µs        ? ?/sec
in_list_cols/Utf8/list=8/match=0%                  1.16     44.0±0.61µs        ? ?/sec    1.00     37.9±0.95µs        ? ?/sec
in_list_cols/Utf8/list=8/match=100%                1.00    190.4±2.71µs        ? ?/sec    1.03    195.7±2.01µs        ? ?/sec
in_list_cols/Utf8/list=8/match=50%                 1.03    295.9±4.45µs        ? ?/sec    1.00    287.3±3.26µs        ? ?/sec
```

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
