### PR TITLE
fix: update clickbench expected plan for NDV-aware optimization

### DIFF
--- a/datafusion/sqllogictest/test_files/clickbench.slt
+++ b/datafusion/sqllogictest/test_files/clickbench.slt
@@ -1203,8 +1203,8 @@ logical_plan
 02)--SubqueryAlias: hits
 03)----TableScan: hits_raw projection=[HitColor, BrowserLanguage, BrowserCountry]
 physical_plan
-01)AggregateExec: mode=Single, gby=[], aggr=[count(DISTINCT hits.HitColor), count(DISTINCT hits.BrowserCountry), count(DISTINCT hits.BrowserLanguage)]
-02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/clickbench_hits_10.parquet]]}, projection=[HitColor, BrowserLanguage, BrowserCountry], file_type=parquet
+01)ProjectionExec: expr=[1 as count(DISTINCT hits.HitColor), 1 as count(DISTINCT hits.BrowserCountry), 1 as count(DISTINCT hits.BrowserLanguage)]
+02)--PlaceholderRowExec
 
 query III
 SELECT COUNT(DISTINCT "HitColor"), COUNT(DISTINCT "BrowserCountry"), COUNT(DISTINCT "BrowserLanguage")  FROM hits;


### PR DESCRIPTION
## Which issue does this PR close?

Fixes CI breakage on `main` introduced by #19957.

## Rationale for this change

#19957 introduced NDV extraction from Parquet metadata. The optimizer now sees NDV=1 for `HitColor`, `BrowserCountry`, `BrowserLanguage` in the clickbench test file and short-circuits `COUNT(DISTINCT)` to a constant projection, skipping the full table scan.

## What changes are included in this PR?

Updates the expected EXPLAIN plan in `clickbench.slt` to match the new (better) physical plan:

```diff
-   01)AggregateExec: mode=Single, gby=[], aggr=[count(DISTINCT hits.HitColor), ...]
-   02)--DataSourceExec: file_groups={1 group: [...]}, projection=[HitColor, BrowserLanguage, BrowserCountry], file_type=parquet
+   01)ProjectionExec: expr=[1 as count(DISTINCT hits.HitColor), 1 as count(DISTINCT hits.BrowserCountry), 1 as count(DISTINCT hits.BrowserLanguage)]
+   02)--PlaceholderRowExec
```

## Are these changes tested?

This PR *is* the test fix. Verified locally with `cargo test --profile ci -p datafusion-sqllogictest --test sqllogictests`.

## Are there any user-facing changes?

No.