### PR TITLE
fix: run generated docs check on docs-only PRs

### DIFF
--- a/.github/workflows/docs_generated.yaml
+++ b/.github/workflows/docs_generated.yaml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Generated Docs
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths:
+      - ".github/workflows/docs_generated.yaml"
+      - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-rust-runtime/**"
+      - "ci/scripts/utils/tool_versions.sh"
+      - "datafusion/**"
+      - "dev/update_config_docs.sh"
+      - "dev/update_function_docs.sh"
+      - "docs/source/user-guide/configs.md"
+      - "docs/source/user-guide/sql/aggregate_functions.md"
+      - "docs/source/user-guide/sql/scalar_functions.md"
+      - "docs/source/user-guide/sql/window_functions.md"
+  pull_request:
+    paths:
+      - ".github/workflows/docs_generated.yaml"
+      - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-rust-runtime/**"
+      - "ci/scripts/utils/tool_versions.sh"
+      - "datafusion/**"
+      - "dev/update_config_docs.sh"
+      - "dev/update_function_docs.sh"
+      - "docs/source/user-guide/configs.md"
+      - "docs/source/user-guide/sql/aggregate_functions.md"
+      - "docs/source/user-guide/sql/scalar_functions.md"
+      - "docs/source/user-guide/sql/window_functions.md"
+  workflow_dispatch:
+
+jobs:
+  generated-docs-check:
+    name: check configs.md and ***_functions.md is up-to-date
+    runs-on: ${{ github.repository_owner == 'apache' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion', github.run_id) || 'ubuntu-latest' }}
+    container:
+      image: amd64/rust
+    steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e  # v2.0.3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          submodules: true
+          fetch-depth: 1
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
+        with:
+          node-version: "20"
+      - name: Check if configs.md has been modified
+        run: |
+          # If you encounter an error, run './dev/update_config_docs.sh' and commit
+          ./dev/update_config_docs.sh
+          git diff --exit-code
+      - name: Check if any of the ***_functions.md has been modified
+        run: |
+          # If you encounter an error, run './dev/update_function_docs.sh' and commit
+          ./dev/update_function_docs.sh
+          git diff --exit-code

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -694,36 +694,6 @@ jobs:
       - name: Check Cargo.toml formatting
         run: taplo format --check
 
-  config-docs-check:
-    name: check configs.md and ***_functions.md is up-to-date
-    needs: linux-build-lib
-    runs-on: ${{ github.repository_owner == 'apache' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion', github.run_id) || 'ubuntu-latest' }}
-    container:
-      image: amd64/rust
-    steps:
-      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e  # v2.0.3
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          submodules: true
-          fetch-depth: 1
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
-        with:
-          node-version: "20"
-      - name: Check if configs.md has been modified
-        run: |
-          # If you encounter an error, run './dev/update_config_docs.sh' and commit
-          ./dev/update_config_docs.sh
-          git diff --exit-code
-      - name: Check if any of the ***_functions.md has been modified
-        run: |
-          # If you encounter an error, run './dev/update_function_docs.sh' and commit
-          ./dev/update_function_docs.sh
-          git diff --exit-code
-
 # This job ensures `datafusion-examples/README.md` stays in sync with the source code:
 # 1. Generates README automatically using the Rust examples docs generator
 #    (parsing documentation from `examples/<group>/main.rs`)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #19095

## Rationale for this change

The generated-doc drift check currently lives in `rust.yml`, but `rust.yml` ignores docs-only and markdown-only PRs via `paths-ignore`:

- `docs/**`
- `**.md`

That means a PR can directly edit autogenerated files such as:

- `docs/source/user-guide/configs.md`
- `docs/source/user-guide/sql/aggregate_functions.md`
- `docs/source/user-guide/sql/scalar_functions.md`
- `docs/source/user-guide/sql/window_functions.md`

and still pass CI, because the workflow that runs:

- `./dev/update_config_docs.sh`
- `./dev/update_function_docs.sh`

never executes.

I reproduced this locally and summarized the findings on the issue:
- https://github.com/apache/datafusion/issues/19095#issuecomment-4064309069

## What changes are included in this PR?

1. Add a dedicated `Generated Docs` workflow in `.github/workflows/docs_generated.yaml`
2. Trigger that workflow on:
   - generated doc files
   - generator scripts
   - `ci/scripts/utils/tool_versions.sh`
   - `datafusion/**`
   - the workflow file and setup actions it depends on
3. Preserve the existing job name:
   - `check configs.md and ***_functions.md is up-to-date`
4. Remove the old generated-doc check job from `rust.yml`

This keeps `rust.yml` path filtering unchanged while ensuring docs-only edits to autogenerated files still run the drift check.

## Are these changes tested?

Yes, locally:

- Parsed workflow YAML successfully with `PyYAML`
- Verified trigger behavior for:
  - generated docs edits
  - ordinary docs edits
  - source/script/setup changes
- Ran:
  - `./dev/update_config_docs.sh`
  - `./dev/update_function_docs.sh`
- Confirmed both commands exited successfully and produced no diffs in generated docs

## Are there any user-facing changes?

No. This is CI/process-only.
