### PR TITLE
feat: preallocate final aggregation hash maps based on partial group …

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -1043,14 +1043,22 @@ impl DefaultPhysicalPlanner {
                     input_exec
                 };
 
-                let initial_aggr = Arc::new(AggregateExec::try_new(
-                    AggregateMode::Partial,
-                    groups.clone(),
-                    aggregates,
-                    filters.clone(),
-                    input_exec,
-                    Arc::clone(&physical_input_schema),
-                )?);
+                // Share the partial group count between partial and final
+                // aggregation so the final stage can preallocate its hash map.
+                let partial_group_count =
+                    Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+                let initial_aggr = Arc::new(
+                    AggregateExec::try_new(
+                        AggregateMode::Partial,
+                        groups.clone(),
+                        aggregates,
+                        filters.clone(),
+                        input_exec,
+                        Arc::clone(&physical_input_schema),
+                    )?
+                    .with_partial_group_count(Arc::clone(&partial_group_count)),
+                );
 
                 let can_repartition = !groups.is_empty()
                     && session_state.config().target_partitions() > 1
@@ -1074,14 +1082,17 @@ impl DefaultPhysicalPlanner {
 
                 let final_grouping_set = initial_aggr.group_expr().as_final();
 
-                Arc::new(AggregateExec::try_new(
-                    next_partition_mode,
-                    final_grouping_set,
-                    updated_aggregates,
-                    filters,
-                    initial_aggr,
-                    Arc::clone(&physical_input_schema),
-                )?)
+                Arc::new(
+                    AggregateExec::try_new(
+                        next_partition_mode,
+                        final_grouping_set,
+                        updated_aggregates,
+                        filters,
+                        initial_aggr,
+                        Arc::clone(&physical_input_schema),
+                    )?
+                    .with_partial_group_count(partial_group_count),
+                )
             }
             LogicalPlan::Projection(Projection { input, expr, .. }) => self
                 .create_project_physical_exec(

--- a/datafusion/physical-plan/src/aggregates/group_values/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/mod.rs
@@ -113,6 +113,14 @@ pub trait GroupValues: Send {
 
     /// Clear the contents and shrink the capacity to the size of the batch (free up memory usage)
     fn clear_shrink(&mut self, num_rows: usize);
+
+    /// Preallocate internal storage for the given number of groups.
+    ///
+    /// This is a hint and implementations may ignore it.
+    /// Used to avoid repeated rehashing when the approximate number of
+    /// groups is known ahead of time (e.g. from input statistics in
+    /// Final/FinalPartitioned aggregation).
+    fn prealloc(&mut self, _capacity: usize) {}
 }
 
 /// Return a specialized implementation of [`GroupValues`] for the given schema.

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -1195,6 +1195,12 @@ impl<const STREAMING: bool> GroupValues for GroupValuesColumn<STREAMING> {
             self.vectorized_operation_buffers.clear();
         }
     }
+
+    fn prealloc(&mut self, capacity: usize) {
+        self.map.reserve(capacity, |_| 0);
+        self.map_size = self.map.capacity() * size_of::<(u64, usize)>();
+        self.hashes_buffer.reserve(capacity);
+    }
 }
 
 /// Returns true if [`GroupValuesColumn`] supported for the specified schema

--- a/datafusion/physical-plan/src/aggregates/group_values/row.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/row.rs
@@ -254,6 +254,12 @@ impl GroupValues for GroupValuesRows {
         self.hashes_buffer.clear();
         self.hashes_buffer.shrink_to(num_rows);
     }
+
+    fn prealloc(&mut self, capacity: usize) {
+        self.map.reserve(capacity, |_| 0); // hasher does not matter for reservation
+        self.map_size = self.map.capacity() * size_of::<(u64, usize)>();
+        self.hashes_buffer.reserve(capacity);
+    }
 }
 
 fn dictionary_encode_if_necessary(

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -220,4 +220,9 @@ where
         self.map.clear();
         self.map.shrink_to(num_rows, |_| 0); // hasher does not matter since the map is cleared
     }
