### PR TITLE
chore: Cleanup Cargo profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,13 +252,13 @@ unused_qualifications = "deny"
 [profile.release]
 codegen-units = 1
 lto = true
-strip = true            # Eliminate debug info to minimize binary size
+strip = true      # Eliminate debug info to minimize binary size
 
 [profile.release-nonlto]
 inherits = "release"
 codegen-units = 16
 lto = false
-strip = false           # Retain debug info for flamegraphs
+strip = false        # Retain debug info for flamegraphs
 
 [profile.profiling]
 inherits = "release"


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## Rationale for this change

* Don't explicitly set default values when configuring profiles. For example, `release-nonlto` explicitly set several build settings (e.g., `opt_level`, `overflow_checks`) to their default values, which could be misleading.
* Fix typos, reorder profile configuration, and other general cleanup

No functional changes.

## What changes are included in this PR?

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
