### PR TITLE
Update contributor names in changelog for version 52.4.0

### DIFF
--- a/dev/changelog/52.4.0.md
+++ b/dev/changelog/52.4.0.md
@@ -30,7 +30,7 @@ See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgradi
 - [branch-52] fix: interval analysis error when have two filterexec that inner filter proves zero selectivity (#20743) [#20880](https://github.com/apache/datafusion/pull/20880) (haohuaijin)
 - [branch-52] fix: Return `probe_side.len()` for RightMark/Anti count(\*) queries (#20710) [#20881](https://github.com/apache/datafusion/pull/20881) (jonathanc-n)
 - [branch-52] fix: disable dynamic filter pushdown for non min/max aggregates (#20279) [#20877](https://github.com/apache/datafusion/pull/20877) (notashes)
-- [branch-52] Fix duplicate group keys after hash aggregation spill (#20724) (#20858) [#20917](https://github.com/apache/datafusion/pull/20917) (gboucher90)
+- [branch-52] Fix duplicate group keys after hash aggregation spill (#20724) (#20858) [#20917](https://github.com/apache/datafusion/pull/20917) (rgehan/16pierre/gboucher90)
 - [branch-52] perf: Cache num_output_rows in sort merge join to avoid O(n) recount (#20478) [#20936](https://github.com/apache/datafusion/pull/20936) (andygrove)
 - [branch-52] fix: SanityCheckPlan error with window functions and NVL filter (#20231) [#20931](https://github.com/apache/datafusion/pull/20931) (EeshanBembi)
 - [branch-52] chore: Ignore RUSTSEC-2024-0014 (#20862) [#21020](https://github.com/apache/datafusion/pull/21020) (comphead)
@@ -45,7 +45,7 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
      2	Andrew Lamb
      1	Andy Grove
      1	EeshanBembi
-     1	Guillaume Boucher
+     1	Renan Gehan, Quentin Pierre & Guillaume Boucher
      1	Huaijin
      1	Jeffrey Vo
      1	Jonathan Chen


### PR DESCRIPTION
Updated contributor names to include Renan Gehan and Quentin Pierre.

## Which issue does this PR close?

None

## Rationale for this change

See https://github.com/apache/datafusion/pull/20858#issuecomment-4054254414, a lot of a work for the PR https://github.com/apache/datafusion/pull/20858 was done by Renan Gehan and Quentin Pierre and I would like them to share the credits if possible 🙇 

## What changes are included in this PR?


## Are these changes tested?

Not applicable

## Are there any user-facing changes?

No
