### PR TITLE
kill `check_run_id` and `pr_number` from extended tests

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -47,12 +47,6 @@ on:
       - 'datafusion-testing'
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: 'Pull request number'
-        type: string
-      check_run_id:
-        description: 'Check run ID for status updates'
-        type: string
       pr_head_sha:
         description: 'PR head SHA'
         type: string


### PR DESCRIPTION
follow up on https://github.com/apache/datafusion/pull/17119