### PR TITLE
Use spot instances for extended tests

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -177,4 +177,4 @@ jobs:
           apt-get update && apt-get install -y protobuf-compiler
       - name: Run sqllogictest
         run: |
-          cargo test --features backtrace,parquet_encryption --profile ci-dev --test sqllogictests -- --include-sqlite
+          cargo test --features backtrace,parquet_encryption --profile ci-optimized --test sqllogictests -- --include-sqlite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,8 +258,8 @@ overflow-checks = false
 rpath = false
 strip = false            # Retain debug info for flamegraphs
 
-[profile.ci-dev] # todo: disable once https://github.com/apache/datafusion/pull/21085 is done
-inherits = "dev"
+[profile.ci-optimized]
+inherits = "release"
 codegen-units = 16
 lto = "thin"
 strip = true


### PR DESCRIPTION
I had `spot=false` because those runs were slow. Now they are quite fast, so we can save up while running them:

[Before](https://github.com/apache/datafusion/actions/runs/23683585934/job/68999421156):
<img width="523" height="366" alt="Zen Browser 2026-03-28 22 09 17" src="https://github.com/user-attachments/assets/27eb875f-b99a-4f12-a5ef-9bd5d13ae36b" />

[After](https://github.com/apache/datafusion/actions/runs/23694905456/job/69028518341#step:12:25):
<img width="452" height="379" alt="Zen Browser 2026-03-28 22 09 32" src="https://github.com/user-attachments/assets/c40a446e-3240-4b8c-b139-476b9a4a6a6f" />

Instance family differs between runs (runs-on [picks one](https://runs-on.com/configuration/spot-instances/) based on current cost/availability), but the numbers should be illustrative nonetheless.

I also put cpu to 32 since the tests are quite fast