### PR TITLE
Support Dictionary Arrays in MIN/MAX Aggregates

### DIFF
--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -480,7 +480,9 @@ fn dictionary_scalar_parts(value: &ScalarValue) -> (&ScalarValue, Option<&DataTy
     }
 }
 
-fn is_row_wise_batch_type(data_type: &DataType) -> bool {
+// Primitive, string, and binary types use specialized Arrow min/max kernels.
+// These remaining types fall back to scalar row-by-row logical comparison.
+fn requires_logical_row_scan(data_type: &DataType) -> bool {
     matches!(
         data_type,
         DataType::Struct(_)
@@ -828,7 +830,7 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
                 min_binary_view
             )
         }
-        data_type if is_row_wise_batch_type(data_type) => {
+        data_type if requires_logical_row_scan(data_type) => {
             scalar_row_extreme(values, Ordering::Greater)?
         }
         _ => min_max_batch!(values, min),
@@ -880,7 +882,7 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
             let value = value.map(|e| e.to_vec());
             ScalarValue::FixedSizeBinary(*size, value)
         }
-        data_type if is_row_wise_batch_type(data_type) => {
+        data_type if requires_logical_row_scan(data_type) => {
             scalar_row_extreme(values, Ordering::Less)?
         }
         _ => min_max_batch!(values, max),

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -455,10 +455,7 @@ macro_rules! min_max {
     }};
 }
 
-fn dictionary_batch_extreme(
-    values: &ArrayRef,
-    ordering: Ordering,
-) -> Result<ScalarValue> {
+fn scalar_batch_extreme(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
     let mut extreme: Option<ScalarValue> = None;
 
     for i in 0..values.len() {
@@ -823,32 +820,14 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::FixedSizeList(_, _) => {
             min_max_batch_generic(values, Ordering::Greater)?
         }
-        DataType::Dictionary(_, _) => {
-            dictionary_batch_extreme(values, Ordering::Greater)?
-        }
+        DataType::Dictionary(_, _) => scalar_batch_extreme(values, Ordering::Greater)?,
         _ => min_max_batch!(values, min),
     })
 }
 
 /// Generic min/max implementation for complex types
 fn min_max_batch_generic(array: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
-    let mut non_null_indices = (0..array.len()).filter(|&i| !array.is_null(i));
-    let Some(first_idx) = non_null_indices.next() else {
-        return ScalarValue::try_from(array.data_type());
-    };
-
-    let mut extreme = ScalarValue::try_from_array(array, first_idx)?;
-    for i in non_null_indices {
-        let current = ScalarValue::try_from_array(array, i)?;
-        if current.is_null() {
-            continue;
-        }
-        if extreme.is_null() || extreme.try_cmp(&current)? == ordering {
-            extreme = current;
-        }
-    }
-
-    Ok(extreme)
+    scalar_batch_extreme(array, ordering)
 }
 
 /// dynamically-typed max(array) -> ScalarValue
@@ -900,7 +879,7 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::List(_) => min_max_batch_generic(values, Ordering::Less)?,
         DataType::LargeList(_) => min_max_batch_generic(values, Ordering::Less)?,
         DataType::FixedSizeList(_, _) => min_max_batch_generic(values, Ordering::Less)?,
-        DataType::Dictionary(_, _) => dictionary_batch_extreme(values, Ordering::Less)?,
+        DataType::Dictionary(_, _) => scalar_batch_extreme(values, Ordering::Less)?,
         _ => min_max_batch!(values, max),
     })
 }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -911,7 +911,7 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::DictionaryArray;
+    use arrow::array::{AsArray, DictionaryArray};
     use std::sync::Arc;
 
     #[test]
@@ -997,6 +997,8 @@ mod tests {
         let keys = Int8Array::from(vec![Some(1), None, Some(1), Some(1)]);
         let values = Arc::new(StringArray::from(vec!["zzz", "bbb", "aaa"]));
         let array = Arc::new(DictionaryArray::new(keys, values)) as ArrayRef;
+        let raw_values = array.as_any_dictionary().values();
+        let raw_min = min_batch(raw_values)?;
 
         let min = min_batch(&array)?;
         let max = max_batch(&array)?;
@@ -1005,6 +1007,10 @@ mod tests {
             Box::new(DataType::Int8),
             Box::new(ScalarValue::Utf8(Some("bbb".to_string()))),
         );
+
+        // raw_min is "aaa" because it is the min of the values, but min/max of the dictionary should be "bbb"
+        // because the null key is ignored and all non-null keys point to "bbb".
+        assert_ne!(raw_min, expected);
 
         assert_eq!(min, expected);
         assert_eq!(max, expected);

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -141,6 +141,18 @@ macro_rules! min_max_generic {
     }};
 }
 
+macro_rules! min_max {
+    ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
+        match choose_min_max!($OP) {
+            Ordering::Greater => Ok(min_max_scalar_impl!($VALUE, $DELTA, min)),
+            Ordering::Less => Ok(min_max_scalar_impl!($VALUE, $DELTA, max)),
+            Ordering::Equal => {
+                unreachable!("min/max comparisons do not use equal ordering")
+            }
+        }
+    }};
+}
+
 // min/max of two logically compatible scalar values.
 // Dictionary scalars participate by comparing their inner logical values.
 // When both inputs are dictionaries, matching key types are preserved in the
@@ -462,10 +474,6 @@ fn min_max_scalar(
         Ordering::Less => Ok(min_max_scalar_impl!(lhs, rhs, max)),
         Ordering::Equal => unreachable!("min/max comparisons do not use equal ordering"),
     }
