### PR TITLE
[branch-53] Update  Release Notes

### DIFF
--- a/dev/changelog/53.0.0.md
+++ b/dev/changelog/53.0.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # Apache DataFusion 53.0.0 Changelog
 
-This release consists of 475 commits from 107 contributors. See credits at the end of this changelog for more information.
+This release consists of 475 commits from 114 contributors. See credits at the end of this changelog for more information.
 
 See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgrading.html) for information on how to upgrade from previous versions.
 
@@ -490,31 +490,31 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - Add deterministic per-file timing summary to sqllogictest runner [#20569](https://github.com/apache/datafusion/pull/20569) (kosiew)
 - chore: Enable workspace lint for all workspace members [#20577](https://github.com/apache/datafusion/pull/20577) (neilconway)
 - Fix serde of window lead/lag defaults [#20608](https://github.com/apache/datafusion/pull/20608) (avantgardnerio)
-- [branch-53] fix: make the `sql` feature truly optional (#20625) [#20680](https://github.com/apache/datafusion/pull/20680) (comphead)
+- [branch-53] fix: make the `sql` feature truly optional (#20625) [#20680](https://github.com/apache/datafusion/pull/20680) (linhr)
 - [53] fix: Fix bug in `array_has` scalar path with sliced arrays (#20677) [#20700](https://github.com/apache/datafusion/pull/20700) (neilconway)
 - [branch-53] fix: Return `probe_side.len()` for RightMark/Anti count(\*) queries (#… [#20726](https://github.com/apache/datafusion/pull/20726) (jonathanc-n)
 - [branch-53] FFI_TableOptions are using default values only [#20722](https://github.com/apache/datafusion/pull/20722) (timsaucer)
 - chore(deps): pin substrait to `0.62.2` [#20827](https://github.com/apache/datafusion/pull/20827) (milenkovicm)
 - chore(deps): pin substrait version [#20848](https://github.com/apache/datafusion/pull/20848) (milenkovicm)
-- [branch-53] Fix repartition from dropping data when spilling (#20672) [#20792](https://github.com/apache/datafusion/pull/20792) (hareshkh)
-- [branch-53] fix: `HashJoin` panic with String dictionary keys (don't flatten keys) (#20505) [#20791](https://github.com/apache/datafusion/pull/20791) (hareshkh)
-- [branch-53] cli: Fix datafusion-cli hint edge cases (#20609) [#20887](https://github.com/apache/datafusion/pull/20887) (alamb)
-- [branch-53] perf: Optimize `to_char` to allocate less, fix NULL handling (#20635) [#20885](https://github.com/apache/datafusion/pull/20885) (alamb)
-- [branch-53] fix: interval analysis error when have two filterexec that inner filter proves zero selectivity (#20743) [#20882](https://github.com/apache/datafusion/pull/20882) (alamb)
-- [branch-53] correct parquet leaf index mapping when schema contains struct cols (#20698) [#20884](https://github.com/apache/datafusion/pull/20884) (alamb)
-- [branch-53] ser/de fetch in FilterExec (#20738) [#20883](https://github.com/apache/datafusion/pull/20883) (alamb)
-- [branch-53] fix: use try_shrink instead of shrink in try_resize (#20424) [#20890](https://github.com/apache/datafusion/pull/20890) (alamb)
-- [branch-53] Reattach parquet metadata cache after deserializing in datafusion-proto (#20574) [#20891](https://github.com/apache/datafusion/pull/20891) (alamb)
-- [branch-53] fix: do not recompute hash join exec properties if not required (#20900) [#20903](https://github.com/apache/datafusion/pull/20903) (alamb)
-- [branch-53] fix(spark): handle divide-by-zero in Spark `mod`/`pmod` with ANSI mode support (#20461) [#20896](https://github.com/apache/datafusion/pull/20896) (alamb)
-- [branch-53] fix: Provide more generic API for the capacity limit parsing (#20372) [#20893](https://github.com/apache/datafusion/pull/20893) (alamb)
-- [branch-53] fix: sqllogictest cannot convert <subquery> to Substrait (#19739) [#20897](https://github.com/apache/datafusion/pull/20897) (alamb)
-- [branch-53] Fix DELETE/UPDATE filter extraction when predicates are pushed down into TableScan (#19884) [#20898](https://github.com/apache/datafusion/pull/20898) (alamb)
-- [branch-53] fix: preserve None projection semantics across FFI boundary in ForeignTableProvider::scan (#20393) [#20895](https://github.com/apache/datafusion/pull/20895) (alamb)
-- [branch-53] Fix FilterExec converting Absent column stats to Exact(NULL) (#20391) [#20892](https://github.com/apache/datafusion/pull/20892) (alamb)
+- [branch-53] Fix repartition from dropping data when spilling (#20672) [#20792](https://github.com/apache/datafusion/pull/20792) (xanderbailey)
+- [branch-53] fix: `HashJoin` panic with String dictionary keys (don't flatten keys) (#20505) [#20791](https://github.com/apache/datafusion/pull/20791) (alamb)
+- [branch-53] cli: Fix datafusion-cli hint edge cases (#20609) [#20887](https://github.com/apache/datafusion/pull/20887) (comphead)
+- [branch-53] perf: Optimize `to_char` to allocate less, fix NULL handling (#20635) [#20885](https://github.com/apache/datafusion/pull/20885) (neilconway)
+- [branch-53] fix: interval analysis error when have two filterexec that inner filter proves zero selectivity (#20743) [#20882](https://github.com/apache/datafusion/pull/20882) (haohuaijin)
+- [branch-53] correct parquet leaf index mapping when schema contains struct cols (#20698) [#20884](https://github.com/apache/datafusion/pull/20884) (friendlymatthew)
+- [branch-53] ser/de fetch in FilterExec (#20738) [#20883](https://github.com/apache/datafusion/pull/20883) (haohuaijin)
+- [branch-53] fix: use try_shrink instead of shrink in try_resize (#20424) [#20890](https://github.com/apache/datafusion/pull/20890) (ariel-miculas)
+- [branch-53] Reattach parquet metadata cache after deserializing in datafusion-proto (#20574) [#20891](https://github.com/apache/datafusion/pull/20891) (nathanb9)
+- [branch-53] fix: do not recompute hash join exec properties if not required (#20900) [#20903](https://github.com/apache/datafusion/pull/20903) (askalt)
+- [branch-53] fix(spark): handle divide-by-zero in Spark `mod`/`pmod` with ANSI mode support (#20461) [#20896](https://github.com/apache/datafusion/pull/20896) (davidlghellin)
+- [branch-53] fix: Provide more generic API for the capacity limit parsing (#20372) [#20893](https://github.com/apache/datafusion/pull/20893) (erenavsarogullari)
+- [branch-53] fix: sqllogictest cannot convert <subquery> to Substrait (#19739) [#20897](https://github.com/apache/datafusion/pull/20897) (kumarUjjawal)
+- [branch-53] Fix DELETE/UPDATE filter extraction when predicates are pushed down into TableScan (#19884) [#20898](https://github.com/apache/datafusion/pull/20898) (kosiew)
+- [branch-53] fix: preserve None projection semantics across FFI boundary in ForeignTableProvider::scan (#20393) [#20895](https://github.com/apache/datafusion/pull/20895) (Kontinuation)
+- [branch-53] Fix FilterExec converting Absent column stats to Exact(NULL) (#20391) [#20892](https://github.com/apache/datafusion/pull/20892) (fwojciec)
 - [branch-53] backport: Support Spark `array_contains` builtin function (#20685) [#20914](https://github.com/apache/datafusion/pull/20914) (comphead)
-- [branch-53] Fix duplicate group keys after hash aggregation spill (#20724) (#20858) [#20918](https://github.com/apache/datafusion/pull/20918) (alamb)
-- [branch-53] fix: SanityCheckPlan error with window functions and NVL filter (#20231) [#20932](https://github.com/apache/datafusion/pull/20932) (alamb)
+- [branch-53] Fix duplicate group keys after hash aggregation spill (#20724) (#20858) [#20918](https://github.com/apache/datafusion/pull/20918) (gboucher90)
+- [branch-53] fix: SanityCheckPlan error with window functions and NVL filter (#20231) [#20932](https://github.com/apache/datafusion/pull/20932) (EeshanBembi)
 
 ## Credits
 
@@ -522,91 +522,106 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
 
 ```
     73	dependabot[bot]
-    43	Andrew Lamb
-    36	Neil Conway
-    31	Kumar Ujjawal
+    37	Neil Conway
+    32	Kumar Ujjawal
+    28	Andrew Lamb
     26	Adrian Garcia Badaracco
     21	Jeffrey Vo
     13	cht42
-    10	Albert Skalt
-    10	kosiew
+    11	Albert Skalt
+    11	kosiew
     10	lyne
      8	Nuno Faria
      8	Oleks V
      7	Sergey Zhukov
      7	xudong.w
      6	Daniël Heres
+     6	Huaijin
      5	Adam Gutglick
      5	Gabriel
      5	Jonathan Chen
      4	Andy Grove
      4	Dmitrii Blaginin
-     4	Huaijin
+     4	Eren Avsarogullari
      4	Jack Kleeman
-     4	Tim Saucer
-     4	Yongting You
      4	notashes
      4	theirix
-     3	Eren Avsarogullari
-     3	Haresh Khanna
+     4	Tim Saucer
+     4	Yongting You
+     3	dario curreri
+     3	feniljain
      3	Kazantsev Maksim
      3	Kosta Tarasov
      3	Liang-Chi Hsieh
      3	Lía Adriana
      3	Marko Milenković
-     3	Yu-Chuan Hung
-     3	dario curreri
-     3	feniljain
      3	mishop-15
+     3	Yu-Chuan Hung
      2	Acfboy
      2	Alan Tang
+     2	David López
      2	Devanshu
      2	Frederic Branczyk
      2	Ganesh Patil
+     2	Heran Lin
+     2	jizezhang
      2	Miao
      2	Michael Kleen
+     2	niebayes
      2	Pepijn Van Eeckhoudt
      2	Peter L
      2	Subham Singhal
      2	Tobias Schwarzinger
      2	UBarney
+     2	Xander
      2	Yuvraj
      2	Zhang Xiaofeng
-     2	jizezhang
-     2	niebayes
      1	Andrea Bozzo
      1	Andrew Kane
      1	Anjali Choudhary
      1	Anna-Rose Lescure
+     1	Ariel Miculas-Trif
      1	Aryan Anand
      1	Aviral Garg
      1	Bert Vermeiren
      1	Brent Gardner
      1	ChanTsune
-     1	David López
+     1	comphead
+     1	danielhumanmod
      1	Dewey Dunnington
+     1	discord9
      1	Divyansh Pratap Singh
      1	Eesh Sagar Singh
+     1	EeshanBembi
      1	Emil Ernerfeldt
      1	Emily Matheys
      1	Eric Chang
      1	Evangeli Silva
+     1	Filip Wojciechowski
      1	Filippo
      1	Gabriel Ferraté
      1	Gene Bordegaray
      1	Geoffrey Claude
      1	Goksel Kabadayi
-     1	Heran Lin
+     1	Guillaume Boucher
+     1	Haresh Khanna
+     1	hsiang-c
+     1	iamthinh
      1	Josh Elkind
+     1	karuppuchamysuresh
+     1	Kristin Cowalcijk
      1	Mason
      1	Matt Butrovich
+     1	Matthew Kim
      1	Mikhail Zabaluev
      1	Mohit rao
+     1	nathan
      1	Nathaniel J. Smith
      1	Nick
      1	Oleg V. Kozlyuk
      1	Paul J. Davis
      1	Pierre Lacave
+     1	pmallex
      1	Qi Zhu
      1	Raz Luvaton
      1	Rosai
@@ -618,16 +633,8 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
      1	Tim-53
      1	Tushar Das
      1	Vignesh
-     1	XL Liang
-     1	Xander
      1	Xiangpeng Hao
-     1	comphead
-     1	danielhumanmod
-     1	discord9
-     1	hsiang-c
-     1	iamthinh
-     1	karuppuchamysuresh
-     1	pmallex
+     1	XL Liang
 ```
 
 Thank you also to everyone who contributed in other ways such as filing issues, reviewing PRs, and providing feedback on this release.


### PR DESCRIPTION
## Which issue does this PR close?

- Part of https://github.com/apache/datafusion/issues/19692

## Rationale for this change

We have backported a bunch of bug fixes to branch-53, so let's make sure the release notes reflect that

## What changes are included in this PR?

I ran
```shell
uv run ./dev/release/generate-changelog.py 52.3.0 branch-53 53.0.0 > dev/changelog/53.0.0.md
```

And then had codex review via

```
› Please review dev/changelog/53.0.0.md to ensure it reflects all commits between where `apache/branch-53` and `main` diverged
```

Then I updated the change log to reflect the original authors not the backport authors


## Are these changes tested?

By CI
