### PR TITLE
feat: Create dynamic filters in SortMergeJoin

### DIFF
--- a/datafusion/core/tests/fuzz_cases/mod.rs
+++ b/datafusion/core/tests/fuzz_cases/mod.rs
@@ -21,6 +21,7 @@ mod distinct_count_string_fuzz;
 #[expect(clippy::needless_pass_by_value)]
 mod join_fuzz;
 mod merge_fuzz;
+mod smj_filter_pushdown;
 #[expect(clippy::needless_pass_by_value)]
 mod sort_fuzz;
 #[expect(clippy::needless_pass_by_value)]

--- a/datafusion/core/tests/fuzz_cases/smj_filter_pushdown.rs
+++ b/datafusion/core/tests/fuzz_cases/smj_filter_pushdown.rs
@@ -1,0 +1,327 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Integration tests for dynamic filter pushdown through SortMergeJoinExec.
+//!
+//! These tests verify that when TopK dynamic filters are pushed through
+//! SortMergeJoinExec for Inner joins, the query results remain correct.
+//! Each test runs the same query with and without dynamic filter pushdown
+//! and compares the results.
+//!
+//! Data is written to in-memory parquet files (via an InMemory object store)
+//! so that the DataSourceExec supports filter pushdown — in-memory tables
+//! do not.
+
+use std::sync::Arc;
+
+use arrow::array::{Float64Array, Int32Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use arrow::util::pretty::pretty_format_batches;
+use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_datasource::ListingTableUrl;
+use datafusion_datasource_parquet::ParquetFormat;
+use datafusion_execution::object_store::ObjectStoreUrl;
+use object_store::memory::InMemory;
+use object_store::path::Path;
+use object_store::{ObjectStore, PutPayload};
+use parquet::arrow::ArrowWriter;
+
+fn left_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("score", DataType::Float64, false),
+    ]))
+}
+
+fn left_batch() -> RecordBatch {
+    RecordBatch::try_new(
+        left_schema(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10])),
+            Arc::new(StringArray::from(vec![
+                "alice", "bob", "carol", "dave", "eve", "frank", "grace", "heidi",
+                "ivan", "judy",
+            ])),
+            Arc::new(Float64Array::from(vec![
+                90.0, 85.0, 72.0, 95.0, 60.0, 88.0, 77.0, 91.0, 68.0, 83.0,
+            ])),
+        ],
+    )
+    .unwrap()
+}
+
+fn right_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("dept", DataType::Utf8, false),
+        Field::new("rating", DataType::Utf8, false),
+    ]))
+}
+
+fn right_batch() -> RecordBatch {
+    RecordBatch::try_new(
+        right_schema(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 3, 5, 7, 9, 11, 13])),
+            Arc::new(StringArray::from(vec![
+                "eng", "sales", "eng", "hr", "sales", "eng", "hr",
+            ])),
+            Arc::new(StringArray::from(vec!["A", "B", "C", "A", "B", "A", "C"])),
+        ],
+    )
+    .unwrap()
+}
+
+/// Write a RecordBatch to an in-memory object store as a parquet file.
+async fn write_parquet(store: &Arc<dyn ObjectStore>, path: &str, batch: &RecordBatch) {
+    let mut buf = vec![];
+    let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), None).unwrap();
+    writer.write(batch).unwrap();
+    writer.close().unwrap();
+    store
+        .put(&Path::from(path), PutPayload::from(buf))
+        .await
+        .unwrap();
+}
+
+/// Register a parquet-backed listing table from an in-memory object store.
+fn register_listing_table(
+    ctx: &SessionContext,
+    table_name: &str,
+    schema: Arc<Schema>,
+    path: &str,
+) {
+    let format = Arc::new(
+        ParquetFormat::default()
+            .with_options(ctx.state().table_options().parquet.clone()),
+    );
+    let options = ListingOptions::new(format);
+    let table_path = ListingTableUrl::parse(format!("memory:///{path}")).unwrap();
+    let config = ListingTableConfig::new(table_path)
+        .with_listing_options(options)
+        .with_schema(schema);
+    let table = Arc::new(ListingTable::try_new(config).unwrap());
+    ctx.register_table(table_name, table).unwrap();
+}
+
+/// Build a SessionContext backed by in-memory parquet, with SMJ forced.
+///
+/// Uses 2 target partitions so that the optimizer inserts hash-repartitioning
+/// and sort nodes — exercising the filter-passthrough through these operators —
+/// while still producing a SortMergeJoinExec (not CollectLeft HashJoin, which
+/// is preferred at target_partitions=1).
+async fn build_ctx(enable_dynamic_filters: bool) -> SessionContext {
+    let cfg = SessionConfig::new()
+        .with_target_partitions(2)
+        .set_bool("datafusion.optimizer.prefer_hash_join", false)
+        .set_bool(
+            "datafusion.optimizer.enable_dynamic_filter_pushdown",
+            enable_dynamic_filters,
+        );
+    let ctx = SessionContext::new_with_config(cfg);
+
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let url = ObjectStoreUrl::parse("memory://").unwrap();
+    ctx.register_object_store(url.as_ref(), Arc::clone(&store));
+
+    write_parquet(&store, "left.parquet", &left_batch()).await;
+    write_parquet(&store, "right.parquet", &right_batch()).await;
+
+    register_listing_table(&ctx, "left_t", left_schema(), "left.parquet");
+    register_listing_table(&ctx, "right_t", right_schema(), "right.parquet");
+
+    ctx
+}
+
+/// Run a query with and without dynamic filter pushdown, assert same results,
+/// and verify the plan uses SortMergeJoinExec.
+async fn run_and_compare(query: &str) {
+    // Run without dynamic filters (baseline)
+    let ctx_off = build_ctx(false).await;
+    let expected = ctx_off.sql(query).await.unwrap().collect().await.unwrap();
+
+    // Run with dynamic filters
+    let ctx_on = build_ctx(true).await;
+    let actual = ctx_on.sql(query).await.unwrap().collect().await.unwrap();
+
+    // Verify results match
+    let expected_str = pretty_format_batches(&expected).unwrap().to_string();
+    let actual_str = pretty_format_batches(&actual).unwrap().to_string();
+    assert_eq!(
+        expected_str, actual_str,
+        "Results differ for query: {query}\n\nExpected:\n{expected_str}\n\nActual:\n{actual_str}"
+    );
+
+    // Verify plan uses SortMergeJoinExec
+    let explain = ctx_on
+        .sql(&format!("EXPLAIN {query}"))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let plan_str = pretty_format_batches(&explain).unwrap().to_string();
+    assert!(
+        plan_str.contains("SortMergeJoinExec"),
+        "Expected SortMergeJoinExec in plan for query: {query}\n\nPlan:\n{plan_str}"
+    );
+}
+
+// ---- Test cases ----
+
+#[tokio::test]
+async fn test_smj_topk_on_left_column() {
+    run_and_compare(
+        "SELECT l.id, l.name, r.dept \
+         FROM left_t l INNER JOIN right_t r ON l.id = r.id \
+         ORDER BY l.name LIMIT 3",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_smj_topk_on_right_column() {
+    run_and_compare(
+        "SELECT l.id, l.name, r.dept, r.rating \
+         FROM left_t l INNER JOIN right_t r ON l.id = r.id \
+         ORDER BY r.rating LIMIT 2",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_smj_topk_on_join_key() {
+    run_and_compare(
+        "SELECT l.id, l.name, r.dept \
+         FROM left_t l INNER JOIN right_t r ON l.id = r.id \
+         ORDER BY l.id LIMIT 3",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_smj_topk_desc_order() {
+    run_and_compare(
+        "SELECT l.id, l.name, r.dept \
+         FROM left_t l INNER JOIN right_t r ON l.id = r.id \
+         ORDER BY l.score DESC LIMIT 2",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_smj_topk_multi_column_order() {
+    run_and_compare(
+        "SELECT l.id, l.name, r.dept, r.rating \
+         FROM left_t l INNER JOIN right_t r ON l.id = r.id \
+         ORDER BY r.dept, l.name LIMIT 3",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_smj_topk_with_where_clause() {
+    run_and_compare(
+        "SELECT l.id, l.name, r.dept \
+         FROM left_t l INNER JOIN right_t r ON l.id = r.id \
+         WHERE l.score > 70.0 \
+         ORDER BY l.name LIMIT 2",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_smj_topk_limit_one() {
+    run_and_compare(
+        "SELECT l.id, l.name, r.dept \
+         FROM left_t l INNER JOIN right_t r ON l.id = r.id \
+         ORDER BY l.score LIMIT 1",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_smj_topk_limit_exceeds_rows() {
+    run_and_compare(
+        "SELECT l.id, l.name, r.dept \
+         FROM left_t l INNER JOIN right_t r ON l.id = r.id \
+         ORDER BY l.id LIMIT 100",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_smj_left_join_correctness() {
+    // Left join should produce correct results with or without dynamic filters.
+    // No DynamicFilter is pushed through SMJ for non-Inner joins (conservative).
+    run_and_compare(
+        "SELECT l.id, l.name, r.dept \
+         FROM left_t l LEFT JOIN right_t r ON l.id = r.id \
+         ORDER BY l.id LIMIT 3",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_smj_nested_joins_topk() {
+    run_and_compare(
+        "SELECT l.id, l.name, r1.dept, r2.rating \
+         FROM left_t l \
+         INNER JOIN right_t r1 ON l.id = r1.id \
+         INNER JOIN right_t r2 ON l.id = r2.id \
+         ORDER BY l.name LIMIT 3",
+    )
+    .await;
+}
+
+/// Verify that with dynamic filters enabled, the physical plan for an Inner
+/// join + TopK query contains a DynamicFilter pushed down to a DataSourceExec.
+/// This confirms the feature is effective end-to-end with parquet.
+#[tokio::test]
+async fn test_smj_dynamic_filter_present_in_plan() {
+    let query = "SELECT l.id, l.name, r.dept \
+                 FROM left_t l INNER JOIN right_t r ON l.id = r.id \
+                 ORDER BY l.name LIMIT 3";
+
+    let ctx = build_ctx(true).await;
+    let explain = ctx
+        .sql(&format!("EXPLAIN {query}"))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let plan_str = pretty_format_batches(&explain).unwrap().to_string();
+
+    assert!(
+        plan_str.contains("SortMergeJoinExec"),
+        "Expected SortMergeJoinExec in plan\n\nPlan:\n{plan_str}"
+    );
+
+    // With parquet + SMJ + TopK, a DynamicFilter should be pushed through
+    // the SortMergeJoinExec to one of the DataSourceExec nodes.
+    let has_dynamic_filter = plan_str
+        .lines()
+        .any(|l| l.contains("DataSourceExec") && l.contains("DynamicFilter"));
+    assert!(
+        has_dynamic_filter,
+        "Expected DynamicFilter pushed to DataSourceExec through SortMergeJoinExec\n\nPlan:\n{plan_str}"
+    );
+}

--- a/datafusion/core/tests/fuzz_cases/smj_filter_pushdown.rs
+++ b/datafusion/core/tests/fuzz_cases/smj_filter_pushdown.rs
@@ -39,7 +39,7 @@ use datafusion_datasource_parquet::ParquetFormat;
 use datafusion_execution::object_store::ObjectStoreUrl;
 use object_store::memory::InMemory;
 use object_store::path::Path;
-use object_store::{ObjectStore, PutPayload};
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
 use parquet::arrow::ArrowWriter;
 
 fn left_schema() -> Arc<Schema> {
@@ -270,7 +270,7 @@ async fn test_smj_topk_limit_exceeds_rows() {
 #[tokio::test]
 async fn test_smj_left_join_correctness() {
     // Left join should produce correct results with or without dynamic filters.
-    // No DynamicFilter is pushed through SMJ for non-Inner joins (conservative).
+    // DynamicFilter is pushed through SMJ for any join type that preserves the filtered side.
     run_and_compare(
         "SELECT l.id, l.name, r.dept \
          FROM left_t l LEFT JOIN right_t r ON l.id = r.id \

--- a/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
@@ -486,6 +486,7 @@ fn smj_join(
 /// - Left-side filters are pushed down to the left child
 /// - Right-side filters are pushed down to the right child
 /// - Cross-side filters (referencing both sides) remain as FilterExec
+///
 /// Also tests that non-Inner join types (Left) reject pushdown.
 #[test]
 fn test_static_filter_pushdown_through_sort_merge_join() {
@@ -582,7 +583,7 @@ fn test_static_filter_pushdown_through_sort_merge_join() {
     // The two adjacent FilterExec nodes get collapsed into a single combined predicate.
     insta::assert_snapshot!(
         OptimizationTest::new(plan, FilterPushdown::new(), true),
-        @r"
+        @"
     OptimizationTest:
       input:
         - FilterExec: e@4 = ba
@@ -592,9 +593,9 @@ fn test_static_filter_pushdown_through_sort_merge_join() {
         -       DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[d, e, f], file_type=test, pushdown_supported=true
       output:
         Ok:
-          - FilterExec: e@4 = ba AND a@0 = aa
+          - FilterExec: e@4 = ba
           -   SortMergeJoinExec: join_type=Left, on=[(a@0, d@0)]
-          -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=true
+          -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=true, predicate=a@0 = aa
           -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[d, e, f], file_type=test, pushdown_supported=true
     "
     );
@@ -671,11 +672,11 @@ async fn test_dynamic_filter_pushdown_through_sort_merge_join_with_topk() {
     // The TopK dynamic filter should pass through the SMJ to the right scan
     insta::assert_snapshot!(
         format_plan_for_test(&plan),
-        @r"
+        @"
     - SortExec: TopK(fetch=2), expr=[e@4 ASC], preserve_partitioning=[false]
-    -   SortMergeJoinExec: join_type=Inner, on=[(a@0, d@0)]
-    -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=true
-    -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[d, e, f], file_type=test, pushdown_supported=true, predicate=DynamicFilter [ empty ]
+    -   SortMergeJoinExec: join_type=Inner, on=[(a@0, d@0)], left_dynamic_filter=DynamicFilter [ empty ], right_dynamic_filter=DynamicFilter [ empty ]
+    -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=true, predicate=DynamicFilter [ empty ]
+    -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[d, e, f], file_type=test, pushdown_supported=true, predicate=DynamicFilter [ empty ] AND DynamicFilter [ empty ]
     "
     );
 
@@ -694,19 +695,72 @@ async fn test_dynamic_filter_pushdown_through_sort_merge_join_with_topk() {
     // After execution, the dynamic filter should be populated with actual bounds
     insta::assert_snapshot!(
         format_plan_for_test(&plan),
-        @r"
+        @"
     - SortExec: TopK(fetch=2), expr=[e@4 ASC], preserve_partitioning=[false], filter=[e@4 IS NULL OR e@4 < bb]
-    -   SortMergeJoinExec: join_type=Inner, on=[(a@0, d@0)]
-    -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=true
-    -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[d, e, f], file_type=test, pushdown_supported=true, predicate=DynamicFilter [ e@1 IS NULL OR e@1 < bb ]
+    -   SortMergeJoinExec: join_type=Inner, on=[(a@0, d@0)], left_dynamic_filter=DynamicFilter [ false ], right_dynamic_filter=DynamicFilter [ false ]
+    -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=true, predicate=DynamicFilter [ false ]
+    -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[d, e, f], file_type=test, pushdown_supported=true, predicate=DynamicFilter [ false ] AND DynamicFilter [ e@1 IS NULL OR e@1 < bb ]
     "
     );
 }
 
-/// Tests filter pushdown for all non-Inner join types to ensure they correctly
-/// reject pushdown (conservative behavior).
+/// Tests filter pushdown for Full join to ensure it correctly rejects pushdown.
 #[test]
-fn test_smj_filter_pushdown_non_inner_unsupported() {
+fn test_smj_filter_pushdown_unsupported() {
+    use datafusion_common::JoinType;
+
+    let left_schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Utf8, false),
+        Field::new("b", DataType::Utf8, false),
+    ]));
+    let right_schema = Arc::new(Schema::new(vec![
+        Field::new("c", DataType::Utf8, false),
+        Field::new("d", DataType::Utf8, false),
+    ]));
+
+    {
+        let join_type = JoinType::Full;
+        let left_scan = TestScanBuilder::new(Arc::clone(&left_schema))
+            .with_support(true)
+            .build();
+        let right_scan = TestScanBuilder::new(Arc::clone(&right_schema))
+            .with_support(true)
+            .build();
+        let on = vec![(
+            col("a", &left_schema).unwrap(),
+            col("c", &right_schema).unwrap(),
+        )];
+        let join = smj_join(left_scan, right_scan, on, join_type);
+
+        let join_schema = join.schema();
+        let filter_pred = col_lit_predicate("a", "x", &join_schema);
+        let plan = Arc::new(FilterExec::try_new(filter_pred, join).unwrap())
+            as Arc<dyn ExecutionPlan>;
+
+        let result = OptimizationTest::new(plan, FilterPushdown::new(), true);
+        let full_output = format!("{result}");
+        let output = full_output
+            .split("output:")
+            .nth(1)
+            .expect("Expected output section in result");
+
+        // The filter should remain as a FilterExec (not pushed into the scan)
+        assert!(
+            output.contains("FilterExec"),
+            "Expected FilterExec to remain for {join_type:?} join, got:\n{full_output}"
+        );
+        // The scan should NOT have a predicate
+        assert!(
+            !output.contains("predicate="),
+            "Expected no predicate pushdown for {join_type:?} join, got:\n{full_output}"
+        );
+    }
+}
+
+/// Tests filter pushdown for other non-Inner join types to ensure they correctly
+/// support pushdown for their preserved side.
+#[test]
+fn test_smj_filter_pushdown_supported() {
     use datafusion_common::JoinType;
 
     let left_schema = Arc::new(Schema::new(vec![
@@ -722,7 +776,6 @@ fn test_smj_filter_pushdown_non_inner_unsupported() {
     for join_type in [
         JoinType::Left,
         JoinType::Right,
-        JoinType::Full,
         JoinType::LeftSemi,
         JoinType::LeftAnti,
         JoinType::RightSemi,
@@ -744,7 +797,7 @@ fn test_smj_filter_pushdown_non_inner_unsupported() {
         // Pick a column from the join output; for semi/anti joins only
         // one side's columns are present
         let filter_col = match join_type {
-            JoinType::RightSemi | JoinType::RightAnti => "c",
+            JoinType::RightSemi | JoinType::RightAnti | JoinType::Right => "c",
             _ => "a",
         };
         let filter_pred = col_lit_predicate(filter_col, "x", &join_schema);
@@ -752,16 +805,21 @@ fn test_smj_filter_pushdown_non_inner_unsupported() {
             as Arc<dyn ExecutionPlan>;
 
         let result = OptimizationTest::new(plan, FilterPushdown::new(), true);
-        let output = format!("{result}");
-        // The filter should remain as a FilterExec (not pushed into the scan)
+        let full_output = format!("{result}");
+        let output = full_output
+            .split("output:")
+            .nth(1)
+            .expect("Expected output section in result");
+
+        // The filter should NOT remain as a FilterExec (pushed into the scan)
         assert!(
-            output.contains("FilterExec"),
-            "Expected FilterExec to remain for {join_type:?} join, got:\n{output}"
+            !output.contains("FilterExec"),
+            "Expected FilterExec to be pushed for {join_type:?} join, got:\n{full_output}"
         );
-        // The scan should NOT have a predicate
+        // The scan should HAVE a predicate
         assert!(
-            !output.contains("predicate="),
-            "Expected no predicate pushdown for {join_type:?} join, got:\n{output}"
+            output.contains("predicate="),
+            "Expected predicate pushdown for {join_type:?} join, got:\n{full_output}"
         );
     }
 }

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -277,7 +277,13 @@ impl ExecutionPlan for CoalesceBatchesExec {
         child_pushdown_result: ChildPushdownResult,
         _config: &ConfigOptions,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+        let mut result = FilterPushdownPropagation::if_all(child_pushdown_result);
+        if let Some(updated_child) = result.updated_node {
+            let mut new_self = self.clone();
+            new_self.input = updated_child;
+            result.updated_node = Some(Arc::new(new_self) as _);
+        }
+        Ok(result)
     }
 
     fn try_pushdown_sort(

--- a/datafusion/physical-plan/src/coop.rs
+++ b/datafusion/physical-plan/src/coop.rs
@@ -350,7 +350,12 @@ impl ExecutionPlan for CooperativeExec {
         child_pushdown_result: ChildPushdownResult,
         _config: &ConfigOptions,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+        let mut result = FilterPushdownPropagation::if_all(child_pushdown_result);
+        if let Some(updated_child) = result.updated_node {
+            result.updated_node =
+                Some(Arc::new(CooperativeExec::new(updated_child)) as _);
+        }
+        Ok(result)
     }
 
     fn try_pushdown_sort(

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -655,8 +655,14 @@ impl ExecutionPlan for FilterExec {
         child_pushdown_result: ChildPushdownResult,
         _config: &ConfigOptions,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        if phase != FilterPushdownPhase::Pre {
-            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
+        if !matches!(phase, FilterPushdownPhase::Pre) {
+            let mut result = FilterPushdownPropagation::if_all(child_pushdown_result);
+            if let Some(updated_child) = result.updated_node {
+                let mut new_self = self.clone();
+                new_self.input = updated_child;
+                result.updated_node = Some(Arc::new(new_self) as _);
+            }
+            return Ok(result);
         }
         // We absorb any parent filters that were not handled by our children
         let mut unsupported_parent_filters: Vec<Arc<dyn PhysicalExpr>> =

--- a/datafusion/physical-plan/src/filter_pushdown.rs
+++ b/datafusion/physical-plan/src/filter_pushdown.rs
@@ -444,13 +444,15 @@ impl ChildFilterDescription {
         })
     }
 
-    /// Mark all parent filters as unsupported for this child.
+    /// Create a child filter description where all parent filters are marked as unsupported,
+    /// and no self filters are pushed down.
     pub fn all_unsupported(parent_filters: &[Arc<dyn PhysicalExpr>]) -> Self {
+        let parent_filters = parent_filters
+            .iter()
+            .map(|f| PushedDownPredicate::unsupported(Arc::clone(f)))
+            .collect();
         Self {
-            parent_filters: parent_filters
-                .iter()
-                .map(|f| PushedDownPredicate::unsupported(Arc::clone(f)))
-                .collect(),
+            parent_filters,
             self_filters: vec![],
         }
     }

--- a/datafusion/physical-plan/src/joins/sort_merge_join/bitwise_stream.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/bitwise_stream.rs
@@ -126,6 +126,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use crate::RecordBatchStream;
+use crate::joins::sort_merge_join::shared_bounds::SharedSortMergeBoundsAccumulator;
 use crate::joins::utils::{JoinFilter, compare_join_arrays};
 use crate::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder,
@@ -320,6 +321,17 @@ pub(crate) struct BitwiseSortMergeJoinStream {
     baseline_metrics: BaselineMetrics,
     peak_mem_used: Gauge,
 
+    // ========================================================================
+    // DYNAMIC FILTER FIELDS:
+    // These fields manage dynamic filter pushdown.
+    // ========================================================================
+    /// Dynamic filter for the streamed side
+    pub streamed_dynamic_filter: Option<Arc<SharedSortMergeBoundsAccumulator>>,
+    /// Dynamic filter for the buffered side
+    pub buffered_dynamic_filter: Option<Arc<SharedSortMergeBoundsAccumulator>>,
+    /// Partition ID of this stream
+    pub partition: usize,
+
     // Memory / spill — only the inner key buffer is tracked via reservation,
     // matching existing SMJ (which tracks only the buffered side). The outer
     // batch is a single batch at a time and cannot be spilled.
@@ -355,6 +367,8 @@ impl BitwiseSortMergeJoinStream {
         reservation: MemoryReservation,
         spill_manager: SpillManager,
         runtime_env: Arc<datafusion_execution::runtime_env::RuntimeEnv>,
+        streamed_dynamic_filter: Option<Arc<SharedSortMergeBoundsAccumulator>>,
+        buffered_dynamic_filter: Option<Arc<SharedSortMergeBoundsAccumulator>>,
     ) -> Result<Self> {
         debug_assert!(
             matches!(
@@ -409,6 +423,9 @@ impl BitwiseSortMergeJoinStream {
             input_rows,
             baseline_metrics,
             peak_mem_used,
+            streamed_dynamic_filter,
+            buffered_dynamic_filter,
+            partition,
             reservation,
             spill_manager,
             runtime_env,
@@ -454,8 +471,23 @@ impl BitwiseSortMergeJoinStream {
     /// Poll for the next outer batch. Returns true if a batch was loaded.
     fn poll_next_outer_batch(&mut self, cx: &mut Context<'_>) -> Poll<Result<bool>> {
         loop {
+            // Report last join key before pulling next batch
+            if let Some(accumulator) = &self.buffered_dynamic_filter
+                && let Some(batch) = &self.outer_batch
+                && let Some(key) = self.outer_key_arrays.first().and_then(|arr| {
+                    ScalarValue::try_from_array(arr, batch.num_rows() - 1).ok()
+                })
+            {
+                accumulator.report_head(self.partition, key)?;
+            }
+
             match ready!(self.outer.poll_next_unpin(cx)) {
-                None => return Poll::Ready(Ok(false)),
+                None => {
+                    if let Some(accumulator) = &self.buffered_dynamic_filter {
+                        accumulator.mark_exhausted(self.partition)?;
+                    }
+                    return Poll::Ready(Ok(false));
+                }
                 Some(Err(e)) => return Poll::Ready(Err(e)),
                 Some(Ok(batch)) => {
                     let batch_num_rows = batch.num_rows();
@@ -465,6 +497,16 @@ impl BitwiseSortMergeJoinStream {
                         continue;
                     }
                     let keys = evaluate_join_keys(&batch, &self.on_outer)?;
+
+                    // Report first join key to the BUFFERED side's dynamic filter
+                    if let Some(accumulator) = &self.buffered_dynamic_filter
+                        && let Some(key) = keys
+                            .first()
+                            .and_then(|arr| ScalarValue::try_from_array(arr, 0).ok())
+                    {
+                        accumulator.report_head(self.partition, key)?;
+                    }
+
                     self.outer_batch = Some(batch);
                     self.outer_offset = 0;
                     self.outer_key_arrays = keys;
@@ -480,8 +522,23 @@ impl BitwiseSortMergeJoinStream {
     /// Poll for the next inner batch. Returns true if a batch was loaded.
     fn poll_next_inner_batch(&mut self, cx: &mut Context<'_>) -> Poll<Result<bool>> {
         loop {
+            // Report last join key before pulling next batch
+            if let Some(accumulator) = &self.streamed_dynamic_filter
+                && let Some(batch) = &self.inner_batch
+                && let Some(key) = self.inner_key_arrays.first().and_then(|arr| {
+                    ScalarValue::try_from_array(arr, batch.num_rows() - 1).ok()
+                })
+            {
+                accumulator.report_head(self.partition, key)?;
+            }
+
             match ready!(self.inner.poll_next_unpin(cx)) {
-                None => return Poll::Ready(Ok(false)),
+                None => {
+                    if let Some(accumulator) = &self.streamed_dynamic_filter {
+                        accumulator.mark_exhausted(self.partition)?;
+                    }
+                    return Poll::Ready(Ok(false));
+                }
                 Some(Err(e)) => return Poll::Ready(Err(e)),
                 Some(Ok(batch)) => {
                     let batch_num_rows = batch.num_rows();
@@ -491,6 +548,16 @@ impl BitwiseSortMergeJoinStream {
                         continue;
                     }
                     let keys = evaluate_join_keys(&batch, &self.on_inner)?;
+
+                    // Report first join key to the STREAMED side's dynamic filter
+                    if let Some(accumulator) = &self.streamed_dynamic_filter
+                        && let Some(key) = keys
+                            .first()
+                            .and_then(|arr| ScalarValue::try_from_array(arr, 0).ok())
+                    {
+                        accumulator.report_head(self.partition, key)?;
+                    }
+
                     self.inner_batch = Some(batch);
                     self.inner_offset = 0;
                     self.inner_key_arrays = keys;

--- a/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
@@ -21,8 +21,8 @@
 
 use std::any::Any;
 use std::collections::HashSet;
-use std::fmt::Formatter;
-use std::sync::Arc;
+use std::fmt::{Debug, Formatter};
+use std::sync::{Arc, OnceLock};
 
 use super::bitwise_stream::BitwiseSortMergeJoinStream;
 use super::materializing_stream::MaterializingSortMergeJoinStream;
@@ -33,6 +33,7 @@ use crate::filter_pushdown::{
     ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
     FilterPushdownPropagation,
 };
+use crate::joins::sort_merge_join::shared_bounds::SharedSortMergeBoundsAccumulator;
 use crate::joins::utils::{
     JoinFilter, JoinOn, JoinOnRef, build_join_schema, check_join_is_valid,
     estimate_join_statistics, reorder_output_after_swap,
@@ -60,6 +61,7 @@ use datafusion_common::{
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_physical_expr::equivalence::join_equivalence_properties;
+use datafusion_physical_expr::expressions::{DynamicFilterPhysicalExpr, lit};
 use datafusion_physical_expr_common::physical_expr::{
     PhysicalExpr, PhysicalExprRef, fmt_sql,
 };
@@ -113,7 +115,7 @@ use datafusion_physical_expr_common::sort_expr::{LexOrdering, OrderingRequiremen
 ///
 /// Helpful short video demonstration:
 /// <https://www.youtube.com/watch?v=jiWCPJtDE2c>.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SortMergeJoinExec {
     /// Left sorted joining execution plan
     pub left: Arc<dyn ExecutionPlan>,
@@ -139,6 +141,47 @@ pub struct SortMergeJoinExec {
     pub null_equality: NullEquality,
     /// Cache holding plan properties like equivalences, output partitioning etc.
     cache: Arc<PlanProperties>,
+    /// Dynamic filter for the left side
+    left_dynamic_filter: Option<SortMergeJoinExecDynamicFilter>,
+    /// Dynamic filter for the right side
+    right_dynamic_filter: Option<SortMergeJoinExecDynamicFilter>,
+}
+
+impl Debug for SortMergeJoinExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SortMergeJoinExec")
+            .field("left", &self.left)
+            .field("right", &self.right)
+            .field("on", &self.on)
+            .field("filter", &self.filter)
+            .field("join_type", &self.join_type)
+            .field("schema", &self.schema)
+            .field("metrics", &self.metrics)
+            .field("left_sort_exprs", &self.left_sort_exprs)
+            .field("right_sort_exprs", &self.right_sort_exprs)
+            .field("sort_options", &self.sort_options)
+            .field("null_equality", &self.null_equality)
+            .field("cache", &self.cache)
+            // Explicitly exclude dynamic_filter to avoid runtime state differences in tests
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+struct SortMergeJoinExecDynamicFilter {
+    /// Dynamic filter that we'll update with the results of the other side.
+    filter: Arc<DynamicFilterPhysicalExpr>,
+    /// Shared bounds accumulator to collect information from each partition.
+    /// It is lazily initialized during execution.
+    accumulator: Arc<OnceLock<Arc<SharedSortMergeBoundsAccumulator>>>,
+}
+
+impl Debug for SortMergeJoinExecDynamicFilter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SortMergeJoinExecDynamicFilter")
+            .field("filter", &self.filter)
+            .finish()
+    }
 }
 
 impl SortMergeJoinExec {
@@ -210,7 +253,55 @@ impl SortMergeJoinExec {
             sort_options,
             null_equality,
             cache: Arc::new(cache),
+            left_dynamic_filter: None,
+            right_dynamic_filter: None,
         })
+    }
+
+    fn allow_join_dynamic_filter_pushdown(&self, config: &ConfigOptions) -> bool {
+        if !matches!(
+            self.join_type,
+            JoinType::Inner | JoinType::LeftSemi | JoinType::RightSemi
+        ) || !config.optimizer.enable_join_dynamic_filter_pushdown
+        {
+            return false;
+        }
+
+        true
+    }
+
+    pub(crate) fn create_dynamic_filter(
+        on: &JoinOn,
+        side: JoinSide,
+    ) -> Arc<DynamicFilterPhysicalExpr> {
+        let keys = match side {
+            JoinSide::Left => on.iter().map(|(l, _)| Arc::clone(l)).collect::<Vec<_>>(),
+            JoinSide::Right => on.iter().map(|(_, r)| Arc::clone(r)).collect::<Vec<_>>(),
+            JoinSide::None => vec![],
+        };
+        Arc::new(DynamicFilterPhysicalExpr::new(keys, lit(true)))
+    }
+
+    pub fn with_left_dynamic_filter(
+        mut self,
+        dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
+    ) -> Self {
+        self.left_dynamic_filter = Some(SortMergeJoinExecDynamicFilter {
+            filter: dynamic_filter,
+            accumulator: Arc::new(OnceLock::new()),
+        });
+        self
+    }
+
+    pub fn with_right_dynamic_filter(
+        mut self,
+        dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
+    ) -> Self {
+        self.right_dynamic_filter = Some(SortMergeJoinExecDynamicFilter {
+            filter: dynamic_filter,
+            accumulator: Arc::new(OnceLock::new()),
+        });
+        self
     }
 
     /// Get probe side (e.g streaming side) information for this sort merge join.
@@ -385,9 +476,17 @@ impl DisplayAs for SortMergeJoinExec {
                     } else {
                         ""
                     };
+                let left_df = self.left_dynamic_filter.as_ref().map_or_else(
+                    || "".to_string(),
+                    |f| format!(", left_dynamic_filter={}", f.filter),
+                );
+                let right_df = self.right_dynamic_filter.as_ref().map_or_else(
+                    || "".to_string(),
+                    |f| format!(", right_dynamic_filter={}", f.filter),
+                );
                 write!(
                     f,
-                    "{}: join_type={:?}, on=[{}]{}{}",
+                    "{}: join_type={:?}, on=[{}]{}{}{}{}",
                     Self::static_name(),
                     self.join_type,
                     on,
@@ -396,6 +495,8 @@ impl DisplayAs for SortMergeJoinExec {
                         |f| format!(", filter={}", f.expression())
                     ),
                     display_null_equality,
+                    left_df,
+                    right_df,
                 )
             }
             DisplayFormatType::TreeRender => {
@@ -415,6 +516,13 @@ impl DisplayAs for SortMergeJoinExec {
 
                 if self.null_equality() == NullEquality::NullEqualsNull {
                     writeln!(f, "NullsEqual: true")?;
+                }
+
+                if let Some(filter) = &self.left_dynamic_filter {
+                    writeln!(f, "left_dynamic_filter={}", filter.filter)?;
+                }
+                if let Some(filter) = &self.right_dynamic_filter {
+                    writeln!(f, "right_dynamic_filter={}", filter.filter)?;
                 }
 
                 Ok(())
@@ -486,17 +594,47 @@ impl ExecutionPlan for SortMergeJoinExec {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         check_if_same_properties!(self, children);
         match &children[..] {
-            [left, right] => Ok(Arc::new(SortMergeJoinExec::try_new(
-                Arc::clone(left),
-                Arc::clone(right),
-                self.on.clone(),
-                self.filter.clone(),
-                self.join_type,
-                self.sort_options.clone(),
-                self.null_equality,
-            )?)),
+            [left, right] => {
+                let mut node = SortMergeJoinExec::try_new(
+                    Arc::clone(left),
+                    Arc::clone(right),
+                    self.on.clone(),
+                    self.filter.clone(),
+                    self.join_type,
+                    self.sort_options.clone(),
+                    self.null_equality,
+                )?;
+                node.left_dynamic_filter
+                    .clone_from(&self.left_dynamic_filter);
+                node.right_dynamic_filter
+                    .clone_from(&self.right_dynamic_filter);
+                Ok(Arc::new(node))
+            }
             _ => internal_err!("SortMergeJoin wrong number of children"),
         }
+    }
+
+    fn reset_state(self: Arc<Self>) -> Result<Arc<dyn ExecutionPlan>> {
+        let mut new_node = (*self).clone();
+
+        // Reset dynamic filters by creating new containers with fresh OnceLocks
+        if let Some(f) = &self.left_dynamic_filter {
+            new_node.left_dynamic_filter = Some(SortMergeJoinExecDynamicFilter {
+                filter: Arc::clone(&f.filter),
+                accumulator: Arc::new(OnceLock::new()),
+            });
+        }
+        if let Some(f) = &self.right_dynamic_filter {
+            new_node.right_dynamic_filter = Some(SortMergeJoinExecDynamicFilter {
+                filter: Arc::clone(&f.filter),
+                accumulator: Arc::new(OnceLock::new()),
+            });
+        }
+
+        // Reset metrics
+        new_node.metrics = ExecutionPlanMetricsSet::new();
+
+        Ok(Arc::new(new_node))
     }
 
     fn execute(
@@ -512,22 +650,58 @@ impl ExecutionPlan for SortMergeJoinExec {
             "Invalid SortMergeJoinExec, partition count mismatch {left_partitions}!={right_partitions},\
                  consider using RepartitionExec"
         );
-        let (on_left, on_right) = self.on.iter().cloned().unzip();
+        let (on_left, on_right): (Vec<_>, Vec<_>) = self.on.iter().cloned().unzip();
         let (streamed, buffered, on_streamed, on_buffered) =
             if SortMergeJoinExec::probe_side(&self.join_type) == JoinSide::Left {
                 (
                     Arc::clone(&self.left),
                     Arc::clone(&self.right),
-                    on_left,
-                    on_right,
+                    on_left.clone(),
+                    on_right.clone(),
                 )
             } else {
                 (
                     Arc::clone(&self.right),
                     Arc::clone(&self.left),
-                    on_right,
-                    on_left,
+                    on_right.clone(),
+                    on_left.clone(),
                 )
+            };
+
+        let metrics = SortMergeJoinMetrics::new(partition, &self.metrics);
+
+        // Initialize dynamic filters if they exist
+        let left_dynamic_filter = self.left_dynamic_filter.as_ref().map(|f| {
+            let accumulator = f.accumulator.get_or_init(|| {
+                Arc::new(SharedSortMergeBoundsAccumulator::new(
+                    left_partitions,
+                    self.sort_options[0],
+                    Arc::clone(&on_left[0]),
+                    Arc::clone(&f.filter),
+                    Some(metrics.dynamic_filter_updates()),
+                ))
+            });
+            Arc::clone(accumulator)
+        });
+
+        let right_dynamic_filter = self.right_dynamic_filter.as_ref().map(|f| {
+            let accumulator = f.accumulator.get_or_init(|| {
+                Arc::new(SharedSortMergeBoundsAccumulator::new(
+                    right_partitions,
+                    self.sort_options[0],
+                    Arc::clone(&on_right[0]),
+                    Arc::clone(&f.filter),
+                    Some(metrics.dynamic_filter_updates()),
+                ))
+            });
+            Arc::clone(accumulator)
+        });
+
+        let (streamed_dynamic_filter, buffered_dynamic_filter) =
+            if SortMergeJoinExec::probe_side(&self.join_type) == JoinSide::Left {
+                (left_dynamic_filter, right_dynamic_filter)
+            } else {
+                (right_dynamic_filter, left_dynamic_filter)
             };
 
         // execute children plans
@@ -569,6 +743,8 @@ impl ExecutionPlan for SortMergeJoinExec {
                 reservation,
                 spill_manager,
                 context.runtime_env(),
+                streamed_dynamic_filter,
+                buffered_dynamic_filter,
             )?))
         } else {
             Ok(Box::pin(MaterializingSortMergeJoinStream::try_new(
@@ -586,6 +762,9 @@ impl ExecutionPlan for SortMergeJoinExec {
                 reservation,
                 spill_manager,
                 context.runtime_env(),
+                streamed_dynamic_filter,
+                buffered_dynamic_filter,
+                partition,
             )?))
         }
     }
@@ -662,7 +841,7 @@ impl ExecutionPlan for SortMergeJoinExec {
             self.children()[1],
         )?;
 
-        Ok(Some(Arc::new(SortMergeJoinExec::try_new(
+        let mut node = SortMergeJoinExec::try_new(
             Arc::new(new_left),
             Arc::new(new_right),
             new_on,
@@ -670,46 +849,95 @@ impl ExecutionPlan for SortMergeJoinExec {
             self.join_type,
             self.sort_options.clone(),
             self.null_equality,
-        )?)))
+        )?;
+        node.left_dynamic_filter
+            .clone_from(&self.left_dynamic_filter);
+        node.right_dynamic_filter
+            .clone_from(&self.right_dynamic_filter);
+        Ok(Some(Arc::new(node)))
     }
 
     fn gather_filters_for_pushdown(
         &self,
-        _phase: FilterPushdownPhase,
+        phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
+        config: &ConfigOptions,
     ) -> Result<FilterDescription> {
-        // Only support Inner joins for now — other join types have complex
-        // column routing semantics (e.g. nullable sides, semi/anti output
-        // restrictions) that require careful handling.
-        if self.join_type != JoinType::Inner {
-            return Ok(FilterDescription::all_unsupported(
-                &parent_filters,
-                &self.children(),
-            ));
-        }
+        // This is the physical-plan equivalent of `push_down_all_join` in
+        // `datafusion/optimizer/src/push_down_filter.rs`.
+        //
+        // We determine which parent filters can be pushed down to which child based on two criteria:
+        // 1. **Column Preservation**: A side is "preserved" if its columns are present in the join output.
+        //    For example, in a `Left` join, the left side is preserved but the right side is not (right columns are null-padded).
+        //    We can only push filters to preserved sides because non-preserved sides may need all rows
+        //    to correctly produce null-padded matches.
+        // 2. **Column References**: `ChildFilterDescription::from_child` ensures that a filter is only
+        //    routed to a child if that child's schema contains all columns referenced by the filter.
+        let (left_preserved, right_preserved) = match self.join_type {
+            JoinType::Inner => (true, true),
+            JoinType::Left => (true, false),
+            JoinType::Right => (false, true),
+            JoinType::Full => (false, false),
+            JoinType::LeftSemi | JoinType::LeftAnti | JoinType::LeftMark => (true, false),
+            JoinType::RightSemi | JoinType::RightAnti | JoinType::RightMark => {
+                (false, true)
+            }
+        };
 
         // For Inner joins, the output schema is [left_cols..., right_cols...].
         // Build allowed index sets for each side so that
         // `from_child_with_allowed_indices` can route each parent filter to
         // the correct child based on column references.
-        let left_col_count = self.left.schema().fields().len();
-        let total_col_count = self.schema.fields().len();
+        let column_indices =
+            build_join_schema(&self.left.schema(), &self.right.schema(), &self.join_type)
+                .1;
+        let (mut left_allowed, mut right_allowed) = (HashSet::new(), HashSet::new());
+        column_indices
+            .iter()
+            .enumerate()
+            .for_each(|(output_idx, ci)| {
+                match ci.side {
+                    JoinSide::Left => left_allowed.insert(output_idx),
+                    JoinSide::Right => right_allowed.insert(output_idx),
+                    JoinSide::None => false,
+                };
+            });
 
-        let left_allowed: HashSet<usize> = (0..left_col_count).collect();
-        let right_allowed: HashSet<usize> = (left_col_count..total_col_count).collect();
+        let mut left_child = if left_preserved {
+            ChildFilterDescription::from_child_with_allowed_indices(
+                &parent_filters,
+                left_allowed,
+                &self.left,
+            )?
+        } else {
+            ChildFilterDescription::all_unsupported(&parent_filters)
+        };
 
-        let left_child = ChildFilterDescription::from_child_with_allowed_indices(
-            &parent_filters,
-            left_allowed,
-            &self.left,
-        )?;
+        let mut right_child = if right_preserved {
+            ChildFilterDescription::from_child_with_allowed_indices(
+                &parent_filters,
+                right_allowed,
+                &self.right,
+            )?
+        } else {
+            ChildFilterDescription::all_unsupported(&parent_filters)
+        };
 
-        let right_child = ChildFilterDescription::from_child_with_allowed_indices(
-            &parent_filters,
-            right_allowed,
-            &self.right,
-        )?;
+        // Add dynamic filters in Post phase if enabled
+        if matches!(phase, FilterPushdownPhase::Post)
+            && self.allow_join_dynamic_filter_pushdown(config)
+        {
+            if left_preserved {
+                let dynamic_filter =
+                    Self::create_dynamic_filter(&self.on, JoinSide::Left);
+                left_child = left_child.with_self_filter(dynamic_filter);
+            }
+            if right_preserved {
+                let dynamic_filter =
+                    Self::create_dynamic_filter(&self.on, JoinSide::Right);
+                right_child = right_child.with_self_filter(dynamic_filter);
+            }
+        }
 
         Ok(FilterDescription::new()
             .with_child(left_child)
@@ -722,6 +950,62 @@ impl ExecutionPlan for SortMergeJoinExec {
         child_pushdown_result: ChildPushdownResult,
         _config: &ConfigOptions,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        Ok(FilterPushdownPropagation::if_any(child_pushdown_result))
+        // This method performs the "Upward Handshake" of the physical optimizer.
+        // It receives the result of pushing filters down to our children and decides
+        // whether to update this node to reflect those changes.
+        let mut result: FilterPushdownPropagation<Arc<dyn ExecutionPlan>> =
+            FilterPushdownPropagation::if_any(child_pushdown_result.clone());
+        assert_eq!(child_pushdown_result.self_filters.len(), 2);
+
+        let left_child_self_filters = &child_pushdown_result.self_filters[0];
+        let right_child_self_filters = &child_pushdown_result.self_filters[1];
+
+        let mut node = (*self).clone();
+        let mut node_updated_with_filters = false;
+
+        // 1. Check if our children accepted the dynamic filters we generated in `gather_filters_for_pushdown`.
+        // If so, we store the filter reference in this node so we can update it during execution.
+        if let Some(filter) = left_child_self_filters.first() {
+            let predicate = Arc::clone(&filter.predicate);
+            if let Ok(dynamic_filter) =
+                Arc::downcast::<DynamicFilterPhysicalExpr>(predicate)
+            {
+                node = node.with_left_dynamic_filter(dynamic_filter);
+                node_updated_with_filters = true;
+            }
+        }
+
+        if let Some(filter) = right_child_self_filters.first() {
+            let predicate = Arc::clone(&filter.predicate);
+            if let Ok(dynamic_filter) =
+                Arc::downcast::<DynamicFilterPhysicalExpr>(predicate)
+            {
+                node = node.with_right_dynamic_filter(dynamic_filter);
+                node_updated_with_filters = true;
+            }
+        }
+
+        // 2. Determine the final updated node to return to the parent.
+        if let Some(updated_child_plan) = result.updated_node.take() {
+            // Case A: The optimizer rule already provided an updated version of this node
+            // (e.g., because children were replaced). We must ensure our dynamic filters
+            // are applied to that specific version to maintain the chain.
+            let mut final_node = updated_child_plan
+                .as_any()
+                .downcast_ref::<SortMergeJoinExec>()
+                .expect("updated_node must be SortMergeJoinExec")
+                .clone();
+
+            if node_updated_with_filters {
+                final_node.left_dynamic_filter = node.left_dynamic_filter;
+                final_node.right_dynamic_filter = node.right_dynamic_filter;
+            }
+            result.updated_node = Some(Arc::new(final_node) as _);
+        } else if node_updated_with_filters {
+            // Case B: Children didn't change, but we added dynamic filters to ourselves.
+            result.updated_node = Some(Arc::new(node) as _);
+        }
+
+        Ok(result)
     }
 }

--- a/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/exec.rs
@@ -20,6 +20,7 @@
 //! joined output by given join type and other options.
 
 use std::any::Any;
+use std::collections::HashSet;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
@@ -28,6 +29,10 @@ use super::materializing_stream::MaterializingSortMergeJoinStream;
 use super::metrics::SortMergeJoinMetrics;
 use crate::execution_plan::{EmissionType, boundedness_from_children};
 use crate::expressions::PhysicalSortExpr;
+use crate::filter_pushdown::{
+    ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
+    FilterPushdownPropagation,
+};
 use crate::joins::utils::{
     JoinFilter, JoinOn, JoinOnRef, build_join_schema, check_join_is_valid,
     estimate_join_statistics, reorder_output_after_swap,
@@ -46,6 +51,7 @@ use crate::{
 
 use arrow::compute::SortOptions;
 use arrow::datatypes::SchemaRef;
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{
     JoinSide, JoinType, NullEquality, Result, assert_eq_or_internal_err, internal_err,
@@ -54,7 +60,9 @@ use datafusion_common::{
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_physical_expr::equivalence::join_equivalence_properties;
-use datafusion_physical_expr_common::physical_expr::{PhysicalExprRef, fmt_sql};
+use datafusion_physical_expr_common::physical_expr::{
+    PhysicalExpr, PhysicalExprRef, fmt_sql,
+};
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, OrderingRequirements};
 
 /// Join execution plan that executes equi-join predicates on multiple partitions using Sort-Merge
@@ -457,7 +465,7 @@ impl ExecutionPlan for SortMergeJoinExec {
 
     fn apply_expressions(
         &self,
-        f: &mut dyn FnMut(&dyn crate::PhysicalExpr) -> Result<TreeNodeRecursion>,
+        f: &mut dyn FnMut(&dyn PhysicalExpr) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
         // Apply to join keys from both sides
         let mut tnr = TreeNodeRecursion::Continue;
@@ -663,5 +671,57 @@ impl ExecutionPlan for SortMergeJoinExec {
             self.sort_options.clone(),
             self.null_equality,
         )?)))
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        // Only support Inner joins for now — other join types have complex
+        // column routing semantics (e.g. nullable sides, semi/anti output
+        // restrictions) that require careful handling.
+        if self.join_type != JoinType::Inner {
+            return Ok(FilterDescription::all_unsupported(
+                &parent_filters,
+                &self.children(),
+            ));
+        }
+
+        // For Inner joins, the output schema is [left_cols..., right_cols...].
+        // Build allowed index sets for each side so that
+        // `from_child_with_allowed_indices` can route each parent filter to
+        // the correct child based on column references.
+        let left_col_count = self.left.schema().fields().len();
+        let total_col_count = self.schema.fields().len();
+
+        let left_allowed: HashSet<usize> = (0..left_col_count).collect();
+        let right_allowed: HashSet<usize> = (left_col_count..total_col_count).collect();
+
+        let left_child = ChildFilterDescription::from_child_with_allowed_indices(
+            &parent_filters,
+            left_allowed,
+            &self.left,
+        )?;
+
+        let right_child = ChildFilterDescription::from_child_with_allowed_indices(
+            &parent_filters,
+            right_allowed,
+            &self.right,
+        )?;
+
+        Ok(FilterDescription::new()
+            .with_child(left_child)
+            .with_child(right_child))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        Ok(FilterPushdownPropagation::if_any(child_pushdown_result))
     }
 }

--- a/datafusion/physical-plan/src/joins/sort_merge_join/materializing_stream.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/materializing_stream.rs
@@ -38,6 +38,7 @@ use crate::joins::sort_merge_join::filter::{
     get_filter_columns, needs_deferred_filtering,
 };
 use crate::joins::sort_merge_join::metrics::SortMergeJoinMetrics;
+use crate::joins::sort_merge_join::shared_bounds::SharedSortMergeBoundsAccumulator;
 use crate::joins::utils::{JoinFilter, compare_join_arrays};
 use crate::metrics::RecordOutput;
 use crate::spill::spill_manager::SpillManager;
@@ -52,7 +53,7 @@ use arrow::datatypes::{DataType, SchemaRef, TimeUnit};
 use arrow::ipc::reader::StreamReader;
 use datafusion_common::cast::as_uint64_array;
 use datafusion_common::{
-    JoinType, NullEquality, Result, exec_err, internal_err, not_impl_err,
+    JoinType, NullEquality, Result, ScalarValue, exec_err, internal_err, not_impl_err,
 };
 use datafusion_execution::disk_manager::RefCountedTempFile;
 use datafusion_execution::memory_pool::MemoryReservation;
@@ -202,6 +203,26 @@ impl StreamedBatch {
         }
         self.num_output_rows += 1;
     }
+
+    /// Returns the first join key value in this batch
+    fn first_join_key(&self) -> Option<ScalarValue> {
+        if self.batch.num_rows() == 0 {
+            return None;
+        }
+        self.join_arrays
+            .first()
+            .and_then(|arr| ScalarValue::try_from_array(arr, 0).ok())
+    }
+
+    /// Returns the last join key value in this batch
+    fn last_join_key(&self) -> Option<ScalarValue> {
+        if self.batch.num_rows() == 0 {
+            return None;
+        }
+        self.join_arrays.first().and_then(|arr| {
+            ScalarValue::try_from_array(arr, self.batch.num_rows() - 1).ok()
+        })
+    }
 }
 
 /// A buffered batch that contains contiguous rows with same join key
@@ -263,6 +284,26 @@ impl BufferedBatch {
             join_filter_not_matched_map: HashMap::new(),
             num_rows,
         }
+    }
+
+    /// Returns the first join key value in this batch
+    fn first_join_key(&self) -> Option<ScalarValue> {
+        if self.num_rows == 0 {
+            return None;
+        }
+        self.join_arrays
+            .first()
+            .and_then(|arr| ScalarValue::try_from_array(arr, 0).ok())
+    }
+
+    /// Returns the last join key value in this batch
+    fn last_join_key(&self) -> Option<ScalarValue> {
+        if self.num_rows == 0 {
+            return None;
+        }
+        self.join_arrays
+            .first()
+            .and_then(|arr| ScalarValue::try_from_array(arr, self.num_rows - 1).ok())
     }
 }
 
@@ -350,6 +391,17 @@ pub(super) struct MaterializingSortMergeJoinStream {
     pub current_ordering: Ordering,
     /// Manages the process of spilling and reading back intermediate data
     pub spill_manager: SpillManager,
+
+    // ========================================================================
+    // DYNAMIC FILTER FIELDS:
+    // These fields manage dynamic filter pushdown.
+    // ========================================================================
+    /// Dynamic filter for the streamed side
+    pub streamed_dynamic_filter: Option<Arc<SharedSortMergeBoundsAccumulator>>,
+    /// Dynamic filter for the buffered side
+    pub buffered_dynamic_filter: Option<Arc<SharedSortMergeBoundsAccumulator>>,
+    /// Partition ID of this stream
+    pub partition_id: usize,
 
     // ========================================================================
     // EXECUTION RESOURCES:
@@ -760,6 +812,9 @@ impl MaterializingSortMergeJoinStream {
         reservation: MemoryReservation,
         spill_manager: SpillManager,
         runtime_env: Arc<RuntimeEnv>,
+        streamed_dynamic_filter: Option<Arc<SharedSortMergeBoundsAccumulator>>,
+        buffered_dynamic_filter: Option<Arc<SharedSortMergeBoundsAccumulator>>,
+        partition_id: usize,
     ) -> Result<Self> {
         let streamed_schema = streamed.schema();
         let buffered_schema = buffered.schema();
@@ -804,6 +859,9 @@ impl MaterializingSortMergeJoinStream {
             runtime_env,
             spill_manager,
             streamed_batch_counter: AtomicUsize::new(0),
+            streamed_dynamic_filter,
+            buffered_dynamic_filter,
+            partition_id,
         })
     }
 
@@ -853,6 +911,12 @@ impl MaterializingSortMergeJoinStream {
                         self.streamed_state = StreamedState::Ready;
                         return Poll::Ready(Some(Ok(())));
                     } else {
+                        // Report last join key before pulling next batch
+                        if let Some(accumulator) = &self.buffered_dynamic_filter
+                            && let Some(key) = self.streamed_batch.last_join_key()
+                        {
+                            accumulator.report_head(self.partition_id, key)?;
+                        }
                         self.streamed_state = StreamedState::Polling;
                     }
                 }
@@ -862,6 +926,9 @@ impl MaterializingSortMergeJoinStream {
                     }
                     Poll::Ready(None) => {
                         self.streamed_state = StreamedState::Exhausted;
+                        if let Some(accumulator) = &self.buffered_dynamic_filter {
+                            accumulator.mark_exhausted(self.partition_id)?;
+                        }
                     }
                     Poll::Ready(Some(batch)) => {
                         if batch.num_rows() > 0 {
@@ -870,6 +937,14 @@ impl MaterializingSortMergeJoinStream {
                             self.join_metrics.input_rows().add(batch.num_rows());
                             self.streamed_batch =
                                 StreamedBatch::new(batch, &self.on_streamed);
+
+                            // Report first join key to the BUFFERED side's dynamic filter
+                            if let Some(accumulator) = &self.buffered_dynamic_filter
+                                && let Some(key) = self.streamed_batch.first_join_key()
+                            {
+                                accumulator.report_head(self.partition_id, key)?;
+                            }
+
                             // Every incoming streaming batch should have its unique id
                             // Check `JoinedRecordBatches.self.streamed_batch_counter` documentation
                             self.streamed_batch_counter
@@ -969,6 +1044,9 @@ impl MaterializingSortMergeJoinStream {
                     }
                     Poll::Ready(None) => {
                         self.buffered_state = BufferedState::Exhausted;
+                        if let Some(accumulator) = &self.streamed_dynamic_filter {
+                            accumulator.mark_exhausted(self.partition_id)?;
+                        }
                         return Poll::Ready(None);
                     }
                     Poll::Ready(Some(batch)) => {
@@ -978,6 +1056,13 @@ impl MaterializingSortMergeJoinStream {
                         if batch.num_rows() > 0 {
                             let buffered_batch =
                                 BufferedBatch::new(batch, 0..1, &self.on_buffered);
+
+                            // Report first join key to the STREAMED side's dynamic filter
+                            if let Some(accumulator) = &self.streamed_dynamic_filter
+                                && let Some(key) = buffered_batch.first_join_key()
+                            {
+                                accumulator.report_head(self.partition_id, key)?;
+                            }
 
                             self.allocate_reservation(buffered_batch)?;
                             self.buffered_state = BufferedState::PollingRest;
@@ -1004,12 +1089,23 @@ impl MaterializingSortMergeJoinStream {
                             }
                         }
                     } else {
+                        // Report last join key before pulling next batch
+                        if let Some(accumulator) = &self.streamed_dynamic_filter
+                            && let Some(key) =
+                                self.buffered_data.tail_batch().last_join_key()
+                        {
+                            accumulator.report_head(self.partition_id, key)?;
+                        }
+
                         match self.buffered.poll_next_unpin(cx)? {
                             Poll::Pending => {
                                 return Poll::Pending;
                             }
                             Poll::Ready(None) => {
                                 self.buffered_state = BufferedState::Ready;
+                                if let Some(accumulator) = &self.streamed_dynamic_filter {
+                                    accumulator.mark_exhausted(self.partition_id)?;
+                                }
                             }
                             Poll::Ready(Some(batch)) => {
                                 // Polling batches coming concurrently as multiple partitions
@@ -1021,6 +1117,16 @@ impl MaterializingSortMergeJoinStream {
                                         0..0,
                                         &self.on_buffered,
                                     );
+
+                                    // Report first join key to the STREAMED side's dynamic filter
+                                    if let Some(accumulator) =
+                                        &self.streamed_dynamic_filter
+                                        && let Some(key) = buffered_batch.first_join_key()
+                                    {
+                                        accumulator
+                                            .report_head(self.partition_id, key)?;
+                                    }
+
                                     self.allocate_reservation(buffered_batch)?;
                                 }
                             }

--- a/datafusion/physical-plan/src/joins/sort_merge_join/metrics.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/metrics.rs
@@ -35,6 +35,8 @@ pub(super) struct SortMergeJoinMetrics {
     /// Peak memory used for buffered data.
     /// Calculated as sum of peak memory values across partitions
     peak_mem_used: Gauge,
+    /// Number of times the dynamic filter was tightened
+    dynamic_filter_updates: Count,
 }
 
 impl SortMergeJoinMetrics {
@@ -49,6 +51,8 @@ impl SortMergeJoinMetrics {
         let peak_mem_used = MetricBuilder::new(metrics)
             .with_category(MetricCategory::Bytes)
             .gauge("peak_mem_used", partition);
+        let dynamic_filter_updates =
+            MetricBuilder::new(metrics).counter("dynamic_filter_updates", partition);
 
         let baseline_metrics = BaselineMetrics::new(metrics, partition);
 
@@ -58,6 +62,7 @@ impl SortMergeJoinMetrics {
             input_rows,
             baseline_metrics,
             peak_mem_used,
+            dynamic_filter_updates,
         }
     }
 
@@ -79,5 +84,9 @@ impl SortMergeJoinMetrics {
 
     pub fn peak_mem_used(&self) -> Gauge {
         self.peak_mem_used.clone()
+    }
+
+    pub fn dynamic_filter_updates(&self) -> Count {
+        self.dynamic_filter_updates.clone()
     }
 }

--- a/datafusion/physical-plan/src/joins/sort_merge_join/mod.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/mod.rs
@@ -24,6 +24,7 @@ mod exec;
 mod filter;
 pub(crate) mod materializing_stream;
 mod metrics;
+mod shared_bounds;
 
 #[cfg(test)]
 mod tests;

--- a/datafusion/physical-plan/src/joins/sort_merge_join/shared_bounds.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/shared_bounds.rs
@@ -1,0 +1,168 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shared bounds for Sort-Merge Join dynamic filter pushdown.
+
+use crate::metrics::Count;
+use arrow::compute::SortOptions;
+use datafusion_common::{Result, ScalarValue};
+use datafusion_expr::Operator;
+use datafusion_physical_expr::PhysicalExprRef;
+use datafusion_physical_expr::expressions::{BinaryExpr, DynamicFilterPhysicalExpr, lit};
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Coordinates dynamic filter updates for Sort-Merge Join across multiple partitions.
+///
+/// This accumulator implements "consensus of the slowest progress". A global bound
+/// is only published once all active partitions have reported at least one row,
+/// and it advances based on the minimum (for ascending) or maximum (for descending)
+/// of all current partition heads.
+#[derive(Debug)]
+pub(crate) struct SharedSortMergeBoundsAccumulator {
+    /// Shared state for all partitions.
+    state: Mutex<AccumulatorState>,
+    /// Dynamic filter to update.
+    dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
+    /// Sort options of the join key.
+    sort_options: SortOptions,
+    /// Join key expression on the side being filtered.
+    on_expr: PhysicalExprRef,
+    /// Metric to track number of filter updates.
+    metrics: Option<Count>,
+}
+
+#[derive(Debug)]
+struct AccumulatorState {
+    /// Current head values for each partition.
+    /// Index corresponds to the partition ID.
+    heads: Vec<Option<ScalarValue>>,
+    /// Whether each partition is exhausted.
+    exhausted: Vec<bool>,
+}
+
+impl SharedSortMergeBoundsAccumulator {
+    pub fn new(
+        num_partitions: usize,
+        sort_options: SortOptions,
+        on_expr: PhysicalExprRef,
+        dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
+        metrics: Option<Count>,
+    ) -> Self {
+        Self {
+            state: Mutex::new(AccumulatorState {
+                heads: vec![None; num_partitions],
+                exhausted: vec![false; num_partitions],
+            }),
+            dynamic_filter,
+            sort_options,
+            on_expr,
+            metrics,
+        }
+    }
+
+    /// Report current head value from a partition.
+    pub fn report_head(&self, partition_id: usize, head: ScalarValue) -> Result<()> {
+        let mut state = self.state.lock();
+        state.heads[partition_id] = Some(head);
+
+        self.update_filter(&state)
+    }
+
+    /// Mark a partition as exhausted.
+    pub fn mark_exhausted(&self, partition_id: usize) -> Result<()> {
+        let mut state = self.state.lock();
+        state.exhausted[partition_id] = true;
+
+        self.update_filter(&state)?;
+
+        // If all partitions are exhausted, we can mark the filter as complete.
+        if state.exhausted.iter().all(|&e| e) {
+            self.dynamic_filter.mark_complete();
+        }
+
+        Ok(())
+    }
+
+    /// Update the dynamic filter based on current heads.
+    fn update_filter(&self, state: &AccumulatorState) -> Result<()> {
+        // We only publish a bound if all non-exhausted partitions have reported a head.
+        let mut active_heads = Vec::new();
+        let mut any_active = false;
+
+        for (i, head) in state.heads.iter().enumerate() {
+            if !state.exhausted[i] {
+                any_active = true;
+                if let Some(h) = head {
+                    active_heads.push(h);
+                } else {
+                    // At least one active partition hasn't reported yet.
+                    return Ok(());
+                }
+            }
+        }
+
+        if !any_active {
+            // All partitions exhausted: sudden death.
+            // No more matches are possible, so we can prune everything.
+            return self.dynamic_filter.update(lit(false));
+        }
+
+        if active_heads.is_empty() {
+            // This case is reachable if all partitions were marked exhausted
+            // without ever reporting a head (e.g. empty inputs).
+            return self.dynamic_filter.update(lit(false));
+        }
+
+        // Calculate the consensus bound.
+        // For Ascending, it's the minimum of all active heads.
+        // For Descending, it's the maximum of all active heads.
+        let mut consensus = active_heads[0].clone();
+        for head in &active_heads[1..] {
+            if self.sort_options.descending {
+                if *head > &consensus {
+                    consensus = (*head).clone();
+                }
+            } else if *head < &consensus {
+                consensus = (*head).clone();
+            }
+        }
+
+        // Create the filter expression.
+        // For Ascending: col >= consensus
+        // For Descending: col <= consensus
+        let op = if self.sort_options.descending {
+            Operator::LtEq
+        } else {
+            Operator::GtEq
+        };
+
+        let filter_expr = Arc::new(BinaryExpr::new(
+            Arc::clone(&self.on_expr),
+            op,
+            lit(consensus.clone()),
+        ));
+
+        self.dynamic_filter.update(filter_expr)?;
+
+        if let Some(m) = &self.metrics {
+            m.add(1);
+        }
+
+        Ok(())
+    }
+}

--- a/datafusion/physical-plan/src/joins/sort_merge_join/tests.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/tests.rs
@@ -80,6 +80,491 @@ fn build_table(
     TestMemoryExec::try_new_exec(&[vec![batch]], schema, None).unwrap()
 }
 
+#[tokio::test]
+async fn test_sort_merge_join_dynamic_filter_initial_bound() -> Result<()> {
+    let left = build_table(
+        ("a1", &vec![10, 20, 30]),
+        ("b1", &vec![4, 5, 6]),
+        ("c1", &vec![7, 8, 9]),
+    );
+    let right = build_table(
+        ("a2", &vec![10, 25, 35]),
+        ("b2", &vec![4, 5, 6]),
+        ("c2", &vec![7, 8, 9]),
+    );
+
+    let on = vec![(
+        Arc::new(Column::new("a1", 0)) as _,
+        Arc::new(Column::new("a2", 0)) as _,
+    )];
+
+    let join = SortMergeJoinExec::try_new(
+        left,
+        right,
+        on.clone(),
+        None,
+        Inner,
+        vec![SortOptions::default()],
+        NullEquality::NullEqualsNothing,
+    )?;
+
+    // Create dynamic filters
+    let left_filter_expr = SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Left);
+    let right_filter_expr =
+        SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Right);
+
+    let left_filter_clone = Arc::clone(&left_filter_expr);
+    let right_filter_clone = Arc::clone(&right_filter_expr);
+
+    let join = join
+        .with_left_dynamic_filter(left_filter_expr)
+        .with_right_dynamic_filter(right_filter_expr);
+
+    let config = SessionConfig::new().with_batch_size(1);
+    let context = TaskContext::default().with_session_config(config);
+    let mut stream = join.execute(0, Arc::new(context))?;
+
+    // Before polling, filters should be empty
+    assert_eq!(format!("{left_filter_clone}"), "DynamicFilter [ empty ]");
+    assert_eq!(format!("{right_filter_clone}"), "DynamicFilter [ empty ]");
+
+    // Poll once to trigger initial batch reading
+    let _batch = stream.next().await.transpose()?;
+
+    // After polling, both sides should have reported their first values.
+    // Left side first value: 10 -> Right side filter: a2@0 >= 10
+    // Right side first value: 10 -> Left side filter: a1@0 >= 10
+    assert_eq!(
+        format!("{left_filter_clone}"),
+        "DynamicFilter [ a1@0 >= 10 ]"
+    );
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 10 ]"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sort_merge_join_dynamic_filter_progressive_tightening() -> Result<()> {
+    // Each row is in its own batch to trigger batch-boundary updates
+    let batch1 = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("a1", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(vec![10]))],
+    )?;
+    let batch2 = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("a1", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(vec![20]))],
+    )?;
+    let batch3 = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("a1", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(vec![30]))],
+    )?;
+    let batch4 = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("a1", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(vec![40]))],
+    )?;
+    let schema_left = batch1.schema();
+    let left = TestMemoryExec::try_new_exec(
+        &[vec![batch1, batch2, batch3, batch4]],
+        schema_left,
+        None,
+    )?;
+
+    let right_batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("a2", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(vec![10, 20, 30, 40]))],
+    )?;
+    let schema_right = right_batch.schema();
+    let right = TestMemoryExec::try_new_exec(&[vec![right_batch]], schema_right, None)?;
+
+    let on = vec![(
+        Arc::new(Column::new("a1", 0)) as _,
+        Arc::new(Column::new("a2", 0)) as _,
+    )];
+
+    let join = SortMergeJoinExec::try_new(
+        left,
+        right,
+        on.clone(),
+        None,
+        Inner,
+        vec![SortOptions::default()],
+        NullEquality::NullEqualsNothing,
+    )?;
+
+    let left_filter_expr = SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Left);
+    let right_filter_expr =
+        SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Right);
+
+    let left_filter_clone = Arc::clone(&left_filter_expr);
+    let right_filter_clone = Arc::clone(&right_filter_expr);
+
+    let join = join
+        .with_left_dynamic_filter(left_filter_expr)
+        .with_right_dynamic_filter(right_filter_expr);
+
+    let config = SessionConfig::new().with_batch_size(1);
+    let context = TaskContext::default().with_session_config(config);
+    let mut stream = join.execute(0, Arc::new(context))?;
+
+    // 1. Initial poll: reads first values (L:10, R:10)
+    // Produces match for 10
+    let _ = stream.next().await.transpose()?;
+    assert_eq!(
+        format!("{left_filter_clone}"),
+        "DynamicFilter [ a1@0 >= 10 ]"
+    );
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 10 ]"
+    );
+
+    // 2. Next poll: advances to batch 2 (Left: 20)
+    let _ = stream.next().await.transpose()?;
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 20 ]"
+    );
+
+    // 3. Next poll: advances to batch 3 (Left: 30)
+    let _ = stream.next().await.transpose()?;
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 30 ]"
+    );
+
+    // 4. Next poll: advances to batch 4 (Left: 40)
+    let _ = stream.next().await.transpose()?;
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 40 ]"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sort_merge_join_dynamic_filter_consensus() -> Result<()> {
+    // Partition 0: advances fast (10, 20, 30)
+    // Partition 1: advances slow (15, 16, 17)
+    let schema_left =
+        Arc::new(Schema::new(vec![Field::new("a1", DataType::Int32, false)]));
+    let left = TestMemoryExec::try_new_exec(
+        &[
+            vec![
+                RecordBatch::try_new(
+                    Arc::clone(&schema_left),
+                    vec![Arc::new(Int32Array::from(vec![10]))],
+                )?,
+                RecordBatch::try_new(
+                    Arc::clone(&schema_left),
+                    vec![Arc::new(Int32Array::from(vec![20]))],
+                )?,
+                RecordBatch::try_new(
+                    Arc::clone(&schema_left),
+                    vec![Arc::new(Int32Array::from(vec![30]))],
+                )?,
+            ],
+            vec![
+                RecordBatch::try_new(
+                    Arc::clone(&schema_left),
+                    vec![Arc::new(Int32Array::from(vec![15]))],
+                )?,
+                RecordBatch::try_new(
+                    Arc::clone(&schema_left),
+                    vec![Arc::new(Int32Array::from(vec![16]))],
+                )?,
+                RecordBatch::try_new(
+                    Arc::clone(&schema_left),
+                    vec![Arc::new(Int32Array::from(vec![17]))],
+                )?,
+            ],
+        ],
+        Arc::clone(&schema_left),
+        None,
+    )?;
+
+    // Right side: matching values for both partitions
+    let schema_right =
+        Arc::new(Schema::new(vec![Field::new("a2", DataType::Int32, false)]));
+    let right = TestMemoryExec::try_new_exec(
+        &[
+            vec![
+                RecordBatch::try_new(
+                    Arc::clone(&schema_right),
+                    vec![Arc::new(Int32Array::from(vec![10]))],
+                )?,
+                RecordBatch::try_new(
+                    Arc::clone(&schema_right),
+                    vec![Arc::new(Int32Array::from(vec![20]))],
+                )?,
+                RecordBatch::try_new(
+                    Arc::clone(&schema_right),
+                    vec![Arc::new(Int32Array::from(vec![30]))],
+                )?,
+            ],
+            vec![
+                RecordBatch::try_new(
+                    Arc::clone(&schema_right),
+                    vec![Arc::new(Int32Array::from(vec![15]))],
+                )?,
+                RecordBatch::try_new(
+                    Arc::clone(&schema_right),
+                    vec![Arc::new(Int32Array::from(vec![16]))],
+                )?,
+                RecordBatch::try_new(
+                    Arc::clone(&schema_right),
+                    vec![Arc::new(Int32Array::from(vec![17]))],
+                )?,
+            ],
+        ],
+        Arc::clone(&schema_right),
+        None,
+    )?;
+
+    let on = vec![(
+        Arc::new(Column::new("a1", 0)) as _,
+        Arc::new(Column::new("a2", 0)) as _,
+    )];
+
+    let join = SortMergeJoinExec::try_new(
+        left,
+        right,
+        on.clone(),
+        None,
+        Inner,
+        vec![SortOptions::default()],
+        NullEquality::NullEqualsNothing,
+    )?;
+
+    let right_filter_expr =
+        SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Right);
+    let right_filter_clone = Arc::clone(&right_filter_expr);
+
+    let join = join.with_right_dynamic_filter(right_filter_expr);
+
+    let config = SessionConfig::new().with_batch_size(1);
+    let context = Arc::new(TaskContext::default().with_session_config(config));
+
+    // Execute both partitions
+    let mut stream0 = join.execute(0, Arc::clone(&context))?;
+    let mut stream1 = join.execute(1, Arc::clone(&context))?;
+
+    // 1. Initial polls:
+    // P0 reads 10. Filter is still empty because P1 hasn't reported.
+    let _ = stream0.next().await.transpose()?;
+    assert_eq!(format!("{right_filter_clone}"), "DynamicFilter [ empty ]");
+
+    // P1 reads 15. Filter publishes min(10, 15) = 10.
+    let _ = stream1.next().await.transpose()?;
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 10 ]"
+    );
+
+    // 2. Advance P0 to 20.
+    // Filter remains 10 because P1 is still at 15. min(20, 15) = 10 (incorrect, wait)
+    // Wait, the logic is: min(all current heads).
+    // If P0 is at 20 and P1 is at 15, the global min is 15.
+    let _ = stream0.next().await.transpose()?;
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 15 ]"
+    );
+
+    // 3. Advance P0 to 30.
+    // Filter remains 15 because P1 is still at 15.
+    let _ = stream0.next().await.transpose()?;
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 15 ]"
+    );
+
+    // 4. Advance P1 to 16.
+    // Global min becomes 16.
+    let _ = stream1.next().await.transpose()?;
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 16 ]"
+    );
+
+    // 5. Exhaust P1.
+    // P1 was at 17 (last row).
+    let _ = stream1.next().await.transpose()?; // P1 reads 17
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 17 ]"
+    );
+
+    let _ = stream1.next().await.transpose()?; // P1 exhausted
+    // P1 is now removed from consensus. Filter uses P0's current head: 30.
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 30 ]"
+    );
+
+    // 6. Exhaust P0.
+    // Both sides exhausted -> Sudden Death.
+    let _ = stream0.next().await.transpose()?; // P0 reads 20
+    let _ = stream0.next().await.transpose()?; // P0 reads 30
+    let _ = stream0.next().await.transpose()?; // P0 exhausted
+    assert_eq!(format!("{right_filter_clone}"), "DynamicFilter [ false ]");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sort_merge_join_dynamic_filter_sudden_death_empty() -> Result<()> {
+    let left = TestMemoryExec::try_new_exec(
+        &[vec![]],
+        Arc::new(Schema::new(vec![Field::new("a1", DataType::Int32, false)])),
+        None,
+    )?;
+    let right = build_table(
+        ("a2", &vec![10, 20, 30]),
+        ("b2", &vec![4, 5, 6]),
+        ("c2", &vec![7, 8, 9]),
+    );
+
+    let on = vec![(
+        Arc::new(Column::new("a1", 0)) as _,
+        Arc::new(Column::new("a2", 0)) as _,
+    )];
+
+    let join = SortMergeJoinExec::try_new(
+        left,
+        right,
+        on.clone(),
+        None,
+        Inner,
+        vec![SortOptions::default()],
+        NullEquality::NullEqualsNothing,
+    )?;
+
+    let right_filter_expr =
+        SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Right);
+    let right_filter_clone = Arc::clone(&right_filter_expr);
+    let join = join.with_right_dynamic_filter(right_filter_expr);
+
+    let context = TaskContext::default();
+    let mut stream = join.execute(0, Arc::new(context))?;
+
+    // Poll to trigger execution. Left is empty, so it should immediately signal Sudden Death to Right.
+    let _ = stream.next().await.transpose()?;
+    assert_eq!(format!("{right_filter_clone}"), "DynamicFilter [ false ]");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sort_merge_join_dynamic_filter_descending() -> Result<()> {
+    // Both sides are sorted Descending
+    let schema_left =
+        Arc::new(Schema::new(vec![Field::new("a1", DataType::Int32, false)]));
+    let left = TestMemoryExec::try_new_exec(
+        &[vec![
+            RecordBatch::try_new(
+                Arc::clone(&schema_left),
+                vec![Arc::new(Int32Array::from(vec![30]))],
+            )?,
+            RecordBatch::try_new(
+                Arc::clone(&schema_left),
+                vec![Arc::new(Int32Array::from(vec![20]))],
+            )?,
+            RecordBatch::try_new(
+                Arc::clone(&schema_left),
+                vec![Arc::new(Int32Array::from(vec![10]))],
+            )?,
+        ]],
+        Arc::clone(&schema_left),
+        None,
+    )?;
+
+    let schema_right =
+        Arc::new(Schema::new(vec![Field::new("a2", DataType::Int32, false)]));
+    let right = TestMemoryExec::try_new_exec(
+        &[vec![
+            RecordBatch::try_new(
+                Arc::clone(&schema_right),
+                vec![Arc::new(Int32Array::from(vec![30]))],
+            )?,
+            RecordBatch::try_new(
+                Arc::clone(&schema_right),
+                vec![Arc::new(Int32Array::from(vec![20]))],
+            )?,
+            RecordBatch::try_new(
+                Arc::clone(&schema_right),
+                vec![Arc::new(Int32Array::from(vec![10]))],
+            )?,
+        ]],
+        Arc::clone(&schema_right),
+        None,
+    )?;
+
+    let on = vec![(
+        Arc::new(Column::new("a1", 0)) as _,
+        Arc::new(Column::new("a2", 0)) as _,
+    )];
+
+    let sort_options = SortOptions {
+        descending: true,
+        nulls_first: false,
+    };
+
+    let join = SortMergeJoinExec::try_new(
+        left,
+        right,
+        on.clone(),
+        None,
+        Inner,
+        vec![sort_options],
+        NullEquality::NullEqualsNothing,
+    )?;
+
+    let left_filter_expr = SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Left);
+    let right_filter_expr =
+        SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Right);
+
+    let left_filter_clone = Arc::clone(&left_filter_expr);
+    let right_filter_clone = Arc::clone(&right_filter_expr);
+
+    let join = join
+        .with_left_dynamic_filter(left_filter_expr)
+        .with_right_dynamic_filter(right_filter_expr);
+
+    let config = SessionConfig::new().with_batch_size(1);
+    let context = TaskContext::default().with_session_config(config);
+    let mut stream = join.execute(0, Arc::new(context))?;
+
+    // Poll once: L:30, R:30
+    // For Descending, we want matches <= global_max.
+    // Right side filter: a2 <= max(L_heads) = 30
+    // Left side filter: a1 <= max(R_heads) = 30
+    let _ = stream.next().await.transpose()?;
+    assert_eq!(
+        format!("{left_filter_clone}"),
+        "DynamicFilter [ a1@0 <= 20 ]"
+    );
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 <= 30 ]"
+    );
+
+    // Next poll:
+    let _ = stream.next().await.transpose()?;
+    assert_eq!(
+        format!("{left_filter_clone}"),
+        "DynamicFilter [ a1@0 <= 10 ]"
+    );
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 <= 20 ]"
+    );
+
+    Ok(())
+}
 fn build_table_from_batches(batches: Vec<RecordBatch>) -> Arc<dyn ExecutionPlan> {
     let schema = batches.first().unwrap().schema();
     TestMemoryExec::try_new_exec(&[batches], schema, None).unwrap()
@@ -3894,6 +4379,8 @@ async fn filter_buffer_pending_loses_inner_rows() -> Result<()> {
         reservation,
         spill_manager,
         runtime_env,
+        None,
+        None,
     )?;
 
     let batches = collect_stream(stream).await?;
@@ -3993,6 +4480,8 @@ async fn no_filter_boundary_pending_loses_outer_rows() -> Result<()> {
         reservation,
         spill_manager,
         runtime_env,
+        None,
+        None,
     )?;
 
     let batches = collect_stream(stream).await?;
@@ -4106,6 +4595,8 @@ async fn filtered_boundary_pending_outer_rows() -> Result<()> {
         reservation,
         spill_manager,
         runtime_env,
+        None,
+        None,
     )?;
 
     let batches = collect_stream(stream).await?;
@@ -4380,6 +4871,8 @@ async fn spill_filtered_boundary_loses_outer_rows() -> Result<()> {
             reservation,
             spill_manager,
             Arc::clone(&runtime),
+            None,
+            None,
         )?;
 
         let batches = collect_stream(stream).await?;
@@ -4403,6 +4896,70 @@ async fn spill_filtered_boundary_loses_outer_rows() -> Result<()> {
             _ => unreachable!(),
         }
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_bitwise_sort_merge_join_dynamic_filter() -> Result<()> {
+    let left = build_table(
+        ("a1", &vec![10, 20, 30]),
+        ("b1", &vec![4, 5, 6]),
+        ("c1", &vec![7, 8, 9]),
+    );
+    let right = build_table(
+        ("a2", &vec![10, 25, 35]),
+        ("b2", &vec![4, 5, 6]),
+        ("c2", &vec![7, 8, 9]),
+    );
+
+    let on = vec![(
+        Arc::new(Column::new("a1", 0)) as _,
+        Arc::new(Column::new("a2", 0)) as _,
+    )];
+
+    // LeftSemi join uses BitwiseSortMergeJoinStream
+    let join = SortMergeJoinExec::try_new(
+        left,
+        right,
+        on.clone(),
+        None,
+        LeftSemi,
+        vec![SortOptions::default()],
+        NullEquality::NullEqualsNothing,
+    )?;
+
+    let left_filter_expr = SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Left);
+    let right_filter_expr =
+        SortMergeJoinExec::create_dynamic_filter(&on, JoinSide::Right);
+
+    let left_filter_clone = Arc::clone(&left_filter_expr);
+    let right_filter_clone = Arc::clone(&right_filter_expr);
+
+    let join = join
+        .with_left_dynamic_filter(left_filter_expr)
+        .with_right_dynamic_filter(right_filter_expr);
+
+    let config = SessionConfig::new().with_batch_size(1);
+    let context = TaskContext::default().with_session_config(config);
+    let mut stream = join.execute(0, Arc::new(context))?;
+
+    // Before polling, filters should be empty
+    assert_eq!(format!("{left_filter_clone}"), "DynamicFilter [ empty ]");
+    assert_eq!(format!("{right_filter_clone}"), "DynamicFilter [ empty ]");
+
+    // Poll once to trigger initial batch reading
+    let _batch = stream.next().await.transpose()?;
+
+    // After polling, both sides should have reported their first values.
+    assert_eq!(
+        format!("{left_filter_clone}"),
+        "DynamicFilter [ a1@0 >= 10 ]"
+    );
+    assert_eq!(
+        format!("{right_filter_clone}"),
+        "DynamicFilter [ a2@0 >= 10 ]"
+    );
 
     Ok(())
 }

--- a/datafusion/physical-plan/src/limit.rs
+++ b/datafusion/physical-plan/src/limit.rs
@@ -28,6 +28,10 @@ use super::{
     SendableRecordBatchStream, Statistics,
 };
 use crate::execution_plan::{Boundedness, CardinalityEffect};
+use crate::filter_pushdown::{
+    ChildPushdownResult, FilterDescription, FilterPushdownPhase,
+    FilterPushdownPropagation,
+};
 use crate::{
     DisplayFormatType, Distribution, ExecutionPlan, Partitioning,
     check_if_same_properties,
@@ -35,6 +39,7 @@ use crate::{
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{Result, assert_eq_or_internal_err, internal_err};
 use datafusion_execution::TaskContext;
@@ -251,6 +256,32 @@ impl ExecutionPlan for GlobalLimitExec {
     fn supports_limit_pushdown(&self) -> bool {
         true
     }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let mut result = FilterPushdownPropagation::if_all(child_pushdown_result);
+        if let Some(updated_child) = result.updated_node {
+            result.updated_node = Some(Arc::new(GlobalLimitExec::new(
+                updated_child,
+                self.skip,
+                self.fetch,
+            )) as _);
+        }
+        Ok(result)
+    }
 }
 
 /// LocalLimitExec applies a limit to a single partition
@@ -435,6 +466,29 @@ impl ExecutionPlan for LocalLimitExec {
 
     fn cardinality_effect(&self) -> CardinalityEffect {
         CardinalityEffect::LowerEqual
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let mut result = FilterPushdownPropagation::if_all(child_pushdown_result);
+        if let Some(updated_child) = result.updated_node {
+            result.updated_node =
+                Some(Arc::new(LocalLimitExec::new(updated_child, self.fetch)) as _);
+        }
+        Ok(result)
     }
 }
 

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -433,7 +433,13 @@ impl ExecutionPlan for ProjectionExec {
         child_pushdown_result: ChildPushdownResult,
         _config: &ConfigOptions,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+        let mut result = FilterPushdownPropagation::if_all(child_pushdown_result);
+        if let Some(updated_child) = result.updated_node {
+            let mut new_self = self.clone();
+            new_self.input = updated_child;
+            result.updated_node = Some(Arc::new(new_self) as _);
+        }
+        Ok(result)
     }
 
     fn try_pushdown_sort(

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -1201,7 +1201,13 @@ impl ExecutionPlan for RepartitionExec {
         child_pushdown_result: ChildPushdownResult,
         _config: &ConfigOptions,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+        let mut result = FilterPushdownPropagation::if_all(child_pushdown_result);
+        if let Some(updated_child) = result.updated_node {
+            let mut new_self = self.clone();
+            new_self.input = updated_child;
+            result.updated_node = Some(Arc::new(new_self) as _);
+        }
+        Ok(result)
     }
 
     fn try_pushdown_sort(

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -32,7 +32,8 @@ use crate::execution_plan::{
 };
 use crate::expressions::PhysicalSortExpr;
 use crate::filter_pushdown::{
-    ChildFilterDescription, FilterDescription, FilterPushdownPhase,
+    ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
+    FilterPushdownPropagation,
 };
 use crate::limit::LimitStream;
 use crate::metrics::{
@@ -1429,6 +1430,21 @@ impl ExecutionPlan for SortExec {
         }
 
         Ok(FilterDescription::new().with_child(child))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &datafusion_common::config::ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let mut result = FilterPushdownPropagation::if_all(child_pushdown_result);
+        if let Some(updated_child) = result.updated_node {
+            let mut new_self = self.cloned();
+            new_self.input = updated_child;
+            result.updated_node = Some(Arc::new(new_self) as _);
+        }
+        Ok(result)
     }
 }
 

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -21,6 +21,10 @@ use std::any::Any;
 use std::sync::Arc;
 
 use crate::common::spawn_buffered;
+use crate::filter_pushdown::{
+    ChildPushdownResult, FilterDescription, FilterPushdownPhase,
+    FilterPushdownPropagation,
+};
 use crate::limit::LimitStream;
 use crate::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use crate::projection::{ProjectionExec, make_with_child, update_ordering};
@@ -31,6 +35,7 @@ use crate::{
     check_if_same_properties,
 };
 
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{Result, assert_eq_or_internal_err, internal_err};
 use datafusion_execution::TaskContext;
@@ -430,6 +435,35 @@ impl ExecutionPlan for SortPreservingMergeExec {
             )
             .with_fetch(self.fetch()),
         )))
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        Ok(FilterDescription::new().with_child(
+            crate::filter_pushdown::ChildFilterDescription::from_child(
+                &parent_filters,
+                &self.input,
+            )?,
+        ))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let mut result = FilterPushdownPropagation::if_all(child_pushdown_result);
+        if let Some(updated_child) = result.updated_node {
+            let mut new_self = self.clone();
+            new_self.input = updated_child;
+            result.updated_node = Some(Arc::new(new_self) as _);
+        }
+        Ok(result)
     }
 }
 

--- a/datafusion/sqllogictest/test_files/dynamic_filter_pushdown_config.slt
+++ b/datafusion/sqllogictest/test_files/dynamic_filter_pushdown_config.slt
@@ -787,6 +787,117 @@ DROP TABLE t1_20213;
 statement ok
 DROP TABLE t2_20213;
 
+# Test 7: SortMergeJoin dynamic filter pushdown
+# When prefer_hash_join is false, the planner uses SortMergeJoinExec.
+# Dynamic filters (from TopK) should pass through SMJ to reach scan nodes.
+
+statement ok
+SET datafusion.optimizer.prefer_hash_join = false;
+
+# TopK dynamic filter should propagate through SortMergeJoinExec to the probe side scan.
+query TT
+EXPLAIN SELECT l.*, r.info
+FROM left_parquet l
+INNER JOIN right_parquet r ON l.id = r.id
+ORDER BY l.id LIMIT 2;
+----
+logical_plan
+01)Sort: l.id ASC NULLS LAST, fetch=2
+02)--Projection: l.id, l.data, r.info
+03)----Inner Join: l.id = r.id
+04)------SubqueryAlias: l
+05)--------TableScan: left_parquet projection=[id, data]
+06)------SubqueryAlias: r
+07)--------TableScan: right_parquet projection=[id, info]
+physical_plan
+01)SortExec: TopK(fetch=2), expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
+02)--ProjectionExec: expr=[id@0 as id, data@1 as data, info@3 as info]
+03)----SortMergeJoinExec: join_type=Inner, on=[(id@0, id@0)]
+04)------SortExec: expr=[id@0 ASC], preserve_partitioning=[false]
+05)--------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/dynamic_filter_pushdown_config/join_left.parquet]]}, projection=[id, data], file_type=parquet, predicate=DynamicFilter [ empty ]
+06)------SortExec: expr=[id@0 ASC], preserve_partitioning=[false]
+07)--------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/dynamic_filter_pushdown_config/join_right.parquet]]}, projection=[id, info], file_type=parquet
+
+# Correctness check: same results regardless of join strategy
+query ITT
+SELECT l.*, r.info
+FROM left_parquet l
+INNER JOIN right_parquet r ON l.id = r.id
+ORDER BY l.id LIMIT 2;
+----
+1 left1 right1
+3 left3 right3
+
+# TopK on a non-key column: dynamic filter on right-side column pushed through SMJ
+query TT
+EXPLAIN SELECT l.id, l.data, r.info
+FROM left_parquet l
+INNER JOIN right_parquet r ON l.id = r.id
+ORDER BY r.info LIMIT 2;
+----
+logical_plan
+01)Sort: r.info ASC NULLS LAST, fetch=2
+02)--Projection: l.id, l.data, r.info
+03)----Inner Join: l.id = r.id
+04)------SubqueryAlias: l
+05)--------TableScan: left_parquet projection=[id, data]
+06)------SubqueryAlias: r
+07)--------TableScan: right_parquet projection=[id, info]
+physical_plan
+01)SortExec: TopK(fetch=2), expr=[info@2 ASC NULLS LAST], preserve_partitioning=[false]
+02)--ProjectionExec: expr=[id@0 as id, data@1 as data, info@3 as info]
+03)----SortMergeJoinExec: join_type=Inner, on=[(id@0, id@0)]
+04)------SortExec: expr=[id@0 ASC], preserve_partitioning=[false]
+05)--------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/dynamic_filter_pushdown_config/join_left.parquet]]}, projection=[id, data], file_type=parquet
+06)------SortExec: expr=[id@0 ASC], preserve_partitioning=[false]
+07)--------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/dynamic_filter_pushdown_config/join_right.parquet]]}, projection=[id, info], file_type=parquet, predicate=DynamicFilter [ empty ]
+
+query ITT
+SELECT l.id, l.data, r.info
+FROM left_parquet l
+INNER JOIN right_parquet r ON l.id = r.id
+ORDER BY r.info LIMIT 2;
+----
+1 left1 right1
+3 left3 right3
+
+# Non-inner joins: no dynamic filter pushdown through SMJ (conservative)
+query TT
+EXPLAIN SELECT l.*, r.info
+FROM left_parquet l
+LEFT JOIN right_parquet r ON l.id = r.id
+ORDER BY l.id LIMIT 2;
+----
+logical_plan
+01)Sort: l.id ASC NULLS LAST, fetch=2
+02)--Projection: l.id, l.data, r.info
+03)----Left Join: l.id = r.id
+04)------SubqueryAlias: l
+05)--------TableScan: left_parquet projection=[id, data]
+06)------SubqueryAlias: r
+07)--------TableScan: right_parquet projection=[id, info]
+physical_plan
+01)SortExec: TopK(fetch=2), expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
+02)--ProjectionExec: expr=[id@0 as id, data@1 as data, info@3 as info]
+03)----SortMergeJoinExec: join_type=Left, on=[(id@0, id@0)]
+04)------SortExec: expr=[id@0 ASC], preserve_partitioning=[false]
+05)--------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/dynamic_filter_pushdown_config/join_left.parquet]]}, projection=[id, data], file_type=parquet
+06)------SortExec: expr=[id@0 ASC], preserve_partitioning=[false]
+07)--------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/dynamic_filter_pushdown_config/join_right.parquet]]}, projection=[id, info], file_type=parquet
+
+# LEFT JOIN correctness
+query ITT
+SELECT l.*, r.info
+FROM left_parquet l
+LEFT JOIN right_parquet r ON l.id = r.id
+ORDER BY l.id LIMIT 2;
+----
+1 left1 right1
+2 left2 NULL
+
+statement ok
+SET datafusion.optimizer.prefer_hash_join = true;
+
 # Cleanup
 
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20443.

## Rationale for this change

This change fixes #20443, and adds support for generating dynamic filters for the left and right sides of a `SortMergeJoin`, in order to allow for range-based pruning of both sides of the join. Some consumers of the dynamic filter may even be able to seek/skip ahead on their inputs.

## What changes are included in this PR?

To allow `SortMergeJoin` to actually propagate dynamic filters down to scans and get things working end to end, it was necessary to fix the `handle_child_pushdown_result` implementations of a variety of nodes which were failing to clone and update themselves.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

Explain will now show dynamic filters for `SortMergeJoin`, and for the scans that they consume.
