### PR TITLE
Replace `&Vec<_>` by `&[_]`

### DIFF
--- a/datafusion-examples/examples/dataframe/cache_factory.rs
+++ b/datafusion-examples/examples/dataframe/cache_factory.rs
@@ -223,7 +223,7 @@ impl CacheManager {
         self.cache.insert(k, v);
     }
 
-    pub fn get(&self, k: &LogicalPlan) -> Option<&Vec<Vec<RecordBatch>>> {
-        self.cache.get(k)
+    pub fn get(&self, k: &LogicalPlan) -> Option<&[Vec<RecordBatch>]> {
+        self.cache.get(k).map(Vec::as_slice)
     }
 }

--- a/datafusion/catalog-listing/src/table.rs
+++ b/datafusion/catalog-listing/src/table.rs
@@ -274,7 +274,7 @@ impl ListingTable {
     }
 
     /// Get paths ref
-    pub fn table_paths(&self) -> &Vec<ListingTableUrl> {
+    pub fn table_paths(&self) -> &[ListingTableUrl] {
         &self.table_paths
     }
 
@@ -662,7 +662,7 @@ impl TableProvider for ListingTable {
         let config = FileSinkConfig {
             original_url: String::default(),
             object_store_url: self.table_paths()[0].object_store(),
-            table_paths: self.table_paths().clone(),
+            table_paths: self.table_paths().to_vec(),
             file_group,
             output_schema: self.schema(),
             table_partition_cols: self.options.table_partition_cols.clone(),

--- a/datafusion/catalog/src/information_schema.rs
+++ b/datafusion/catalog/src/information_schema.rs
@@ -318,7 +318,7 @@ impl InformationSchemaConfig {
         let catalog_name = &config_options.catalog.default_catalog;
         let schema_name = &config_options.catalog.default_schema;
         let mut add_parameters = |func_name: &str,
-                                  args: Option<&Vec<(String, String)>>,
+                                  args: Option<&[(String, String)]>,
                                   arg_types: Vec<String>,
                                   return_type: Option<String>,
                                   is_variadic: bool,
@@ -361,7 +361,7 @@ impl InformationSchemaConfig {
             for (rid, (arg_types, return_type)) in combinations.into_iter().enumerate() {
                 add_parameters(
                     func_name,
-                    args.as_ref(),
+                    args.as_deref(),
                     arg_types,
                     return_type,
                     Self::is_variadic(udf.signature()),
@@ -376,7 +376,7 @@ impl InformationSchemaConfig {
             for (rid, (arg_types, return_type)) in combinations.into_iter().enumerate() {
                 add_parameters(
                     func_name,
-                    args.as_ref(),
+                    args.as_deref(),
                     arg_types,
                     return_type,
                     Self::is_variadic(udaf.signature()),
@@ -391,7 +391,7 @@ impl InformationSchemaConfig {
             for (rid, (arg_types, return_type)) in combinations.into_iter().enumerate() {
                 add_parameters(
                     func_name,
-                    args.as_ref(),
+                    args.as_deref(),
                     arg_types,
                     return_type,
                     Self::is_variadic(udwf.signature()),

--- a/datafusion/catalog/src/stream.rs
+++ b/datafusion/catalog/src/stream.rs
@@ -336,7 +336,7 @@ impl TableProvider for StreamTable {
         Ok(Arc::new(StreamingTableExec::try_new(
             Arc::clone(self.0.source.schema()),
             vec![Arc::new(StreamRead(Arc::clone(&self.0))) as _],
-            projection,
+            projection.map(Vec::as_slice),
             projected_schema,
             true,
             limit,

--- a/datafusion/catalog/src/streaming.rs
+++ b/datafusion/catalog/src/streaming.rs
@@ -122,7 +122,7 @@ impl TableProvider for StreamingTable {
         Ok(Arc::new(StreamingTableExec::try_new(
             Arc::clone(&self.schema),
             self.partitions.clone(),
-            projection,
+            projection.map(Vec::as_slice),
             LexOrdering::new(physical_sort),
             self.infinite,
             limit,

--- a/datafusion/core/src/bin/print_functions_docs.rs
+++ b/datafusion/core/src/bin/print_functions_docs.rs
@@ -300,7 +300,7 @@ impl DocProvider for Arc<dyn HigherOrderUDF> {
 }
 
 #[expect(clippy::borrowed_box)]
-fn get_names_and_aliases(functions: &Vec<&Box<dyn DocProvider>>) -> Vec<String> {
+fn get_names_and_aliases(functions: &[&Box<dyn DocProvider>]) -> Vec<String> {
     functions
         .iter()
         .flat_map(|f| {

--- a/datafusion/core/src/datasource/file_format/parquet.rs
+++ b/datafusion/core/src/datasource/file_format/parquet.rs
@@ -1594,7 +1594,7 @@ mod tests {
 
     fn assert_file_metadata(
         parquet_meta_data: ParquetMetaData,
-        expected_kv: &Vec<KeyValue>,
+        expected_kv: &[KeyValue],
     ) {
         let file_metadata = parquet_meta_data.file_metadata();
         let schema_descr = file_metadata.schema_descr();

--- a/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
@@ -561,7 +561,7 @@ fn test_streaming_table_after_projection() -> Result<()> {
                 Field::new("e", DataType::Int32, true),
             ])),
         }) as _],
-        Some(&vec![0_usize, 2, 4, 3]),
+        Some(&[0_usize, 2, 4, 3]),
         vec![
             [
                 PhysicalSortExpr {

--- a/datafusion/datasource-arrow/src/file_format.rs
+++ b/datafusion/datasource-arrow/src/file_format.rs
@@ -199,7 +199,7 @@ impl FileFormat for ArrowFormat {
 
         let table_schema = TableSchema::new(
             Arc::clone(conf.file_schema()),
-            conf.table_partition_cols().clone(),
+            conf.table_partition_cols().to_vec(),
         );
 
         let mut source: Arc<dyn FileSource> =

--- a/datafusion/datasource-parquet/src/row_group_filter.rs
+++ b/datafusion/datasource-parquet/src/row_group_filter.rs
@@ -82,7 +82,7 @@ impl RowGroupAccessPlanFilter {
     }
 
     /// Returns the is_fully_matched vector
-    pub fn is_fully_matched(&self) -> &Vec<bool> {
+    pub fn is_fully_matched(&self) -> &[bool] {
         &self.is_fully_matched
     }
 

--- a/datafusion/datasource/src/file_scan_config/mod.rs
+++ b/datafusion/datasource/src/file_scan_config/mod.rs
@@ -1068,7 +1068,7 @@ impl FileScanConfig {
     }
 
     /// Get the table partition columns
-    pub fn table_partition_cols(&self) -> &Vec<FieldRef> {
+    pub fn table_partition_cols(&self) -> &[FieldRef] {
         self.file_source.table_schema().table_partition_cols()
     }
 

--- a/datafusion/datasource/src/table_schema.rs
+++ b/datafusion/datasource/src/table_schema.rs
@@ -166,7 +166,7 @@ impl TableSchema {
     ///
     /// These are the columns derived from the directory structure that
     /// will be appended to each row during query execution.
-    pub fn table_partition_cols(&self) -> &Vec<FieldRef> {
+    pub fn table_partition_cols(&self) -> &[FieldRef] {
         &self.table_partition_cols
     }
 

--- a/datafusion/functions/src/crypto/basic.rs
+++ b/datafusion/functions/src/crypto/basic.rs
@@ -225,8 +225,9 @@ pub(crate) fn digest_process(
                     .digest_scalar(a.as_ref().map(|s: &String| s.as_bytes()))),
                 ScalarValue::Binary(a)
                 | ScalarValue::LargeBinary(a)
-                | ScalarValue::BinaryView(a) => Ok(digest_algorithm
-                    .digest_scalar(a.as_ref().map(|v: &Vec<u8>| v.as_slice()))),
+                | ScalarValue::BinaryView(a) => {
+                    Ok(digest_algorithm.digest_scalar(a.as_deref()))
+                }
                 other => exec_err!(
                     "Unsupported data type {other:?} for function {digest_algorithm}"
                 ),

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -213,7 +213,7 @@ impl DynamicFilterPhysicalExpr {
 
     fn remap_children(
         children: &[Arc<dyn PhysicalExpr>],
-        remapped_children: Option<&Vec<Arc<dyn PhysicalExpr>>>,
+        remapped_children: Option<&[Arc<dyn PhysicalExpr>]>,
         expr: Arc<dyn PhysicalExpr>,
     ) -> Result<Arc<dyn PhysicalExpr>> {
         if let Some(remapped_children) = remapped_children {
@@ -250,7 +250,7 @@ impl DynamicFilterPhysicalExpr {
     /// remapped to match calls to [`PhysicalExpr::with_new_children`].
     pub fn current(&self) -> Result<Arc<dyn PhysicalExpr>> {
         let expr = Arc::clone(self.inner.read().expr());
-        Self::remap_children(&self.children, self.remapped_children.as_ref(), expr)
+        Self::remap_children(&self.children, self.remapped_children.as_deref(), expr)
     }
 
     /// Update the current expression and notify all waiters.
@@ -266,7 +266,7 @@ impl DynamicFilterPhysicalExpr {
         // and the same externally facing `PhysicalExpr` is used for both `with_new_children` and `update()`.`
         let new_expr = Self::remap_children(
             &self.children,
-            self.remapped_children.as_ref(),
+            self.remapped_children.as_deref(),
             new_expr,
         )?;
 

--- a/datafusion/physical-optimizer/src/join_selection.rs
+++ b/datafusion/physical-optimizer/src/join_selection.rs
@@ -587,7 +587,7 @@ pub(crate) fn swap_join_according_to_unboundedness(
 /// auxiliary boundedness information, is in the `PipelineStatePropagator` object.
 fn apply_subrules(
     mut input: Arc<dyn ExecutionPlan>,
-    subrules: &Vec<Box<PipelineFixerSubrule>>,
+    subrules: &[Box<PipelineFixerSubrule>],
     config_options: &ConfigOptions,
 ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
     let original = Arc::clone(&input);

--- a/datafusion/physical-plan/benches/aggregate_vectorized.rs
+++ b/datafusion/physical-plan/benches/aggregate_vectorized.rs
@@ -85,7 +85,7 @@ fn bytes_bench(
     group: &mut BenchmarkGroup<WallTime>,
     bench_prefix: &str,
     size: usize,
-    rows: &Vec<usize>,
+    rows: &[usize],
     null_density: f32,
     input: &ArrayRef,
 ) {
@@ -182,7 +182,7 @@ fn primitive_vectorized_append(c: &mut Criterion) {
 fn bench_single_primitive<const NULLABLE: bool>(
     group: &mut BenchmarkGroup<WallTime>,
     size: usize,
-    rows: &Vec<usize>,
+    rows: &[usize],
     null_density: f32,
 ) {
     if !NULLABLE {

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -1467,7 +1467,7 @@ pub fn execute_input_stream(
 /// is returned.
 pub fn check_not_null_constraints(
     batch: RecordBatch,
-    column_indices: &Vec<usize>,
+    column_indices: &[usize],
 ) -> Result<RecordBatch> {
     for &index in column_indices {
         if batch.num_columns() <= index {
@@ -1862,7 +1862,7 @@ mod tests {
                 Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)])),
                 vec![Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)]))],
             )?,
-            &vec![0],
+            &[0],
         )?;
         Ok(())
     }
@@ -1874,7 +1874,7 @@ mod tests {
                 Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)])),
                 vec![Arc::new(Int32Array::from(vec![Some(1), None, Some(3)]))],
             )?,
-            &vec![0],
+            &[0],
         );
         assert!(result.is_err());
         assert_eq!(
@@ -1899,7 +1899,7 @@ mod tests {
                 )])),
                 vec![Arc::new(run_end_array)],
             )?,
-            &vec![0],
+            &[0],
         );
         assert!(result.is_err());
         assert_eq!(
@@ -1923,7 +1923,7 @@ mod tests {
                 )])),
                 vec![Arc::new(dictionary)],
             )?,
-            &vec![0],
+            &[0],
         );
         assert!(result.is_err());
         assert_eq!(
@@ -1953,7 +1953,7 @@ mod tests {
                 )])),
                 vec![Arc::new(dictionary)],
             )?,
-            &vec![0],
+            &[0],
         )?;
         Ok(())
     }
@@ -1966,7 +1966,7 @@ mod tests {
                 Arc::new(Schema::new(vec![Field::new("a", DataType::Null, true)])),
                 vec![Arc::new(NullArray::new(3))],
             )?,
-            &vec![0],
+            &[0],
         );
         assert!(result.is_err());
         assert_eq!(

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -984,7 +984,7 @@ pub fn batch_filter(
 fn filter_and_project(
     batch: &RecordBatch,
     predicate: &Arc<dyn PhysicalExpr>,
-    projection: Option<&Vec<usize>>,
+    projection: Option<&[usize]>,
 ) -> Result<RecordBatch> {
     predicate
         .evaluate(batch)

--- a/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
+++ b/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
@@ -78,7 +78,7 @@ impl SortedStreamBatch {
         }
     }
 
-    fn compare_key_values(&self) -> &Vec<ArrayRef> {
+    fn compare_key_values(&self) -> &[ArrayRef] {
         &self.compare_key_values
     }
 }

--- a/datafusion/physical-plan/src/memory.rs
+++ b/datafusion/physical-plan/src/memory.rs
@@ -249,7 +249,7 @@ impl LazyMemoryExec {
     }
 
     /// Get the batch generators
-    pub fn generators(&self) -> &Vec<Arc<RwLock<dyn LazyBatchGenerator>>> {
+    pub fn generators(&self) -> &[Arc<RwLock<dyn LazyBatchGenerator>>] {
         &self.batch_generators
     }
 }

--- a/datafusion/physical-plan/src/streaming.rs
+++ b/datafusion/physical-plan/src/streaming.rs
@@ -77,7 +77,7 @@ impl StreamingTableExec {
     pub fn try_new(
         schema: SchemaRef,
         partitions: Vec<Arc<dyn PartitionStream>>,
-        projection: Option<&Vec<usize>>,
+        projection: Option<&[usize]>,
         projected_output_ordering: impl IntoIterator<Item = LexOrdering>,
         infinite: bool,
         limit: Option<usize>,
@@ -108,7 +108,7 @@ impl StreamingTableExec {
         Ok(Self {
             partitions,
             projected_schema,
-            projection: projection.cloned().map(Into::into),
+            projection: projection.map(Into::into),
             projected_output_ordering,
             infinite,
             limit,
@@ -117,7 +117,7 @@ impl StreamingTableExec {
         })
     }
 
-    pub fn partitions(&self) -> &Vec<Arc<dyn PartitionStream>> {
+    pub fn partitions(&self) -> &[Arc<dyn PartitionStream>] {
         &self.partitions
     }
 
@@ -318,7 +318,7 @@ impl ExecutionPlan for StreamingTableExec {
 
         StreamingTableExec::try_new(
             Arc::clone(self.partition_schema()),
-            self.partitions().clone(),
+            self.partitions().to_vec(),
             Some(new_projections.as_ref()),
             lex_orderings,
             self.is_infinite(),
@@ -421,7 +421,7 @@ mod test {
             StreamingTableExec::try_new(
                 self.schema.unwrap(),
                 self.partitions,
-                self.projection.as_ref(),
+                self.projection.as_deref(),
                 self.projected_output_ordering,
                 self.infinite,
                 self.limit,

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -161,7 +161,7 @@ impl UnionExec {
     }
 
     /// Get inputs of the execution plan
-    pub fn inputs(&self) -> &Vec<Arc<dyn ExecutionPlan>> {
+    pub fn inputs(&self) -> &[Arc<dyn ExecutionPlan>] {
         &self.inputs
     }
 
@@ -526,7 +526,7 @@ impl InterleaveExec {
     }
 
     /// Get inputs of the execution plan
-    pub fn inputs(&self) -> &Vec<Arc<dyn ExecutionPlan>> {
+    pub fn inputs(&self) -> &[Arc<dyn ExecutionPlan>] {
         &self.inputs
     }
 

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -3485,7 +3485,7 @@ impl protobuf::PhysicalPlanNode {
         let generators = exec.generators();
 
         // ensure we only have one generator
-        let [generator] = generators.as_slice() else {
+        let [generator] = generators else {
             return Ok(None);
         };
 

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -504,7 +504,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     /// Returns a vector of (column_name, default_expr) pairs
     pub(super) fn build_column_defaults(
         &self,
-        columns: &Vec<SQLColumnDef>,
+        columns: &[SQLColumnDef],
         planner_context: &mut PlannerContext,
     ) -> Result<Vec<(String, Expr)>> {
         let mut column_defaults = vec![];

--- a/datafusion/sql/src/query.rs
+++ b/datafusion/sql/src/query.rs
@@ -388,7 +388,7 @@ fn to_order_by_exprs(order_by: Option<OrderBy>) -> Result<Vec<OrderByExpr>> {
 /// Returns the order by expressions from the query with the select expressions.
 pub(crate) fn to_order_by_exprs_with_select(
     order_by: Option<OrderBy>,
-    select_exprs: Option<&Vec<Expr>>,
+    select_exprs: Option<&[Expr]>,
 ) -> Result<Vec<OrderByExpr>> {
     let Some(OrderBy { kind, interpolate }) = order_by else {
         // If no order by, return an empty array.

--- a/datafusion/substrait/src/extensions.rs
+++ b/datafusion/substrait/src/extensions.rs
@@ -78,11 +78,11 @@ impl Extensions {
     }
 }
 
-impl TryFrom<&Vec<SimpleExtensionDeclaration>> for Extensions {
+impl TryFrom<&[SimpleExtensionDeclaration]> for Extensions {
     type Error = DataFusionError;
 
     fn try_from(
-        value: &Vec<SimpleExtensionDeclaration>,
+        value: &[SimpleExtensionDeclaration],
     ) -> datafusion::common::Result<Self> {
         let mut functions = HashMap::new();
         let mut types = HashMap::new();

--- a/datafusion/substrait/src/logical_plan/consumer/expr/function_arguments.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/expr/function_arguments.rs
@@ -24,7 +24,7 @@ use substrait::proto::function_argument::ArgType;
 /// Convert Substrait FunctionArguments to DataFusion Exprs
 pub async fn from_substrait_func_args(
     consumer: &impl SubstraitConsumer,
-    arguments: &Vec<FunctionArgument>,
+    arguments: &[FunctionArgument],
     input_schema: &DFSchema,
 ) -> datafusion::common::Result<Vec<Expr>> {
     let mut args: Vec<Expr> = vec![];

--- a/datafusion/substrait/src/logical_plan/consumer/expr/literal.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/expr/literal.rs
@@ -61,13 +61,13 @@ pub(crate) fn from_substrait_literal_without_names(
     consumer: &impl SubstraitConsumer,
     lit: &Literal,
 ) -> datafusion::common::Result<ScalarValue> {
-    from_substrait_literal(consumer, lit, &vec![], &mut 0)
+    from_substrait_literal(consumer, lit, &[], &mut 0)
 }
 
 pub(crate) fn from_substrait_literal(
     consumer: &impl SubstraitConsumer,
     lit: &Literal,
-    dfs_names: &Vec<String>,
+    dfs_names: &[String],
     name_idx: &mut usize,
 ) -> datafusion::common::Result<ScalarValue> {
     let scalar_value = match &lit.literal_type {

--- a/datafusion/substrait/src/logical_plan/consumer/expr/mod.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/expr/mod.rs
@@ -117,7 +117,7 @@ pub async fn from_substrait_extended_expr(
     extended_expr: &ExtendedExpression,
 ) -> datafusion::common::Result<ExprContainer> {
     // Register function extension
-    let extensions = Extensions::try_from(&extended_expr.extensions)?;
+    let extensions = Extensions::try_from(extended_expr.extensions.as_slice())?;
     if !extensions.type_variations.is_empty() {
         return not_impl_err!("Type variation extensions are not supported");
     }
@@ -185,7 +185,7 @@ pub struct ExprContainer {
 /// Convert Substrait Expressions to DataFusion Exprs
 pub async fn from_substrait_rex_vec(
     consumer: &impl SubstraitConsumer,
-    exprs: &Vec<Expression>,
+    exprs: &[Expression],
     input_schema: &DFSchema,
 ) -> datafusion::common::Result<Vec<Expr>> {
     let mut expressions: Vec<Expr> = vec![];

--- a/datafusion/substrait/src/logical_plan/consumer/plan.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/plan.rs
@@ -30,7 +30,7 @@ pub async fn from_substrait_plan(
     plan: &Plan,
 ) -> datafusion::common::Result<LogicalPlan> {
     // Register function extension
-    let extensions = Extensions::try_from(&plan.extensions)?;
+    let extensions = Extensions::try_from(plan.extensions.as_slice())?;
     if !extensions.type_variations.is_empty() {
         return not_impl_err!("Type variation extensions are not supported");
     }

--- a/datafusion/substrait/src/logical_plan/consumer/utils.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/utils.rs
@@ -58,7 +58,7 @@ pub(super) fn next_struct_field_name(
 /// Traverse through the field, renaming the provided field itself and all its inner struct fields.
 pub fn rename_field(
     field: &Field,
-    dfs_names: &Vec<String>,
+    dfs_names: &[String],
     unnamed_field_suffix: usize, // If Substrait doesn't provide a name, we'll use this "c{unnamed_field_suffix}"
     name_idx: &mut usize,        // Index into dfs_names
 ) -> datafusion::common::Result<Field> {
@@ -69,7 +69,7 @@ pub fn rename_field(
 /// Rename the field's data type but not the field itself.
 pub fn rename_fields_data_type(
     field: Field,
-    dfs_names: &Vec<String>,
+    dfs_names: &[String],
     name_idx: &mut usize, // Index into dfs_names
 ) -> datafusion::common::Result<Field> {
     let dt = rename_data_type(field.data_type(), dfs_names, name_idx)?;
@@ -79,7 +79,7 @@ pub fn rename_fields_data_type(
 /// Traverse through the data type (incl. lists/maps/etc), renaming all inner struct fields.
 pub fn rename_data_type(
     data_type: &DataType,
-    dfs_names: &Vec<String>,
+    dfs_names: &[String],
     name_idx: &mut usize, // Index into dfs_names
 ) -> datafusion::common::Result<DataType> {
     match data_type {
@@ -227,7 +227,7 @@ pub fn rename_data_type(
 /// to rename the schema to match the expected names.
 pub(super) fn make_renamed_schema(
     schema: &DFSchemaRef,
-    dfs_names: &Vec<String>,
+    dfs_names: &[String],
 ) -> datafusion::common::Result<DFSchema> {
     let mut name_idx = 0;
 
@@ -458,7 +458,7 @@ impl NameTracker {
 /// Convert Substrait Sorts to DataFusion Exprs
 pub async fn from_substrait_sorts(
     consumer: &impl SubstraitConsumer,
-    substrait_sorts: &Vec<SortField>,
+    substrait_sorts: &[SortField],
     input_schema: &DFSchema,
 ) -> datafusion::common::Result<Vec<Sort>> {
     let mut sorts: Vec<Sort> = vec![];

--- a/datafusion/substrait/src/logical_plan/producer/rel/join.rs
+++ b/datafusion/substrait/src/logical_plan/producer/rel/join.rs
@@ -85,7 +85,7 @@ pub fn from_join(
 
 fn to_substrait_join_expr(
     producer: &mut impl SubstraitProducer,
-    join_conditions: &Vec<(Expr, Expr)>,
+    join_conditions: &[(Expr, Expr)],
     eq_op: Operator,
     join_schema: &DFSchemaRef,
 ) -> datafusion::common::Result<Option<Expression>> {


### PR DESCRIPTION
## Rationale for this change

`&[T]` is a bit nicer than `&Vec<T>` because it removes one indirection (it points directly to the data instead of pointing to the `Vec` struct that points to the data. The API for both is nearly the same.

## What changes are included in this PR?

Migrates a lot of places from `&Vec<_>` to `&[_]`. Does not touch `TableProvider::scan` method that is currently deprecated.

## Are there any user-facing changes?

Some minor API changes. The Rust compiler is fairly helpful and suggested me relevant changes for all broken places in DataFusion.