### PR TITLE
Make PartitionFile extensions a type map

### DIFF
--- a/datafusion-examples/examples/data_io/parquet_advanced_index.rs
+++ b/datafusion-examples/examples/data_io/parquet_advanced_index.rs
@@ -481,7 +481,7 @@ impl TableProvider for IndexTableProvider {
             .partitioned_file()
             // provide the starting access plan to the DataSourceExec by
             // storing it as  "extensions" on PartitionedFile
-            .with_extensions(Arc::new(access_plan) as _);
+            .with_extension(Arc::new(access_plan));
 
         // Prepare for scanning
         let schema = self.schema();

--- a/datafusion/core/tests/parquet/custom_reader.rs
+++ b/datafusion/core/tests/parquet/custom_reader.rs
@@ -71,7 +71,7 @@ async fn route_data_access_ops_to_parquet_file_reader_factory() {
         .into_iter()
         .map(|meta| {
             PartitionedFile::new_from_meta(meta)
-                .with_extensions(Arc::new(String::from(EXPECTED_USER_DEFINED_METADATA)))
+                .with_extension(Arc::new(String::from(EXPECTED_USER_DEFINED_METADATA)))
         })
         .collect();
 
@@ -119,12 +119,8 @@ impl ParquetFileReaderFactory for InMemoryParquetFileReaderFactory {
         metrics: &ExecutionPlanMetricsSet,
     ) -> Result<Box<dyn AsyncFileReader + Send>> {
         let metadata = partitioned_file
-            .extensions
-            .as_ref()
+            .get_extension::<String>()
             .expect("has user defined metadata");
-        let metadata = metadata
-            .downcast_ref::<String>()
-            .expect("has string metadata");
 
         assert_eq!(EXPECTED_USER_DEFINED_METADATA, &metadata[..]);
 

--- a/datafusion/core/tests/parquet/external_access_plan.rs
+++ b/datafusion/core/tests/parquet/external_access_plan.rs
@@ -349,7 +349,7 @@ impl TestFull {
 
         // add the access plan, if any, as an extension
         if let Some(access_plan) = access_plan {
-            partitioned_file = partitioned_file.with_extensions(Arc::new(access_plan));
+            partitioned_file = partitioned_file.with_extension(Arc::new(access_plan));
         }
 
         // Create a DataSourceExec to read the file

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -130,7 +130,7 @@ impl FileOpener for ParquetOpener {
         // Step: prepare configurations, etc.
         // -----------------------------------
         let file_range = partitioned_file.range.clone();
-        let extensions = partitioned_file.extensions.clone();
+        let access_plan = partitioned_file.get_extension::<ParquetAccessPlan>();
         let file_location = partitioned_file.object_meta.location.clone();
         let file_name = file_location.to_string();
         let file_metrics =
@@ -413,7 +413,7 @@ impl FileOpener for ParquetOpener {
             let rg_metadata = file_metadata.row_groups();
             // track which row groups to actually read
             let access_plan =
-                create_initial_plan(&file_name, extensions, rg_metadata.len())?;
+                create_initial_plan(&file_name, access_plan, rg_metadata.len())?;
             let mut row_groups = RowGroupAccessPlanFilter::new(access_plan);
             // if there is a range restricting what parts of the file to read
             if let Some(range) = file_range.as_ref() {
@@ -945,23 +945,19 @@ impl ParquetOpener {
 /// Note: file_name is only used for error messages
 fn create_initial_plan(
     file_name: &str,
-    extensions: Option<Arc<dyn std::any::Any + Send + Sync>>,
+    access_plan: Option<Arc<ParquetAccessPlan>>,
     row_group_count: usize,
 ) -> Result<ParquetAccessPlan> {
-    if let Some(extensions) = extensions {
-        if let Some(access_plan) = extensions.downcast_ref::<ParquetAccessPlan>() {
-            let plan_len = access_plan.len();
-            if plan_len != row_group_count {
-                return exec_err!(
-                    "Invalid ParquetAccessPlan for {file_name}. Specified {plan_len} row groups, but file has {row_group_count}"
-                );
-            }
-
-            // check row group count matches the plan
-            return Ok(access_plan.clone());
-        } else {
-            debug!("DataSourceExec Ignoring unknown extension specified for {file_name}");
+    if let Some(access_plan) = access_plan {
+        let plan_len = access_plan.len();
+        if plan_len != row_group_count {
+            return exec_err!(
+                "Invalid ParquetAccessPlan for {file_name}. Specified {plan_len} row groups, but file has {row_group_count}"
+            );
         }
+
+        // check row group count matches the plan
+        return Ok(access_plan.as_ref().clone());
     }
 
     // default to scanning all row groups
@@ -1899,7 +1895,7 @@ mod test {
             "test.parquet".to_string(),
             u64::try_from(data_len).unwrap(),
         )
-        .with_extensions(Arc::new(access_plan));
+        .with_extension(Arc::new(access_plan));
 
         let make_opener = |reverse_scan: bool| {
             ParquetOpenerBuilder::new()
@@ -2000,7 +1996,7 @@ mod test {
             "test.parquet".to_string(),
             u64::try_from(data_len).unwrap(),
         )
-        .with_extensions(Arc::new(access_plan));
+        .with_extension(Arc::new(access_plan));
 
         let make_opener = |reverse_scan: bool| {
             ParquetOpenerBuilder::new()

--- a/datafusion/datasource-parquet/src/source.rs
+++ b/datafusion/datasource-parquet/src/source.rs
@@ -230,7 +230,7 @@ use parquet::encryption::decrypt::FileDecryptionProperties;
 /// access_plan.skip(4);
 /// // provide the plan as extension to the FileScanConfig
 /// let partitioned_file = PartitionedFile::new("my_file.parquet", 1234)
-///   .with_extensions(Arc::new(access_plan));
+///   .with_extension(Arc::new(access_plan));
 /// // create a FileScanConfig to scan this file
 /// let config = FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), Arc::new(ParquetSource::new(schema())))
 ///     .with_file(partitioned_file).build();

--- a/datafusion/datasource/src/mod.rs
+++ b/datafusion/datasource/src/mod.rs
@@ -66,9 +66,12 @@ pub use table_schema::TableSchema;
 #[expect(deprecated)]
 pub use statistics::add_row_stats;
 pub use statistics::compute_all_files_statistics;
+use std::any::TypeId;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
+
+use datafusion_execution::config::AnyMap;
 
 /// Stream of files get listed from object store
 #[deprecated(
@@ -147,8 +150,12 @@ pub struct PartitionedFile {
     /// underlying format (for example, Parquet `sorting_columns`), but it may also be set
     /// explicitly via [`Self::with_ordering`].
     pub ordering: Option<LexOrdering>,
-    /// An optional field for user defined per object metadata
-    pub extensions: Option<Arc<dyn std::any::Any + Send + Sync>>,
+    /// A type map for user defined per object metadata.
+    ///
+    /// Multiple extensions of different types can be stored simultaneously.
+    /// Use [`Self::with_extension`] and [`Self::get_extension`] to interact
+    /// with the extensions.
+    pub extensions: AnyMap,
     /// The estimated size of the parquet metadata, in bytes
     pub metadata_size_hint: Option<usize>,
 }
@@ -168,7 +175,7 @@ impl PartitionedFile {
             range: None,
             statistics: None,
             ordering: None,
-            extensions: None,
+            extensions: AnyMap::default(),
             metadata_size_hint: None,
         }
     }
@@ -181,7 +188,7 @@ impl PartitionedFile {
             range: None,
             statistics: None,
             ordering: None,
-            extensions: None,
+            extensions: AnyMap::default(),
             metadata_size_hint: None,
         }
     }
@@ -200,7 +207,7 @@ impl PartitionedFile {
             range: Some(FileRange { start, end }),
             statistics: None,
             ordering: None,
-            extensions: None,
+            extensions: AnyMap::default(),
             metadata_size_hint: None,
         }
         .with_range(start, end)
@@ -256,15 +263,31 @@ impl PartitionedFile {
         self
     }
 
-    /// Update the user defined extensions for this file.
+    /// Add a typed extension to this file.
     ///
-    /// This can be used to pass reader specific information.
-    pub fn with_extensions(
-        mut self,
-        extensions: Arc<dyn std::any::Any + Send + Sync>,
-    ) -> Self {
-        self.extensions = Some(extensions);
+    /// Multiple extensions of different types can be stored simultaneously.
+    /// This can be used to pass reader specific information, such as a
+    /// [`ParquetAccessPlan`].
+    ///
+    /// See [`Self::get_extension`] to retrieve an extension by type.
+    ///
+    /// [`ParquetAccessPlan`]: https://docs.rs/datafusion/latest/datafusion/datasource/physical_plan/parquet/struct.ParquetAccessPlan.html
+    pub fn with_extension<T: Send + Sync + 'static>(mut self, ext: Arc<T>) -> Self {
+        let ext = ext as Arc<dyn std::any::Any + Send + Sync + 'static>;
+        let id = TypeId::of::<T>();
+        self.extensions.insert(id, ext);
         self
+    }
+
+    /// Retrieve a typed extension from this file, if one exists.
+    ///
+    /// See [`Self::with_extension`] to add an extension by type.
+    pub fn get_extension<T: Send + Sync + 'static>(&self) -> Option<Arc<T>> {
+        let id = TypeId::of::<T>();
+        self.extensions
+            .get(&id)
+            .cloned()
+            .map(|ext| Arc::downcast(ext).expect("TypeId unique"))
     }
 
     /// Update the statistics for this file.
@@ -337,7 +360,7 @@ impl From<ObjectMeta> for PartitionedFile {
             range: None,
             statistics: None,
             ordering: None,
-            extensions: None,
+            extensions: AnyMap::default(),
             metadata_size_hint: None,
         }
     }
@@ -534,7 +557,7 @@ pub fn generate_test_files(num_files: usize, overlap_factor: f64) -> Vec<FileGro
                 }],
             })),
             ordering: None,
-            extensions: None,
+            extensions: AnyMap::default(),
             metadata_size_hint: None,
         };
         files.push(file);

--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -628,7 +628,7 @@ impl From<ConfigOptions> for SessionConfig {
 /// Data is wrapped into an [`Arc`] to enable [`Clone`] while still being [object safe].
 ///
 /// [object safe]: https://doc.rust-lang.org/reference/items/traits.html#object-safety
-type AnyMap =
+pub type AnyMap =
     HashMap<TypeId, Arc<dyn Any + Send + Sync + 'static>, BuildHasherDefault<IdHasher>>;
 
 /// Hasher for [`AnyMap`].
@@ -636,7 +636,7 @@ type AnyMap =
 /// With [`TypeId`]s as keys, there's no need to hash them. They are already hashes themselves, coming from the compiler.
 /// The [`IdHasher`] just holds the [`u64`] of the [`TypeId`], and then returns it, instead of doing any bit fiddling.
 #[derive(Default)]
-struct IdHasher(u64);
+pub struct IdHasher(u64);
 
 impl Hasher for IdHasher {
     fn write(&mut self, _: &[u8]) {


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/21191

## Rationale for this change

See the original issue, but essentially allows us to use our own custom extensions alongside a parquet access plan

## What changes are included in this PR?

Adjusts the `PartitionFile` to use `AnyMap` for its `extensions` field, and makes those type aliases public from config

## Are these changes tested?

Yes, existing tests have coverage

## Are there any user-facing changes?

Yes, this is a breaking change (albeit an extremely compatible one), so will need to be a major version bump to include it.  I can't add labels to this PR to reflect this
