### PR TITLE
[docs] Add weekly sync details to contributor communication guide

### DIFF
--- a/docs/source/contributor-guide/communication.md
+++ b/docs/source/contributor-guide/communication.md
@@ -68,6 +68,15 @@ In Slack, we use these channels:
 - `#datafusion-comet`
 - `#datafusion-python`
 
+## Weekly Video Call Syncs
+
+The DataFusion community also holds a weekly video call sync for real-time
+discussion and coordination. You can join the meeting using the Google Meet
+link below, and use the shared meeting document for agenda items and notes:
+
+- [Video call link](https://meet.google.com/nfg-eviu-qrm)
+- [Meeting details and notes](https://docs.google.com/document/d/1NBpkIAuU7O9h8Br5CbFksDhX-L9TyO9wmGLPMe0Plc8)
+
 ### Job Board
 
 There are plenty of opportunities to work with DataFusion advertised on the


### PR DESCRIPTION
## Which issue does this PR close?

- N/A (documentation update)

## Rationale for this change

The contributor communication guide did not mention the weekly DataFusion community video sync. Adding the meeting link and shared notes document makes it easier for contributors to find the recurring meeting information from the docs.

## What changes are included in this PR?

- Add a `Weekly Video Call Syncs` section to the contributor communication guide
- Include the Google Meet link for the weekly sync
- Include the shared meeting notes and agenda document link

## Are these changes tested?

This is a documentation-only change. 

## Are there any user-facing changes?

Yes. The contributor documentation now includes the weekly community video sync information.
