### PR TITLE
docs: add KalamDB to known users

### DIFF
--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -137,6 +137,7 @@ Here are some active projects using DataFusion:
 - [Vortex] An extensible, state of the art columnar file format
 - [Telemetry](https://telemetry.sh/) Structured logging made easy
 - [Xorq](https://github.com/xorq-labs/xorq/) Xorq is a multi-engine batch transformation framework built on Ibis, DataFusion and Arrow
+- [KalamDB](https://github.com/jamals86/KalamDB) SQL-first realtime state database for AI agents, chat products, and multi-tenant SaaS.
 
 Here are some less active projects that used DataFusion:
 


### PR DESCRIPTION
## Which issue does this PR close?

- N/A. This is a small documentation-only update adding KalamDB to the Known Users list.

## Rationale for this change

KalamDB uses DataFusion as part of its SQL execution layer. Adding it to the documentation helps keep the Known Users section accurate and shows another real-world DataFusion adoption example.

## What changes are included in this PR?

- Added `KalamDB` to the active projects list in `docs/source/user-guide/introduction.md`.
- Described KalamDB as an SQL-first realtime state database for AI agents, chat products, and multi-tenant SaaS.

## Are these changes tested?

No code or behavior changed. This PR only updates documentation text, so no additional tests were needed.

## Are there any user-facing changes?

Yes. The DataFusion user guide will list KalamDB in the Known Users section.