### PR TITLE
[bench]

### DIFF
--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -71,6 +71,7 @@ use crate::sort_pushdown::SortOrderPushdownResult;
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
 use datafusion_physical_expr_common::utils::evaluate_expressions_to_arrays;
 use futures::stream::Stream;
+use futures::future::join_all;
 use futures::{FutureExt, StreamExt, TryStreamExt, ready};
 use log::trace;
 use parking_lot::Mutex;
@@ -1469,31 +1470,40 @@ impl RepartitionExec {
             Err(e) => {
                 let e = Arc::new(e);
 
-                for (_, tx) in txs {
-                    let err = Err(DataFusionError::Context(
-                        "Join Error".to_string(),
-                        Box::new(DataFusionError::External(Box::new(Arc::clone(&e)))),
-                    ));
-                    tx.send(Some(err)).await.ok();
-                }
+                join_all(txs.into_values().map(|tx| {
+                    let e = Arc::clone(&e);
+                    async move {
+                        let err = Err(DataFusionError::Context(
+                            "Join Error".to_string(),
+                            Box::new(DataFusionError::External(Box::new(e))),
+                        ));
+                        tx.send(Some(err)).await.ok();
+                    }
+                }))
+                .await;
             }
             // Error from running input task
             Ok(Err(e)) => {
                 // send the same Arc'd error to all output partitions
                 let e = Arc::new(e);
 
-                for (_, tx) in txs {
-                    // wrap it because need to send error to all output partitions
-                    let err = Err(DataFusionError::from(&e));
-                    tx.send(Some(err)).await.ok();
-                }
+                join_all(txs.into_values().map(|tx| {
+                    let e = Arc::clone(&e);
+                    async move {
+                        let err = Err(DataFusionError::from(&e));
+                        tx.send(Some(err)).await.ok();
+                    }
+                }))
+                .await;
             }
             // Input task completed successfully
             Ok(Ok(())) => {
                 // notify each output partition that this input partition has no more data
-                for (_partition, tx) in txs {
-                    tx.send(None).await.ok();
-                }
+                join_all(
+                    txs.into_values()
+                        .map(|tx| async move { tx.send(None).await.ok() }),
+                )
+                .await;
             }
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

The current implementation sends error messages to output partitions sequentially using a for loop. This can be inefficient when there are many output partitions, as each `send()` operation is awaited individually. By using `futures::future::join_all()`, we can parallelize these operations, allowing multiple sends to happen concurrently rather than sequentially.

This change improves performance in error scenarios by reducing the total time spent notifying all output partitions of errors or completion.

## What changes are included in this PR?


## Are these changes tested?

The changes are covered by existing tests in the DataFusion test suite. The refactoring maintains the same functional behavior (all error messages and completion signals are still sent to all output partitions), only changing the execution model from sequential to concurrent.

## Are there any user-facing changes?

No user-facing changes. This is an internal optimization to the physical execution layer that improves performance without changing the external API or behavior.

https://claude.ai/code/session_01GDTBavJzih6tSSBd9SRNmk