+
+    fn prealloc(&mut self, capacity: usize) {
+        self.map.reserve(capacity, |_| 0);
+        self.values.reserve(capacity);
+    }
 }

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -19,6 +19,7 @@
 
 use std::any::Any;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::{DisplayAs, ExecutionPlanProperties, PlanProperties};
 use crate::aggregates::{
@@ -660,6 +661,10 @@ pub struct AggregateExec {
     /// it remains `Some(..)` to enable dynamic filtering during aggregate execution;
     /// otherwise, it is cleared to `None`.
     dynamic_filter: Option<Arc<AggrDynFilter>>,
+    /// Shared counter for the total number of groups emitted by partial
+    /// aggregation. Written by partial aggregation streams (via `fetch_add`)
+    /// and read by final aggregation streams to preallocate hash maps.
+    partial_group_count: Arc<AtomicUsize>,
 }
 
 impl AggregateExec {
@@ -685,6 +690,7 @@ impl AggregateExec {
             schema: Arc::clone(&self.schema),
             input_schema: Arc::clone(&self.input_schema),
             dynamic_filter: self.dynamic_filter.clone(),
+            partial_group_count: Arc::clone(&self.partial_group_count),
         }
     }
 
@@ -705,6 +711,7 @@ impl AggregateExec {
             schema: Arc::clone(&self.schema),
             input_schema: Arc::clone(&self.input_schema),
             dynamic_filter: self.dynamic_filter.clone(),
+            partial_group_count: Arc::clone(&self.partial_group_count),
         }
     }
 
@@ -839,6 +846,7 @@ impl AggregateExec {
             input_order_mode,
             cache: Arc::new(cache),
             dynamic_filter: None,
+            partial_group_count: Arc::new(AtomicUsize::new(0)),
         };
 
         exec.init_dynamic_filter();
@@ -890,6 +898,21 @@ impl AggregateExec {
     /// Get the input schema before any aggregates are applied
     pub fn input_schema(&self) -> SchemaRef {
         Arc::clone(&self.input_schema)
+    }
+
+    /// Returns the shared partial group count counter.
+    pub fn partial_group_count(&self) -> &Arc<AtomicUsize> {
+        &self.partial_group_count
+    }
+
+    /// Set the shared partial group count counter (used to share between
+    /// partial and final aggregation).
+    pub fn with_partial_group_count(
+        mut self,
+        group_count: Arc<AtomicUsize>,
+    ) -> Self {
+        self.partial_group_count = group_count;
+        self
     }
 
     fn execute_typed(
@@ -1448,6 +1471,21 @@ impl ExecutionPlan for AggregateExec {
     }
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        // For partial aggregation, if the runtime group count has been
+        // recorded (input fully consumed), use the actual count instead
+        // of the static estimate. The raw count is the sum across all
+        // partial partitions and may over-count because the same group
+        // can appear in multiple partitions.
+        if self.mode == AggregateMode::Partial {
+            let runtime_count = self.partial_group_count.load(Ordering::Relaxed);
+            if runtime_count > 0 {
+                let child_statistics = self.input().partition_statistics(partition)?;
+                let mut stats = self.statistics_inner(&child_statistics)?;
+                stats.num_rows = Precision::Inexact(runtime_count);
+                return Ok(stats);
+            }
+        }
+
         let child_statistics = self.input().partition_statistics(partition)?;
         self.statistics_inner(&child_statistics)
     }

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -18,6 +18,7 @@
 //! Hash aggregation
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Context, Poll};
 use std::vec;
 
