### PR TITLE
test: scale remaining sort-merge join (SMJ) benchmark queries

### DIFF
--- a/benchmarks/src/smj.rs
+++ b/benchmarks/src/smj.rs
@@ -39,7 +39,7 @@ use futures::StreamExt;
 #[derive(Debug, Args, Clone)]
 #[command(verbatim_doc_comment)]
 pub struct RunOpt {
-    /// Query number (between 1 and 26). If not specified, runs all queries
+    /// Query number (between 1 and 23). If not specified, runs all queries
     #[arg(short, long)]
     query: Option<usize>,
 
@@ -456,72 +456,6 @@ const SMJ_QUERIES: &[&str] = &[
           ON t1_sorted.key = t2_sorted.key
          AND t1_sorted.data + t2_sorted.data < 10000000
     "#,
-    // Q24: LEFT MARK 1M x 10M | 1:10 | 1%
-    r#"
-        WITH t1_sorted AS (
-            SELECT value % 100000 as key, value as data
-            FROM range(1000000)
-            ORDER BY key, data
-        ),
-        t2_sorted AS (
-            SELECT value % 100000 as key, value as data
-            FROM range(10000000)
-            ORDER BY key, data
-        )
-        SELECT t1_sorted.key, t1_sorted.data
-        FROM t1_sorted
-        WHERE t1_sorted.data < 0
-           OR EXISTS (
-            SELECT 1 FROM t2_sorted
-            WHERE t2_sorted.key = t1_sorted.key
-              AND t2_sorted.data <> t1_sorted.data
-              AND t2_sorted.data % 100 = 0
-        )
-    "#,
-    // Q25: LEFT MARK 1M x 10M | 1:10 | 50%
-    r#"
-        WITH t1_sorted AS (
-            SELECT value % 100000 as key, value as data
-            FROM range(1000000)
-            ORDER BY key, data
-        ),
-        t2_sorted AS (
-            SELECT value % 100000 as key, value as data
-            FROM range(10000000)
-            ORDER BY key, data
-        )
-        SELECT t1_sorted.key, t1_sorted.data
-        FROM t1_sorted
-        WHERE t1_sorted.data < 0
-           OR EXISTS (
-            SELECT 1 FROM t2_sorted
-            WHERE t2_sorted.key = t1_sorted.key
-              AND t2_sorted.data <> t1_sorted.data
-              AND t2_sorted.data % 2 = 0
-        )
-    "#,
-    // Q26: LEFT MARK 1M x 10M | 1:10 | 90%
-    r#"
-        WITH t1_sorted AS (
-            SELECT value % 100000 as key, value as data
-            FROM range(1000000)
-            ORDER BY key, data
-        ),
-        t2_sorted AS (
-            SELECT value % 100000 as key, value as data
-            FROM range(10000000)
-            ORDER BY key, data
-        )
-        SELECT t1_sorted.key, t1_sorted.data
-        FROM t1_sorted
-        WHERE t1_sorted.data < 0
-           OR EXISTS (
-            SELECT 1 FROM t2_sorted
-            WHERE t2_sorted.key = t1_sorted.key
-              AND t2_sorted.data <> t1_sorted.data
-              AND t2_sorted.data % 10 <> 0
-        )
-    "#,
 ];
 
 impl RunOpt {
@@ -555,10 +489,7 @@ impl RunOpt {
 
             let sql = SMJ_QUERIES[query_index];
             benchmark_run.start_new_case(&format!("Query {query_id}"));
-            let expect_mark = query_id >= 24;
-            let query_run = self
-                .benchmark_query(sql, &query_id.to_string(), expect_mark, &ctx)
-                .await;
+            let query_run = self.benchmark_query(sql, &query_id.to_string(), &ctx).await;
             match query_run {
                 Ok(query_results) => {
                     for iter in query_results {
@@ -582,7 +513,6 @@ impl RunOpt {
         &self,
         sql: &str,
         query_name: &str,
-        expect_mark: bool,
         ctx: &SessionContext,
     ) -> Result<Vec<QueryResult>> {
         let mut query_results = vec![];
@@ -595,12 +525,6 @@ impl RunOpt {
         if !plan_string.contains("SortMergeJoinExec") {
             return Err(exec_datafusion_err!(
                 "Query {query_name} does not use Sort Merge Join. Physical plan: {plan_string}"
-            ));
-        }
-
-        if expect_mark && !plan_string.contains("LeftMark") {
-            return Err(exec_datafusion_err!(
-                "Query {query_name} expected LeftMark join. Physical plan: {plan_string}"
             ));
         }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Our SMJ benchmark queries finish too quickly to demonstrate improvements that aren't massive. For example, I am working on an optimization that introduces `DynComparator` (part of #20910) and it's about a 10% improvement, but only when you actually make the queries run long enough. The new queries for #21184 are scaled enough to see improvements, but we need to scale the older queries.

I am also continuing to see SMJ issues with Comet when running joins with billions (sometimes trillions) of rows. We can't do that for microbenchmarks, but we can at least start hitting millions of rows to look at more than a handful of batches.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Bring our SMJ queries into alignment with some of the newer ones (Q21-23) to demonstrate further performance wins.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I ran the benchmark. On my M3 Max, here's how long it takes:

| Query | Join Type | Rows | Keys | Filter | Median (ms) |                                                                                                                                                                                                                            
  |-------|-----------|------|------|--------|-------------|                                                                                                                                                                                                                          
  | Q1 | INNER | 1M×1M | 1:1 | — | 16.3 |                                                                                                                                                                                                                                               
  | Q2 | INNER | 1M×10M | 1:10 | — | 117.4 |                                                                                                                                                                                                                                            
  | Q3 | INNER | 1M×1M | 1:100 | — | 74.2 |                                                                                                                                                                                                                                             
  | Q4 | INNER | 1M×10M | 1:10 | 1% | 17.1 |                                                                                                                                                                                                                                          
  | Q5 | INNER | 1M×1M | 1:100 | 10% | 18.4 |
  | Q6 | LEFT | 1M×10M | 1:10 | — | 129.3 |
  | Q7 | LEFT | 1M×10M | 1:10 | 50% | 150.2 |
  | Q8 | FULL | 1M×1M | 1:10 | — | 16.6 |
  | Q9 | FULL | 1M×10M | 1:10 | 10% | 153.5 |
  | Q10 | LEFT SEMI | 1M×10M | 1:10 | — | 53.1 |
  | Q11 | LEFT SEMI | 1M×10M | 1:10 | 1% | 15.5 |
  | Q12 | LEFT SEMI | 1M×10M | 1:10 | 50% | 65.0 |
  | Q13 | LEFT SEMI | 1M×10M | 1:10 | 90% | 105.7 |
  | Q14 | LEFT ANTI | 1M×10M | 1:10 | — | 54.3 |
  | Q15 | LEFT ANTI | 1M×10M | 1:10 | partial | 51.5 |
  | Q16 | LEFT ANTI | 1M×1M | 1:1 | — | 10.3 |
  | Q17 | INNER | 1M×50M | 1:50 | 5% | 75.9 |
  | Q18 | LEFT SEMI | 1M×50M | 1:50 | 2% | 50.2 |
  | Q19 | LEFT ANTI | 1M×50M | 1:50 | partial | 336.4 |
  | Q20 | INNER | 1M×10M | 1:100 | GROUP BY | 763.7 |
  | Q21 | INNER | 10M×10M | 1:1 | 50% | 186.1 |
  | Q22 | LEFT | 10M×10M | 1:1 | 50% | 10,193.8 |
  | Q23 | FULL | 10M×10M | 1:1 | 50% | 10,194.7 |

Note that Q22 and Q23 will be about 20x faster when #21184 merges, so taking 10 seconds to run is just a short-term issue.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No.