### PR TITLE
fix: avoid internal errors for OneOf signature mismatches

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -1557,9 +1557,12 @@ mod tests {
 
         let err = fields_with_udf(&current_fields, &MockUdf(signature)).unwrap_err();
         assert!(matches!(err, DataFusionError::Plan(_)));
-        assert_eq!(
-            err.to_string(),
-            "Error during planning: Function 'test' requires String, but received Int64 (DataType: Int64)."
+        assert!(
+            err.to_string().starts_with(
+                "Error during planning: Function 'test' requires String, but received Int64 (DataType: Int64)."
+            ),
+            "{}",
+            err
         );
     }
 

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -16,20 +16,22 @@
 // under the License.
 
 use super::binary::binary_numeric_coercion;
-use crate::{AggregateUDF, ScalarUDF, Signature, TypeSignature, WindowUDF};
+use crate::{
+    AggregateUDF, ScalarUDF, Signature, TypeSignature, TypeSignatureClass, WindowUDF,
+};
 use arrow::datatypes::{Field, FieldRef};
 use arrow::{
     compute::can_cast_types,
     datatypes::{DataType, TimeUnit},
 };
-use datafusion_common::types::LogicalType;
+use datafusion_common::types::{LogicalType, NativeType, logical_string};
 use datafusion_common::utils::{
     ListCoercion, base_type, coerced_fixed_size_list_to_list,
 };
 use datafusion_common::{
-    Result, exec_err, internal_err, plan_err, types::NativeType, utils::list_ndims,
+    DataFusionError, Result, internal_err, plan_err, utils::list_ndims,
 };
-use datafusion_expr_common::signature::ArrayFunctionArgument;
+use datafusion_expr_common::signature::{Arity, ArrayFunctionArgument, Coercion};
 use datafusion_expr_common::type_coercion::binary::type_union_resolution;
 use datafusion_expr_common::{
     signature::{ArrayFunctionSignature, FIXED_SIZE_LIST_WILDCARD, TIMEZONE_WILDCARD},
@@ -37,6 +39,7 @@ use datafusion_expr_common::{
     type_coercion::binary::string_coercion,
 };
 use itertools::Itertools as _;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 /// Extension trait to unify common functionality between [`ScalarUDF`], [`AggregateUDF`]
@@ -50,6 +53,15 @@ pub trait UDFCoercionExt {
     /// Should delegate to [`ScalarUDF::coerce_types`], [`AggregateUDF::coerce_types`]
     /// or [`WindowUDF::coerce_types`].
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>>;
+
+    /// Return a function-specific signature failure when generic `OneOf`
+    /// diagnostics are not descriptive enough.
+    fn diagnose_failed_signature(
+        &self,
+        _arg_types: &[DataType],
+    ) -> Option<DataFusionError> {
+        None
+    }
 }
 
 impl UDFCoercionExt for ScalarUDF {
@@ -77,6 +89,13 @@ impl UDFCoercionExt for AggregateUDF {
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         self.coerce_types(arg_types)
+    }
+
+    fn diagnose_failed_signature(
+        &self,
+        arg_types: &[DataType],
+    ) -> Option<DataFusionError> {
+        self.diagnose_failed_signature(arg_types)
     }
 }
 
@@ -307,51 +326,305 @@ fn try_coerce_types(
     )
 }
 
+#[derive(Debug)]
+struct PlanFailure {
+    err: DataFusionError,
+    matches_arity: bool,
+    has_hint: bool,
+    detail: Option<TypeMismatchDetail>,
+}
+
+#[derive(Debug)]
+enum SignatureFailure {
+    Plan(PlanFailure),
+    NonPlan(DataFusionError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TypeMismatchDetail {
+    arg_index: usize,
+    required_type: String,
+    received_type: String,
+    data_type: String,
+}
+
+fn signature_matches_arity(signature: &TypeSignature, actual: usize) -> bool {
+    match signature.arity() {
+        Arity::Fixed(expected) => expected == actual,
+        Arity::Variable => true,
+    }
+}
+
+fn collect_fixed_arities(signature: &TypeSignature, arities: &mut BTreeSet<usize>) {
+    match signature {
+        TypeSignature::OneOf(signatures) => {
+            for signature in signatures {
+                collect_fixed_arities(signature, arities);
+            }
+        }
+        _ => {
+            if let Arity::Fixed(expected) = signature.arity() {
+                arities.insert(expected);
+            }
+        }
+    }
+}
+
+fn build_one_of_arity_error(
+    function_name: &str,
+    actual: usize,
+    expected_arities: &[usize],
+) -> Option<DataFusionError> {
+    if expected_arities.is_empty() {
+        return None;
+    }
+
+    let expected = expected_arities.to_vec();
+    let message = if expected.len() == 1 {
+        format!(
+            "Function '{function_name}' expects {} arguments but received {actual}",
+            expected[0]
+        )
+    } else if expected.windows(2).all(|window| window[1] == window[0] + 1) {
+        format!(
+            "Function '{function_name}' expects {} to {} arguments but received {actual}",
+            expected.first().unwrap(),
+            expected.last().unwrap()
+        )
+    } else {
+        format!(
+            "Function '{function_name}' expects one of {} arguments but received {actual}",
+            expected.iter().join(", ")
+        )
+    };
+
+    Some(DataFusionError::Plan(message))
+}
+
+fn combine_type_mismatch_failures(
+    function_name: &str,
+    failures: &[PlanFailure],
+) -> Option<DataFusionError> {
+    let details = failures
+        .iter()
+        .map(|failure| failure.detail.as_ref())
+        .collect::<Option<Vec<_>>>()?;
+
+    let first = details.first()?;
+    if !details.iter().all(|detail| {
+        detail.arg_index == first.arg_index
+            && detail.received_type == first.received_type
+            && detail.data_type == first.data_type
+    }) {
+        return None;
+    }
+
+    let required_types = details
+        .iter()
+        .map(|detail| detail.required_type.as_str())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    if required_types.is_empty() {
+        return None;
+    }
+
+    let required = if required_types.len() == 1 {
+        required_types[0].to_string()
+    } else {
+        format!("one of {}", required_types.join(", "))
+    };
+
+    Some(DataFusionError::Plan(format!(
+        "Function '{function_name}' requires {required}, but received {} (DataType: {}).",
+        first.received_type, first.data_type
+    )))
+}
+
+fn select_best_plan_failure(
+    function_name: &str,
+    failures: Vec<PlanFailure>,
+) -> Option<DataFusionError> {
+    let matching_failures = failures
+        .into_iter()
+        .filter(|failure| failure.matches_arity)
+        .collect::<Vec<_>>();
+
+    if matching_failures.is_empty() {
+        return None;
+    }
+
+    if matching_failures.len() == 1 {
+        return Some(matching_failures.into_iter().next().unwrap().err);
+    }
+
+    let hinted = matching_failures
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, failure)| failure.has_hint.then_some(idx))
+        .collect::<Vec<_>>();
+    if hinted.len() == 1 {
+        return Some(matching_failures.into_iter().nth(hinted[0]).unwrap().err);
+    }
+
+    let messages = matching_failures
+        .iter()
+        .map(|failure| failure.err.strip_backtrace().to_string())
+        .collect::<Vec<_>>();
+    if messages.windows(2).all(|pair| pair[0] == pair[1]) {
+        return Some(matching_failures.into_iter().next().unwrap().err);
+    }
+
+    combine_type_mismatch_failures(function_name, &matching_failures)
+}
+
+fn coercible_mismatch_detail(
+    coercions: &[Coercion],
+    current_types: &[DataType],
+) -> Option<TypeMismatchDetail> {
+    if coercions.len() != current_types.len() {
+        return None;
+    }
+
+    for (arg_index, (param, current_type)) in
+        coercions.iter().zip(current_types.iter()).enumerate()
+    {
+        let current_native_type = NativeType::from(current_type);
+        let desired_type = param.desired_type();
+        let desired_matches = desired_type.matches_native_type(&current_native_type);
+        let allowed_matches = param
+            .allowed_source_types()
+            .iter()
+            .any(|source_type| source_type.matches_native_type(&current_native_type));
+
+        if !desired_matches && !allowed_matches {
+            return Some(TypeMismatchDetail {
+                arg_index,
+                required_type: desired_type.to_string(),
+                received_type: current_native_type.to_string(),
+                data_type: current_type.to_string(),
+            });
+        }
+    }
+
+    None
+}
+
+fn to_signature_failure(
+    signature: &TypeSignature,
+    current_types: &[DataType],
+    err: DataFusionError,
+) -> Box<SignatureFailure> {
+    match err {
+        DataFusionError::Plan(message) => Box::new(SignatureFailure::Plan(PlanFailure {
+            matches_arity: signature_matches_arity(signature, current_types.len()),
+            has_hint: message.contains("Hint:"),
+            detail: match signature {
+                TypeSignature::Coercible(coercions) => {
+                    coercible_mismatch_detail(coercions, current_types)
+                }
+                _ => None,
+            },
+            err: DataFusionError::Plan(message),
+        })),
+        err => Box::new(SignatureFailure::NonPlan(err)),
+    }
+}
+
+fn evaluate_one_of_with_udf<F: UDFCoercionExt>(
+    signatures: &[TypeSignature],
+    current_types: &[DataType],
+    func: &F,
+) -> Result<Vec<Vec<DataType>>> {
+    let actual = current_types.len();
+    let mut valid_types = vec![];
+    let mut plan_failures = vec![];
+    let mut deferred_non_plan = None;
+    let mut fixed_arities = BTreeSet::new();
+
+    for signature in signatures {
+        collect_fixed_arities(signature, &mut fixed_arities);
+
+        match evaluate_signature_with_udf(signature, current_types, func) {
+            Ok(types) => valid_types.extend(types),
+            Err(failure) => match *failure {
+                SignatureFailure::Plan(failure) => plan_failures.push(failure),
+                SignatureFailure::NonPlan(err) => {
+                    if deferred_non_plan.is_none() {
+                        deferred_non_plan = Some(err);
+                    }
+                }
+            },
+        }
+    }
+
+    if !valid_types.is_empty() {
+        return Ok(valid_types);
+    }
+
+    if let Some(err) = func.diagnose_failed_signature(current_types) {
+        return Err(err);
+    }
+
+    if let Some(err) = select_best_plan_failure(func.name(), plan_failures) {
+        return Err(err);
+    }
+
+    let matching_arity_exists = signatures
+        .iter()
+        .any(|signature| signature_matches_arity(signature, actual));
+    let expected_arities = fixed_arities.iter().copied().collect::<Vec<_>>();
+    if !matching_arity_exists
+        && let Some(err) =
+            build_one_of_arity_error(func.name(), actual, &expected_arities)
+    {
+        return Err(err);
+    }
+
+    if let Some(err) = deferred_non_plan {
+        return Err(err);
+    }
+
+    plan_err!("Function '{}' failed to match any signature", func.name())
+}
+
+fn evaluate_signature_with_udf<F: UDFCoercionExt>(
+    signature: &TypeSignature,
+    current_types: &[DataType],
+    func: &F,
+) -> std::result::Result<Vec<Vec<DataType>>, Box<SignatureFailure>> {
+    match signature {
+        TypeSignature::UserDefined => match func.coerce_types(current_types) {
+            Ok(coerced_types) => Ok(vec![coerced_types]),
+            Err(e) => Err(Box::new(SignatureFailure::NonPlan(
+                DataFusionError::Execution(format!(
+                    "Function '{}' user-defined coercion failed with: {}",
+                    func.name(),
+                    e.strip_backtrace()
+                )),
+            ))),
+        },
+        TypeSignature::OneOf(signatures) => {
+            evaluate_one_of_with_udf(signatures, current_types, func)
+                .map_err(|err| to_signature_failure(signature, current_types, err))
+        }
+        _ => get_valid_types(func.name(), signature, current_types)
+            .map_err(|err| to_signature_failure(signature, current_types, err)),
+    }
+}
+
 fn get_valid_types_with_udf<F: UDFCoercionExt>(
     signature: &TypeSignature,
     current_types: &[DataType],
     func: &F,
 ) -> Result<Vec<Vec<DataType>>> {
-    let valid_types = match signature {
-        TypeSignature::UserDefined => match func.coerce_types(current_types) {
-            Ok(coerced_types) => vec![coerced_types],
-            Err(e) => {
-                return exec_err!(
-                    "Function '{}' user-defined coercion failed with: {}",
-                    func.name(),
-                    e.strip_backtrace()
-                );
-            }
-        },
-        TypeSignature::OneOf(signatures) => {
-            let mut res = vec![];
-            let mut errors = vec![];
-            for sig in signatures {
-                match get_valid_types_with_udf(sig, current_types, func) {
-                    Ok(valid_types) => {
-                        res.extend(valid_types);
-                    }
-                    Err(e) => {
-                        errors.push(e.to_string());
-                    }
-                }
-            }
-
-            // Every signature failed, return the joined error
-            if res.is_empty() {
-                return internal_err!(
-                    "Function '{}' failed to match any signature, errors: {}",
-                    func.name(),
-                    errors.join(",")
-                );
-            } else {
-                res
-            }
+    evaluate_signature_with_udf(signature, current_types, func).map_err(|failure| {
+        match *failure {
+            SignatureFailure::Plan(failure) => failure.err,
+            SignatureFailure::NonPlan(err) => err,
         }
-        _ => get_valid_types(func.name(), signature, current_types)?,
-    };
-
-    Ok(valid_types)
+    })
 }
 
 /// Returns a Vec of all possible valid argument types for the given signature.
@@ -635,7 +908,10 @@ fn get_valid_types(
                         default_casted_type.default_cast_for(current_type)?;
                     new_types.push(casted_type);
                 } else {
-                    let hint = if matches!(current_native_type, NativeType::Binary) {
+                    let hint = if matches!(current_native_type, NativeType::Binary)
+                        && param.desired_type()
+                            == &TypeSignatureClass::Native(logical_string())
+                    {
                         "\n\nHint: Binary types are not automatically coerced to String. Use CAST(column AS VARCHAR) to convert Binary data to String."
                     } else {
                         ""
@@ -946,7 +1222,7 @@ mod tests {
     use super::*;
     use arrow::datatypes::IntervalUnit;
     use datafusion_common::{
-        assert_contains,
+        assert_contains, exec_err,
         types::{logical_binary, logical_int64},
     };
     use datafusion_expr_common::signature::{Coercion, TypeSignatureClass};
@@ -1180,6 +1456,215 @@ mod tests {
         fn coerce_types(&self, _arg_types: &[DataType]) -> Result<Vec<DataType>> {
             unimplemented!()
         }
+    }
+
+    struct AlwaysExecErrUdf(Signature);
+
+    impl UDFCoercionExt for AlwaysExecErrUdf {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.0
+        }
+
+        fn coerce_types(&self, _arg_types: &[DataType]) -> Result<Vec<DataType>> {
+            exec_err!("boom")
+        }
+    }
+
+    struct DiagnoseErrUdf(Signature);
+
+    impl UDFCoercionExt for DiagnoseErrUdf {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.0
+        }
+
+        fn coerce_types(&self, _arg_types: &[DataType]) -> Result<Vec<DataType>> {
+            unimplemented!()
+        }
+
+        fn diagnose_failed_signature(
+            &self,
+            _arg_types: &[DataType],
+        ) -> Option<DataFusionError> {
+            Some(DataFusionError::Plan(
+                "test semantic signature failure".to_string(),
+            ))
+        }
+    }
+
+    #[test]
+    fn test_one_of_drops_internal_error_and_combines_type_errors() {
+        let current_fields = vec![Arc::new(Field::new("t", DataType::Boolean, true))];
+        let signature = Signature::one_of(
+            vec![
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Decimal,
+                )]),
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Duration,
+                )]),
+            ],
+            Volatility::Immutable,
+        );
+
+        let err = fields_with_udf(&current_fields, &MockUdf(signature)).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        let err = err.to_string();
+
+        assert_eq!(
+            err,
+            "Error during planning: Function 'test' requires one of Decimal, Duration, but received Boolean (DataType: Boolean)."
+        );
+        assert!(!err.contains("Internal error"));
+        assert!(!err.contains("TypeSignatureClass"));
+    }
+
+    #[test]
+    fn test_one_of_restores_arity_error() {
+        let current_fields = vec![Arc::new(Field::new("t", DataType::Int32, true))];
+        let signature = Signature::one_of(
+            vec![TypeSignature::Any(2), TypeSignature::Any(3)],
+            Volatility::Immutable,
+        );
+
+        let err = fields_with_udf(&current_fields, &MockUdf(signature)).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        assert_eq!(
+            err.to_string(),
+            "Error during planning: Function 'test' expects 2 to 3 arguments but received 1"
+        );
+    }
+
+    #[test]
+    fn test_one_of_uses_specific_error_for_unique_matching_signature() {
+        let current_fields = vec![Arc::new(Field::new("t", DataType::Int64, true))];
+        let signature = Signature::one_of(
+            vec![
+                TypeSignature::Any(3),
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Native(logical_string()),
+                )]),
+            ],
+            Volatility::Immutable,
+        );
+
+        let err = fields_with_udf(&current_fields, &MockUdf(signature)).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        assert_eq!(
+            err.to_string(),
+            "Error during planning: Function 'test' requires String, but received Int64 (DataType: Int64)."
+        );
+    }
+
+    #[test]
+    fn test_one_of_prefers_hinted_matching_signature() {
+        let current_fields = vec![Arc::new(Field::new("t", DataType::Binary, true))];
+        let signature = Signature::one_of(
+            vec![
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Decimal,
+                )]),
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Native(logical_string()),
+                )]),
+            ],
+            Volatility::Immutable,
+        );
+
+        let err = fields_with_udf(&current_fields, &MockUdf(signature)).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        let err = err.to_string();
+
+        assert!(err.contains("Function 'test' requires String, but received Binary"));
+        assert!(
+            err.contains("Hint: Binary types are not automatically coerced to String.")
+        );
+    }
+
+    #[test]
+    fn test_one_of_combines_same_arity_type_mismatches() {
+        let current_fields = vec![Arc::new(Field::new("t", DataType::Utf8, true))];
+        let signature = Signature::one_of(
+            vec![
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Decimal,
+                )]),
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Float,
+                )]),
+            ],
+            Volatility::Immutable,
+        );
+
+        let err = fields_with_udf(&current_fields, &MockUdf(signature)).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        assert_eq!(
+            err.to_string(),
+            "Error during planning: Function 'test' requires one of Decimal, Float, but received String (DataType: Utf8)."
+        );
+    }
+
+    #[test]
+    fn test_one_of_propagates_non_plan_errors_when_no_plan_error_exists() {
+        let current_fields = vec![Arc::new(Field::new("t", DataType::Int32, true))];
+        let signature =
+            Signature::one_of(vec![TypeSignature::UserDefined], Volatility::Immutable);
+
+        let err =
+            fields_with_udf(&current_fields, &AlwaysExecErrUdf(signature)).unwrap_err();
+        assert!(matches!(err, DataFusionError::Execution(_)));
+        assert!(err.to_string().starts_with(
+            "Execution error: Function 'test' user-defined coercion failed with: Execution error: boom"
+        ));
+    }
+
+    #[test]
+    fn test_one_of_keeps_success_when_later_user_defined_branch_fails() -> Result<()> {
+        let current_fields = vec![Arc::new(Field::new("t", DataType::Int32, true))];
+        let signature = Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![DataType::Int32]),
+                TypeSignature::UserDefined,
+            ],
+            Volatility::Immutable,
+        );
+
+        let fields = fields_with_udf(&current_fields, &AlwaysExecErrUdf(signature))?;
+
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].data_type(), &DataType::Int32);
+        Ok(())
+    }
+
+    #[test]
+    fn test_one_of_allows_function_specific_diagnostic_override() {
+        let current_fields = vec![Arc::new(Field::new("t", DataType::Boolean, true))];
+        let signature = Signature::one_of(
+            vec![
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Decimal,
+                )]),
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Duration,
+                )]),
+            ],
+            Volatility::Immutable,
+        );
+
+        let err =
+            fields_with_udf(&current_fields, &DiagnoseErrUdf(signature)).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        assert_eq!(
+            err.to_string(),
+            "Error during planning: test semantic signature failure"
+        );
     }
 
     #[test]

