### PR TITLE
Enable debug assertions in CI.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,6 +239,9 @@ unused_qualifications = "deny"
 # - ci: derived from `dev` but disables incremental builds and strips dependency
 #     symbols to keep CI artifacts small and reproducible.
 #     Run: cargo run --profile ci
+# - ci-optimized: derived from `release` but enables debug assertions, and uses
+#     lighter optimizations. Used for long-running CI tasks.
+#     Run: cargo run --profile ci-release
 #
 # If you want to optimize compilation, the `compile_profile` benchmark can be useful.
 # See `benchmarks/README.md` for more details.
@@ -260,6 +263,7 @@ strip = false            # Retain debug info for flamegraphs
 
 [profile.ci-optimized]
 inherits = "release"
+debug-assertions = true
 codegen-units = 16
 lto = "thin"
 strip = true
@@ -268,6 +272,7 @@ strip = true
 debug = false
 inherits = "dev"
 incremental = false
+debug-assertions = true
 
 # This rule applies to every package except workspace members (dependencies
 # such as `arrow` and `tokio`). It disables debug info and related features on


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20831.

## Rationale for this change

CI uses release profiles to allow tests to run more quickly (and potentially also to provide more coverage for the most realistic case for end users of the system). But debug assertions can expose real bugs / mistaken assumptions, and so they should be covered in CI as well.

## What changes are included in this PR?

Adjust the Rust build profiles which are used in CI to enable debug assertions.

## Are these changes tested?

Yes, by CI.

## Are there any user-facing changes?

No.