-}
-
-macro_rules! min_max {
-    ($VALUE:expr, $DELTA:expr, $OP:ident) => {{ min_max_scalar($VALUE, $DELTA, choose_min_max!($OP)) }};
 }
 
 /// Finds the min/max by scanning logical rows via `ScalarValue::try_from_array`.

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -143,7 +143,8 @@ macro_rules! min_max_generic {
 
 // min/max of two logically compatible scalar values.
 // Dictionary scalars are unwrapped to their inner values for comparison,
-// then rewrapped with the dictionary key type when both inputs are dictionaries.
+// then rewrapped with the dictionary key type when both inputs are dictionaries
+// after validating that their key types match.
 macro_rules! min_max {
     ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
         Ok(match ($VALUE, $DELTA) {
@@ -424,8 +425,19 @@ macro_rules! min_max {
                 let result = min_max_generic!(lhs, rhs, $OP);
 
                 match lhs_key_type.zip(rhs_key_type) {
-                    Some((key_type, _)) => {
-                        ScalarValue::Dictionary(Box::new(key_type.clone()), Box::new(result))
+                    Some((lhs_key_type, rhs_key_type)) => {
+                        if lhs_key_type != rhs_key_type {
+                            return internal_err!(
+                                "MIN/MAX is not expected to receive dictionary scalars with different key types ({:?} vs {:?})",
+                                lhs_key_type,
+                                rhs_key_type
+                            );
+                        }
+
+                        ScalarValue::Dictionary(
+                            Box::new(lhs_key_type.clone()),
+                            Box::new(result),
+                        )
                     }
                     None => result,
                 }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -413,6 +413,28 @@ macro_rules! min_max {
                 min_max_generic!(lhs, rhs, $OP)
             }
 
+            (
+                ScalarValue::Dictionary(key_type, lhs_inner),
+                ScalarValue::Dictionary(_, rhs_inner),
+            ) => {
+                let winner = min_max_generic!(lhs_inner.as_ref(), rhs_inner.as_ref(), $OP);
+                ScalarValue::Dictionary(key_type.clone(), Box::new(winner))
+            }
+
+            (
+                ScalarValue::Dictionary(_, lhs_inner),
+                rhs,
+            ) => {
+                min_max_generic!(lhs_inner.as_ref(), rhs, $OP)
+            }
+
+            (
+                lhs,
+                ScalarValue::Dictionary(_, rhs_inner),
+            ) => {
+                min_max_generic!(lhs, rhs_inner.as_ref(), $OP)
+            }
+
             e => {
                 return internal_err!(
                     "MIN/MAX is not expected to receive scalars of incompatible types {:?}",
@@ -766,9 +788,10 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::FixedSizeList(_, _) => {
             min_max_batch_generic(values, Ordering::Greater)?
         }
-        DataType::Dictionary(_, _) => {
-            let values = values.as_any_dictionary().values();
-            min_batch(values)?
+        DataType::Dictionary(key_type, _) => {
+            let dict_values = values.as_any_dictionary().values();
+            let inner = min_batch(dict_values)?;
+            ScalarValue::Dictionary(key_type.clone(), Box::new(inner))
         }
         _ => min_max_batch!(values, min),
     })
@@ -847,9 +870,10 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::List(_) => min_max_batch_generic(values, Ordering::Less)?,
         DataType::LargeList(_) => min_max_batch_generic(values, Ordering::Less)?,
         DataType::FixedSizeList(_, _) => min_max_batch_generic(values, Ordering::Less)?,
-        DataType::Dictionary(_, _) => {
-            let values = values.as_any_dictionary().values();
-            max_batch(values)?
+        DataType::Dictionary(key_type, _) => {
+            let dict_values = values.as_any_dictionary().values();
+            let inner = max_batch(dict_values)?;
+            ScalarValue::Dictionary(key_type.clone(), Box::new(inner))
         }
         _ => min_max_batch!(values, max),
     })

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -141,7 +141,9 @@ macro_rules! min_max_generic {
     }};
 }
 
-// min/max of two scalar values of the same type
+// min/max of two logically compatible scalar values.
+// Dictionary scalars are unwrapped to their inner values for comparison,
+// then rewrapped with the dictionary key type when both inputs are dictionaries.
 macro_rules! min_max {
     ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
         Ok(match ($VALUE, $DELTA) {
@@ -431,7 +433,7 @@ macro_rules! min_max {
 
             e => {
                 return internal_err!(
-                    "MIN/MAX is not expected to receive scalars of incompatible types {:?}",
+                    "MIN/MAX is not expected to receive logically incompatible scalar values {:?}",
                     e
                 )
             }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -417,26 +417,29 @@ macro_rules! min_max_scalar_impl {
             }
 
             (
-                ScalarValue::Dictionary(lhs_key_type, lhs),
-                ScalarValue::Dictionary(rhs_key_type, rhs),
+                ScalarValue::Dictionary(lhs_dict_key_type, lhs_dict_value),
+                ScalarValue::Dictionary(rhs_dict_key_type, rhs_dict_value),
             ) => {
-                if lhs_key_type != rhs_key_type {
+                if lhs_dict_key_type != rhs_dict_key_type {
                     return internal_err!(
                         "MIN/MAX is not expected to receive dictionary scalars with different key types ({:?} vs {:?})",
-                        lhs_key_type,
-                        rhs_key_type
+                        lhs_dict_key_type,
+                        rhs_dict_key_type
                     );
                 }
 
-                let result =
-                    min_max_scalar(lhs.as_ref(), rhs.as_ref(), choose_min_max!($OP))?;
-                ScalarValue::Dictionary(lhs_key_type.clone(), Box::new(result))
+                let result = min_max_scalar(
+                    lhs_dict_value.as_ref(),
+                    rhs_dict_value.as_ref(),
+                    choose_min_max!($OP),
+                )?;
+                ScalarValue::Dictionary(lhs_dict_key_type.clone(), Box::new(result))
             }
-            (ScalarValue::Dictionary(_, lhs), rhs) => {
-                min_max_scalar(lhs.as_ref(), rhs, choose_min_max!($OP))?
+            (ScalarValue::Dictionary(_, lhs_dict_value), rhs_scalar) => {
+                min_max_scalar(lhs_dict_value.as_ref(), rhs_scalar, choose_min_max!($OP))?
             }
-            (lhs, ScalarValue::Dictionary(_, rhs)) => {
-                min_max_scalar(lhs, rhs.as_ref(), choose_min_max!($OP))?
+            (lhs_scalar, ScalarValue::Dictionary(_, rhs_dict_value)) => {
+                min_max_scalar(lhs_scalar, rhs_dict_value.as_ref(), choose_min_max!($OP))?
             }
 
             e => {
@@ -462,9 +465,7 @@ fn min_max_scalar(
 }
 
 macro_rules! min_max {
-    ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
-        min_max_scalar($VALUE, $DELTA, choose_min_max!($OP))
-    }};
+    ($VALUE:expr, $DELTA:expr, $OP:ident) => {{ min_max_scalar($VALUE, $DELTA, choose_min_max!($OP)) }};
 }
 
 /// Finds the min/max by scanning logical rows via `ScalarValue::try_from_array`.

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -141,6 +141,16 @@ macro_rules! min_max_generic {
     }};
 }
 
+macro_rules! min_max_dictionary {
+    ($VALUE:expr, $DELTA:expr, wrap $KEY_TYPE:expr, $OP:ident) => {{
+        let winner = min_max_generic!($VALUE, $DELTA, $OP);
+        ScalarValue::Dictionary($KEY_TYPE.clone(), Box::new(winner))
+    }};
+    ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
+        min_max_generic!($VALUE, $DELTA, $OP)
+    }};
+}
+
 // min/max of two scalar values of the same type
 macro_rules! min_max {
     ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
@@ -417,22 +427,26 @@ macro_rules! min_max {
                 ScalarValue::Dictionary(key_type, lhs_inner),
                 ScalarValue::Dictionary(_, rhs_inner),
             ) => {
-                let winner = min_max_generic!(lhs_inner.as_ref(), rhs_inner.as_ref(), $OP);
-                ScalarValue::Dictionary(key_type.clone(), Box::new(winner))
+                min_max_dictionary!(
+                    lhs_inner.as_ref(),
+                    rhs_inner.as_ref(),
+                    wrap key_type,
+                    $OP
+                )
             }
 
             (
                 ScalarValue::Dictionary(_, lhs_inner),
                 rhs,
             ) => {
-                min_max_generic!(lhs_inner.as_ref(), rhs, $OP)
+                min_max_dictionary!(lhs_inner.as_ref(), rhs, $OP)
             }
 
             (
                 lhs,
                 ScalarValue::Dictionary(_, rhs_inner),
             ) => {
-                min_max_generic!(lhs, rhs_inner.as_ref(), $OP)
+                min_max_dictionary!(lhs, rhs_inner.as_ref(), $OP)
             }
 
             e => {
@@ -443,6 +457,17 @@ macro_rules! min_max {
             }
         })
     }};
+}
+
+fn dictionary_batch_extreme(
+    values: &ArrayRef,
+    extreme_fn: fn(&ArrayRef) -> Result<ScalarValue>,
+) -> Result<ScalarValue> {
+    let DataType::Dictionary(key_type, _) = values.data_type() else {
+        unreachable!("dictionary_batch_extreme requires dictionary arrays")
+    };
+    let inner = extreme_fn(values.as_any_dictionary().values())?;
+    Ok(ScalarValue::Dictionary(key_type.clone(), Box::new(inner)))
 }
 
 /// An accumulator to compute the maximum value
@@ -788,32 +813,22 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::FixedSizeList(_, _) => {
             min_max_batch_generic(values, Ordering::Greater)?
         }
-        DataType::Dictionary(key_type, _) => {
-            let dict_values = values.as_any_dictionary().values();
-            let inner = min_batch(dict_values)?;
-            ScalarValue::Dictionary(key_type.clone(), Box::new(inner))
-        }
+        DataType::Dictionary(_, _) => dictionary_batch_extreme(values, min_batch)?,
         _ => min_max_batch!(values, min),
     })
 }
 
 /// Generic min/max implementation for complex types
 fn min_max_batch_generic(array: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
-    if array.len() == array.null_count() {
+    let mut non_null_indices = (0..array.len()).filter(|&i| !array.is_null(i));
+    let Some(first_idx) = non_null_indices.next() else {
         return ScalarValue::try_from(array.data_type());
-    }
-    let mut extreme = ScalarValue::try_from_array(array, 0)?;
-    for i in 1..array.len() {
+    };
+
+    let mut extreme = ScalarValue::try_from_array(array, first_idx)?;
+    for i in non_null_indices {
         let current = ScalarValue::try_from_array(array, i)?;
-        if current.is_null() {
-            continue;
-        }
-        if extreme.is_null() {
-            extreme = current;
-            continue;
-        }
-        let cmp = extreme.try_cmp(&current)?;
-        if cmp == ordering {
+        if extreme.try_cmp(&current)? == ordering {
             extreme = current;
         }
     }
@@ -870,11 +885,7 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::List(_) => min_max_batch_generic(values, Ordering::Less)?,
         DataType::LargeList(_) => min_max_batch_generic(values, Ordering::Less)?,
         DataType::FixedSizeList(_, _) => min_max_batch_generic(values, Ordering::Less)?,
-        DataType::Dictionary(key_type, _) => {
-            let dict_values = values.as_any_dictionary().values();
-            let inner = max_batch(dict_values)?;
-            ScalarValue::Dictionary(key_type.clone(), Box::new(inner))
-        }
+        DataType::Dictionary(_, _) => dictionary_batch_extreme(values, max_batch)?,
         _ => min_max_batch!(values, max),
     })
 }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -823,6 +823,10 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
 }
 
 /// Finds the min/max by scanning logical rows via `ScalarValue::try_from_array`.
