### PR TITLE
fix: use datafusion_expr instead of datafusion crate in spark 

### DIFF
--- a/datafusion/spark/src/function/bitmap/bitmap_bit_position.rs
+++ b/datafusion/spark/src/function/bitmap/bitmap_bit_position.rs
@@ -18,10 +18,12 @@
 use arrow::array::{ArrayRef, AsArray, Int64Array};
 use arrow::datatypes::Field;
 use arrow::datatypes::{DataType, FieldRef, Int8Type, Int16Type, Int32Type, Int64Type};
-use datafusion::logical_expr::{ColumnarValue, Signature, TypeSignature, Volatility};
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{Result, internal_err};
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl};
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
+    Volatility,
+};
 use datafusion_functions::utils::make_scalar_function;
 use std::any::Any;
 use std::sync::Arc;

--- a/datafusion/spark/src/function/bitmap/bitmap_bucket_number.rs
+++ b/datafusion/spark/src/function/bitmap/bitmap_bucket_number.rs
@@ -18,10 +18,12 @@
 use arrow::array::{ArrayRef, AsArray, Int64Array};
 use arrow::datatypes::Field;
 use arrow::datatypes::{DataType, FieldRef, Int8Type, Int16Type, Int32Type, Int64Type};
-use datafusion::logical_expr::{ColumnarValue, Signature, TypeSignature, Volatility};
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{Result, internal_err};
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl};
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
+    Volatility,
+};
 use datafusion_functions::utils::make_scalar_function;
 use std::any::Any;
 use std::sync::Arc;

--- a/datafusion/spark/src/function/math/bin.rs
+++ b/datafusion/spark/src/function/math/bin.rs
@@ -17,11 +17,13 @@
 
 use arrow::array::{ArrayRef, AsArray, StringArray};
 use arrow::datatypes::{DataType, Field, FieldRef, Int64Type};
-use datafusion::logical_expr::{ColumnarValue, Signature, TypeSignature, Volatility};
 use datafusion_common::types::{NativeType, logical_int64};
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{Result, internal_err};
-use datafusion_expr::{Coercion, ScalarFunctionArgs, ScalarUDFImpl, TypeSignatureClass};
+use datafusion_expr::{
+    Coercion, ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
+    TypeSignatureClass, Volatility,
+};
 use datafusion_functions::utils::make_scalar_function;
 use std::any::Any;
 use std::sync::Arc;


### PR DESCRIPTION
## Which issue does this PR close?

NA

## Rationale for this change

Three files in `datafusion-spark` import from `datafusion::logical_expr` instead of `datafusion_expr` directly. This compiles fine in the full workspace but fails when building the crate in isolation (`cargo clippy -p datafusion-spark `).


## What changes are included in this PR?

Replaced `use datafusion::logical_expr::{...}` with `use datafusion_expr::{...}` in:
- `datafusion/spark/src/function/bitmap/bitmap_bit_position.rs`
- `datafusion/spark/src/function/bitmap/bitmap_bucket_number.rs`
- `datafusion/spark/src/function/math/bin.rs`

No logic changes — imports only.

## Are these changes tested?

NA

## Are there any user-facing changes?

NA
