### PR TITLE
optimizer: extract null-restriction evaluator and add syntactic fast-path with focused tests

### DIFF
--- a/datafusion/core/benches/sql_planner_extended.rs
+++ b/datafusion/core/benches/sql_planner_extended.rs
@@ -18,30 +18,20 @@
 use arrow::array::{ArrayRef, RecordBatch};
 use arrow_schema::DataType;
 use arrow_schema::TimeUnit::Nanosecond;
-use criterion::{
-    BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
-    measurement::WallTime,
-};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion_catalog::MemTable;
-use datafusion_common::{Column, ScalarValue};
+use datafusion_common::ScalarValue;
 use datafusion_expr::Expr::Literal;
-use datafusion_expr::logical_plan::LogicalPlan;
-use datafusion_expr::utils::split_conjunction_owned;
 use datafusion_expr::{cast, col, lit, not, try_cast, when};
 use datafusion_functions::expr_fn::{
     btrim, length, regexp_like, regexp_replace, to_timestamp, upper,
 };
-use std::env;
 use std::fmt::Write;
 use std::hint::black_box;
 use std::ops::Rem;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
-
-const FULL_PREDICATE_SWEEP: [usize; 5] = [10, 20, 30, 40, 60];
-const FULL_DEPTH_SWEEP: [usize; 3] = [1, 2, 3];
-const DEFAULT_SWEEP_POINTS: [(usize, usize); 3] = [(10, 1), (30, 2), (60, 3)];
 
 // This benchmark suite is designed to test the performance of
 // logical planning with a large plan containing unions, many columns
@@ -228,9 +218,7 @@ fn build_test_data_frame(ctx: &SessionContext, rt: &Runtime) -> DataFrame {
 fn build_case_heavy_left_join_df(ctx: &SessionContext, rt: &Runtime) -> DataFrame {
     register_string_table(ctx, 100, 1000);
     let query = build_case_heavy_left_join_query(30, 1);
-    let df = rt.block_on(async { ctx.sql(&query).await.unwrap() });
-    assert_case_heavy_left_join_inference_candidates(&df, 30);
-    df
+    rt.block_on(async { ctx.sql(&query).await.unwrap() })
 }
 
 fn build_case_heavy_left_join_query(predicate_count: usize, case_depth: usize) -> String {
@@ -249,17 +237,12 @@ fn build_case_heavy_left_join_query(predicate_count: usize, case_depth: usize) -
             query.push_str(" AND ");
         }
 
-        let left_payload_col = (i % 19) + 1;
-        let right_payload_col = ((i + 7) % 19) + 1;
-        let mut expr = format!(
-            "CASE WHEN l.c0 IS NOT NULL THEN length(l.c{left_payload_col}) ELSE length(r.c{right_payload_col}) END"
-        );
+        let mut expr = format!("length(l.c{})", i % 20);
         for depth in 0..case_depth {
-            let left_col = ((i + depth + 3) % 19) + 1;
-            let right_col = ((i + depth + 11) % 19) + 1;
-            let join_key_ref = if (i + depth) % 2 == 0 { "l.c0" } else { "r.c0" };
+            let left_col = (i + depth + 1) % 20;
+            let right_col = (i + depth + 2) % 20;
             expr = format!(
-                "CASE WHEN {join_key_ref} IS NOT NULL THEN {expr} ELSE CASE WHEN l.c{left_col} IS NOT NULL THEN length(l.c{left_col}) ELSE length(r.c{right_col}) END END"
+                "CASE WHEN l.c{left_col} IS NOT NULL THEN {expr} ELSE length(r.c{right_col}) END"
             );
         }
 
@@ -267,6 +250,26 @@ fn build_case_heavy_left_join_query(predicate_count: usize, case_depth: usize) -
     }
 
     query
