### PR TITLE
docs: Add explicit fmt and clippy commands to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,24 @@ Before committing any changes, you MUST follow the instructions in
 and ensure the required checks listed there pass. Do not commit code that
 fails any of those checks.
 
+At a minimum, you MUST run and fix any errors from these commands before
+committing:
+
+```bash
+# Format code
+cargo fmt --all
+
+# Lint (must pass with no warnings)
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+You can also run the full lint suite used by CI:
+
+```bash
+./dev/rust_lint.sh
+# or auto-fix: ./dev/rust_lint.sh --write --allow-dirty
+```
+
 When creating a PR, you MUST follow the [PR template](.github/pull_request_template.md).
 
 ## Testing


### PR DESCRIPTION
## Which issue does this PR close?

N/A - minor documentation improvement.

## Rationale for this change

The "Before Committing" section in `AGENTS.md` (symlinked as `CLAUDE.md`) tells agents to follow the contributor guide but does not list the concrete commands. Agents may skip `cargo fmt` or `cargo clippy` and submit PRs with formatting/lint errors that fail CI.

## What changes are included in this PR?

Adds explicit `cargo fmt --all` and `cargo clippy` commands that agents MUST run before committing, along with a pointer to the full `./dev/rust_lint.sh` suite.

## Are these changes tested?

Documentation only — no code changes.

## Are there any user-facing changes?

No.