### PR TITLE
[branch-52] Update to use lz4_flex 0.12.1 and quinn-proto 0.11.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4864,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Which issue does this PR close?

- part of https://github.com/apache/datafusion/issues/20855

## Rationale for this change

`cargo audit` is failing on on branch-52 like this:

```
...
Crate:     lz4_flex
Version:   0.12.0
Warning:   yanked

error: 2 vulnerabilities found!
warning: 4 allowed warnings found
```

here is an example of that heppening on CI: https://github.com/apache/datafusion/actions/runs/23209529148/job/67454157529?pr=21004



## What changes are included in this PR?


- Update lz4_flex 50 0.12.1 (non yanked)

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
