### PR TITLE
Support `UPDATE ... FROM` and preserve source-qualified assignments

### DIFF
--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -25,10 +25,11 @@ use std::sync::Arc;
 use crate::TableProvider;
 
 use arrow::array::{
-    Array, ArrayRef, BooleanArray, RecordBatch as ArrowRecordBatch, UInt64Array,
+    Array, ArrayRef, BooleanArray, MutableArrayData, RecordBatch as ArrowRecordBatch,
+    UInt64Array, make_array,
 };
 use arrow::compute::kernels::zip::zip;
-use arrow::compute::{and, filter_record_batch};
+use arrow::compute::{and, concat_batches, filter_record_batch};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::error::Result;
@@ -47,7 +48,7 @@ use datafusion_physical_plan::repartition::RepartitionExec;
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
-    PhysicalExpr, PlanProperties, common,
+    PhysicalExpr, PlanProperties, collect, common,
 };
 use datafusion_session::Session;
 
@@ -500,6 +501,155 @@ impl TableProvider for MemTable {
 
         Ok(Arc::new(DmlResultExec::new(total_updated)))
     }
+
+    async fn update_from(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        filters: Vec<Expr>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if self.batches.is_empty() {
+            return Ok(Arc::new(DmlResultExec::new(0)));
+        }
+
+        self.schema()
+            .logically_equivalent_names_and_types(&input.schema())?;
+
+        let replacement_batches = collect(input, state.task_ctx()).await?;
+        let replacement_row_count = replacement_batches
+            .iter()
+            .map(ArrowRecordBatch::num_rows)
+            .sum::<usize>();
+
+        *self.sort_order.lock() = vec![];
+
+        let replacement_batch = if replacement_row_count == 0 {
+            ArrowRecordBatch::new_empty(Arc::clone(&self.schema))
+        } else {
+            concat_batches(&self.schema, &replacement_batches)?
+        };
+
+        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
+        let mut expected_updates = 0usize;
+
+        for partition_data in &self.batches {
+            let partition = partition_data.read().await;
+            for batch in partition.iter() {
+                let filter_mask = evaluate_filters_to_mask(
+                    &filters,
+                    batch,
+                    &df_schema,
+                    state.execution_props(),
+                )?;
+                let update_count = match filter_mask {
+                    Some(mask) => mask.iter().filter(|v| v == &Some(true)).count(),
+                    None => batch.num_rows(),
+                };
+                expected_updates += update_count;
+            }
+        }
+
+        if expected_updates != replacement_row_count {
+            return plan_err!(
+                "UPDATE ... FROM produced {replacement_row_count} replacement rows but target filters matched {expected_updates} rows"
+            );
+        }
+
+        let mut replace_cursor = 0usize;
+
+        for partition_data in &self.batches {
+            let mut partition = partition_data.write().await;
+            let mut new_batches = Vec::with_capacity(partition.len());
+
+            for batch in partition.iter() {
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+
+                let filter_mask = evaluate_filters_to_mask(
+                    &filters,
+                    batch,
+                    &df_schema,
+                    state.execution_props(),
+                )?;
+
+                let (update_count, update_mask) = match filter_mask {
+                    Some(mask) => {
+                        let count = mask.iter().filter(|v| v == &Some(true)).count();
+                        let normalized: BooleanArray =
+                            mask.iter().map(|v| Some(v == Some(true))).collect();
+                        (count, normalized)
+                    }
+                    None => (
+                        batch.num_rows(),
+                        BooleanArray::from(vec![true; batch.num_rows()]),
+                    ),
+                };
+
+                if update_count == 0 {
+                    new_batches.push(batch.clone());
+                    continue;
+                }
+
+                let mut new_columns = Vec::with_capacity(batch.num_columns());
+                for column_idx in 0..batch.num_columns() {
+                    let original_column = batch.column(column_idx);
+                    let replacement_segment = replacement_batch
+                        .column(column_idx)
+                        .slice(replace_cursor, update_count);
+                    let merged = merge_with_update_mask(
+                        original_column,
+                        replacement_segment.as_ref(),
+                        &update_mask,
+                    )?;
+                    new_columns.push(merged);
+                }
+
+                replace_cursor += update_count;
+                let updated_batch =
+                    ArrowRecordBatch::try_new(Arc::clone(&self.schema), new_columns)?;
+                new_batches.push(updated_batch);
+            }
+
+            *partition = new_batches;
+        }
+
+        Ok(Arc::new(DmlResultExec::new(expected_updates as u64)))
+    }
+}
+
+fn merge_with_update_mask(
+    original: &ArrayRef,
+    replacement_rows: &dyn Array,
+    update_mask: &BooleanArray,
+) -> Result<ArrayRef> {
+    let original_data = original.to_data();
+    let replacement_data = replacement_rows.to_data();
+    let mut mutable = MutableArrayData::new(
+        vec![&original_data, &replacement_data],
+        false,
+        update_mask.len(),
+    );
+    let mut replacement_idx = 0usize;
+
+    for row_idx in 0..update_mask.len() {
+        if update_mask.value(row_idx) {
+            mutable.extend(1, replacement_idx, replacement_idx + 1);
+            replacement_idx += 1;
+        } else {
+            mutable.extend(0, row_idx, row_idx + 1);
+        }
+    }
+
+    if replacement_idx != replacement_rows.len() {
+        return plan_err!(
+            "Invalid UPDATE ... FROM replacement rows: expected {}, consumed {}",
+            replacement_rows.len(),
+            replacement_idx
+        );
+    }
+
+    Ok(make_array(mutable.freeze()))
 }
 
 /// Evaluate filter expressions against a batch and return a combined boolean mask.

--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -41,7 +41,7 @@ use datafusion_common_runtime::JoinSet;
 use datafusion_datasource::memory::{MemSink, MemorySourceConfig};
 use datafusion_datasource::sink::DataSinkExec;
 use datafusion_datasource::source::DataSourceExec;
-use datafusion_expr::dml::InsertOp;
+use datafusion_expr::dml::{InsertOp, update_from_old_column_name};
 use datafusion_expr::{Expr, SortExpr, TableType};
 use datafusion_physical_expr::{
     LexOrdering, create_physical_expr, create_physical_sort_exprs,
@@ -62,8 +62,6 @@ use tokio::sync::RwLock;
 
 // backward compatibility
 pub use datafusion_datasource::memory::PartitionData;
-
-const UPDATE_FROM_OLD_COLUMN_PREFIX: &str = "__df_update_old_";
 
 /// In-memory data source for presenting a `Vec<RecordBatch>` as a
 /// data source that can be queried by DataFusion. This allows data to
@@ -735,10 +733,6 @@ fn merge_with_replacement_indices(
     }
 
     Ok(make_array(mutable.freeze()))
-}
-
-fn update_from_old_column_name(column_name: &str) -> String {
-    format!("{UPDATE_FROM_OLD_COLUMN_PREFIX}{column_name}")
 }
 
 /// Evaluate filter expressions against a batch and return a combined boolean mask.

--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -18,7 +18,7 @@
 //! [`MemTable`] for querying `Vec<RecordBatch>` by DataFusion.
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -34,7 +34,9 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::error::Result;
 use datafusion_common::tree_node::TreeNodeRecursion;
-use datafusion_common::{Constraints, DFSchema, SchemaExt, not_impl_err, plan_err};
+use datafusion_common::{
+    Constraints, DFSchema, ScalarValue, SchemaExt, not_impl_err, plan_err,
+};
 use datafusion_common_runtime::JoinSet;
 use datafusion_datasource::memory::{MemSink, MemorySourceConfig};
 use datafusion_datasource::sink::DataSinkExec;
@@ -60,6 +62,8 @@ use tokio::sync::RwLock;
 
 // backward compatibility
 pub use datafusion_datasource::memory::PartitionData;
+
+const UPDATE_FROM_OLD_COLUMN_PREFIX: &str = "__df_update_old_";
 
 /// In-memory data source for presenting a `Vec<RecordBatch>` as a
 /// data source that can be queried by DataFusion. This allows data to
@@ -506,20 +510,39 @@ impl TableProvider for MemTable {
         &self,
         state: &dyn Session,
         input: Arc<dyn ExecutionPlan>,
-        filters: Vec<Expr>,
+        _filters: Vec<Expr>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if self.batches.is_empty() {
             return Ok(Arc::new(DmlResultExec::new(0)));
         }
 
-        self.schema()
-            .logically_equivalent_names_and_types(&input.schema())?;
+        validate_update_from_input_schema(&self.schema, &input.schema())?;
 
-        let replacement_batches = collect(input, state.task_ctx()).await?;
-        let replacement_row_count = replacement_batches
-            .iter()
-            .map(ArrowRecordBatch::num_rows)
-            .sum::<usize>();
+        let input_batches = collect(input, state.task_ctx()).await?;
+        let mut original_row_matches: HashMap<Vec<ScalarValue>, VecDeque<usize>> =
+            HashMap::new();
+        let mut replacement_batches = Vec::with_capacity(input_batches.len());
+        let mut replacement_row_count = 0usize;
+
+        for batch in input_batches {
+            replacement_row_count += batch.num_rows();
+            let replacement_batch = ArrowRecordBatch::try_new(
+                Arc::clone(&self.schema),
+                replacement_columns(&batch, self.schema.fields().len()),
+            )?;
+
+            for row_idx in 0..batch.num_rows() {
+                original_row_matches
+                    .entry(row_signature(
+                        original_columns(&batch, self.schema.fields().len()),
+                        row_idx,
+                    )?)
+                    .or_default()
+                    .push_back(replacement_row_count - batch.num_rows() + row_idx);
+            }
+
+            replacement_batches.push(replacement_batch);
+        }
 
         *self.sort_order.lock() = vec![];
 
@@ -528,34 +551,7 @@ impl TableProvider for MemTable {
         } else {
             concat_batches(&self.schema, &replacement_batches)?
         };
-
-        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
-        let mut expected_updates = 0usize;
-
-        for partition_data in &self.batches {
-            let partition = partition_data.read().await;
-            for batch in partition.iter() {
-                let filter_mask = evaluate_filters_to_mask(
-                    &filters,
-                    batch,
-                    &df_schema,
-                    state.execution_props(),
-                )?;
-                let update_count = match filter_mask {
-                    Some(mask) => mask.iter().filter(|v| v == &Some(true)).count(),
-                    None => batch.num_rows(),
-                };
-                expected_updates += update_count;
-            }
-        }
-
-        if expected_updates != replacement_row_count {
-            return plan_err!(
-                "UPDATE ... FROM produced {replacement_row_count} replacement rows but target filters matched {expected_updates} rows"
-            );
-        }
-
-        let mut replace_cursor = 0usize;
+        let mut matched_updates = 0usize;
 
         for partition_data in &self.batches {
             let mut partition = partition_data.write().await;
@@ -566,90 +562,183 @@ impl TableProvider for MemTable {
                     continue;
                 }
 
-                let filter_mask = evaluate_filters_to_mask(
-                    &filters,
-                    batch,
-                    &df_schema,
-                    state.execution_props(),
-                )?;
-
-                let (update_count, update_mask) = match filter_mask {
-                    Some(mask) => {
-                        let count = mask.iter().filter(|v| v == &Some(true)).count();
-                        let normalized: BooleanArray =
-                            mask.iter().map(|v| Some(v == Some(true))).collect();
-                        (count, normalized)
-                    }
-                    None => (
-                        batch.num_rows(),
-                        BooleanArray::from(vec![true; batch.num_rows()]),
-                    ),
-                };
+                let replacement_indices =
+                    find_replacement_indices(batch, &mut original_row_matches)?;
+                let update_count = replacement_indices.iter().flatten().count();
 
                 if update_count == 0 {
                     new_batches.push(batch.clone());
                     continue;
                 }
 
-                let mut new_columns = Vec::with_capacity(batch.num_columns());
-                for column_idx in 0..batch.num_columns() {
-                    let original_column = batch.column(column_idx);
-                    let replacement_segment = replacement_batch
-                        .column(column_idx)
-                        .slice(replace_cursor, update_count);
-                    let merged = merge_with_update_mask(
-                        original_column,
-                        replacement_segment.as_ref(),
-                        &update_mask,
-                    )?;
-                    new_columns.push(merged);
-                }
-
-                replace_cursor += update_count;
-                let updated_batch =
-                    ArrowRecordBatch::try_new(Arc::clone(&self.schema), new_columns)?;
+                matched_updates += update_count;
+                let updated_batch = build_updated_batch_from_replacement_indices(
+                    batch,
+                    &replacement_batch,
+                    &replacement_indices,
+                    &self.schema,
+                )?;
                 new_batches.push(updated_batch);
             }
 
             *partition = new_batches;
         }
 
-        Ok(Arc::new(DmlResultExec::new(expected_updates as u64)))
+        if matched_updates != replacement_row_count {
+            return plan_err!(
+                "UPDATE ... FROM produced {replacement_row_count} replacement rows but matched {matched_updates} target rows"
+            );
+        }
+
+        Ok(Arc::new(DmlResultExec::new(matched_updates as u64)))
     }
 }
 