+///
+/// Callers are responsible for routing dictionary arrays to this helper.
+/// Passing `dictionary.values()` is semantically incorrect because it can
+/// include unreferenced dictionary entries and ignore null key positions.
 fn min_max_batch_generic(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
     let mut index = 0;
     let mut extreme = loop {
@@ -907,7 +911,7 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{AsArray, DictionaryArray};
+    use arrow::array::DictionaryArray;
     use std::sync::Arc;
 
     #[test]
@@ -993,12 +997,9 @@ mod tests {
         let keys = Int8Array::from(vec![Some(1), None, Some(1), Some(1)]);
         let values = Arc::new(StringArray::from(vec!["zzz", "bbb", "aaa"]));
         let array = Arc::new(DictionaryArray::new(keys, values)) as ArrayRef;
-        let raw_values = array.as_any_dictionary().values();
 
         let min = min_batch(&array)?;
         let max = max_batch(&array)?;
-        let raw_min = min_batch(raw_values)?;
-        let raw_max = max_batch(raw_values)?;
 
         let expected = ScalarValue::Dictionary(
             Box::new(DataType::Int8),
@@ -1007,8 +1008,6 @@ mod tests {
 
         assert_eq!(min, expected);
         assert_eq!(max, expected);
-        assert_eq!(raw_min, ScalarValue::Utf8(Some("aaa".to_string())));
-        assert_eq!(raw_max, ScalarValue::Utf8(Some("zzz".to_string())));
 
         Ok(())
     }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -823,10 +823,6 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
 }
 
 /// Finds the min/max by scanning logical rows via `ScalarValue::try_from_array`.
-///
-/// Callers are responsible for routing dictionary arrays to this helper.
-/// Passing `dictionary.values()` is semantically incorrect because it can
-/// include unreferenced dictionary entries and ignore null key positions.
 fn min_max_batch_generic(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
     let mut index = 0;
     let mut extreme = loop {
@@ -911,7 +907,7 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::DictionaryArray;
+    use arrow::array::{AsArray, DictionaryArray};
     use std::sync::Arc;
 
     #[test]
@@ -997,9 +993,12 @@ mod tests {
         let keys = Int8Array::from(vec![Some(1), None, Some(1), Some(1)]);
         let values = Arc::new(StringArray::from(vec!["zzz", "bbb", "aaa"]));
         let array = Arc::new(DictionaryArray::new(keys, values)) as ArrayRef;
+        let raw_values = array.as_any_dictionary().values();
 
         let min = min_batch(&array)?;
         let max = max_batch(&array)?;
+        let raw_min = min_batch(raw_values)?;
+        let raw_max = max_batch(raw_values)?;
 
         let expected = ScalarValue::Dictionary(
             Box::new(DataType::Int8),
@@ -1008,6 +1007,8 @@ mod tests {
 
         assert_eq!(min, expected);
         assert_eq!(max, expected);
+        assert_eq!(raw_min, ScalarValue::Utf8(Some("aaa".to_string())));
+        assert_eq!(raw_max, ScalarValue::Utf8(Some("zzz".to_string())));
 
         Ok(())
     }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -142,9 +142,9 @@ macro_rules! min_max_generic {
 }
 
 // min/max of two logically compatible scalar values.
-// Dictionary scalars are unwrapped to their inner values for comparison,
-// then rewrapped with the dictionary key type when both inputs are dictionaries
-// after validating that their key types match.
+// Dictionary scalars participate by comparing their inner logical values.
+// When both inputs are dictionaries, matching key types are preserved in the
+// result; differing key types remain an unexpected invariant violation.
 macro_rules! min_max {
     ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
         Ok(match ($VALUE, $DELTA) {
@@ -416,31 +416,38 @@ macro_rules! min_max {
                 min_max_generic!(lhs, rhs, $OP)
             }
 
-            (lhs, rhs)
-                if matches!(lhs, ScalarValue::Dictionary(_, _))
-                    || matches!(rhs, ScalarValue::Dictionary(_, _)) =>
-            {
-                let (lhs, lhs_key_type) = dictionary_scalar_parts(lhs);
-                let (rhs, rhs_key_type) = dictionary_scalar_parts(rhs);
-                let result = min_max_generic!(lhs, rhs, $OP);
-
-                match lhs_key_type.zip(rhs_key_type) {
-                    Some((lhs_key_type, rhs_key_type)) => {
-                        if lhs_key_type != rhs_key_type {
-                            return internal_err!(
-                                "MIN/MAX is not expected to receive dictionary scalars with different key types ({:?} vs {:?})",
-                                lhs_key_type,
-                                rhs_key_type
-                            );
-                        }
-
-                        ScalarValue::Dictionary(
-                            Box::new(lhs_key_type.clone()),
-                            Box::new(result),
-                        )
-                    }
-                    None => result,
+            (
+                ScalarValue::Dictionary(lhs_key_type, lhs),
+                ScalarValue::Dictionary(rhs_key_type, rhs),
+            ) => {
+                if lhs_key_type != rhs_key_type {
+                    return internal_err!(
+                        "MIN/MAX is not expected to receive dictionary scalars with different key types ({:?} vs {:?})",
+                        lhs_key_type,
+                        rhs_key_type
+                    );
                 }
+
+                let result = dictionary_inner_scalar_min_max(
+                    lhs.as_ref(),
+                    rhs.as_ref(),
+                    choose_min_max!($OP),
+                )?;
+                ScalarValue::Dictionary(lhs_key_type.clone(), Box::new(result))
+            }
+            (ScalarValue::Dictionary(_, lhs), rhs) => {
+                dictionary_inner_scalar_min_max(
+                    lhs.as_ref(),
+                    rhs,
+                    choose_min_max!($OP),
+                )?
+            }
+            (lhs, ScalarValue::Dictionary(_, rhs)) => {
+                dictionary_inner_scalar_min_max(
+                    lhs,
+                    rhs.as_ref(),
+                    choose_min_max!($OP),
+                )?
             }
 
             e => {
@@ -485,12 +492,15 @@ fn min_max_batch_generic(values: &ArrayRef, ordering: Ordering) -> Result<Scalar
     Ok(extreme)
 }
 
-fn dictionary_scalar_parts(value: &ScalarValue) -> (&ScalarValue, Option<&DataType>) {
-    match value {
-        ScalarValue::Dictionary(key_type, inner) => {
-            (inner.as_ref(), Some(key_type.as_ref()))
-        }
-        other => (other, None),
+fn dictionary_inner_scalar_min_max(
+    lhs: &ScalarValue,
+    rhs: &ScalarValue,
+    ordering: Ordering,
+) -> Result<ScalarValue> {
+    match ordering {
+        Ordering::Greater => min_max!(lhs, rhs, min),
+        Ordering::Less => min_max!(lhs, rhs, max),
+        Ordering::Equal => unreachable!("min/max comparisons do not use equal ordering"),
     }
 }
 
@@ -892,4 +902,89 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
         | DataType::Dictionary(_, _) => min_max_batch_generic(values, Ordering::Less)?,
         _ => min_max_batch!(values, max),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn min_max_dictionary_and_scalar_compare_by_inner_value() -> Result<()> {
+        let dictionary = ScalarValue::Dictionary(
+            Box::new(DataType::Int32),
+            Box::new(ScalarValue::Float32(Some(1.0))),
+        );
+        let scalar = ScalarValue::Float32(Some(2.0));
+
+        let result: Result<ScalarValue, DataFusionError> =
+            min_max!(&dictionary, &scalar, max);
+        let result = result?;
+
+        assert_eq!(result, ScalarValue::Float32(Some(2.0)));
+        Ok(())
+    }
+
+    #[test]
+    fn min_max_dictionary_same_key_type_rewraps_result() -> Result<()> {
+        let lhs = ScalarValue::Dictionary(
+            Box::new(DataType::Int32),
+            Box::new(ScalarValue::Float32(Some(1.0))),
+        );
+        let rhs = ScalarValue::Dictionary(
+            Box::new(DataType::Int32),
+            Box::new(ScalarValue::Float32(Some(2.0))),
+        );
+
+        let result: Result<ScalarValue, DataFusionError> = min_max!(&lhs, &rhs, max);
+        let result = result?;
+
+        assert_eq!(
+            result,
+            ScalarValue::Dictionary(
+                Box::new(DataType::Int32),
+                Box::new(ScalarValue::Float32(Some(2.0))),
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn min_max_dictionary_different_key_types_error() -> Result<()> {
+        let lhs = ScalarValue::Dictionary(
+            Box::new(DataType::Int8),
+            Box::new(ScalarValue::Float32(Some(1.0))),
+        );
+        let rhs = ScalarValue::Dictionary(
+            Box::new(DataType::Int32),
+            Box::new(ScalarValue::Float32(Some(2.0))),
+        );
+
+        let error: DataFusionError = min_max!(&lhs, &rhs, max).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("dictionary scalars with different key types")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn min_max_dictionary_and_incompatible_scalar_error() -> Result<()> {
+        let dictionary = ScalarValue::Dictionary(
+            Box::new(DataType::Int32),
+            Box::new(ScalarValue::Float32(Some(1.0))),
+        );
+        let scalar = ScalarValue::Int32(Some(2));
+
+        let error: DataFusionError =
+            min_max!(&dictionary, &scalar, max).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("logically incompatible scalar values")
+        );
+        Ok(())
+    }
 }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -18,8 +18,8 @@
 //! Basic min/max functionality shared across DataFusion aggregate functions
 
 use arrow::array::{
-    ArrayRef, AsArray as _, BinaryArray, BinaryViewArray, BooleanArray, Date32Array,
-    Date64Array, Decimal32Array, Decimal64Array, Decimal128Array, Decimal256Array,
+    ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Date64Array,
+    Decimal32Array, Decimal64Array, Decimal128Array, Decimal256Array,
     DurationMicrosecondArray, DurationMillisecondArray, DurationNanosecondArray,
     DurationSecondArray, FixedSizeBinaryArray, Float16Array, Float32Array, Float64Array,
     Int8Array, Int16Array, Int32Array, Int64Array, IntervalDayTimeArray,
@@ -457,13 +457,23 @@ macro_rules! min_max {
 
 fn dictionary_batch_extreme(
     values: &ArrayRef,
-    extreme_fn: fn(&ArrayRef) -> Result<ScalarValue>,
+    ordering: Ordering,
 ) -> Result<ScalarValue> {
-    let DataType::Dictionary(key_type, _) = values.data_type() else {
-        unreachable!("dictionary_batch_extreme requires dictionary arrays")
-    };
-    let inner = extreme_fn(values.as_any_dictionary().values())?;
-    Ok(wrap_dictionary_scalar(key_type.as_ref(), inner))
+    let mut extreme: Option<ScalarValue> = None;
+
+    for i in 0..values.len() {
+        let current = ScalarValue::try_from_array(values, i)?;
+        if current.is_null() {
+            continue;
+        }
+
+        match &extreme {
+            Some(existing) if existing.try_cmp(&current)? != ordering => {}
+            _ => extreme = Some(current),
+        }
+    }
+
+    extreme.map_or_else(|| ScalarValue::try_from(values.data_type()), Ok)
 }
 
 fn wrap_dictionary_scalar(key_type: &DataType, value: ScalarValue) -> ScalarValue {
@@ -813,7 +823,9 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::FixedSizeList(_, _) => {
             min_max_batch_generic(values, Ordering::Greater)?
         }
-        DataType::Dictionary(_, _) => dictionary_batch_extreme(values, min_batch)?,
+        DataType::Dictionary(_, _) => {
+            dictionary_batch_extreme(values, Ordering::Greater)?
+        }
         _ => min_max_batch!(values, min),
     })
 }
@@ -828,7 +840,10 @@ fn min_max_batch_generic(array: &ArrayRef, ordering: Ordering) -> Result<ScalarV
     let mut extreme = ScalarValue::try_from_array(array, first_idx)?;
     for i in non_null_indices {
         let current = ScalarValue::try_from_array(array, i)?;
-        if extreme.try_cmp(&current)? == ordering {
+        if current.is_null() {
+            continue;
+        }
+        if extreme.is_null() || extreme.try_cmp(&current)? == ordering {
             extreme = current;
         }
     }
@@ -885,7 +900,7 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::List(_) => min_max_batch_generic(values, Ordering::Less)?,
         DataType::LargeList(_) => min_max_batch_generic(values, Ordering::Less)?,
         DataType::FixedSizeList(_, _) => min_max_batch_generic(values, Ordering::Less)?,
-        DataType::Dictionary(_, _) => dictionary_batch_extreme(values, max_batch)?,
+        DataType::Dictionary(_, _) => dictionary_batch_extreme(values, Ordering::Less)?,
         _ => min_max_batch!(values, max),
     })
 }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -439,7 +439,12 @@ macro_rules! min_max {
     }};
 }
 
-fn scalar_batch_extreme(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
+/// Finds the min/max by scanning logical rows via `ScalarValue::try_from_array`.
+///
+/// This path is required for dictionary arrays because comparing
+/// `dictionary.values()` is not semantically correct: it can include
+/// unreferenced values and ignore null key positions.
+fn scalar_row_extreme(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
     let mut index = 0;
     let mut extreme = loop {
         if index == values.len() {
@@ -824,7 +829,7 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
             )
         }
         data_type if is_row_wise_batch_type(data_type) => {
-            scalar_batch_extreme(values, Ordering::Greater)?
+            scalar_row_extreme(values, Ordering::Greater)?
         }
         _ => min_max_batch!(values, min),
     })
@@ -876,7 +881,7 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
             ScalarValue::FixedSizeBinary(*size, value)
         }
         data_type if is_row_wise_batch_type(data_type) => {
-            scalar_batch_extreme(values, Ordering::Less)?
+            scalar_row_extreme(values, Ordering::Less)?
         }
         _ => min_max_batch!(values, max),
     })

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -903,8 +903,6 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{AsArray, DictionaryArray};
-    use std::sync::Arc;
 
     #[test]
     fn min_max_dictionary_and_scalar_compare_by_inner_value() -> Result<()> {
@@ -981,32 +979,6 @@ mod tests {
                 .to_string()
                 .contains("logically incompatible scalar values")
         );
-        Ok(())
-    }
-
-    #[test]
-    fn min_max_batch_dictionary_uses_logical_rows() -> Result<()> {
-        let keys = Int8Array::from(vec![Some(1), None, Some(1), Some(1)]);
-        let values = Arc::new(StringArray::from(vec!["zzz", "bbb", "aaa"]));
-        let array = Arc::new(DictionaryArray::new(keys, values)) as ArrayRef;
-        let raw_values = array.as_any_dictionary().values();
-        let raw_min = min_batch(raw_values)?;
-
-        let min = min_batch(&array)?;
-        let max = max_batch(&array)?;
-
-        let expected = ScalarValue::Dictionary(
-            Box::new(DataType::Int8),
-            Box::new(ScalarValue::Utf8(Some("bbb".to_string()))),
-        );
-
-        // raw_min is "aaa" because it is the min of the values, but min/max of the dictionary should be "bbb"
-        // because the null key is ignored and all non-null keys point to "bbb".
-        assert_ne!(raw_min, expected);
-
-        assert_eq!(min, expected);
-        assert_eq!(max, expected);
-
         Ok(())
     }
 }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -476,38 +476,6 @@ fn min_max_scalar(
     }
 }
 
-/// Finds the min/max by scanning logical rows via `ScalarValue::try_from_array`.
-///
-/// This path is required for dictionary arrays because comparing
-/// `dictionary.values()` is not semantically correct: it can include
-/// unreferenced values and ignore null key positions.
-fn min_max_batch_generic(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
-    let mut index = 0;
-    let mut extreme = loop {
-        if index == values.len() {
-            return ScalarValue::try_from(values.data_type());
-        }
-
-        let current = ScalarValue::try_from_array(values, index)?;
-        index += 1;
-
-        if !current.is_null() {
-            break current;
-        }
-    };
-
-    while index < values.len() {
-        let current = ScalarValue::try_from_array(values, index)?;
-        index += 1;
-
-        if !current.is_null() && extreme.try_cmp(&current)? == ordering {
-            extreme = current;
-        }
-    }
-
-    Ok(extreme)
-}
-
 /// An accumulator to compute the maximum value
 #[derive(Debug, Clone)]
 pub struct MaxAccumulator {
@@ -852,6 +820,38 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
         | DataType::Dictionary(_, _) => min_max_batch_generic(values, Ordering::Greater)?,
         _ => min_max_batch!(values, min),
     })
+}
+
+/// Finds the min/max by scanning logical rows via `ScalarValue::try_from_array`.
+///
+/// This path is required for dictionary arrays because comparing
+/// `dictionary.values()` is not semantically correct: it can include
+/// unreferenced values and ignore null key positions.
+fn min_max_batch_generic(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
+    let mut index = 0;
+    let mut extreme = loop {
+        if index == values.len() {
+            return ScalarValue::try_from(values.data_type());
+        }
+
+        let current = ScalarValue::try_from_array(values, index)?;
+        index += 1;
+
+        if !current.is_null() {
+            break current;
+        }
+    };
+
+    while index < values.len() {
+        let current = ScalarValue::try_from_array(values, index)?;
+        index += 1;
+
+        if !current.is_null() && extreme.try_cmp(&current)? == ordering {
+            extreme = current;
+        }
+    }
+
+    Ok(extreme)
 }
 
 /// dynamically-typed max(array) -> ScalarValue

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -141,10 +141,6 @@ macro_rules! min_max_generic {
     }};
 }
 
-macro_rules! min_max_dictionary {
-    ($VALUE:expr, $DELTA:expr, $OP:ident) => {{ min_max_generic!($VALUE, $DELTA, $OP) }};
-}
-
 // min/max of two scalar values of the same type
 macro_rules! min_max {
     ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
@@ -417,32 +413,20 @@ macro_rules! min_max {
                 min_max_generic!(lhs, rhs, $OP)
             }
 
-            (
-                ScalarValue::Dictionary(key_type, lhs_inner),
-                ScalarValue::Dictionary(_, rhs_inner),
-            ) => {
-                wrap_dictionary_scalar(
-                    key_type.as_ref(),
-                    min_max_dictionary!(
-                    lhs_inner.as_ref(),
-                    rhs_inner.as_ref(),
-                    $OP
-                    ),
-                )
-            }
+            (lhs, rhs)
+                if matches!(lhs, ScalarValue::Dictionary(_, _))
+                    || matches!(rhs, ScalarValue::Dictionary(_, _)) =>
+            {
+                let (lhs, lhs_key_type) = dictionary_scalar_parts(lhs);
+                let (rhs, rhs_key_type) = dictionary_scalar_parts(rhs);
+                let result = min_max_generic!(lhs, rhs, $OP);
 
-            (
-                ScalarValue::Dictionary(_, lhs_inner),
-                rhs,
-            ) => {
-                min_max_dictionary!(lhs_inner.as_ref(), rhs, $OP)
-            }
-
-            (
-                lhs,
-                ScalarValue::Dictionary(_, rhs_inner),
-            ) => {
-                min_max_dictionary!(lhs, rhs_inner.as_ref(), $OP)
+                match lhs_key_type.zip(rhs_key_type) {
+                    Some((key_type, _)) => {
+                        ScalarValue::Dictionary(Box::new(key_type.clone()), Box::new(result))
+                    }
+                    None => result,
+                }
             }
 
             e => {
@@ -456,25 +440,50 @@ macro_rules! min_max {
 }
 
 fn scalar_batch_extreme(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
-    let mut extreme: Option<ScalarValue> = None;
-
-    for i in 0..values.len() {
-        let current = ScalarValue::try_from_array(values, i)?;
-        if current.is_null() {
-            continue;
+    let mut index = 0;
+    let mut extreme = loop {
+        if index == values.len() {
+            return ScalarValue::try_from(values.data_type());
         }
 
-        match &extreme {
-            Some(existing) if existing.try_cmp(&current)? != ordering => {}
-            _ => extreme = Some(current),
+        let current = ScalarValue::try_from_array(values, index)?;
+        index += 1;
+
+        if !current.is_null() {
+            break current;
+        }
+    };
+
+    while index < values.len() {
+        let current = ScalarValue::try_from_array(values, index)?;
+        index += 1;
+
+        if !current.is_null() && extreme.try_cmp(&current)? == ordering {
+            extreme = current;
         }
     }
 
-    extreme.map_or_else(|| ScalarValue::try_from(values.data_type()), Ok)
+    Ok(extreme)
 }
 
-fn wrap_dictionary_scalar(key_type: &DataType, value: ScalarValue) -> ScalarValue {
-    ScalarValue::Dictionary(Box::new(key_type.clone()), Box::new(value))
+fn dictionary_scalar_parts(value: &ScalarValue) -> (&ScalarValue, Option<&DataType>) {
+    match value {
+        ScalarValue::Dictionary(key_type, inner) => {
+            (inner.as_ref(), Some(key_type.as_ref()))
+        }
+        other => (other, None),
+    }
+}
+
+fn is_row_wise_batch_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Struct(_)
+            | DataType::List(_)
+            | DataType::LargeList(_)
+            | DataType::FixedSizeList(_, _)
+            | DataType::Dictionary(_, _)
+    )
 }
 
 /// An accumulator to compute the maximum value
@@ -814,20 +823,11 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
                 min_binary_view
             )
         }
-        DataType::Struct(_) => min_max_batch_generic(values, Ordering::Greater)?,
-        DataType::List(_) => min_max_batch_generic(values, Ordering::Greater)?,
-        DataType::LargeList(_) => min_max_batch_generic(values, Ordering::Greater)?,
-        DataType::FixedSizeList(_, _) => {
-            min_max_batch_generic(values, Ordering::Greater)?
+        data_type if is_row_wise_batch_type(data_type) => {
+            scalar_batch_extreme(values, Ordering::Greater)?
         }
-        DataType::Dictionary(_, _) => scalar_batch_extreme(values, Ordering::Greater)?,
         _ => min_max_batch!(values, min),
     })
-}
-
-/// Generic min/max implementation for complex types
-fn min_max_batch_generic(array: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
-    scalar_batch_extreme(array, ordering)
 }
 
 /// dynamically-typed max(array) -> ScalarValue
@@ -875,11 +875,9 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
             let value = value.map(|e| e.to_vec());
             ScalarValue::FixedSizeBinary(*size, value)
         }
-        DataType::Struct(_) => min_max_batch_generic(values, Ordering::Less)?,
-        DataType::List(_) => min_max_batch_generic(values, Ordering::Less)?,
-        DataType::LargeList(_) => min_max_batch_generic(values, Ordering::Less)?,
-        DataType::FixedSizeList(_, _) => min_max_batch_generic(values, Ordering::Less)?,
-        DataType::Dictionary(_, _) => scalar_batch_extreme(values, Ordering::Less)?,
+        data_type if is_row_wise_batch_type(data_type) => {
+            scalar_batch_extreme(values, Ordering::Less)?
+        }
         _ => min_max_batch!(values, max),
     })
 }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -428,26 +428,15 @@ macro_rules! min_max_scalar_impl {
                     );
                 }
 
