### PR TITLE
test: update sqllogictest expectation for negation type coercion

### DIFF
--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1764,7 +1764,7 @@ SELECT null, -null
 ----
 NULL NULL
 
-query error DataFusion error: Error during planning: Negation only supports numeric, interval and timestamp types
+query error type_coercion\ncaused by\nError during planning: Negation only supports numeric, interval and timestamp types
 SELECT -'100'
 
 query error DataFusion error: Error during planning: Unary operator '\+' only supports numeric, interval and timestamp types


### PR DESCRIPTION
## Which issue does this PR close?

- Fixes CI breakage on main introduced by #20965.

link: https://github.com/apache/datafusion/actions/runs/23406116823/job/68085237860

## Rationale for this change

#20965 moved invalid negation validation into the analyzer/type coercion path.

After that change, the `SELECT -'100'` sqllogictest case now reports the error through `type_coercion`, but `scalar.slt` was still expecting the older error form. This follow-up updates the sqllogictest expectation to match the current behavior.

## What changes are included in this PR?

- update the `scalar.slt` expectation for `SELECT -'100'`
- keep the expected error aligned with the analyzer/type coercion error shape introduced by #20965

## Are these changes tested?

Yes.

I reproduced the failure locally and verified the updated expectation with:
  - `cargo test -p datafusion-sqllogictest --test sqllogictests -- scalar`

## Are there any user-facing changes?

No.