### PR TITLE
chore: add `.claude/settings.local.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ datafusion-examples/examples/datafusion-examples/
 
 # Samply profile data
 profile.json.gz
+
+# Claude Code personal settings
+.claude/settings.local.json


### PR DESCRIPTION
## Which issue does this PR close?

  - N/A

  ## Rationale for this change

  `.claude/settings.local.json` is a personal project-specific settings file for Claude Code and should not be committed to the repo.

Ref: https://code.claude.com/docs/en/settings#available-scopes
<img width="700" height="270" alt="CleanShot 2026-04-02 at 10 41 12@2x" src="https://github.com/user-attachments/assets/57522960-3538-4d25-96a7-b6d4ec0e0bd0" />

  ## What changes are included in this PR?

  Add `.claude/settings.local.json` to `.gitignore`.

  ## Are these changes tested?

  No code changes — only a `.gitignore` update.

  ## Are there any user-facing changes?

  No.