### PR TITLE
[Minor]: fix ambiguous column references error when decorrelating multiple scalar subqueries

### DIFF
--- a/datafusion/optimizer/src/scalar_subquery_to_join.rs
+++ b/datafusion/optimizer/src/scalar_subquery_to_join.rs
@@ -30,7 +30,9 @@ use datafusion_common::alias::AliasGenerator;
 use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion, TreeNodeRewriter,
 };
-use datafusion_common::{Column, Result, ScalarValue, assert_or_internal_err, plan_err};
+use datafusion_common::{
+    Column, Result, ScalarValue, TableReference, assert_or_internal_err, plan_err,
+};
 use datafusion_expr::expr_rewriter::create_col_from_scalar_expr;
 use datafusion_expr::logical_plan::{JoinType, Subquery};
 use datafusion_expr::utils::conjunction;
@@ -363,9 +365,10 @@ fn build_join(
                     expr: None,
                     when_then_expr: vec![
                         (
-                            Box::new(Expr::IsNull(Box::new(Expr::Column(
-                                Column::new_unqualified(UN_MATCHED_ROW_INDICATOR),
-                            )))),
+                            Box::new(Expr::IsNull(Box::new(Expr::Column(Column::new(
+                                Some(TableReference::bare(subquery_alias)),
+                                UN_MATCHED_ROW_INDICATOR,
+                            ))))),
                             Box::new(result),
                         ),
                         (
@@ -373,7 +376,8 @@ fn build_join(
                             Box::new(Expr::Literal(ScalarValue::Null, None)),
                         ),
                     ],
-                    else_expr: Some(Box::new(Expr::Column(Column::new_unqualified(
+                    else_expr: Some(Box::new(Expr::Column(Column::new(
+                        Some(TableReference::bare(subquery_alias)),
                         name.clone(),
                     )))),
                 })
@@ -381,12 +385,14 @@ fn build_join(
                 Expr::Case(expr::Case {
                     expr: None,
                     when_then_expr: vec![(
-                        Box::new(Expr::IsNull(Box::new(Expr::Column(
-                            Column::new_unqualified(UN_MATCHED_ROW_INDICATOR),
-                        )))),
+                        Box::new(Expr::IsNull(Box::new(Expr::Column(Column::new(
+                            Some(TableReference::bare(subquery_alias)),
+                            UN_MATCHED_ROW_INDICATOR,
+                        ))))),
                         Box::new(result),
                     )],
-                    else_expr: Some(Box::new(Expr::Column(Column::new_unqualified(
+                    else_expr: Some(Box::new(Expr::Column(Column::new(
+                        Some(TableReference::bare(subquery_alias)),
                         name.clone(),
                     )))),
                 })

--- a/datafusion/sqllogictest/test_files/subquery.slt
+++ b/datafusion/sqllogictest/test_files/subquery.slt
@@ -388,7 +388,7 @@ query TT
 explain SELECT t1_id, t1_name, t1_int FROM t1 WHERE EXISTS(SELECT t1_int FROM t1 WHERE t1.t1_id > t1.t1_int)
 ----
 logical_plan
-01)LeftSemi Join: 
+01)LeftSemi Join:
 02)--TableScan: t1 projection=[t1_id, t1_name, t1_int]
 03)--SubqueryAlias: __correlated_sq_1
 04)----Projection:
@@ -607,7 +607,7 @@ query TT
 explain SELECT t1_id, t1_name FROM t1 WHERE EXISTS (SELECT NULL)
 ----
 logical_plan
-01)LeftSemi Join: 
+01)LeftSemi Join:
 02)--TableScan: t1 projection=[t1_id, t1_name]
 03)--SubqueryAlias: __correlated_sq_1
 04)----EmptyRelation: rows=1
@@ -690,7 +690,7 @@ explain SELECT t1_id, (SELECT t2_id FROM t2 limit 0) FROM t1
 ----
 logical_plan
 01)Projection: t1.t1_id, __scalar_sq_1.t2_id AS t2_id
-02)--Left Join: 
+02)--Left Join:
 03)----TableScan: t1 projection=[t1_id]
 04)----EmptyRelation: rows=0
 
@@ -735,7 +735,7 @@ explain select (select count(*) from t1) as b, (select count(1) from t2)
 ----
 logical_plan
 01)Projection: __scalar_sq_1.count(*) AS b, __scalar_sq_2.count(Int64(1)) AS count(Int64(1))
-02)--Left Join: 
+02)--Left Join:
 03)----SubqueryAlias: __scalar_sq_1
 04)------Projection: count(Int64(1)) AS count(*)
 05)--------Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]
@@ -752,7 +752,7 @@ explain select (select count(*) from t1) as b, (select count(1) from t2)
 ----
 logical_plan
 01)Projection: __scalar_sq_1.count(*) AS b, __scalar_sq_2.count(Int64(1)) AS count(Int64(1))