-                let result = dictionary_inner_scalar_min_max(
-                    lhs.as_ref(),
-                    rhs.as_ref(),
-                    choose_min_max!($OP),
-                )?;
+                let result =
+                    min_max_scalar(lhs.as_ref(), rhs.as_ref(), choose_min_max!($OP))?;
                 ScalarValue::Dictionary(lhs_key_type.clone(), Box::new(result))
             }
             (ScalarValue::Dictionary(_, lhs), rhs) => {
-                dictionary_inner_scalar_min_max(
-                    lhs.as_ref(),
-                    rhs,
-                    choose_min_max!($OP),
-                )?
+                min_max_scalar(lhs.as_ref(), rhs, choose_min_max!($OP))?
             }
             (lhs, ScalarValue::Dictionary(_, rhs)) => {
-                dictionary_inner_scalar_min_max(
-                    lhs,
-                    rhs.as_ref(),
-                    choose_min_max!($OP),
-                )?
+                min_max_scalar(lhs, rhs.as_ref(), choose_min_max!($OP))?
             }
 
             e => {
@@ -508,14 +497,6 @@ fn min_max_batch_generic(values: &ArrayRef, ordering: Ordering) -> Result<Scalar
     }
 
     Ok(extreme)
-}
-
-fn dictionary_inner_scalar_min_max(
-    lhs: &ScalarValue,
-    rhs: &ScalarValue,
-    ordering: Ordering,
-) -> Result<ScalarValue> {
-    min_max_scalar(lhs, rhs, ordering)
 }
 
 /// An accumulator to compute the maximum value

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -145,9 +145,9 @@ macro_rules! min_max_generic {
 // Dictionary scalars participate by comparing their inner logical values.
 // When both inputs are dictionaries, matching key types are preserved in the
 // result; differing key types remain an unexpected invariant violation.
-macro_rules! min_max {
+macro_rules! min_max_scalar_impl {
     ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
-        Ok(match ($VALUE, $DELTA) {
+        match ($VALUE, $DELTA) {
             (ScalarValue::Null, ScalarValue::Null) => ScalarValue::Null,
             (
                 lhs @ ScalarValue::Decimal32(lhsv, lhsp, lhss),
@@ -456,7 +456,25 @@ macro_rules! min_max {
                     e
                 )
             }
-        })
+        }
+    }};
+}
+
+fn min_max_scalar(
+    lhs: &ScalarValue,
+    rhs: &ScalarValue,
+    ordering: Ordering,
+) -> Result<ScalarValue> {
+    match ordering {
+        Ordering::Greater => Ok(min_max_scalar_impl!(lhs, rhs, min)),
+        Ordering::Less => Ok(min_max_scalar_impl!(lhs, rhs, max)),
+        Ordering::Equal => unreachable!("min/max comparisons do not use equal ordering"),
+    }
+}
+
+macro_rules! min_max {
+    ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
+        min_max_scalar($VALUE, $DELTA, choose_min_max!($OP))
     }};
 }
 