-fn merge_with_update_mask(
+fn validate_update_from_input_schema(
+    target_schema: &SchemaRef,
+    input_schema: &SchemaRef,
+) -> Result<()> {
+    let target_fields = target_schema.fields();
+    let input_fields = input_schema.fields();
+    let expected_len = target_fields.len() * 2;
+
+    if input_fields.len() != expected_len {
+        return plan_err!(
+            "Invalid UPDATE ... FROM input schema: expected {expected_len} columns, got {}",
+            input_fields.len()
+        );
+    }
+
+    for (idx, target_field) in target_fields.iter().enumerate() {
+        let replacement_field = &input_fields[idx];
+        if replacement_field.name() != target_field.name()
+            || replacement_field.data_type() != target_field.data_type()
+        {
+            return plan_err!(
+                "Invalid UPDATE ... FROM replacement column at index {idx}: expected '{}', got '{}'",
+                target_field.name(),
+                replacement_field.name()
+            );
+        }
+
+        let original_field = &input_fields[idx + target_fields.len()];
+        let expected_original_name = update_from_old_column_name(target_field.name());
+        if original_field.name() != &expected_original_name
+            || original_field.data_type() != target_field.data_type()
+        {
+            return plan_err!(
+                "Invalid UPDATE ... FROM original row column at index {}: expected '{}', got '{}'",
+                idx + target_fields.len(),
+                expected_original_name,
+                original_field.name()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn replacement_columns(
+    batch: &ArrowRecordBatch,
+    target_column_count: usize,
+) -> Vec<ArrayRef> {
+    (0..target_column_count)
+        .map(|idx| Arc::clone(batch.column(idx)))
+        .collect()
+}
+
+fn original_columns(batch: &ArrowRecordBatch, target_column_count: usize) -> &[ArrayRef] {
+    &batch.columns()[target_column_count..]
+}
+
+fn row_signature(columns: &[ArrayRef], row_idx: usize) -> Result<Vec<ScalarValue>> {
+    columns
+        .iter()
+        .map(|column| ScalarValue::try_from_array(column, row_idx))
+        .collect()
+}
+
+fn find_replacement_indices(
+    batch: &ArrowRecordBatch,
+    original_row_matches: &mut HashMap<Vec<ScalarValue>, VecDeque<usize>>,
+) -> Result<Vec<Option<usize>>> {
+    let mut replacement_indices = Vec::with_capacity(batch.num_rows());
+
+    for row_idx in 0..batch.num_rows() {
+        let signature = row_signature(batch.columns(), row_idx)?;
+        let replacement_idx =
+            if let Some(indices) = original_row_matches.get_mut(&signature) {
+                let next = indices.pop_front();
+                let should_remove = indices.is_empty();
+                if should_remove {
+                    original_row_matches.remove(&signature);
+                }
+                next
+            } else {
+                None
+            };
+        replacement_indices.push(replacement_idx);
+    }
+
+    Ok(replacement_indices)
+}
+
+fn build_updated_batch_from_replacement_indices(
+    batch: &ArrowRecordBatch,
+    replacement_batch: &ArrowRecordBatch,
+    replacement_indices: &[Option<usize>],
+    schema: &SchemaRef,
+) -> Result<ArrowRecordBatch> {
+    let mut new_columns = Vec::with_capacity(batch.num_columns());
+    for column_idx in 0..batch.num_columns() {
+        let original_column = batch.column(column_idx);
+        let merged = merge_with_replacement_indices(
+            original_column,
+            replacement_batch.column(column_idx).as_ref(),
+            replacement_indices,
+        )?;
+        new_columns.push(merged);
+    }
+
+    Ok(ArrowRecordBatch::try_new(Arc::clone(schema), new_columns)?)
+}
+
+fn merge_with_replacement_indices(
     original: &ArrayRef,
     replacement_rows: &dyn Array,
-    update_mask: &BooleanArray,
+    replacement_indices: &[Option<usize>],
 ) -> Result<ArrayRef> {
     let original_data = original.to_data();
     let replacement_data = replacement_rows.to_data();
     let mut mutable = MutableArrayData::new(
         vec![&original_data, &replacement_data],
         false,
-        update_mask.len(),
+        replacement_indices.len(),
     );
-    let mut replacement_idx = 0usize;
+    let mut consumed_replacement_rows = 0usize;
 
-    for row_idx in 0..update_mask.len() {
-        if update_mask.value(row_idx) {
-            mutable.extend(1, replacement_idx, replacement_idx + 1);
-            replacement_idx += 1;
+    for (row_idx, replacement_idx) in replacement_indices.iter().enumerate() {
+        if let Some(replacement_idx) = replacement_idx {
+            mutable.extend(1, *replacement_idx, *replacement_idx + 1);
+            consumed_replacement_rows += 1;
         } else {
             mutable.extend(0, row_idx, row_idx + 1);
         }
     }
 
-    if replacement_idx != replacement_rows.len() {
+    if consumed_replacement_rows > replacement_rows.len() {
         return plan_err!(
             "Invalid UPDATE ... FROM replacement rows: expected {}, consumed {}",
             replacement_rows.len(),
-            replacement_idx
+            consumed_replacement_rows
         );
     }
 
     Ok(make_array(mutable.freeze()))
+}
+
+fn update_from_old_column_name(column_name: &str) -> String {
+    format!("{UPDATE_FROM_OLD_COLUMN_PREFIX}{column_name}")
 }
 
 /// Evaluate filter expressions against a batch and return a combined boolean mask.

--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -599,7 +599,8 @@ fn validate_update_from_input_schema(
 ) -> Result<()> {
     let target_fields = target_schema.fields();
     let input_fields = input_schema.fields();
-    let expected_len = target_fields.len() * 2;
+    let target_field_count = target_fields.len();
+    let expected_len = target_field_count * 2;
 
     if input_fields.len() != expected_len {
         return plan_err!(
@@ -608,8 +609,11 @@ fn validate_update_from_input_schema(
         );
     }
 
-    for (idx, target_field) in target_fields.iter().enumerate() {
-        let replacement_field = &input_fields[idx];
+    for (idx, (target_field, replacement_field)) in target_fields
+        .iter()
+        .zip(&input_fields[..target_field_count])
+        .enumerate()
+    {
         if replacement_field.name() != target_field.name()
             || replacement_field.data_type() != target_field.data_type()
         {
@@ -620,14 +624,15 @@ fn validate_update_from_input_schema(
             );
         }
 
-        let original_field = &input_fields[idx + target_fields.len()];
+        let original_idx = idx + target_field_count;
+        let original_field = &input_fields[original_idx];
         let expected_original_name = update_from_old_column_name(target_field.name());
         if original_field.name() != &expected_original_name
             || original_field.data_type() != target_field.data_type()
         {
             return plan_err!(
                 "Invalid UPDATE ... FROM original row column at index {}: expected '{}', got '{}'",
-                idx + target_fields.len(),
+                original_idx,
                 expected_original_name,
                 original_field.name()
             );
@@ -651,17 +656,16 @@ fn find_replacement_indices(
 
     for row_idx in 0..batch.num_rows() {
         let signature = row_signature(batch.columns(), row_idx)?;
-        let replacement_idx =
-            if let Some(indices) = original_row_matches.get_mut(&signature) {
+        let replacement_idx = match original_row_matches.get_mut(&signature) {
+            Some(indices) => {
                 let next = indices.pop_front();
-                let should_remove = indices.is_empty();
-                if should_remove {
+                if indices.is_empty() {
                     original_row_matches.remove(&signature);
                 }
                 next
-            } else {
-                None
-            };
+            }
+            None => None,
+        };
         replacement_indices.push(replacement_idx);
     }
 

--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -650,24 +650,21 @@ fn find_replacement_indices(
     batch: &ArrowRecordBatch,
     original_row_matches: &mut HashMap<Vec<ScalarValue>, VecDeque<usize>>,
 ) -> Result<Vec<Option<usize>>> {
-    let mut replacement_indices = Vec::with_capacity(batch.num_rows());
-
-    for row_idx in 0..batch.num_rows() {
-        let signature = row_signature(batch.columns(), row_idx)?;
-        let replacement_idx = match original_row_matches.get_mut(&signature) {
-            Some(indices) => {
-                let next = indices.pop_front();
-                if indices.is_empty() {
-                    original_row_matches.remove(&signature);
+    (0..batch.num_rows())
+        .map(|row_idx| {
+            let signature = row_signature(batch.columns(), row_idx)?;
+            Ok(match original_row_matches.get_mut(&signature) {
+                Some(indices) => {
+                    let next = indices.pop_front();
+                    if indices.is_empty() {
+                        original_row_matches.remove(&signature);
+                    }
+                    next
                 }
-                next
-            }
-            None => None,
-        };
-        replacement_indices.push(replacement_idx);
-    }
-
-    Ok(replacement_indices)
+                None => None,
+            })
+        })
+        .collect()
 }
 
 fn build_updated_batch_from_replacement_indices(

--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -565,19 +565,17 @@ impl TableProvider for MemTable {
                     find_replacement_indices(batch, &mut original_row_matches)?;
                 let update_count = replacement_indices.iter().flatten().count();
 
-                if update_count == 0 {
-                    new_batches.push(batch.clone());
-                    continue;
-                }
-
                 matched_updates += update_count;
-                let updated_batch = build_updated_batch_from_replacement_indices(
-                    batch,
-                    &replacement_batch,
-                    &replacement_indices,
-                    &self.schema,
-                )?;
-                new_batches.push(updated_batch);
+                new_batches.push(if update_count == 0 {
+                    batch.clone()
+                } else {
+                    build_updated_batch_from_replacement_indices(
+                        batch,
+                        &replacement_batch,
+                        &replacement_indices,
+                        &self.schema,
+                    )?
+                });
             }
 
             *partition = new_batches;
@@ -609,9 +607,11 @@ fn validate_update_from_input_schema(
         );
     }
 
-    for (idx, (target_field, replacement_field)) in target_fields
+    let (replacement_fields, original_fields) = input_fields.split_at(target_field_count);
+    for (idx, ((target_field, replacement_field), original_field)) in target_fields
         .iter()
-        .zip(&input_fields[..target_field_count])
+        .zip(replacement_fields)
+        .zip(original_fields)
         .enumerate()
     {
         if replacement_field.name() != target_field.name()
@@ -624,15 +624,13 @@ fn validate_update_from_input_schema(
             );
         }
 
-        let original_idx = idx + target_field_count;
-        let original_field = &input_fields[original_idx];
         let expected_original_name = update_from_old_column_name(target_field.name());
         if original_field.name() != &expected_original_name
             || original_field.data_type() != target_field.data_type()
         {
             return plan_err!(
                 "Invalid UPDATE ... FROM original row column at index {}: expected '{}', got '{}'",
-                original_idx,
+                idx + target_field_count,
                 expected_original_name,
                 original_field.name()
             );

--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -517,34 +517,35 @@ impl TableProvider for MemTable {
         validate_update_from_input_schema(&self.schema, &input.schema())?;
 
         let input_batches = collect(input, state.task_ctx()).await?;
+        let target_column_count = self.schema.fields().len();
         let mut original_row_matches: HashMap<Vec<ScalarValue>, VecDeque<usize>> =
             HashMap::new();
         let mut replacement_batches = Vec::with_capacity(input_batches.len());
-        let mut replacement_row_count = 0usize;
+        let mut next_replacement_idx = 0usize;
 
         for batch in input_batches {
-            replacement_row_count += batch.num_rows();
+            let row_count = batch.num_rows();
+            let (replacement_columns, original_columns) =
+                batch.columns().split_at(target_column_count);
             let replacement_batch = ArrowRecordBatch::try_new(
                 Arc::clone(&self.schema),
-                replacement_columns(&batch, self.schema.fields().len()),
+                replacement_columns.to_vec(),
             )?;
 
-            for row_idx in 0..batch.num_rows() {
+            for row_idx in 0..row_count {
                 original_row_matches
-                    .entry(row_signature(
-                        original_columns(&batch, self.schema.fields().len()),
-                        row_idx,
-                    )?)
+                    .entry(row_signature(original_columns, row_idx)?)
                     .or_default()
-                    .push_back(replacement_row_count - batch.num_rows() + row_idx);
+                    .push_back(next_replacement_idx + row_idx);
             }
 
             replacement_batches.push(replacement_batch);
+            next_replacement_idx += row_count;
         }
 
         *self.sort_order.lock() = vec![];
 
-        let replacement_batch = if replacement_row_count == 0 {
+        let replacement_batch = if next_replacement_idx == 0 {
             ArrowRecordBatch::new_empty(Arc::clone(&self.schema))
         } else {
             concat_batches(&self.schema, &replacement_batches)?
@@ -582,9 +583,9 @@ impl TableProvider for MemTable {
             *partition = new_batches;
         }
 
-        if matched_updates != replacement_row_count {
+        if matched_updates != next_replacement_idx {
             return plan_err!(
-                "UPDATE ... FROM produced {replacement_row_count} replacement rows but matched {matched_updates} target rows"
+                "UPDATE ... FROM produced {next_replacement_idx} replacement rows but matched {matched_updates} target rows"
             );
         }
 
@@ -635,20 +636,6 @@ fn validate_update_from_input_schema(
 
     Ok(())
 }
-
-fn replacement_columns(
-    batch: &ArrowRecordBatch,
-    target_column_count: usize,
-) -> Vec<ArrayRef> {
-    (0..target_column_count)
-        .map(|idx| Arc::clone(batch.column(idx)))
-        .collect()
-}
-
-fn original_columns(batch: &ArrowRecordBatch, target_column_count: usize) -> &[ArrayRef] {
-    &batch.columns()[target_column_count..]
-}
-
 fn row_signature(columns: &[ArrayRef], row_idx: usize) -> Result<Vec<ScalarValue>> {
     columns
         .iter()
@@ -687,16 +674,15 @@ fn build_updated_batch_from_replacement_indices(
     replacement_indices: &[Option<usize>],
     schema: &SchemaRef,
 ) -> Result<ArrowRecordBatch> {
-    let mut new_columns = Vec::with_capacity(batch.num_columns());
-    for column_idx in 0..batch.num_columns() {
-        let original_column = batch.column(column_idx);
-        let merged = merge_with_replacement_indices(
-            original_column,
-            replacement_batch.column(column_idx).as_ref(),
-            replacement_indices,
-        )?;
-        new_columns.push(merged);
-    }
+    let new_columns = (0..batch.num_columns())
+        .map(|column_idx| {
+            merge_with_replacement_indices(
+                batch.column(column_idx),
+                replacement_batch.column(column_idx).as_ref(),
+                replacement_indices,
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(ArrowRecordBatch::try_new(Arc::clone(schema), new_columns)?)
 }
@@ -713,17 +699,16 @@ fn merge_with_replacement_indices(
         false,
         replacement_indices.len(),
     );
-    let mut consumed_replacement_rows = 0usize;
 
     for (row_idx, replacement_idx) in replacement_indices.iter().enumerate() {
         if let Some(replacement_idx) = replacement_idx {
             mutable.extend(1, *replacement_idx, *replacement_idx + 1);
-            consumed_replacement_rows += 1;
         } else {
             mutable.extend(0, row_idx, row_idx + 1);
         }
     }
 
+    let consumed_replacement_rows = replacement_indices.iter().flatten().count();
     if consumed_replacement_rows > replacement_rows.len() {
         return plan_err!(
             "Invalid UPDATE ... FROM replacement rows: expected {}, consumed {}",

--- a/datafusion/catalog/src/table.rs
+++ b/datafusion/catalog/src/table.rs
@@ -362,6 +362,16 @@ pub trait TableProvider: Debug + Sync + Send {
     /// This is used for multi-table `UPDATE ... FROM` statements where
     /// assignment expressions may reference external tables.
     ///
+    /// The `input` plan is expected to produce one row per matched target row with
+    /// a schema shaped as:
+    ///
+    /// 1. New target-row values, in target-table schema order
+    /// 2. Original target-row values, in target-table schema order
+    ///
+    /// Original-value columns must be named with
+    /// [`datafusion_expr::dml::update_from_old_column_name`] (prefix
+    /// [`datafusion_expr::dml::UPDATE_FROM_OLD_COLUMN_PREFIX`]).
+    ///
     /// Returns an [`ExecutionPlan`] producing a single row with `count` (UInt64).
     async fn update_from(
         &self,

--- a/datafusion/catalog/src/table.rs
+++ b/datafusion/catalog/src/table.rs
@@ -345,6 +345,9 @@ pub trait TableProvider: Debug + Sync + Send {
     ///
     /// Returns an [`ExecutionPlan`] producing a single row with `count` (UInt64).
     /// Empty `filters` updates all rows.
+    ///
+    /// Assignment expressions may include qualified column references for
+    /// multi-table UPDATE statements (for example, `UPDATE t1 SET c = t2.c FROM t2`).
     async fn update(
         &self,
         _state: &dyn Session,

--- a/datafusion/catalog/src/table.rs
+++ b/datafusion/catalog/src/table.rs
@@ -357,6 +357,24 @@ pub trait TableProvider: Debug + Sync + Send {
         not_impl_err!("UPDATE not supported for {} table", self.table_type())
     }
 
+    /// Update rows using precomputed row values from a physical input plan.
+    ///
+    /// This is used for multi-table `UPDATE ... FROM` statements where
+    /// assignment expressions may reference external tables.
+    ///
+    /// Returns an [`ExecutionPlan`] producing a single row with `count` (UInt64).
+    async fn update_from(
+        &self,
+        _state: &dyn Session,
+        _input: Arc<dyn ExecutionPlan>,
+        _filters: Vec<Expr>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        not_impl_err!(
+            "UPDATE ... FROM not supported for {} table",
+            self.table_type()
+        )
+    }
+
     /// Remove all rows from the table.
     ///
     /// Should return an [ExecutionPlan] producing a single row with count (UInt64),

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -781,41 +781,14 @@ impl DefaultPhysicalPlanner {
                 if let Some(provider) =
                     target.as_any().downcast_ref::<DefaultTableSource>()
                 {
-                    let filters = extract_dml_filters(input, table_name)?;
-                    if plan_contains_join(input)? {
-                        let input_exec = children.one()?;
-                        // `update_from` may execute the input plan eagerly as part of
-                        // table mutation. Ensure join partitioning modes (e.g. Auto)
-                        // are fully resolved before handing the plan to providers.
-                        let input_exec = self.optimize_physical_plan(
-                            input_exec,
-                            session_state,
-                            |_, _| {},
-                        )?;
-                        provider
-                            .table_provider
-                            .update_from(session_state, input_exec, filters)
-                            .await
-                            .map_err(|e| {
-                                e.context(format!(
-                                    "UPDATE operation on table '{table_name}'"
-                                ))
-                            })?
-                    } else {
-                        // For single-table UPDATE, assignments are encoded in the
-                        // projection of input and can be evaluated using only target
-                        // columns.
-                        let assignments = extract_update_assignments(input, table_name)?;
-                        provider
-                            .table_provider
-                            .update(session_state, assignments, filters)
-                            .await
-                            .map_err(|e| {
-                                e.context(format!(
-                                    "UPDATE operation on table '{table_name}'"
-                                ))
-                            })?
-                    }
+                    self.plan_update_with_provider(
+                        provider,
+                        table_name,
+                        input,
+                        session_state,
+                        children,
+                    )
+                    .await?
                 } else {
                     return exec_err!(
                         "Table source can't be downcasted to DefaultTableSource"
@@ -1800,6 +1773,45 @@ impl DefaultPhysicalPlanner {
             }
         };
         Ok(exec_node)
+    }
+
+    async fn plan_update_with_provider(
+        &self,
+        provider: &DefaultTableSource,
+        table_name: &TableReference,
+        input: &Arc<LogicalPlan>,
+        session_state: &SessionState,
+        children: ChildrenContainer,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let filters = extract_dml_filters(input, table_name)?;
+
+        if plan_contains_join(input)? {
+            let input_exec = children.one()?;
+            // `update_from` may execute the input plan eagerly as part of
+            // table mutation. Ensure join partitioning modes (e.g. Auto)
+            // are fully resolved before handing the plan to providers.
+            let input_exec =
+                self.optimize_physical_plan(input_exec, session_state, |_, _| {})?;
+            provider
+                .table_provider
+                .update_from(session_state, input_exec, filters)
+                .await
+                .map_err(|e| {
+                    e.context(format!("UPDATE operation on table '{table_name}'"))
+                })
+        } else {
+            // For single-table UPDATE, assignments are encoded in the
+            // projection of input and can be evaluated using only target
+            // columns.
+            let assignments = extract_update_assignments(input, table_name)?;
+            provider
+                .table_provider
+                .update(session_state, assignments, filters)
+                .await
+                .map_err(|e| {
+                    e.context(format!("UPDATE operation on table '{table_name}'"))
+                })
+        }
     }
 
     fn create_grouping_physical_expr(

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2128,9 +2128,10 @@ fn extract_dml_filters(
 ) -> Result<Vec<Expr>> {
     let mut filters = Vec::new();
     let mut allowed_refs = vec![target.clone()];
+    let target_branch = find_update_target_branch(input)?;
 
     // First pass: collect any alias references to the target table
-    input.apply(|node| {
+    target_branch.apply(|node| {
         if let LogicalPlan::SubqueryAlias(alias) = node
             // Check if this alias points to the target table
             && let LogicalPlan::TableScan(scan) = alias.input.as_ref()
@@ -2148,20 +2149,6 @@ fn extract_dml_filters(
                 for predicate in split_conjunction(&filter.predicate) {
                     if predicate_is_on_target_multi(predicate, &allowed_refs)? {
                         filters.push(predicate.clone());
-                    }
-                }
-            }
-            LogicalPlan::TableScan(TableScan {
-                table_name,
-                filters: scan_filters,
-                ..
-            }) => {
-                // Only extract filters from the target table scan.
-                // This prevents incorrect filter extraction in UPDATE...FROM scenarios
-                // where multiple table scans may have filters.
-                if table_name.resolved_eq(target) {
-                    for filter in scan_filters {
-                        filters.extend(split_conjunction(filter).into_iter().cloned());
                     }
                 }
             }
@@ -2188,12 +2175,28 @@ fn extract_dml_filters(
             | LogicalPlan::Sort(_)
             | LogicalPlan::Union(_)
             | LogicalPlan::Join(_)
+            | LogicalPlan::TableScan(_)
             | LogicalPlan::Repartition(_)
             | LogicalPlan::Aggregate(_)
             | LogicalPlan::Window(_)
             | LogicalPlan::Subquery(_) => {
                 // Filter information may appear in child nodes; continue traversal
                 // to extract filters from Filter/TableScan nodes deeper in the plan
+            }
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+
+    target_branch.apply(|node| {
+        if let LogicalPlan::TableScan(TableScan {
+            table_name,
+            filters: scan_filters,
+            ..
+        }) = node
+            && table_name.resolved_eq(target)
+        {
+            for filter in scan_filters {
+                filters.extend(split_conjunction(filter).into_iter().cloned());
             }
         }
         Ok(TreeNodeRecursion::Continue)
@@ -2376,34 +2379,67 @@ fn collect_update_target_references(
     input: &Arc<LogicalPlan>,
     target_table: &TableReference,
 ) -> Result<Vec<TableReference>> {
-    let mut refs = vec![target_table.clone()];
-    input.apply(|node| {
-        if let LogicalPlan::SubqueryAlias(alias) = node
-            && plan_contains_table_scan(&alias.input, target_table)?
-            && !refs.iter().any(|r| r.resolved_eq(&alias.alias))
-        {
-            refs.push(alias.alias.clone());
-        }
-        Ok(TreeNodeRecursion::Continue)
-    })?;
+    let mut refs = collect_update_target_branch_references(
+        find_update_target_branch(input)?,
+        target_table,
+    )?;
+    if !refs.iter().any(|r| r.resolved_eq(target_table)) {
+        refs.insert(0, target_table.clone());
+    }
     Ok(refs)
 }
 
-fn plan_contains_table_scan(
+fn find_update_target_branch(input: &Arc<LogicalPlan>) -> Result<&Arc<LogicalPlan>> {
+    match input.as_ref() {
+        LogicalPlan::Projection(projection) => {
+            find_update_target_branch(&projection.input)
+        }
+        LogicalPlan::Filter(filter) => find_update_target_branch(&filter.input),
+        LogicalPlan::Join(join) => find_update_target_branch(&join.left),
+        LogicalPlan::SubqueryAlias(_) | LogicalPlan::TableScan(_) => Ok(input),
+        other => internal_err!(
+            "Unexpected logical plan node in UPDATE target branch: {}",
+            other.display()
+        ),
+    }
+}
+
+fn collect_update_target_branch_references(
     input: &Arc<LogicalPlan>,
     target_table: &TableReference,
-) -> Result<bool> {
-    let mut found = false;
-    input.apply(|node| {
-        if let LogicalPlan::TableScan(TableScan { table_name, .. }) = node
-            && table_name.resolved_eq(target_table)
-        {
-            found = true;
-            return Ok(TreeNodeRecursion::Stop);
+) -> Result<Vec<TableReference>> {
+    match input.as_ref() {
+        LogicalPlan::Projection(projection) => {
+            collect_update_target_branch_references(&projection.input, target_table)
         }
-        Ok(TreeNodeRecursion::Continue)
-    })?;
-    Ok(found)
+        LogicalPlan::Filter(filter) => {
+            collect_update_target_branch_references(&filter.input, target_table)
+        }
+        LogicalPlan::SubqueryAlias(alias) => {
+            let mut refs =
+                collect_update_target_branch_references(&alias.input, target_table)?;
+            if !refs.iter().any(|r| r.resolved_eq(&alias.alias)) {
+                refs.push(alias.alias.clone());
+            }
+            Ok(refs)
+        }
+        LogicalPlan::Join(join) => {
+            collect_update_target_branch_references(&join.left, target_table)
+        }
+        LogicalPlan::TableScan(TableScan { table_name, .. }) => {
+            if table_name.resolved_eq(target_table) {
+                Ok(vec![table_name.clone()])
+            } else {
+                internal_err!(
+                    "Expected UPDATE target branch to scan '{target_table}', found '{table_name}'"
+                )
+            }
+        }
+        other => internal_err!(
+            "Unexpected logical plan node in UPDATE target branch: {}",
+            other.display()
+        ),
+    }
 }
 
 /// Check if window bounds are valid after schema information is available, and
@@ -3639,6 +3675,45 @@ mod tests {
         assert!(
             d_expr.contains("d"),
             "Unexpected assignment expression: {d_expr}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_extract_update_assignments_preserves_self_join_source_aliases()
+    -> Result<()> {
+        let (input, table_name) = make_update_from_plan(
+            "UPDATE t1 AS dst \
+             SET b = src.b, d = src.d \
+             FROM t1 AS src \
+             WHERE dst.a = src.a + 1",
+        )
+        .await?;
+
+        let assignments = extract_update_assignments(&input, &table_name)?;
+        let b_expr = assignments
+            .iter()
+            .find(|(name, _)| name == "b")
+            .map(|(_, expr)| expr.to_string())
+            .ok_or_else(|| {
+                internal_datafusion_err!("Expected assignment for target column b")
+            })?;
+        let d_expr = assignments
+            .iter()
+            .find(|(name, _)| name == "d")
+            .map(|(_, expr)| expr.to_string())
+            .ok_or_else(|| {
+                internal_datafusion_err!("Expected assignment for target column d")
+            })?;
+
+        assert!(
+            b_expr.contains("src.b"),
+            "Self-join source alias should be preserved: {b_expr}"
+        );
+        assert!(
+            d_expr.contains("src.d"),
+            "Self-join source alias should be preserved: {d_expr}"
         );
 
         Ok(())

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2103,12 +2103,18 @@ fn get_physical_expr_pair(
 
 /// Extract filter predicates from a DML input plan (DELETE/UPDATE).
 ///
-/// Walks the logical plan tree and collects Filter predicates and any filters
-/// pushed down into TableScan nodes, splitting AND conjunctions into individual expressions.
+/// This function combines whole-plan predicate scanning with target-branch
+/// discovery to keep DELETE and UPDATE semantics aligned:
 ///
-/// For UPDATE...FROM queries involving multiple tables, this function only extracts predicates
-/// that reference the target table. Filters from source table scans are excluded to prevent
-/// incorrect filter semantics.
+/// 1. Discover the DML target branch (`find_dml_target_branch`).
+/// 2. Collect aliases for the target relation from that branch.
+/// 3. Scan the full input tree for `Filter` predicates, retaining only
+///    predicates that reference the target relation (or its aliases).
+/// 4. Collect pushed-down `TableScan.filters` only from scans on the target branch.
+///
+/// This avoids leaking source-side predicates for `UPDATE ... FROM` while still
+/// extracting target predicates regardless of where `Filter` nodes appear in the
+/// broader DML input plan.
 ///
 /// Column qualifiers are stripped so expressions can be evaluated against the TableProvider's
 /// schema. Deduplication is performed because filters may appear in both Filter nodes and
@@ -2130,7 +2136,7 @@ fn extract_dml_filters(
     let mut allowed_refs = vec![target.clone()];
     let target_branch = find_dml_target_branch(input)?;
 
-    // First pass: collect any alias references to the target table
+    // Pass 1: collect alias references for the target relation from the target branch.
     target_branch.apply(|node| {
         if let LogicalPlan::SubqueryAlias(alias) = node
             // Check if this alias points to the target table
@@ -2142,6 +2148,8 @@ fn extract_dml_filters(
         Ok(TreeNodeRecursion::Continue)
     })?;
 
+    // Pass 2: scan the whole DML input for Filter predicates, but keep only
+    // predicates that reference the target relation (or its aliases).
     input.apply(|node| {
         match node {
             LogicalPlan::Filter(filter) => {
@@ -2187,6 +2195,7 @@ fn extract_dml_filters(
         Ok(TreeNodeRecursion::Continue)
     })?;
 
+    // Pass 3: collect pushdown filters only from target-branch scans.
     target_branch.apply(|node| {
         if let LogicalPlan::TableScan(TableScan {
             table_name,

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -781,18 +781,33 @@ impl DefaultPhysicalPlanner {
                 if let Some(provider) =
                     target.as_any().downcast_ref::<DefaultTableSource>()
                 {
-                    // For UPDATE, the assignments are encoded in the projection of input
-                    // We pass the filters and let the provider handle the projection
                     let filters = extract_dml_filters(input, table_name)?;
-                    // Extract assignments from the projection in input plan
-                    let assignments = extract_update_assignments(input, table_name)?;
-                    provider
-                        .table_provider
-                        .update(session_state, assignments, filters)
-                        .await
-                        .map_err(|e| {
-                            e.context(format!("UPDATE operation on table '{table_name}'"))
-                        })?
+                    if plan_contains_join(input)? {
+                        let input_exec = children.one()?;
+                        provider
+                            .table_provider
+                            .update_from(session_state, input_exec, filters)
+                            .await
+                            .map_err(|e| {
+                                e.context(format!(
+                                    "UPDATE operation on table '{table_name}'"
+                                ))
+                            })?
+                    } else {
+                        // For single-table UPDATE, assignments are encoded in the
+                        // projection of input and can be evaluated using only target
+                        // columns.
+                        let assignments = extract_update_assignments(input, table_name)?;
+                        provider
+                            .table_provider
+                            .update(session_state, assignments, filters)
+                            .await
+                            .map_err(|e| {
+                                e.context(format!(
+                                    "UPDATE operation on table '{table_name}'"
+                                ))
+                            })?
+                    }
                 } else {
                     return exec_err!(
                         "Table source can't be downcasted to DefaultTableSource"

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2294,46 +2294,22 @@ fn extract_update_assignments(
 
     // Find the top-level projection
     if let LogicalPlan::Projection(projection) = input.as_ref() {
-        for expr in &projection.expr {
-            if let Expr::Alias(alias) = expr {
-                // The alias name is the column name being updated
-                // The inner expression is the new value
-                let column_name = alias.name.clone();
-                // Only include if it's not just a column reference to itself
-                // (those are columns that aren't being updated)
-                if !is_identity_assignment(&alias.expr, &column_name, &target_refs) {
-                    let assignment_expr = if is_multi_table_update {
-                        (*alias.expr).clone()
-                    } else {
-                        // Preserve existing single-table behavior for table providers
-                        // that expect unqualified assignment columns.
-                        strip_column_qualifiers((*alias.expr).clone())?
-                    };
-                    assignments.push((column_name, assignment_expr));
-                }
-            }
-        }
+        append_update_assignments_from_projection(
+            &mut assignments,
+            projection,
+            is_multi_table_update,
+            &target_refs,
+        )?;
     } else {
         // Try to find projection deeper in the plan
         input.apply(|node| {
             if let LogicalPlan::Projection(projection) = node {
-                for expr in &projection.expr {
-                    if let Expr::Alias(alias) = expr {
-                        let column_name = alias.name.clone();
-                        if !is_identity_assignment(
-                            &alias.expr,
-                            &column_name,
-                            &target_refs,
-                        ) {
-                            let assignment_expr = if is_multi_table_update {
-                                (*alias.expr).clone()
-                            } else {
-                                strip_column_qualifiers((*alias.expr).clone())?
-                            };
-                            assignments.push((column_name, assignment_expr));
-                        }
-                    }
-                }
+                append_update_assignments_from_projection(
+                    &mut assignments,
+                    projection,
+                    is_multi_table_update,
+                    &target_refs,
+                )?;
                 return Ok(TreeNodeRecursion::Stop);
             }
             Ok(TreeNodeRecursion::Continue)
@@ -2341,6 +2317,43 @@ fn extract_update_assignments(
     }
 
     Ok(assignments)
+}
+
+fn projection_alias_assignments(projection: &Projection) -> Vec<(String, Expr)> {
+    projection
+        .expr
+        .iter()
+        .filter_map(|expr| {
+            if let Expr::Alias(alias) = expr {
+                Some((alias.name.clone(), alias.expr.as_ref().clone()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn append_update_assignments_from_projection(
+    assignments: &mut Vec<(String, Expr)>,
+    projection: &Projection,
+    is_multi_table_update: bool,
+    target_refs: &[TableReference],
+) -> Result<()> {
+    for (column_name, assignment_expr) in projection_alias_assignments(projection) {
+        // Only include assignments that modify the target column value.
+        if !is_identity_assignment(&assignment_expr, &column_name, target_refs) {
+            let assignment_expr = if is_multi_table_update {
+                assignment_expr
+            } else {
+                // Preserve existing single-table behavior for table providers
+                // that expect unqualified assignment columns.
+                strip_column_qualifiers(assignment_expr)?
+            };
+            assignments.push((column_name, assignment_expr));
+        }
+    }
+
+    Ok(())
 }
 
 /// Check if an assignment is an identity assignment (column = column)

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2402,6 +2402,19 @@ fn collect_update_target_references(
     Ok(refs)
 }
 
+/// Locate the branch that contains the DML target relation.
+///
+/// This helper is intentionally narrow and only models wrappers that can appear
+/// above DELETE/UPDATE targets in DataFusion logical plans:
+/// - `Projection`
+/// - `Filter`
+/// - `Limit`
+/// - `Join` (follow `left` side for `UPDATE ... FROM`)
+/// - `SubqueryAlias`
+/// - `TableScan`
+///
+/// It is not a general logical-plan walker. Unexpected nodes are treated as
+/// planner-shape errors to avoid silently broadening DML target discovery.
 fn find_dml_target_branch(input: &Arc<LogicalPlan>) -> Result<&Arc<LogicalPlan>> {
     match input.as_ref() {
         LogicalPlan::Projection(projection) => find_dml_target_branch(&projection.input),
@@ -2410,6 +2423,8 @@ fn find_dml_target_branch(input: &Arc<LogicalPlan>) -> Result<&Arc<LogicalPlan>>
         LogicalPlan::Join(join) => find_dml_target_branch(&join.left),
         LogicalPlan::SubqueryAlias(_) | LogicalPlan::TableScan(_) => Ok(input),
         other => internal_err!(
+            // Keep this helper DML-scoped rather than turning it into
+            // a generic plan traversal utility.
             "Unexpected logical plan node in DML target branch: {}",
             other.display()
         ),

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -784,6 +784,14 @@ impl DefaultPhysicalPlanner {
                     let filters = extract_dml_filters(input, table_name)?;
                     if plan_contains_join(input)? {
                         let input_exec = children.one()?;
+                        // `update_from` may execute the input plan eagerly as part of
+                        // table mutation. Ensure join partitioning modes (e.g. Auto)
+                        // are fully resolved before handing the plan to providers.
+                        let input_exec = self.optimize_physical_plan(
+                            input_exec,
+                            session_state,
+                            |_, _| {},
+                        )?;
                         provider
                             .table_provider
                             .update_from(session_state, input_exec, filters)

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2128,7 +2128,7 @@ fn extract_dml_filters(
 ) -> Result<Vec<Expr>> {
     let mut filters = Vec::new();
     let mut allowed_refs = vec![target.clone()];
-    let target_branch = find_update_target_branch(input)?;
+    let target_branch = find_dml_target_branch(input)?;
 
     // First pass: collect any alias references to the target table
     target_branch.apply(|node| {
@@ -2393,7 +2393,7 @@ fn collect_update_target_references(
     target_table: &TableReference,
 ) -> Result<Vec<TableReference>> {
     let mut refs = collect_update_target_branch_references(
-        find_update_target_branch(input)?,
+        find_dml_target_branch(input)?,
         target_table,
     )?;
     if !refs.iter().any(|r| r.resolved_eq(target_table)) {
@@ -2402,16 +2402,15 @@ fn collect_update_target_references(
     Ok(refs)
 }
 
-fn find_update_target_branch(input: &Arc<LogicalPlan>) -> Result<&Arc<LogicalPlan>> {
+fn find_dml_target_branch(input: &Arc<LogicalPlan>) -> Result<&Arc<LogicalPlan>> {
     match input.as_ref() {
-        LogicalPlan::Projection(projection) => {
-            find_update_target_branch(&projection.input)
-        }
-        LogicalPlan::Filter(filter) => find_update_target_branch(&filter.input),
-        LogicalPlan::Join(join) => find_update_target_branch(&join.left),
+        LogicalPlan::Projection(projection) => find_dml_target_branch(&projection.input),
+        LogicalPlan::Filter(filter) => find_dml_target_branch(&filter.input),
+        LogicalPlan::Limit(limit) => find_dml_target_branch(&limit.input),
+        LogicalPlan::Join(join) => find_dml_target_branch(&join.left),
         LogicalPlan::SubqueryAlias(_) | LogicalPlan::TableScan(_) => Ok(input),
         other => internal_err!(
-            "Unexpected logical plan node in UPDATE target branch: {}",
+            "Unexpected logical plan node in DML target branch: {}",
             other.display()
         ),
     }
@@ -3336,6 +3335,32 @@ mod tests {
         }
     }
 
+    async fn make_delete_plan(sql: &str) -> Result<(Arc<LogicalPlan>, TableReference)> {
+        let ctx = SessionContext::new();
+        let t1_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::Float64, true),
+            Field::new("d", DataType::Int32, true),
+        ]));
+        let t1 = MemTable::try_new(
+            Arc::clone(&t1_schema),
+            vec![vec![RecordBatch::new_empty(Arc::clone(&t1_schema))]],
+        )?;
+        ctx.register_table("t1", Arc::new(t1))?;
+
+        let plan = ctx.sql(sql).await?.into_unoptimized_plan();
+        match plan {
+            LogicalPlan::Dml(DmlStatement {
+                table_name,
+                op: WriteOp::Delete,
+                input,
+                ..
+            }) => Ok((input, table_name)),
+            other => internal_err!("Expected DELETE DML plan, got: {other}"),
+        }
+    }
+
     fn make_session_state() -> SessionState {
         let runtime = Arc::new(RuntimeEnv::default());
         let config = SessionConfig::new().with_target_partitions(4);
@@ -3727,6 +3752,39 @@ mod tests {
         assert!(
             d_expr.contains("src.d"),
             "Self-join source alias should be preserved: {d_expr}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_extract_dml_filters_delete_limit_without_where() -> Result<()> {
+        let (input, table_name) = make_delete_plan("DELETE FROM t1 LIMIT 10").await?;
+
+        let filters = extract_dml_filters(&input, &table_name)?;
+        assert!(
+            filters.is_empty(),
+            "DELETE ... LIMIT without WHERE should not synthesize filters: {filters:?}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_extract_dml_filters_delete_where_limit() -> Result<()> {
+        let (input, table_name) =
+            make_delete_plan("DELETE FROM t1 WHERE a > 1 LIMIT 10").await?;
+
+        let filters = extract_dml_filters(&input, &table_name)?;
+        assert_eq!(
+            filters.len(),
+            1,
+            "Expected one target predicate from DELETE WHERE ... LIMIT"
+        );
+        let rendered = filters[0].to_string();
+        assert!(
+            rendered.starts_with("a > Int") && rendered.ends_with("(1)"),
+            "Unexpected rendered filter for DELETE WHERE ... LIMIT: {rendered}"
         );
 
         Ok(())

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -785,7 +785,7 @@ impl DefaultPhysicalPlanner {
                     // We pass the filters and let the provider handle the projection
                     let filters = extract_dml_filters(input, table_name)?;
                     // Extract assignments from the projection in input plan
-                    let assignments = extract_update_assignments(input)?;
+                    let assignments = extract_update_assignments(input, table_name)?;
                     provider
                         .table_provider
                         .update(session_state, assignments, filters)
@@ -2233,9 +2233,16 @@ fn strip_column_qualifiers(expr: Expr) -> Result<Expr> {
 /// Extract column assignments from an UPDATE input plan.
 /// For UPDATE statements, the SQL planner encodes assignments as a projection
 /// over the source table. This function extracts column name and expression pairs
-/// from the projection. Column qualifiers are stripped from the expressions.
+/// from the projection.
 ///
-fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, Expr)>> {
+/// For single-table UPDATE, qualifiers are stripped for compatibility with
+/// table providers that evaluate assignment expressions against unqualified
+/// target schemas. For multi-table UPDATE ... FROM, qualifiers are preserved.
+///
+fn extract_update_assignments(
+    input: &Arc<LogicalPlan>,
+    target_table: &TableReference,
+) -> Result<Vec<(String, Expr)>> {
     // The UPDATE input plan structure is:
     // Projection(updated columns as expressions with aliases)
     //   Filter(optional WHERE clause)
@@ -2243,6 +2250,9 @@ fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, E
     //
     // Each projected expression has an alias matching the column name
     let mut assignments = Vec::new();
+
+    let is_multi_table_update = plan_contains_join(input)?;
+    let target_refs = collect_update_target_references(input, target_table)?;
 
     // Find the top-level projection
     if let LogicalPlan::Projection(projection) = input.as_ref() {
@@ -2253,10 +2263,15 @@ fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, E
                 let column_name = alias.name.clone();
                 // Only include if it's not just a column reference to itself
                 // (those are columns that aren't being updated)
-                if !is_identity_assignment(&alias.expr, &column_name) {
-                    // Strip qualifiers from the assignment expression
-                    let stripped_expr = strip_column_qualifiers((*alias.expr).clone())?;
-                    assignments.push((column_name, stripped_expr));
+                if !is_identity_assignment(&alias.expr, &column_name, &target_refs) {
+                    let assignment_expr = if is_multi_table_update {
+                        (*alias.expr).clone()
+                    } else {
+                        // Preserve existing single-table behavior for table providers
+                        // that expect unqualified assignment columns.
+                        strip_column_qualifiers((*alias.expr).clone())?
+                    };
+                    assignments.push((column_name, assignment_expr));
                 }
             }
         }
@@ -2267,10 +2282,17 @@ fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, E
                 for expr in &projection.expr {
                     if let Expr::Alias(alias) = expr {
                         let column_name = alias.name.clone();
-                        if !is_identity_assignment(&alias.expr, &column_name) {
-                            let stripped_expr =
-                                strip_column_qualifiers((*alias.expr).clone())?;
-                            assignments.push((column_name, stripped_expr));
+                        if !is_identity_assignment(
+                            &alias.expr,
+                            &column_name,
+                            &target_refs,
+                        ) {
+                            let assignment_expr = if is_multi_table_update {
+                                (*alias.expr).clone()
+                            } else {
+                                strip_column_qualifiers((*alias.expr).clone())?
+                            };
+                            assignments.push((column_name, assignment_expr));
                         }
                     }
                 }
@@ -2285,11 +2307,68 @@ fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, E
 
 /// Check if an assignment is an identity assignment (column = column)
 /// These are columns that are not being modified in the UPDATE
-fn is_identity_assignment(expr: &Expr, column_name: &str) -> bool {
+fn is_identity_assignment(
+    expr: &Expr,
+    column_name: &str,
+    target_refs: &[TableReference],
+) -> bool {
     match expr {
-        Expr::Column(col) => col.name == column_name,
+        Expr::Column(col) => {
+            col.name == column_name
+                && col.relation.as_ref().is_none_or(|relation| {
+                    target_refs
+                        .iter()
+                        .any(|target| relation.resolved_eq(target))
+                })
+        }
         _ => false,
     }
+}
+
+fn plan_contains_join(input: &Arc<LogicalPlan>) -> Result<bool> {
+    let mut has_join = false;
+    input.apply(|node| {
+        if matches!(node, LogicalPlan::Join(_)) {
+            has_join = true;
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(has_join)
+}
+
+fn collect_update_target_references(
+    input: &Arc<LogicalPlan>,
+    target_table: &TableReference,
+) -> Result<Vec<TableReference>> {
+    let mut refs = vec![target_table.clone()];
+    input.apply(|node| {
+        if let LogicalPlan::SubqueryAlias(alias) = node
+            && plan_contains_table_scan(&alias.input, target_table)?
+            && !refs.iter().any(|r| r.resolved_eq(&alias.alias))
+        {
+            refs.push(alias.alias.clone());
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(refs)
+}
+
+fn plan_contains_table_scan(
+    input: &Arc<LogicalPlan>,
+    target_table: &TableReference,
+) -> Result<bool> {
+    let mut found = false;
+    input.apply(|node| {
+        if let LogicalPlan::TableScan(TableScan { table_name, .. }) = node
+            && table_name.resolved_eq(target_table)
+        {
+            found = true;
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(found)
 }
 
 /// Check if window bounds are valid after schema information is available, and
@@ -3115,7 +3194,8 @@ mod tests {
 
     use crate::execution::session_state::SessionStateBuilder;
     use arrow::array::{ArrayRef, DictionaryArray, Int32Array};
-    use arrow::datatypes::{DataType, Field, Int32Type};
+    use arrow::datatypes::{DataType, Field, Int32Type, Schema};
+    use arrow::record_batch::RecordBatch;
     use arrow_schema::SchemaRef;
     use datafusion_common::config::ConfigOptions;
     use datafusion_common::{
@@ -3125,12 +3205,52 @@ mod tests {
     use datafusion_execution::runtime_env::RuntimeEnv;
     use datafusion_expr::builder::subquery_alias;
     use datafusion_expr::{
-        LogicalPlanBuilder, TableSource, UserDefinedLogicalNodeCore, col, lit,
+        DmlStatement, LogicalPlanBuilder, TableSource, UserDefinedLogicalNodeCore,
+        WriteOp, col, lit,
     };
     use datafusion_functions_aggregate::count::count_all;
     use datafusion_functions_aggregate::expr_fn::sum;
     use datafusion_physical_expr::EquivalenceProperties;
     use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
+
+    async fn make_update_from_plan(
+        sql: &str,
+    ) -> Result<(Arc<LogicalPlan>, TableReference)> {
+        let ctx = SessionContext::new();
+        let t1_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::Float64, true),
+            Field::new("d", DataType::Int32, true),
+        ]));
+        let t2_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::Float64, true),
+            Field::new("d", DataType::Int32, true),
+        ]));
+        let t1 = MemTable::try_new(
+            Arc::clone(&t1_schema),
+            vec![vec![RecordBatch::new_empty(Arc::clone(&t1_schema))]],
+        )?;
+        let t2 = MemTable::try_new(
+            Arc::clone(&t2_schema),
+            vec![vec![RecordBatch::new_empty(Arc::clone(&t2_schema))]],
+        )?;
+        ctx.register_table("t1", Arc::new(t1))?;
+        ctx.register_table("t2", Arc::new(t2))?;
+
+        let plan = ctx.sql(sql).await?.into_unoptimized_plan();
+        match plan {
+            LogicalPlan::Dml(DmlStatement {
+                table_name,
+                op: WriteOp::Update,
+                input,
+                ..
+            }) => Ok((input, table_name)),
+            other => internal_err!("Expected UPDATE DML plan, got: {other}"),
+        }
+    }
 
     fn make_session_state() -> SessionState {
         let runtime = Arc::new(RuntimeEnv::default());
@@ -3414,6 +3534,77 @@ mod tests {
             },
         )
         "#);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_extract_update_assignments_preserves_source_qualifiers_for_update_from()
+    -> Result<()> {
+        let (input, table_name) = make_update_from_plan(
+            "UPDATE t1 AS dst \
+             SET b = src.b, d = src.d \
+             FROM t2 AS src \
+             WHERE dst.a = src.a",
+        )
+        .await?;
+
+        let assignments = extract_update_assignments(&input, &table_name)?;
+        let b_expr = assignments
+            .iter()
+            .find(|(name, _)| name == "b")
+            .map(|(_, expr)| expr.to_string())
+            .ok_or_else(|| {
+                internal_datafusion_err!("Expected assignment for target column b")
+            })?;
+        let d_expr = assignments
+            .iter()
+            .find(|(name, _)| name == "d")
+            .map(|(_, expr)| expr.to_string())
+            .ok_or_else(|| {
+                internal_datafusion_err!("Expected assignment for target column d")
+            })?;
+
+        assert!(
+            b_expr.contains("src.b"),
+            "Unexpected b assignment: {b_expr}"
+        );
+        assert!(
+            d_expr.contains("src.d"),
+            "Unexpected d assignment: {d_expr}"
+        );
+        assert!(
+            assignments.iter().all(|(name, _)| name != "a"),
+            "Identity target columns should not be extracted as assignments"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_extract_update_assignments_strips_target_qualifiers_single_table()
+    -> Result<()> {
+        let (input, table_name) =
+            make_update_from_plan("UPDATE t1 AS dst SET d = dst.d + 1 WHERE dst.a > 0")
+                .await?;
+
+        let assignments = extract_update_assignments(&input, &table_name)?;
+        let d_expr = assignments
+            .iter()
+            .find(|(name, _)| name == "d")
+            .map(|(_, expr)| expr.to_string())
+            .ok_or_else(|| {
+                internal_datafusion_err!("Expected assignment for target column d")
+            })?;
+
+        assert!(
+            !d_expr.contains("dst."),
+            "Single-table assignment should not keep target qualifiers: {d_expr}"
+        );
+        assert!(
+            d_expr.contains("d"),
+            "Unexpected assignment expression: {d_expr}"
+        );
 
         Ok(())
     }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2297,7 +2297,6 @@ fn extract_update_assignments(
     //
     // Each projected expression has an alias matching the column name
     let mut assignments = Vec::new();
-
     let is_multi_table_update = plan_contains_join(input)?;
     let target_refs = collect_update_target_references(input, target_table)?;
 
@@ -2328,41 +2327,36 @@ fn extract_update_assignments(
     Ok(assignments)
 }
 
-fn projection_alias_assignments(projection: &Projection) -> Vec<(String, Expr)> {
-    projection
-        .expr
-        .iter()
-        .filter_map(|expr| {
-            if let Expr::Alias(alias) = expr {
-                Some((alias.name.clone(), alias.expr.as_ref().clone()))
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
 fn append_update_assignments_from_projection(
     assignments: &mut Vec<(String, Expr)>,
     projection: &Projection,
     is_multi_table_update: bool,
     target_refs: &[TableReference],
 ) -> Result<()> {
-    for (column_name, assignment_expr) in projection_alias_assignments(projection) {
-        // Only include assignments that modify the target column value.
-        if !is_identity_assignment(&assignment_expr, &column_name, target_refs) {
-            let assignment_expr = if is_multi_table_update {
-                assignment_expr
-            } else {
-                // Preserve existing single-table behavior for table providers
-                // that expect unqualified assignment columns.
-                strip_column_qualifiers(assignment_expr)?
-            };
-            assignments.push((column_name, assignment_expr));
-        }
-    }
+    projection
+        .expr
+        .iter()
+        .filter_map(|expr| match expr {
+            Expr::Alias(alias) => Some((alias.name.clone(), alias.expr.as_ref().clone())),
+            _ => None,
+        })
+        .try_for_each(|(column_name, assignment_expr)| {
+            if is_identity_assignment(&assignment_expr, &column_name, target_refs) {
+                return Ok(());
+            }
 
-    Ok(())
+            assignments.push((
+                column_name,
+                if is_multi_table_update {
+                    assignment_expr
+                } else {
+                    // Preserve existing single-table behavior for table providers
+                    // that expect unqualified assignment columns.
+                    strip_column_qualifiers(assignment_expr)?
+                },
+            ));
+            Ok(())
+        })
 }
 
 /// Check if an assignment is an identity assignment (column = column)

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2394,13 +2394,25 @@ fn collect_update_target_references(
     input: &Arc<LogicalPlan>,
     target_table: &TableReference,
 ) -> Result<Vec<TableReference>> {
-    let mut refs = collect_update_target_branch_references(
-        find_dml_target_branch(input)?,
-        target_table,
-    )?;
-    if !refs.iter().any(|r| r.resolved_eq(target_table)) {
-        refs.insert(0, target_table.clone());
-    }
+    let mut refs = vec![target_table.clone()];
+    find_dml_target_branch(input)?.apply(|node| {
+        match node {
+            LogicalPlan::SubqueryAlias(alias) => {
+                if !refs.iter().any(|r| r.resolved_eq(&alias.alias)) {
+                    refs.push(alias.alias.clone());
+                }
+            }
+            LogicalPlan::TableScan(TableScan { table_name, .. })
+                if !table_name.resolved_eq(target_table) =>
+            {
+                return internal_err!(
+                    "Expected UPDATE target branch to scan '{target_table}', found '{table_name}'"
+                )
+            }
+            _ => {}
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
     Ok(refs)
 }
 
@@ -2428,44 +2440,6 @@ fn find_dml_target_branch(input: &Arc<LogicalPlan>) -> Result<&Arc<LogicalPlan>>
             // Keep this helper DML-scoped rather than turning it into
             // a generic plan traversal utility.
             "Unexpected logical plan node in DML target branch: {}",
-            other.display()
-        ),
-    }
-}
-
-fn collect_update_target_branch_references(
-    input: &Arc<LogicalPlan>,
-    target_table: &TableReference,
-) -> Result<Vec<TableReference>> {
-    match input.as_ref() {
-        LogicalPlan::Projection(projection) => {
-            collect_update_target_branch_references(&projection.input, target_table)
-        }
-        LogicalPlan::Filter(filter) => {
-            collect_update_target_branch_references(&filter.input, target_table)
-        }
-        LogicalPlan::SubqueryAlias(alias) => {
-            let mut refs =
-                collect_update_target_branch_references(&alias.input, target_table)?;
-            if !refs.iter().any(|r| r.resolved_eq(&alias.alias)) {
-                refs.push(alias.alias.clone());
-            }
-            Ok(refs)
-        }
-        LogicalPlan::Join(join) => {
-            collect_update_target_branch_references(&join.left, target_table)
-        }
-        LogicalPlan::TableScan(TableScan { table_name, .. }) => {
-            if table_name.resolved_eq(target_table) {
-                Ok(vec![table_name.clone()])
-            } else {
-                internal_err!(
-                    "Expected UPDATE target branch to scan '{target_table}', found '{table_name}'"
-                )
-            }
-        }
-        other => internal_err!(
-            "Unexpected logical plan node in UPDATE target branch: {}",
             other.display()
         ),
     }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2299,32 +2299,32 @@ fn extract_update_assignments(
     let mut assignments = Vec::new();
     let is_multi_table_update = plan_contains_join(input)?;
     let target_refs = collect_update_target_references(input, target_table)?;
-
-    // Find the top-level projection
-    if let LogicalPlan::Projection(projection) = input.as_ref() {
+    if let Some(projection) = find_projection(input)? {
         append_update_assignments_from_projection(
             &mut assignments,
             projection,
             is_multi_table_update,
             &target_refs,
         )?;
-    } else {
-        // Try to find projection deeper in the plan
-        input.apply(|node| {
-            if let LogicalPlan::Projection(projection) = node {
-                append_update_assignments_from_projection(
-                    &mut assignments,
-                    projection,
-                    is_multi_table_update,
-                    &target_refs,
-                )?;
-                return Ok(TreeNodeRecursion::Stop);
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })?;
     }
 
     Ok(assignments)
+}
+
+fn find_projection(input: &Arc<LogicalPlan>) -> Result<Option<&Projection>> {
+    if let LogicalPlan::Projection(projection) = input.as_ref() {
+        return Ok(Some(projection));
+    }
+
+    let mut found = None;
+    input.apply(|node| {
+        if let LogicalPlan::Projection(projection) = node {
+            found = Some(projection);
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(found)
 }
 
 fn append_update_assignments_from_projection(

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2299,23 +2299,21 @@ fn extract_update_assignments(
     let mut assignments = Vec::new();
     let is_multi_table_update = plan_contains_join(input)?;
     let target_refs = collect_update_target_references(input, target_table)?;
-    if let Some(projection) = find_projection(input)? {
-        append_update_assignments_from_projection(
-            &mut assignments,
-            projection,
-            is_multi_table_update,
-            &target_refs,
-        )?;
-    }
+    find_projection(input)?
+        .map(|projection| {
+            append_update_assignments_from_projection(
+                &mut assignments,
+                projection,
+                is_multi_table_update,
+                &target_refs,
+            )
+        })
+        .transpose()?;
 
     Ok(assignments)
 }
 
 fn find_projection(input: &Arc<LogicalPlan>) -> Result<Option<&Projection>> {
-    if let LogicalPlan::Projection(projection) = input.as_ref() {
-        return Ok(Some(projection));
-    }
-
     let mut found = None;
     input.apply(|node| {
         if let LogicalPlan::Projection(projection) = node {

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2366,17 +2366,16 @@ fn is_identity_assignment(
     column_name: &str,
     target_refs: &[TableReference],
 ) -> bool {
-    match expr {
-        Expr::Column(col) => {
-            col.name == column_name
+    matches!(
+        expr,
+        Expr::Column(col)
+            if col.name == column_name
                 && col.relation.as_ref().is_none_or(|relation| {
                     target_refs
                         .iter()
                         .any(|target| relation.resolved_eq(target))
                 })
-        }
-        _ => false,
-    }
+    )
 }
 
 fn plan_contains_join(input: &Arc<LogicalPlan>) -> Result<bool> {

--- a/datafusion/core/tests/custom_sources_cases/dml_planning.rs
+++ b/datafusion/core/tests/custom_sources_cases/dml_planning.rs
@@ -238,6 +238,21 @@ impl TableProvider for CaptureUpdateProvider {
 
         Ok(vec![self.filter_pushdown.clone(); filters.len()])
     }
+
+    async fn update_from(
+        &self,
+        _state: &dyn Session,
+        _input: Arc<dyn ExecutionPlan>,
+        filters: Vec<Expr>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        *self.received_filters.lock().unwrap() = Some(filters);
+        // Multi-table update_from uses projected input rows and does not pass
+        // assignment expressions directly.
+        *self.received_assignments.lock().unwrap() = Some(vec![]);
+        Ok(Arc::new(EmptyExec::new(Arc::new(Schema::new(vec![
+            Field::new("count", DataType::UInt64, false),
+        ])))))
+    }
 }
 
 /// A TableProvider that captures whether truncate() was called.

--- a/datafusion/core/tests/custom_sources_cases/dml_planning.rs
+++ b/datafusion/core/tests/custom_sources_cases/dml_planning.rs
@@ -725,117 +725,126 @@ async fn test_delete_target_table_scoping() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_from_drops_non_target_predicates() -> Result<()> {
-    // UPDATE ... FROM is currently not working
-    // TODO fix https://github.com/apache/datafusion/issues/19950
+    let target_schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, true),
+        Field::new("c", DataType::Float64, true),
+        Field::new("d", DataType::Int32, true),
+    ]));
     let target_provider = Arc::new(CaptureUpdateProvider::new_with_filter_pushdown(
-        test_schema(),
+        Arc::clone(&target_schema),
         TableProviderFilterPushDown::Exact,
     ));
     let ctx = SessionContext::new();
     ctx.register_table("t1", Arc::clone(&target_provider) as Arc<dyn TableProvider>)?;
 
     let source_schema = Arc::new(Schema::new(vec![
-        Field::new("id", DataType::Int32, false),
-        Field::new("status", DataType::Utf8, true),
-        // t2-only column to avoid false negatives after qualifier stripping
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, true),
+        Field::new("c", DataType::Float64, true),
+        Field::new("d", DataType::Int32, true),
         Field::new("src_only", DataType::Utf8, true),
     ]));
     let source_table = datafusion::datasource::empty::EmptyTable::new(source_schema);
     ctx.register_table("t2", Arc::new(source_table))?;
 
-    let result = ctx
+    let df = ctx
         .sql(
-            "UPDATE t1 SET value = 1 FROM t2 \
-             WHERE t1.id = t2.id AND t2.src_only = 'active' AND t1.value > 10",
+            "UPDATE t1 SET d = 1 FROM t2 \
+             WHERE t1.a = t2.a AND t2.src_only = 'active' AND t1.d > 10",
         )
-        .await;
+        .await?;
 
-    // Verify UPDATE ... FROM is rejected with appropriate error
-    // TODO fix https://github.com/apache/datafusion/issues/19950
-    assert!(result.is_err());
-    let err = result.unwrap_err();
+    df.collect().await?;
+
+    let filters = target_provider
+        .captured_filters()
+        .expect("filters should be captured");
+    assert_eq!(
+        filters.len(),
+        1,
+        "only target-table predicates should be retained for provider update"
+    );
     assert!(
-        err.to_string().contains("UPDATE ... FROM is not supported"),
-        "Expected 'UPDATE ... FROM is not supported' error, got: {err}"
+        filters[0].to_string().contains("d"),
+        "Expected target predicate on d, got: {}",
+        filters[0]
     );
     Ok(())
 }
 
 #[tokio::test]
-async fn test_update_from_alias_variants_are_rejected() -> Result<()> {
-    // UPDATE ... FROM is currently not working
-    // TODO fix https://github.com/apache/datafusion/issues/19950
+async fn test_update_from_alias_variants_are_accepted() -> Result<()> {
+    let target_schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, true),
+        Field::new("c", DataType::Float64, true),
+        Field::new("d", DataType::Int32, true),
+    ]));
     let target_provider = Arc::new(CaptureUpdateProvider::new_with_filter_pushdown(
-        test_schema(),
+        Arc::clone(&target_schema),
         TableProviderFilterPushDown::Exact,
     ));
     let ctx = SessionContext::new();
     ctx.register_table("t1", Arc::clone(&target_provider) as Arc<dyn TableProvider>)?;
 
     let source_schema = Arc::new(Schema::new(vec![
-        Field::new("id", DataType::Int32, false),
-        Field::new("status", DataType::Utf8, true),
-        Field::new("value", DataType::Int32, true),
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, true),
+        Field::new("c", DataType::Float64, true),
+        Field::new("d", DataType::Int32, true),
     ]));
     let source_table = datafusion::datasource::empty::EmptyTable::new(source_schema);
     ctx.register_table("t2", Arc::new(source_table))?;
 
     let alias_queries = [
         "UPDATE t1 AS dst \
-         SET status = src.status, value = src.value + dst.value \
+         SET b = src.b, d = src.d \
          FROM t2 AS src \
-         WHERE dst.id = src.id AND src.status = 'active'",
+         WHERE dst.a = src.a AND src.b = 'active'",
         "UPDATE t1 \
          FROM t2 AS src \
-         SET status = src.status, value = t1.value + src.value \
-         WHERE t1.id = src.id",
+         SET b = src.b, d = src.d \
+         WHERE t1.a = src.a",
     ];
 
     for sql in alias_queries {
-        let result = ctx.sql(sql).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            err.to_string().contains("UPDATE ... FROM is not supported"),
-            "Expected 'UPDATE ... FROM is not supported' error for `{sql}`, got: {err}"
-        );
+        let _ = ctx.sql(sql).await?;
     }
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_update_from_joined_assignments_are_rejected() -> Result<()> {
-    // This captures joined assignment patterns that currently fail if UPDATE ... FROM
-    // planning is enabled without full qualifier-safe assignment handling.
-    // TODO fix https://github.com/apache/datafusion/issues/19950
-    let target_provider = Arc::new(CaptureUpdateProvider::new(test_schema()));
+async fn test_update_from_joined_assignments_plan_success() -> Result<()> {
+    let target_schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, true),
+        Field::new("c", DataType::Float64, true),
+        Field::new("d", DataType::Int32, true),
+    ]));
+    let target_provider =
+        Arc::new(CaptureUpdateProvider::new(Arc::clone(&target_schema)));
     let ctx = SessionContext::new();
     ctx.register_table("t1", Arc::clone(&target_provider) as Arc<dyn TableProvider>)?;
 
     let source_schema = Arc::new(Schema::new(vec![
-        Field::new("id", DataType::Int32, false),
-        Field::new("status", DataType::Utf8, true),
-        Field::new("value", DataType::Int32, true),
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, true),
+        Field::new("c", DataType::Float64, true),
+        Field::new("d", DataType::Int32, true),
     ]));
     let source_table = datafusion::datasource::empty::EmptyTable::new(source_schema);
     ctx.register_table("t2", Arc::new(source_table))?;
 
-    let result = ctx
+    let _ = ctx
         .sql(
             "UPDATE t1 AS dst \
-             SET status = src.status, value = src.value + dst.value \
+             SET b = src.b, d = src.d \
              FROM t2 AS src \
-             WHERE dst.id = src.id AND src.value > 10 AND dst.value > 0",
+             WHERE dst.a = src.a AND src.b = 'active'",
         )
-        .await;
-
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.to_string().contains("UPDATE ... FROM is not supported"),
-        "Expected 'UPDATE ... FROM is not supported' error, got: {err}"
-    );
+        .await?;
 
     Ok(())
 }

--- a/datafusion/core/tests/custom_sources_cases/dml_planning.rs
+++ b/datafusion/core/tests/custom_sources_cases/dml_planning.rs
@@ -323,6 +323,29 @@ fn test_schema() -> SchemaRef {
     ]))
 }
 
+/// Construct a simple schema containing columns `a`, `b`, `c` and `d`.
+///
+/// Many of the DML tests use this four‑column layout.  Callers can
+/// provide additional fields that will be appended to the base set –
+/// for example the `src_only` column used in some `UPDATE ... FROM`
+/// queries.  Returns an `Arc<Schema>` for convenience in tests.
+fn abcd_schema(extra: &[Field]) -> SchemaRef {
+    let mut fields = vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, true),
+        Field::new("c", DataType::Float64, true),
+        Field::new("d", DataType::Int32, true),
+    ];
+    fields.extend_from_slice(extra);
+    Arc::new(Schema::new(fields))
+}
+
+/// Convenience wrapper for the common case where no extra columns are
+/// needed.
+fn abcd_schema_no_extra() -> SchemaRef {
+    abcd_schema(&[])
+}
+
 #[tokio::test]
 async fn test_delete_single_filter() -> Result<()> {
     let provider = Arc::new(CaptureDeleteProvider::new(test_schema()));
@@ -740,12 +763,7 @@ async fn test_delete_target_table_scoping() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_from_drops_non_target_predicates() -> Result<()> {
-    let target_schema = Arc::new(Schema::new(vec![
-        Field::new("a", DataType::Int32, false),
-        Field::new("b", DataType::Utf8, true),
-        Field::new("c", DataType::Float64, true),
-        Field::new("d", DataType::Int32, true),
-    ]));
+    let target_schema = abcd_schema_no_extra();
     let target_provider = Arc::new(CaptureUpdateProvider::new_with_filter_pushdown(
         Arc::clone(&target_schema),
         TableProviderFilterPushDown::Exact,
@@ -753,13 +771,7 @@ async fn test_update_from_drops_non_target_predicates() -> Result<()> {
     let ctx = SessionContext::new();
     ctx.register_table("t1", Arc::clone(&target_provider) as Arc<dyn TableProvider>)?;
 
-    let source_schema = Arc::new(Schema::new(vec![
-        Field::new("a", DataType::Int32, false),
-        Field::new("b", DataType::Utf8, true),
-        Field::new("c", DataType::Float64, true),
-        Field::new("d", DataType::Int32, true),
-        Field::new("src_only", DataType::Utf8, true),
-    ]));
+    let source_schema = abcd_schema(&[Field::new("src_only", DataType::Utf8, true)]);
     let source_table = datafusion::datasource::empty::EmptyTable::new(source_schema);
     ctx.register_table("t2", Arc::new(source_table))?;
 
@@ -790,12 +802,7 @@ async fn test_update_from_drops_non_target_predicates() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_from_alias_variants_are_accepted() -> Result<()> {
-    let target_schema = Arc::new(Schema::new(vec![
-        Field::new("a", DataType::Int32, false),
-        Field::new("b", DataType::Utf8, true),
-        Field::new("c", DataType::Float64, true),
-        Field::new("d", DataType::Int32, true),
-    ]));
+    let target_schema = abcd_schema_no_extra();
     let target_provider = Arc::new(CaptureUpdateProvider::new_with_filter_pushdown(
         Arc::clone(&target_schema),
         TableProviderFilterPushDown::Exact,
@@ -803,12 +810,7 @@ async fn test_update_from_alias_variants_are_accepted() -> Result<()> {
     let ctx = SessionContext::new();
     ctx.register_table("t1", Arc::clone(&target_provider) as Arc<dyn TableProvider>)?;
 
-    let source_schema = Arc::new(Schema::new(vec![
-        Field::new("a", DataType::Int32, false),
-        Field::new("b", DataType::Utf8, true),
-        Field::new("c", DataType::Float64, true),
-        Field::new("d", DataType::Int32, true),
-    ]));
+    let source_schema = abcd_schema_no_extra();
     let source_table = datafusion::datasource::empty::EmptyTable::new(source_schema);
     ctx.register_table("t2", Arc::new(source_table))?;
 
@@ -832,23 +834,13 @@ async fn test_update_from_alias_variants_are_accepted() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_from_joined_assignments_plan_success() -> Result<()> {
-    let target_schema = Arc::new(Schema::new(vec![
-        Field::new("a", DataType::Int32, false),
-        Field::new("b", DataType::Utf8, true),
-        Field::new("c", DataType::Float64, true),
-        Field::new("d", DataType::Int32, true),
-    ]));
+    let target_schema = abcd_schema_no_extra();
     let target_provider =
         Arc::new(CaptureUpdateProvider::new(Arc::clone(&target_schema)));
     let ctx = SessionContext::new();
     ctx.register_table("t1", Arc::clone(&target_provider) as Arc<dyn TableProvider>)?;
 
-    let source_schema = Arc::new(Schema::new(vec![
-        Field::new("a", DataType::Int32, false),
-        Field::new("b", DataType::Utf8, true),
-        Field::new("c", DataType::Float64, true),
-        Field::new("d", DataType::Int32, true),
-    ]));
+    let source_schema = abcd_schema_no_extra();
     let source_table = datafusion::datasource::empty::EmptyTable::new(source_schema);
     ctx.register_table("t2", Arc::new(source_table))?;
 

--- a/datafusion/core/tests/custom_sources_cases/dml_planning.rs
+++ b/datafusion/core/tests/custom_sources_cases/dml_planning.rs
@@ -762,6 +762,85 @@ async fn test_update_from_drops_non_target_predicates() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_update_from_alias_variants_are_rejected() -> Result<()> {
+    // UPDATE ... FROM is currently not working
+    // TODO fix https://github.com/apache/datafusion/issues/19950
+    let target_provider = Arc::new(CaptureUpdateProvider::new_with_filter_pushdown(
+        test_schema(),
+        TableProviderFilterPushDown::Exact,
+    ));
+    let ctx = SessionContext::new();
+    ctx.register_table("t1", Arc::clone(&target_provider) as Arc<dyn TableProvider>)?;
+
+    let source_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("status", DataType::Utf8, true),
+        Field::new("value", DataType::Int32, true),
+    ]));
+    let source_table = datafusion::datasource::empty::EmptyTable::new(source_schema);
+    ctx.register_table("t2", Arc::new(source_table))?;
+
+    let alias_queries = [
+        "UPDATE t1 AS dst \
+         SET status = src.status, value = src.value + dst.value \
+         FROM t2 AS src \
+         WHERE dst.id = src.id AND src.status = 'active'",
+        "UPDATE t1 \
+         FROM t2 AS src \
+         SET status = src.status, value = t1.value + src.value \
+         WHERE t1.id = src.id",
+    ];
+
+    for sql in alias_queries {
+        let result = ctx.sql(sql).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("UPDATE ... FROM is not supported"),
+            "Expected 'UPDATE ... FROM is not supported' error for `{sql}`, got: {err}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_update_from_joined_assignments_are_rejected() -> Result<()> {
+    // This captures joined assignment patterns that currently fail if UPDATE ... FROM
+    // planning is enabled without full qualifier-safe assignment handling.
+    // TODO fix https://github.com/apache/datafusion/issues/19950
+    let target_provider = Arc::new(CaptureUpdateProvider::new(test_schema()));
+    let ctx = SessionContext::new();
+    ctx.register_table("t1", Arc::clone(&target_provider) as Arc<dyn TableProvider>)?;
+
+    let source_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("status", DataType::Utf8, true),
+        Field::new("value", DataType::Int32, true),
+    ]));
+    let source_table = datafusion::datasource::empty::EmptyTable::new(source_schema);
+    ctx.register_table("t2", Arc::new(source_table))?;
+
+    let result = ctx
+        .sql(
+            "UPDATE t1 AS dst \
+             SET status = src.status, value = src.value + dst.value \
+             FROM t2 AS src \
+             WHERE dst.id = src.id AND src.value > 10 AND dst.value > 0",
+        )
+        .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("UPDATE ... FROM is not supported"),
+        "Expected 'UPDATE ... FROM is not supported' error, got: {err}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_delete_qualifier_stripping_and_validation() -> Result<()> {
     // Test that filter qualifiers are properly stripped and validated
     // Unqualified predicates should work fine

--- a/datafusion/core/tests/custom_sources_cases/dml_planning.rs
+++ b/datafusion/core/tests/custom_sources_cases/dml_planning.rs
@@ -927,6 +927,40 @@ async fn test_update_from_with_join_only_predicates_executes() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_update_from_self_join_drops_source_side_predicates() -> Result<()> {
+    let target_schema = abcd_schema_no_extra();
+    let target_provider = Arc::new(CaptureUpdateProvider::new_with_filter_pushdown(
+        Arc::clone(&target_schema),
+        TableProviderFilterPushDown::Exact,
+    ));
+    let ctx = SessionContext::new();
+    ctx.register_table("t1", Arc::clone(&target_provider) as Arc<dyn TableProvider>)?;
+
+    let df = ctx
+        .sql(
+            "UPDATE t1 AS dst \
+             SET b = src.b \
+             FROM t1 AS src \
+             WHERE dst.a = src.a AND dst.d > 10 AND src.b = 'active'",
+        )
+        .await?;
+
+    df.collect().await?;
+
+    let filters = target_provider
+        .captured_filters()
+        .expect("filters should be captured");
+    assert_eq!(
+        filters.len(),
+        1,
+        "only target-side predicates should be forwarded in self-join updates"
+    );
+    assert_eq!(filters[0].to_string(), "d > Int32(10)");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_delete_qualifier_stripping_and_validation() -> Result<()> {
     // Test that filter qualifiers are properly stripped and validated
     // Unqualified predicates should work fine

--- a/datafusion/core/tests/custom_sources_cases/dml_planning.rs
+++ b/datafusion/core/tests/custom_sources_cases/dml_planning.rs
@@ -20,8 +20,12 @@
 use std::any::Any;
 use std::sync::{Arc, Mutex};
 
+use arrow::array::{Float64Array, Int32Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
+use datafusion::assert_batches_eq;
+use datafusion::datasource::MemTable;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::Result;
 use datafusion::execution::context::{SessionConfig, SessionContext};
@@ -852,6 +856,72 @@ async fn test_update_from_joined_assignments_plan_success() -> Result<()> {
              WHERE dst.a = src.a AND src.b = 'active'",
         )
         .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_update_from_with_join_only_predicates_executes() -> Result<()> {
+    let ctx =
+        SessionContext::new_with_config(SessionConfig::new().with_target_partitions(4));
+
+    let t1_schema = abcd_schema_no_extra();
+    let t1_batch = RecordBatch::try_new(
+        Arc::clone(&t1_schema),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["zoo", "qux", "bar"])),
+            Arc::new(Float64Array::from(vec![2.0, 3.0, 4.0])),
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+        ],
+    )?;
+    let t1 = MemTable::try_new(Arc::clone(&t1_schema), vec![vec![t1_batch]])?;
+    ctx.register_table("t1", Arc::new(t1))?;
+
+    let t2_schema = abcd_schema_no_extra();
+    let t2_batch = RecordBatch::try_new(
+        Arc::clone(&t2_schema),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 4])),
+            Arc::new(StringArray::from(vec![
+                "updated_b",
+                "updated_b2",
+                "updated_b3",
+            ])),
+            Arc::new(Float64Array::from(vec![5.0, 2.5, 1.5])),
+            Arc::new(Int32Array::from(vec![40, 50, 60])),
+        ],
+    )?;
+    let t2 = MemTable::try_new(Arc::clone(&t2_schema), vec![vec![t2_batch]])?;
+    ctx.register_table("t2", Arc::new(t2))?;
+
+    ctx.sql(
+        "UPDATE t1 AS dst \
+         SET b = src.b, c = src.a, d = 1 \
+         FROM t2 AS src \
+         WHERE dst.a = src.a AND src.c > 1.0",
+    )
+    .await?
+    .collect()
+    .await?;
+
+    let actual = ctx
+        .sql("SELECT * FROM t1 ORDER BY a")
+        .await?
+        .collect()
+        .await?;
+    assert_batches_eq!(
+        [
+            "+---+------------+-----+----+",
+            "| a | b          | c   | d  |",
+            "+---+------------+-----+----+",
+            "| 1 | updated_b  | 1.0 | 1  |",
+            "| 2 | updated_b2 | 2.0 | 1  |",
+            "| 3 | bar        | 4.0 | 30 |",
+            "+---+------------+-----+----+",
+        ],
+        &actual
+    );
 
     Ok(())
 }

--- a/datafusion/core/tests/custom_sources_cases/dml_planning.rs
+++ b/datafusion/core/tests/custom_sources_cases/dml_planning.rs
@@ -927,6 +927,73 @@ async fn test_update_from_with_join_only_predicates_executes() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_update_from_with_only_join_predicate_executes() -> Result<()> {
+    let ctx =
+        SessionContext::new_with_config(SessionConfig::new().with_target_partitions(4));
+
+    let t1_schema = abcd_schema_no_extra();
+    let t1_batch = RecordBatch::try_new(
+        Arc::clone(&t1_schema),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["zoo", "qux", "bar"])),
+            Arc::new(Float64Array::from(vec![2.0, 3.0, 4.0])),
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+        ],
+    )?;
+    let t1 = MemTable::try_new(Arc::clone(&t1_schema), vec![vec![t1_batch]])?;
+    ctx.register_table("t1", Arc::new(t1))?;
+
+    let t2_schema = abcd_schema_no_extra();
+    let t2_batch = RecordBatch::try_new(
+        Arc::clone(&t2_schema),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 4])),
+            Arc::new(StringArray::from(vec![
+                "updated_b",
+                "updated_b2",
+                "updated_b3",
+            ])),
+            Arc::new(Float64Array::from(vec![5.0, 2.5, 1.5])),
+            Arc::new(Int32Array::from(vec![40, 50, 60])),
+        ],
+    )?;
+    let t2 = MemTable::try_new(Arc::clone(&t2_schema), vec![vec![t2_batch]])?;
+    ctx.register_table("t2", Arc::new(t2))?;
+
+    // Regression case: UPDATE ... FROM with only join predicates in WHERE.
+    ctx.sql(
+        "UPDATE t1 AS dst \
+         SET b = src.b, c = src.a, d = src.d \
+         FROM t2 AS src \
+         WHERE dst.a = src.a",
+    )
+    .await?
+    .collect()
+    .await?;
+
+    let actual = ctx
+        .sql("SELECT * FROM t1 ORDER BY a")
+        .await?
+        .collect()
+        .await?;
+    assert_batches_eq!(
+        [
+            "+---+------------+-----+----+",
+            "| a | b          | c   | d  |",
+            "+---+------------+-----+----+",
+            "| 1 | updated_b  | 1.0 | 40 |",
+            "| 2 | updated_b2 | 2.0 | 50 |",
+            "| 3 | bar        | 4.0 | 30 |",
+            "+---+------------+-----+----+",
+        ],
+        &actual
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_update_from_self_join_drops_source_side_predicates() -> Result<()> {
     let target_schema = abcd_schema_no_extra();
     let target_provider = Arc::new(CaptureUpdateProvider::new_with_filter_pushdown(

--- a/datafusion/expr/src/logical_plan/dml.rs
+++ b/datafusion/expr/src/logical_plan/dml.rs
@@ -27,6 +27,16 @@ use datafusion_common::{DFSchemaRef, TableReference};
 
 use crate::{LogicalPlan, TableSource};
 
+/// Prefix used for hidden columns carrying the original target-row values in
+/// `UPDATE ... FROM` plans.
+pub const UPDATE_FROM_OLD_COLUMN_PREFIX: &str = "__df_update_old_";
+
+/// Returns the hidden `UPDATE ... FROM` column name used to carry the original
+/// value of `column_name` from the target table.
+pub fn update_from_old_column_name(column_name: &str) -> String {
+    format!("{UPDATE_FROM_OLD_COLUMN_PREFIX}{column_name}")
+}
+
 /// Operator that copies the contents of a database to file(s)
 #[derive(Clone)]
 pub struct CopyTo {

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -38,7 +38,7 @@ use datafusion_common::{
     internal_err, not_impl_err, plan_datafusion_err, plan_err, schema_err,
     unqualified_field_not_found,
 };
-use datafusion_expr::dml::{CopyTo, InsertOp};
+use datafusion_expr::dml::{CopyTo, InsertOp, update_from_old_column_name};
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas_and_ambiguity_check;
 use datafusion_expr::logical_plan::DdlStatement;
 use datafusion_expr::logical_plan::builder::project;
@@ -68,8 +68,6 @@ use sqlparser::ast::{
     TransactionMode, UnaryOperator, Value,
 };
 use sqlparser::parser::ParserError::ParserError;
-
-const UPDATE_FROM_OLD_COLUMN_PREFIX: &str = "__df_update_old_";
 
 fn ident_to_string(ident: &Ident) -> String {
     normalize_ident(ident.to_owned())
@@ -2591,8 +2589,4 @@ fn update_target_column_expr(
     } else {
         Expr::Column(Column::from((qualifier, field)))
     }
-}
-
-fn update_from_old_column_name(column_name: &str) -> String {
-    format!("{UPDATE_FROM_OLD_COLUMN_PREFIX}{column_name}")
 }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1084,12 +1084,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
                 let update_from = from_clauses.and_then(|mut f| f.pop());
 
-                // UPDATE ... FROM is currently not working
-                // TODO fix https://github.com/apache/datafusion/issues/19950
-                if update_from.is_some() {
-                    return not_impl_err!("UPDATE ... FROM is not supported");
-                }
-
                 if returning.is_some() {
                     plan_err!("Update-returning clause not yet supported")?;
                 }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -25,7 +25,7 @@ use crate::parser::{
     LexOrdering, ResetStatement, Statement as DFStatement,
 };
 use crate::planner::{
-    ContextProvider, PlannerContext, SqlToRel, object_name_to_qualifier,
+    ContextProvider, IdentNormalizer, PlannerContext, SqlToRel, object_name_to_qualifier,
 };
 use crate::utils::normalize_ident;
 
@@ -68,6 +68,8 @@ use sqlparser::ast::{
     TransactionMode, UnaryOperator, Value,
 };
 use sqlparser::parser::ParserError::ParserError;
+
+const UPDATE_FROM_OLD_COLUMN_PREFIX: &str = "__df_update_old_";
 
 fn ident_to_string(ident: &Ident) -> String {
     normalize_ident(ident.to_owned())
@@ -2185,6 +2187,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             .collect::<Result<HashMap<String, SQLExpr>>>()?;
 
         // Build scan, join with from table if it exists.
+        let has_update_from = from.is_some();
         let mut input_tables = vec![table];
         input_tables.extend(from);
         let scan = self.plan_from_tables(input_tables, &mut planner_context)?;
@@ -2210,7 +2213,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         };
 
         // Build updated values for each column, using the previous value if not modified
-        let exprs = table_schema
+        let mut exprs = table_schema
             .iter()
             .map(|(qualifier, field)| {
                 let expr = match assign_map.remove(field.name()) {
@@ -2230,21 +2233,28 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         // Cast to target column type, if necessary
                         expr.cast_to(field.data_type(), source.schema())?
                     }
-                    None => {
-                        // If the target table has an alias, use it to qualify the column name
-                        if let Some(alias) = &table_alias {
-                            Expr::Column(Column::new(
-                                Some(self.ident_normalizer.normalize(alias.name.clone())),
-                                field.name(),
-                            ))
-                        } else {
-                            Expr::Column(Column::from((qualifier, field)))
-                        }
-                    }
+                    None => update_target_column_expr(
+                        &self.ident_normalizer,
+                        &table_alias,
+                        qualifier,
+                        field,
+                    ),
                 };
                 Ok(expr.alias(field.name()))
             })
             .collect::<Result<Vec<_>>>()?;
+
+        if has_update_from {
+            exprs.extend(table_schema.iter().map(|(qualifier, field)| {
+                update_target_column_expr(
+                    &self.ident_normalizer,
+                    &table_alias,
+                    qualifier,
+                    field,
+                )
+                .alias(update_from_old_column_name(field.name()))
+            }));
+        }
 
         let source = project(source, exprs)?;
 
@@ -2565,4 +2575,24 @@ ON p.function_name = r.routine_name
             }
         }
     }
+}
+
+fn update_target_column_expr(
+    ident_normalizer: &IdentNormalizer,
+    table_alias: &Option<ast::TableAlias>,
+    qualifier: Option<&TableReference>,
+    field: &FieldRef,
+) -> Expr {
+    if let Some(alias) = table_alias {
+        Expr::Column(Column::new(
+            Some(ident_normalizer.normalize(alias.name.clone())),
+            field.name(),
+        ))
+    } else {
+        Expr::Column(Column::from((qualifier, field)))
+    }
+}
+
+fn update_from_old_column_name(column_name: &str) -> String {
+    format!("{UPDATE_FROM_OLD_COLUMN_PREFIX}{column_name}")
 }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -2210,6 +2210,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             }
         };
 
+        let target_column = |qualifier, field| {
+            update_target_column_expr(
+                &self.ident_normalizer,
+                &table_alias,
+                qualifier,
+                field,
+            )
+        };
+
         // Build updated values for each column, using the previous value if not modified
         let mut exprs = table_schema
             .iter()
@@ -2231,12 +2240,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         // Cast to target column type, if necessary
                         expr.cast_to(field.data_type(), source.schema())?
                     }
-                    None => update_target_column_expr(
-                        &self.ident_normalizer,
-                        &table_alias,
-                        qualifier,
-                        field,
-                    ),
+                    None => target_column(qualifier, field),
                 };
                 Ok(expr.alias(field.name()))
             })
@@ -2244,13 +2248,8 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
 
         if has_update_from {
             exprs.extend(table_schema.iter().map(|(qualifier, field)| {
-                update_target_column_expr(
-                    &self.ident_normalizer,
-                    &table_alias,
-                    qualifier,
-                    field,
-                )
-                .alias(update_from_old_column_name(field.name()))
+                target_column(qualifier, field)
+                    .alias(update_from_old_column_name(field.name()))
             }));
         }
 

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -2581,12 +2581,13 @@ fn update_target_column_expr(
     qualifier: Option<&TableReference>,
     field: &FieldRef,
 ) -> Expr {
-    if let Some(alias) = table_alias {
-        Expr::Column(Column::new(
-            Some(ident_normalizer.normalize(alias.name.clone())),
-            field.name(),
-        ))
-    } else {
-        Expr::Column(Column::from((qualifier, field)))
-    }
+    table_alias.as_ref().map_or_else(
+        || Expr::Column(Column::from((qualifier, field))),
+        |alias| {
+            Expr::Column(Column::new(
+                Some(ident_normalizer.normalize(alias.name.clone())),
+                field.name(),
+            ))
+        },
+    )
 }

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -739,6 +739,28 @@ fn plan_update() {
     );
 }
 
+#[test]
+fn plan_update_from_projects_original_target_row() {
+    let sql = "update person as dst \
+               set last_name = src.last_name, age = src.age \
+               from person as src \
+               where dst.id = src.id";
+    let plan = logical_plan(sql).unwrap();
+    assert_snapshot!(
+        plan,
+        @r#"
+    Dml: op=[Update] table=[person]
+      Projection: dst.id AS id, dst.first_name AS first_name, src.last_name AS last_name, src.age AS age, dst.state AS state, dst.salary AS salary, dst.birth_date AS birth_date, dst.😀 AS 😀, dst.id AS __df_update_old_id, dst.first_name AS __df_update_old_first_name, dst.last_name AS __df_update_old_last_name, dst.age AS __df_update_old_age, dst.state AS __df_update_old_state, dst.salary AS __df_update_old_salary, dst.birth_date AS __df_update_old_birth_date, dst.😀 AS __df_update_old_😀
+        Filter: dst.id = src.id
+          Cross Join:
+            SubqueryAlias: dst
+              TableScan: person
+            SubqueryAlias: src
+              TableScan: person
+    "#
+    );
+}
+
 #[rstest]
 #[case::missing_assignment_target("UPDATE person SET doesnotexist = true")]
 #[case::missing_assignment_expression("UPDATE person SET age = doesnotexist + 42")]

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -79,10 +79,9 @@ logical_plan
 04)------Cross Join:
 05)--------TableScan: t1
 06)--------TableScan: t2
-physical_plan_error
-01)UPDATE operation on table 't1'
-02)caused by
-03)Schema error: No field named t2.b. Did you mean 'b'?.
+physical_plan
+01)CooperativeExec
+02)--DmlResultExec: rows_affected=0
 
 # update from (FROM before SET syntax)
 # UPDATE ... FROM is currently unsupported
@@ -97,10 +96,9 @@ logical_plan
 04)------Cross Join:
 05)--------TableScan: t1
 06)--------TableScan: t2
-physical_plan_error
-01)UPDATE operation on table 't1'
-02)caused by
-03)Schema error: No field named t2.b. Did you mean 'b'?.
+physical_plan
+01)CooperativeExec
+02)--DmlResultExec: rows_affected=0
 
 # update from with explicit aliases and joined assignment expressions
 # UPDATE ... FROM is currently unsupported
@@ -117,10 +115,9 @@ logical_plan
 06)----------TableScan: t1
 07)--------SubqueryAlias: src
 08)----------TableScan: t2
-physical_plan_error
-01)UPDATE operation on table 't1'
-02)caused by
-03)Schema error: No field named src.b. Did you mean 'b'?.
+physical_plan
+01)CooperativeExec
+02)--DmlResultExec: rows_affected=0
 
 # test update from other table with actual data
 statement ok
@@ -129,15 +126,9 @@ insert into t1 values (1, 'zoo', 2.0, 10), (2, 'qux', 3.0, 20), (3, 'bar', 4.0, 
 statement ok
 insert into t2 values (1, 'updated_b', 5.0, 40), (2, 'updated_b2', 2.5, 50), (4, 'updated_b3', 1.5, 60);
 
-# UPDATE ... FROM is currently unsupported - qualifier stripping breaks source column references
-# causing assignments like 'b = t2.b' to resolve to target table's 'b' instead of source table's 'b'
-# TODO fix https://github.com/apache/datafusion/issues/19950
-statement error
+# UPDATE ... FROM assignment binding now resolves source-table references
+statement ok
 update t1 set b = t2.b, c = t2.a, d = 1 from t2 where t1.a = t2.a and t1.b > 'foo' and t2.c > 1.0;
-----
-DataFusion error: UPDATE operation on table 't1'
-caused by
-Schema error: No field named t2.b. Did you mean 'b'?.
 
 
 # set from multiple tables, DataFusion only supports from one table
@@ -158,10 +149,9 @@ logical_plan
 05)--------SubqueryAlias: t
 06)----------TableScan: t1
 07)--------TableScan: t2
-physical_plan_error
-01)UPDATE operation on table 't1'
-02)caused by
-03)Schema error: No field named t2.b. Did you mean 'b'?.
+physical_plan
+01)CooperativeExec
+02)--DmlResultExec: rows_affected=2
 
 # test update with table alias with actual data
 statement ok
@@ -176,14 +166,9 @@ insert into t1 values (1, 'zebra', 1.5, 5), (2, 'wolf', 2.0, 10), (3, 'apple', 3
 statement ok
 insert into t2 values (1, 'new_val', 2.0, 100), (2, 'new_val2', 1.5, 200);
 
-# UPDATE ... FROM is currently unsupported
-# TODO fix https://github.com/apache/datafusion/issues/19950
-statement error
+# UPDATE ... FROM with target alias resolves and executes
+statement ok
 update t1 as T set b = t2.b, c = t.a, d = 1 from t2 where t.a = t2.a and t.b > 'foo' and t2.c > 1.0;
-----
-DataFusion error: UPDATE operation on table 't1'
-caused by
-Schema error: No field named t2.b. Did you mean 'b'?.
 
 
 # test source alias permutations with joined assignments
@@ -194,4 +179,4 @@ update t1 as dst set b = src.b, c = src.a + dst.a, d = src.d from t2 as src wher
 ----
 DataFusion error: UPDATE operation on table 't1'
 caused by
-Schema error: No field named src.b. Did you mean 'b'?.
+Error during planning: UPDATE ... FROM produced 2 replacement rows but target filters matched 3 rows

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -69,20 +69,58 @@ physical_plan_error This feature is not implemented: Physical plan does not supp
 # set from other table
 # UPDATE ... FROM is currently unsupported
 # TODO fix https://github.com/apache/datafusion/issues/19950
-query error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+query TT
 explain update t1 set b = t2.b, c = t2.a, d = 1 from t2 where t1.a = t2.a and t1.b > 'foo' and t2.c > 1.0;
+----
+logical_plan
+01)Dml: op=[Update] table=[t1]
+02)--Projection: t1.a AS a, t2.b AS b, CAST(t2.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d
+03)----Filter: t1.a = t2.a AND t1.b > CAST(Utf8("foo") AS Utf8View) AND t2.c > Float64(1)
+04)------Cross Join:
+05)--------TableScan: t1
+06)--------TableScan: t2
+physical_plan_error
+01)UPDATE operation on table 't1'
+02)caused by
+03)Schema error: No field named t2.b. Did you mean 'b'?.
 
 # update from (FROM before SET syntax)
 # UPDATE ... FROM is currently unsupported
 # TODO fix https://github.com/apache/datafusion/issues/19950
-query error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+query TT
 explain update t1 from t2 set b = t2.b, c = t1.a + t2.a where t1.a = t2.a;
+----
+logical_plan
+01)Dml: op=[Update] table=[t1]
+02)--Projection: t1.a AS a, t2.b AS b, CAST(t1.a + t2.a AS Float64) AS c, t1.d AS d
+03)----Filter: t1.a = t2.a
+04)------Cross Join:
+05)--------TableScan: t1
+06)--------TableScan: t2
+physical_plan_error
+01)UPDATE operation on table 't1'
+02)caused by
+03)Schema error: No field named t2.b. Did you mean 'b'?.
 
 # update from with explicit aliases and joined assignment expressions
 # UPDATE ... FROM is currently unsupported
 # TODO fix https://github.com/apache/datafusion/issues/19950
-query error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+query TT
 explain update t1 as dst set b = src.b, c = src.a + dst.a, d = dst.d + src.d from t2 as src where dst.a = src.a and src.c > dst.c;
+----
+logical_plan
+01)Dml: op=[Update] table=[t1]
+02)--Projection: dst.a AS a, src.b AS b, CAST(src.a + dst.a AS Float64) AS c, dst.d + src.d AS d
+03)----Filter: dst.a = src.a AND src.c > dst.c
+04)------Cross Join:
+05)--------SubqueryAlias: dst
+06)----------TableScan: t1
+07)--------SubqueryAlias: src
+08)----------TableScan: t2
+physical_plan_error
+01)UPDATE operation on table 't1'
+02)caused by
+03)Schema error: No field named src.b. Did you mean 'b'?.
 
 # test update from other table with actual data
 statement ok
@@ -94,8 +132,13 @@ insert into t2 values (1, 'updated_b', 5.0, 40), (2, 'updated_b2', 2.5, 50), (4,
 # UPDATE ... FROM is currently unsupported - qualifier stripping breaks source column references
 # causing assignments like 'b = t2.b' to resolve to target table's 'b' instead of source table's 'b'
 # TODO fix https://github.com/apache/datafusion/issues/19950
-statement error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+statement error
 update t1 set b = t2.b, c = t2.a, d = 1 from t2 where t1.a = t2.a and t1.b > 'foo' and t2.c > 1.0;
+----
+DataFusion error: UPDATE operation on table 't1'
+caused by
+Schema error: No field named t2.b. Did you mean 'b'?.
+
 
 # set from multiple tables, DataFusion only supports from one table
 statement error DataFusion error: This feature is not implemented: Multiple tables in UPDATE SET FROM not yet supported
@@ -104,8 +147,21 @@ explain update t1 set b = t2.b, c = t3.a, d = 1 from t2, t3 where t1.a = t2.a an
 # test table alias
 # UPDATE ... FROM is currently unsupported
 # TODO fix https://github.com/apache/datafusion/issues/19950
-statement error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+query TT
 explain update t1 as T set b = t2.b, c = t.a, d = 1 from t2 where t.a = t2.a and t.b > 'foo' and t2.c > 1.0;
+----
+logical_plan
+01)Dml: op=[Update] table=[t1]
+02)--Projection: t.a AS a, t2.b AS b, CAST(t.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d
+03)----Filter: t.a = t2.a AND t.b > CAST(Utf8("foo") AS Utf8View) AND t2.c > Float64(1)
+04)------Cross Join:
+05)--------SubqueryAlias: t
+06)----------TableScan: t1
+07)--------TableScan: t2
+physical_plan_error
+01)UPDATE operation on table 't1'
+02)caused by
+03)Schema error: No field named t2.b. Did you mean 'b'?.
 
 # test update with table alias with actual data
 statement ok
@@ -122,11 +178,20 @@ insert into t2 values (1, 'new_val', 2.0, 100), (2, 'new_val2', 1.5, 200);
 
 # UPDATE ... FROM is currently unsupported
 # TODO fix https://github.com/apache/datafusion/issues/19950
-statement error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+statement error
 update t1 as T set b = t2.b, c = t.a, d = 1 from t2 where t.a = t2.a and t.b > 'foo' and t2.c > 1.0;
+----
+DataFusion error: UPDATE operation on table 't1'
+caused by
+Schema error: No field named t2.b. Did you mean 'b'?.
+
 
 # test source alias permutations with joined assignments
 # UPDATE ... FROM is currently unsupported
 # TODO fix https://github.com/apache/datafusion/issues/19950
-statement error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+statement error
 update t1 as dst set b = src.b, c = src.a + dst.a, d = src.d from t2 as src where dst.a = src.a and src.c > 1.0;
+----
+DataFusion error: UPDATE operation on table 't1'
+caused by
+Schema error: No field named src.b. Did you mean 'b'?.

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -72,6 +72,18 @@ physical_plan_error This feature is not implemented: Physical plan does not supp
 query error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
 explain update t1 set b = t2.b, c = t2.a, d = 1 from t2 where t1.a = t2.a and t1.b > 'foo' and t2.c > 1.0;
 
+# update from (FROM before SET syntax)
+# UPDATE ... FROM is currently unsupported
+# TODO fix https://github.com/apache/datafusion/issues/19950
+query error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+explain update t1 from t2 set b = t2.b, c = t1.a + t2.a where t1.a = t2.a;
+
+# update from with explicit aliases and joined assignment expressions
+# UPDATE ... FROM is currently unsupported
+# TODO fix https://github.com/apache/datafusion/issues/19950
+query error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+explain update t1 as dst set b = src.b, c = src.a + dst.a, d = dst.d + src.d from t2 as src where dst.a = src.a and src.c > dst.c;
+
 # test update from other table with actual data
 statement ok
 insert into t1 values (1, 'zoo', 2.0, 10), (2, 'qux', 3.0, 20), (3, 'bar', 4.0, 30);
@@ -112,3 +124,9 @@ insert into t2 values (1, 'new_val', 2.0, 100), (2, 'new_val2', 1.5, 200);
 # TODO fix https://github.com/apache/datafusion/issues/19950
 statement error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
 update t1 as T set b = t2.b, c = t.a, d = 1 from t2 where t.a = t2.a and t.b > 'foo' and t2.c > 1.0;
+
+# test source alias permutations with joined assignments
+# UPDATE ... FROM is currently unsupported
+# TODO fix https://github.com/apache/datafusion/issues/19950
+statement error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+update t1 as dst set b = src.b, c = src.a + dst.a, d = src.d from t2 as src where dst.a = src.a and src.c > 1.0;

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -67,8 +67,7 @@ logical_plan
 physical_plan_error This feature is not implemented: Physical plan does not support logical expression ScalarSubquery(<subquery>)
 
 # set from other table
-# UPDATE ... FROM is currently unsupported
-# TODO fix https://github.com/apache/datafusion/issues/19950
+# UPDATE ... FROM (single source table) is supported
 query TT
 explain update t1 set b = t2.b, c = t2.a, d = 1 from t2 where t1.a = t2.a and t1.b > 'foo' and t2.c > 1.0;
 ----
@@ -84,8 +83,7 @@ physical_plan
 02)--DmlResultExec: rows_affected=0
 
 # update from (FROM before SET syntax)
-# UPDATE ... FROM is currently unsupported
-# TODO fix https://github.com/apache/datafusion/issues/19950
+# UPDATE ... FROM supports both FROM-before-SET and FROM-after-SET syntax
 query TT
 explain update t1 from t2 set b = t2.b, c = t1.a + t2.a where t1.a = t2.a;
 ----
@@ -101,8 +99,7 @@ physical_plan
 02)--DmlResultExec: rows_affected=0
 
 # update from with explicit aliases and joined assignment expressions
-# UPDATE ... FROM is currently unsupported
-# TODO fix https://github.com/apache/datafusion/issues/19950
+# UPDATE ... FROM supports source/target aliases in assignment and filter expressions
 query TT
 explain update t1 as dst set b = src.b, c = src.a + dst.a, d = dst.d + src.d from t2 as src where dst.a = src.a and src.c > dst.c;
 ----
@@ -143,8 +140,7 @@ statement error DataFusion error: This feature is not implemented: Multiple tabl
 explain update t1 set b = t2.b, c = t3.a, d = 1 from t2, t3 where t1.a = t2.a and t1.a = t3.a;
 
 # test table alias
-# UPDATE ... FROM is currently unsupported
-# TODO fix https://github.com/apache/datafusion/issues/19950
+# UPDATE ... FROM with target alias in assignments and predicates
 query TT
 explain update t1 as T set b = t2.b, c = t.a, d = 1 from t2 where t.a = t2.a and t.b > 'foo' and t2.c > 1.0;
 ----
@@ -186,8 +182,7 @@ select * from t1 order by a;
 
 
 # test source alias permutations with joined assignments
-# UPDATE ... FROM is currently unsupported
-# TODO fix https://github.com/apache/datafusion/issues/19950
+# UPDATE ... FROM can still fail when replacement rows and matched target rows differ
 statement error
 update t1 as dst set b = src.b, c = src.a + dst.a, d = src.d from t2 as src where dst.a = src.a and src.c > 1.0;
 ----

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -130,6 +130,13 @@ insert into t2 values (1, 'updated_b', 5.0, 40), (2, 'updated_b2', 2.5, 50), (4,
 statement ok
 update t1 set b = t2.b, c = t2.a, d = 1 from t2 where t1.a = t2.a and t1.b > 'foo' and t2.c > 1.0;
 
+query ITRI
+select * from t1 order by a;
+----
+1 updated_b 1 1
+2 updated_b2 2 1
+3 bar 4 30
+
 
 # set from multiple tables, DataFusion only supports from one table
 statement error DataFusion error: This feature is not implemented: Multiple tables in UPDATE SET FROM not yet supported
@@ -169,6 +176,13 @@ insert into t2 values (1, 'new_val', 2.0, 100), (2, 'new_val2', 1.5, 200);
 # UPDATE ... FROM with target alias resolves and executes
 statement ok
 update t1 as T set b = t2.b, c = t.a, d = 1 from t2 where t.a = t2.a and t.b > 'foo' and t2.c > 1.0;
+
+query ITRI
+select * from t1 order by a;
+----
+1 new_val 1 1
+2 new_val2 2 1
+3 apple 3.5 15
 
 
 # test source alias permutations with joined assignments

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -192,3 +192,10 @@ select * from t1 order by a;
 1 new_val 2 100
 2 new_val2 4 200
 3 apple 3.5 15
+
+# regression: one target row matching multiple source rows should error
+statement ok
+insert into t2 values (1, 'duplicate_match', 9.9, 300);
+
+statement error DataFusion error: UPDATE operation on table 't1'
+update t1 as dst set b = src.b, c = src.a + dst.a, d = src.d from t2 as src where dst.a = src.a and dst.a = 1;

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -73,7 +73,7 @@ explain update t1 set b = t2.b, c = t2.a, d = 1 from t2 where t1.a = t2.a and t1
 ----
 logical_plan
 01)Dml: op=[Update] table=[t1]
-02)--Projection: t1.a AS a, t2.b AS b, CAST(t2.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d
+02)--Projection: t1.a AS a, t2.b AS b, CAST(t2.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d, t1.a AS __df_update_old_a, t1.b AS __df_update_old_b, t1.c AS __df_update_old_c, t1.d AS __df_update_old_d
 03)----Filter: t1.a = t2.a AND t1.b > CAST(Utf8("foo") AS Utf8View) AND t2.c > Float64(1)
 04)------Cross Join:
 05)--------TableScan: t1
@@ -89,7 +89,7 @@ explain update t1 from t2 set b = t2.b, c = t1.a + t2.a where t1.a = t2.a;
 ----
 logical_plan
 01)Dml: op=[Update] table=[t1]
-02)--Projection: t1.a AS a, t2.b AS b, CAST(t1.a + t2.a AS Float64) AS c, t1.d AS d
+02)--Projection: t1.a AS a, t2.b AS b, CAST(t1.a + t2.a AS Float64) AS c, t1.d AS d, t1.a AS __df_update_old_a, t1.b AS __df_update_old_b, t1.c AS __df_update_old_c, t1.d AS __df_update_old_d
 03)----Filter: t1.a = t2.a
 04)------Cross Join:
 05)--------TableScan: t1
