### PR TITLE
docs: Document the TableProvider evaluation order for filter, limit and projection

### DIFF
--- a/datafusion/catalog/src/table.rs
+++ b/datafusion/catalog/src/table.rs
@@ -177,7 +177,7 @@ pub trait TableProvider: Debug + Sync + Send {
     /// - `filters = [b > 5]`
     /// - `limit = Some(3)`
     ///
-    /// It must logically produce results like:
+    /// It must logically produce results equivalent to:
     ///
     /// ```text
     /// PROJECTION a (LIMIT 3 (SCAN WHERE b > 5))


### PR DESCRIPTION

## Which issue does this PR close?

- Follow on to https://github.com/apache/datafusion/pull/21057

## Rationale for this change

As mentioned by @hareshkh on https://github.com/apache/datafusion/pull/21057#discussion_r2966432536:

It is not clear from the existing documentation that the (logical) evaluation order for push down operations is 'filter -> limit -> projection'

this is the actual order implemented by the built in providers, but it wasn't documented anywhere explicitly

## What changes are included in this PR?

1. Explicitly document the evaluation order on TableProvider
2. Some drive by cleanups of the documentation 

## Are these changes tested?

By CI

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
