### PR TITLE
chore(deps): pin substrait to `0.62.2`

### DIFF
--- a/datafusion/substrait/Cargo.toml
+++ b/datafusion/substrait/Cargo.toml
@@ -44,7 +44,7 @@ object_store = { workspace = true }
 # We need to match the version in substrait, so we don't use the workspace version here
 pbjson-types = { version = "0.8.0" }
 prost = { workspace = true }
-substrait = { version = "0.62", features = ["serde"] }
+substrait = { version = "0.62.2", features = ["serde"] }
 url = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 


### PR DESCRIPTION
## Which issue does this PR close?

Relates to #20785 

## Rationale for this change

substrait has released patch release 0.62.3 which is backward incompatible, which breaks datafusion `52.2.0`

## What changes are included in this PR?

pins version of substrait to `0.62.2` which works with datafusion 52 and 53 

## Are these changes tested?

existing tests 

## Are there any user-facing changes?

no 