@@ -105,7 +105,7 @@ explain update t1 as dst set b = src.b, c = src.a + dst.a, d = dst.d + src.d fro
 ----
 logical_plan
 01)Dml: op=[Update] table=[t1]
-02)--Projection: dst.a AS a, src.b AS b, CAST(src.a + dst.a AS Float64) AS c, dst.d + src.d AS d
+02)--Projection: dst.a AS a, src.b AS b, CAST(src.a + dst.a AS Float64) AS c, dst.d + src.d AS d, dst.a AS __df_update_old_a, dst.b AS __df_update_old_b, dst.c AS __df_update_old_c, dst.d AS __df_update_old_d
 03)----Filter: dst.a = src.a AND src.c > dst.c
 04)------Cross Join:
 05)--------SubqueryAlias: dst
@@ -146,7 +146,7 @@ explain update t1 as T set b = t2.b, c = t.a, d = 1 from t2 where t.a = t2.a and
 ----
 logical_plan
 01)Dml: op=[Update] table=[t1]
-02)--Projection: t.a AS a, t2.b AS b, CAST(t.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d
+02)--Projection: t.a AS a, t2.b AS b, CAST(t.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d, t.a AS __df_update_old_a, t.b AS __df_update_old_b, t.c AS __df_update_old_c, t.d AS __df_update_old_d
 03)----Filter: t.a = t2.a AND t.b > CAST(Utf8("foo") AS Utf8View) AND t2.c > Float64(1)
 04)------Cross Join:
 05)--------SubqueryAlias: t
