### PR TITLE
[Bench] u32 group indices

### DIFF
--- a/datafusion-examples/examples/udf/advanced_udaf.rs
+++ b/datafusion-examples/examples/udf/advanced_udaf.rs
@@ -31,8 +31,8 @@ use arrow_schema::FieldRef;
 use datafusion::common::{ScalarValue, cast::as_float64_array};
 use datafusion::error::Result;
 use datafusion::logical_expr::{
-    Accumulator, AggregateUDF, AggregateUDFImpl, EmitTo, GroupsAccumulator, Signature,
-    expr::AggregateFunction,
+    Accumulator, AggregateUDF, AggregateUDFImpl, EmitTo, GroupIndex, GroupsAccumulator,
+    Signature, expr::AggregateFunction,
     function::{AccumulatorArgs, AggregateFunctionSimplification, StateFieldsArgs},
     simplify::SimplifyContext,
 };
@@ -241,7 +241,7 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&arrow::array::BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -258,10 +258,10 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
             opt_filter,
             total_num_groups,
             |group_index, new_value| {
-                let prod = &mut self.prods[group_index];
+                let prod = &mut self.prods[group_index as usize];
                 *prod = prod.mul_wrapping(new_value);
 
-                self.counts[group_index] += 1;
+                self.counts[group_index as usize] += 1;
             },
         );
 
@@ -272,7 +272,7 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&arrow::array::BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -288,7 +288,7 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
             opt_filter,
             total_num_groups,
             |group_index, partial_count| {
-                self.counts[group_index] += partial_count;
+                self.counts[group_index as usize] += partial_count;
             },
         );
 
@@ -300,7 +300,7 @@ impl GroupsAccumulator for GeometricMeanGroupsAccumulator {
             opt_filter,
             total_num_groups,
             |group_index, new_value: <Float64Type as ArrowPrimitiveType>::Native| {
-                let prod = &mut self.prods[group_index];
+                let prod = &mut self.prods[group_index as usize];
                 *prod = prod.mul_wrapping(new_value);
             },
         );

--- a/datafusion/core/tests/user_defined/user_defined_aggregates.rs
+++ b/datafusion/core/tests/user_defined/user_defined_aggregates.rs
@@ -56,8 +56,9 @@ use datafusion_common::{cast::as_primitive_array, exec_err};
 
 use datafusion_expr::expr::WindowFunction;
 use datafusion_expr::{
-    AggregateUDFImpl, Expr, GroupsAccumulator, LogicalPlanBuilder, SimpleAggregateUDF,
-    WindowFunctionDefinition, col, create_udaf, function::AccumulatorArgs,
+    AggregateUDFImpl, Expr, GroupIndex, GroupsAccumulator, LogicalPlanBuilder,
+    SimpleAggregateUDF, WindowFunctionDefinition, col, create_udaf,
+    function::AccumulatorArgs,
 };
 use datafusion_functions_aggregate::average::AvgAccumulator;
 