@@ -32,6 +33,7 @@ use crate::aggregates::{
 use crate::metrics::{BaselineMetrics, MetricBuilder, RecordOutput};
 use crate::sorts::streaming_merge::{SortedSpillFile, StreamingMergeBuilder};
 use crate::spill::spill_manager::{GetSlicedSize, SpillManager};
+use crate::execution_plan::ExecutionPlanProperties;
 use crate::{PhysicalExpr, aggregates, metrics};
 use crate::{RecordBatchStream, SendableRecordBatchStream};
 
@@ -455,6 +457,19 @@ pub(crate) struct GroupedHashAggregateStream {
 
     /// Reduction factor metric, calculated as `output_rows/input_rows` (only for partial aggregation)
     reduction_factor: Option<metrics::RatioMetrics>,
+
+    /// Shared counter for the number of groups emitted by partial aggregation.
+    /// Written by partial streams, read by final streams for hash map
+    /// preallocation.
+    partial_group_count: Arc<AtomicUsize>,
+
+    /// Number of input partitions (used to scale down the partial group count
+    /// hint for preallocation in final aggregation).
+    num_input_partitions: usize,
+
+    /// Whether the hash map has already been preallocated (prevents repeated
+    /// preallocation after spill-and-reload cycles).
+    preallocated: bool,
 }
 
 impl GroupedHashAggregateStream {
@@ -679,6 +694,13 @@ impl GroupedHashAggregateStream {
             group_values_soft_limit: agg.limit_options().map(|config| config.limit()),
             skip_aggregation_probe,
             reduction_factor,
+            partial_group_count: Arc::clone(agg.partial_group_count()),
+            num_input_partitions: agg
+                .input
+                .output_partitioning()
+                .partition_count()
+                .max(1),
+            preallocated: false,
         })
     }
 }
@@ -941,6 +963,36 @@ impl GroupedHashAggregateStream {
         } else {
             evaluate_optional(&self.filter_expressions, batch)?
         };
+
+        // In Final/FinalPartitioned mode, use the runtime group count from
+        // partial aggregation to preallocate the hash map.
+        //
+        // partial_group_count sums groups across all partial partitions,
+        // over-counting when the same group appears in multiple partitions.
+        // Dividing by num_input_partitions gives a reasonable estimate:
+        // - If groups are shared across all partitions (common case):
+        //   each partition reports ~unique_groups, so sum / N ≈ unique_groups
+        // - If groups are disjoint across partitions:
+        //   sum = unique_groups, so sum / N underestimates, but the map will
+        //   grow as needed (still avoids the worst-case growth from 0)
+        if !self.preallocated
+            && matches!(
+                self.mode,
+                AggregateMode::Final | AggregateMode::FinalPartitioned
+            )
+        {
+            self.preallocated = true;
+            let group_count = self.partial_group_count.load(Ordering::Relaxed);
+            if group_count > 0 {
+                let hint = group_count / self.num_input_partitions;
+                if hint > 0 {
+                    self.group_values.prealloc(hint);
+                    // Update reservation immediately so the memory pool is
+                    // aware of the preallocation.
+                    self.update_memory_reservation()?;
+                }
+            }
+        }
 
         for group_values in &group_by_values {
             let groups_start_time = Instant::now();
@@ -1226,6 +1278,15 @@ impl GroupedHashAggregateStream {
     fn set_input_done_and_produce_output(&mut self) -> Result<()> {
         self.input_done = true;
         self.group_ordering.input_done();
+
+        // Record the number of groups for downstream consumers (e.g. final
+        // aggregation) before we start emitting. Multiple partial partitions
+        // may contribute via fetch_add.
+        if self.mode == AggregateMode::Partial {
+            self.partial_group_count
+                .fetch_add(self.group_values.len(), Ordering::Relaxed);
+        }
+
         let elapsed_compute = self.baseline_metrics.elapsed_compute().clone();
         let timer = elapsed_compute.timer();
         self.exec_state = if self.spill_state.spills.is_empty() {


### PR DESCRIPTION
…count

Share an Arc<AtomicUsize> between partial and final AggregateExec to pass the runtime group count from partial aggregation. Final/FinalPartitioned aggregation uses this to preallocate hash maps, avoiding repeated rehashing as maps grow from empty to their final size.

The partial group count is divided by the number of input partitions to estimate unique groups per partition (since the same group may appear across multiple partial partitions).

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