@@ -182,10 +182,13 @@ select * from t1 order by a;
 
 
 # test source alias permutations with joined assignments
-# UPDATE ... FROM can still fail when replacement rows and matched target rows differ
-statement error
+# UPDATE ... FROM matches target rows using the original target row image
+statement ok
 update t1 as dst set b = src.b, c = src.a + dst.a, d = src.d from t2 as src where dst.a = src.a and src.c > 1.0;
+
+query ITRI
+select * from t1 order by a;
 ----
-DataFusion error: UPDATE operation on table 't1'
-caused by
-Error during planning: UPDATE ... FROM produced 2 replacement rows but target filters matched 3 rows
+1 new_val 2 100
+2 new_val2 4 200
+3 apple 3.5 15


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #19950.

## Rationale for this change

`UPDATE ... FROM` was previously rejected or behaved incorrectly because joined assignment expressions were not preserved end-to-end. In particular, source-table references such as `t2.b` could be lost during planning, which meant updates either failed outright or used the wrong values when applying joined assignments.

This change fixes that gap so `UPDATE ... FROM` works for the supported single-source-table form and produces the expected target-row updates. It also aligns filter extraction and assignment handling with the semantics users expect from joined updates, including aliased target/source tables and self-joins.

## What changes are included in this PR?

This PR adds end-to-end support for `UPDATE ... FROM` across SQL planning, physical planning, and `MemTable` execution.