@@ -852,7 +853,7 @@ impl GroupsAccumulator for TestGroupsAccumulator {
     fn update_batch(
         &mut self,
         _values: &[ArrayRef],
-        _group_indices: &[usize],
+        _group_indices: &[GroupIndex],
         _opt_filter: Option<&arrow::array::BooleanArray>,
         _total_num_groups: usize,
     ) -> Result<()> {
@@ -876,7 +877,7 @@ impl GroupsAccumulator for TestGroupsAccumulator {
     fn merge_batch(
         &mut self,
         _values: &[ArrayRef],
-        _group_indices: &[usize],
+        _group_indices: &[GroupIndex],
         _opt_filter: Option<&arrow::array::BooleanArray>,
         _total_num_groups: usize,
     ) -> Result<()> {

--- a/datafusion/expr-common/src/groups_accumulator.rs
+++ b/datafusion/expr-common/src/groups_accumulator.rs
@@ -20,6 +20,15 @@
 use arrow::array::{ArrayRef, BooleanArray};
 use datafusion_common::{Result, not_impl_err};
 
+/// Type alias for group indices used in aggregation.
+///
+/// Using `u32` instead of `usize` halves the memory needed to store group
+/// indices on 64-bit platforms, improving cache utilization during aggregation.
+/// A `u32` supports up to ~4 billion groups which is more than sufficient in
+/// practice — 4 billion groups times even a single byte of accumulator state
+/// would exceed available memory long before this limit is reached.
+pub type GroupIndex = u32;
+
 /// Describes how many rows should be emitted during grouping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EmitTo {
@@ -132,7 +141,7 @@ pub trait GroupsAccumulator: Send {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()>;
@@ -193,7 +202,7 @@ pub trait GroupsAccumulator: Send {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()>;

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -93,7 +93,7 @@ pub use datafusion_doc::{
 };
 pub use datafusion_expr_common::accumulator::Accumulator;
 pub use datafusion_expr_common::columnar_value::ColumnarValue;
-pub use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
+pub use datafusion_expr_common::groups_accumulator::{EmitTo, GroupIndex, GroupsAccumulator};
 pub use datafusion_expr_common::operator::Operator;
 pub use datafusion_expr_common::placement::ExpressionPlacement;
 pub use datafusion_expr_common::signature::{

--- a/datafusion/ffi/src/udaf/groups_accumulator.rs
+++ b/datafusion/ffi/src/udaf/groups_accumulator.rs
@@ -26,7 +26,7 @@ use arrow::array::{Array, ArrayRef, BooleanArray};
 use arrow::error::ArrowError;
 use arrow::ffi::to_ffi;
 use datafusion_common::error::{DataFusionError, Result};
-use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::{EmitTo, GroupIndex, GroupsAccumulator};
 
 use crate::arrow_wrappers::{WrappedArray, WrappedSchema};
 use crate::util::FFIResult;
@@ -41,7 +41,7 @@ pub struct FFI_GroupsAccumulator {
     pub update_batch: unsafe extern "C" fn(
         accumulator: &mut Self,
         values: RVec<WrappedArray>,
-        group_indices: RVec<usize>,
+        group_indices: RVec<u32>,
         opt_filter: ROption<WrappedArray>,
         total_num_groups: usize,
     ) -> FFIResult<()>,
@@ -62,7 +62,7 @@ pub struct FFI_GroupsAccumulator {
     pub merge_batch: unsafe extern "C" fn(
         accumulator: &mut Self,
         values: RVec<WrappedArray>,
-        group_indices: RVec<usize>,
+        group_indices: RVec<u32>,
         opt_filter: ROption<WrappedArray>,
         total_num_groups: usize,
     ) -> FFIResult<()>,
@@ -132,14 +132,14 @@ fn process_opt_filter(opt_filter: ROption<WrappedArray>) -> Result<Option<Boolea
 unsafe extern "C" fn update_batch_fn_wrapper(
     accumulator: &mut FFI_GroupsAccumulator,
     values: RVec<WrappedArray>,
-    group_indices: RVec<usize>,
+    group_indices: RVec<u32>,
     opt_filter: ROption<WrappedArray>,
     total_num_groups: usize,
 ) -> FFIResult<()> {
     unsafe {
         let accumulator = accumulator.inner_mut();
         let values = rresult_return!(process_values(values));
-        let group_indices: Vec<usize> = group_indices.into_iter().collect();
+        let group_indices: Vec<GroupIndex> = group_indices.into_iter().collect();
         let opt_filter = rresult_return!(process_opt_filter(opt_filter));
 
         rresult!(accumulator.update_batch(
@@ -191,14 +191,14 @@ unsafe extern "C" fn state_fn_wrapper(
 unsafe extern "C" fn merge_batch_fn_wrapper(
     accumulator: &mut FFI_GroupsAccumulator,
     values: RVec<WrappedArray>,
-    group_indices: RVec<usize>,
+    group_indices: RVec<u32>,
     opt_filter: ROption<WrappedArray>,
     total_num_groups: usize,
 ) -> FFIResult<()> {
     unsafe {
         let accumulator = accumulator.inner_mut();
         let values = rresult_return!(process_values(values));
-        let group_indices: Vec<usize> = group_indices.into_iter().collect();
+        let group_indices: Vec<GroupIndex> = group_indices.into_iter().collect();
         let opt_filter = rresult_return!(process_opt_filter(opt_filter));
 
         rresult!(accumulator.merge_batch(
@@ -305,7 +305,7 @@ impl GroupsAccumulator for ForeignGroupsAccumulator {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -314,7 +314,7 @@ impl GroupsAccumulator for ForeignGroupsAccumulator {
                 .iter()
                 .map(WrappedArray::try_from)
                 .collect::<std::result::Result<Vec<_>, ArrowError>>()?;
-            let group_indices = group_indices.iter().cloned().collect();
+            let group_indices: RVec<u32> = group_indices.iter().cloned().collect();
             let opt_filter = opt_filter
                 .map(|bool_array| to_ffi(&bool_array.to_data()))
                 .transpose()?
@@ -368,7 +368,7 @@ impl GroupsAccumulator for ForeignGroupsAccumulator {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -377,7 +377,7 @@ impl GroupsAccumulator for ForeignGroupsAccumulator {
                 .iter()
                 .map(WrappedArray::try_from)
                 .collect::<std::result::Result<Vec<_>, ArrowError>>()?;
-            let group_indices = group_indices.iter().cloned().collect();
+            let group_indices: RVec<u32> = group_indices.iter().cloned().collect();
             let opt_filter = opt_filter
                 .map(|bool_array| to_ffi(&bool_array.to_data()))
                 .transpose()?
@@ -486,7 +486,7 @@ mod tests {
             create_array!(Boolean, vec![true, true, true, true, false, false]);
         foreign_accum.update_batch(
             &[values],
-            &[0, 0, 1, 1, 2, 2],
+            &[0u32, 0, 1, 1, 2, 2],
             Some(opt_filter.as_ref()),
             3,
         )?;
@@ -508,7 +508,7 @@ mod tests {
             vec![make_array(create_array!(Boolean, vec![false]).to_data())];
 
         let opt_filter = create_array!(Boolean, vec![true]);
-        foreign_accum.merge_batch(&second_states, &[0], Some(opt_filter.as_ref()), 1)?;
+        foreign_accum.merge_batch(&second_states, &[0u32], Some(opt_filter.as_ref()), 1)?;
         let groups_bool = foreign_accum.evaluate(EmitTo::All)?;
         assert_eq!(groups_bool.len(), 1);
         assert_eq!(

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator.rs
@@ -34,7 +34,7 @@ use arrow::{
 };
 use datafusion_common::{Result, ScalarValue, arrow_datafusion_err};
 use datafusion_expr_common::accumulator::Accumulator;
-use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
+use datafusion_expr_common::groups_accumulator::{EmitTo, GroupIndex, GroupsAccumulator};
 
 /// An adapter that implements [`GroupsAccumulator`] for any [`Accumulator`]
 ///
@@ -186,7 +186,7 @@ impl GroupsAccumulatorAdapter {
     fn invoke_per_accumulator<F>(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
         f: F,
@@ -201,8 +201,8 @@ impl GroupsAccumulatorAdapter {
         // figure out which input rows correspond to which groups.
         // Note that self.state.indices starts empty for all groups
         // (it is cleared out below)
-        for (idx, group_index) in group_indices.iter().enumerate() {
-            self.states[*group_index].indices.push(idx as u32);
+        for (idx, &group_index) in group_indices.iter().enumerate() {
+            self.states[group_index as usize].indices.push(idx as u32);
         }
 
         // groups_with_rows holds a list of group indexes that have
@@ -299,7 +299,7 @@ impl GroupsAccumulator for GroupsAccumulatorAdapter {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -374,7 +374,7 @@ impl GroupsAccumulator for GroupsAccumulatorAdapter {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/accumulate.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/accumulate.rs
@@ -23,7 +23,7 @@ use arrow::array::{Array, BooleanArray, BooleanBufferBuilder, PrimitiveArray};
 use arrow::buffer::NullBuffer;
 use arrow::datatypes::ArrowPrimitiveType;
 
-use datafusion_expr_common::groups_accumulator::EmitTo;
+use datafusion_expr_common::groups_accumulator::{EmitTo, GroupIndex};
 
 /// If the input has nulls, then the accumulator must potentially
 /// handle each input null value specially (e.g. for `SUM` to mark the
@@ -162,14 +162,14 @@ impl NullState {
     /// 1. `self.seen_values[group_index]` to true for all rows that had a non null value
     pub fn accumulate<T, F>(
         &mut self,
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         values: &PrimitiveArray<T>,
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
         mut value_fn: F,
     ) where
         T: ArrowPrimitiveType + Send,
-        F: FnMut(usize, T::Native) + Send,
+        F: FnMut(GroupIndex, T::Native) + Send,
     {
         // skip null handling if no nulls in input or accumulator
         if let SeenValues::All { num_values } = &mut self.seen_values
@@ -183,7 +183,7 @@ impl NullState {
 
         let seen_values = self.seen_values.get_builder(total_num_groups);
         accumulate(group_indices, values, opt_filter, |group_index, value| {
-            seen_values.set_bit(group_index, true);
+            seen_values.set_bit(group_index as usize, true);
             value_fn(group_index, value);
         });
     }
@@ -200,13 +200,13 @@ impl NullState {
     /// more details on other arguments.
     pub fn accumulate_boolean<F>(
         &mut self,
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         values: &BooleanArray,
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
         mut value_fn: F,
     ) where
-        F: FnMut(usize, bool) + Send,
+        F: FnMut(GroupIndex, bool) + Send,
     {
         let data = values.values();
         assert_eq!(data.len(), group_indices.len());
@@ -235,7 +235,7 @@ impl NullState {
                 // buffer is big enough (start everything at valid)
                 group_indices.iter().zip(data.iter()).for_each(
                     |(&group_index, new_value)| {
-                        seen_values.set_bit(group_index, true);
+                        seen_values.set_bit(group_index as usize, true);
                         value_fn(group_index, new_value)
                     },
                 )
@@ -249,7 +249,7 @@ impl NullState {
                     .zip(nulls.iter())
                     .for_each(|((&group_index, new_value), is_valid)| {
                         if is_valid {
-                            seen_values.set_bit(group_index, true);
+                            seen_values.set_bit(group_index as usize, true);
                             value_fn(group_index, new_value);
                         }
                     })
@@ -264,7 +264,7 @@ impl NullState {
                     .zip(filter.iter())
                     .for_each(|((&group_index, new_value), filter_value)| {
                         if let Some(true) = filter_value {
-                            seen_values.set_bit(group_index, true);
+                            seen_values.set_bit(group_index as usize, true);
                             value_fn(group_index, new_value);
                         }
                     })
@@ -280,7 +280,7 @@ impl NullState {
                         if let Some(true) = filter_value
                             && let Some(new_value) = new_value
                         {
-                            seen_values.set_bit(group_index, true);
+                            seen_values.set_bit(group_index as usize, true);
                             value_fn(group_index, new_value)
                         }
                     })
@@ -368,13 +368,13 @@ impl NullState {
 /// value_fn(0, 300)
 /// ```
 pub fn accumulate<T, F>(
-    group_indices: &[usize],
+    group_indices: &[GroupIndex],
     values: &PrimitiveArray<T>,
     opt_filter: Option<&BooleanArray>,
     mut value_fn: F,
 ) where
     T: ArrowPrimitiveType + Send,
-    F: FnMut(usize, T::Native) + Send,
+    F: FnMut(GroupIndex, T::Native) + Send,
 {
     let data: &[T::Native] = values.values();
     assert_eq!(data.len(), group_indices.len());
@@ -483,13 +483,13 @@ pub fn accumulate<T, F>(
 ///     * `batch_idx`: The index of the current row in the input arrays
 ///     * `columns`: Reference to all input arrays for accessing values
 pub fn accumulate_multiple<T, F>(
-    group_indices: &[usize],
+    group_indices: &[GroupIndex],
     value_columns: &[&PrimitiveArray<T>],
     opt_filter: Option<&BooleanArray>,
     mut value_fn: F,
 ) where
     T: ArrowPrimitiveType + Send,
-    F: FnMut(usize, usize, &[&PrimitiveArray<T>]) + Send,
+    F: FnMut(GroupIndex, usize, &[&PrimitiveArray<T>]) + Send,
 {
     // Calculate `valid_indices` to accumulate, non-valid indices are ignored.
     // `valid_indices` is a bit mask corresponding to the `group_indices`. An index
@@ -546,12 +546,12 @@ pub fn accumulate_multiple<T, F>(
 /// See [`NullState::accumulate`], for more details on other
 /// arguments.
 pub fn accumulate_indices<F>(
-    group_indices: &[usize],
+    group_indices: &[GroupIndex],
     nulls: Option<&NullBuffer>,
     opt_filter: Option<&BooleanArray>,
     mut index_fn: F,
 ) where
-    F: FnMut(usize) + Send,
+    F: FnMut(GroupIndex) + Send,
 {
     match (nulls, opt_filter) {
         (None, None) => {
@@ -840,7 +840,7 @@ mod test {
         /// Calls `NullState::accumulate` and `accumulate_indices` to
         /// ensure it generates the correct values.
         fn accumulate_test(
-            group_indices: &[usize],
+            group_indices: &[GroupIndex],
             values: &UInt32Array,
             opt_filter: Option<&BooleanArray>,
             total_num_groups: usize,
@@ -869,7 +869,7 @@ mod test {
         /// This is effectively a different implementation of
         /// accumulate that we compare with the above implementation
         fn accumulate_values_test(
-            group_indices: &[usize],
+            group_indices: &[GroupIndex],
             values: &UInt32Array,
             opt_filter: Option<&BooleanArray>,
             total_num_groups: usize,
@@ -944,7 +944,7 @@ mod test {
         // Calls `accumulate_indices`
         // and opt_filter and ensures it calls the right values
         fn accumulate_indices_test(
-            group_indices: &[usize],
+            group_indices: &[GroupIndex],
             nulls: Option<&NullBuffer>,
             opt_filter: Option<&BooleanArray>,
         ) {
@@ -998,7 +998,7 @@ mod test {
         /// This is effectively a different implementation of
         /// accumulate_boolean that we compare with the above implementation
         fn accumulate_boolean_test(
-            group_indices: &[usize],
+            group_indices: &[GroupIndex],
             values: &BooleanArray,
             opt_filter: Option<&BooleanArray>,
             total_num_groups: usize,

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/bool_op.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/bool_op.rs
@@ -21,7 +21,7 @@ use crate::aggregate::groups_accumulator::nulls::filtered_null_mask;
 use arrow::array::{ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder};
 use arrow::buffer::BooleanBuffer;
 use datafusion_common::Result;
-use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
+use datafusion_expr_common::groups_accumulator::{EmitTo, GroupIndex, GroupsAccumulator};
 
 use super::accumulate::NullState;
 
@@ -74,7 +74,7 @@ where
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -95,9 +95,9 @@ where
             opt_filter,
             total_num_groups,
             |group_index, new_value| {
-                let current_value = self.values.get_bit(group_index);
+                let current_value = self.values.get_bit(group_index as usize);
                 let value = (self.bool_fn)(current_value, new_value);
-                self.values.set_bit(group_index, value);
+                self.values.set_bit(group_index as usize, value);
             },
         );
 
@@ -131,7 +131,7 @@ where
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/prim_op.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/prim_op.rs
@@ -24,7 +24,7 @@ use arrow::compute;
 use arrow::datatypes::ArrowPrimitiveType;
 use arrow::datatypes::DataType;
 use datafusion_common::{DataFusionError, Result, internal_datafusion_err};
-use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
+use datafusion_expr_common::groups_accumulator::{EmitTo, GroupIndex, GroupsAccumulator};
 
 use super::accumulate::NullState;
 
@@ -89,7 +89,7 @@ where
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -107,7 +107,7 @@ where
             total_num_groups,
             |group_index, new_value| {
                 // SAFETY: group_index is guaranteed to be in bounds
-                let value = unsafe { self.values.get_unchecked_mut(group_index) };
+                let value = unsafe { self.values.get_unchecked_mut(group_index as usize) };
                 (self.prim_fn)(value, new_value);
             },
         );
@@ -130,7 +130,7 @@ where
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {

--- a/datafusion/functions-aggregate/src/array_agg.rs
+++ b/datafusion/functions-aggregate/src/array_agg.rs
@@ -39,7 +39,7 @@ use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
     Accumulator, AggregateUDFImpl, Documentation, EmitTo, GroupsAccumulator, Signature,
-    Volatility,
+    Volatility, groups_accumulator::GroupIndex,
 };
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::nulls::filter_to_nulls;
 use datafusion_functions_aggregate_common::merge_arrays::merge_ordered_arrays;
@@ -548,7 +548,7 @@ impl GroupsAccumulator for ArrayAggGroupsAccumulator {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -580,7 +580,7 @@ impl GroupsAccumulator for ArrayAggGroupsAccumulator {
                 continue;
             }
 
-            entries.push((group_idx as u32, row_idx as u32));
+            entries.push((group_idx, row_idx as u32));
         }
 
         // We only need to record the batch if it was non-empty.
@@ -677,7 +677,7 @@ impl GroupsAccumulator for ArrayAggGroupsAccumulator {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         _opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -699,7 +699,7 @@ impl GroupsAccumulator for ArrayAggGroupsAccumulator {
             let start = list_offsets[row_idx] as u32;
             let end = list_offsets[row_idx + 1] as u32;
             for pos in start..end {
-                entries.push((group_idx as u32, pos));
+                entries.push((group_idx, pos));
             }
         }
 

--- a/datafusion/functions-aggregate/src/average.rs
+++ b/datafusion/functions-aggregate/src/average.rs
@@ -38,7 +38,7 @@ use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
     Accumulator, AggregateUDFImpl, Coercion, Documentation, EmitTo, Expr,
     GroupsAccumulator, ReversedUDAF, Signature, TypeSignature, TypeSignatureClass,
-    Volatility,
+    Volatility, groups_accumulator::GroupIndex,
 };
 use datafusion_functions_aggregate_common::aggregate::avg_distinct::{
     DecimalDistinctAvgAccumulator, Float64DistinctAvgAccumulator,
@@ -805,7 +805,7 @@ where
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -821,6 +821,7 @@ where
             opt_filter,
             total_num_groups,
             |group_index, new_value| {
+                let group_index = group_index as usize;
                 // SAFETY: group_index is guaranteed to be in bounds
                 let sum = unsafe { self.sums.get_unchecked_mut(group_index) };
                 *sum = sum.add_wrapping(new_value);
@@ -892,7 +893,7 @@ where
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -908,6 +909,7 @@ where
             opt_filter,
             total_num_groups,
             |group_index, partial_count| {
+                let group_index = group_index as usize;
                 // SAFETY: group_index is guaranteed to be in bounds
                 let count = unsafe { self.counts.get_unchecked_mut(group_index) };
                 *count += partial_count;
@@ -922,6 +924,7 @@ where
             opt_filter,
             total_num_groups,
             |group_index, new_value: <T as ArrowPrimitiveType>::Native| {
+                let group_index = group_index as usize;
                 // SAFETY: group_index is guaranteed to be in bounds
                 let sum = unsafe { self.sums.get_unchecked_mut(group_index) };
                 *sum = sum.add_wrapping(new_value);

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -32,7 +32,7 @@ use arrow::{
     array::ArrayRef,
     datatypes::{DataType, Field},
 };
-use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::{EmitTo, GroupsAccumulator, groups_accumulator::GroupIndex};
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::accumulate::accumulate_multiple;
 use log::debug;
 
@@ -319,7 +319,7 @@ impl CorrelationGroupsAccumulator {
 /// intermediate states created within the accumulator, instead of inputs from
 /// outside.
 fn accumulate_correlation_states(
-    group_indices: &[usize],
+    group_indices: &[GroupIndex],
     state_arrays: (
         &UInt64Array,  // count
         &Float64Array, // sum_x
@@ -328,7 +328,7 @@ fn accumulate_correlation_states(
         &Float64Array, // sum_xx
         &Float64Array, // sum_yy
     ),
-    mut value_fn: impl FnMut(usize, u64, &[f64]),
+    mut value_fn: impl FnMut(GroupIndex, u64, &[f64]),
 ) {
     let (counts, sum_x, sum_y, sum_xy, sum_xx, sum_yy) = state_arrays;
 
@@ -377,7 +377,7 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -396,6 +396,7 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
             &[&array_x, &array_y],
             opt_filter,
             |group_index, batch_index, columns| {
+                let group_index = group_index as usize;
                 let x = columns[0].value(batch_index);
                 let y = columns[1].value(batch_index);
                 self.count[group_index] += 1;
@@ -494,7 +495,7 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -530,6 +531,7 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
                 partial_sum_yy,
             ),
             |group_index, count, values| {
+                let group_index = group_index as usize;
                 self.count[group_index] += count;
                 self.sum_x[group_index] += values[0];
                 self.sum_y[group_index] += values[1];
@@ -560,7 +562,7 @@ mod tests {
     #[test]
     fn test_accumulate_correlation_states() {
         // Test data
-        let group_indices = vec![0, 1, 0, 1];
+        let group_indices: Vec<GroupIndex> = vec![0, 1, 0, 1];
         let counts = UInt64Array::from(vec![1, 2, 3, 4]);
         let sum_x = Float64Array::from(vec![10.0, 20.0, 30.0, 40.0]);
         let sum_y = Float64Array::from(vec![1.0, 2.0, 3.0, 4.0]);
@@ -578,10 +580,10 @@ mod tests {
         );
 
         let expected = vec![
-            (0, 1, vec![10.0, 1.0, 10.0, 100.0, 1.0]),
-            (1, 2, vec![20.0, 2.0, 40.0, 400.0, 4.0]),
-            (0, 3, vec![30.0, 3.0, 90.0, 900.0, 9.0]),
-            (1, 4, vec![40.0, 4.0, 160.0, 1600.0, 16.0]),
+            (0u32, 1, vec![10.0, 1.0, 10.0, 100.0, 1.0]),
+            (1u32, 2, vec![20.0, 2.0, 40.0, 400.0, 4.0]),
+            (0u32, 3, vec![30.0, 3.0, 90.0, 900.0, 9.0]),
+            (1u32, 4, vec![40.0, 4.0, 160.0, 1600.0, 16.0]),
         ];
         assert_eq!(accumulated, expected);
 

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -39,6 +39,7 @@ use datafusion_expr::{
     WindowFunctionDefinition,
     expr::WindowFunction,
     function::{AccumulatorArgs, StateFieldsArgs},
+    groups_accumulator::GroupIndex,
     utils::format_state_name,
 };
 use datafusion_functions_aggregate_common::aggregate::{
@@ -574,7 +575,7 @@ impl GroupsAccumulator for CountGroupsAccumulator {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -590,7 +591,8 @@ impl GroupsAccumulator for CountGroupsAccumulator {
             opt_filter,
             |group_index| {
                 // SAFETY: group_index is guaranteed to be in bounds
-                let count = unsafe { self.counts.get_unchecked_mut(group_index) };
+                let count =
+                    unsafe { self.counts.get_unchecked_mut(group_index as usize) };
                 *count += 1;
             },
         );
@@ -601,7 +603,7 @@ impl GroupsAccumulator for CountGroupsAccumulator {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         // Since aggregate filter should be applied in partial stage, in final stage there should be no filter
         _opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
@@ -618,7 +620,7 @@ impl GroupsAccumulator for CountGroupsAccumulator {
         self.counts.resize(total_num_groups, 0);
         group_indices.iter().zip(partial_counts.iter()).for_each(
             |(&group_index, partial_count)| {
-                self.counts[group_index] += partial_count;
+                self.counts[group_index as usize] += partial_count;
             },
         );
 

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -48,6 +48,7 @@ use datafusion_expr::utils::{AggregateOrderSensitivity, format_state_name};
 use datafusion_expr::{
     Accumulator, AggregateUDFImpl, Documentation, EmitTo, Expr, ExprFunctionExt,
     GroupsAccumulator, ReversedUDAF, Signature, SortExpr, Volatility,
+    groups_accumulator::GroupIndex,
 };
 use datafusion_functions_aggregate_common::utils::get_sort_options;
 use datafusion_macros::user_doc;
@@ -528,7 +529,7 @@ where
     fn get_filtered_min_of_each_group(
         &mut self,
         orderings: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         vals: &PrimitiveArray<T>,
         is_set_arr: Option<&BooleanArray>,
@@ -557,7 +558,7 @@ where
         };
 
         for (idx_in_val, group_idx) in group_indices.iter().enumerate() {
-            let group_idx = *group_idx;
+            let group_idx = *group_idx as usize;
 
             let passed_filter = opt_filter.is_none_or(|x| x.value(idx_in_val));
             let is_set = is_set_arr.is_none_or(|x| x.value(idx_in_val));
@@ -616,7 +617,7 @@ where
         &mut self,
         // e.g. first_value(a order by b): values_and_order_cols will be [a, b]
         values_and_order_cols: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -692,7 +693,7 @@ where
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -1699,7 +1700,7 @@ mod tests {
 
         group_acc.update_batch(
             &val_with_orderings,
-            &[0, 1, 2, 1],
+            &[0u32, 1, 2, 1],
             Some(&BooleanArray::from(vec![true, true, false, true])),
             3,
         )?;
@@ -1724,7 +1725,7 @@ mod tests {
 
         group_acc.merge_batch(
             &state,
-            &[0, 1, 2],
+            &[0u32, 1, 2],
             Some(&BooleanArray::from(vec![true, false, false])),
             3,
         )?;
@@ -1738,7 +1739,7 @@ mod tests {
         val_with_orderings.push(Arc::new(Int64Array::from(vec![6, 6])));
         val_with_orderings.push(Arc::new(Int64Array::from(vec![6, 6])));
 
-        group_acc.update_batch(&val_with_orderings, &[1, 2], None, 4)?;
+        group_acc.update_batch(&val_with_orderings, &[1u32, 2], None, 4)?;
 
         let binding = group_acc.evaluate(EmitTo::All)?;
         let eval_result = binding.as_any().downcast_ref::<Int64Array>().unwrap();
@@ -1815,7 +1816,7 @@ mod tests {
                 group_acc.compute_size_of_orderings()
             );
 
-            group_acc.merge_batch(&s, &Vec::from_iter(0..s[0].len()), None, 100)?;
+            group_acc.merge_batch(&s, &Vec::from_iter(0..s[0].len() as u32), None, 100)?;
             assert_eq!(
                 group_acc.size_of_orderings,
                 group_acc.compute_size_of_orderings()
@@ -1874,7 +1875,7 @@ mod tests {
 
         group_acc.update_batch(
             &val_with_orderings,
-            &[0, 1, 2, 1],
+            &[0u32, 1, 2, 1],
             Some(&BooleanArray::from(vec![true, true, false, true])),
             3,
         )?;
@@ -1890,7 +1891,7 @@ mod tests {
 
         group_acc.merge_batch(
             &state,
-            &[0, 1, 2],
+            &[0u32, 1, 2],
             Some(&BooleanArray::from(vec![true, false, false])),
             3,
         )?;
@@ -1899,7 +1900,7 @@ mod tests {
         val_with_orderings.push(Arc::new(Int64Array::from(vec![66, 6])));
         val_with_orderings.push(Arc::new(Int64Array::from(vec![66, 6])));
 
-        group_acc.update_batch(&val_with_orderings, &[1, 2], None, 4)?;
+        group_acc.update_batch(&val_with_orderings, &[1u32, 2], None, 4)?;
 
         let binding = group_acc.evaluate(EmitTo::All)?;
         let eval_result = binding.as_any().downcast_ref::<Int64Array>().unwrap();

--- a/datafusion/functions-aggregate/src/median.rs
+++ b/datafusion/functions-aggregate/src/median.rs
@@ -49,6 +49,7 @@ use datafusion_expr::{
     function::AccumulatorArgs, utils::format_state_name,
 };
 use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::groups_accumulator::GroupIndex;
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::accumulate::accumulate;
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::nulls::filtered_null_mask;
 use datafusion_functions_aggregate_common::utils::GenericDistinctBuffer;
@@ -353,7 +354,7 @@ impl<T: ArrowNumericType + Send> GroupsAccumulator for MedianGroupsAccumulator<T
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -367,7 +368,7 @@ impl<T: ArrowNumericType + Send> GroupsAccumulator for MedianGroupsAccumulator<T
             values,
             opt_filter,
             |group_index, new_value| {
-                self.group_values[group_index].push(new_value);
+                self.group_values[group_index as usize].push(new_value);
             },
         );
 
@@ -377,7 +378,7 @@ impl<T: ArrowNumericType + Send> GroupsAccumulator for MedianGroupsAccumulator<T
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         // Since aggregate filter should be applied in partial stage, in final stage there should be no filter
         _opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
@@ -419,7 +420,7 @@ impl<T: ArrowNumericType + Send> GroupsAccumulator for MedianGroupsAccumulator<T
             .for_each(|(&group_index, values_opt)| {
                 if let Some(values) = values_opt {
                     let values = values.as_primitive::<T>();
-                    self.group_values[group_index].extend(values.values().iter());
+                    self.group_values[group_index as usize].extend(values.values().iter());
                 }
             });
 

--- a/datafusion/functions-aggregate/src/min_max/min_max_bytes.rs
+++ b/datafusion/functions-aggregate/src/min_max/min_max_bytes.rs
@@ -22,7 +22,7 @@ use arrow::array::{
 use arrow::datatypes::DataType;
 use datafusion_common::hash_map::Entry;
 use datafusion_common::{HashMap, Result, internal_err};
-use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::{EmitTo, GroupsAccumulator, groups_accumulator::GroupIndex};
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::nulls::apply_filter_as_nulls;
 use std::mem::size_of;
 use std::sync::Arc;
@@ -66,7 +66,7 @@ impl GroupsAccumulator for MinMaxBytesAccumulator {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -306,7 +306,7 @@ impl GroupsAccumulator for MinMaxBytesAccumulator {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -431,7 +431,7 @@ impl MinMaxBytesState {
     fn update_batch<'a, F, I>(
         &mut self,
         iter: I,
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         total_num_groups: usize,
         mut cmp: F,
     ) -> Result<()>
@@ -447,7 +447,7 @@ impl MinMaxBytesState {
 
         // Figure out the new min value for each group
         for (new_val, group_index) in iter.into_iter().zip(group_indices.iter()) {
-            let group_index = *group_index;
+            let group_index = *group_index as usize;
             let Some(new_val) = new_val else {
                 continue; // skip nulls
             };

--- a/datafusion/functions-aggregate/src/min_max/min_max_struct.rs
+++ b/datafusion/functions-aggregate/src/min_max/min_max_struct.rs
@@ -27,7 +27,7 @@ use datafusion_common::{
     Result, internal_err,
     scalar::{copy_array_data, partial_cmp_struct},
 };
-use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::{EmitTo, GroupsAccumulator, groups_accumulator::GroupIndex};
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::nulls::apply_filter_as_nulls;
 
 /// Accumulator for MIN/MAX operations on Struct data types.
@@ -63,7 +63,7 @@ impl GroupsAccumulator for MinMaxStructAccumulator {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -131,7 +131,7 @@ impl GroupsAccumulator for MinMaxStructAccumulator {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -217,7 +217,7 @@ impl MinMaxStructState {
     fn update_batch<F>(
         &mut self,
         array: &StructArray,
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         total_num_groups: usize,
         mut cmp: F,
     ) -> Result<()>
@@ -232,7 +232,7 @@ impl MinMaxStructState {
 
         // Figure out the new min value for each group
         for (index, group_index) in (0..array.len()).zip(group_indices.iter()) {
-            let group_index = *group_index;
+            let group_index = *group_index as usize;
             if array.is_null(index) {
                 continue;
             }
@@ -354,7 +354,7 @@ mod tests {
         let mut max_accumulator =
             MinMaxStructAccumulator::new_max(array.data_type().clone());
         let values = vec![Arc::new(array) as ArrayRef];
-        let group_indices = vec![0, 0, 0];
+        let group_indices: Vec<GroupIndex> = vec![0, 0, 0];
 
         min_accumulator
             .update_batch(&values, &group_indices, None, 1)
@@ -392,7 +392,7 @@ mod tests {
         let mut max_accumulator =
             MinMaxStructAccumulator::new_max(array.data_type().clone());
         let values = vec![Arc::new(array) as ArrayRef];
-        let group_indices = vec![0, 0, 0];
+        let group_indices: Vec<GroupIndex> = vec![0, 0, 0];
 
         min_accumulator
             .update_batch(&values, &group_indices, None, 1)
@@ -432,7 +432,7 @@ mod tests {
         let mut max_accumulator =
             MinMaxStructAccumulator::new_max(array.data_type().clone());
         let values = vec![Arc::new(array) as ArrayRef];
-        let group_indices = vec![0, 0, 0];
+        let group_indices: Vec<GroupIndex> = vec![0, 0, 0];
 
         min_accumulator
             .update_batch(&values, &group_indices, None, 1)
@@ -470,7 +470,7 @@ mod tests {
         let mut max_accumulator =
             MinMaxStructAccumulator::new_max(array.data_type().clone());
         let values = vec![Arc::new(array) as ArrayRef];
-        let group_indices = vec![0, 1, 0, 1];
+        let group_indices: Vec<GroupIndex> = vec![0, 1, 0, 1];
 
         min_accumulator
             .update_batch(&values, &group_indices, None, 2)
@@ -515,7 +515,7 @@ mod tests {
         let mut max_accumulator =
             MinMaxStructAccumulator::new_max(array.data_type().clone());
         let values = vec![Arc::new(array) as ArrayRef];
-        let group_indices = vec![0, 0, 0, 0];
+        let group_indices: Vec<GroupIndex> = vec![0, 0, 0, 0];
 
         min_accumulator
             .update_batch(&values, &group_indices, Some(&filter), 1)

--- a/datafusion/functions-aggregate/src/percentile_cont.rs
+++ b/datafusion/functions-aggregate/src/percentile_cont.rs
@@ -45,7 +45,7 @@ use datafusion_expr::{
     Accumulator, AggregateUDFImpl, Coercion, Documentation, Expr, Signature,
     TypeSignatureClass, Volatility,
 };
-use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::{EmitTo, GroupsAccumulator, groups_accumulator::GroupIndex};
 use datafusion_expr::{
     expr::{AggregateFunction, Sort},
     function::{AccumulatorArgs, AggregateFunctionSimplification, StateFieldsArgs},
@@ -510,7 +510,7 @@ where
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -526,7 +526,7 @@ where
             values,
             opt_filter,
             |group_index, new_value| {
-                self.group_values[group_index].push(new_value);
+                self.group_values[group_index as usize].push(new_value);
             },
         );
 
@@ -536,7 +536,7 @@ where
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         // Since aggregate filter should be applied in partial stage, in final stage there should be no filter
         _opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
@@ -555,7 +555,7 @@ where
             .for_each(|(&group_index, values_opt)| {
                 if let Some(values) = values_opt {
                     let values = values.as_primitive::<T>();
-                    self.group_values[group_index].extend(values.values().iter());
+                    self.group_values[group_index as usize].extend(values.values().iter());
                 }
             });
 

--- a/datafusion/functions-aggregate/src/stddev.rs
+++ b/datafusion/functions-aggregate/src/stddev.rs
@@ -33,6 +33,7 @@ use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
     Accumulator, AggregateUDFImpl, Documentation, GroupsAccumulator, Signature,
     Volatility,
+    groups_accumulator::GroupIndex,
 };
 use datafusion_functions_aggregate_common::stats::StatsType;
 use datafusion_macros::user_doc;
@@ -328,7 +329,7 @@ impl GroupsAccumulator for StddevGroupsAccumulator {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&arrow::array::BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -339,7 +340,7 @@ impl GroupsAccumulator for StddevGroupsAccumulator {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&arrow::array::BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {

--- a/datafusion/functions-aggregate/src/variance.rs
+++ b/datafusion/functions-aggregate/src/variance.rs
@@ -30,6 +30,7 @@ use datafusion_expr::{
     Accumulator, AggregateUDFImpl, Documentation, GroupsAccumulator, Signature,
     Volatility,
     function::{AccumulatorArgs, StateFieldsArgs},
+    groups_accumulator::GroupIndex,
     utils::format_state_name,
 };
 use datafusion_functions_aggregate_common::utils::GenericDistinctBuffer;
@@ -451,7 +452,7 @@ impl VarianceGroupsAccumulator {
     }
 
     fn merge<F>(
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         counts: &UInt64Array,
         means: &Float64Array,
         m2s: &Float64Array,
@@ -470,7 +471,7 @@ impl VarianceGroupsAccumulator {
             .zip(means.values().iter())
             .zip(m2s.values().iter())
             .for_each(|(((&group_index, &count), &mean), &m2)| {
-                value_fn(group_index, count, mean, m2);
+                value_fn(group_index as usize, count, mean, m2);
             });
     }
 
@@ -503,7 +504,7 @@ impl GroupsAccumulator for VarianceGroupsAccumulator {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -512,6 +513,7 @@ impl GroupsAccumulator for VarianceGroupsAccumulator {
 
         self.resize(total_num_groups);
         accumulate(group_indices, values, opt_filter, |group_index, value| {
+            let group_index = group_index as usize;
             let (new_count, new_mean, new_m2) = update(
                 self.counts[group_index],
                 self.means[group_index],
@@ -528,7 +530,7 @@ impl GroupsAccumulator for VarianceGroupsAccumulator {
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         // Since aggregate filter should be applied in partial stage, in final stage there should be no filter
         _opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
@@ -551,16 +553,16 @@ impl GroupsAccumulator for VarianceGroupsAccumulator {
                     return;
                 }
                 let (new_count, new_mean, new_m2) = merge(
-                    self.counts[group_index],
-                    self.means[group_index],
-                    self.m2s[group_index],
+                    self.counts[group_index as usize],
+                    self.means[group_index as usize],
+                    self.m2s[group_index as usize],
                     partial_count,
                     partial_mean,
                     partial_m2,
                 );
-                self.counts[group_index] = new_count;
-                self.means[group_index] = new_mean;
-                self.m2s[group_index] = new_m2;
+                self.counts[group_index as usize] = new_count;
+                self.means[group_index as usize] = new_mean;
+                self.m2s[group_index as usize] = new_m2;
             },
         );
         Ok(())
@@ -674,8 +676,8 @@ mod tests {
             Arc::new(Float64Array::from(vec![1.0])),
         ];
         let mut acc = VarianceGroupsAccumulator::new(StatsType::Sample);
-        acc.merge_batch(&state_1, &[0], None, 1)?;
-        acc.merge_batch(&state_2, &[0], None, 1)?;
+        acc.merge_batch(&state_1, &[0u32], None, 1)?;
+        acc.merge_batch(&state_2, &[0u32], None, 1)?;
         let result = acc.evaluate(EmitTo::All)?;
         let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
         assert_eq!(result.len(), 1);

--- a/datafusion/physical-plan/src/aggregates/group_values/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/mod.rs
@@ -26,7 +26,7 @@ use arrow::array::{ArrayRef, downcast_primitive};
 use arrow::datatypes::{DataType, SchemaRef, TimeUnit};
 use datafusion_common::Result;
 
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupIndex};
 
 pub mod multi_group_by;
 
@@ -85,7 +85,7 @@ pub(crate) use metrics::GroupByMetrics;
 /// # Group Ids
 ///
 /// Each distinct group in a hash aggregation is identified by a unique group id
-/// (usize) which is assigned by instances of this trait. Group ids are
+/// ([`GroupIndex`]) which is assigned by instances of this trait. Group ids are
 /// continuous without gaps, starting from 0.
 pub trait GroupValues: Send {
     /// Calculates the group id for each input row of `cols`, assigning new
@@ -97,7 +97,7 @@ pub trait GroupValues: Send {
     /// If a row has the same value as a previous row, the same group id is
     /// assigned. If a row has a new value, the next available group id is
     /// assigned.
-    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<usize>) -> Result<()>;
+    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<GroupIndex>) -> Result<()>;
 
     /// Returns the number of bytes of memory used by this [`GroupValues`]
     fn size(&self) -> usize;

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -43,7 +43,7 @@ use arrow::datatypes::{
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::{Result, internal_datafusion_err, not_impl_err};
 use datafusion_execution::memory_pool::proxy::{HashTableAllocExt, VecAllocExt};
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupIndex};
 use datafusion_physical_expr::binary_map::OutputType;
 
 use hashbrown::hash_table::HashTable;
@@ -321,7 +321,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
     fn scalarized_intern(
         &mut self,
         cols: &[ArrayRef],
-        groups: &mut Vec<usize>,
+        groups: &mut Vec<GroupIndex>,
     ) -> Result<()> {
         let n_rows = cols[0].len();
 
@@ -402,7 +402,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
                     group_idx
                 }
             };
-            groups.push(group_idx);
+            groups.push(group_idx as GroupIndex);
         }
 
         Ok(())
@@ -422,13 +422,13 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
     fn vectorized_intern(
         &mut self,
         cols: &[ArrayRef],
-        groups: &mut Vec<usize>,
+        groups: &mut Vec<GroupIndex>,
     ) -> Result<()> {
         let n_rows = cols[0].len();
 
         // tracks to which group each of the input rows belongs
         groups.clear();
-        groups.resize(n_rows, usize::MAX);
+        groups.resize(n_rows, GroupIndex::MAX);
 
         let mut batch_hashes = mem::take(&mut self.hashes_buffer);
         batch_hashes.clear();
@@ -489,7 +489,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
     fn collect_vectorized_process_context(
         &mut self,
         batch_hashes: &[u64],
-        groups: &mut [usize],
+        groups: &mut [GroupIndex],
     ) {
         self.vectorized_operation_buffers.append_row_indices.clear();
         self.vectorized_operation_buffers
@@ -526,7 +526,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
                     .push(row);
 
                 // Set group index to row in `groups`
-                groups[row] = current_group_idx;
+                groups[row] = current_group_idx as GroupIndex;
 
                 group_values_len += 1;
                 continue;
@@ -593,7 +593,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
     ///    and perform `scalarized_intern` for them after.
     ///    Usually, such `rows` having same hash but different value with `exists rows`
     ///    are very few.
-    fn vectorized_equal_to(&mut self, cols: &[ArrayRef], groups: &mut [usize]) {
+    fn vectorized_equal_to(&mut self, cols: &[ArrayRef], groups: &mut [GroupIndex]) {
         assert_eq!(
             self.vectorized_operation_buffers
                 .equal_to_group_indices
@@ -648,7 +648,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
             // Equal to case, set the `group_indices` to `rows` in `groups`
             if equal_to_result {
                 groups[row] =
-                    self.vectorized_operation_buffers.equal_to_group_indices[idx];
+                    self.vectorized_operation_buffers.equal_to_group_indices[idx] as GroupIndex;
             }
             current_row_equal_to_result |= equal_to_result;
 
@@ -716,7 +716,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
         &mut self,
         cols: &[ArrayRef],
         batch_hashes: &[u64],
-        groups: &mut [usize],
+        groups: &mut [GroupIndex],
     ) -> Result<()> {
         if self
             .vectorized_operation_buffers
@@ -789,7 +789,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
                 *group_index_view = new_group_index_view;
             }
 
-            groups[row] = group_idx;
+            groups[row] = group_idx as GroupIndex;
         }
 
         self.map = map;
@@ -801,7 +801,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
         group_index_view: &GroupIndexView,
         cols: &[ArrayRef],
         row: usize,
-        groups: &mut [usize],
+        groups: &mut [GroupIndex],
     ) -> bool {
         // Check if this row exists in `group_values`
         fn check_row_equal(
@@ -827,7 +827,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
                 }
 
                 if check_result {
-                    groups[row] = group_idx;
+                    groups[row] = group_idx as GroupIndex;
                     return true;
                 }
             }
@@ -842,7 +842,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
                 }
             }
 
-            groups[row] = group_idx;
+            groups[row] = group_idx as GroupIndex;
             true
         }
     }
@@ -889,7 +889,7 @@ macro_rules! instantiate_primitive {
 }
 
 impl<const STREAMING: bool> GroupValues for GroupValuesColumn<STREAMING> {
-    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<usize>) -> Result<()> {
+    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<GroupIndex>) -> Result<()> {
         if self.group_values.is_empty() {
             let mut v = Vec::with_capacity(cols.len());
 

--- a/datafusion/physical-plan/src/aggregates/group_values/row.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/row.rs
@@ -24,7 +24,7 @@ use arrow::row::{RowConverter, Rows, SortField};
 use datafusion_common::Result;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_execution::memory_pool::proxy::{HashTableAllocExt, VecAllocExt};
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupIndex};
 use hashbrown::hash_table::HashTable;
 use log::debug;
 use std::mem::size_of;
@@ -112,7 +112,7 @@ impl GroupValuesRows {
 }
 
 impl GroupValues for GroupValuesRows {
-    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<usize>) -> Result<()> {
+    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<GroupIndex>) -> Result<()> {
         // Convert the group keys into the row format
         let group_rows = &mut self.rows_buffer;
         group_rows.clear();
@@ -164,7 +164,7 @@ impl GroupValues for GroupValuesRows {
                     group_idx
                 }
             };
-            groups.push(group_idx);
+            groups.push(group_idx as GroupIndex);
         }
 
         self.group_values = Some(group_values);

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/boolean.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/boolean.rs
@@ -21,7 +21,7 @@ use arrow::array::{
     ArrayRef, AsArray as _, BooleanArray, BooleanBufferBuilder, NullBufferBuilder,
 };
 use datafusion_common::Result;
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupIndex};
 use std::{mem::size_of, sync::Arc};
 
 #[derive(Debug)]
@@ -42,7 +42,7 @@ impl GroupValuesBoolean {
 }
 
 impl GroupValues for GroupValuesBoolean {
-    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<usize>) -> Result<()> {
+    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<GroupIndex>) -> Result<()> {
         let array = cols[0].as_boolean();
         groups.clear();
 
@@ -77,7 +77,7 @@ impl GroupValues for GroupValuesBoolean {
                 }
             };
 
-            groups.push(index);
+            groups.push(index as GroupIndex);
         }
 
         Ok(())

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes.rs
@@ -21,7 +21,7 @@ use crate::aggregates::group_values::GroupValues;
 
 use arrow::array::{Array, ArrayRef, OffsetSizeTrait};
 use datafusion_common::Result;
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupIndex};
 use datafusion_physical_expr_common::binary_map::{ArrowBytesMap, OutputType};
 
 /// A [`GroupValues`] storing single column of Utf8/LargeUtf8/Binary/LargeBinary values
@@ -45,7 +45,7 @@ impl<O: OffsetSizeTrait> GroupValuesBytes<O> {
 }
 
 impl<O: OffsetSizeTrait> GroupValues for GroupValuesBytes<O> {
-    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<usize>) -> Result<()> {
+    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<GroupIndex>) -> Result<()> {
         assert_eq!(cols.len(), 1);
 
         // look up / add entries in the table
@@ -63,7 +63,7 @@ impl<O: OffsetSizeTrait> GroupValues for GroupValuesBytes<O> {
             },
             // called for each group
             |group_idx| {
-                groups.push(group_idx);
+                groups.push(group_idx as GroupIndex);
             },
         );
 

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes_view.rs
@@ -17,7 +17,7 @@
 
 use crate::aggregates::group_values::GroupValues;
 use arrow::array::{Array, ArrayRef};
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupIndex};
 use datafusion_physical_expr::binary_map::OutputType;
 use datafusion_physical_expr_common::binary_view_map::ArrowBytesViewMap;
 use std::mem::size_of;
@@ -46,7 +46,7 @@ impl GroupValues for GroupValuesBytesView {
     fn intern(
         &mut self,
         cols: &[ArrayRef],
-        groups: &mut Vec<usize>,
+        groups: &mut Vec<GroupIndex>,
     ) -> datafusion_common::Result<()> {
         assert_eq!(cols.len(), 1);
 
@@ -65,7 +65,7 @@ impl GroupValues for GroupValuesBytesView {
             },
             // called for each group
             |group_idx| {
-                groups.push(group_idx);
+                groups.push(group_idx as GroupIndex);
             },
         );
 

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -25,7 +25,7 @@ use arrow::array::{
 use arrow::datatypes::{DataType, i256};
 use datafusion_common::Result;
 use datafusion_execution::memory_pool::proxy::VecAllocExt;
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupIndex};
 use half::f16;
 use hashbrown::hash_table::HashTable;
 use std::mem::size_of;
@@ -112,7 +112,7 @@ impl<T: ArrowPrimitiveType> GroupValues for GroupValuesPrimitive<T>
 where
     T::Native: HashValue,
 {
-    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<usize>) -> Result<()> {
+    fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<GroupIndex>) -> Result<()> {
         assert_eq!(cols.len(), 1);
         groups.clear();
 
@@ -145,7 +145,7 @@ where
                     }
                 }
             };
-            groups.push(group_id)
+            groups.push(group_id as GroupIndex)
         }
         Ok(())
     }

--- a/datafusion/physical-plan/src/aggregates/order/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/order/mod.rs
@@ -19,7 +19,7 @@ use std::mem::size_of;
 
 use arrow::array::ArrayRef;
 use datafusion_common::Result;
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupIndex};
 
 mod full;
 mod partial;
@@ -93,7 +93,7 @@ impl GroupOrdering {
     pub fn new_groups(
         &mut self,
         batch_group_values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         total_num_groups: usize,
     ) -> Result<()> {
         match self {

--- a/datafusion/physical-plan/src/aggregates/order/partial.rs
+++ b/datafusion/physical-plan/src/aggregates/order/partial.rs
@@ -25,7 +25,7 @@ use arrow_ord::partition::partition;
 use datafusion_common::utils::{compare_rows, get_row_at_idx};
 use datafusion_common::{Result, ScalarValue};
 use datafusion_execution::memory_pool::proxy::VecAllocExt;
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupIndex};
 
 /// Tracks grouping state when the data is ordered by some subset of
 /// the group keys.
@@ -208,7 +208,7 @@ impl GroupOrderingPartial {
     pub fn new_groups(
         &mut self,
         batch_group_values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         total_num_groups: usize,
     ) -> Result<()> {
         assert!(total_num_groups > 0);
@@ -236,7 +236,7 @@ impl GroupOrderingPartial {
         let ranges = partition(&sort_keys)?.ranges();
         let last_range = ranges.last().unwrap();
 
-        let range_current_sort = group_indices[last_range.start];
+        let range_current_sort = group_indices[last_range.start] as usize;
         let range_sort_key = get_row_at_idx(&sort_keys, last_range.start)?;
 
         let (current_sort, sort_key) = if last_range.start == 0 {
@@ -284,7 +284,7 @@ mod tests {
             Arc::new(Int32Array::from(vec![2, 1, 3])),
         ];
 
-        let group_indices = vec![0, 1, 2];
+        let group_indices: Vec<GroupIndex> = vec![0, 1, 2];
         let total_num_groups = 3;
 
         group_ordering.new_groups(
@@ -307,7 +307,7 @@ mod tests {
             Arc::new(Int32Array::from(vec![3, 3, 3])),
             Arc::new(Int32Array::from(vec![2, 1, 7])),
         ];
-        let group_indices = vec![3, 4, 5];
+        let group_indices: Vec<GroupIndex> = vec![3, 4, 5];
         let total_num_groups = 6;
 
         group_ordering.new_groups(
@@ -330,7 +330,7 @@ mod tests {
             Arc::new(Int32Array::from(vec![4, 4, 4])),
             Arc::new(Int32Array::from(vec![1, 1, 1])),
         ];
-        let group_indices = vec![6, 7, 8];
+        let group_indices: Vec<GroupIndex> = vec![6, 7, 8];
         let total_num_groups = 9;
 
         group_ordering.new_groups(

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -44,7 +44,7 @@ use datafusion_common::{
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::proxy::VecAllocExt;
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
-use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::{EmitTo, GroupIndex, GroupsAccumulator};
 use datafusion_physical_expr::aggregate::AggregateFunctionExpr;
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_expr::{GroupsAccumulatorAdapter, PhysicalSortExpr};
@@ -412,7 +412,7 @@ pub(crate) struct GroupedHashAggregateStream {
 
     /// scratch space for the current input [`RecordBatch`] being
     /// processed. Reused across batches here to avoid reallocations
-    current_group_indices: Vec<usize>,
+    current_group_indices: Vec<GroupIndex>,
 
     /// Accumulators, one for each `AggregateFunctionExpr` in the query
     ///

--- a/datafusion/physical-plan/src/recursive_query.rs
+++ b/datafusion/physical-plan/src/recursive_query.rs
@@ -41,6 +41,7 @@ use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::{Result, internal_datafusion_err, not_impl_err};
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
+use datafusion_expr::GroupIndex;
 use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 
@@ -440,7 +441,7 @@ struct DistinctDeduplicator {
     /// Grouped rows used for distinct
     group_values: Box<dyn GroupValues>,
     reservation: MemoryReservation,
-    intern_output_buffer: Vec<usize>,
+    intern_output_buffer: Vec<GroupIndex>,
 }
 
 impl DistinctDeduplicator {
@@ -476,14 +477,14 @@ impl DistinctDeduplicator {
 
 /// Return a mask, each element being true if, and only if, the element is greater than all previous elements and greater or equal than the provided max_already_seen_group_id
 fn new_groups_mask(
-    values: &[usize],
+    values: &[GroupIndex],
     mut max_already_seen_group_id: usize,
 ) -> BooleanArray {
     let mut output = BooleanBuilder::with_capacity(values.len());
     for value in values {
-        if *value >= max_already_seen_group_id {
+        if *value as usize >= max_already_seen_group_id {
             output.append_value(true);
-            max_already_seen_group_id = *value + 1; // We want to be increasing
+            max_already_seen_group_id = *value as usize + 1; // We want to be increasing
         } else {
             output.append_value(false);
         }

--- a/datafusion/spark/src/function/aggregate/avg.rs
+++ b/datafusion/spark/src/function/aggregate/avg.rs
@@ -28,8 +28,8 @@ use datafusion_common::{Result, ScalarValue, not_impl_err};
 use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
-    Accumulator, AggregateUDFImpl, Coercion, EmitTo, GroupsAccumulator, ReversedUDAF,
-    Signature, TypeSignatureClass, Volatility,
+    Accumulator, AggregateUDFImpl, Coercion, EmitTo, GroupIndex, GroupsAccumulator,
+    ReversedUDAF, Signature, TypeSignatureClass, Volatility,
 };
 use std::{any::Any, sync::Arc};
 
@@ -251,7 +251,7 @@ where
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         _opt_filter: Option<&arrow::array::BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -266,6 +266,7 @@ where
         let iter = group_indices.iter().zip(data.iter());
         if values.null_count() == 0 {
             for (&group_index, &value) in iter {
+                let group_index = group_index as usize;
                 let sum = &mut self.sums[group_index];
                 *sum = (*sum).add_wrapping(value);
                 self.counts[group_index] += 1;
@@ -275,6 +276,7 @@ where
                 if values.is_null(idx) {
                     continue;
                 }
+                let group_index = group_index as usize;
                 let sum = &mut self.sums[group_index];
                 *sum = (*sum).add_wrapping(value);
 
@@ -288,7 +290,7 @@ where
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
-        group_indices: &[usize],
+        group_indices: &[GroupIndex],
         _opt_filter: Option<&arrow::array::BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
@@ -300,14 +302,14 @@ where
         self.counts.resize(total_num_groups, 0);
         let iter1 = group_indices.iter().zip(partial_counts.values().iter());
         for (&group_index, &partial_count) in iter1 {
-            self.counts[group_index] += partial_count;
+            self.counts[group_index as usize] += partial_count;
         }
 
         // update sums
         self.sums.resize(total_num_groups, T::default_value());
         let iter2 = group_indices.iter().zip(partial_sums.values().iter());
         for (&group_index, &new_value) in iter2 {
-            let sum = &mut self.sums[group_index];
+            let sum = &mut self.sums[group_index as usize];
             *sum = sum.add_wrapping(new_value);
         }
 


### PR DESCRIPTION
Introduce GroupIndex type alias (u32) for group indices in aggregations, replacing the previous usize. This halves the memory per group index on 64-bit platforms (4 bytes vs 8 bytes), improving cache utilization during hash aggregation. A u32 supports up to ~4 billion groups, which is more than sufficient in practice since accumulator state memory would be exhausted long before reaching that limit.

Changes:
- Add `GroupIndex = u32` type alias in `datafusion-expr-common`
- Update `GroupsAccumulator` trait methods to use `&[GroupIndex]`
- Update `GroupValues::intern()` to produce `Vec<GroupIndex>`
- Update all accumulate helpers (NullState, accumulate_indices, etc.)
- Update all GroupsAccumulator and GroupValues implementations
- Update FFI layer to use `RVec<u32>` for group indices
- Update call sites in row_hash, recursive_query, and order tracking

https://claude.ai/code/session_011CtJW17mfcKqhc5SYCs7JZ

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
