### PR TITLE
Coalesce adjacent ranges in ParquetPushDecoder I/O requests

### DIFF
--- a/datafusion/core/tests/datasource/object_store_access.rs
+++ b/datafusion/core/tests/datasource/object_store_access.rs
@@ -478,8 +478,8 @@ async fn query_single_parquet_file() {
     RequestCountingObjectStore()
     Total Requests: 3
     - GET  (opts) path=parquet_table.parquet head=true
-    - GET  (ranges) path=parquet_table.parquet ranges=4-534,534-1064
-    - GET  (ranges) path=parquet_table.parquet ranges=1064-1594,1594-2124
+    - GET  (ranges) path=parquet_table.parquet ranges=4-1064
+    - GET  (ranges) path=parquet_table.parquet ranges=1064-2124
     "
     );
 }
@@ -502,7 +502,7 @@ async fn query_single_parquet_file_with_single_predicate() {
     RequestCountingObjectStore()
     Total Requests: 2
     - GET  (opts) path=parquet_table.parquet head=true
-    - GET  (ranges) path=parquet_table.parquet ranges=1064-1481,1481-1594,1594-2011,2011-2124
+    - GET  (ranges) path=parquet_table.parquet ranges=1064-2124
     "
     );
 }
@@ -526,8 +526,8 @@ async fn query_single_parquet_file_multi_row_groups_multiple_predicates() {
     RequestCountingObjectStore()
     Total Requests: 3
     - GET  (opts) path=parquet_table.parquet head=true
-    - GET  (ranges) path=parquet_table.parquet ranges=4-421,421-534,534-951,951-1064
-    - GET  (ranges) path=parquet_table.parquet ranges=1064-1481,1481-1594,1594-2011,2011-2124
+    - GET  (ranges) path=parquet_table.parquet ranges=4-1064
+    - GET  (ranges) path=parquet_table.parquet ranges=1064-2124
     "
     );
 }

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -33,6 +33,7 @@ use datafusion_physical_expr_adapter::replace_columns_with_literals;
 use std::collections::HashMap;
 use std::future::Future;
 use std::mem;
+use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -1193,8 +1194,9 @@ impl PushDecoderStreamState {
     async fn transition(&mut self) -> Option<Result<RecordBatch>> {
         loop {
             match self.decoder.try_decode() {
-                Ok(DecodeResult::NeedsData(ranges)) => {
+                Ok(DecodeResult::NeedsData(mut ranges)) => {
                     let fetch = async {
+                        coalesce_ranges(&mut ranges);
                         let data = self.reader.get_byte_ranges(ranges.clone()).await?;
                         self.decoder.push_ranges(ranges, data)?;
                         Ok::<_, ParquetError>(())
@@ -1570,6 +1572,24 @@ fn should_enable_page_index(
             .as_ref()
             .map(|p| p.filter_number() > 0)
             .unwrap_or(false)
+}
+
+/// Coalesce adjacent or overlapping ranges in-place into fewer, larger ranges.
+fn coalesce_ranges(ranges: &mut Vec<Range<u64>>) {
+    if ranges.len() <= 1 {
+        return;
+    }
+    ranges.sort_by_key(|r| r.start);
+    let mut write = 0;
+    for read in 1..ranges.len() {
+        if ranges[read].start <= ranges[write].end {
+            ranges[write].end = ranges[write].end.max(ranges[read].end);
+        } else {
+            write += 1;
+            ranges[write] = ranges[read].clone();
+        }
+    }
+    ranges.truncate(write + 1);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

The `ParquetPushDecoder` may request adjacent byte ranges (e.g. `4-534` and `534-1064`) that can be merged into a single range (`4-1064`), reducing the number of object store I/O operations.

## What changes are included in this PR?

- Added `coalesce_ranges()` function that merges adjacent/overlapping byte ranges in-place
- Applied coalescing to the `NeedsData` branch of the `PushDecoderStreamState` transition loop in `opener.rs`
- Updated test expectations to reflect the reduced number of range requests

## Are these changes tested?

Yes, existing tests in `object_store_access.rs` verify the coalesced ranges.

## Are there any user-facing changes?

No API changes. Users may see improved I/O performance when reading Parquet files due to fewer object store requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)