### PR TITLE
Compare length + prefix together in ArrowBytesViewMap find

### DIFF
--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -310,10 +310,8 @@ where
                             return header.view == view_u128;
                         }
 
-                        // For larger strings: first compare the 4-byte prefix
-                        let stored_prefix = (header.view >> 32) as u32;
-                        let input_prefix = (view_u128 >> 32) as u32;
-                        if stored_prefix != input_prefix {
+                        // For larger strings: compare length + 4-byte prefix together
+                        if (header.view as u64) != (view_u128 as u64) {
                             return false;
                         }
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A - performance optimization

## Rationale for this change

When probing `ArrowBytesViewMap` for strings > 12 bytes, the existing code only compared the 4-byte prefix before falling through to a full byte comparison. It did not compare the string length first, so two strings with different lengths but the same hash and prefix would unnecessarily perform a full memcmp.

## What changes are included in this PR?

Compare the first 8 bytes of the StringView (length + 4-byte prefix) as a single `u64` instead of extracting and comparing only the 4-byte prefix. This:
- Rejects length mismatches earlier (before the full byte comparison)
- Is simpler (one `u64` comparison vs one `u32` extraction + comparison)
- Is no slower (one 8-byte cmp vs one 4-byte cmp on modern CPUs)

## Are these changes tested?

Existing tests cover this code path.

## Are there any user-facing changes?

No, this is a performance optimization only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)