### PR TITLE
[branch-53] fix: use try_shrink instead of shrink in try_resize (#20424)

### DIFF
--- a/datafusion/execution/src/memory_pool/mod.rs
+++ b/datafusion/execution/src/memory_pool/mod.rs
@@ -434,7 +434,9 @@ impl MemoryReservation {
         let size = self.size.load(atomic::Ordering::Relaxed);
         match capacity.cmp(&size) {
             Ordering::Greater => self.try_grow(capacity - size)?,
-            Ordering::Less => self.shrink(size - capacity),
+            Ordering::Less => {
+                self.try_shrink(size - capacity)?;
+            }
             _ => {}
         };
         Ok(())


### PR DESCRIPTION
- Part of https://github.com/apache/datafusion/issues/19692

This PR:
- Backports https://github.com/apache/datafusion/pull/20424 from @ariel-miculas to the branch-53 line
