### PR TITLE
chore: Remove duplicate imports in test code

### DIFF
--- a/datafusion/catalog-listing/src/helpers.rs
+++ b/datafusion/catalog-listing/src/helpers.rs
@@ -462,7 +462,7 @@ mod tests {
     use std::ops::Not;
 
     use super::*;
-    use datafusion_expr::{Expr, case, col, lit};
+    use datafusion_expr::{case, col};
 
     #[test]
     fn test_split_files() {

--- a/datafusion/catalog-listing/src/table.rs
+++ b/datafusion/catalog-listing/src/table.rs
@@ -920,7 +920,6 @@ mod tests {
     use arrow::compute::SortOptions;
     use datafusion_physical_expr::expressions::Column;
     use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
-    use std::sync::Arc;
 
     /// Helper to create a PhysicalSortExpr
     fn sort_expr(

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -5336,7 +5336,6 @@ impl ScalarType<i32> for Date32Type {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::cast::{as_list_array, as_map_array, as_struct_array};
@@ -5354,7 +5353,6 @@ mod tests {
     };
     use arrow::error::ArrowError;
     use arrow::util::pretty::pretty_format_columns;
-    use chrono::NaiveDate;
     use insta::assert_snapshot;
     use rand::Rng;
 

--- a/datafusion/common/src/types/logical.rs
+++ b/datafusion/common/src/types/logical.rs
@@ -143,7 +143,7 @@ mod tests {
         LogicalField, LogicalFields, logical_boolean, logical_date, logical_float32,
         logical_float64, logical_int32, logical_int64, logical_null, logical_string,
     };
-    use arrow::datatypes::{DataType, Field, Fields};
+    use arrow::datatypes::{Field, Fields};
     use insta::assert_snapshot;
 
     #[test]

--- a/datafusion/common/src/types/native.rs
+++ b/datafusion/common/src/types/native.rs
@@ -565,7 +565,6 @@ impl NativeType {
 mod tests {
     use super::*;
     use crate::types::LogicalField;
-    use arrow::datatypes::Field;
     use insta::assert_snapshot;
 
     #[test]

--- a/datafusion/core/src/dataframe/parquet.rs
+++ b/datafusion/core/src/dataframe/parquet.rs
@@ -107,7 +107,6 @@ impl DataFrame {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
 
     use super::super::Result;
     use super::*;

--- a/datafusion/core/src/datasource/listing_table_factory.rs
+++ b/datafusion/core/src/datasource/listing_table_factory.rs
@@ -557,9 +557,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_with_invalid_session() {
-        use async_trait::async_trait;
-        use datafusion_catalog::Session;
-        use datafusion_common::Result;
         use datafusion_common::config::TableOptions;
         use datafusion_execution::TaskContext;
         use datafusion_execution::config::SessionConfig;
@@ -567,7 +564,6 @@ mod tests {
         use datafusion_physical_plan::ExecutionPlan;
         use std::any::Any;
         use std::collections::HashMap;
-        use std::sync::Arc;
 
         // A mock Session that is NOT SessionState
         #[derive(Debug)]

--- a/datafusion/datasource-arrow/src/file_format.rs
+++ b/datafusion/datasource-arrow/src/file_format.rs
@@ -557,7 +557,7 @@ mod tests {
     use datafusion_expr::execution_props::ExecutionProps;
     use datafusion_expr::{AggregateUDF, Expr, LogicalPlan, ScalarUDF, WindowUDF};
     use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
-    use object_store::{chunked::ChunkedStore, memory::InMemory, path::Path};
+    use object_store::{chunked::ChunkedStore, memory::InMemory};
 
     struct MockSession {
         config: SessionConfig,

--- a/datafusion/datasource-json/src/source.rs
+++ b/datafusion/datasource-json/src/source.rs
@@ -523,7 +523,6 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use bytes::Bytes;
     use datafusion_datasource::FileRange;
-    use futures::TryStreamExt;
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::{ObjectStoreExt, PutPayload};

--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -1808,11 +1808,9 @@ async fn output_single_parquet_file_parallelized(
 #[cfg(test)]
 mod tests {
     use parquet::arrow::parquet_to_arrow_schema;
-    use std::sync::Arc;
 
     use super::*;
 
-    use arrow::datatypes::DataType;
     use parquet::schema::parser::parse_message_type;
 
     #[test]

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -793,9 +793,7 @@ fn sorting_columns_to_physical_exprs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{ArrayRef, BooleanArray, Int32Array};
-    use datafusion_common::ScalarValue;
-    use std::sync::Arc;
+    use arrow::array::Int32Array;
 
     #[test]
     fn test_has_any_exact_match() {
@@ -847,12 +845,11 @@ mod tests {
     mod ndv_tests {
         use super::*;
         use arrow::datatypes::Field;
-        use parquet::arrow::parquet_to_arrow_schema;
         use parquet::basic::Type as PhysicalType;
-        use parquet::file::metadata::{ColumnChunkMetaData, RowGroupMetaData};
+        use parquet::file::metadata::ColumnChunkMetaData;
         use parquet::file::reader::{FileReader, SerializedFileReader};
         use parquet::file::statistics::Statistics as ParquetStatistics;
-        use parquet::schema::types::{SchemaDescriptor, Type as SchemaType};
+        use parquet::schema::types::Type as SchemaType;
         use std::fs::File;
         use std::path::PathBuf;
 

--- a/datafusion/datasource-parquet/src/row_group_filter.rs
+++ b/datafusion/datasource-parquet/src/row_group_filter.rs
@@ -651,14 +651,12 @@ impl PruningStatistics for RowGroupPruningStatistics<'_> {
 #[cfg(test)]
 mod tests {
     use std::ops::Rem;
-    use std::sync::Arc;
 
     use super::*;
     use crate::reader::ParquetFileReader;
 
     use arrow::datatypes::DataType::Decimal128;
     use arrow::datatypes::{DataType, Field};
-    use datafusion_common::Result;
     use datafusion_expr::{Expr, cast, col, lit};
     use datafusion_physical_expr::planner::logical2physical;
     use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;

--- a/datafusion/datasource-parquet/src/source.rs
+++ b/datafusion/datasource-parquet/src/source.rs
@@ -895,7 +895,6 @@ mod tests {
     #[test]
     fn test_reverse_scan_with_other_options() {
         use arrow::datatypes::Schema;
-        use datafusion_common::config::TableParquetOptions;
 
         let schema = Arc::new(Schema::empty());
         let options = TableParquetOptions::default();

--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -1540,13 +1540,12 @@ mod tests {
     };
 
     use arrow::datatypes::Field;
+    use datafusion_common::ColumnStatistics;
     use datafusion_common::stats::Precision;
-    use datafusion_common::{ColumnStatistics, internal_err};
-    use datafusion_expr::{Operator, SortExpr};
+    use datafusion_expr::SortExpr;
     use datafusion_physical_expr::create_physical_sort_expr;
-    use datafusion_physical_expr::expressions::{BinaryExpr, Column, Literal};
+    use datafusion_physical_expr::expressions::Literal;
     use datafusion_physical_expr::projection::ProjectionExpr;
-    use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
 
     #[derive(Clone)]
     struct InexactSortPushdownSource {

--- a/datafusion/datasource/src/memory.rs
+++ b/datafusion/datasource/src/memory.rs
@@ -870,7 +870,6 @@ mod tests {
     use datafusion_physical_plan::expressions::lit;
 
     use datafusion_physical_plan::ExecutionPlan;
-    use futures::StreamExt;
 
     #[tokio::test]
     async fn exec_with_limit() -> Result<()> {

--- a/datafusion/datasource/src/url.rs
+++ b/datafusion/datasource/src/url.rs
@@ -527,7 +527,6 @@ mod tests {
     use std::any::Any;
     use std::collections::HashMap;
     use std::ops::Range;
-    use std::sync::Arc;
     use tempfile::tempdir;
 
     #[test]

--- a/datafusion/execution/src/cache/cache_manager.rs
+++ b/datafusion/execution/src/cache/cache_manager.rs
@@ -507,15 +507,12 @@ impl CacheManagerConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::DefaultListFilesCache;
 
     /// Test to verify that TTL is preserved when not explicitly set in config.
     /// This fixes issue #19396 where TTL was being unset from DefaultListFilesCache
     /// when CacheManagerConfig::list_files_cache_ttl was not set explicitly.
     #[test]
     fn test_ttl_preserved_when_not_set_in_config() {
-        use std::time::Duration;
-
         // Create a cache with TTL = 1 second
         let list_file_cache =
             DefaultListFilesCache::new(1024, Some(Duration::from_secs(1)));
@@ -553,8 +550,6 @@ mod tests {
     /// Test to verify that TTL can still be overridden when explicitly set in config.
     #[test]
     fn test_ttl_overridden_when_set_in_config() {
-        use std::time::Duration;
-
         // Create a cache with TTL = 1 second
         let list_file_cache =
             DefaultListFilesCache::new(1024, Some(Duration::from_secs(1)));

--- a/datafusion/execution/src/cache/cache_unit.rs
+++ b/datafusion/execution/src/cache/cache_unit.rs
@@ -101,7 +101,6 @@ impl FileStatisticsCache for DefaultFileStatisticsCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::CacheAccessor;
     use crate::cache::cache_manager::{
         CachedFileMetadata, FileStatisticsCache, FileStatisticsCacheEntry,
     };
@@ -114,7 +113,6 @@ mod tests {
     use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
     use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
     use object_store::ObjectMeta;
-    use object_store::path::Path;
     use std::sync::Arc;
 
     fn create_test_meta(path: &str, size: u64) -> ObjectMeta {

--- a/datafusion/expr-common/src/casts.rs
+++ b/datafusion/expr-common/src/casts.rs
@@ -382,7 +382,7 @@ fn try_cast_binary(
 mod tests {
     use super::*;
     use arrow::compute::{CastOptions, cast_with_options};
-    use arrow::datatypes::{Field, Fields, TimeUnit};
+    use arrow::datatypes::{Field, Fields};
     use std::sync::Arc;
 
     #[derive(Debug, Clone)]

--- a/datafusion/expr/src/expr_rewriter/guarantees.rs
+++ b/datafusion/expr/src/expr_rewriter/guarantees.rs
@@ -303,7 +303,6 @@ mod tests {
     use super::*;
 
     use crate::{Operator, col};
-    use datafusion_common::ScalarValue;
     use datafusion_common::tree_node::TransformedResult;
 
     #[test]

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -721,8 +721,7 @@ mod tests {
     use super::*;
     use crate::{and, col, lit, not, or, out_ref_col_with_metadata, when};
 
-    use arrow::datatypes::FieldRef;
-    use datafusion_common::{DFSchema, ScalarValue, assert_or_internal_err};
+    use datafusion_common::{DFSchema, assert_or_internal_err};
 
     macro_rules! test_is_expr_nullable {
         ($EXPR_TYPE:ident) => {{

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -2259,7 +2259,7 @@ mod tests {
     use super::*;
     use crate::lit_with_metadata;
     use crate::logical_plan::StringifiedPlan;
-    use crate::{col, expr, expr_fn::exists, in_subquery, lit, scalar_subquery};
+    use crate::{col, expr, expr_fn::exists, in_subquery, scalar_subquery};
 
     use crate::test::function_stub::sum;
     use datafusion_common::{

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -4343,7 +4343,7 @@ mod tests {
     use datafusion_common::tree_node::{
         TransformedResult, TreeNodeRewriter, TreeNodeVisitor,
     };
-    use datafusion_common::{Constraint, ScalarValue, not_impl_err};
+    use datafusion_common::{Constraint, not_impl_err};
     use insta::{assert_debug_snapshot, assert_snapshot};
     use std::hash::DefaultHasher;
 

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -944,7 +944,7 @@ mod tests {
     use crate::Volatility;
 
     use super::*;
-    use arrow::datatypes::{Field, IntervalUnit};
+    use arrow::datatypes::IntervalUnit;
     use datafusion_common::{
         assert_contains,
         types::{logical_binary, logical_int64},

--- a/datafusion/expr/src/udf_eq.rs
+++ b/datafusion/expr/src/udf_eq.rs
@@ -125,7 +125,6 @@ mod tests {
     use datafusion_expr_common::columnar_value::ColumnarValue;
     use datafusion_expr_common::signature::{Signature, Volatility};
     use std::any::Any;
-    use std::hash::DefaultHasher;
 
     #[derive(Debug, PartialEq, Eq, Hash)]
     struct TestScalarUDF {

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -1314,7 +1314,7 @@ mod tests {
         test::function_stub::{max_udaf, min_udaf, sum_udaf},
     };
     use arrow::datatypes::{UnionFields, UnionMode};
-    use datafusion_expr_common::signature::{TypeSignature, Volatility};
+    use datafusion_expr_common::signature::Volatility;
 
     #[test]
     fn test_group_window_expr_by_sort_keys_empty_case() -> Result<()> {

--- a/datafusion/ffi/src/session/mod.rs
+++ b/datafusion/ffi/src/session/mod.rs
@@ -630,11 +630,9 @@ impl Session for ForeignSession {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::execution::SessionStateBuilder;
-    use datafusion_common::DataFusionError;
     use datafusion_expr::col;
     use datafusion_expr::registry::FunctionRegistry;
     use datafusion_proto::logical_plan::DefaultLogicalExtensionCodec;

--- a/datafusion/functions-aggregate-common/src/merge_arrays.rs
+++ b/datafusion/functions-aggregate-common/src/merge_arrays.rs
@@ -209,13 +209,12 @@ pub fn merge_ordered_arrays(
 mod tests {
     use super::*;
 
-    use std::collections::VecDeque;
     use std::sync::Arc;
 
     use arrow::array::{ArrayRef, Int64Array};
 
+    use datafusion_common::Result;
     use datafusion_common::utils::get_row_at_idx;
-    use datafusion_common::{Result, ScalarValue};
 
     #[test]
     fn test_merge_asc() -> Result<()> {

--- a/datafusion/functions-aggregate/src/array_agg.rs
+++ b/datafusion/functions-aggregate/src/array_agg.rs
@@ -1146,13 +1146,11 @@ impl Accumulator for OrderSensitiveArrayAggAccumulator {
 mod tests {
     use super::*;
     use arrow::array::{ListBuilder, StringBuilder};
-    use arrow::datatypes::{FieldRef, Schema};
+    use arrow::datatypes::Schema;
     use datafusion_common::cast::as_generic_string_array;
     use datafusion_common::internal_err;
     use datafusion_physical_expr::PhysicalExpr;
     use datafusion_physical_expr::expressions::Column;
-    use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
-    use std::sync::Arc;
 
     #[test]
     fn no_duplicates_no_distinct() -> Result<()> {

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -555,7 +555,6 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Float64Array, UInt64Array};
 
     #[test]
     fn test_accumulate_correlation_states() {

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -1154,7 +1154,6 @@ mod tests {
         check(&mut max(), &[&[zero, neg_inf]], zero);
     }
 
-    use datafusion_common::Result;
     use rand::Rng;
 
     fn get_random_vec_i32(len: usize) -> Vec<i32> {

--- a/datafusion/functions-aggregate/src/stddev.rs
+++ b/datafusion/functions-aggregate/src/stddev.rs
@@ -369,7 +369,6 @@ mod tests {
     use datafusion_expr::AggregateUDF;
     use datafusion_functions_aggregate_common::utils::get_accum_scalar_values_as_arrays;
     use datafusion_physical_expr::expressions::col;
-    use std::sync::Arc;
 
     #[test]
     fn stddev_f64_merge_1() -> Result<()> {

--- a/datafusion/functions-aggregate/src/string_agg.rs
+++ b/datafusion/functions-aggregate/src/string_agg.rs
@@ -419,7 +419,6 @@ mod tests {
     use arrow::array::LargeStringArray;
     use arrow::compute::SortOptions;
     use arrow::datatypes::{Fields, Schema};
-    use datafusion_common::internal_err;
     use datafusion_physical_expr::expressions::Column;
     use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
     use std::sync::Arc;

--- a/datafusion/functions-window/src/lead_lag.rs
+++ b/datafusion/functions-window/src/lead_lag.rs
@@ -680,7 +680,6 @@ mod tests {
     use arrow::array::*;
     use datafusion_common::cast::as_int32_array;
     use datafusion_physical_expr::expressions::{Column, Literal};
-    use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 
     fn test_i32_result(
         expr: WindowShift,

--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -546,8 +546,6 @@ mod tests {
     use arrow::array::*;
     use datafusion_common::cast::as_int32_array;
     use datafusion_physical_expr::expressions::{Column, Literal};
-    use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
-    use std::sync::Arc;
 
     fn test_i32_result(
         expr: NthValue,

--- a/datafusion/functions-window/src/row_number.rs
+++ b/datafusion/functions-window/src/row_number.rs
@@ -168,7 +168,6 @@ impl PartitionEvaluator for NumRowsEvaluator {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use datafusion_common::arrow::array::{Array, BooleanArray};
     use datafusion_common::cast::as_uint64_array;

--- a/datafusion/functions/src/datetime/current_time.rs
+++ b/datafusion/functions/src/datetime/current_time.rs
@@ -139,9 +139,8 @@ fn datetime_to_time_nanos<Tz: TimeZone>(dt: &chrono::DateTime<Tz>) -> Option<i64
 mod tests {
     use super::*;
     use chrono::{DateTime, Utc};
+    use datafusion_common::DFSchema;
     use datafusion_common::config::ConfigOptions;
-    use datafusion_common::{DFSchema, ScalarValue};
-    use datafusion_expr::simplify::{ExprSimplifyResult, SimplifyContext};
     use std::sync::Arc;
 
     fn set_session_timezone_env(tz: &str, start_time: DateTime<Utc>) -> SimplifyContext {

--- a/datafusion/functions/src/datetime/to_timestamp.rs
+++ b/datafusion/functions/src/datetime/to_timestamp.rs
@@ -828,7 +828,6 @@ fn to_timestamp_impl<T: ArrowTimestampType + ScalarType<i64>>(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use arrow::array::types::Int64Type;
     use arrow::array::{
@@ -838,9 +837,8 @@ mod tests {
     use arrow::array::{ArrayRef, Int64Array, StringBuilder};
     use arrow::datatypes::{Field, TimeUnit};
     use chrono::{DateTime, FixedOffset, Utc};
-    use datafusion_common::config::ConfigOptions;
-    use datafusion_common::{DataFusionError, ScalarValue, assert_contains};
-    use datafusion_expr::{ScalarFunctionArgs, ScalarFunctionImplementation};
+    use datafusion_common::{DataFusionError, assert_contains};
+    use datafusion_expr::ScalarFunctionImplementation;
 
     use super::*;
 

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -418,7 +418,6 @@ mod tests {
     use arrow::datatypes::{DECIMAL256_MAX_PRECISION, Field};
     use datafusion_common::cast::{as_float32_array, as_float64_array};
     use datafusion_common::config::ConfigOptions;
-    use datafusion_expr::simplify::SimplifyContext;
 
     #[test]
     fn test_log_decimal_native() {

--- a/datafusion/functions/src/math/monotonicity.rs
+++ b/datafusion/functions/src/math/monotonicity.rs
@@ -737,7 +737,6 @@ pub fn get_tanh_doc() -> &'static Documentation {
 #[cfg(test)]
 mod tests {
     use arrow::compute::SortOptions;
-    use datafusion_common::Result;
 
     use super::*;
 

--- a/datafusion/functions/src/regex/regexpinstr.rs
+++ b/datafusion/functions/src/regex/regexpinstr.rs
@@ -446,7 +446,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::Int64Array;
     use arrow::array::{GenericStringArray, StringViewArray};
     use arrow::datatypes::Field;
     use datafusion_common::config::ConfigOptions;

--- a/datafusion/functions/src/string/chr.rs
+++ b/datafusion/functions/src/string/chr.rs
@@ -149,11 +149,10 @@ impl ScalarUDFImpl for ChrFunc {
 mod tests {
     use super::*;
 
-    use arrow::array::{Array, Int64Array, StringArray};
+    use arrow::array::{Array, StringArray};
     use arrow::datatypes::Field;
     use datafusion_common::assert_contains;
     use datafusion_common::config::ConfigOptions;
-    use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl};
 
     fn invoke_chr(arg: ColumnarValue, number_rows: usize) -> Result<ColumnarValue> {
         ChrFunc::new().invoke_with_args(ScalarFunctionArgs {

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -376,8 +376,8 @@ mod tests {
     use super::*;
     use crate::utils::test::test_function;
     use DataType::*;
-    use arrow::array::{Array, LargeStringArray, StringViewArray};
     use arrow::array::{ArrayRef, StringArray};
+    use arrow::array::{LargeStringArray, StringViewArray};
     use arrow::datatypes::Field;
     use datafusion_common::config::ConfigOptions;
 

--- a/datafusion/functions/src/string/starts_with.rs
+++ b/datafusion/functions/src/string/starts_with.rs
@@ -228,11 +228,8 @@ mod tests {
     use crate::utils::test::test_function;
     use arrow::array::{Array, BooleanArray, StringArray};
     use arrow::datatypes::DataType::Boolean;
-    use arrow::datatypes::{DataType, Field};
+    use arrow::datatypes::Field;
     use datafusion_common::config::ConfigOptions;
-    use datafusion_common::{Result, ScalarValue};
-    use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl};
-    use std::sync::Arc;
 
     use super::*;
 

--- a/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
+++ b/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
@@ -538,7 +538,7 @@ mod tests {
     use crate::assert_optimized_plan_eq_display_indent_snapshot;
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_expr::builder::table_source;
-    use datafusion_expr::{and, binary_expr, col, lit, not, out_ref_col, table_scan};
+    use datafusion_expr::{and, binary_expr, col, out_ref_col, table_scan};
 
     macro_rules! assert_optimized_plan_equal {
         (

--- a/datafusion/optimizer/src/eliminate_group_by_constant.rs
+++ b/datafusion/optimizer/src/eliminate_group_by_constant.rs
@@ -152,7 +152,6 @@ mod tests {
     use crate::test::*;
 
     use arrow::datatypes::DataType;
-    use datafusion_common::Result;
     use datafusion_expr::expr::ScalarFunction;
     use datafusion_expr::{
         ColumnarValue, LogicalPlanBuilder, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl,

--- a/datafusion/optimizer/src/eliminate_limit.rs
+++ b/datafusion/optimizer/src/eliminate_limit.rs
@@ -97,7 +97,6 @@ mod tests {
         col,
         logical_plan::{JoinType, builder::LogicalPlanBuilder},
     };
-    use std::sync::Arc;
 
     use crate::assert_optimized_plan_eq_snapshot;
     use crate::push_down_limit::PushDownLimit;

--- a/datafusion/optimizer/src/extract_leaf_expressions.rs
+++ b/datafusion/optimizer/src/extract_leaf_expressions.rs
@@ -1246,16 +1246,13 @@ fn try_push_into_inputs(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::optimize_projections::OptimizeProjections;
     use crate::test::udfs::PlacementTestUDF;
     use crate::test::*;
     use crate::{Optimizer, OptimizerContext};
-    use datafusion_common::Result;
     use datafusion_expr::expr::ScalarFunction;
-    use datafusion_expr::{Expr, ExpressionPlacement};
     use datafusion_expr::{
         ScalarUDF, col, lit, logical_plan::builder::LogicalPlanBuilder,
     };

--- a/datafusion/optimizer/src/propagate_empty_relation.rs
+++ b/datafusion/optimizer/src/propagate_empty_relation.rs
@@ -232,11 +232,10 @@ fn empty_child(plan: &LogicalPlan) -> Result<Option<LogicalPlan>> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use arrow::datatypes::{DataType, Field, Schema};
 
-    use datafusion_common::{Column, DFSchema, JoinType};
+    use datafusion_common::{Column, DFSchema};
     use datafusion_expr::logical_plan::table_scan;
     use datafusion_expr::{
         Operator, binary_expr, col, lit, logical_plan::builder::LogicalPlanBuilder,

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1458,11 +1458,11 @@ mod tests {
     use std::cmp::Ordering;
     use std::fmt::{Debug, Formatter};
 
-    use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+    use arrow::datatypes::{Field, Schema, SchemaRef};
     use async_trait::async_trait;
 
     use datafusion_common::{DFSchemaRef, DataFusionError, ScalarValue};
-    use datafusion_expr::expr::{ScalarFunction, WindowFunction};
+    use datafusion_expr::expr::ScalarFunction;
     use datafusion_expr::logical_plan::table_scan;
     use datafusion_expr::{
         ColumnarValue, ExprFunctionExt, Extension, LogicalPlanBuilder,

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -2349,7 +2349,6 @@ fn simplify_right_is_one_case(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::simplify_expressions::SimplifyContext;
     use crate::test::test_table_scan_with_name;
     use arrow::{
         array::{Int32Array, StructArray},

--- a/datafusion/physical-expr-adapter/src/schema_rewriter.rs
+++ b/datafusion/physical-expr-adapter/src/schema_rewriter.rs
@@ -666,13 +666,10 @@ mod tests {
         BooleanArray, Int32Array, Int64Array, RecordBatch, RecordBatchOptions,
         StringArray, StringViewArray, StructArray,
     };
-    use arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
-    use datafusion_common::{Result, ScalarValue, assert_contains, record_batch};
+    use arrow::datatypes::{Fields, Schema};
+    use datafusion_common::{assert_contains, record_batch};
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{Column, Literal, col, lit};
-    use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
-    use itertools::Itertools;
-    use std::sync::Arc;
 
     fn create_test_schema() -> (Schema, Schema) {
         let physical_schema = Schema::new(vec![
@@ -707,8 +704,6 @@ mod tests {
 
     #[test]
     fn test_rewrite_column_with_metadata_or_nullability_mismatch() -> Result<()> {
-        use std::collections::HashMap;
-
         let physical_schema = Schema::new(vec![Field::new("a", DataType::Int64, true)]);
         let logical_schema =
             Schema::new(vec![Field::new("a", DataType::Int64, false).with_metadata(
@@ -916,8 +911,6 @@ mod tests {
 
     #[test]
     fn test_rewrite_missing_column_propagates_metadata() -> Result<()> {
-        use std::collections::HashMap;
-
         let physical_schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let logical_schema = Schema::new(vec![
             Field::new("a", DataType::Int32, false),

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -488,7 +488,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use arrow::array::{BinaryViewArray, GenericByteViewArray, StringViewArray};
+    use arrow::array::{GenericByteViewArray, StringViewArray};
     use datafusion_common::HashMap;
 
     use super::*;

--- a/datafusion/physical-expr-common/src/utils.rs
+++ b/datafusion/physical-expr-common/src/utils.rs
@@ -129,7 +129,6 @@ pub fn evaluate_expressions_to_arrays_with_metrics<'a>(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use arrow::array::Int32Array;
 

--- a/datafusion/physical-expr/src/equivalence/class.rs
+++ b/datafusion/physical-expr/src/equivalence/class.rs
@@ -910,10 +910,9 @@ impl From<Vec<EquivalenceClass>> for EquivalenceGroup {
 mod tests {
     use super::*;
     use crate::equivalence::tests::create_test_params;
-    use crate::expressions::{BinaryExpr, Column, Literal, binary, col, lit};
+    use crate::expressions::{BinaryExpr, Column, binary, col, lit};
     use arrow::datatypes::{DataType, Field, Schema};
 
-    use datafusion_common::{Result, ScalarValue};
     use datafusion_expr::Operator;
 
     #[test]

--- a/datafusion/physical-expr/src/equivalence/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/mod.rs
@@ -60,7 +60,6 @@ mod tests {
     use crate::expressions::{Column, col};
     use crate::{LexRequirement, PhysicalSortExpr};
 
-    use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
     use datafusion_common::Result;
     use datafusion_physical_expr_common::sort_expr::PhysicalSortRequirement;

--- a/datafusion/physical-expr/src/equivalence/properties/dependency.rs
+++ b/datafusion/physical-expr/src/equivalence/properties/dependency.rs
@@ -383,7 +383,6 @@ pub fn generate_dependency_orderings(
 #[cfg(test)]
 mod tests {
     use std::ops::Not;
-    use std::sync::Arc;
 
     use super::*;
     use crate::equivalence::tests::{
@@ -401,7 +400,6 @@ mod tests {
     use datafusion_expr::Operator;
     use datafusion_expr::sort_properties::SortProperties;
     use datafusion_functions::string::concat;
-    use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
     use datafusion_physical_expr_common::sort_expr::{
         LexRequirement, PhysicalSortRequirement,
     };

--- a/datafusion/physical-expr/src/equivalence/properties/joins.rs
+++ b/datafusion/physical-expr/src/equivalence/properties/joins.rs
@@ -140,7 +140,6 @@ mod tests {
 
     use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field, Fields, Schema};
-    use datafusion_common::Result;
 
     #[test]
     fn test_join_equivalence_properties() -> Result<()> {

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -1424,13 +1424,13 @@ mod tests {
     use super::*;
 
     use crate::expressions;
-    use crate::expressions::{BinaryExpr, binary, cast, col, is_not_null, lit};
+    use crate::expressions::{BinaryExpr, binary, cast, col, is_not_null};
     use arrow::buffer::Buffer;
     use arrow::datatypes::DataType::Float64;
     use arrow::datatypes::Field;
     use datafusion_common::cast::{as_float64_array, as_int32_array};
     use datafusion_common::plan_err;
-    use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
+    use datafusion_common::tree_node::TransformedResult;
     use datafusion_expr::type_coercion::binary::comparison_coercion;
     use datafusion_expr_common::operator::Operator;
     use datafusion_physical_expr_common::physical_expr::fmt_sql;

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -941,7 +941,6 @@ pub fn in_list(
 mod tests {
     use super::*;
     use crate::expressions::{col, lit, try_cast};
-    use arrow::buffer::NullBuffer;
     use arrow::datatypes::{IntervalDayTime, IntervalMonthDayNano, i256};
     use datafusion_common::plan_err;
     use datafusion_expr::type_coercion::binary::comparison_coercion;

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -155,7 +155,6 @@ mod tests {
     use super::*;
 
     use arrow::array::Int32Array;
-    use arrow::datatypes::Field;
     use datafusion_common::cast::as_int32_array;
     use datafusion_physical_expr_common::physical_expr::fmt_sql;
 

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -768,7 +768,7 @@ fn reverse_tuple<T, U>((first, second): (T, U)) -> (U, T) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expressions::{BinaryExpr, Column};
+    use crate::expressions::Column;
     use crate::intervals::test_utils::gen_conjunctive_numerical_expr;
 
     use arrow::array::types::{IntervalDayTime, IntervalMonthDayNano};

--- a/datafusion/physical-expr/src/physical_expr.rs
+++ b/datafusion/physical-expr/src/physical_expr.rs
@@ -233,15 +233,15 @@ pub fn add_offset_to_physical_sort_exprs(
 mod tests {
     use super::*;
 
-    use crate::expressions::{BinaryExpr, Column, Literal};
+    use crate::expressions::{BinaryExpr, Literal};
     use crate::physical_expr::{
         physical_exprs_bag_equal, physical_exprs_contains, physical_exprs_equal,
     };
     use datafusion_physical_expr_common::physical_expr::is_volatile;
 
-    use arrow::datatypes::{DataType, Schema};
+    use arrow::datatypes::DataType;
     use arrow::record_batch::RecordBatch;
-    use datafusion_common::{Result, ScalarValue};
+    use datafusion_common::ScalarValue;
     use datafusion_expr::ColumnarValue;
     use datafusion_expr::Operator;
     use std::any::Any;

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -446,7 +446,7 @@ mod tests {
     use arrow::array::{ArrayRef, BooleanArray, RecordBatch, StringArray};
     use arrow::datatypes::{DataType, Field};
     use datafusion_common::datatype::DataTypeExt;
-    use datafusion_expr::{Operator, col, lit};
+    use datafusion_expr::col;
 
     use super::*;
 

--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -1196,15 +1196,13 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::equivalence::{EquivalenceProperties, convert_to_orderings};
-    use crate::expressions::{BinaryExpr, Literal, col};
+    use crate::expressions::{BinaryExpr, col};
     use crate::utils::tests::TestScalarUDF;
     use crate::{PhysicalExprRef, ScalarFunctionExpr};
 
     use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use arrow::datatypes::{DataType, TimeUnit};
     use datafusion_common::config::ConfigOptions;
-    use datafusion_common::stats::Precision;
-    use datafusion_common::{ScalarValue, Statistics};
     use datafusion_expr::{Operator, ScalarUDF};
     use insta::assert_snapshot;
 

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -374,10 +374,9 @@ impl PhysicalExpr for ScalarFunctionExpr {
 mod tests {
     use super::*;
     use crate::expressions::Column;
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::datatypes::Field;
     use datafusion_expr::{ScalarUDFImpl, Signature};
     use datafusion_physical_expr_common::physical_expr::is_volatile;
-    use std::any::Any;
 
     /// Test helper to create a mock UDF with a specific volatility
     #[derive(Debug, PartialEq, Eq, Hash)]

--- a/datafusion/physical-expr/src/simplifier/mod.rs
+++ b/datafusion/physical-expr/src/simplifier/mod.rs
@@ -97,7 +97,7 @@ mod tests {
     use crate::expressions::{
         BinaryExpr, CastExpr, Literal, NotExpr, TryCastExpr, col, in_list, lit,
     };
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::datatypes::{DataType, Field};
     use datafusion_common::ScalarValue;
     use datafusion_expr::Operator;
 

--- a/datafusion/physical-expr/src/simplifier/unwrap_cast.rs
+++ b/datafusion/physical-expr/src/simplifier/unwrap_cast.rs
@@ -137,10 +137,9 @@ fn try_unwrap_cast_comparison(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expressions::{col, lit};
-    use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_common::{ScalarValue, tree_node::TreeNode};
-    use datafusion_expr::Operator;
+    use crate::expressions::col;
+    use arrow::datatypes::Field;
+    use datafusion_common::tree_node::TreeNode;
 
     /// Check if an expression is a cast expression
     fn is_cast_expr(expr: &Arc<dyn PhysicalExpr>) -> bool {

--- a/datafusion/physical-expr/src/utils/mod.rs
+++ b/datafusion/physical-expr/src/utils/mod.rs
@@ -274,7 +274,7 @@ pub(crate) mod tests {
     use crate::expressions::{Literal, binary, cast, col, in_list, lit};
 
     use arrow::array::{ArrayRef, Float32Array, Float64Array};
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::datatypes::{DataType, Field};
     use datafusion_common::{ScalarValue, exec_err, internal_datafusion_err};
     use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
     use datafusion_expr::{

--- a/datafusion/physical-optimizer/src/ensure_coop.rs
+++ b/datafusion/physical-optimizer/src/ensure_coop.rs
@@ -130,7 +130,6 @@ impl PhysicalOptimizerRule for EnsureCooperative {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_common::config::ConfigOptions;
     use datafusion_physical_plan::{displayable, test::scan_partitioned};
     use insta::assert_snapshot;
 
@@ -264,8 +263,8 @@ mod tests {
     async fn test_eager_evaluation_resets_cooperative_context() {
         // Test that cooperative context is reset when encountering an eager evaluation boundary.
         use arrow::datatypes::Schema;
+        use datafusion_common::internal_err;
         use datafusion_common::tree_node::TreeNodeRecursion;
-        use datafusion_common::{Result, internal_err};
         use datafusion_execution::TaskContext;
         use datafusion_physical_expr::EquivalenceProperties;
         use datafusion_physical_plan::{
@@ -274,7 +273,6 @@ mod tests {
             execution_plan::{Boundedness, EmissionType},
         };
         use std::any::Any;
-        use std::fmt::Formatter;
 
         #[derive(Debug)]
         struct DummyExec {

--- a/datafusion/physical-optimizer/src/limit_pushdown_past_window.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown_past_window.rs
@@ -265,21 +265,17 @@ fn bound_to_usize(bound: &WindowFrameBound) -> Option<usize> {
 mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_common::ScalarValue;
-    use datafusion_expr::{WindowFrame, WindowFrameBound, WindowFrameUnits};
+    use datafusion_expr::WindowFrame;
     use datafusion_functions_window::row_number::row_number_udwf;
     use datafusion_physical_expr::expressions::col;
-    use datafusion_physical_expr::window::StandardWindowExpr;
     use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
     use datafusion_physical_plan::InputOrderMode;
     use datafusion_physical_plan::displayable;
-    use datafusion_physical_plan::limit::LocalLimitExec;
     use datafusion_physical_plan::placeholder_row::PlaceholderRowExec;
     use datafusion_physical_plan::windows::{
         BoundedWindowAggExec, create_udwf_window_expr,
     };
     use insta::assert_snapshot;
-    use std::sync::Arc;
 
     fn plan_str(plan: &dyn ExecutionPlan) -> String {
         displayable(plan).indent(true).to_string()

--- a/datafusion/physical-optimizer/src/topk_repartition.rs
+++ b/datafusion/physical-optimizer/src/topk_repartition.rs
@@ -185,7 +185,6 @@ mod tests {
     use datafusion_physical_plan::displayable;
     use datafusion_physical_plan::test::scan_partitioned;
     use insta::assert_snapshot;
-    use std::sync::Arc;
 
     fn schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -2022,9 +2022,9 @@ mod tests {
         UInt32Array, UInt64Array,
     };
     use arrow::compute::{SortOptions, concat_batches};
-    use arrow::datatypes::{DataType, Int32Type};
+    use arrow::datatypes::Int32Type;
     use datafusion_common::test_util::{batches_to_sort_string, batches_to_string};
-    use datafusion_common::{DataFusionError, ScalarValue, internal_err};
+    use datafusion_common::{DataFusionError, internal_err};
     use datafusion_execution::config::SessionConfig;
     use datafusion_execution::memory_pool::FairSpillPool;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
@@ -2038,7 +2038,6 @@ mod tests {
     use datafusion_physical_expr::PhysicalSortExpr;
     use datafusion_physical_expr::aggregate::AggregateExprBuilder;
     use datafusion_physical_expr::expressions::Literal;
-    use datafusion_physical_expr::expressions::lit;
 
     use crate::projection::ProjectionExec;
     use datafusion_physical_expr::projection::ProjectionExpr;

--- a/datafusion/physical-plan/src/aggregates/order/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/order/mod.rs
@@ -150,7 +150,7 @@ mod tests {
 
     use std::sync::Arc;
 
-    use arrow::array::{ArrayRef, Int32Array};
+    use arrow::array::Int32Array;
 
     #[test]
     fn test_oom_emit_to_none_ordering() {

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -1359,12 +1359,10 @@ mod tests {
     use crate::test::TestMemoryExec;
     use arrow::array::{Int32Array, Int64Array};
     use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_execution::TaskContext;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_functions_aggregate::count::count_udaf;
     use datafusion_physical_expr::aggregate::AggregateExprBuilder;
     use datafusion_physical_expr::expressions::col;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_double_emission_race_condition_bug() -> Result<()> {

--- a/datafusion/physical-plan/src/buffer.rs
+++ b/datafusion/physical-plan/src/buffer.rs
@@ -432,7 +432,6 @@ mod tests {
     };
     use std::error::Error;
     use std::fmt::Debug;
-    use std::sync::Arc;
     use std::time::Duration;
     use tokio::time::timeout;
 

--- a/datafusion/physical-plan/src/column_rewriter.rs
+++ b/datafusion/physical-plan/src/column_rewriter.rs
@@ -74,12 +74,11 @@ impl<'a> TreeNodeRewriter for PhysicalColumnRewriter<'a> {
 mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_common::{DataFusionError, Result, tree_node::TreeNode};
+    use datafusion_common::{Result, tree_node::TreeNode};
     use datafusion_physical_expr::{
         PhysicalExpr,
         expressions::{Column, binary, col, lit},
     };
-    use std::sync::Arc;
 
     /// Helper function to create a test schema
     fn create_test_schema() -> Arc<Schema> {

--- a/datafusion/physical-plan/src/coop.rs
+++ b/datafusion/physical-plan/src/coop.rs
@@ -401,11 +401,10 @@ pub fn make_cooperative(stream: SendableRecordBatchStream) -> SendableRecordBatc
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stream::RecordBatchStreamAdapter;
 
     use arrow_schema::SchemaRef;
 
-    use futures::{StreamExt, stream};
+    use futures::stream;
 
     // This is the hardcoded value Tokio uses
     const TASK_BUDGET: usize = 128;

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -1578,16 +1578,12 @@ pub(crate) fn stub_properties() -> Arc<PlanProperties> {
 
 #[cfg(test)]
 mod tests {
-    use std::any::Any;
-    use std::sync::Arc;
 
     use super::*;
     use crate::{DisplayAs, DisplayFormatType, ExecutionPlan};
 
     use arrow::array::{DictionaryArray, Int32Array, NullArray, RunArray};
-    use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-    use datafusion_common::{Result, Statistics};
-    use datafusion_execution::{SendableRecordBatchStream, TaskContext};
+    use arrow::datatypes::{DataType, Field, Schema};
 
     #[derive(Debug)]
     pub struct EmptyExec;
@@ -1754,7 +1750,7 @@ mod tests {
             self
         }
 
-        fn properties(&self) -> &std::sync::Arc<PlanProperties> {
+        fn properties(&self) -> &Arc<PlanProperties> {
             unimplemented!()
         }
 

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -1075,7 +1075,6 @@ mod tests {
     use crate::test;
     use crate::test::exec::StatisticsExec;
     use arrow::datatypes::{Field, Schema, UnionFields, UnionMode};
-    use datafusion_common::ScalarValue;
 
     #[tokio::test]
     async fn collect_columns_predicates() -> Result<()> {

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -2147,7 +2147,6 @@ mod tests {
     };
     use arrow::buffer::NullBuffer;
     use arrow::datatypes::{DataType, Field};
-    use arrow_schema::Schema;
     use datafusion_common::hash_utils::create_hashes;
     use datafusion_common::test_util::{batches_to_sort_string, batches_to_string};
     use datafusion_common::{
@@ -2157,7 +2156,6 @@ mod tests {
     use datafusion_execution::config::SessionConfig;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_expr::Operator;
-    use datafusion_physical_expr::PhysicalExpr;
     use datafusion_physical_expr::expressions::{BinaryExpr, Literal};
     use hashbrown::HashTable;
     use insta::{allow_duplicates, assert_snapshot};

--- a/datafusion/physical-plan/src/joins/hash_join/inlist_builder.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/inlist_builder.rs
@@ -83,8 +83,6 @@ mod tests {
     use arrow::array::{
         DictionaryArray, Int8Array, Int32Array, StringArray, StringDictionaryBuilder,
     };
-    use arrow_schema::DataType;
-    use std::sync::Arc;
 
     #[test]
     fn test_build_single_column_inlist_array() {

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -2335,8 +2335,8 @@ pub(crate) mod tests {
 
     use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field};
+    use datafusion_common::assert_contains;
     use datafusion_common::test_util::batches_to_sort_string;
-    use datafusion_common::{ScalarValue, assert_contains};
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{BinaryExpr, Literal};

--- a/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
+++ b/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
@@ -662,7 +662,6 @@ mod tests {
     use arrow_schema::{DataType, Field};
     use datafusion_common::test_util::batches_to_string;
     use datafusion_execution::TaskContext;
-    use datafusion_expr::JoinType;
     use datafusion_physical_expr::{PhysicalExpr, expressions::Column};
     use insta::assert_snapshot;
     use std::sync::Arc;

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -1926,7 +1926,6 @@ mod tests {
 
     use super::*;
 
-    use arrow::array::Int32Array;
     use arrow::datatypes::{DataType, Fields};
     use arrow::error::{ArrowError, Result as ArrowResult};
     use datafusion_common::stats::Precision::{Absent, Exact, Inexact};
@@ -2918,12 +2917,12 @@ mod tests {
 
         let build_batch = RecordBatch::try_new(
             Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)])),
-            vec![Arc::new(arrow::array::Int32Array::from(vec![1, 2, 3]))],
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
         )?;
 
         let probe_batch = RecordBatch::try_new(
             Arc::new(Schema::new(vec![Field::new("b", DataType::Int32, true)])),
-            vec![Arc::new(arrow::array::Int32Array::from(vec![4, 5, 6, 7]))],
+            vec![Arc::new(Int32Array::from(vec![4, 5, 6, 7]))],
         )?;
 
         let result = build_batch_empty_build_side(

--- a/datafusion/physical-plan/src/limit.rs
+++ b/datafusion/physical-plan/src/limit.rs
@@ -574,7 +574,6 @@ mod tests {
     use arrow::array::RecordBatchOptions;
     use arrow::datatypes::Schema;
     use datafusion_common::stats::Precision;
-    use datafusion_physical_expr::PhysicalExpr;
     use datafusion_physical_expr::expressions::col;
 
     #[tokio::test]

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -1171,7 +1171,6 @@ fn new_columns_for_join_on(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
 
     use crate::common::collect;
 

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -2631,7 +2631,6 @@ mod test {
     use crate::union::UnionExec;
 
     use datafusion_physical_expr::expressions::col;
-    use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
 
     /// Asserts that the plan is as expected
     ///
@@ -2709,7 +2708,6 @@ mod test {
 
     #[tokio::test]
     async fn test_preserve_order_with_spilling() -> Result<()> {
-        use datafusion_execution::TaskContext;
         use datafusion_execution::runtime_env::RuntimeEnvBuilder;
 
         // Create sorted input data across multiple partitions
@@ -2836,7 +2834,6 @@ mod test {
 
     #[tokio::test]
     async fn test_hash_partitioning_with_spilling() -> Result<()> {
-        use datafusion_execution::TaskContext;
         use datafusion_execution::runtime_env::RuntimeEnvBuilder;
 
         // Create input data similar to the round-robin test

--- a/datafusion/physical-plan/src/sorts/cursor.rs
+++ b/datafusion/physical-plan/src/sorts/cursor.rs
@@ -445,7 +445,6 @@ mod tests {
     use datafusion_execution::memory_pool::{
         GreedyMemoryPool, MemoryConsumer, MemoryPool,
     };
-    use std::sync::Arc;
 
     use super::*;
 

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -1430,7 +1430,6 @@ mod tests {
     use super::*;
     use crate::coalesce_partitions::CoalescePartitionsExec;
     use crate::collect;
-    use crate::execution_plan::Boundedness;
     use crate::expressions::col;
     use crate::test;
     use crate::test::TestMemoryExec;
@@ -1440,9 +1439,9 @@ mod tests {
     use arrow::array::*;
     use arrow::compute::SortOptions;
     use arrow::datatypes::*;
+    use datafusion_common::ScalarValue;
     use datafusion_common::cast::as_primitive_array;
     use datafusion_common::test_util::batches_to_string;
-    use datafusion_common::{DataFusionError, Result, ScalarValue};
     use datafusion_execution::RecordBatchStream;
     use datafusion_execution::config::SessionConfig;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
@@ -2751,7 +2750,6 @@ mod tests {
         use datafusion_execution::memory_pool::{
             GreedyMemoryPool, MemoryConsumer, MemoryPool,
         };
-        use futures::TryStreamExt;
 
         let sort_spill_reservation_bytes: usize = 10 * 1024; // 10 KB
 

--- a/datafusion/physical-plan/src/spill/mod.rs
+++ b/datafusion/physical-plan/src/spill/mod.rs
@@ -355,13 +355,9 @@ mod tests {
     use crate::test::build_table_i32;
     use arrow::array::{ArrayRef, Int32Array, StringArray};
     use arrow::compute::cast;
-    use arrow::datatypes::{DataType, Field, Schema};
-    use arrow::record_batch::RecordBatch;
-    use datafusion_common::Result;
+    use arrow::datatypes::{DataType, Field};
     use datafusion_execution::runtime_env::RuntimeEnv;
     use futures::StreamExt as _;
-
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_batch_spill_and_read() -> Result<()> {

--- a/datafusion/physical-plan/src/spill/spill_pool.rs
+++ b/datafusion/physical-plan/src/spill/spill_pool.rs
@@ -748,7 +748,6 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common_runtime::SpawnedTask;
     use datafusion_execution::runtime_env::RuntimeEnv;
-    use futures::StreamExt;
 
     fn create_test_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -1059,7 +1059,7 @@ impl RecordBatchStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Float64Array, Int32Array, RecordBatch};
+    use arrow::array::{Float64Array, Int32Array};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow_schema::SortOptions;
     use datafusion_common::assert_batches_eq;

--- a/datafusion/physical-plan/src/union.rs
+++ b/datafusion/physical-plan/src/union.rs
@@ -913,7 +913,6 @@ mod tests {
     use arrow::compute::SortOptions;
     use arrow::datatypes::DataType;
     use datafusion_common::ScalarValue;
-    use datafusion_common::stats::Precision;
     use datafusion_physical_expr::equivalence::convert_to_orderings;
     use datafusion_physical_expr::expressions::col;
 

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -844,10 +844,6 @@ impl TryFrom<&protobuf::FileSinkConfig> for FileSinkConfig {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{TimeZone, Utc};
-    use datafusion_datasource::PartitionedFile;
-    use object_store::ObjectMeta;
-    use object_store::path::Path;
 
     use super::*;
 

--- a/datafusion/spark/src/function/aggregate/try_sum.rs
+++ b/datafusion/spark/src/function/aggregate/try_sum.rs
@@ -339,8 +339,8 @@ impl AggregateUDFImpl for SparkTrySum {
 
 #[cfg(test)]
 mod tests {
-    use arrow::array::{BooleanArray, Decimal128Array, Float64Array, Int64Array};
-    use datafusion_common::{DataFusionError, ScalarValue};
+    use arrow::array::{Decimal128Array, Float64Array, Int64Array};
+    use datafusion_common::DataFusionError;
     use std::sync::Arc;
 
     use super::*;

--- a/datafusion/spark/src/function/bitwise/bit_count.rs
+++ b/datafusion/spark/src/function/bitwise/bit_count.rs
@@ -176,7 +176,7 @@ mod tests {
         Array, BooleanArray, Int8Array, Int16Array, Int32Array, Int64Array, UInt8Array,
         UInt16Array, UInt32Array, UInt64Array,
     };
-    use arrow::datatypes::{Field, Int32Type};
+    use arrow::datatypes::Field;
 
     #[test]
     fn test_bit_count_basic() {

--- a/datafusion/spark/src/function/bitwise/bit_get.rs
+++ b/datafusion/spark/src/function/bitwise/bit_get.rs
@@ -128,7 +128,6 @@ fn spark_bit_get(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::Field;
 
     #[test]
     fn test_bit_get_nullability_non_nullable_inputs() {

--- a/datafusion/spark/src/function/bitwise/bit_shift.rs
+++ b/datafusion/spark/src/function/bitwise/bit_shift.rs
@@ -297,8 +297,6 @@ impl ScalarUDFImpl for SparkBitShift {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::Field;
-    use datafusion_expr::ReturnFieldArgs;
 
     #[test]
     fn test_bit_shift_nullability() -> Result<()> {

--- a/datafusion/spark/src/function/bitwise/bitwise_not.rs
+++ b/datafusion/spark/src/function/bitwise/bitwise_not.rs
@@ -123,10 +123,7 @@ pub fn spark_bitwise_not(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::{DataType, Field};
     use std::sync::Arc;
-
-    use datafusion_expr::ReturnFieldArgs;
 
     #[test]
     fn test_bitwise_not_nullability() {

--- a/datafusion/spark/src/function/datetime/date_add.rs
+++ b/datafusion/spark/src/function/datetime/date_add.rs
@@ -136,7 +136,6 @@ fn spark_date_add(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::Field;
 
     #[test]
     fn test_date_add_non_nullable_inputs() {

--- a/datafusion/spark/src/function/datetime/last_day.rs
+++ b/datafusion/spark/src/function/datetime/last_day.rs
@@ -143,10 +143,7 @@ fn spark_last_day(days: i32) -> Result<i32> {
 mod tests {
     use super::*;
     use crate::function::utils::test::test_scalar_function;
-    use arrow::array::{Array, Date32Array};
-    use arrow::datatypes::Field;
-    use datafusion_common::ScalarValue;
-    use datafusion_expr::{ColumnarValue, ReturnFieldArgs};
+    use arrow::array::Array;
 
     #[test]
     fn test_last_day_nullability_matches_input() {

--- a/datafusion/spark/src/function/datetime/make_dt_interval.rs
+++ b/datafusion/spark/src/function/datetime/make_dt_interval.rs
@@ -244,13 +244,11 @@ fn make_interval_dt_nano(day: i32, hour: i32, min: i32, sec: f64) -> Option<i64>
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use arrow::array::{DurationMicrosecondArray, Float64Array, Int32Array};
     use arrow::datatypes::DataType::Duration;
-    use arrow::datatypes::{DataType, Field, TimeUnit::Microsecond};
-    use datafusion_common::{DataFusionError, Result, internal_datafusion_err};
-    use datafusion_expr::{ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs};
+    use arrow::datatypes::TimeUnit::Microsecond;
+    use datafusion_common::internal_datafusion_err;
 
     use super::*;
 

--- a/datafusion/spark/src/function/datetime/next_day.rs
+++ b/datafusion/spark/src/function/datetime/next_day.rs
@@ -253,7 +253,6 @@ fn spark_next_day(days: i32, day_of_week: &str) -> Option<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_expr::ReturnFieldArgs;
 
     #[test]
     fn return_type_is_not_used() {

--- a/datafusion/spark/src/function/json/json_tuple.rs
+++ b/datafusion/spark/src/function/json/json_tuple.rs
@@ -196,7 +196,6 @@ fn json_tuple_inner(args: &[ArrayRef], return_type: &DataType) -> Result<ArrayRe
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_expr::ReturnFieldArgs;
 
     #[test]
     fn test_return_field_shape() {

--- a/datafusion/spark/src/function/map/map_from_arrays.rs
+++ b/datafusion/spark/src/function/map/map_from_arrays.rs
@@ -117,8 +117,6 @@ fn map_from_arrays_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::Field;
-    use datafusion_expr::ReturnFieldArgs;
 
     #[test]
     fn test_map_from_arrays_nullability_and_type() {

--- a/datafusion/spark/src/function/map/map_from_entries.rs
+++ b/datafusion/spark/src/function/map/map_from_entries.rs
@@ -160,7 +160,6 @@ fn map_from_entries_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 mod tests {
     use super::*;
     use arrow::datatypes::Fields;
-    use datafusion_expr::ReturnFieldArgs;
 
     fn make_entries_field(array_nullable: bool, element_nullable: bool) -> FieldRef {
         let struct_type = DataType::Struct(Fields::from(vec![

--- a/datafusion/spark/src/function/math/abs.rs
+++ b/datafusion/spark/src/function/math/abs.rs
@@ -515,10 +515,6 @@ mod tests {
 
     #[test]
     fn test_abs_nullability() {
-        use arrow::datatypes::{DataType, Field};
-        use datafusion_expr::ReturnFieldArgs;
-        use std::sync::Arc;
-
         let abs = SparkAbs::new();
 
         // --- non-nullable Int32 input ---

--- a/datafusion/spark/src/function/math/width_bucket.rs
+++ b/datafusion/spark/src/function/math/width_bucket.rs
@@ -442,7 +442,6 @@ pub(crate) fn width_bucket_interval_mdn_exact(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
 
     use arrow::array::{
         ArrayRef, DurationMicrosecondArray, Float64Array, Int32Array, Int64Array,

--- a/datafusion/spark/src/function/string/ascii.rs
+++ b/datafusion/spark/src/function/string/ascii.rs
@@ -94,7 +94,6 @@ impl ScalarUDFImpl for SparkAscii {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_expr::ReturnFieldArgs;
 
     #[test]
     fn test_return_field_nullable_input() {

--- a/datafusion/spark/src/function/string/concat.rs
+++ b/datafusion/spark/src/function/string/concat.rs
@@ -167,10 +167,6 @@ mod tests {
     use super::*;
     use crate::function::utils::test::test_scalar_function;
     use arrow::array::{Array, StringArray};
-    use arrow::datatypes::{DataType, Field};
-    use datafusion_common::Result;
-    use datafusion_expr::ReturnFieldArgs;
-    use std::sync::Arc;
 
     #[test]
     fn test_concat_basic() -> Result<()> {

--- a/datafusion/spark/src/function/string/elt.rs
+++ b/datafusion/spark/src/function/string/elt.rs
@@ -150,11 +150,6 @@ fn elt(args: &[ArrayRef]) -> Result<ArrayRef, DataFusionError> {
 mod tests {
     use super::*;
     use arrow::array::Int64Array;
-    use datafusion_common::Result;
-
-    use arrow::array::{ArrayRef, StringArray};
-    use datafusion_common::DataFusionError;
-    use std::sync::Arc;
 
     fn run_elt_arrays(arrs: Vec<ArrayRef>) -> Result<Arc<StringArray>> {
         let arr = elt(&arrs)?;

--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -2361,7 +2361,6 @@ fn trim_trailing_0s_hex(number: &str) -> &str {
 mod tests {
     use super::*;
     use arrow::datatypes::DataType::Utf8;
-    use datafusion_common::Result;
 
     #[test]
     fn test_format_string_nullability() -> Result<()> {

--- a/datafusion/spark/src/function/string/ilike.rs
+++ b/datafusion/spark/src/function/string/ilike.rs
@@ -92,9 +92,8 @@ mod tests {
     use super::*;
     use crate::function::utils::test::test_scalar_function;
     use arrow::array::{Array, BooleanArray};
-    use arrow::datatypes::{DataType::Boolean, Field};
-    use datafusion_common::{Result, ScalarValue};
-    use datafusion_expr::{ColumnarValue, ReturnFieldArgs, ScalarUDFImpl};
+    use arrow::datatypes::DataType::Boolean;
+    use datafusion_common::ScalarValue;
 
     macro_rules! test_ilike_string_invoke {
         ($INPUT1:expr, $INPUT2:expr, $EXPECTED:expr) => {

--- a/datafusion/spark/src/function/string/length.rs
+++ b/datafusion/spark/src/function/string/length.rs
@@ -202,11 +202,9 @@ where
 mod tests {
     use super::*;
     use crate::function::utils::test::test_scalar_function;
-    use arrow::array::{Array, Int32Array};
+    use arrow::array::Int32Array;
     use arrow::datatypes::DataType::Int32;
-    use arrow::datatypes::{Field, FieldRef};
     use datafusion_common::{Result, ScalarValue};
-    use datafusion_expr::{ColumnarValue, ReturnFieldArgs, ScalarUDFImpl};
 
     macro_rules! test_spark_length_string {
         ($INPUT:expr, $EXPECTED:expr) => {

--- a/datafusion/spark/src/function/string/like.rs
+++ b/datafusion/spark/src/function/string/like.rs
@@ -94,9 +94,8 @@ mod tests {
     use super::*;
     use crate::function::utils::test::test_scalar_function;
     use arrow::array::{Array, BooleanArray};
-    use arrow::datatypes::{DataType::Boolean, Field};
-    use datafusion_common::{Result, ScalarValue};
-    use datafusion_expr::{ColumnarValue, ReturnFieldArgs, ScalarUDFImpl};
+    use arrow::datatypes::DataType::Boolean;
+    use datafusion_common::ScalarValue;
 
     macro_rules! test_like_string_invoke {
         ($INPUT1:expr, $INPUT2:expr, $EXPECTED:expr) => {

--- a/datafusion/spark/src/function/url/parse_url.rs
+++ b/datafusion/spark/src/function/url/parse_url.rs
@@ -336,10 +336,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{ArrayRef, Int32Array, StringArray};
-    use datafusion_common::Result;
+    use arrow::array::Int32Array;
     use std::array::from_ref;
-    use std::sync::Arc;
 
     fn sa(vals: &[Option<&str>]) -> ArrayRef {
         Arc::new(StringArray::from(vals.to_vec())) as ArrayRef

--- a/datafusion/spark/src/function/url/try_url_decode.rs
+++ b/datafusion/spark/src/function/url/try_url_decode.rs
@@ -84,7 +84,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::StringArray;
-    use datafusion_common::{Result, cast::as_string_array};
+    use datafusion_common::cast::as_string_array;
 
     use super::*;
 

--- a/datafusion/spark/src/function/url/url_decode.rs
+++ b/datafusion/spark/src/function/url/url_decode.rs
@@ -208,8 +208,6 @@ pub fn spark_handled_url_decode(
 
 #[cfg(test)]
 mod tests {
-    use arrow::array::StringArray;
-    use datafusion_common::Result;
 
     use super::*;
 

--- a/datafusion/substrait/src/logical_plan/consumer/substrait_consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/substrait_consumer.rs
@@ -588,7 +588,7 @@ impl SubstraitConsumer for DefaultSubstraitConsumer<'_> {
 mod tests {
     use super::*;
     use crate::logical_plan::consumer::utils::tests::test_consumer;
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::datatypes::{Field, Schema};
 
     fn make_schema(fields: &[(&str, DataType)]) -> Arc<DFSchema> {
         let arrow_fields: Vec<Field> = fields

--- a/datafusion/substrait/src/logical_plan/producer/types.rs
+++ b/datafusion/substrait/src/logical_plan/producer/types.rs
@@ -394,7 +394,7 @@ mod tests {
         from_substrait_type_without_names,
     };
     use crate::logical_plan::producer::DefaultSubstraitProducer;
-    use datafusion::arrow::datatypes::{Field, Fields, Schema, TimeUnit};
+    use datafusion::arrow::datatypes::{Fields, Schema, TimeUnit};
     use datafusion::common::{DFSchema, Result};
     use datafusion::prelude::SessionContext;
     use std::sync::Arc;


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

`clippy` doesn't warn about `use` statements that re-import an item that is already available via a glob import (`use super::*`), but in many cases the `use` statement is redundant and can be safely removed. In particular, there was a lot of test code that did both `use super::*` and also imported items that were imported by the module under test; the test-specific import can be safely removed.

## What changes are included in this PR?

* Mechanical removal of duplicate imports between test code and code under test

## Are these changes tested?

Yes, via `cargo check` and `cargo clippy`

## Are there any user-facing changes?

No.
