### PR TITLE
Minor: make signatures of `SessionContext::register_*` methods consistent

### DIFF
--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -530,19 +530,14 @@ impl SessionContext {
         self.runtime_env().deregister_object_store(url)
     }
 
-    /// Registers the [`RecordBatch`] as the specified table name
+    /// Registers the given [`RecordBatch`] as the specified table reference.
     pub fn register_batch(
         &self,
-        table_name: &str,
+        table_ref: impl Into<TableReference>,
         batch: RecordBatch,
     ) -> Result<Option<Arc<dyn TableProvider>>> {
         let table = MemTable::try_new(batch.schema(), vec![vec![batch]])?;
-        self.register_table(
-            TableReference::Bare {
-                table: table_name.into(),
-            },
-            Arc::new(table),
-        )
+        self.register_table(table_ref, Arc::new(table))
     }
 
     /// Return the [RuntimeEnv] used to run queries with this `SessionContext`
@@ -1758,15 +1753,14 @@ impl SessionContext {
     /// SQL statements executed against this context.
     pub async fn register_arrow(
         &self,
-        name: &str,
-        table_path: &str,
+        table_ref: impl Into<TableReference>,
+        table_path: impl AsRef<str>,
         options: ArrowReadOptions<'_>,
     ) -> Result<()> {
         let listing_options = options
             .to_listing_options(&self.copied_config(), self.copied_table_options());
-
         self.register_listing_table(
-            name,
+            table_ref,
             table_path,
             listing_options,
             options.schema.map(|s| Arc::new(s.to_owned())),


### PR DESCRIPTION
## Which issue does this PR close?

None.

## Rationale for this change

All `register_*` methods on `SessionContext` should have similar signatures for the sake of API consistency.

## What changes are included in this PR?

Update `SessionContext::register_batch` and `SessionContext::register_arrow` to have similar signatures than the rest of `SessionContext::register_*` methods.

## Are these changes tested?

I don't think any tests are required for this. Type checking done by the compiler should be enough. Let me know if you disagree.

## Are there any user-facing changes?

I don't think so. All previous calls to these methods should still work as before.