@@ -497,11 +515,7 @@ fn dictionary_inner_scalar_min_max(
     rhs: &ScalarValue,
     ordering: Ordering,
 ) -> Result<ScalarValue> {
-    match ordering {
-        Ordering::Greater => min_max!(lhs, rhs, min),
-        Ordering::Less => min_max!(lhs, rhs, max),
-        Ordering::Equal => unreachable!("min/max comparisons do not use equal ordering"),
-    }
+    min_max_scalar(lhs, rhs, ordering)
 }
 
 /// An accumulator to compute the maximum value
@@ -916,9 +930,7 @@ mod tests {
         );
         let scalar = ScalarValue::Float32(Some(2.0));
 
-        let result: Result<ScalarValue, DataFusionError> =
-            min_max!(&dictionary, &scalar, max);
-        let result = result?;
+        let result = min_max_scalar(&dictionary, &scalar, Ordering::Less)?;
 
         assert_eq!(result, ScalarValue::Float32(Some(2.0)));
         Ok(())
@@ -935,8 +947,7 @@ mod tests {
             Box::new(ScalarValue::Float32(Some(2.0))),
         );
 
-        let result: Result<ScalarValue, DataFusionError> = min_max!(&lhs, &rhs, max);
-        let result = result?;
+        let result = min_max_scalar(&lhs, &rhs, Ordering::Less)?;
 
         assert_eq!(
             result,
@@ -959,7 +970,8 @@ mod tests {
             Box::new(ScalarValue::Float32(Some(2.0))),
         );
 
-        let error: DataFusionError = min_max!(&lhs, &rhs, max).unwrap_err();
+        let error: DataFusionError =
+            min_max_scalar(&lhs, &rhs, Ordering::Less).unwrap_err();
 
         assert!(
             error
@@ -978,7 +990,7 @@ mod tests {
         let scalar = ScalarValue::Int32(Some(2));
 
         let error: DataFusionError =
-            min_max!(&dictionary, &scalar, max).unwrap_err();
+            min_max_scalar(&dictionary, &scalar, Ordering::Less).unwrap_err();
 
         assert!(
             error

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -824,9 +824,9 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
 
 /// Finds the min/max by scanning logical rows via `ScalarValue::try_from_array`.
 ///
-/// This path is required for dictionary arrays because comparing
-/// `dictionary.values()` is not semantically correct: it can include
-/// unreferenced values and ignore null key positions.
+/// Callers are responsible for routing dictionary arrays to this helper.
+/// Passing `dictionary.values()` is semantically incorrect because it can
+/// include unreferenced dictionary entries and ignore null key positions.
 fn min_max_batch_generic(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
     let mut index = 0;
     let mut extreme = loop {
@@ -911,6 +911,8 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::DictionaryArray;
+    use std::sync::Arc;
 
     #[test]
     fn min_max_dictionary_and_scalar_compare_by_inner_value() -> Result<()> {
@@ -987,6 +989,26 @@ mod tests {
                 .to_string()
                 .contains("logically incompatible scalar values")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn min_max_batch_dictionary_uses_logical_rows() -> Result<()> {
+        let keys = Int8Array::from(vec![Some(1), None, Some(1), Some(1)]);
+        let values = Arc::new(StringArray::from(vec!["zzz", "bbb", "aaa"]));
+        let array = Arc::new(DictionaryArray::new(keys, values)) as ArrayRef;
+
+        let min = min_batch(&array)?;
+        let max = max_batch(&array)?;
+
+        let expected = ScalarValue::Dictionary(
+            Box::new(DataType::Int8),
+            Box::new(ScalarValue::Utf8(Some("bbb".to_string()))),
+        );
+
+        assert_eq!(min, expected);
+        assert_eq!(max, expected);
+
         Ok(())
     }
 }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -458,7 +458,7 @@ macro_rules! min_max {
 /// This path is required for dictionary arrays because comparing
 /// `dictionary.values()` is not semantically correct: it can include
 /// unreferenced values and ignore null key positions.
-fn scalar_row_extreme(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
+fn min_max_batch_generic(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
     let mut index = 0;
     let mut extreme = loop {
         if index == values.len() {
@@ -492,19 +492,6 @@ fn dictionary_scalar_parts(value: &ScalarValue) -> (&ScalarValue, Option<&DataTy
         }
         other => (other, None),
     }
-}
-
-// Primitive, string, and binary types use specialized Arrow min/max kernels.
-// These remaining types fall back to scalar row-by-row logical comparison.
-fn requires_logical_row_scan(data_type: &DataType) -> bool {
-    matches!(
-        data_type,
-        DataType::Struct(_)
-            | DataType::List(_)
-            | DataType::LargeList(_)
-            | DataType::FixedSizeList(_, _)
-            | DataType::Dictionary(_, _)
-    )
 }
 
 /// An accumulator to compute the maximum value
@@ -844,9 +831,11 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
                 min_binary_view
             )
         }
-        data_type if requires_logical_row_scan(data_type) => {
-            scalar_row_extreme(values, Ordering::Greater)?
-        }
+        DataType::Struct(_)
+        | DataType::List(_)
+        | DataType::LargeList(_)
+        | DataType::FixedSizeList(_, _)
+        | DataType::Dictionary(_, _) => min_max_batch_generic(values, Ordering::Greater)?,
         _ => min_max_batch!(values, min),
     })
 }
@@ -896,9 +885,11 @@ pub fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
             let value = value.map(|e| e.to_vec());
             ScalarValue::FixedSizeBinary(*size, value)
         }
-        data_type if requires_logical_row_scan(data_type) => {
-            scalar_row_extreme(values, Ordering::Less)?
-        }
+        DataType::Struct(_)
+        | DataType::List(_)
+        | DataType::LargeList(_)
+        | DataType::FixedSizeList(_, _)
+        | DataType::Dictionary(_, _) => min_max_batch_generic(values, Ordering::Less)?,
         _ => min_max_batch!(values, max),
     })
 }

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -142,13 +142,7 @@ macro_rules! min_max_generic {
 }
 
 macro_rules! min_max_dictionary {
-    ($VALUE:expr, $DELTA:expr, wrap $KEY_TYPE:expr, $OP:ident) => {{
-        let winner = min_max_generic!($VALUE, $DELTA, $OP);
-        ScalarValue::Dictionary($KEY_TYPE.clone(), Box::new(winner))
-    }};
-    ($VALUE:expr, $DELTA:expr, $OP:ident) => {{
-        min_max_generic!($VALUE, $DELTA, $OP)
-    }};
+    ($VALUE:expr, $DELTA:expr, $OP:ident) => {{ min_max_generic!($VALUE, $DELTA, $OP) }};
 }
 
 // min/max of two scalar values of the same type
@@ -427,11 +421,13 @@ macro_rules! min_max {
                 ScalarValue::Dictionary(key_type, lhs_inner),
                 ScalarValue::Dictionary(_, rhs_inner),
             ) => {
-                min_max_dictionary!(
+                wrap_dictionary_scalar(
+                    key_type.as_ref(),
+                    min_max_dictionary!(
                     lhs_inner.as_ref(),
                     rhs_inner.as_ref(),
-                    wrap key_type,
                     $OP
+                    ),
                 )
             }
 
@@ -467,7 +463,11 @@ fn dictionary_batch_extreme(
         unreachable!("dictionary_batch_extreme requires dictionary arrays")
     };
     let inner = extreme_fn(values.as_any_dictionary().values())?;
-    Ok(ScalarValue::Dictionary(key_type.clone(), Box::new(inner)))
+    Ok(wrap_dictionary_scalar(key_type.as_ref(), inner))
+}
+
+fn wrap_dictionary_scalar(key_type: &DataType, value: ScalarValue) -> ScalarValue {
+    ScalarValue::Dictionary(Box::new(key_type.clone()), Box::new(value))
 }
 
 /// An accumulator to compute the maximum value

--- a/datafusion/functions-aggregate-common/src/min_max.rs
+++ b/datafusion/functions-aggregate-common/src/min_max.rs
@@ -822,31 +822,23 @@ pub fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
     })
 }
 
