### PR TITLE
Check sqllogictests for any dangling config settings (#17914)

### DIFF
--- a/datafusion/sqllogictest/src/engines/datafusion_engine/runner.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/runner.rs
@@ -44,13 +44,13 @@ pub struct DataFusion {
 
 impl DataFusion {
     pub fn new(ctx: SessionContext, relative_path: PathBuf, pb: ProgressBar) -> Self {
-        let default_config = SessionContext::new()
+        let default_config = ctx
             .state()
             .config()
             .options()
             .entries()
-            .into_iter()
-            .map(|e| (e.key, e.value))
+            .iter()
+            .map(|e| (e.key.clone(), e.value.clone()))
             .collect();
 
         Self {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #https://github.com/apache/datafusion/issues/17914.

## Rationale for this change
In a previous PR https://github.com/apache/datafusion/pull/20474, I added a bash script that parsed the `SLT` files and checked whether any DataFusion configuration options were modified without being reset.

While that approach worked, it relied on external scripting and additional parsing logic. This PR introduces a simpler and more direct solution implemented in Rust.

At the end of each `SLT` test file execution, the current configuration is compared with the default configuration using a `Drop` implementation. If any configuration values were modified and not restored, a warning is printed.

This approach is easier to maintain and keeps the validation logic within the Rust codebase rather than relying on an external bash script.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Capture the default DataFusion configuration when the `SLT` runner is initialized.
- Implement `Drop` for the DataFusion SLT engine.
- When an `SLT` file finishes executing, compare the current configuration with the default configuration.
- If differences are detected, print a warning showing which configuration options were modified.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
This behavior is exercised by the existing `SLT` test suite. The configuration check runs automatically when each `SLT` file completes execution.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No. This change only affects internal `SLT` test infrastructure and does not modify any public APIs.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
