### PR TITLE
Used constant with mapping instead of write! to display scalar value bytes 

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -26,6 +26,7 @@ use std::cmp::Ordering;
 use std::collections::{HashSet, VecDeque};
 use std::convert::Infallible;
 use std::fmt;
+use std::fmt::Write;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::iter::repeat_n;
@@ -4959,8 +4960,10 @@ impl fmt::Display for ScalarValue {
             | ScalarValue::BinaryView(e) => match e {
                 Some(bytes) => {
                     // print up to first 10 bytes, with trailing ... if needed
+                    const HEX_CHARS_UPPER: &[u8; 16] = b"0123456789ABCDEF";
                     for b in bytes.iter().take(10) {
-                        write!(f, "{b:02X}")?;
+                        f.write_char(HEX_CHARS_UPPER[(b >> 4) as usize] as char)?;
+                        f.write_char(HEX_CHARS_UPPER[(b & 0x0f) as usize] as char)?;
                     }
                     if bytes.len() > 10 {
                         write!(f, "...")?;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #19569.

## Rationale for this change
This was the latest usage as far as I can see so I've changed it. I think this is not on the hot path so if you want we can close the PR and issue with it. 

## What changes are included in this PR?
Instead of using write! format string write hex with using constant char mapping

## Are these changes tested?
Runned debug display tests:
```
running 1 test
test scalar::tests::test_binary_display ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 364 filtered out; finished in 0.00s
```


## Are there any user-facing changes?
No