--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -26,7 +26,9 @@ use std::vec;
 
 use arrow::datatypes::{DataType, Field, FieldRef};
 
-use datafusion_common::{Result, ScalarValue, Statistics, exec_err, not_impl_err};
+use datafusion_common::{
+    DataFusionError, Result, ScalarValue, Statistics, exec_err, not_impl_err,
+};
 use datafusion_expr_common::dyn_eq::{DynEq, DynHash};
 use datafusion_expr_common::operator::Operator;
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
@@ -270,6 +272,16 @@ impl AggregateUDF {
 
     pub fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         self.inner.coerce_types(arg_types)
+    }
+
+    /// Returns a function-specific signature failure for argument combinations
+    /// that are better described semantically than by generic signature
+    /// diagnostics.
+    pub fn diagnose_failed_signature(
+        &self,
+        arg_types: &[DataType],
+    ) -> Option<DataFusionError> {
+        self.inner.diagnose_failed_signature(arg_types)
     }
 
     /// See [`AggregateUDFImpl::with_beneficial_ordering`] for more details.
@@ -797,6 +809,16 @@ pub trait AggregateUDFImpl: Debug + DynEq + DynHash + Send + Sync + Any {
     /// arguments to these specific types.
     fn coerce_types(&self, _arg_types: &[DataType]) -> Result<Vec<DataType>> {
         not_impl_err!("Function {} does not implement coerce_types", self.name())
+    }
+
+    /// Returns a semantic signature failure for argument combinations that
+    /// should be surfaced directly instead of going through generic `OneOf`
+    /// diagnostics.
+    fn diagnose_failed_signature(
+        &self,
+        _arg_types: &[DataType],
+    ) -> Option<DataFusionError> {
+        None
     }
 
     /// If this function is max, return true
@@ -1337,6 +1359,13 @@ impl AggregateUDFImpl for AliasedAggregateUDFImpl {
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         self.inner.coerce_types(arg_types)
+    }
+
+    fn diagnose_failed_signature(
+        &self,
+        arg_types: &[DataType],
+    ) -> Option<DataFusionError> {
+        self.inner.diagnose_failed_signature(arg_types)
     }
 
     fn return_field(&self, arg_fields: &[FieldRef]) -> Result<FieldRef> {

--- a/datafusion/functions-aggregate/src/average.rs
+++ b/datafusion/functions-aggregate/src/average.rs
@@ -32,7 +32,9 @@ use arrow::datatypes::{
     DurationSecondType, Field, FieldRef, Float64Type, TimeUnit, UInt64Type, i256,
 };
 use datafusion_common::types::{NativeType, logical_float64};
-use datafusion_common::{Result, ScalarValue, exec_err, not_impl_err};
+use datafusion_common::{
+    DataFusionError, Result, ScalarValue, exec_err, not_impl_err, plan_datafusion_err,
+};
 use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
@@ -132,6 +134,18 @@ impl AggregateUDFImpl for Avg {
 
     fn signature(&self) -> &Signature {
         &self.signature
+    }
+
+    fn diagnose_failed_signature(
+        &self,
+        arg_types: &[DataType],
+    ) -> Option<DataFusionError> {
+        match arg_types {
+            [DataType::Boolean] => {
+                Some(plan_datafusion_err!("Avg not supported for Boolean"))
+            }
+            _ => None,
+        }
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {

--- a/datafusion/functions-aggregate/src/sum.rs
+++ b/datafusion/functions-aggregate/src/sum.rs
@@ -32,7 +32,10 @@ use datafusion_common::types::{
     NativeType, logical_float64, logical_int8, logical_int16, logical_int32,
     logical_int64, logical_uint8, logical_uint16, logical_uint32, logical_uint64,
 };
-use datafusion_common::{HashMap, Result, ScalarValue, exec_err, not_impl_err};
+use datafusion_common::{
+    DataFusionError, HashMap, Result, ScalarValue, exec_err, not_impl_err,
+    plan_datafusion_err,
+};
 use datafusion_expr::expr::AggregateFunction;
 use datafusion_expr::expr_fn::cast;
 use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
@@ -206,6 +209,18 @@ impl AggregateUDFImpl for Sum {
 
     fn signature(&self) -> &Signature {
         &self.signature
+    }
+
+    fn diagnose_failed_signature(
+        &self,
+        arg_types: &[DataType],
+    ) -> Option<DataFusionError> {
+        match arg_types {
+            [DataType::Boolean] => {
+                Some(plan_datafusion_err!("Sum not supported for Boolean"))
+            }
+            _ => None,
+        }
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {

--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -28,7 +28,7 @@ use datafusion_doc::window_doc_sections::DOC_SECTION_ANALYTICAL;
 use datafusion_expr::window_state::WindowAggState;
 use datafusion_expr::{
     Documentation, LimitEffect, Literal, PartitionEvaluator, ReversedUDWF, Signature,
-    TypeSignature, Volatility, WindowUDFImpl,
+    Volatility, WindowUDFImpl,
 };
 use datafusion_functions_window_common::field;
 use datafusion_functions_window_common::partition::PartitionEvaluatorArgs;
@@ -96,17 +96,14 @@ pub struct NthValue {
 impl NthValue {
     /// Create a new `nth_value` function
     pub fn new(kind: NthValueKind) -> Self {
-        Self {
-            signature: Signature::one_of(
-                vec![
-                    TypeSignature::Nullary,
-                    TypeSignature::Any(1),
-                    TypeSignature::Any(2),
-                ],
-                Volatility::Immutable,
-            ),
-            kind,
-        }
+        let signature = match kind {
+            NthValueKind::First | NthValueKind::Last => {
+                Signature::any(1, Volatility::Immutable)
+            }
+            NthValueKind::Nth => Signature::any(2, Volatility::Immutable),
+        };
+
+        Self { signature, kind }
     }
 
     pub fn first() -> Self {

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -8399,17 +8399,17 @@ select generate_series(arrow_cast('2021-01-01T00:00:00', 'Timestamp(Nanosecond, 
 [2021-01-01T00:00:00-05:00, 2021-01-01T01:29:54.500-05:00, 2021-01-01T02:59:49-05:00, 2021-01-01T04:29:43.500-05:00, 2021-01-01T05:59:38-05:00]
 
 ## mixing types for timestamps is not supported
-query error DataFusion error: Error during planning: Internal error: Function 'generate_series' failed to match any signature
+query error DataFusion error: Error during planning: Function 'generate_series' failed to match any signature
 select generate_series(arrow_cast('2021-01-01T00:00:00', 'Timestamp(Nanosecond, Some("-05:00"))'), DATE '2021-01-02', INTERVAL '1' HOUR);
 
 ## mixing types not allowed even if an argument is null
-query error DataFusion error: Error during planning: Internal error: Function 'generate_series' failed to match any signature
+query error DataFusion error: Error during planning: Function 'generate_series' failed to match any signature
 select generate_series(TIMESTAMP '1992-09-01', DATE '1993-03-01', NULL);
 
-query error DataFusion error: Error during planning: Internal error: Function 'generate_series' failed to match any signature
+query error DataFusion error: Error during planning: Function 'generate_series' failed to match any signature
 select generate_series(1, '2024-01-01', '2025-01-02');
 
-query error DataFusion error: Error during planning: Internal error: Function 'generate_series' failed to match any signature
+query error DataFusion error: Error during planning: Function 'generate_series' failed to match any signature
 select generate_series('2024-01-01'::timestamp, '2025-01-02', interval '1 day');
 
 ## should return NULL

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -125,12 +125,38 @@ from aggregate_test_100
 order by c9
 
 # WindowFunction wrong signature
-statement error DataFusion error: Error during planning: Internal error: Function 'nth_value' failed to match any signature
+statement error DataFusion error: Error during planning: The function 'nth_value' expected 2 arguments but received 3
 select
 c9,
 nth_value(c5, 2, 3) over (order by c9) as nv1
 from aggregate_test_100
 order by c9
+
+statement error DataFusion error: Error during planning: The function 'nth_value' expected 2 arguments but received 1
+select
+c9,
+nth_value(c5) over (order by c9) as nv2
+from aggregate_test_100
+order by c9
+
+statement error DataFusion error: Error during planning: The function 'first_value' expected 1 arguments but received 2
+select
+c9,
+first_value(c5, 2) over (order by c9) as fv1
+from aggregate_test_100
+order by c9
+
+statement error DataFusion error: Error during planning: 'nth_value' does not support zero arguments
+select nth_value() over (order by x) from (values (1), (2)) as t(x)
+
+statement error DataFusion error: Error during planning: 'first_value' does not support zero arguments
+select first_value() over (order by x) from (values (1), (2)) as t(x)
+
+query error DataFusion error: Error during planning: Sum not supported for Boolean
+select sum(bool_col) from (values (true), (false), (null)) as t(bool_col);
+
+query error DataFusion error: Error during planning: Avg not supported for Boolean
+select avg(bool_col) from (values (true), (false), (null)) as t(bool_col);
 
 
 # nth_value with wrong name

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -208,10 +208,10 @@ SELECT substr('alphabet', NULL, 2)
 ----
 NULL
 
-statement error Function 'substr' failed to match any signature
+statement error DataFusion error: Error during planning: Function 'substr' requires String, but received Int64
 SELECT substr(1, 3)
 
-statement error Function 'substr' failed to match any signature
+statement error DataFusion error: Error during planning: Function 'substr' requires String, but received Int64
 SELECT substr(1, 3, 4)
 
 query T

--- a/datafusion/sqllogictest/test_files/named_arguments.slt
+++ b/datafusion/sqllogictest/test_files/named_arguments.slt
@@ -86,7 +86,7 @@ SELECT substr("STR" => 'hello world', "start_pos" => 7);
 
 # Error: wrong number of arguments
 # This query provides only 1 argument but substr requires 2 or 3
-query error Function 'substr' failed to match any signature
+query error DataFusion error: Error during planning: Function 'substr' expects 2 to 3 arguments but received 1
 SELECT substr(str => 'hello world');
 
 #############

--- a/datafusion/sqllogictest/test_files/spark/math/hex.slt
+++ b/datafusion/sqllogictest/test_files/spark/math/hex.slt
@@ -56,7 +56,7 @@ SELECT hex(column1) FROM VALUES (arrow_cast('hello', 'LargeBinary')), (NULL), (a
 NULL
 776F726C64
 
-statement error Function 'hex' expects 1 arguments but received 2
+statement error DataFusion error: Error during planning: Function 'hex' expects 1 arguments but received 2
 SELECT hex(1, 2);
 
 query T

--- a/datafusion/sqllogictest/test_files/string/string_literal.slt
+++ b/datafusion/sqllogictest/test_files/string/string_literal.slt
@@ -132,10 +132,10 @@ SELECT substr('Hello🌏世界', 5, 3)
 ----
 o🌏世
 
-statement error Function 'substr' failed to match any signature
+statement error DataFusion error: Error during planning: Function 'substr' requires String, but received Int64
 SELECT substr(1, 3)
 
-statement error Function 'substr' failed to match any signature
+statement error DataFusion error: Error during planning: Function 'substr' requires String, but received Int64
 SELECT substr(1, 3, 4)
 
 statement error Execution error: negative count not allowed


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20501.

## Rationale for this change

After [#18769](https://github.com/apache/datafusion/pull/18769), unsupported calls such as `SUM(Boolean)` started producing misleading internal errors.

The immediate problem is that `TypeSignature::OneOf` aggregates branch failures into an `Internal error`, which then becomes visible during planning together with internal `TypeSignatureClass::...` details.

This PR fixes that path in the shared coercion logic, while preserving more actionable diagnostics where they can be determined reliably.

This PR is still narrower than [#20070](https://github.com/apache/datafusion/pull/20070): it focuses on `TypeSignature::OneOf` error selection and the affected public function contracts, rather than changing the broader error-formatting flow.

## What changes are included in this PR?

In `datafusion/expr/src/type_coercion/functions.rs`:

- keep the existing success path when any `OneOf` branch matches
- stop turning all-failed `OneOf` resolution into an `Internal error`
- restore concrete `arity` errors instead of falling back to a generic mismatch
- preserve concrete type errors for unique matching branches
- preserve hinted errors such as the `Binary -> String` cast hint
- combine same-arity `Coercible` mismatches into a concrete type error instead of falling back to a generic one
- continue to propagate non-`Plan` errors only when no matching branch succeeds and no better planner diagnostic is available

For aggregate functions that need semantic diagnostics beyond what the generic `OneOf` logic can express:

- restore function-specific diagnostics for `sum(Boolean)` and `avg(Boolean)`

For shared window-function implementations:

- narrow the public `signature()` of `first_value`, `last_value`, and `nth_value` so validation, candidate signatures, and introspection all reflect the real public arity contract

## Are these changes tested?

Yes.

Added or updated unit tests covering:

- `OneOf` mismatches no longer returning `Internal error`
- `OneOf` arity mismatches restoring concrete planning errors
- unique matching branches preserving concrete type errors
- same-arity `Coercible` mismatches combining into a concrete type error
- hinted mismatches preserving the hint
- function-specific semantic diagnostics for `sum(Boolean)` / `avg(Boolean)`

Updated sqllogictests for affected user-visible errors, including:

- `sum(Boolean)`
- `avg(Boolean)`
- `nth_value(...)`
- `first_value(...)`
- `last_value(...)`
- `substr(...)`
- `hex(...)`
- `generate_series(...)`

## Are there any user-facing changes?

Yes.

For failed `TypeSignature::OneOf` function calls, DataFusion now returns normal planning errors instead of an `Internal error`, while preserving more specific diagnostics where possible, including:

- concrete arity errors
- concrete type mismatch errors
- cast hints
- restored semantic errors such as `Sum not supported for Boolean`

For `first_value`, `last_value`, and `nth_value`, the advertised candidate signatures now match the real public arity contract.