-/// Finds the min/max by scanning logical rows via `ScalarValue::try_from_array`.
-///
-/// Callers are responsible for routing dictionary arrays to this helper.
-/// Passing `dictionary.values()` is semantically incorrect because it can
-/// include unreferenced dictionary entries and ignore null key positions.
-fn min_max_batch_generic(values: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
-    let mut index = 0;
-    let mut extreme = loop {
-        if index == values.len() {
-            return ScalarValue::try_from(values.data_type());
+/// Generic min/max implementation for complex types
+fn min_max_batch_generic(array: &ArrayRef, ordering: Ordering) -> Result<ScalarValue> {
+    if array.len() == array.null_count() {
+        return ScalarValue::try_from(array.data_type());
+    }
+    let mut extreme = ScalarValue::try_from_array(array, 0)?;
+    for i in 1..array.len() {
+        let current = ScalarValue::try_from_array(array, i)?;
+        if current.is_null() {
+            continue;
         }
-
-        let current = ScalarValue::try_from_array(values, index)?;
-        index += 1;
-
-        if !current.is_null() {
-            break current;
+        if extreme.is_null() {
+            extreme = current;
+            continue;
         }
-    };
-
-    while index < values.len() {
-        let current = ScalarValue::try_from_array(values, index)?;
-        index += 1;
-
-        if !current.is_null() && extreme.try_cmp(&current)? == ordering {
+        let cmp = extreme.try_cmp(&current)?;
+        if cmp == ordering {
             extreme = current;
         }
     }

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -1355,10 +1355,8 @@ mod tests {
 
     #[test]
     fn test_min_max_dictionary_ignores_unreferenced_values() -> Result<()> {
-        let dict_array_ref = string_dictionary_batch(
-            &["a", "z", "zz_unused"],
-            &[Some(1), Some(1), None],
-        );
+        let dict_array_ref =
+            string_dictionary_batch(&["a", "z", "zz_unused"], &[Some(1), Some(1), None]);
         let dict_type = dict_array_ref.data_type().clone();
 
         assert_dictionary_min_max(&dict_type, &[dict_array_ref], "z", "z")

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -1004,12 +1004,13 @@ mod tests {
     use super::*;
     use arrow::{
         array::{
-            DictionaryArray, Float32Array, Int32Array, IntervalDayTimeArray,
-            IntervalMonthDayNanoArray, IntervalYearMonthArray, StringArray,
+            Array, DictionaryArray, Float32Array, Int32Array, Int8Array,
+            IntervalDayTimeArray, IntervalMonthDayNanoArray, PrimitiveArray,
+            IntervalYearMonthArray, StringArray,
         },
         datatypes::{
-            IntervalDayTimeType, IntervalMonthDayNanoType, IntervalUnit,
-            IntervalYearMonthType,
+            ArrowDictionaryKeyType, IntervalDayTimeType, IntervalMonthDayNanoType,
+            IntervalUnit, IntervalYearMonthType,
         },
     };
     use std::sync::Arc;
@@ -1272,10 +1273,18 @@ mod tests {
     }
 
     fn string_dictionary_batch(values: &[&str], keys: &[Option<i32>]) -> ArrayRef {
+        string_dictionary_batch_with_keys(Int32Array::from(keys.to_vec()), values)
+    }
+
+    fn string_dictionary_batch_with_keys<K>(
+        keys: PrimitiveArray<K>,
+        values: &[&str],
+    ) -> ArrayRef
+    where
+        K: ArrowDictionaryKeyType,
+    {
         let values = Arc::new(StringArray::from(values.to_vec())) as ArrayRef;
-        Arc::new(
-            DictionaryArray::try_new(Int32Array::from(keys.to_vec()), values).unwrap(),
-        ) as ArrayRef
+        Arc::new(DictionaryArray::try_new(keys, values).unwrap()) as ArrayRef
     }
 
     fn optional_string_dictionary_batch(
@@ -1381,6 +1390,18 @@ mod tests {
         let batch2 = string_dictionary_batch(&["a", "d"], &[Some(0), Some(1)]);
 
         assert_dictionary_min_max(&dict_type, &[batch1, batch2], "a", "d")
+    }
+
+    #[test]
+    fn test_min_max_dictionary_int8_keys() -> Result<()> {
+        let dict_type =
+            DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8));
+        let dict_array_ref = string_dictionary_batch_with_keys(
+            Int8Array::from(vec![Some(0), Some(1), Some(2), Some(3)]),
+            &["b", "c", "a", "d"],
+        );
+
+        assert_dictionary_min_max(&dict_type, &[dict_array_ref], "a", "d")
     }
 
     #[test]

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -1004,9 +1004,9 @@ mod tests {
     use super::*;
     use arrow::{
         array::{
-            Array, DictionaryArray, Float32Array, Int32Array, Int8Array,
-            IntervalDayTimeArray, IntervalMonthDayNanoArray, PrimitiveArray,
-            IntervalYearMonthArray, StringArray,
+            Array, DictionaryArray, Float32Array, Int8Array, Int32Array,
+            IntervalDayTimeArray, IntervalMonthDayNanoArray, IntervalYearMonthArray,
+            PrimitiveArray, StringArray,
         },
         datatypes::{
             ArrowDictionaryKeyType, IntervalDayTimeType, IntervalMonthDayNanoType,

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -1288,6 +1288,13 @@ mod tests {
         ) as ArrayRef
     }
 
+    fn float_dictionary_batch(values: &[f32], keys: &[Option<i32>]) -> ArrayRef {
+        let values = Arc::new(Float32Array::from(values.to_vec())) as ArrayRef;
+        Arc::new(
+            DictionaryArray::try_new(Int32Array::from(keys.to_vec()), values).unwrap(),
+        ) as ArrayRef
+    }
+
     fn evaluate_dictionary_accumulator(
         mut acc: impl Accumulator,
         batches: &[ArrayRef],
@@ -1376,5 +1383,36 @@ mod tests {
         let batch2 = string_dictionary_batch(&["a", "d"], &[Some(0), Some(1)]);
 
         assert_dictionary_min_max(&dict_type, &[batch1, batch2], "a", "d")
+    }
+
+    #[test]
+    fn test_min_max_dictionary_float_with_nans() -> Result<()> {
+        let dict_type =
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Float32));
+        let batch1 = float_dictionary_batch(&[0.0, f32::NAN], &[Some(0), Some(1)]);
+        let batch2 = float_dictionary_batch(&[f32::NEG_INFINITY], &[Some(0)]);
+
+        let min_result = evaluate_dictionary_accumulator(
+            MinAccumulator::try_new(&dict_type)?,
+            &[Arc::clone(&batch1), Arc::clone(&batch2)],
+        )?;
+        assert_eq!(
+            min_result,
+            dict_scalar(
+                DataType::Int32,
+                ScalarValue::Float32(Some(f32::NEG_INFINITY)),
+            )
+        );
+
+        let max_result = evaluate_dictionary_accumulator(
+            MaxAccumulator::try_new(&dict_type)?,
+            &[batch1, batch2],
+        )?;
+        assert_eq!(
+            max_result,
+            dict_scalar(DataType::Int32, ScalarValue::Float32(Some(f32::NAN)))
+        );
+
+        Ok(())
     }
 }

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -1262,4 +1262,99 @@ mod tests {
         assert_eq!(max_result, ScalarValue::Utf8(Some("🦀".to_string())));
         Ok(())
     }
+
+    fn dict_scalar(key_type: DataType, inner: ScalarValue) -> ScalarValue {
+        ScalarValue::Dictionary(Box::new(key_type), Box::new(inner))
+    }
+
+    #[test]
+    fn test_min_max_dictionary_without_coercion() -> Result<()> {
+        let values = StringArray::from(vec!["b", "c", "a", "d"]);
+        let keys = Int32Array::from(vec![Some(0), Some(1), Some(2), Some(3)]);
+        let dict_array =
+            DictionaryArray::try_new(keys, Arc::new(values) as ArrayRef).unwrap();
+        let dict_array_ref = Arc::new(dict_array) as ArrayRef;
+        let dict_type = dict_array_ref.data_type().clone();
+
+        let mut min_acc = MinAccumulator::try_new(&dict_type)?;
+        min_acc.update_batch(&[Arc::clone(&dict_array_ref)])?;
+        let min_result = min_acc.evaluate()?;
+        assert_eq!(
+            min_result,
+            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("a".to_string())))
+        );
+
+        let mut max_acc = MaxAccumulator::try_new(&dict_type)?;
+        max_acc.update_batch(&[Arc::clone(&dict_array_ref)])?;
+        let max_result = max_acc.evaluate()?;
+        assert_eq!(
+            max_result,
+            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("d".to_string())))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_min_max_dictionary_with_nulls() -> Result<()> {
+        let values = StringArray::from(vec!["b", "c", "a"]);
+        let keys = Int32Array::from(vec![None, Some(0), None, Some(1), Some(2)]);
+        let dict_array =
+            DictionaryArray::try_new(keys, Arc::new(values) as ArrayRef).unwrap();
+        let dict_array_ref = Arc::new(dict_array) as ArrayRef;
+        let dict_type = dict_array_ref.data_type().clone();
+
+        let mut min_acc = MinAccumulator::try_new(&dict_type)?;
+        min_acc.update_batch(&[Arc::clone(&dict_array_ref)])?;
+        let min_result = min_acc.evaluate()?;
+        assert_eq!(
+            min_result,
+            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("a".to_string())))
+        );
+
+        let mut max_acc = MaxAccumulator::try_new(&dict_type)?;
+        max_acc.update_batch(&[Arc::clone(&dict_array_ref)])?;
+        let max_result = max_acc.evaluate()?;
+        assert_eq!(
+            max_result,
+            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("c".to_string())))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_min_max_dictionary_multi_batch() -> Result<()> {
+        let dict_type =
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+
+        let values1 = StringArray::from(vec!["b", "c"]);
+        let keys1 = Int32Array::from(vec![Some(0), Some(1)]);
+        let batch1 = Arc::new(
+            DictionaryArray::try_new(keys1, Arc::new(values1) as ArrayRef).unwrap(),
+        ) as ArrayRef;
+
+        let values2 = StringArray::from(vec!["a", "d"]);
+        let keys2 = Int32Array::from(vec![Some(0), Some(1)]);
+        let batch2 = Arc::new(
+            DictionaryArray::try_new(keys2, Arc::new(values2) as ArrayRef).unwrap(),
+        ) as ArrayRef;
+
+        let mut min_acc = MinAccumulator::try_new(&dict_type)?;
+        min_acc.update_batch(&[Arc::clone(&batch1)])?;
+        min_acc.update_batch(&[Arc::clone(&batch2)])?;
+        let min_result = min_acc.evaluate()?;
+        assert_eq!(
+            min_result,
+            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("a".to_string())))
+        );
+
+        let mut max_acc = MaxAccumulator::try_new(&dict_type)?;
+        max_acc.update_batch(&[Arc::clone(&batch1)])?;
+        max_acc.update_batch(&[Arc::clone(&batch2)])?;
+        let max_result = max_acc.evaluate()?;
+        assert_eq!(
+            max_result,
+            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("d".to_string())))
+        );
+        Ok(())
+    }
 }

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -1267,94 +1267,79 @@ mod tests {
         ScalarValue::Dictionary(Box::new(key_type), Box::new(inner))
     }
 
