### PR TITLE
ci: use ubuntu-slim runner for lightweight CI jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Actions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -41,7 +41,7 @@ jobs:
 
   prettier:
     name: Use prettier to check formatting of documents
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   process:
     name: Process
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # only run for users whose permissions allow them to update PRs
     # otherwise labeler is failing:
     # https://github.com/apache/datafusion/issues/3743

--- a/.github/workflows/large_files.yml
+++ b/.github/workflows/large_files.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   check-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   close-stale-prs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   issue_assign:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: (!github.event.issue.pull_request) && (github.event.comment.body == 'take' || github.event.comment.body == 'untake')
     concurrency:
       group: ${{ github.actor }}-issue-assign


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20870.

## Rationale for this change

`ubuntu-slim` is a cost-efficient runner that can save ASF infrastructure resources for lightweight CI jobs. This was raised in the Apache ORC project and adopted by other Apache projects like iceberg-rust (apache/iceberg-rust#2187).

## What changes are included in this PR?

Switch 6 lightweight CI jobs from `ubuntu-latest` to `ubuntu-slim`:
- `take.yml`: `issue_assign` — curl API calls only
- `large_files.yml`: `check-files` — git commands only
- `stale.yml`: `close-stale-prs` — actions/stale
- `labeler.yml`: `process` — actions/labeler
- `codeql.yml`: `analyze` — codeql-action on Actions YAML
- `dev.yml`: `prettier` — setup-node + prettier

## Are these changes tested?

CI only — this changes the runner type, not workflow logic.

## Are there any user-facing changes?

No.