### PR TITLE
fix: string_to_array('', delim) returns empty array for PostgreSQL compatibility

### DIFF
--- a/datafusion/functions-nested/src/string.rs
+++ b/datafusion/functions-nested/src/string.rs
@@ -733,31 +733,31 @@ where
     let mut list_builder = ListBuilder::new(string_builder);
 
     match null_value_array {
-        None => {
-            string_array.iter().zip(delimiter_array.iter()).for_each(
-                |(string, delimiter)| {
-                    match (string, delimiter) {
-                        (Some(string), Some("")) => {
-                            list_builder.values().append_value(string);
-                            list_builder.append(true);
-                        }
-                        (Some(string), Some(delimiter)) => {
-                            string.split(delimiter).for_each(|s| {
-                                list_builder.values().append_value(s);
-                            });
-                            list_builder.append(true);
-                        }
-                        (Some(string), None) => {
-                            string.chars().map(|c| c.to_string()).for_each(|c| {
-                                list_builder.values().append_value(c.as_str());
-                            });
-                            list_builder.append(true);
-                        }
-                        _ => list_builder.append(false), // null value
+        None => string_array.iter().zip(delimiter_array.iter()).for_each(
+            |(string, delimiter)| match (string, delimiter) {
+                (Some(string), Some("")) => {
+                    if !string.is_empty() {
+                        list_builder.values().append_value(string);
                     }
-                },
-            )
-        }
+                    list_builder.append(true);
+                }
+                (Some(string), Some(delimiter)) => {
+                    if !string.is_empty() {
+                        string.split(delimiter).for_each(|s| {
+                            list_builder.values().append_value(s);
+                        });
+                    }
+                    list_builder.append(true);
+                }
+                (Some(string), None) => {
+                    string.chars().map(|c| c.to_string()).for_each(|c| {
+                        list_builder.values().append_value(c.as_str());
+                    });
+                    list_builder.append(true);
+                }
+                _ => list_builder.append(false),
+            },
+        ),
         Some(null_value_array) => string_array
             .iter()
             .zip(delimiter_array.iter())
@@ -765,21 +765,25 @@ where
             .for_each(|((string, delimiter), null_value)| {
                 match (string, delimiter) {
                     (Some(string), Some("")) => {
-                        if Some(string) == null_value {
-                            list_builder.values().append_null();
-                        } else {
-                            list_builder.values().append_value(string);
+                        if !string.is_empty() {
+                            if Some(string) == null_value {
+                                list_builder.values().append_null();
+                            } else {
+                                list_builder.values().append_value(string);
+                            }
                         }
                         list_builder.append(true);
                     }
                     (Some(string), Some(delimiter)) => {
-                        string.split(delimiter).for_each(|s| {
-                            if Some(s) == null_value {
-                                list_builder.values().append_null();
-                            } else {
-                                list_builder.values().append_value(s);
-                            }
-                        });
+                        if !string.is_empty() {
+                            string.split(delimiter).for_each(|s| {
+                                if Some(s) == null_value {
+                                    list_builder.values().append_null();
+                                } else {
+                                    list_builder.values().append_value(s);
+                                }
+                            });
+                        }
                         list_builder.append(true);
                     }
                     (Some(string), None) => {

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -8623,6 +8623,26 @@ SELECT string_to_array('abcxxxdef', 'xxx')
 ----
 [abc, def]
 
+query I
+SELECT cardinality(string_to_array('', ','))
+----
+0
+
+query I
+SELECT cardinality(string_to_array('', ''))
+----
+0
+
+query I
+SELECT cardinality(string_to_array('', ',', 'x'))
+----
+0
+
+query I
+SELECT cardinality(string_to_array('', '', 'x'))
+----
+0
+
 query ?
 SELECT string_to_array('abc', '')
 ----


### PR DESCRIPTION
## Problem

`string_to_array` was returning incorrect results for empty string input — both when the delimiter is non-empty and when the delimiter is itself an empty string. This diverges from PostgreSQL behavior.

| Query | DataFusion (before) | PostgreSQL (expected) |
|---|---|---|
| `string_to_array('', ',')` | `['']` | `{}` |
| `string_to_array('', '')` | `['']` | `{}` |
| `string_to_array('', ',', 'x')` | `['']` | `{}` |
| `string_to_array('', '', 'x')` | `['']` | `{}` |

Results from datafusion-cli
<img width="1435" height="104" alt="Screenshot 2026-03-23 at 9 14 08 AM" src="https://github.com/user-attachments/assets/2eaae366-7f8a-4220-87d2-f0b311c26712" />

**Root cause:** Rust's `str::split()` on an empty string always yields one empty-string element, so `"".split(",")` produces `[""]`. Additionally, the empty-delimiter branch unconditionally appended the (empty) string value. This is subtle because Arrow's text display format appears not to quote strings, so `[""]` renders as `[]` — indistinguishable from an actual empty array. Using `cardinality()` reveals the current length is 1, not 0.

**PostgreSQL reference:** [db-fiddle](https://www.db-fiddle.com/f/oCF8EPaZFkDNKSg28rVVWy/3)

## Fix

In `datafusion/functions-nested/src/string.rs`:

- **Non-empty delimiter** `(Some(string), Some(delimiter))`: added `if !string.is_empty()` guard to skip splitting when input is empty.
- **Empty delimiter** `(Some(string), Some(""))`: added `if !string.is_empty()` guard so the string value is only appended when non-empty.

Both the plain variant and the `null_value` variant are fixed (4 checks total).

## Tests

Added sqllogictest cases in `datafusion/sqllogictest/test_files/array.slt` using `cardinality()` to unambiguously verify the arrays are truly empty (not just displaying as empty):

```sql
SELECT cardinality(string_to_array('', ','))    -- 0
SELECT cardinality(string_to_array('', ''))     -- 0
SELECT cardinality(string_to_array('', ',', 'x'))  -- 0
SELECT cardinality(string_to_array('', '', 'x'))   -- 0
```

Each test covers one of the four `is_empty` guard checks. All four fail without the fix (returning 1 instead of 0).