-    #[test]
-    fn test_min_max_dictionary_without_coercion() -> Result<()> {
-        let values = StringArray::from(vec!["b", "c", "a", "d"]);
-        let keys = Int32Array::from(vec![Some(0), Some(1), Some(2), Some(3)]);
-        let dict_array =
-            DictionaryArray::try_new(keys, Arc::new(values) as ArrayRef).unwrap();
-        let dict_array_ref = Arc::new(dict_array) as ArrayRef;
-        let dict_type = dict_array_ref.data_type().clone();
+    fn utf8_dict_scalar(key_type: DataType, value: &str) -> ScalarValue {
+        dict_scalar(key_type, ScalarValue::Utf8(Some(value.to_string())))
+    }
 
-        let mut min_acc = MinAccumulator::try_new(&dict_type)?;
-        min_acc.update_batch(&[Arc::clone(&dict_array_ref)])?;
-        let min_result = min_acc.evaluate()?;
+    fn string_dictionary_batch(
+        values: Vec<&str>,
+        keys: Vec<Option<i32>>,
+    ) -> ArrayRef {
+        let values = Arc::new(StringArray::from(values)) as ArrayRef;
+        Arc::new(DictionaryArray::try_new(Int32Array::from(keys), values).unwrap())
+            as ArrayRef
+    }
+
+    fn assert_dictionary_min_max(
+        dict_type: &DataType,
+        batches: &[ArrayRef],
+        expected_min: &str,
+        expected_max: &str,
+    ) -> Result<()> {
+        let key_type = match dict_type {
+            DataType::Dictionary(key_type, _) => key_type.as_ref().clone(),
+            other => panic!("expected dictionary type, got {other:?}"),
+        };
+
+        let mut min_acc = MinAccumulator::try_new(dict_type)?;
+        for batch in batches {
+            min_acc.update_batch(&[Arc::clone(batch)])?;
+        }
         assert_eq!(
-            min_result,
-            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("a".to_string())))
+            min_acc.evaluate()?,
+            utf8_dict_scalar(key_type.clone(), expected_min)
         );
 
-        let mut max_acc = MaxAccumulator::try_new(&dict_type)?;
-        max_acc.update_batch(&[Arc::clone(&dict_array_ref)])?;
-        let max_result = max_acc.evaluate()?;
-        assert_eq!(
-            max_result,
-            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("d".to_string())))
-        );
+        let mut max_acc = MaxAccumulator::try_new(dict_type)?;
+        for batch in batches {
+            max_acc.update_batch(&[Arc::clone(batch)])?;
+        }
+        assert_eq!(max_acc.evaluate()?, utf8_dict_scalar(key_type, expected_max));
+
         Ok(())
     }
 
     #[test]
-    fn test_min_max_dictionary_with_nulls() -> Result<()> {
-        let values = StringArray::from(vec!["b", "c", "a"]);
-        let keys = Int32Array::from(vec![None, Some(0), None, Some(1), Some(2)]);
-        let dict_array =
-            DictionaryArray::try_new(keys, Arc::new(values) as ArrayRef).unwrap();
-        let dict_array_ref = Arc::new(dict_array) as ArrayRef;
+    fn test_min_max_dictionary_without_coercion() -> Result<()> {
+        let dict_array_ref = string_dictionary_batch(
+            vec!["b", "c", "a", "d"],
+            vec![Some(0), Some(1), Some(2), Some(3)],
+        );
         let dict_type = dict_array_ref.data_type().clone();
 
-        let mut min_acc = MinAccumulator::try_new(&dict_type)?;
-        min_acc.update_batch(&[Arc::clone(&dict_array_ref)])?;
-        let min_result = min_acc.evaluate()?;
-        assert_eq!(
-            min_result,
-            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("a".to_string())))
-        );
+        assert_dictionary_min_max(&dict_type, &[dict_array_ref], "a", "d")
+    }
 
