### PR TITLE
Minor: Deprecate unused `PartitionedFileStream`

### DIFF
--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -21,7 +21,8 @@
 mod table;
 pub use datafusion_catalog_listing::helpers;
 pub use datafusion_catalog_listing::{ListingOptions, ListingTable, ListingTableConfig};
-pub use datafusion_datasource::{
-    FileRange, ListingTableUrl, PartitionedFile, PartitionedFileStream,
-};
+// Keep for backwards compatibility until removed
+#[expect(deprecated)]
+pub use datafusion_datasource::PartitionedFileStream;
+pub use datafusion_datasource::{FileRange, ListingTableUrl, PartitionedFile};
 pub use table::ListingTableConfigExt;

--- a/datafusion/datasource/src/mod.rs
+++ b/datafusion/datasource/src/mod.rs
@@ -71,6 +71,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 /// Stream of files get listed from object store
+#[deprecated(
+    since = "54.0.0",
+    note = "This type is unused and will be removed in a future release"
+)]
 pub type PartitionedFileStream =
     Pin<Box<dyn Stream<Item = Result<PartitionedFile>> + Send + Sync + 'static>>;
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

I ran across this unused type, so let's deprecate it so it is clear it is actually unused

## What changes are included in this PR?

1. Deprecate type

## Are these changes tested?

By CI
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