+}
+
+fn build_case_heavy_left_join_df_with_push_down_filter(
+    rt: &Runtime,
+    predicate_count: usize,
+    case_depth: usize,
+    push_down_filter_enabled: bool,
+) -> DataFrame {
+    let ctx = SessionContext::new();
+    register_string_table(&ctx, 100, 1000);
+    if !push_down_filter_enabled {
+        let removed = ctx.remove_optimizer_rule("push_down_filter");
+        assert!(
+            removed,
+            "push_down_filter rule should be present in the default optimizer"
+        );
+    }
+
+    let query = build_case_heavy_left_join_query(predicate_count, case_depth);
+    rt.block_on(async { ctx.sql(&query).await.unwrap() })
 }
 
 fn build_non_case_left_join_query(
@@ -301,11 +304,10 @@ fn build_non_case_left_join_query(
     query
 }
 
-fn build_left_join_df_with_push_down_filter(
+fn build_non_case_left_join_df_with_push_down_filter(
     rt: &Runtime,
-    query_builder: impl Fn(usize, usize) -> String,
     predicate_count: usize,
-    depth: usize,
+    nesting_depth: usize,
     push_down_filter_enabled: bool,
 ) -> DataFrame {
     let ctx = SessionContext::new();
@@ -318,136 +320,8 @@ fn build_left_join_df_with_push_down_filter(
         );
     }
 
-    let query = query_builder(predicate_count, depth);
+    let query = build_non_case_left_join_query(predicate_count, nesting_depth);
     rt.block_on(async { ctx.sql(&query).await.unwrap() })
-}
-
-fn build_case_heavy_left_join_df_with_push_down_filter(
-    rt: &Runtime,
-    predicate_count: usize,
-    case_depth: usize,
-    push_down_filter_enabled: bool,
-) -> DataFrame {
-    let df = build_left_join_df_with_push_down_filter(
-        rt,
-        build_case_heavy_left_join_query,
-        predicate_count,
-        case_depth,
-        push_down_filter_enabled,
-    );
-    assert_case_heavy_left_join_inference_candidates(&df, predicate_count);
-    df
-}
-
-fn build_non_case_left_join_df_with_push_down_filter(
-    rt: &Runtime,
-    predicate_count: usize,
-    nesting_depth: usize,
-    push_down_filter_enabled: bool,
-) -> DataFrame {
-    build_left_join_df_with_push_down_filter(
-        rt,
-        build_non_case_left_join_query,
-        predicate_count,
-        nesting_depth,
-        push_down_filter_enabled,
-    )
-}
-
-fn find_filter_predicates(plan: &LogicalPlan) -> Vec<datafusion_expr::Expr> {
-    match plan {
-        LogicalPlan::Filter(filter) => split_conjunction_owned(filter.predicate.clone()),
-        LogicalPlan::Projection(projection) => find_filter_predicates(projection.input.as_ref()),
-        other => panic!("expected benchmark query plan to contain a Filter, found {other:?}"),
-    }
-}
-
-fn assert_case_heavy_left_join_inference_candidates(
-    df: &DataFrame,
-    expected_predicate_count: usize,
-) {
-    let predicates = find_filter_predicates(df.logical_plan());
-    assert_eq!(predicates.len(), expected_predicate_count);
-
-    let left_join_key = Column::from_qualified_name("l.c0");
-    let right_join_key = Column::from_qualified_name("r.c0");
-
-    for predicate in predicates {
-        let column_refs = predicate.column_refs();
-        assert!(
-            column_refs.contains(&&left_join_key) || column_refs.contains(&&right_join_key),
-            "benchmark predicate should reference a join key: {predicate}"
-        );
-        assert!(
-            column_refs
-                .iter()
-                .any(|col| **col != left_join_key && **col != right_join_key),
-            "benchmark predicate should reference a non-join column: {predicate}"
-        );
-    }
-}
-
-fn include_full_push_down_filter_sweep() -> bool {
-    env::var("DATAFUSION_PUSH_DOWN_FILTER_FULL_SWEEP")
-        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
-
-fn push_down_filter_sweep_points() -> Vec<(usize, usize)> {
-    if include_full_push_down_filter_sweep() {
-        FULL_DEPTH_SWEEP
-            .into_iter()
-            .flat_map(|depth| {
-                FULL_PREDICATE_SWEEP
-                    .into_iter()
-                    .map(move |predicate_count| (predicate_count, depth))
-            })
-            .collect()
-    } else {
-        DEFAULT_SWEEP_POINTS.to_vec()
-    }
-}
-
-fn bench_push_down_filter_ab<BuildFn>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
-    rt: &Runtime,
-    sweep_points: &[(usize, usize)],
-    build_df: BuildFn,
-) where
-    BuildFn: Fn(&Runtime, usize, usize, bool) -> DataFrame,
-{
-    for &(predicate_count, depth) in sweep_points {
-        let with_push_down_filter = build_df(rt, predicate_count, depth, true);
-        let without_push_down_filter = build_df(rt, predicate_count, depth, false);
-
-        let input_label = format!("predicates={predicate_count},nesting_depth={depth}");
-
-        group.bench_with_input(
-            BenchmarkId::new("with_push_down_filter", &input_label),
-            &with_push_down_filter,
-            |b, df| {
-                b.iter(|| {
-                    let df_clone = df.clone();
-                    black_box(
-                        rt.block_on(async { df_clone.into_optimized_plan().unwrap() }),
-                    );
-                })
-            },
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("without_push_down_filter", &input_label),
-            &without_push_down_filter,
-            |b, df| {
-                b.iter(|| {
-                    let df_clone = df.clone();
-                    black_box(
-                        rt.block_on(async { df_clone.into_optimized_plan().unwrap() }),
-                    );
-                })
-            },
-        );
-    }
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -475,40 +349,116 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    let sweep_points = push_down_filter_sweep_points();
+    let predicate_sweep = [10, 20, 30, 40, 60];
+    let case_depth_sweep = [1, 2, 3];
 
     let mut hotspot_group =
         c.benchmark_group("push_down_filter_hotspot_case_heavy_left_join_ab");
-    bench_push_down_filter_ab(
-        &mut hotspot_group,
-        &rt,
-        &sweep_points,
-        |rt, predicate_count, depth, enable| {
-            build_case_heavy_left_join_df_with_push_down_filter(
-                rt,
-                predicate_count,
-                depth,
-                enable,
-            )
-        },
-    );
+    for case_depth in case_depth_sweep {
+        for predicate_count in predicate_sweep {
+            let with_push_down_filter =
+                build_case_heavy_left_join_df_with_push_down_filter(
+                    &rt,
+                    predicate_count,
+                    case_depth,
+                    true,
+                );
+            let without_push_down_filter =
+                build_case_heavy_left_join_df_with_push_down_filter(
+                    &rt,
+                    predicate_count,
+                    case_depth,
+                    false,
+                );
+
+            let input_label =
+                format!("predicates={predicate_count},case_depth={case_depth}");
+            // A/B interpretation:
+            // - with_push_down_filter: default optimizer path (rule enabled)
+            // - without_push_down_filter: control path with the rule removed
+            // Compare both IDs at the same sweep point to isolate rule impact.
+            hotspot_group.bench_with_input(
+                BenchmarkId::new("with_push_down_filter", &input_label),
+                &with_push_down_filter,
+                |b, df| {
+                    b.iter(|| {
+                        let df_clone = df.clone();
+                        black_box(
+                            rt.block_on(async {
+                                df_clone.into_optimized_plan().unwrap()
+                            }),
+                        );
+                    })
+                },
+            );
+            hotspot_group.bench_with_input(
+                BenchmarkId::new("without_push_down_filter", &input_label),
+                &without_push_down_filter,
+                |b, df| {
+                    b.iter(|| {
+                        let df_clone = df.clone();
+                        black_box(
+                            rt.block_on(async {
+                                df_clone.into_optimized_plan().unwrap()
+                            }),
+                        );
+                    })
+                },
+            );
+        }
+    }
     hotspot_group.finish();
 
     let mut control_group =
         c.benchmark_group("push_down_filter_control_non_case_left_join_ab");
-    bench_push_down_filter_ab(
-        &mut control_group,
-        &rt,
-        &sweep_points,
-        |rt, predicate_count, depth, enable| {
-            build_non_case_left_join_df_with_push_down_filter(
-                rt,
+    for nesting_depth in case_depth_sweep {
+        for predicate_count in predicate_sweep {
+            let with_push_down_filter = build_non_case_left_join_df_with_push_down_filter(
+                &rt,
                 predicate_count,
-                depth,
-                enable,
-            )
-        },
-    );
+                nesting_depth,
+                true,
+            );
+            let without_push_down_filter =
+                build_non_case_left_join_df_with_push_down_filter(
+                    &rt,
+                    predicate_count,
+                    nesting_depth,
+                    false,
+                );
+
+            let input_label =
+                format!("predicates={predicate_count},nesting_depth={nesting_depth}");
+            control_group.bench_with_input(
+                BenchmarkId::new("with_push_down_filter", &input_label),
+                &with_push_down_filter,
+                |b, df| {
+                    b.iter(|| {
+                        let df_clone = df.clone();
+                        black_box(
+                            rt.block_on(async {
+                                df_clone.into_optimized_plan().unwrap()
+                            }),
+                        );
+                    })
+                },
+            );
+            control_group.bench_with_input(
+                BenchmarkId::new("without_push_down_filter", &input_label),
+                &without_push_down_filter,
+                |b, df| {
+                    b.iter(|| {
+                        let df_clone = df.clone();
+                        black_box(
+                            rt.block_on(async {
+                                df_clone.into_optimized_plan().unwrap()
+                            }),
+                        );
+                    })
+                },
+            );
+        }
+    }
     control_group.finish();
 }
 

--- a/datafusion/core/benches/sql_planner_extended.rs
+++ b/datafusion/core/benches/sql_planner_extended.rs
@@ -18,20 +18,30 @@
 use arrow::array::{ArrayRef, RecordBatch};
 use arrow_schema::DataType;
 use arrow_schema::TimeUnit::Nanosecond;
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{
+    BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
+    measurement::WallTime,
+};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion_catalog::MemTable;
-use datafusion_common::ScalarValue;
+use datafusion_common::{Column, ScalarValue};
 use datafusion_expr::Expr::Literal;
+use datafusion_expr::logical_plan::LogicalPlan;
+use datafusion_expr::utils::split_conjunction_owned;
 use datafusion_expr::{cast, col, lit, not, try_cast, when};
 use datafusion_functions::expr_fn::{
     btrim, length, regexp_like, regexp_replace, to_timestamp, upper,
 };
+use std::env;
 use std::fmt::Write;
 use std::hint::black_box;
 use std::ops::Rem;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
+
+const FULL_PREDICATE_SWEEP: [usize; 5] = [10, 20, 30, 40, 60];
+const FULL_DEPTH_SWEEP: [usize; 3] = [1, 2, 3];
+const DEFAULT_SWEEP_POINTS: [(usize, usize); 3] = [(10, 1), (30, 2), (60, 3)];
 
 // This benchmark suite is designed to test the performance of
 // logical planning with a large plan containing unions, many columns
@@ -218,7 +228,9 @@ fn build_test_data_frame(ctx: &SessionContext, rt: &Runtime) -> DataFrame {
 fn build_case_heavy_left_join_df(ctx: &SessionContext, rt: &Runtime) -> DataFrame {
     register_string_table(ctx, 100, 1000);
     let query = build_case_heavy_left_join_query(30, 1);
-    rt.block_on(async { ctx.sql(&query).await.unwrap() })
+    let df = rt.block_on(async { ctx.sql(&query).await.unwrap() });
+    assert_case_heavy_left_join_inference_candidates(&df, 30);
+    df
 }
 
 fn build_case_heavy_left_join_query(predicate_count: usize, case_depth: usize) -> String {
@@ -237,12 +249,17 @@ fn build_case_heavy_left_join_query(predicate_count: usize, case_depth: usize) -
             query.push_str(" AND ");
         }
 
-        let mut expr = format!("length(l.c{})", i % 20);
+        let left_payload_col = (i % 19) + 1;
+        let right_payload_col = ((i + 7) % 19) + 1;
+        let mut expr = format!(
+            "CASE WHEN l.c0 IS NOT NULL THEN length(l.c{left_payload_col}) ELSE length(r.c{right_payload_col}) END"
+        );
         for depth in 0..case_depth {
-            let left_col = (i + depth + 1) % 20;
-            let right_col = (i + depth + 2) % 20;
+            let left_col = ((i + depth + 3) % 19) + 1;
+            let right_col = ((i + depth + 11) % 19) + 1;
+            let join_key_ref = if (i + depth) % 2 == 0 { "l.c0" } else { "r.c0" };
             expr = format!(
-                "CASE WHEN l.c{left_col} IS NOT NULL THEN {expr} ELSE length(r.c{right_col}) END"
+                "CASE WHEN {join_key_ref} IS NOT NULL THEN {expr} ELSE CASE WHEN l.c{left_col} IS NOT NULL THEN length(l.c{left_col}) ELSE length(r.c{right_col}) END END"
             );
         }
 
@@ -250,26 +267,6 @@ fn build_case_heavy_left_join_query(predicate_count: usize, case_depth: usize) -
     }
 
     query
-}
-
-fn build_case_heavy_left_join_df_with_push_down_filter(
-    rt: &Runtime,
-    predicate_count: usize,
-    case_depth: usize,
-    push_down_filter_enabled: bool,
-) -> DataFrame {
-    let ctx = SessionContext::new();
-    register_string_table(&ctx, 100, 1000);
-    if !push_down_filter_enabled {
-        let removed = ctx.remove_optimizer_rule("push_down_filter");
-        assert!(
-            removed,
-            "push_down_filter rule should be present in the default optimizer"
-        );
-    }
-
-    let query = build_case_heavy_left_join_query(predicate_count, case_depth);
-    rt.block_on(async { ctx.sql(&query).await.unwrap() })
 }
 
 fn build_non_case_left_join_query(
@@ -304,10 +301,11 @@ fn build_non_case_left_join_query(
     query
 }
 
-fn build_non_case_left_join_df_with_push_down_filter(
+fn build_left_join_df_with_push_down_filter(
     rt: &Runtime,
+    query_builder: impl Fn(usize, usize) -> String,
     predicate_count: usize,
-    nesting_depth: usize,
+    depth: usize,
     push_down_filter_enabled: bool,
 ) -> DataFrame {
     let ctx = SessionContext::new();
@@ -320,8 +318,136 @@ fn build_non_case_left_join_df_with_push_down_filter(
         );
     }
 
-    let query = build_non_case_left_join_query(predicate_count, nesting_depth);
+    let query = query_builder(predicate_count, depth);
     rt.block_on(async { ctx.sql(&query).await.unwrap() })
+}
+
+fn build_case_heavy_left_join_df_with_push_down_filter(
+    rt: &Runtime,
+    predicate_count: usize,
+    case_depth: usize,
+    push_down_filter_enabled: bool,
+) -> DataFrame {
+    let df = build_left_join_df_with_push_down_filter(
+        rt,
+        build_case_heavy_left_join_query,
+        predicate_count,
+        case_depth,
+        push_down_filter_enabled,
+    );
+    assert_case_heavy_left_join_inference_candidates(&df, predicate_count);
+    df
+}
+
+fn build_non_case_left_join_df_with_push_down_filter(
+    rt: &Runtime,
+    predicate_count: usize,
+    nesting_depth: usize,
+    push_down_filter_enabled: bool,
+) -> DataFrame {
+    build_left_join_df_with_push_down_filter(
+        rt,
+        build_non_case_left_join_query,
+        predicate_count,
+        nesting_depth,
+        push_down_filter_enabled,
+    )
+}
+
+fn find_filter_predicates(plan: &LogicalPlan) -> Vec<datafusion_expr::Expr> {
+    match plan {
+        LogicalPlan::Filter(filter) => split_conjunction_owned(filter.predicate.clone()),
+        LogicalPlan::Projection(projection) => find_filter_predicates(projection.input.as_ref()),
+        other => panic!("expected benchmark query plan to contain a Filter, found {other:?}"),
+    }
+}
+
+fn assert_case_heavy_left_join_inference_candidates(
+    df: &DataFrame,
+    expected_predicate_count: usize,
+) {
+    let predicates = find_filter_predicates(df.logical_plan());
+    assert_eq!(predicates.len(), expected_predicate_count);
+
+    let left_join_key = Column::from_qualified_name("l.c0");
+    let right_join_key = Column::from_qualified_name("r.c0");
+
+    for predicate in predicates {
+        let column_refs = predicate.column_refs();
+        assert!(
+            column_refs.contains(&&left_join_key) || column_refs.contains(&&right_join_key),
+            "benchmark predicate should reference a join key: {predicate}"
+        );
+        assert!(
+            column_refs
+                .iter()
+                .any(|col| **col != left_join_key && **col != right_join_key),
+            "benchmark predicate should reference a non-join column: {predicate}"
+        );
+    }
+}
+
+fn include_full_push_down_filter_sweep() -> bool {
+    env::var("DATAFUSION_PUSH_DOWN_FILTER_FULL_SWEEP")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn push_down_filter_sweep_points() -> Vec<(usize, usize)> {
+    if include_full_push_down_filter_sweep() {
+        FULL_DEPTH_SWEEP
+            .into_iter()
+            .flat_map(|depth| {
+                FULL_PREDICATE_SWEEP
+                    .into_iter()
+                    .map(move |predicate_count| (predicate_count, depth))
+            })
+            .collect()
+    } else {
+        DEFAULT_SWEEP_POINTS.to_vec()
+    }
+}
+
+fn bench_push_down_filter_ab<BuildFn>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    rt: &Runtime,
+    sweep_points: &[(usize, usize)],
+    build_df: BuildFn,
+) where
+    BuildFn: Fn(&Runtime, usize, usize, bool) -> DataFrame,
+{
+    for &(predicate_count, depth) in sweep_points {
+        let with_push_down_filter = build_df(rt, predicate_count, depth, true);
+        let without_push_down_filter = build_df(rt, predicate_count, depth, false);
+
+        let input_label = format!("predicates={predicate_count},nesting_depth={depth}");
+
+        group.bench_with_input(
+            BenchmarkId::new("with_push_down_filter", &input_label),
+            &with_push_down_filter,
+            |b, df| {
+                b.iter(|| {
+                    let df_clone = df.clone();
+                    black_box(
+                        rt.block_on(async { df_clone.into_optimized_plan().unwrap() }),
+                    );
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("without_push_down_filter", &input_label),
+            &without_push_down_filter,
+            |b, df| {
+                b.iter(|| {
+                    let df_clone = df.clone();
+                    black_box(
+                        rt.block_on(async { df_clone.into_optimized_plan().unwrap() }),
+                    );
+                })
+            },
+        );
+    }
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -349,116 +475,40 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    let predicate_sweep = [10, 20, 30, 40, 60];
-    let case_depth_sweep = [1, 2, 3];
+    let sweep_points = push_down_filter_sweep_points();
 
     let mut hotspot_group =
         c.benchmark_group("push_down_filter_hotspot_case_heavy_left_join_ab");
-    for case_depth in case_depth_sweep {
-        for predicate_count in predicate_sweep {
-            let with_push_down_filter =
-                build_case_heavy_left_join_df_with_push_down_filter(
-                    &rt,
-                    predicate_count,
-                    case_depth,
-                    true,
-                );
-            let without_push_down_filter =
-                build_case_heavy_left_join_df_with_push_down_filter(
-                    &rt,
-                    predicate_count,
-                    case_depth,
-                    false,
-                );
-
-            let input_label =
-                format!("predicates={predicate_count},case_depth={case_depth}");
-            // A/B interpretation:
-            // - with_push_down_filter: default optimizer path (rule enabled)
-            // - without_push_down_filter: control path with the rule removed
-            // Compare both IDs at the same sweep point to isolate rule impact.
-            hotspot_group.bench_with_input(
-                BenchmarkId::new("with_push_down_filter", &input_label),
-                &with_push_down_filter,
-                |b, df| {
-                    b.iter(|| {
-                        let df_clone = df.clone();
-                        black_box(
-                            rt.block_on(async {
-                                df_clone.into_optimized_plan().unwrap()
-                            }),
-                        );
-                    })
-                },
-            );
-            hotspot_group.bench_with_input(
-                BenchmarkId::new("without_push_down_filter", &input_label),
-                &without_push_down_filter,
-                |b, df| {
-                    b.iter(|| {
-                        let df_clone = df.clone();
-                        black_box(
-                            rt.block_on(async {
-                                df_clone.into_optimized_plan().unwrap()
-                            }),
-                        );
-                    })
-                },
-            );
-        }
-    }
+    bench_push_down_filter_ab(
+        &mut hotspot_group,
+        &rt,
+        &sweep_points,
+        |rt, predicate_count, depth, enable| {
+            build_case_heavy_left_join_df_with_push_down_filter(
+                rt,
+                predicate_count,
+                depth,
+                enable,
+            )
+        },
+    );
     hotspot_group.finish();
 
     let mut control_group =
         c.benchmark_group("push_down_filter_control_non_case_left_join_ab");
-    for nesting_depth in case_depth_sweep {
-        for predicate_count in predicate_sweep {
-            let with_push_down_filter = build_non_case_left_join_df_with_push_down_filter(
-                &rt,
+    bench_push_down_filter_ab(
+        &mut control_group,
+        &rt,
+        &sweep_points,
+        |rt, predicate_count, depth, enable| {
+            build_non_case_left_join_df_with_push_down_filter(
+                rt,
                 predicate_count,
-                nesting_depth,
-                true,
-            );
-            let without_push_down_filter =
-                build_non_case_left_join_df_with_push_down_filter(
-                    &rt,
-                    predicate_count,
-                    nesting_depth,
-                    false,
-                );
-
-            let input_label =
-                format!("predicates={predicate_count},nesting_depth={nesting_depth}");
-            control_group.bench_with_input(
-                BenchmarkId::new("with_push_down_filter", &input_label),
-                &with_push_down_filter,
-                |b, df| {
-                    b.iter(|| {
-                        let df_clone = df.clone();
-                        black_box(
-                            rt.block_on(async {
-                                df_clone.into_optimized_plan().unwrap()
-                            }),
-                        );
-                    })
-                },
-            );
-            control_group.bench_with_input(
-                BenchmarkId::new("without_push_down_filter", &input_label),
-                &without_push_down_filter,
-                |b, df| {
-                    b.iter(|| {
-                        let df_clone = df.clone();
-                        black_box(
-                            rt.block_on(async {
-                                df_clone.into_optimized_plan().unwrap()
-                            }),
-                        );
-                    })
-                },
-            );
-        }
-    }
+                depth,
+                enable,
+            )
+        },
+    );
     control_group.finish();
 }
 

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -87,11 +87,6 @@ pub fn is_restrict_null_predicate<'a>(
     predicate: Expr,
     join_cols_of_predicate: impl IntoIterator<Item = &'a Column>,
 ) -> Result<bool> {
-    // Fast path for a bare column reference.
-    if matches!(predicate, Expr::Column(_)) {
-        return Ok(true);
-    }
-
     let join_cols: HashSet<Column> =
         join_cols_of_predicate.into_iter().cloned().collect();
 
@@ -299,6 +294,14 @@ mod tests {
     fn expr_mixed_reference_predicate_does_not_restrict() -> Result<()> {
         let column_a = Column::from_name("a");
 
+        // col("b") — "b" is not a join column → non-restricting
+        let predicate = col("b");
+        let actual = is_restrict_null_predicate(predicate, std::iter::once(&column_a))?;
+        assert!(
+            !actual,
+            "bare non-join column predicate must be non-restricting"
+        );
+
         // col("b") > 5 — "b" is not a join column → non-restricting
         let predicate = binary_expr(col("b"), Operator::Gt, lit(5i64));
         let actual = is_restrict_null_predicate(predicate, std::iter::once(&column_a))?;
@@ -326,6 +329,34 @@ mod tests {
     /// comparison operators).
     #[test]
     fn expr_syntactic_fast_path_agrees_with_authoritative() -> Result<()> {
+        fn authoritative_restrict_null_predicate(
+            predicate: Expr,
+            join_cols: impl IntoIterator<Item = Column>,
+        ) -> Result<bool> {
+            let join_cols = join_cols.into_iter().collect::<Vec<_>>();
+
+            if matches!(predicate, Expr::Column(_)) {
+                return evaluates_to_null(predicate, join_cols.iter());
+            }
+
+            Ok(
+                match evaluate_expr_with_null_column(predicate, join_cols.iter())? {
+                    ColumnarValue::Array(array) => {
+                        if array.len() == 1 {
+                            let boolean_array = as_boolean_array(&array)?;
+                            boolean_array.is_null(0) || !boolean_array.value(0)
+                        } else {
+                            false
+                        }
+                    }
+                    ColumnarValue::Scalar(scalar) => matches!(
+                        scalar,
+                        ScalarValue::Boolean(None) | ScalarValue::Boolean(Some(false))
+                    ),
+                },
+            )
+        }
+
         let column_a = Column::from_name("a");
         let join_cols_set: HashSet<Column> = std::iter::once(column_a.clone()).collect();
 
@@ -349,11 +380,11 @@ mod tests {
                 &predicate,
                 &join_cols_set,
             );
-            // Authoritative result (both evaluators should agree when syntactic decides).
+            // Authoritative result computed without going through the wrapper under test.
             if let Some(syn_result) = syntactic {
-                let authoritative = is_restrict_null_predicate(
+                let authoritative = authoritative_restrict_null_predicate(
                     predicate.clone(),
-                    std::iter::once(&column_a),
+                    std::iter::once(column_a.clone()),
                 )?;
                 let syn_bool =
                     syn_result == null_restriction::SyntacticNullRestriction::Restricts;

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -17,6 +17,8 @@
 
 //! Utility functions leveraged by the query optimizer rules
 
+pub(crate) mod null_restriction;
+
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::analyzer::type_coercion::TypeCoercionRewriter;
@@ -71,18 +73,52 @@ pub fn log_plan(description: &str, plan: &LogicalPlan) {
 /// Determine whether a predicate can restrict NULLs. e.g.
 /// `c0 > 8` return true;
 /// `c0 IS NULL` return false.
+///
+/// The function uses a two-phase evaluation strategy:
+/// 1. **Syntactic fast path** (`null_restriction` module): inspects the expression
+///    shape without executing code. Returns immediately when it can decide.
+/// 2. **Authoritative path**: builds a physical expression and evaluates it with
+///    all join columns replaced by `NULL`.
+///
+/// Predicates that reference columns outside `join_cols_of_predicate` are returned
+/// as non-restricting (`false`) without entering the authoritative path, because
+/// the authoritative evaluator cannot safely handle such columns.
 pub fn is_restrict_null_predicate<'a>(
     predicate: Expr,
     join_cols_of_predicate: impl IntoIterator<Item = &'a Column>,
 ) -> Result<bool> {
+    // Fast path for a bare column reference.
     if matches!(predicate, Expr::Column(_)) {
         return Ok(true);
     }
 
+    let join_cols: HashSet<Column> =
+        join_cols_of_predicate.into_iter().cloned().collect();
+
+    // Early return for mixed-reference predicates: if the predicate references any
+    // column that is not in the join-column set, the authoritative evaluator would
+    // fail (those columns are absent from its minimal schema). Conservatively treat
+    // such predicates as non-restricting so they are never incorrectly discarded.
+    let predicate_cols = predicate.column_refs();
+    if predicate_cols.iter().any(|c| !join_cols.contains(*c)) {
+        return Ok(false);
+    }
+
+    // Syntactic fast path: decide without expression execution.
+    if let Some(result) =
+        null_restriction::syntactic_null_restriction_check(&predicate, &join_cols)
+    {
+        return Ok(
+            result == null_restriction::SyntacticNullRestriction::Restricts,
+        );
+    }
+
+    // Authoritative path: build and execute a physical expression where every
+    // join column is replaced by NULL, then check the outcome.
     // If result is single `true`, return false;
-    // If result is single `NULL` or `false`, return true;
+    // If result is single `NULL` or `false`, return true.
     Ok(
-        match evaluate_expr_with_null_column(predicate, join_cols_of_predicate)? {
+        match evaluate_expr_with_null_column(predicate, join_cols.iter())? {
             ColumnarValue::Array(array) => {
                 if array.len() == 1 {
                     let boolean_array = as_boolean_array(&array)?;
@@ -254,6 +290,78 @@ mod tests {
             let actual =
                 is_restrict_null_predicate(predicate.clone(), join_cols_of_predicate)?;
             assert_eq!(actual, expected, "{predicate}");
+        }
+
+        Ok(())
+    }
+
+    /// Verify that predicates referencing columns outside the join-column set are
+    /// treated as non-restricting (the mixed-reference early return).
+    #[test]
+    fn expr_mixed_reference_predicate_does_not_restrict() -> Result<()> {
+        let column_a = Column::from_name("a");
+
+        // col("b") > 5 — "b" is not a join column → non-restricting
+        let predicate = binary_expr(col("b"), Operator::Gt, lit(5i64));
+        let actual = is_restrict_null_predicate(predicate, std::iter::once(&column_a))?;
+        assert!(!actual, "predicate referencing non-join col must be non-restricting");
+
+        // col("a") > 5 AND col("b") IS NULL — mixed reference: "b" ∉ join_cols
+        // The AND has a restricting left side, but right side references "b" which is
+        // outside the join-column set → must be treated as non-restricting.
+        let predicate = binary_expr(
+            binary_expr(col("a"), Operator::Gt, lit(5i64)),
+            Operator::And,
+            is_null(col("b")),
+        );
+        let actual = is_restrict_null_predicate(predicate, std::iter::once(&column_a))?;
+        assert!(!actual, "mixed-reference predicate must be non-restricting");
+
+        Ok(())
+    }
+
+    /// Verify that the syntactic fast path agrees with the authoritative evaluator
+    /// for the predicate shapes it handles (simple column, IS NULL, IS NOT NULL,
+    /// comparison operators).
+    #[test]
+    fn expr_syntactic_fast_path_agrees_with_authoritative() -> Result<()> {
+        let column_a = Column::from_name("a");
+        let join_cols_set: HashSet<Column> =
+            std::iter::once(column_a.clone()).collect();
+
+        // These predicates only reference the join column so both evaluators apply.
+        let parity_cases = vec![
+            col("a"),
+            is_null(col("a")),
+            Expr::IsNotNull(Box::new(col("a"))),
+            binary_expr(col("a"), Operator::Gt, lit(8i64)),
+            binary_expr(col("a"), Operator::LtEq, lit(8i32)),
+            binary_expr(
+                col("a"),
+                Operator::Eq,
+                Expr::Literal(ScalarValue::Null, None),
+            ),
+        ];
+
+        for predicate in parity_cases {
+            // Syntactic path result.
+            let syntactic = null_restriction::syntactic_null_restriction_check(
+                &predicate,
+                &join_cols_set,
+            );
+            // Authoritative result (both evaluators should agree when syntactic decides).
+            if let Some(syn_result) = syntactic {
+                let authoritative = is_restrict_null_predicate(
+                    predicate.clone(),
+                    std::iter::once(&column_a),
+                )?;
+                let syn_bool = syn_result
+                    == null_restriction::SyntacticNullRestriction::Restricts;
+                assert_eq!(
+                    syn_bool, authoritative,
+                    "syntactic and authoritative disagree for {predicate}"
+                );
+            }
         }
 
         Ok(())

--- a/datafusion/optimizer/src/utils.rs
+++ b/datafusion/optimizer/src/utils.rs
@@ -108,9 +108,7 @@ pub fn is_restrict_null_predicate<'a>(
     if let Some(result) =
         null_restriction::syntactic_null_restriction_check(&predicate, &join_cols)
     {
-        return Ok(
-            result == null_restriction::SyntacticNullRestriction::Restricts,
-        );
+        return Ok(result == null_restriction::SyntacticNullRestriction::Restricts);
     }
 
     // Authoritative path: build and execute a physical expression where every
@@ -304,7 +302,10 @@ mod tests {
         // col("b") > 5 — "b" is not a join column → non-restricting
         let predicate = binary_expr(col("b"), Operator::Gt, lit(5i64));
         let actual = is_restrict_null_predicate(predicate, std::iter::once(&column_a))?;
-        assert!(!actual, "predicate referencing non-join col must be non-restricting");
+        assert!(
+            !actual,
+            "predicate referencing non-join col must be non-restricting"
+        );
 
         // col("a") > 5 AND col("b") IS NULL — mixed reference: "b" ∉ join_cols
         // The AND has a restricting left side, but right side references "b" which is
@@ -326,8 +327,7 @@ mod tests {
     #[test]
     fn expr_syntactic_fast_path_agrees_with_authoritative() -> Result<()> {
         let column_a = Column::from_name("a");
-        let join_cols_set: HashSet<Column> =
-            std::iter::once(column_a.clone()).collect();
+        let join_cols_set: HashSet<Column> = std::iter::once(column_a.clone()).collect();
 
         // These predicates only reference the join column so both evaluators apply.
         let parity_cases = vec![
@@ -355,8 +355,8 @@ mod tests {
                     predicate.clone(),
                     std::iter::once(&column_a),
                 )?;
-                let syn_bool = syn_result
-                    == null_restriction::SyntacticNullRestriction::Restricts;
+                let syn_bool =
+                    syn_result == null_restriction::SyntacticNullRestriction::Restricts;
                 assert_eq!(
                     syn_bool, authoritative,
                     "syntactic and authoritative disagree for {predicate}"

--- a/datafusion/optimizer/src/utils/null_restriction.rs
+++ b/datafusion/optimizer/src/utils/null_restriction.rs
@@ -1,0 +1,449 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Syntactic null-restriction fast path for optimizer predicates.
+//!
+//! This module provides a conservative syntactic check that quickly determines
+//! whether a predicate restricts NULL values for specified join columns, without
+//! executing the full physical expression evaluation.
+//!
+//! "Restricts nulls" means: when the join columns are substituted with `NULL`,
+//! the predicate evaluates to `NULL` or `false` (not `true`). If it evaluates
+//! to `NULL` or `false`, then rows with NULL join-column values would be filtered
+//! out — the predicate "restricts" them.
+//!
+//! The syntactic check is deliberately conservative:
+//! - It returns `Some(true)` or `Some(false)` only when it can prove the outcome
+//!   from the expression shape alone.
+//! - It returns `None` for unrecognised patterns, signalling the caller to fall
+//!   back to the authoritative physical-expression evaluator.
+
+use std::collections::HashSet;
+
+use datafusion_common::Column;
+use datafusion_expr::{Expr, Operator, expr::BinaryExpr};
+
+/// Result of a syntactic null-restriction check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SyntacticNullRestriction {
+    /// The expression definitely restricts nulls:
+    /// it evaluates to `NULL` or `false` when join columns are `NULL`.
+    Restricts,
+    /// The expression definitely does **not** restrict nulls:
+    /// it evaluates to `true` when join columns are `NULL`.
+    DoesNotRestrict,
+}
+
+/// Syntactically determine whether `expr` restricts NULL values for `join_cols`.
+///
+/// Returns `Some(result)` when the expression shape is recognized and a definitive
+/// conclusion can be reached; returns `None` when the syntactic check cannot decide
+/// and the caller should fall back to the authoritative evaluator.
+///
+/// This check is conservative: it only claims `Some` for patterns where the outcome
+/// is provable without execution.
+pub(crate) fn syntactic_null_restriction_check(
+    expr: &Expr,
+    join_cols: &HashSet<Column>,
+) -> Option<SyntacticNullRestriction> {
+    use SyntacticNullRestriction::*;
+
+    match expr {
+        // A bare join-column reference: NULL column → NULL predicate → filtered out.
+        Expr::Column(col) => {
+            if join_cols.contains(col) {
+                Some(Restricts)
+            } else {
+                // Non-join column: result depends on data, cannot determine.
+                None
+            }
+        }
+
+        // IS NULL: NULL IS NULL = TRUE → predicate passes → does NOT restrict.
+        Expr::IsNull(inner) => {
+            if is_direct_join_col(inner, join_cols) {
+                Some(DoesNotRestrict)
+            } else {
+                None
+            }
+        }
+
+        // IS NOT NULL: NULL IS NOT NULL = FALSE → predicate fails → restricts.
+        Expr::IsNotNull(inner) => {
+            if is_direct_join_col(inner, join_cols) {
+                Some(Restricts)
+            } else {
+                None
+            }
+        }
+
+        // NOT: flips DoesNotRestrict → Restricts; Restricts is uncertain
+        // because NOT(NULL)=NULL (restricts) but NOT(false)=true (doesn't restrict).
+        Expr::Not(inner) => {
+            match syntactic_null_restriction_check(inner, join_cols)? {
+                DoesNotRestrict => Some(Restricts),
+                // NOT(null or false): NOT(null)=null→restricts, NOT(false)=true→doesn't.
+                // Cannot prove either way without knowing which case applies.
+                Restricts => None,
+            }
+        }
+
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
+            syntactic_binary(left, *op, right, join_cols)
+        }
+
+        _ => None,
+    }
+}
+
+/// Evaluate null-restriction for a binary expression.
+fn syntactic_binary(
+    left: &Expr,
+    op: Operator,
+    right: &Expr,
+    join_cols: &HashSet<Column>,
+) -> Option<SyntacticNullRestriction> {
+    use SyntacticNullRestriction::*;
+
+    match op {
+        // Comparison operators all propagate NULLs through their operands.
+        // If either operand is (or directly contains) a join column, the result
+        // is NULL when that column is NULL → restricts.
+        Operator::Eq
+        | Operator::NotEq
+        | Operator::Lt
+        | Operator::LtEq
+        | Operator::Gt
+        | Operator::GtEq => {
+            if is_direct_join_col(left, join_cols) || is_direct_join_col(right, join_cols) {
+                Some(Restricts)
+            } else {
+                None
+            }
+        }
+
+        // AND propagation rules (SQL three-value logic):
+        //   NULL AND x  = NULL or false  → always restricts
+        //   false AND x = false          → always restricts
+        //   true  AND x = x
+        //
+        // Conclusion: AND restricts if EITHER side restricts.
+        //             AND does not restrict if BOTH sides do not restrict.
+        //             Otherwise unknown.
+        Operator::And => {
+            let left_check = syntactic_null_restriction_check(left, join_cols);
+            let right_check = syntactic_null_restriction_check(right, join_cols);
+
+            let left_restricts = matches!(left_check, Some(Restricts));
+            let right_restricts = matches!(right_check, Some(Restricts));
+            let left_passes = matches!(left_check, Some(DoesNotRestrict));
+            let right_passes = matches!(right_check, Some(DoesNotRestrict));
+
+            if left_restricts || right_restricts {
+                Some(Restricts)
+            } else if left_passes && right_passes {
+                Some(DoesNotRestrict)
+            } else {
+                None
+            }
+        }
+
+        // OR propagation rules (SQL three-value logic):
+        //   true  OR x = true → does NOT restrict, regardless of x
+        //   NULL  OR true = true → does NOT restrict
+        //   NULL  OR false = NULL → restricts
+        //   NULL  OR NULL = NULL → restricts
+        //   false OR x = x
+        //
+        // Conclusion: OR does NOT restrict if EITHER side does not restrict.
+        //             OR restricts only if BOTH sides restrict.
+        //             Otherwise unknown.
+        Operator::Or => {
+            let left_check = syntactic_null_restriction_check(left, join_cols);
+            let right_check = syntactic_null_restriction_check(right, join_cols);
+
+            match (left_check, right_check) {
+                (Some(Restricts), Some(Restricts)) => Some(Restricts),
+                (Some(DoesNotRestrict), _) | (_, Some(DoesNotRestrict)) => {
+                    Some(DoesNotRestrict)
+                }
+                _ => None,
+            }
+        }
+
+        _ => None,
+    }
+}
+
+/// Returns true if `expr` is a direct column reference that belongs to `join_cols`.
+fn is_direct_join_col(expr: &Expr, join_cols: &HashSet<Column>) -> bool {
+    matches!(expr.as_ref(), Expr::Column(col) if join_cols.contains(col))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion_expr::{Operator, binary_expr, col, in_list, is_null, lit};
+    use datafusion_common::ScalarValue;
+
+    fn join_cols(names: &[&str]) -> HashSet<Column> {
+        names.iter().map(|n| Column::from_name(*n)).collect()
+    }
+
+    fn check(expr: &Expr, cols: &[&str]) -> Option<SyntacticNullRestriction> {
+        syntactic_null_restriction_check(expr, &join_cols(cols))
+    }
+
+    // -----------------------------------------------------------------------
+    // Column reference
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_join_column_restricts() {
+        // col("a") with join_cols = {"a"} → Restricts (NULL → NULL → filtered)
+        let result = check(&col("a"), &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_non_join_column_unknown() {
+        // col("b") with join_cols = {"a"} → None (cannot determine without data)
+        let result = check(&col("b"), &["a"]);
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // IS NULL / IS NOT NULL
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_null_join_col_does_not_restrict() {
+        // IS NULL(col("a")) with join_cols = {"a"} → DoesNotRestrict
+        // NULL IS NULL = TRUE → row passes → does not restrict
+        let result = check(&is_null(col("a")), &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::DoesNotRestrict));
+    }
+
+    #[test]
+    fn test_is_not_null_join_col_restricts() {
+        // IS NOT NULL(col("a")) with join_cols = {"a"} → Restricts
+        // NULL IS NOT NULL = FALSE → row filtered → restricts
+        let result = check(&Expr::IsNotNull(Box::new(col("a"))), &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_is_null_non_join_col_unknown() {
+        // IS NULL(col("b")) with join_cols = {"a"} → None
+        let result = check(&is_null(col("b")), &["a"]);
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // NOT
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_not_is_null_restricts() {
+        // NOT(IS NULL(col("a"))) = NOT(DoesNotRestrict) → Restricts
+        // NOT(TRUE) = FALSE → restricts
+        let expr = Expr::Not(Box::new(is_null(col("a"))));
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_not_join_col_unknown() {
+        // NOT(col("a")) = NOT(Restricts) → None
+        // NOT(null) = null (restricts), NOT(false) = true (doesn't restrict): uncertain
+        let expr = Expr::Not(Box::new(col("a")));
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Comparison operators
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_comparison_gt_restricts() {
+        // col("a") > 8 → Restricts (NULL > 8 = NULL → filtered)
+        let expr = binary_expr(col("a"), Operator::Gt, lit(8i64));
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_comparison_lteq_restricts() {
+        // col("a") <= 8 → Restricts
+        let expr = binary_expr(col("a"), Operator::LtEq, lit(8i32));
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_comparison_eq_null_literal_restricts() {
+        // col("a") = NULL → Restricts (NULL = NULL = NULL in SQL → filtered)
+        let expr = binary_expr(
+            col("a"),
+            Operator::Eq,
+            Expr::Literal(ScalarValue::Null, None),
+        );
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_comparison_non_join_col_unknown() {
+        // col("b") > 8 with join_cols = {"a"} → None
+        let expr = binary_expr(col("b"), Operator::Gt, lit(8i64));
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // AND expressions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_and_one_side_restricts() {
+        // col("a") > 5 AND col("a") IS NULL  → Restricts (left restricts)
+        let expr = binary_expr(
+            binary_expr(col("a"), Operator::Gt, lit(5i64)),
+            Operator::And,
+            is_null(col("a")),
+        );
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_and_both_restrict() {
+        // col("a") > 5 AND col("a") > 1 → Restricts
+        let expr = binary_expr(
+            binary_expr(col("a"), Operator::Gt, lit(5i64)),
+            Operator::And,
+            binary_expr(col("a"), Operator::Gt, lit(1i64)),
+        );
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_and_both_do_not_restrict() {
+        // IS NULL(a) AND IS NULL(a) → DoesNotRestrict
+        let expr = binary_expr(is_null(col("a")), Operator::And, is_null(col("a")));
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::DoesNotRestrict));
+    }
+
+    #[test]
+    fn test_and_unknown_unknown() {
+        // col("b") > 5 AND col("c") > 1 with join_cols = {"a"} → None
+        let expr = binary_expr(
+            binary_expr(col("b"), Operator::Gt, lit(5i64)),
+            Operator::And,
+            binary_expr(col("c"), Operator::Gt, lit(1i64)),
+        );
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // OR expressions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_or_both_restrict() {
+        // col("a") > 5 OR col("a") > 1 → Restricts
+        let expr = binary_expr(
+            binary_expr(col("a"), Operator::Gt, lit(5i64)),
+            Operator::Or,
+            binary_expr(col("a"), Operator::Gt, lit(1i64)),
+        );
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_or_one_side_does_not_restrict() {
+        // col("a") > 5 OR IS NULL(col("a")) → DoesNotRestrict
+        // Because IS NULL(a) when a=NULL → TRUE, so OR returns TRUE → doesn't restrict
+        let expr = binary_expr(
+            binary_expr(col("a"), Operator::Gt, lit(5i64)),
+            Operator::Or,
+            is_null(col("a")),
+        );
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::DoesNotRestrict));
+    }
+
+    #[test]
+    fn test_or_one_side_unknown() {
+        // col("a") > 5 OR col("b") > 1 with join_cols = {"a"} → None
+        let expr = binary_expr(
+            binary_expr(col("a"), Operator::Gt, lit(5i64)),
+            Operator::Or,
+            binary_expr(col("b"), Operator::Gt, lit(1i64)),
+        );
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Mixed-reference predicates: parity with authoritative evaluator
+    //
+    // These tests verify that for all predicate shapes the syntactic evaluator
+    // handles, its answer agrees with what the authoritative physical evaluator
+    // would produce. They also document the None (unknown) cases where the
+    // syntactic check correctly defers to the authoritative path.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_in_list_join_col_unknown() {
+        // col("a") IN (1, 2, 3) with join_cols = {"a"}
+        // The syntactic check does not handle InList → None (falls to authoritative)
+        let expr = in_list(col("a"), vec![lit(1i64), lit(2i64), lit(3i64)], false);
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_multiple_join_cols_and() {
+        // col("a") > 1 AND col("b") > 1 with join_cols = {"a", "b"} → Restricts
+        let expr = binary_expr(
+            binary_expr(col("a"), Operator::Gt, lit(1i64)),
+            Operator::And,
+            binary_expr(col("b"), Operator::Gt, lit(1i64)),
+        );
+        let result = check(&expr, &["a", "b"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+
+    #[test]
+    fn test_mixed_ref_in_and_restricts_via_join_col_side() {
+        // col("a") > 5 AND col("b") IS NULL with join_cols = {"a"}
+        // Left = Restricts (join col), right = None (b not join col) → Restricts
+        let expr = binary_expr(
+            binary_expr(col("a"), Operator::Gt, lit(5i64)),
+            Operator::And,
+            is_null(col("b")),
+        );
+        let result = check(&expr, &["a"]);
+        assert_eq!(result, Some(SyntacticNullRestriction::Restricts));
+    }
+}

--- a/datafusion/optimizer/src/utils/null_restriction.rs
+++ b/datafusion/optimizer/src/utils/null_restriction.rs
@@ -27,8 +27,9 @@
 //! out — the predicate "restricts" them.
 //!
 //! The syntactic check is deliberately conservative:
-//! - It returns `Some(true)` or `Some(false)` only when it can prove the outcome
-//!   from the expression shape alone.
+//! - It returns `Some(SyntacticNullRestriction::Restricts)` or
+//!   `Some(SyntacticNullRestriction::DoesNotRestrict)` only when it can prove
+//!   the outcome from the expression shape alone.
 //! - It returns `None` for unrecognised patterns, signalling the caller to fall
 //!   back to the authoritative physical-expression evaluator.
 

--- a/datafusion/optimizer/src/utils/null_restriction.rs
+++ b/datafusion/optimizer/src/utils/null_restriction.rs
@@ -129,7 +129,8 @@ fn syntactic_binary(
         | Operator::LtEq
         | Operator::Gt
         | Operator::GtEq => {
-            if is_direct_join_col(left, join_cols) || is_direct_join_col(right, join_cols) {
+            if is_direct_join_col(left, join_cols) || is_direct_join_col(right, join_cols)
+            {
                 Some(Restricts)
             } else {
                 None
@@ -197,8 +198,8 @@ fn is_direct_join_col(expr: &Expr, join_cols: &HashSet<Column>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion_expr::{Operator, binary_expr, col, in_list, is_null, lit};
     use datafusion_common::ScalarValue;
+    use datafusion_expr::{Operator, binary_expr, col, in_list, is_null, lit};
 
     fn join_cols(names: &[&str]) -> HashSet<Column> {
         names.iter().map(|n| Column::from_name(*n)).collect()

--- a/datafusion/optimizer/src/utils/null_restriction.rs
+++ b/datafusion/optimizer/src/utils/null_restriction.rs
@@ -193,7 +193,7 @@ fn syntactic_binary(
 
 /// Returns true if `expr` is a direct column reference that belongs to `join_cols`.
 fn is_direct_join_col(expr: &Expr, join_cols: &HashSet<Column>) -> bool {
-    matches!(expr.as_ref(), Expr::Column(col) if join_cols.contains(col))
+    matches!(expr, Expr::Column(col) if join_cols.contains(col))
 }
 
 #[cfg(test)]


### PR DESCRIPTION

## Which issue does this PR close?

* Part of #20002

---

## Rationale for this change

This PR extracts and formalizes the null-restriction evaluation logic into a dedicated utility module to improve clarity, performance, and reviewability.

Previously, null-restriction determination relied solely on evaluating physical expressions, which is more expensive and harder to reason about in isolation. Additionally, the logic was embedded in a broader set of changes, making it difficult to review independently.

This change introduces a conservative syntactic fast path that can determine null-restriction behavior for common predicate shapes without executing expressions. This improves optimizer efficiency while maintaining correctness by falling back to the authoritative evaluation path when needed.

The PR also explicitly guards against mixed-reference predicates (those referencing columns outside the provided join-column set), ensuring they are treated conservatively as non-restricting to avoid incorrect pruning.

---

## What changes are included in this PR?

* Introduced new module `utils/null_restriction.rs` containing:

  * A syntactic null-restriction evaluator
  * Conservative pattern matching for common predicate shapes (column refs, IS NULL, IS NOT NULL, comparisons, AND/OR/NOT)
  * Clear semantics via `SyntacticNullRestriction` enum

* Updated `is_restrict_null_predicate` in `utils.rs` to:

  * Add early return for mixed-reference predicates (columns outside join set)
  * Use the syntactic evaluator as a fast path when possible
  * Fall back to the authoritative physical-expression evaluation when needed

* Improved internal documentation explaining:

  * Two-phase evaluation strategy (syntactic + authoritative)
  * Safety guarantees and conservative behavior

* Added focused unit tests:

  * Mixed-reference predicate handling (ensuring non-restricting behavior)
  * Parity between syntactic and authoritative evaluators for supported cases
  * Coverage of boolean logic (AND/OR/NOT) and comparison operators

---

## Are these changes tested?

Yes.

This PR includes comprehensive unit tests that:

1. Validate that the syntactic fast path agrees with the authoritative evaluator for supported predicate shapes
2. Ensure mixed-reference predicates are conservatively treated as non-restricting
3. Cover key SQL boolean semantics (AND, OR, NOT) and comparison operators
4. Verify fallback behavior when the syntactic evaluator cannot determine the result

These tests help prevent regressions and document expected behavior.

### Benchmark 

Below are the benchmark results, using the modified #21029 benchmark

```
                    Criterion Benchmark Summary (Statistically Significant Changes)
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ Benchmark                                                                         ┃ Mean Change ┃  P-value ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ logical_plan_optimize_hotspot_case_heavy_left_join                                │      -1.74% │ 0.000000 │
│ push_down_filter_control_non_case_left_join_ab/with_push_down_filter/predicates=… │      -2.32% │ 0.010000 │
│ (predicates=10,nesting_depth=1)                                                   │             │          │
│ push_down_filter_hotspot_case_heavy_left_join_ab/with_push_down_filter/predicate… │      -2.99% │ 0.000000 │
│ (predicates=10,nesting_depth=1)                                                   │             │          │
│ push_down_filter_hotspot_case_heavy_left_join_ab/with_push_down_filter/predicate… │      -1.96% │ 0.000000 │
│ (predicates=30,nesting_depth=2)                                                   │             │          │
│ push_down_filter_hotspot_case_heavy_left_join_ab/with_push_down_filter/predicate… │      -1.94% │ 0.000000 │
│ (predicates=60,nesting_depth=3)                                                   │             │          │
└───────────────────────────────────────────────────────────────────────────────────┴─────────────┴──────────┘

Summary: 5 improvements, 0 regressions (p < 0.05)
```

---

## Are there any user-facing changes?

No.

This change is internal to the optimizer and does not modify public APIs or user-visible behavior. It improves performance and maintainability without altering query results.

---

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