-        let mut max_acc = MaxAccumulator::try_new(&dict_type)?;
-        max_acc.update_batch(&[Arc::clone(&dict_array_ref)])?;
-        let max_result = max_acc.evaluate()?;
-        assert_eq!(
-            max_result,
-            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("c".to_string())))
+    #[test]
+    fn test_min_max_dictionary_with_nulls() -> Result<()> {
+        let dict_array_ref = string_dictionary_batch(
+            vec!["b", "c", "a"],
+            vec![None, Some(0), None, Some(1), Some(2)],
         );
-        Ok(())
+        let dict_type = dict_array_ref.data_type().clone();
+
+        assert_dictionary_min_max(&dict_type, &[dict_array_ref], "a", "c")
     }
 
     #[test]
     fn test_min_max_dictionary_multi_batch() -> Result<()> {
         let dict_type =
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+        let batch1 =
+            string_dictionary_batch(vec!["b", "c"], vec![Some(0), Some(1)]);
+        let batch2 =
+            string_dictionary_batch(vec!["a", "d"], vec![Some(0), Some(1)]);
 
-        let values1 = StringArray::from(vec!["b", "c"]);
-        let keys1 = Int32Array::from(vec![Some(0), Some(1)]);
-        let batch1 = Arc::new(
-            DictionaryArray::try_new(keys1, Arc::new(values1) as ArrayRef).unwrap(),
-        ) as ArrayRef;
-
-        let values2 = StringArray::from(vec!["a", "d"]);
-        let keys2 = Int32Array::from(vec![Some(0), Some(1)]);
-        let batch2 = Arc::new(
-            DictionaryArray::try_new(keys2, Arc::new(values2) as ArrayRef).unwrap(),
-        ) as ArrayRef;
-
-        let mut min_acc = MinAccumulator::try_new(&dict_type)?;
-        min_acc.update_batch(&[Arc::clone(&batch1)])?;
-        min_acc.update_batch(&[Arc::clone(&batch2)])?;
-        let min_result = min_acc.evaluate()?;
-        assert_eq!(
-            min_result,
-            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("a".to_string())))
-        );
-
-        let mut max_acc = MaxAccumulator::try_new(&dict_type)?;
-        max_acc.update_batch(&[Arc::clone(&batch1)])?;
-        max_acc.update_batch(&[Arc::clone(&batch2)])?;
-        let max_result = max_acc.evaluate()?;
-        assert_eq!(
-            max_result,
-            dict_scalar(DataType::Int32, ScalarValue::Utf8(Some("d".to_string())))
-        );
-        Ok(())
+        assert_dictionary_min_max(&dict_type, &[batch1, batch2], "a", "d")
     }
 }

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -1271,13 +1271,21 @@ mod tests {
         dict_scalar(key_type, ScalarValue::Utf8(Some(value.to_string())))
     }
 
-    fn string_dictionary_batch(
-        values: Vec<&str>,
-        keys: Vec<Option<i32>>,
-    ) -> ArrayRef {
-        let values = Arc::new(StringArray::from(values)) as ArrayRef;
-        Arc::new(DictionaryArray::try_new(Int32Array::from(keys), values).unwrap())
-            as ArrayRef
+    fn string_dictionary_batch(values: &[&str], keys: &[Option<i32>]) -> ArrayRef {
+        let values = Arc::new(StringArray::from(values.to_vec())) as ArrayRef;
+        Arc::new(
+            DictionaryArray::try_new(Int32Array::from(keys.to_vec()), values).unwrap(),
+        ) as ArrayRef
+    }
+
+    fn evaluate_dictionary_accumulator(
+        mut acc: impl Accumulator,
+        batches: &[ArrayRef],
+    ) -> Result<ScalarValue> {
+        for batch in batches {
+            acc.update_batch(&[Arc::clone(batch)])?;
+        }
+        acc.evaluate()
     }
 
     fn assert_dictionary_min_max(
@@ -1291,20 +1299,17 @@ mod tests {
             other => panic!("expected dictionary type, got {other:?}"),
         };
 
-        let mut min_acc = MinAccumulator::try_new(dict_type)?;
-        for batch in batches {
-            min_acc.update_batch(&[Arc::clone(batch)])?;
-        }
-        assert_eq!(
-            min_acc.evaluate()?,
-            utf8_dict_scalar(key_type.clone(), expected_min)
-        );
+        let min_result = evaluate_dictionary_accumulator(
+            MinAccumulator::try_new(dict_type)?,
+            batches,
+        )?;
+        assert_eq!(min_result, utf8_dict_scalar(key_type.clone(), expected_min));
 
-        let mut max_acc = MaxAccumulator::try_new(dict_type)?;
-        for batch in batches {
-            max_acc.update_batch(&[Arc::clone(batch)])?;
-        }
-        assert_eq!(max_acc.evaluate()?, utf8_dict_scalar(key_type, expected_max));
+        let max_result = evaluate_dictionary_accumulator(
+            MaxAccumulator::try_new(dict_type)?,
+            batches,
+        )?;
+        assert_eq!(max_result, utf8_dict_scalar(key_type, expected_max));
 
         Ok(())
     }
@@ -1312,8 +1317,8 @@ mod tests {
     #[test]
     fn test_min_max_dictionary_without_coercion() -> Result<()> {
         let dict_array_ref = string_dictionary_batch(
-            vec!["b", "c", "a", "d"],
-            vec![Some(0), Some(1), Some(2), Some(3)],
+            &["b", "c", "a", "d"],
+            &[Some(0), Some(1), Some(2), Some(3)],
         );
         let dict_type = dict_array_ref.data_type().clone();
 
@@ -1323,8 +1328,8 @@ mod tests {
     #[test]
     fn test_min_max_dictionary_with_nulls() -> Result<()> {
         let dict_array_ref = string_dictionary_batch(
-            vec!["b", "c", "a"],
-            vec![None, Some(0), None, Some(1), Some(2)],
+            &["b", "c", "a"],
+            &[None, Some(0), None, Some(1), Some(2)],
         );
         let dict_type = dict_array_ref.data_type().clone();
 
@@ -1335,10 +1340,8 @@ mod tests {
     fn test_min_max_dictionary_multi_batch() -> Result<()> {
         let dict_type =
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
-        let batch1 =
-            string_dictionary_batch(vec!["b", "c"], vec![Some(0), Some(1)]);
-        let batch2 =
-            string_dictionary_batch(vec!["a", "d"], vec![Some(0), Some(1)]);
+        let batch1 = string_dictionary_batch(&["b", "c"], &[Some(0), Some(1)]);
+        let batch2 = string_dictionary_batch(&["a", "d"], &[Some(0), Some(1)]);
 
         assert_dictionary_min_max(&dict_type, &[batch1, batch2], "a", "d")
     }

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -1259,7 +1259,7 @@ mod tests {
         let mut max_acc = MaxAccumulator::try_new(&rt_type)?;
         max_acc.update_batch(&[Arc::clone(&dict_array_ref)])?;
         let max_result = max_acc.evaluate()?;
-        assert_eq!(max_result, ScalarValue::Utf8(Some("🦀".to_string())));
+        assert_eq!(max_result, ScalarValue::Utf8(Some("d".to_string())));
         Ok(())
     }
 
@@ -1272,6 +1272,16 @@ mod tests {
     }
 
     fn string_dictionary_batch(values: &[&str], keys: &[Option<i32>]) -> ArrayRef {
+        let values = Arc::new(StringArray::from(values.to_vec())) as ArrayRef;
+        Arc::new(
+            DictionaryArray::try_new(Int32Array::from(keys.to_vec()), values).unwrap(),
+        ) as ArrayRef
+    }
+
+    fn optional_string_dictionary_batch(
+        values: &[Option<&str>],
+        keys: &[Option<i32>],
+    ) -> ArrayRef {
         let values = Arc::new(StringArray::from(values.to_vec())) as ArrayRef;
         Arc::new(
             DictionaryArray::try_new(Int32Array::from(keys.to_vec()), values).unwrap(),
@@ -1334,6 +1344,28 @@ mod tests {
         let dict_type = dict_array_ref.data_type().clone();
 
         assert_dictionary_min_max(&dict_type, &[dict_array_ref], "a", "c")
+    }
+
+    #[test]
+    fn test_min_max_dictionary_ignores_unreferenced_values() -> Result<()> {
+        let dict_array_ref = string_dictionary_batch(
+            &["a", "z", "zz_unused"],
+            &[Some(1), Some(1), None],
+        );
+        let dict_type = dict_array_ref.data_type().clone();
+
+        assert_dictionary_min_max(&dict_type, &[dict_array_ref], "z", "z")
+    }
+
+    #[test]
+    fn test_min_max_dictionary_ignores_referenced_null_values() -> Result<()> {
+        let dict_array_ref = optional_string_dictionary_batch(
+            &[Some("b"), None, Some("a"), Some("d")],
+            &[Some(0), Some(1), Some(2), Some(3)],
+        );
+        let dict_type = dict_array_ref.data_type().clone();
+
+        assert_dictionary_min_max(&dict_type, &[dict_array_ref], "a", "d")
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #21150.

---

## Rationale for this change

The existing implementation of `min`/`max` does not correctly support dictionary-encoded arrays. Previously, dictionary arrays were handled by directly evaluating their underlying values array, which is semantically incorrect because:

* It may include unreferenced values that do not appear in the logical dataset
* It ignores nulls in the key array
* It does not preserve dictionary key semantics in scalar results

This leads to incorrect aggregation results for dictionary types.

This PR introduces a logical row-based evaluation for dictionary arrays and ensures scalar comparisons correctly unwrap and rewrap dictionary values when needed.

---

## What changes are included in this PR?

* Add logical row-based min/max computation (`scalar_row_extreme`) for:

  * Dictionary arrays
  * Struct, List, LargeList, and FixedSizeList types
* Replace previous dictionary handling that operated on `values()` with correct row-wise evaluation
* Introduce `requires_logical_row_scan` to centralize fallback logic for complex types
* Enhance scalar comparison logic:

  * Unwrap dictionary scalars before comparison
  * Rewrap results when both inputs are dictionaries with matching key types
  * Validate key type compatibility
* Improve error messaging for incompatible scalar comparisons
* Remove obsolete `min_max_batch_generic` implementation

---

## Are these changes tested?

Yes. Comprehensive tests have been added to validate correctness across multiple scenarios:

* Basic dictionary min/max behavior
* Handling of null keys and null values
* Ignoring unreferenced dictionary values
* Multi-batch aggregation behavior
* Float dictionary handling including `NaN` and infinities

These tests ensure correctness and guard against regressions.

---

## Are there any user-facing changes?

Yes. The behavior of `min` and `max` on dictionary-encoded arrays is now:

* Correct and semantically aligned with logical row values
* Consistent with other data types

Previously incorrect results may now differ, which is a correctness fix rather than a breaking API change.

---

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