-02)--Left Join: 
+02)--Left Join:
 03)----SubqueryAlias: __scalar_sq_1
 04)------Projection: count(Int64(1)) AS count(*)
 05)--------Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]
@@ -1439,7 +1439,7 @@ query TT
 explain SELECT a FROM t1 WHERE EXISTS (SELECT count(*) FROM t2)
 ----
 logical_plan
-01)LeftSemi Join: 
+01)LeftSemi Join:
 02)--TableScan: t1 projection=[a]
 03)--SubqueryAlias: __correlated_sq_1
 04)----EmptyRelation: rows=1
@@ -1456,7 +1456,7 @@ statement count 0
 create table person(id int, last_name int, state int);
 
 query TT
-explain SELECT id FROM person p WHERE EXISTS 
+explain SELECT id FROM person p WHERE EXISTS
     (SELECT * FROM person WHERE last_name = p.last_name AND state = p.state)
 ----
 logical_plan
@@ -1581,6 +1581,53 @@ logical_plan
 11)----------------SubqueryAlias: __correlated_sq_1
 12)------------------Projection: lineitem.l_extendedprice AS price, lineitem.l_extendedprice, lineitem.l_orderkey
 13)--------------------TableScan: lineitem projection=[l_orderkey, l_extendedprice]
+
+# Multiple correlated scalar subqueries should not cause
+# "Ambiguous reference to unqualified field __always_true"
+
+statement ok
+CREATE TABLE activity (region TEXT, duration DOUBLE) AS VALUES
+('US', 10.0), ('EU', 20.0), ('US', 15.0), ('EU', 25.0), ('APAC', 30.0);
+
+# multiple_correlated_scalar_subqueries_count_and_max (issue reproduction for https://github.com/apache/datafusion/issues/20315)
+query TRIR rowsort
+SELECT
+    region,
+    SUM(duration) as total_duration,
+    (SELECT COUNT(*) FROM activity WHERE region = a.region) as count,
+    (SELECT MAX(duration) FROM activity WHERE region = a.region) as max_duration
+FROM activity a
+GROUP BY region
+----
+APAC 30 1 30
+EU 45 2 25
+US 25 2 15
+
+# multiple_correlated_scalar_subqueries_both_count (issue repro variant)
+query TRI rowsort
+SELECT
+    region,
+    SUM(duration) as total_duration,
+    (SELECT COUNT(*) FROM activity WHERE region = a.region) as count
+FROM activity a
+GROUP BY region
+----
+APAC 30 1
+EU 45 2
+US 25 2
+
+# multiple_correlated_scalar_subqueries_in_where
+query TR rowsort
+SELECT region, SUM(duration) as total_duration
+FROM activity a
+GROUP BY region
+HAVING (SELECT COUNT(*) FROM activity WHERE region = a.region) > 1
+   AND (SELECT MAX(duration) FROM activity WHERE region = a.region) > 20
+----
+EU 45
+
+statement ok
+DROP TABLE activity;
 
 # Setup tables for recursive correlation tests
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20315.

## Rationale for this change
Issue has details but when we've multiple correlated scalar subqueries optimizer fails with:
```
Schema error: Ambiguous reference to unqualified field __always_true
```

without the fix:
```


External error: 2 errors in file /Users/buraksen/d/personal/datafusion2/datafusion/sqllogictest/test_files/subquery.slt

1. query failed: DataFusion error: Optimizer rule 'scalar_subquery_to_join' failed
caused by
Schema error: Ambiguous reference to unqualified field __always_true
[SQL] SELECT
    region,
    SUM(duration) as total_duration,
    (SELECT COUNT(*) FROM activity WHERE region = a.region) as count,
    (SELECT MAX(duration) FROM activity WHERE region = a.region) as max_duration
FROM activity a
GROUP BY region
at /Users/buraksen/d/personal/datafusion2/datafusion/sqllogictest/test_files/subquery.slt:1593


2. query failed: DataFusion error: Optimizer rule 'scalar_subquery_to_join' failed
caused by
Schema error: Ambiguous reference to unqualified field __always_true
[SQL] SELECT region, SUM(duration) as total_duration
FROM activity a
GROUP BY region
HAVING (SELECT COUNT(*) FROM activity WHERE region = a.region) > 1
   AND (SELECT MAX(duration) FROM activity WHERE region = a.region) > 20
at /Users/buraksen/d/personal/datafusion2/datafusion/sqllogictest/test_files/subquery.slt:1620



Error: Execution("2 failures")
error: test failed, to rerun pass `-p datafusion-sqllogictest --test sqllogictests`
```

This is because we dont alias queries 

## What changes are included in this PR?


## Are these changes tested?
added slt tests (I've taken these from the issue repro steps)

## Are there any user-facing changes?
no