### PR TITLE
chore: Optimize schema rewriter usages

### DIFF
--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -358,17 +358,27 @@ impl FileOpener for ParquetOpener {
             // and we can avoid doing any more work on the file (bloom filters, loading the page index, etc.).
             // Additionally, if any casts were inserted we can move casts from the column to the literal side:
             // `CAST(col AS INT) = 5` can become `col = CAST(5 AS <col type>)`, which can be evaluated statically.
-            let rewriter = expr_adapter_factory.create(
-                Arc::clone(&logical_file_schema),
-                Arc::clone(&physical_file_schema),
-            )?;
-            let simplifier = PhysicalExprSimplifier::new(&physical_file_schema);
-            predicate = predicate
-                .map(|p| simplifier.simplify(rewriter.rewrite(p)?))
-                .transpose()?;
-            // Adapt projections to the physical file schema as well
-            projection = projection
-                .try_map_exprs(|p| simplifier.simplify(rewriter.rewrite(p)?))?;
+            //
+            // When the schemas are identical and there is no predicate, the
+            // rewriter is a no-op: column indices already match (partition
+            // columns are appended after file columns in the table schema),
+            // types are the same, and there are no missing columns. Skip the
+            // tree walk entirely in that case.
+            let needs_rewrite =
+                predicate.is_some() || logical_file_schema != physical_file_schema;
+            if needs_rewrite {
+                let rewriter = expr_adapter_factory.create(
+                    Arc::clone(&logical_file_schema),
+                    Arc::clone(&physical_file_schema),
+                )?;
+                let simplifier = PhysicalExprSimplifier::new(&physical_file_schema);
+                predicate = predicate
+                    .map(|p| simplifier.simplify(rewriter.rewrite(p)?))
+                    .transpose()?;
+                // Adapt projections to the physical file schema as well
+                projection = projection
+                    .try_map_exprs(|p| simplifier.simplify(rewriter.rewrite(p)?))?;
+            }
 
             // Build predicates for this specific file
             let (pruning_predicate, page_pruning_predicate) = build_pruning_predicates(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

 The rewriter actually has 3 responsibilities:                                                                                                                                                                                                                                                                    
  1. Index remapping — column indices in expressions may not match the file schema 
  2. Type casting — when logical and physical field types differ
  3. Missing column handling — replacing references to absent columns with nulls

Do not use cycles for schema rewrite if predicate is not set or logic schema equal to physical schema

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