At a high level, the changes include:

* removing the SQL planner restriction that rejected `UPDATE ... FROM`
* extending DML planning to project both:

  * the new target-row values, and
  * a hidden copy of the original target-row values using `__df_update_old_*` columns
* adding `TableProvider::update_from(...)` as a dedicated API for providers that need precomputed joined update rows
* implementing `update_from(...)` for `MemTable`
* matching replacement rows back to original target rows using the projected original-row image
* preserving source qualifiers for multi-table update assignments while keeping existing single-table `UPDATE` behavior
* improving DML filter extraction so only target-table predicates are forwarded to providers in `UPDATE ... FROM` and self-join cases
* resolving join partitioning before handing joined update plans to table providers
* adding helper utilities and documentation for hidden original-row column naming

## Are these changes tested?

Yes.

This PR adds and updates tests across SQL planning, physical planning, provider behavior, and sqllogictest coverage. The new tests cover:

* logical planning for `UPDATE ... FROM`, including projection of hidden original-row columns
* preservation of source aliases in joined assignment expressions
* single-table `UPDATE` qualifier stripping behavior remaining unchanged
* correct extraction of only target-side predicates for `UPDATE ... FROM`
* alias variants and self-join cases
* successful execution of joined updates against `MemTable`
* regression coverage for duplicate matches, which now surface as an error when replacement rows do not map cleanly to target rows
* related DELETE filter-extraction cases to keep DML behavior consistent

## Are there any user-facing changes?

Yes.

Users can now run supported `UPDATE ... FROM` statements successfully in DataFusion, including cases with aliases and joined assignment expressions such as:

```sql
UPDATE t1 AS dst
SET b = src.b, d = src.d
FROM t2 AS src
WHERE dst.a = src.a;
```

This is a functional improvement to SQL behavior. It also introduces a new `TableProvider::update_from(...)` hook for provider implementations that want to support joined updates.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
