### PR TITLE
fix: Run release verification with `--profile=ci`

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -22,7 +22,7 @@
 check_dependencies() {
   local missing_deps=0
   local required_deps=("curl" "git" "gpg" "cc" "protoc")
-  
+
   # Either shasum or sha256sum/sha512sum are required
   local has_sha_tools=0
 
@@ -32,7 +32,7 @@ check_dependencies() {
       missing_deps=1
     fi
   done
-  
+
   # Check for either shasum or sha256sum/sha512sum
   if command -v shasum &> /dev/null; then
     has_sha_tools=1
@@ -42,7 +42,7 @@ check_dependencies() {
     echo "Error: Neither shasum nor sha256sum/sha512sum are installed or in PATH"
     missing_deps=1
   fi
-  
+
   if [ $missing_deps -ne 0 ]; then
     echo "Please install missing dependencies and try again"
     exit 1
@@ -163,7 +163,7 @@ test_source_distribution() {
   git clone https://github.com/apache/parquet-testing.git parquet-testing
 
   cargo build
-  cargo test --all --features=avro
+  cargo test --profile=ci --all --features=avro
 
   if ( find -iname 'Cargo.toml' | xargs grep SNAPSHOT ); then
     echo "Cargo.toml version should not contain SNAPSHOT for releases"


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/20689
- Closes https://github.com/apache/datafusion/issues/20992
- part of https://github.com/apache/datafusion/issues/19692


## Rationale for this change

While verifying DataFusion 53.0.0, we found that the `verify_release_candidate` script was not working correctly, as it was hitting an assertion

Specifically:

```shell
$ ./dev/release/verify-release-candidate.sh 53.0.0 2
...
    joins::sort_merge_join::tests::test_should_emit_early_when_have_enough_data_to_emit

test result: FAILED. 1190 passed; 78 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.89s

error: test failed, to rerun pass `-p datafusion-physical-plan --lib`
+ cleanup
+ '[' no = yes ']'
+ echo 'Failed to verify release candidate. See /var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-53.0.0.XXXXX.d5aUZcsu7v for details.'
Failed to verify release candidate. See /var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-53.0.0.XXXXX.d5aUZcsu7v for details.
```

The failure is due to an overzealous assert in arrow-rs (see https://github.com/apache/arrow-rs/issues/9506) that will be fixed in the next release

The reason this isn' triggered on CI is that sqllogictests are run with `--profile=ci` -- see
https://github.com/apache/datafusion/blob/11b9693952cd419b73dd03cc39f22c8b343bc05c/.github/workflows/rust.yml#L299-L298

## What changes are included in this PR?

1. Update verify_release.sh to use `--profile=ci` when running sqllogictests to mirror CI

## Are these changes tested?

I tested it manually (STILLRUNNING)

```shell
$ ./dev/release/verify-release-candidate.sh 53.0.0 2
...
/var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-53.0.0.XXXXX.j0FgM9yH5J
+ TEST_SUCCESS=yes
+ echo 'Release candidate looks good!'
Release candidate looks good!
+ exit 0
+ cleanup
+ '[' yes = yes ']'
+ rm -fr /var/folders/1l/tg68jc6550gg8xqf1hr4mlwr0000gn/T/datafusion-53.0.0.XXXXX.j0FgM9yH5J
```

## Are there any user-facing changes?
No
