### PR TITLE
docs: Add `RESET` Command Documentation

### DIFF
--- a/dev/update_config_docs.sh
+++ b/dev/update_config_docs.sh
@@ -101,8 +101,23 @@ EOF
 echo "Running CLI and inserting config docs table"
 $PRINT_CONFIG_DOCS_COMMAND >> "$TARGET_FILE"
 
-echo "Inserting runtime config header"
+echo "Inserting reset command details and runtime config header"
 cat <<'EOF' >> "$TARGET_FILE"
+
+You can also reset configuration options to default settings via SQL using the `RESET` command. For
+example, to set and reset `datafusion.execution.batch_size`:
+
+```sql
+SET datafusion.execution.batch_size = '10000';
+
+SHOW datafusion.execution.batch_size;
+datafusion.execution.batch_size 10000
+
+RESET datafusion.execution.batch_size;
+
+SHOW datafusion.execution.batch_size;
+datafusion.execution.batch_size 8192
+```
 
 # Runtime Configuration Settings
 

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -197,8 +197,6 @@ The following configuration settings are available:
 | datafusion.format.duration_format                                       | pretty                    | Duration format. Can be either `"pretty"` or `"ISO8601"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | datafusion.format.types_info                                            | false                     | Show types in visual representation batches                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
-# Reset Configuration Settings
-
 You can also reset configuration options to default settings via SQL using the `RESET` command. For
 example, to set and reset `datafusion.execution.batch_size`:
 
@@ -234,23 +232,6 @@ The following runtime configuration settings are available:
 | datafusion.runtime.memory_limit            | NULL    | Maximum memory limit for query execution. Supports suffixes K (kilobytes), M (megabytes), and G (gigabytes). Example: '2G' for 2 gigabytes.                               |
 | datafusion.runtime.metadata_cache_limit    | 50M     | Maximum memory to use for file metadata cache such as Parquet metadata. Supports suffixes K (kilobytes), M (megabytes), and G (gigabytes). Example: '2G' for 2 gigabytes. |
 | datafusion.runtime.temp_directory          | NULL    | The path to the temporary file directory.                                                                                                                                 |
-
-# Reset Runtime Configuration Settings
-
-You can also reset runtime configuration options to default settings via SQL using the `RESET` command. For
-example, to set and reset `datafusion.runtime.list_files_cache_limit`:
-
-```sql
-SET datafusion.runtime.list_files_cache_limit = '10M';
-
-SHOW datafusion.runtime.list_files_cache_limit;
-datafusion.runtime.list_files_cache_limit 10M
-
-RESET datafusion.runtime.list_files_cache_limit;
-
-SHOW datafusion.runtime.list_files_cache_limit;
-datafusion.runtime.list_files_cache_limit 1M
-```
 
 # Tuning Guide
 


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #21244.

## Rationale for this change
`datafusion.catalog/execution/optimizer/explain/sql_parser/format.*` and `datafusion.runtime.*` configurations can be set by using `SET` Command. Also, they can be reset to their default value by using `RESET` Command. SET command has documentation but RESET does not have so this PR aims to add RESET Command documentation like SET Command.

## What changes are included in this PR?
RESET Command Documentation is being added.

## Are these changes tested?
Not required.

## Are there any user-facing changes?
Yes
