### PR TITLE
chore: fix upgrade guide link for object_store release notes

### DIFF
--- a/docs/source/library-user-guide/upgrading/53.0.0.md
+++ b/docs/source/library-user-guide/upgrading/53.0.0.md
@@ -37,7 +37,7 @@ these crates.
 See the [Arrow 58.0.0 release notes] and the [object_store 0.13.0 upgrade guide] for details on breaking changes in those versions.
 
 [arrow 58.0.0 release notes]: https://github.com/apache/arrow-rs/releases/tag/58.0.0
-[object_store 0.13.0 upgrade guide]: https://github.com/apache/arrow-rs/releases/tag/58.0.0
+[object_store 0.13.0 upgrade guide]: https://github.com/apache/arrow-rs-object-store/blob/v0.13.0/CHANGELOG.md
 
 ### `ExecutionPlan::properties` now returns `&Arc<PlanProperties>`
 


### PR DESCRIPTION
fix object_store release notes link in datafusion 53 upgrade guide

find this when i try upgrade datafusion to 53