### PR TITLE
docs: Update `map_extract` examples

### DIFF
--- a/datafusion/functions-nested/src/map_extract.rs
+++ b/datafusion/functions-nested/src/map_extract.rs
@@ -57,6 +57,11 @@ SELECT map_extract(MAP {1: 'one', 2: 'two'}, 2);
 
 SELECT map_extract(MAP {'x': 10, 'y': NULL, 'z': 30}, 'y');
 ----
+[NULL]
+
+-- non-existing key
+SELECT map_extract(MAP {'x': 10, 'y': NULL, 'z': 30}, 'a');
+----
 []
 ```"#,
     argument(

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -5006,6 +5006,11 @@ SELECT map_extract(MAP {1: 'one', 2: 'two'}, 2);
 
 SELECT map_extract(MAP {'x': 10, 'y': NULL, 'z': 30}, 'y');
 ----
+[NULL]
+
+-- non-existing key
+SELECT map_extract(MAP {'x': 10, 'y': NULL, 'z': 30}, 'a');
+----
 []
 ```
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A.

## Rationale for this change

While reviewing https://github.com/apache/datafusion-python/pull/1461, I noticed that an example in the `map_extract` function was wrong:

```sql
-- example
SELECT map_extract(MAP {'x': 10, 'y': NULL, 'z': 30}, 'y');
----
[]

-- datafusion
SELECT map_extract(MAP {'x': 10, 'y': NULL, 'z': 30}, 'y');
----
[NULL]
```

## What changes are included in this PR?

- Fixed the previous example.
- Also added a new example showing a `map_extract` on an empty key.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
