### PR TITLE
[Bench] emit early

### DIFF
--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -776,6 +776,24 @@ impl Stream for GroupedHashAggregateStream {
                                     self.exec_state = new_state;
                                     break 'reading_input;
                                 }
+
+                                // Emit early when the hash table exceeds 8MB
+                                // (each entry is ~16 bytes: hash u64 + offset u64)
+                                const MAP_SIZE_LIMIT: usize = 8 * 1024 * 1024;
+                                if self.group_values.len() * size_of::<(u64, u64)>()
+                                    >= MAP_SIZE_LIMIT
+                                {
+                                    let batch_size = self.batch_size;
+                                    if let Some(batch) =
+                                        self.emit(EmitTo::All, false)?
+                                    {
+                                        timer.done();
+                                        self.clear_shrink(batch_size);
+                                        self.exec_state =
+                                            ExecutionState::ProducingOutput(batch);
+                                        break 'reading_input;
+                                    }
+                                }
                             }
 
                             // If we reach this point, try to update the memory reservation


### PR DESCRIPTION
When the hash map in partial aggregation grows beyond 8MB (based on hash+offset entry size of 16 bytes per group), emit all accumulated groups and clear/reset the hash table. This keeps the hash table small for better lookup performance and reduces memory pressure.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
