### PR TITLE
feat: add array_sum, array_product, array_avg functions and list_min alias

### DIFF
--- a/datafusion/functions-nested/src/array_avg.rs
+++ b/datafusion/functions-nested/src/array_avg.rs
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`ScalarUDFImpl`] definitions for array_avg function.
+
+use crate::utils::make_scalar_function;
+use crate::vector_math::convert_to_f64_array;
+use arrow::array::{ArrayRef, Float64Array, GenericListArray, OffsetSizeTrait};
+use arrow::datatypes::DataType;
+use arrow::datatypes::DataType::{LargeList, List};
+use datafusion_common::cast::{as_large_list_array, as_list_array};
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{Result, exec_err, plan_err};
+use datafusion_doc::Documentation;
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_macros::user_doc;
+use std::sync::Arc;
+
+make_udf_expr_and_func!(
+    ArrayAvg,
+    array_avg,
+    array,
+    "returns the average of all values in the array.",
+    array_avg_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns the average (arithmetic mean) of all numeric values in the array. Always returns Float64. Supports integer and floating-point element types. NULL elements are skipped; an all-NULL or empty array returns NULL.",
+    syntax_example = "array_avg(array)",
+    sql_example = r#"```sql
+> select array_avg([1, 2, 3, 4]);
++--------------------------------------+
+| array_avg(List([1,2,3,4]))           |
++--------------------------------------+
+| 2.5                                  |
++--------------------------------------+
+```"#,
+    argument(
+        name = "array",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ArrayAvg {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for ArrayAvg {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArrayAvg {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::array(Volatility::Immutable),
+            aliases: vec!["list_avg".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for ArrayAvg {
+    fn name(&self) -> &str {
+        "array_avg"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        let [array] = take_function_args(self.name(), arg_types)?;
+        match array {
+            List(_) | LargeList(_) => Ok(DataType::Float64),
+            arg_type => plan_err!("{} does not support type {arg_type}", self.name()),
+        }
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(array_avg_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+fn array_avg_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array] = take_function_args("array_avg", args)?;
+    match array.data_type() {
+        List(_) => array_avg_dispatch(as_list_array(array)?),
+        LargeList(_) => array_avg_dispatch(as_large_list_array(array)?),
+        arg_type => exec_err!("array_avg does not support type: {arg_type}"),
+    }
+}
+
+fn array_avg_dispatch<O: OffsetSizeTrait>(
+    list_array: &GenericListArray<O>,
+) -> Result<ArrayRef> {
+    let result = list_array
+        .iter()
+        .map(compute_array_avg)
+        .collect::<Result<Float64Array>>()?;
+
+    Ok(Arc::new(result) as ArrayRef)
+}
+
+fn compute_array_avg(arr: Option<ArrayRef>) -> Result<Option<f64>> {
+    let value = match arr {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+
+    let values = convert_to_f64_array(&value)?;
+
+    if values.is_empty() {
+        return Ok(None);
+    }
+
+    let mut sum = 0.0;
+    let mut count = 0u64;
+
+    for val in values.iter().flatten() {
+        sum += val;
+        count += 1;
+    }
+
+    if count == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(sum / count as f64))
+    }
+}

--- a/datafusion/functions-nested/src/array_math.rs
+++ b/datafusion/functions-nested/src/array_math.rs
@@ -1,0 +1,795 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [ScalarUDFImpl] definitions for array_add, array_subtract, and array_scale functions.
+
+use crate::utils::make_scalar_function;
+use crate::vector_math::convert_to_f64_array;
+use arrow::array::{
+    Array, ArrayRef, Float64Array, LargeListArray, ListArray, OffsetSizeTrait,
+};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::{
+    DataType, Field,
+    DataType::{FixedSizeList, LargeList, List, Null},
+};
+use datafusion_common::cast::{as_float64_array, as_generic_list_array};
+use datafusion_common::utils::{ListCoercion, coerced_type_with_base_type_only};
+use datafusion_common::{Result, exec_err, plan_err, utils::take_function_args};
+use datafusion_expr::{
+    ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignature, Volatility,
+};
+use datafusion_functions::downcast_arg;
+use datafusion_macros::user_doc;
+use itertools::Itertools;
+use std::sync::Arc;
+
+// ============================================================================
+// array_add
+// ============================================================================
+
+make_udf_expr_and_func!(
+    ArrayAdd,
+    array_add,
+    array1 array2,
+    "returns element-wise addition of two numeric arrays.",
+    array_add_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns a new array with element-wise addition of two input arrays of equal length.",
+    syntax_example = "array_add(array1, array2)",
+    sql_example = r#"```sql
+> select array_add([1.0, 2.0], [3.0, 4.0]);
++------------------------------------------+
+| array_add(List([1.0,2.0]), List([3.0,4.0])) |
++------------------------------------------+
+| [4.0, 6.0]                              |
++------------------------------------------+
+```"#,
+    argument(
+        name = "array1",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    ),
+    argument(
+        name = "array2",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ArrayAdd {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for ArrayAdd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArrayAdd {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+            aliases: vec!["list_add".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for ArrayAdd {
+    fn name(&self) -> &str {
+        "array_add"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        match &arg_types[0] {
+            List(_) | FixedSizeList(..) | Null => Ok(List(Arc::new(
+                Field::new_list_field(DataType::Float64, true),
+            ))),
+            LargeList(_) => Ok(LargeList(Arc::new(Field::new_list_field(
+                DataType::Float64,
+                true,
+            )))),
+            _ => exec_err!("array_add does not support type {}", arg_types[0]),
+        }
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        let [_, _] = take_function_args(self.name(), arg_types)?;
+        let coercion = Some(&ListCoercion::FixedSizedListToList);
+        let arg_types = arg_types.iter().map(|arg_type| {
+            if matches!(arg_type, Null | List(_) | LargeList(_) | FixedSizeList(..)) {
+                Ok(coerced_type_with_base_type_only(
+                    arg_type,
+                    &DataType::Float64,
+                    coercion,
+                ))
+            } else {
+                plan_err!("{} does not support type {arg_type}", self.name())
+            }
+        });
+
+        arg_types.try_collect()
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(array_add_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+fn array_add_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array1, array2] = take_function_args("array_add", args)?;
+    match (array1.data_type(), array2.data_type()) {
+        (List(_), List(_)) => general_array_binary_op::<i32>(args, "array_add", |a, b| a + b),
+        (LargeList(_), LargeList(_)) => {
+            general_array_binary_op::<i64>(args, "array_add", |a, b| a + b)
+        }
+        (arg_type1, arg_type2) => {
+            exec_err!("array_add does not support types {arg_type1} and {arg_type2}")
+        }
+    }
+}
+
+// ============================================================================
+// array_subtract
+// ============================================================================
+
+make_udf_expr_and_func!(
+    ArraySubtract,
+    array_subtract,
+    array1 array2,
+    "returns element-wise subtraction of two numeric arrays.",
+    array_subtract_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns a new array with element-wise subtraction of two input arrays of equal length.",
+    syntax_example = "array_subtract(array1, array2)",
+    sql_example = r#"```sql
+> select array_subtract([5.0, 3.0], [1.0, 2.0]);
++-----------------------------------------------+
+| array_subtract(List([5.0,3.0]), List([1.0,2.0])) |
++-----------------------------------------------+
+| [4.0, 1.0]                                   |
++-----------------------------------------------+
+```"#,
+    argument(
+        name = "array1",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    ),
+    argument(
+        name = "array2",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ArraySubtract {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for ArraySubtract {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArraySubtract {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+            aliases: vec!["list_subtract".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for ArraySubtract {
+    fn name(&self) -> &str {
+        "array_subtract"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        match &arg_types[0] {
+            List(_) | FixedSizeList(..) | Null => Ok(List(Arc::new(
+                Field::new_list_field(DataType::Float64, true),
+            ))),
+            LargeList(_) => Ok(LargeList(Arc::new(Field::new_list_field(
+                DataType::Float64,
+                true,
+            )))),
+            _ => exec_err!(
+                "array_subtract does not support type {}",
+                arg_types[0]
+            ),
+        }
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        let [_, _] = take_function_args(self.name(), arg_types)?;
+        let coercion = Some(&ListCoercion::FixedSizedListToList);
+        let arg_types = arg_types.iter().map(|arg_type| {
+            if matches!(arg_type, Null | List(_) | LargeList(_) | FixedSizeList(..)) {
+                Ok(coerced_type_with_base_type_only(
+                    arg_type,
+                    &DataType::Float64,
+                    coercion,
+                ))
+            } else {
+                plan_err!("{} does not support type {arg_type}", self.name())
+            }
+        });
+
+        arg_types.try_collect()
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(array_subtract_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+fn array_subtract_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array1, array2] = take_function_args("array_subtract", args)?;
+    match (array1.data_type(), array2.data_type()) {
+        (List(_), List(_)) => {
+            general_array_binary_op::<i32>(args, "array_subtract", |a, b| a - b)
+        }
+        (LargeList(_), LargeList(_)) => {
+            general_array_binary_op::<i64>(args, "array_subtract", |a, b| a - b)
+        }
+        (arg_type1, arg_type2) => {
+            exec_err!(
+                "array_subtract does not support types {arg_type1} and {arg_type2}"
+            )
+        }
+    }
+}
+
+// ============================================================================
+// array_scale
+// ============================================================================
+
+make_udf_expr_and_func!(
+    ArrayScale,
+    array_scale,
+    array scalar,
+    "returns array with each element multiplied by a scalar.",
+    array_scale_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns a new array with each element multiplied by the given scalar value.",
+    syntax_example = "array_scale(array, scalar)",
+    sql_example = r#"```sql
+> select array_scale([1.0, 2.0, 3.0], 2.0);
++-------------------------------------------+
+| array_scale(List([1.0,2.0,3.0]), 2.0)    |
++-------------------------------------------+
+| [2.0, 4.0, 6.0]                          |
++-------------------------------------------+
+```"#,
+    argument(
+        name = "array",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    ),
+    argument(
+        name = "scalar",
+        description = "Float64 scalar value to multiply each element by."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ArrayScale {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for ArrayScale {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArrayScale {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Any(2),
+                ],
+                Volatility::Immutable,
+            ),
+            aliases: vec!["list_scale".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for ArrayScale {
+    fn name(&self) -> &str {
+        "array_scale"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        match &arg_types[0] {
+            List(_) | FixedSizeList(..) | Null => Ok(List(Arc::new(
+                Field::new_list_field(DataType::Float64, true),
+            ))),
+            LargeList(_) => Ok(LargeList(Arc::new(Field::new_list_field(
+                DataType::Float64,
+                true,
+            )))),
+            _ => exec_err!("array_scale does not support type {}", arg_types[0]),
+        }
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        let [_, _] = take_function_args(self.name(), arg_types)?;
+
+        let coercion = Some(&ListCoercion::FixedSizedListToList);
+        let first = &arg_types[0];
+        let coerced_first = if matches!(
+            first,
+            Null | List(_) | LargeList(_) | FixedSizeList(..)
+        ) {
+            coerced_type_with_base_type_only(first, &DataType::Float64, coercion)
+        } else {
+            return plan_err!("{} does not support type {first}", self.name());
+        };
+
+        // Second argument is scalar Float64
+        Ok(vec![coerced_first, DataType::Float64])
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(array_scale_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+fn array_scale_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array1, _scalar] = take_function_args("array_scale", args)?;
+    match array1.data_type() {
+        List(_) => general_array_scale::<i32>(args),
+        LargeList(_) => general_array_scale::<i64>(args),
+        arg_type => {
+            exec_err!("array_scale does not support type {arg_type}")
+        }
+    }
+}
+
+fn general_array_scale<O: OffsetSizeTrait>(arrays: &[ArrayRef]) -> Result<ArrayRef> {
+    let list_array = as_generic_list_array::<O>(&arrays[0])?;
+    let scalar_array = as_float64_array(&arrays[1])?;
+
+    let mut result_values: Vec<Option<f64>> = Vec::new();
+    let mut offsets: Vec<O> = vec![O::from_usize(0).unwrap()];
+    let mut nulls: Vec<bool> = Vec::new();
+
+    for (i, arr) in list_array.iter().enumerate() {
+        let scalar_val = if scalar_array.is_null(i) {
+            None
+        } else {
+            Some(scalar_array.value(i))
+        };
+
+        match compute_scale(arr, scalar_val)? {
+            Some(scaled) => {
+                for j in 0..scaled.len() {
+                    if scaled.is_null(j) {
+                        result_values.push(None);
+                    } else {
+                        result_values.push(Some(scaled.value(j)));
+                    }
+                }
+                offsets.push(O::from_usize(result_values.len()).unwrap());
+                nulls.push(true);
+            }
+            None => {
+                offsets.push(O::from_usize(result_values.len()).unwrap());
+                nulls.push(false);
+            }
+        }
+    }
+
+    let values_array = Arc::new(Float64Array::from(result_values)) as ArrayRef;
+    let field = Arc::new(Field::new_list_field(DataType::Float64, true));
+    let offset_buffer = OffsetBuffer::new(offsets.into());
+    let null_buffer = arrow::buffer::NullBuffer::from(nulls);
+
+    Ok(Arc::new(arrow::array::GenericListArray::<O>::new(
+        field,
+        offset_buffer,
+        values_array,
+        Some(null_buffer),
+    )) as ArrayRef)
+}
+
+fn compute_scale(
+    arr: Option<ArrayRef>,
+    scalar: Option<f64>,
+) -> Result<Option<Float64Array>> {
+    let value = match arr {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+    let scalar = match scalar {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+
+    let mut value = value;
+
+    loop {
+        match value.data_type() {
+            List(_) => {
+                if downcast_arg!(value, ListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value = downcast_arg!(value, ListArray).value(0);
+            }
+            LargeList(_) => {
+                if downcast_arg!(value, LargeListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value = downcast_arg!(value, LargeListArray).value(0);
+            }
+            _ => break,
+        }
+    }
+
+    if value.null_count() != 0 {
+        return Ok(None);
+    }
+
+    let values = convert_to_f64_array(&value)?;
+    let scaled: Float64Array = values
+        .iter()
+        .map(|v| v.map(|val| val * scalar))
+        .collect();
+
+    Ok(Some(scaled))
+}
+
+// ============================================================================
+// Shared binary operation helper for array_add / array_subtract
+// ============================================================================
+
+fn general_array_binary_op<O: OffsetSizeTrait>(
+    arrays: &[ArrayRef],
+    fn_name: &str,
+    op: fn(f64, f64) -> f64,
+) -> Result<ArrayRef> {
+    let list_array1 = as_generic_list_array::<O>(&arrays[0])?;
+    let list_array2 = as_generic_list_array::<O>(&arrays[1])?;
+
+    let mut result_values: Vec<Option<f64>> = Vec::new();
+    let mut offsets: Vec<O> = vec![O::from_usize(0).unwrap()];
+    let mut nulls: Vec<bool> = Vec::new();
+
+    for (arr1, arr2) in list_array1.iter().zip(list_array2.iter()) {
+        match compute_binary_op(arr1, arr2, fn_name, op)? {
+            Some(result) => {
+                for i in 0..result.len() {
+                    if result.is_null(i) {
+                        result_values.push(None);
+                    } else {
+                        result_values.push(Some(result.value(i)));
+                    }
+                }
+                offsets.push(O::from_usize(result_values.len()).unwrap());
+                nulls.push(true);
+            }
+            None => {
+                offsets.push(O::from_usize(result_values.len()).unwrap());
+                nulls.push(false);
+            }
+        }
+    }
+
+    let values_array = Arc::new(Float64Array::from(result_values)) as ArrayRef;
+    let field = Arc::new(Field::new_list_field(DataType::Float64, true));
+    let offset_buffer = OffsetBuffer::new(offsets.into());
+    let null_buffer = arrow::buffer::NullBuffer::from(nulls);
+
+    Ok(Arc::new(arrow::array::GenericListArray::<O>::new(
+        field,
+        offset_buffer,
+        values_array,
+        Some(null_buffer),
+    )) as ArrayRef)
+}
+
+fn compute_binary_op(
+    arr1: Option<ArrayRef>,
+    arr2: Option<ArrayRef>,
+    _fn_name: &str,
+    op: fn(f64, f64) -> f64,
+) -> Result<Option<Float64Array>> {
+    let value1 = match arr1 {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+    let value2 = match arr2 {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+
+    let mut value1 = value1;
+    let mut value2 = value2;
+
+    loop {
+        match value1.data_type() {
+            List(_) => {
+                if downcast_arg!(value1, ListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value1 = downcast_arg!(value1, ListArray).value(0);
+            }
+            LargeList(_) => {
+                if downcast_arg!(value1, LargeListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value1 = downcast_arg!(value1, LargeListArray).value(0);
+            }
+            _ => break,
+        }
+
+        match value2.data_type() {
+            List(_) => {
+                if downcast_arg!(value2, ListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value2 = downcast_arg!(value2, ListArray).value(0);
+            }
+            LargeList(_) => {
+                if downcast_arg!(value2, LargeListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value2 = downcast_arg!(value2, LargeListArray).value(0);
+            }
+            _ => break,
+        }
+    }
+
+    if value1.null_count() != 0 || value2.null_count() != 0 {
+        return Ok(None);
+    }
+
+    let values1 = convert_to_f64_array(&value1)?;
+    let values2 = convert_to_f64_array(&value2)?;
+
+    if values1.len() != values2.len() {
+        return exec_err!("Both arrays must have the same length");
+    }
+
+    let result: Float64Array = values1
+        .iter()
+        .zip(values2.iter())
+        .map(|(v1, v2)| match (v1, v2) {
+            (Some(a), Some(b)) => Some(op(a, b)),
+            _ => None,
+        })
+        .collect();
+
+    Ok(Some(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, ListArray};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType, Field};
+    use std::sync::Arc;
+
+    fn make_f64_list_array(values: Vec<Option<Vec<Option<f64>>>>) -> ArrayRef {
+        let mut flat: Vec<Option<f64>> = Vec::new();
+        let mut offsets: Vec<i32> = vec![0];
+        for v in &values {
+            match v {
+                Some(inner) => {
+                    flat.extend(inner);
+                    offsets.push(flat.len() as i32);
+                }
+                None => {
+                    offsets.push(flat.len() as i32);
+                }
+            }
+        }
+        let values_array = Arc::new(Float64Array::from(flat)) as ArrayRef;
+        let field = Arc::new(Field::new_list_field(DataType::Float64, true));
+        let offset_buffer = OffsetBuffer::new(offsets.into());
+        let null_buffer = arrow::buffer::NullBuffer::from(
+            values.iter().map(|v| v.is_some()).collect::<Vec<_>>(),
+        );
+        Arc::new(ListArray::new(
+            field,
+            offset_buffer,
+            values_array,
+            Some(null_buffer),
+        ))
+    }
+
+    fn make_f64_scalar_array(values: Vec<Option<f64>>) -> ArrayRef {
+        Arc::new(Float64Array::from(values)) as ArrayRef
+    }
+
+    // === array_add tests ===
+
+    #[test]
+    fn test_array_add_basic() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(3.0), Some(4.0)])]);
+        let result = array_add_inner(&[arr1, arr2]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        let inner = list.value(0);
+        let values = inner.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((values.value(0) - 4.0).abs() < 1e-10);
+        assert!((values.value(1) - 6.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_array_add_null() {
+        let arr1 = make_f64_list_array(vec![None]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(1.0)])]);
+        let result = array_add_inner(&[arr1, arr2]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0));
+    }
+
+    #[test]
+    fn test_array_add_mismatched_lengths() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(1.0)])]);
+        let result = array_add_inner(&[arr1, arr2]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_array_add_empty() {
+        let arr1 = make_f64_list_array(vec![Some(vec![])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![])]);
+        let result = array_add_inner(&[arr1, arr2]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(!list.is_null(0));
+        assert_eq!(list.value(0).len(), 0);
+    }
+
+    // === array_subtract tests ===
+
+    #[test]
+    fn test_array_subtract_basic() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(5.0), Some(3.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let result = array_subtract_inner(&[arr1, arr2]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        let inner = list.value(0);
+        let values = inner.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((values.value(0) - 4.0).abs() < 1e-10);
+        assert!((values.value(1) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_array_subtract_null() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0)])]);
+        let arr2 = make_f64_list_array(vec![None]);
+        let result = array_subtract_inner(&[arr1, arr2]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0));
+    }
+
+    #[test]
+    fn test_array_subtract_mismatched_lengths() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let result = array_subtract_inner(&[arr1, arr2]);
+        assert!(result.is_err());
+    }
+
+    // === array_scale tests ===
+
+    #[test]
+    fn test_array_scale_basic() {
+        let arr = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0), Some(3.0)])]);
+        let scalar = make_f64_scalar_array(vec![Some(2.0)]);
+        let result = array_scale_inner(&[arr, scalar]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        let inner = list.value(0);
+        let values = inner.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((values.value(0) - 2.0).abs() < 1e-10);
+        assert!((values.value(1) - 4.0).abs() < 1e-10);
+        assert!((values.value(2) - 6.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_array_scale_null_array() {
+        let arr = make_f64_list_array(vec![None]);
+        let scalar = make_f64_scalar_array(vec![Some(2.0)]);
+        let result = array_scale_inner(&[arr, scalar]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0));
+    }
+
+    #[test]
+    fn test_array_scale_null_scalar() {
+        let arr = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let scalar = make_f64_scalar_array(vec![None]);
+        let result = array_scale_inner(&[arr, scalar]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0));
+    }
+
+    #[test]
+    fn test_array_scale_zero() {
+        let arr = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let scalar = make_f64_scalar_array(vec![Some(0.0)]);
+        let result = array_scale_inner(&[arr, scalar]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        let inner = list.value(0);
+        let values = inner.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((values.value(0) - 0.0).abs() < 1e-10);
+        assert!((values.value(1) - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_array_scale_empty() {
+        let arr = make_f64_list_array(vec![Some(vec![])]);
+        let scalar = make_f64_scalar_array(vec![Some(5.0)]);
+        let result = array_scale_inner(&[arr, scalar]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(!list.is_null(0));
+        assert_eq!(list.value(0).len(), 0);
+    }
+}

--- a/datafusion/functions-nested/src/array_math.rs
+++ b/datafusion/functions-nested/src/array_math.rs
@@ -32,7 +32,7 @@ use datafusion_common::utils::{ListCoercion, coerced_type_with_base_type_only};
 use datafusion_common::{Result, exec_err, plan_err, utils::take_function_args};
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
-    TypeSignature, Volatility,
+    Volatility,
 };
 use datafusion_functions::downcast_arg;
 use datafusion_macros::user_doc;
@@ -334,12 +334,7 @@ impl Default for ArrayScale {
 impl ArrayScale {
     pub fn new() -> Self {
         Self {
-            signature: Signature::one_of(
-                vec![
-                    TypeSignature::Any(2),
-                ],
-                Volatility::Immutable,
-            ),
+            signature: Signature::user_defined(Volatility::Immutable),
             aliases: vec!["list_scale".to_string()],
         }
     }

--- a/datafusion/functions-nested/src/array_normalize.rs
+++ b/datafusion/functions-nested/src/array_normalize.rs
@@ -1,0 +1,325 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [ScalarUDFImpl] definitions for array_normalize function.
+
+use crate::utils::make_scalar_function;
+use crate::vector_math::{convert_to_f64_array, magnitude_f64};
+use arrow::array::{
+    Array, ArrayRef, Float64Array, LargeListArray, ListArray, OffsetSizeTrait,
+};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::{
+    DataType, Field,
+    DataType::{FixedSizeList, LargeList, List, Null},
+};
+use datafusion_common::cast::as_generic_list_array;
+use datafusion_common::utils::{ListCoercion, coerced_type_with_base_type_only};
+use datafusion_common::{Result, exec_err, plan_err, utils::take_function_args};
+use datafusion_expr::{
+    ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    Volatility,
+};
+use datafusion_functions::downcast_arg;
+use datafusion_macros::user_doc;
+use itertools::Itertools;
+use std::sync::Arc;
+
+make_udf_expr_and_func!(
+    ArrayNormalize,
+    array_normalize,
+    array,
+    "returns the array normalized to unit length (L2 norm).",
+    array_normalize_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns the input array normalized to unit length (each element divided by the L2 norm). Returns NULL if the array has zero magnitude.",
+    syntax_example = "array_normalize(array)",
+    sql_example = r#"```sql
+> select array_normalize([3.0, 4.0]);
++-----------------------------------+
+| array_normalize(List([3.0,4.0]))  |
++-----------------------------------+
+| [0.6, 0.8]                        |
++-----------------------------------+
+```"#,
+    argument(
+        name = "array",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ArrayNormalize {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for ArrayNormalize {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArrayNormalize {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+            aliases: vec!["list_normalize".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for ArrayNormalize {
+    fn name(&self) -> &str {
+        "array_normalize"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        // Return same list type but with Float64 elements
+        match &arg_types[0] {
+            List(_) | FixedSizeList(..) | Null => Ok(List(Arc::new(Field::new_list_field(
+                DataType::Float64,
+                true,
+            )))),
+            LargeList(_) => Ok(LargeList(Arc::new(Field::new_list_field(
+                DataType::Float64,
+                true,
+            )))),
+            _ => exec_err!(
+                "array_normalize does not support type {}",
+                arg_types[0]
+            ),
+        }
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        let [_] = take_function_args(self.name(), arg_types)?;
+        let coercion = Some(&ListCoercion::FixedSizedListToList);
+        let arg_types = arg_types.iter().map(|arg_type| {
+            if matches!(arg_type, Null | List(_) | LargeList(_) | FixedSizeList(..)) {
+                Ok(coerced_type_with_base_type_only(
+                    arg_type,
+                    &DataType::Float64,
+                    coercion,
+                ))
+            } else {
+                plan_err!("{} does not support type {arg_type}", self.name())
+            }
+        });
+
+        arg_types.try_collect()
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(array_normalize_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+fn array_normalize_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array1] = take_function_args("array_normalize", args)?;
+    match array1.data_type() {
+        List(_) => general_array_normalize::<i32>(args),
+        LargeList(_) => general_array_normalize::<i64>(args),
+        arg_type => {
+            exec_err!("array_normalize does not support type {arg_type}")
+        }
+    }
+}
+
+fn general_array_normalize<O: OffsetSizeTrait>(arrays: &[ArrayRef]) -> Result<ArrayRef> {
+    let list_array = as_generic_list_array::<O>(&arrays[0])?;
+
+    let mut result_values: Vec<Option<f64>> = Vec::new();
+    let mut offsets: Vec<O> = vec![O::from_usize(0).unwrap()];
+    let mut nulls: Vec<bool> = Vec::new();
+
+    for arr in list_array.iter() {
+        match compute_normalize(arr)? {
+            Some(normalized) => {
+                for i in 0..normalized.len() {
+                    if normalized.is_null(i) {
+                        result_values.push(None);
+                    } else {
+                        result_values.push(Some(normalized.value(i)));
+                    }
+                }
+                offsets.push(O::from_usize(result_values.len()).unwrap());
+                nulls.push(true);
+            }
+            None => {
+                offsets.push(O::from_usize(result_values.len()).unwrap());
+                nulls.push(false);
+            }
+        }
+    }
+
+    let values_array = Arc::new(Float64Array::from(result_values)) as ArrayRef;
+    let field = Arc::new(Field::new_list_field(DataType::Float64, true));
+    let offset_buffer = OffsetBuffer::new(offsets.into());
+    let null_buffer = arrow::buffer::NullBuffer::from(nulls);
+
+    Ok(Arc::new(arrow::array::GenericListArray::<O>::new(
+        field,
+        offset_buffer,
+        values_array,
+        Some(null_buffer),
+    )) as ArrayRef)
+}
+
+/// Normalizes an array to unit length by dividing each element by the L2 norm.
+fn compute_normalize(arr: Option<ArrayRef>) -> Result<Option<Float64Array>> {
+    let value = match arr {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+
+    let mut value = value;
+
+    loop {
+        match value.data_type() {
+            List(_) => {
+                if downcast_arg!(value, ListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value = downcast_arg!(value, ListArray).value(0);
+            }
+            LargeList(_) => {
+                if downcast_arg!(value, LargeListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value = downcast_arg!(value, LargeListArray).value(0);
+            }
+            _ => break,
+        }
+    }
+
+    if value.null_count() != 0 {
+        return Ok(None);
+    }
+
+    let values = convert_to_f64_array(&value)?;
+    let mag = magnitude_f64(&values);
+
+    if mag == 0.0 {
+        return Ok(None);
+    }
+
+    let normalized: Float64Array = values
+        .iter()
+        .map(|v| v.map(|val| val / mag))
+        .collect();
+
+    Ok(Some(normalized))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, ListArray};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType, Field};
+    use std::sync::Arc;
+
+    fn make_f64_list_array(values: Vec<Option<Vec<Option<f64>>>>) -> ArrayRef {
+        let mut flat: Vec<Option<f64>> = Vec::new();
+        let mut offsets: Vec<i32> = vec![0];
+        for v in &values {
+            match v {
+                Some(inner) => {
+                    flat.extend(inner);
+                    offsets.push(flat.len() as i32);
+                }
+                None => {
+                    offsets.push(flat.len() as i32);
+                }
+            }
+        }
+        let values_array = Arc::new(Float64Array::from(flat)) as ArrayRef;
+        let field = Arc::new(Field::new_list_field(DataType::Float64, true));
+        let offset_buffer = OffsetBuffer::new(offsets.into());
+        let null_buffer = arrow::buffer::NullBuffer::from(
+            values.iter().map(|v| v.is_some()).collect::<Vec<_>>(),
+        );
+        Arc::new(ListArray::new(
+            field,
+            offset_buffer,
+            values_array,
+            Some(null_buffer),
+        ))
+    }
+
+    #[test]
+    fn test_normalize_basic() {
+        let arr = make_f64_list_array(vec![Some(vec![Some(3.0), Some(4.0)])]);
+        let result = array_normalize_inner(&[arr]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        let inner = list.value(0);
+        let values = inner.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((values.value(0) - 0.6).abs() < 1e-10);
+        assert!((values.value(1) - 0.8).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_normalize_null_array() {
+        let arr = make_f64_list_array(vec![None]);
+        let result = array_normalize_inner(&[arr]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0));
+    }
+
+    #[test]
+    fn test_normalize_zero_magnitude() {
+        let arr = make_f64_list_array(vec![Some(vec![Some(0.0), Some(0.0)])]);
+        let result = array_normalize_inner(&[arr]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0));
+    }
+
+    #[test]
+    fn test_normalize_unit_vector() {
+        let arr = make_f64_list_array(vec![Some(vec![Some(1.0), Some(0.0)])]);
+        let result = array_normalize_inner(&[arr]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        let inner = list.value(0);
+        let values = inner.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((values.value(0) - 1.0).abs() < 1e-10);
+        assert!((values.value(1) - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_normalize_empty_array() {
+        let arr = make_f64_list_array(vec![Some(vec![])]);
+        let result = array_normalize_inner(&[arr]).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        // Zero magnitude -> null
+        assert!(list.is_null(0));
+    }
+}

--- a/datafusion/functions-nested/src/array_product.rs
+++ b/datafusion/functions-nested/src/array_product.rs
@@ -1,0 +1,204 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`ScalarUDFImpl`] definitions for array_product function.
+
+use crate::utils::make_scalar_function;
+use arrow::array::{
+    Array, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, AsArray, GenericListArray,
+    OffsetSizeTrait, PrimitiveBuilder, downcast_primitive,
+};
+use arrow::datatypes::DataType;
+use arrow::datatypes::DataType::{LargeList, List};
+use datafusion_common::cast::{as_large_list_array, as_list_array};
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{Result, exec_err, plan_err};
+use datafusion_doc::Documentation;
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_macros::user_doc;
+use std::sync::Arc;
+
+make_udf_expr_and_func!(
+    ArrayProduct,
+    array_product,
+    array,
+    "returns the product of all values in the array.",
+    array_product_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns the product of all values in the array. The return type is the same as the element type (no widening). NULL elements are skipped; an all-NULL or empty array returns NULL.",
+    syntax_example = "array_product(array)",
+    sql_example = r#"```sql
+> select array_product([2, 3, 4]);
++-----------------------------------------+
+| array_product(List([2,3,4]))            |
++-----------------------------------------+
+| 24                                      |
++-----------------------------------------+
+```"#,
+    argument(
+        name = "array",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ArrayProduct {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for ArrayProduct {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArrayProduct {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::array(Volatility::Immutable),
+            aliases: vec!["list_product".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for ArrayProduct {
+    fn name(&self) -> &str {
+        "array_product"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        let [array] = take_function_args(self.name(), arg_types)?;
+        match array {
+            List(field) | LargeList(field) => Ok(field.data_type().clone()),
+            arg_type => plan_err!("{} does not support type {arg_type}", self.name()),
+        }
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(array_product_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+fn array_product_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array] = take_function_args("array_product", args)?;
+    match array.data_type() {
+        List(_) => array_product_dispatch(as_list_array(array)?),
+        LargeList(_) => array_product_dispatch(as_large_list_array(array)?),
+        arg_type => exec_err!("array_product does not support type: {arg_type}"),
+    }
+}
+
+fn array_product_dispatch<O: OffsetSizeTrait>(
+    list_array: &GenericListArray<O>,
+) -> Result<ArrayRef> {
+    if let Some(result) = try_primitive_array_product(list_array) {
+        return result;
+    }
+    exec_err!(
+        "array_product does not support element type: {}",
+        list_array.value_type()
+    )
+}
+
+fn try_primitive_array_product<O: OffsetSizeTrait>(
+    list_array: &GenericListArray<O>,
+) -> Option<Result<ArrayRef>> {
+    // Reject Decimal types: mul_wrapping on raw scaled integers does not
+    // adjust scale, producing incorrect results for Decimal128/256.
+    if matches!(
+        list_array.value_type(),
+        DataType::Decimal32(_, _)
+            | DataType::Decimal64(_, _)
+            | DataType::Decimal128(_, _)
+            | DataType::Decimal256(_, _)
+    ) {
+        return Some(exec_err!("array_product does not support Decimal types"));
+    }
+    macro_rules! helper {
+        ($t:ty) => {
+            return Some(primitive_array_product::<O, $t>(list_array))
+        };
+    }
+    downcast_primitive! {
+        list_array.value_type() => (helper),
+        _ => {}
+    }
+    None
+}
+
+fn primitive_array_product<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
+    list_array: &GenericListArray<O>,
+) -> Result<ArrayRef> {
+    let values_array = list_array.values().as_primitive::<T>();
+    let values_slice = values_array.values();
+    let values_nulls = values_array.nulls();
+    let mut result_builder = PrimitiveBuilder::<T>::with_capacity(list_array.len())
+        .with_data_type(values_array.data_type().clone());
+
+    for (row, w) in list_array.offsets().windows(2).enumerate() {
+        if list_array.is_null(row) {
+            result_builder.append_null();
+            continue;
+        }
+
+        let start = w[0].as_usize();
+        let end = w[1].as_usize();
+
+        if start == end {
+            result_builder.append_null();
+            continue;
+        }
+
+        let mut has_non_null = false;
+        let mut product = T::Native::ONE;
+
+        for (i, &val) in values_slice[start..end].iter().enumerate() {
+            if let Some(nulls) = values_nulls
+                && !nulls.is_valid(start + i)
+            {
+                continue;
+            }
+            has_non_null = true;
+            product = product.mul_wrapping(val);
+        }
+
+        if has_non_null {
+            result_builder.append_value(product);
+        } else {
+            result_builder.append_null();
+        }
+    }
+
+    Ok(Arc::new(result_builder.finish()) as ArrayRef)
+}

--- a/datafusion/functions-nested/src/array_sum.rs
+++ b/datafusion/functions-nested/src/array_sum.rs
@@ -1,0 +1,196 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`ScalarUDFImpl`] definitions for array_sum function.
+
+use crate::utils::make_scalar_function;
+use arrow::array::{
+    Array, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, AsArray, GenericListArray,
+    OffsetSizeTrait, PrimitiveBuilder, downcast_primitive,
+};
+use arrow::datatypes::DataType;
+use arrow::datatypes::DataType::{LargeList, List};
+use datafusion_common::cast::{as_large_list_array, as_list_array};
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{Result, exec_err, plan_err};
+use datafusion_doc::Documentation;
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_macros::user_doc;
+use std::sync::Arc;
+
+make_udf_expr_and_func!(
+    ArraySum,
+    array_sum,
+    array,
+    "returns the sum of all values in the array.",
+    array_sum_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns the sum of all values in the array. The return type is the same as the element type (no widening). NULL elements are skipped; an all-NULL or empty array returns NULL.",
+    syntax_example = "array_sum(array)",
+    sql_example = r#"```sql
+> select array_sum([1, 2, 3, 4]);
++--------------------------------------+
+| array_sum(List([1,2,3,4]))           |
++--------------------------------------+
+| 10                                   |
++--------------------------------------+
+```"#,
+    argument(
+        name = "array",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ArraySum {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for ArraySum {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArraySum {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::array(Volatility::Immutable),
+            aliases: vec!["list_sum".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for ArraySum {
+    fn name(&self) -> &str {
+        "array_sum"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        let [array] = take_function_args(self.name(), arg_types)?;
+        match array {
+            List(field) | LargeList(field) => Ok(field.data_type().clone()),
+            arg_type => plan_err!("{} does not support type {arg_type}", self.name()),
+        }
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(array_sum_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+fn array_sum_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array] = take_function_args("array_sum", args)?;
+    match array.data_type() {
+        List(_) => array_sum_dispatch(as_list_array(array)?),
+        LargeList(_) => array_sum_dispatch(as_large_list_array(array)?),
+        arg_type => exec_err!("array_sum does not support type: {arg_type}"),
+    }
+}
+
+fn array_sum_dispatch<O: OffsetSizeTrait>(
+    list_array: &GenericListArray<O>,
+) -> Result<ArrayRef> {
+    if let Some(result) = try_primitive_array_sum(list_array) {
+        return result;
+    }
+    exec_err!(
+        "array_sum does not support element type: {}",
+        list_array.value_type()
+    )
+}
+
+/// Dispatches to a typed primitive sum implementation.
+fn try_primitive_array_sum<O: OffsetSizeTrait>(
+    list_array: &GenericListArray<O>,
+) -> Option<Result<ArrayRef>> {
+    macro_rules! helper {
+        ($t:ty) => {
+            return Some(primitive_array_sum::<O, $t>(list_array))
+        };
+    }
+    downcast_primitive! {
+        list_array.value_type() => (helper),
+        _ => {}
+    }
+    None
+}
+
+/// Computes the sum for each row of a primitive ListArray.
+fn primitive_array_sum<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
+    list_array: &GenericListArray<O>,
+) -> Result<ArrayRef> {
+    let values_array = list_array.values().as_primitive::<T>();
+    let values_slice = values_array.values();
+    let values_nulls = values_array.nulls();
+    let mut result_builder = PrimitiveBuilder::<T>::with_capacity(list_array.len())
+        .with_data_type(values_array.data_type().clone());
+
+    for (row, w) in list_array.offsets().windows(2).enumerate() {
+        if list_array.is_null(row) {
+            result_builder.append_null();
+            continue;
+        }
+
+        let start = w[0].as_usize();
+        let end = w[1].as_usize();
+
+        if start == end {
+            // Empty array — return NULL (consistent with SQL SUM over empty set)
+            result_builder.append_null();
+            continue;
+        }
+
+        let mut has_non_null = false;
+        let mut sum = T::Native::default();
+
+        for (i, &val) in values_slice[start..end].iter().enumerate() {
+            if let Some(nulls) = values_nulls
+                && !nulls.is_valid(start + i)
+            {
+                continue;
+            }
+            has_non_null = true;
+            sum = sum.add_wrapping(val);
+        }
+
+        if has_non_null {
+            result_builder.append_value(sum);
+        } else {
+            result_builder.append_null();
+        }
+    }
+
+    Ok(Arc::new(result_builder.finish()) as ArrayRef)
+}

--- a/datafusion/functions-nested/src/cosine_distance.rs
+++ b/datafusion/functions-nested/src/cosine_distance.rs
@@ -1,0 +1,336 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [ScalarUDFImpl] definitions for cosine_distance function.
+
+use crate::utils::make_scalar_function;
+use crate::vector_math::{convert_to_f64_array, dot_product_f64, magnitude_f64};
+use arrow::array::{
+    Array, ArrayRef, Float64Array, LargeListArray, ListArray, OffsetSizeTrait,
+};
+use arrow::datatypes::{
+    DataType,
+    DataType::{FixedSizeList, LargeList, List, Null},
+};
+use datafusion_common::cast::as_generic_list_array;
+use datafusion_common::utils::{ListCoercion, coerced_type_with_base_type_only};
+use datafusion_common::{Result, exec_err, plan_err, utils::take_function_args};
+use datafusion_expr::{
+    ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    Volatility,
+};
+use datafusion_functions::downcast_arg;
+use datafusion_macros::user_doc;
+use itertools::Itertools;
+use std::sync::Arc;
+
+make_udf_expr_and_func!(
+    CosineDistance,
+    cosine_distance,
+    array1 array2,
+    "returns the cosine distance between two numeric arrays.",
+    cosine_distance_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns the cosine distance between two input arrays of equal length. The cosine distance is defined as 1 - cosine_similarity, i.e. `1 - dot(a,b) / (||a|| * ||b||)`.",
+    syntax_example = "cosine_distance(array1, array2)",
+    sql_example = r#"```sql
+> select cosine_distance([1.0, 0.0], [0.0, 1.0]);
++-----------------------------------------------+
+| cosine_distance(List([1.0,0.0]), List([0.0,1.0])) |
++-----------------------------------------------+
+| 1.0                                           |
++-----------------------------------------------+
+```"#,
+    argument(
+        name = "array1",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    ),
+    argument(
+        name = "array2",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct CosineDistance {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for CosineDistance {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CosineDistance {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+            aliases: vec!["list_cosine_distance".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for CosineDistance {
+    fn name(&self) -> &str {
+        "cosine_distance"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Float64)
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        let [_, _] = take_function_args(self.name(), arg_types)?;
+        let coercion = Some(&ListCoercion::FixedSizedListToList);
+        let arg_types = arg_types.iter().map(|arg_type| {
+            if matches!(arg_type, Null | List(_) | LargeList(_) | FixedSizeList(..)) {
+                Ok(coerced_type_with_base_type_only(
+                    arg_type,
+                    &DataType::Float64,
+                    coercion,
+                ))
+            } else {
+                plan_err!("{} does not support type {arg_type}", self.name())
+            }
+        });
+
+        arg_types.try_collect()
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(cosine_distance_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+fn cosine_distance_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array1, array2] = take_function_args("cosine_distance", args)?;
+    match (array1.data_type(), array2.data_type()) {
+        (List(_), List(_)) => general_cosine_distance::<i32>(args),
+        (LargeList(_), LargeList(_)) => general_cosine_distance::<i64>(args),
+        (arg_type1, arg_type2) => {
+            exec_err!(
+                "cosine_distance does not support types {arg_type1} and {arg_type2}"
+            )
+        }
+    }
+}
+
+fn general_cosine_distance<O: OffsetSizeTrait>(arrays: &[ArrayRef]) -> Result<ArrayRef> {
+    let list_array1 = as_generic_list_array::<O>(&arrays[0])?;
+    let list_array2 = as_generic_list_array::<O>(&arrays[1])?;
+
+    let result = list_array1
+        .iter()
+        .zip(list_array2.iter())
+        .map(|(arr1, arr2)| compute_cosine_distance(arr1, arr2))
+        .collect::<Result<Float64Array>>()?;
+
+    Ok(Arc::new(result) as ArrayRef)
+}
+
+/// Computes the cosine distance between two arrays: 1 - dot(a,b) / (||a|| * ||b||)
+fn compute_cosine_distance(
+    arr1: Option<ArrayRef>,
+    arr2: Option<ArrayRef>,
+) -> Result<Option<f64>> {
+    let value1 = match arr1 {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+    let value2 = match arr2 {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+
+    let mut value1 = value1;
+    let mut value2 = value2;
+
+    loop {
+        match value1.data_type() {
+            List(_) => {
+                if downcast_arg!(value1, ListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value1 = downcast_arg!(value1, ListArray).value(0);
+            }
+            LargeList(_) => {
+                if downcast_arg!(value1, LargeListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value1 = downcast_arg!(value1, LargeListArray).value(0);
+            }
+            _ => break,
+        }
+
+        match value2.data_type() {
+            List(_) => {
+                if downcast_arg!(value2, ListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value2 = downcast_arg!(value2, ListArray).value(0);
+            }
+            LargeList(_) => {
+                if downcast_arg!(value2, LargeListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value2 = downcast_arg!(value2, LargeListArray).value(0);
+            }
+            _ => break,
+        }
+    }
+
+    // Check for NULL values inside the arrays
+    if value1.null_count() != 0 || value2.null_count() != 0 {
+        return Ok(None);
+    }
+
+    let values1 = convert_to_f64_array(&value1)?;
+    let values2 = convert_to_f64_array(&value2)?;
+
+    if values1.len() != values2.len() {
+        return exec_err!("Both arrays must have the same length");
+    }
+
+    let dot = dot_product_f64(&values1, &values2);
+    let mag1 = magnitude_f64(&values1);
+    let mag2 = magnitude_f64(&values2);
+
+    if mag1 == 0.0 || mag2 == 0.0 {
+        return Ok(None);
+    }
+
+    Ok(Some(1.0 - dot / (mag1 * mag2)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, ListArray};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType, Field};
+    use std::sync::Arc;
+
+    fn make_f64_list_array(values: Vec<Option<Vec<Option<f64>>>>) -> ArrayRef {
+        let mut flat: Vec<Option<f64>> = Vec::new();
+        let mut offsets: Vec<i32> = vec![0];
+        for v in &values {
+            match v {
+                Some(inner) => {
+                    flat.extend(inner);
+                    offsets.push(flat.len() as i32);
+                }
+                None => {
+                    offsets.push(flat.len() as i32);
+                }
+            }
+        }
+        let values_array = Arc::new(Float64Array::from(flat)) as ArrayRef;
+        let field = Arc::new(Field::new_list_field(DataType::Float64, true));
+        let offset_buffer = OffsetBuffer::new(offsets.into());
+        let null_buffer = arrow::buffer::NullBuffer::from(
+            values.iter().map(|v| v.is_some()).collect::<Vec<_>>(),
+        );
+        Arc::new(ListArray::new(
+            field,
+            offset_buffer,
+            values_array,
+            Some(null_buffer),
+        ))
+    }
+
+    #[test]
+    fn test_cosine_distance_orthogonal() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(0.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(0.0), Some(1.0)])]);
+        let result = cosine_distance_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((result.value(0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cosine_distance_identical() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0), Some(3.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0), Some(3.0)])]);
+        let result = cosine_distance_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!(result.value(0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cosine_distance_opposite() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(0.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(-1.0), Some(0.0)])]);
+        let result = cosine_distance_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((result.value(0) - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cosine_distance_null_array() {
+        let arr1 = make_f64_list_array(vec![None]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let result = cosine_distance_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!(result.is_null(0));
+    }
+
+    #[test]
+    fn test_cosine_distance_mismatched_lengths() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(1.0)])]);
+        let result = cosine_distance_inner(&[arr1, arr2]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cosine_distance_empty_arrays() {
+        let arr1 = make_f64_list_array(vec![Some(vec![])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![])]);
+        let result = cosine_distance_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        // Zero magnitude -> null
+        assert!(result.is_null(0));
+    }
+
+    #[test]
+    fn test_cosine_distance_float32_coerced() {
+        // Float32 gets coerced to Float64 by coerce_types, so the inner function
+        // always receives Float64. This test confirms the pattern works.
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(3.0), Some(4.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(4.0), Some(3.0)])]);
+        let result = cosine_distance_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        // cos_sim = (12+12) / (5*5) = 24/25 = 0.96, distance = 0.04
+        assert!((result.value(0) - 0.04).abs() < 1e-10);
+    }
+}

--- a/datafusion/functions-nested/src/distance.rs
+++ b/datafusion/functions-nested/src/distance.rs
@@ -18,6 +18,7 @@
 //! [ScalarUDFImpl] definitions for array_distance function.
 
 use crate::utils::make_scalar_function;
+use crate::vector_math::convert_to_f64_array;
 use arrow::array::{
     Array, ArrayRef, Float64Array, LargeListArray, ListArray, OffsetSizeTrait,
 };
@@ -25,10 +26,7 @@ use arrow::datatypes::{
     DataType,
     DataType::{FixedSizeList, LargeList, List, Null},
 };
-use datafusion_common::cast::{
-    as_float32_array, as_float64_array, as_generic_list_array, as_int32_array,
-    as_int64_array,
-};
+use datafusion_common::cast::as_generic_list_array;
 use datafusion_common::utils::{ListCoercion, coerced_type_with_base_type_only};
 use datafusion_common::{Result, exec_err, plan_err, utils::take_function_args};
 use datafusion_expr::{
@@ -233,28 +231,4 @@ fn compute_array_distance(
     Ok(Some(sum_squares.sqrt()))
 }
 
-/// Converts an array of any numeric type to a Float64Array.
-fn convert_to_f64_array(array: &ArrayRef) -> Result<Float64Array> {
-    match array.data_type() {
-        DataType::Float64 => Ok(as_float64_array(array)?.clone()),
-        DataType::Float32 => {
-            let array = as_float32_array(array)?;
-            let converted: Float64Array =
-                array.iter().map(|v| v.map(|v| v as f64)).collect();
-            Ok(converted)
-        }
-        DataType::Int64 => {
-            let array = as_int64_array(array)?;
-            let converted: Float64Array =
-                array.iter().map(|v| v.map(|v| v as f64)).collect();
-            Ok(converted)
-        }
-        DataType::Int32 => {
-            let array = as_int32_array(array)?;
-            let converted: Float64Array =
-                array.iter().map(|v| v.map(|v| v as f64)).collect();
-            Ok(converted)
-        }
-        _ => exec_err!("Unsupported array type for conversion to Float64Array"),
-    }
-}
+// convert_to_f64_array is now shared via crate::vector_math

--- a/datafusion/functions-nested/src/inner_product.rs
+++ b/datafusion/functions-nested/src/inner_product.rs
@@ -1,0 +1,311 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [ScalarUDFImpl] definitions for inner_product function.
+
+use crate::utils::make_scalar_function;
+use crate::vector_math::{convert_to_f64_array, dot_product_f64};
+use arrow::array::{
+    Array, ArrayRef, Float64Array, LargeListArray, ListArray, OffsetSizeTrait,
+};
+use arrow::datatypes::{
+    DataType,
+    DataType::{FixedSizeList, LargeList, List, Null},
+};
+use datafusion_common::cast::as_generic_list_array;
+use datafusion_common::utils::{ListCoercion, coerced_type_with_base_type_only};
+use datafusion_common::{Result, exec_err, plan_err, utils::take_function_args};
+use datafusion_expr::{
+    ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    Volatility,
+};
+use datafusion_functions::downcast_arg;
+use datafusion_macros::user_doc;
+use itertools::Itertools;
+use std::sync::Arc;
+
+make_udf_expr_and_func!(
+    InnerProduct,
+    inner_product,
+    array1 array2,
+    "returns the inner (dot) product of two numeric arrays.",
+    inner_product_udf
+);
+
+#[user_doc(
+    doc_section(label = "Array Functions"),
+    description = "Returns the inner product (dot product) of two input arrays of equal length: `sum(a[i] * b[i])`.",
+    syntax_example = "inner_product(array1, array2)",
+    sql_example = r#"```sql
+> select inner_product([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]);
++------------------------------------------------------------+
+| inner_product(List([1.0,2.0,3.0]), List([4.0,5.0,6.0]))   |
++------------------------------------------------------------+
+| 32.0                                                       |
++------------------------------------------------------------+
+```"#,
+    argument(
+        name = "array1",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    ),
+    argument(
+        name = "array2",
+        description = "Array expression. Can be a constant, column, or function, and any combination of array operators."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct InnerProduct {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for InnerProduct {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InnerProduct {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+            aliases: vec![
+                "list_inner_product".to_string(),
+                "dot_product".to_string(),
+            ],
+        }
+    }
+}
+
+impl ScalarUDFImpl for InnerProduct {
+    fn name(&self) -> &str {
+        "inner_product"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Float64)
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        let [_, _] = take_function_args(self.name(), arg_types)?;
+        let coercion = Some(&ListCoercion::FixedSizedListToList);
+        let arg_types = arg_types.iter().map(|arg_type| {
+            if matches!(arg_type, Null | List(_) | LargeList(_) | FixedSizeList(..)) {
+                Ok(coerced_type_with_base_type_only(
+                    arg_type,
+                    &DataType::Float64,
+                    coercion,
+                ))
+            } else {
+                plan_err!("{} does not support type {arg_type}", self.name())
+            }
+        });
+
+        arg_types.try_collect()
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(inner_product_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}
+
+fn inner_product_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array1, array2] = take_function_args("inner_product", args)?;
+    match (array1.data_type(), array2.data_type()) {
+        (List(_), List(_)) => general_inner_product::<i32>(args),
+        (LargeList(_), LargeList(_)) => general_inner_product::<i64>(args),
+        (arg_type1, arg_type2) => {
+            exec_err!(
+                "inner_product does not support types {arg_type1} and {arg_type2}"
+            )
+        }
+    }
+}
+
+fn general_inner_product<O: OffsetSizeTrait>(arrays: &[ArrayRef]) -> Result<ArrayRef> {
+    let list_array1 = as_generic_list_array::<O>(&arrays[0])?;
+    let list_array2 = as_generic_list_array::<O>(&arrays[1])?;
+
+    let result = list_array1
+        .iter()
+        .zip(list_array2.iter())
+        .map(|(arr1, arr2)| compute_inner_product(arr1, arr2))
+        .collect::<Result<Float64Array>>()?;
+
+    Ok(Arc::new(result) as ArrayRef)
+}
+
+/// Computes the inner product of two arrays: sum(a[i] * b[i])
+fn compute_inner_product(
+    arr1: Option<ArrayRef>,
+    arr2: Option<ArrayRef>,
+) -> Result<Option<f64>> {
+    let value1 = match arr1 {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+    let value2 = match arr2 {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+
+    let mut value1 = value1;
+    let mut value2 = value2;
+
+    loop {
+        match value1.data_type() {
+            List(_) => {
+                if downcast_arg!(value1, ListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value1 = downcast_arg!(value1, ListArray).value(0);
+            }
+            LargeList(_) => {
+                if downcast_arg!(value1, LargeListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value1 = downcast_arg!(value1, LargeListArray).value(0);
+            }
+            _ => break,
+        }
+
+        match value2.data_type() {
+            List(_) => {
+                if downcast_arg!(value2, ListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value2 = downcast_arg!(value2, ListArray).value(0);
+            }
+            LargeList(_) => {
+                if downcast_arg!(value2, LargeListArray).null_count() > 0 {
+                    return Ok(None);
+                }
+                value2 = downcast_arg!(value2, LargeListArray).value(0);
+            }
+            _ => break,
+        }
+    }
+
+    // Check for NULL values inside the arrays
+    if value1.null_count() != 0 || value2.null_count() != 0 {
+        return Ok(None);
+    }
+
+    let values1 = convert_to_f64_array(&value1)?;
+    let values2 = convert_to_f64_array(&value2)?;
+
+    if values1.len() != values2.len() {
+        return exec_err!("Both arrays must have the same length");
+    }
+
+    Ok(Some(dot_product_f64(&values1, &values2)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, ListArray};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType, Field};
+    use std::sync::Arc;
+
+    fn make_f64_list_array(values: Vec<Option<Vec<Option<f64>>>>) -> ArrayRef {
+        let mut flat: Vec<Option<f64>> = Vec::new();
+        let mut offsets: Vec<i32> = vec![0];
+        for v in &values {
+            match v {
+                Some(inner) => {
+                    flat.extend(inner);
+                    offsets.push(flat.len() as i32);
+                }
+                None => {
+                    offsets.push(flat.len() as i32);
+                }
+            }
+        }
+        let values_array = Arc::new(Float64Array::from(flat)) as ArrayRef;
+        let field = Arc::new(Field::new_list_field(DataType::Float64, true));
+        let offset_buffer = OffsetBuffer::new(offsets.into());
+        let null_buffer = arrow::buffer::NullBuffer::from(
+            values.iter().map(|v| v.is_some()).collect::<Vec<_>>(),
+        );
+        Arc::new(ListArray::new(
+            field,
+            offset_buffer,
+            values_array,
+            Some(null_buffer),
+        ))
+    }
+
+    #[test]
+    fn test_inner_product_basic() {
+        let arr1 =
+            make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0), Some(3.0)])]);
+        let arr2 =
+            make_f64_list_array(vec![Some(vec![Some(4.0), Some(5.0), Some(6.0)])]);
+        let result = inner_product_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((result.value(0) - 32.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_inner_product_null_array() {
+        let arr1 = make_f64_list_array(vec![None]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let result = inner_product_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!(result.is_null(0));
+    }
+
+    #[test]
+    fn test_inner_product_mismatched_lengths() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(2.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(1.0)])]);
+        let result = inner_product_inner(&[arr1, arr2]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_inner_product_empty_arrays() {
+        let arr1 = make_f64_list_array(vec![Some(vec![])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![])]);
+        let result = inner_product_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((result.value(0) - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_inner_product_orthogonal() {
+        let arr1 = make_f64_list_array(vec![Some(vec![Some(1.0), Some(0.0)])]);
+        let arr2 = make_f64_list_array(vec![Some(vec![Some(0.0), Some(1.0)])]);
+        let result = inner_product_inner(&[arr1, arr2]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((result.value(0) - 0.0).abs() < 1e-10);
+    }
+}

--- a/datafusion/functions-nested/src/lib.rs
+++ b/datafusion/functions-nested/src/lib.rs
@@ -38,9 +38,12 @@
 pub mod macros;
 
 pub mod array_has;
+pub mod array_math;
+pub mod array_normalize;
 pub mod arrays_zip;
 pub mod cardinality;
 pub mod concat;
+pub mod cosine_distance;
 pub mod dimension;
 pub mod distance;
 pub mod empty;
@@ -48,6 +51,7 @@ pub mod except;
 pub mod expr_ext;
 pub mod extract;
 pub mod flatten;
+pub mod inner_product;
 pub mod length;
 pub mod make_array;
 pub mod map;
@@ -68,6 +72,7 @@ pub mod set_ops;
 pub mod sort;
 pub mod string;
 pub mod utils;
+pub mod vector_math;
 
 use datafusion_common::Result;
 use datafusion_execution::FunctionRegistry;
@@ -80,11 +85,16 @@ pub mod expr_fn {
     pub use super::array_has::array_has;
     pub use super::array_has::array_has_all;
     pub use super::array_has::array_has_any;
+    pub use super::array_math::array_add;
+    pub use super::array_math::array_scale;
+    pub use super::array_math::array_subtract;
+    pub use super::array_normalize::array_normalize;
     pub use super::arrays_zip::arrays_zip;
     pub use super::cardinality::cardinality;
     pub use super::concat::array_append;
     pub use super::concat::array_concat;
     pub use super::concat::array_prepend;
+    pub use super::cosine_distance::cosine_distance;
     pub use super::dimension::array_dims;
     pub use super::dimension::array_ndims;
     pub use super::distance::array_distance;
@@ -96,6 +106,7 @@ pub mod expr_fn {
     pub use super::extract::array_pop_front;
     pub use super::extract::array_slice;
     pub use super::flatten::flatten;
+    pub use super::inner_product::inner_product;
     pub use super::length::array_length;
     pub use super::make_array::make_array;
     pub use super::map_entries::map_entries;
@@ -148,10 +159,16 @@ pub fn all_default_nested_functions() -> Vec<Arc<ScalarUDF>> {
         array_has::array_has_udf(),
         array_has::array_has_all_udf(),
         array_has::array_has_any_udf(),
+        array_math::array_add_udf(),
+        array_math::array_subtract_udf(),
+        array_math::array_scale_udf(),
+        array_normalize::array_normalize_udf(),
         empty::array_empty_udf(),
         length::array_length_udf(),
+        cosine_distance::cosine_distance_udf(),
         distance::array_distance_udf(),
         flatten::flatten_udf(),
+        inner_product::inner_product_udf(),
         min_max::array_max_udf(),
         min_max::array_min_udf(),
         sort::array_sort_udf(),

--- a/datafusion/functions-nested/src/lib.rs
+++ b/datafusion/functions-nested/src/lib.rs
@@ -37,9 +37,12 @@
 #[macro_use]
 pub mod macros;
 
+pub mod array_avg;
 pub mod array_has;
 pub mod array_math;
 pub mod array_normalize;
+pub mod array_product;
+pub mod array_sum;
 pub mod arrays_zip;
 pub mod cardinality;
 pub mod concat;
@@ -82,6 +85,7 @@ use std::sync::Arc;
 
 /// Fluent-style API for creating `Expr`s
 pub mod expr_fn {
+    pub use super::array_avg::array_avg;
     pub use super::array_has::array_has;
     pub use super::array_has::array_has_all;
     pub use super::array_has::array_has_any;
@@ -89,6 +93,8 @@ pub mod expr_fn {
     pub use super::array_math::array_scale;
     pub use super::array_math::array_subtract;
     pub use super::array_normalize::array_normalize;
+    pub use super::array_product::array_product;
+    pub use super::array_sum::array_sum;
     pub use super::arrays_zip::arrays_zip;
     pub use super::cardinality::cardinality;
     pub use super::concat::array_append;
@@ -169,6 +175,9 @@ pub fn all_default_nested_functions() -> Vec<Arc<ScalarUDF>> {
         distance::array_distance_udf(),
         flatten::flatten_udf(),
         inner_product::inner_product_udf(),
+        array_avg::array_avg_udf(),
+        array_product::array_product_udf(),
+        array_sum::array_sum_udf(),
         min_max::array_max_udf(),
         min_max::array_min_udf(),
         sort::array_sort_udf(),

--- a/datafusion/functions-nested/src/min_max.rs
+++ b/datafusion/functions-nested/src/min_max.rs
@@ -148,6 +148,7 @@ make_udf_expr_and_func!(
 #[derive(Debug, PartialEq, Eq, Hash)]
 struct ArrayMin {
     signature: Signature,
+    aliases: Vec<String>,
 }
 
 impl Default for ArrayMin {
@@ -160,6 +161,7 @@ impl ArrayMin {
     fn new() -> Self {
         Self {
             signature: Signature::array(Volatility::Immutable),
+            aliases: vec!["list_min".to_string()],
         }
     }
 }
@@ -183,6 +185,10 @@ impl ScalarUDFImpl for ArrayMin {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         make_scalar_function(array_min_inner)(&args.args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
     }
 
     fn documentation(&self) -> Option<&Documentation> {

--- a/datafusion/functions-nested/src/vector_math.rs
+++ b/datafusion/functions-nested/src/vector_math.rs
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shared vector math primitives used by cosine_distance, inner_product,
+//! array_normalize, and related functions.
+
+use arrow::array::{ArrayRef, Float64Array};
+use datafusion_common::cast::{
+    as_float32_array, as_float64_array, as_int32_array, as_int64_array,
+};
+use datafusion_common::{Result, exec_err};
+
+/// Converts an array of any numeric type to a Float64Array.
+pub fn convert_to_f64_array(array: &ArrayRef) -> Result<Float64Array> {
+    match array.data_type() {
+        arrow::datatypes::DataType::Float64 => Ok(as_float64_array(array)?.clone()),
+        arrow::datatypes::DataType::Float32 => {
+            let array = as_float32_array(array)?;
+            let converted: Float64Array =
+                array.iter().map(|v| v.map(|v| v as f64)).collect();
+            Ok(converted)
+        }
+        arrow::datatypes::DataType::Int64 => {
+            let array = as_int64_array(array)?;
+            let converted: Float64Array =
+                array.iter().map(|v| v.map(|v| v as f64)).collect();
+            Ok(converted)
+        }
+        arrow::datatypes::DataType::Int32 => {
+            let array = as_int32_array(array)?;
+            let converted: Float64Array =
+                array.iter().map(|v| v.map(|v| v as f64)).collect();
+            Ok(converted)
+        }
+        _ => exec_err!("Unsupported array type for conversion to Float64Array"),
+    }
+}
+
+/// Computes dot product: sum(a[i] * b[i])
+pub fn dot_product_f64(a: &Float64Array, b: &Float64Array) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(v1, v2)| v1.unwrap_or(0.0) * v2.unwrap_or(0.0))
+        .sum()
+}
+
+/// Computes sum of squares: sum(a[i]^2)
+pub fn sum_of_squares_f64(a: &Float64Array) -> f64 {
+    a.iter()
+        .map(|v| {
+            let val = v.unwrap_or(0.0);
+            val * val
+        })
+        .sum()
+}
+
+/// Computes magnitude (L2 norm): sqrt(sum(a[i]^2))
+pub fn magnitude_f64(a: &Float64Array) -> f64 {
+    sum_of_squares_f64(a).sqrt()
+}

--- a/datafusion/functions-nested/src/vector_math.rs
+++ b/datafusion/functions-nested/src/vector_math.rs
@@ -20,7 +20,8 @@
 
 use arrow::array::{ArrayRef, Float64Array};
 use datafusion_common::cast::{
-    as_float32_array, as_float64_array, as_int32_array, as_int64_array,
+    as_float32_array, as_float64_array, as_int8_array, as_int16_array, as_int32_array,
+    as_int64_array, as_uint8_array, as_uint16_array, as_uint32_array, as_uint64_array,
 };
 use datafusion_common::{Result, exec_err};
 
@@ -30,21 +31,39 @@ pub fn convert_to_f64_array(array: &ArrayRef) -> Result<Float64Array> {
         arrow::datatypes::DataType::Float64 => Ok(as_float64_array(array)?.clone()),
         arrow::datatypes::DataType::Float32 => {
             let array = as_float32_array(array)?;
-            let converted: Float64Array =
-                array.iter().map(|v| v.map(|v| v as f64)).collect();
-            Ok(converted)
+            Ok(array.iter().map(|v| v.map(|v| v as f64)).collect())
         }
         arrow::datatypes::DataType::Int64 => {
             let array = as_int64_array(array)?;
-            let converted: Float64Array =
-                array.iter().map(|v| v.map(|v| v as f64)).collect();
-            Ok(converted)
+            Ok(array.iter().map(|v| v.map(|v| v as f64)).collect())
         }
         arrow::datatypes::DataType::Int32 => {
             let array = as_int32_array(array)?;
-            let converted: Float64Array =
-                array.iter().map(|v| v.map(|v| v as f64)).collect();
-            Ok(converted)
+            Ok(array.iter().map(|v| v.map(|v| v as f64)).collect())
+        }
+        arrow::datatypes::DataType::Int16 => {
+            let array = as_int16_array(array)?;
+            Ok(array.iter().map(|v| v.map(|v| v as f64)).collect())
+        }
+        arrow::datatypes::DataType::Int8 => {
+            let array = as_int8_array(array)?;
+            Ok(array.iter().map(|v| v.map(|v| v as f64)).collect())
+        }
+        arrow::datatypes::DataType::UInt64 => {
+            let array = as_uint64_array(array)?;
+            Ok(array.iter().map(|v| v.map(|v| v as f64)).collect())
+        }
+        arrow::datatypes::DataType::UInt32 => {
+            let array = as_uint32_array(array)?;
+            Ok(array.iter().map(|v| v.map(|v| v as f64)).collect())
+        }
+        arrow::datatypes::DataType::UInt16 => {
+            let array = as_uint16_array(array)?;
+            Ok(array.iter().map(|v| v.map(|v| v as f64)).collect())
+        }
+        arrow::datatypes::DataType::UInt8 => {
+            let array = as_uint8_array(array)?;
+            Ok(array.iter().map(|v| v.map(|v| v as f64)).collect())
         }
         _ => exec_err!("Unsupported array type for conversion to Float64Array"),
     }

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -1757,6 +1757,288 @@ from (
 100 300 Decimal128(20, 4) Decimal128(20, 4)
 
 
+# list_min alias
+query I
+select list_min(make_array(3, 1, 4, 2));
+----
+1
+
+## array_sum (aliases: `list_sum`)
+
+# array_sum with integers
+query I
+select array_sum(make_array(1, 2, 3, 4));
+----
+10
+
+# array_sum with NULLs (skipped)
+query I
+select array_sum(make_array(1, NULL, 3, NULL, 5));
+----
+9
+
+# array_sum with all NULLs (Null element type unsupported at planning)
+query error DataFusion error: Execution error: array_sum does not support element type: Null
+select array_sum(make_array(NULL, NULL));
+
+# array_sum with floats
+query R
+select array_sum(make_array(1.5, 2.5, 3.0));
+----
+7
+
+# array_sum with negative values
+query I
+select array_sum(make_array(-1, -2, 3, 4));
+----
+4
+
+# array_sum with empty array (Null element type unsupported at planning)
+query error DataFusion error: Execution error: array_sum does not support element type: Null
+select array_sum(make_array());
+
+# array_sum with single element
+query I
+select array_sum(make_array(42));
+----
+42
+
+# array_sum with NULL input (Null type unsupported)
+query error DataFusion error: Error during planning: array_sum does not support type Null
+select array_sum(NULL);
+
+# array_sum with LargeList
+query I
+select array_sum(arrow_cast(make_array(10, 20, 30), 'LargeList(Int64)'));
+----
+60
+
+# array_sum over multiple rows
+query I
+select array_sum(column1) from (values
+    (make_array(1, 2, 3)),
+    (make_array(10, 20, 30)),
+    (NULL),
+    (make_array(NULL, 5, NULL)),
+    (make_array(100))
+) as t(column1);
+----
+6
+60
+NULL
+5
+100
+
+# list_sum alias
+query I
+select list_sum(make_array(1, 2, 3));
+----
+6
+
+# array_sum preserves element type (no widening)
+query IT
+select array_sum(make_array(1, 2, 3)), arrow_typeof(array_sum(make_array(1, 2, 3)));
+----
+6 Int64
+
+# array_sum with unsigned integers
+query I
+select array_sum(arrow_cast(make_array(10, 20, 30), 'List(UInt8)'));
+----
+60
+
+# array_sum no arguments error
+query error DataFusion error: Error during planning: 'array_sum' does not support zero arguments
+select array_sum();
+
+# array_sum with string (should error)
+query error DataFusion error: Execution error: array_sum does not support element type: Utf8
+select array_sum(make_array('a', 'b', 'c'));
+
+## array_product (aliases: `list_product`)
+
+# array_product with integers
+query I
+select array_product(make_array(2, 3, 4));
+----
+24
+
+# array_product with NULLs (skipped)
+query I
+select array_product(make_array(2, NULL, 5));
+----
+10
+
+# array_product with all NULLs
+query error DataFusion error: Execution error: array_product does not support element type: Null
+select array_product(make_array(NULL, NULL));
+
+# array_product with floats
+query R
+select array_product(make_array(1.5, 2.0, 3.0));
+----
+9
+
+# array_product with single element
+query I
+select array_product(make_array(42));
+----
+42
+
+# array_product with zero
+query I
+select array_product(make_array(5, 0, 3));
+----
+0
+
+# array_product with LargeList
+query I
+select array_product(arrow_cast(make_array(2, 3, 5), 'LargeList(Int64)'));
+----
+30
+
+# array_product over multiple rows
+query I
+select array_product(column1) from (values
+    (make_array(1, 2, 3)),
+    (make_array(10, 20)),
+    (NULL),
+    (make_array(NULL, 5, NULL)),
+    (make_array(7))
+) as t(column1);
+----
+6
+200
+NULL
+5
+7
+
+# array_product preserves element type
+query IT
+select array_product(make_array(2, 3, 4)), arrow_typeof(array_product(make_array(2, 3, 4)));
+----
+24 Int64
+
+# list_product alias
+query I
+select list_product(make_array(2, 3));
+----
+6
+
+# array_product with unsigned integers
+query I
+select array_product(arrow_cast(make_array(2, 3, 5), 'List(UInt8)'));
+----
+30
+
+# array_product with empty array
+query error DataFusion error: Execution error: array_product does not support element type: Null
+select array_product(make_array());
+
+# array_product with NULL input
+query error DataFusion error: Error during planning: array_product does not support type Null
+select array_product(NULL);
+
+# array_product rejects Decimal types (scale is not adjusted during multiplication)
+query error DataFusion error: Execution error: array_product does not support Decimal types
+select array_product(arrow_cast(make_array(arrow_cast(2, 'Decimal128(10,2)'), arrow_cast(3, 'Decimal128(10,2)')), 'List(Decimal128(10, 2))'));
+
+# array_product no arguments error
+query error DataFusion error: Error during planning: 'array_product' does not support zero arguments
+select array_product();
+
+# array_product with string (should error)
+query error DataFusion error: Execution error: array_product does not support element type: Utf8
+select array_product(make_array('a', 'b', 'c'));
+
+## array_avg (aliases: `list_avg`)
+
+# array_avg with integers
+query R
+select array_avg(make_array(1, 2, 3, 4));
+----
+2.5
+
+# array_avg with NULLs (skipped, count excludes NULLs)
+query R
+select array_avg(make_array(10, NULL, 20));
+----
+15
+
+# array_avg with all NULLs
+query error DataFusion error: Execution error: Unsupported array type for conversion to Float64Array
+select array_avg(make_array(NULL, NULL));
+
+# array_avg with floats
+query R
+select array_avg(make_array(1.0, 2.0, 3.0));
+----
+2
+
+# array_avg with single element
+query R
+select array_avg(make_array(42));
+----
+42
+
+# array_avg always returns Float64
+query RT
+select array_avg(make_array(1, 2, 3)), arrow_typeof(array_avg(make_array(1, 2, 3)));
+----
+2 Float64
+
+# array_avg with LargeList
+query R
+select array_avg(arrow_cast(make_array(10, 20, 30), 'LargeList(Int64)'));
+----
+20
+
+# array_avg over multiple rows
+query R
+select array_avg(column1) from (values
+    (make_array(10, 20, 30)),
+    (make_array(5, 15)),
+    (NULL),
+    (make_array(NULL, 100, NULL)),
+    (make_array(7))
+) as t(column1);
+----
+20
+10
+NULL
+100
+7
+
+# list_avg alias
+query R
+select list_avg(make_array(4, 8));
+----
+6
+
+# array_avg with unsigned integers
+query R
+select array_avg(arrow_cast(make_array(10, 20, 30), 'List(UInt8)'));
+----
+20
+
+# array_avg with typed empty array
+query R
+select array_avg(arrow_cast(make_array(), 'List(Int64)'));
+----
+NULL
+
+# array_avg with NULL input
+query error DataFusion error: Error during planning: array_avg does not support type Null
+select array_avg(NULL);
+
+# array_avg no arguments error
+query error DataFusion error: Error during planning: 'array_avg' does not support zero arguments
+select array_avg();
+
+# array_avg with string (should error)
+query error DataFusion error: Execution error: Unsupported array type for conversion to Float64Array
+select array_avg(make_array('a', 'b', 'c'));
+
 ## array_pop_back (aliases: `list_pop_back`)
 
 # array_pop_back scalar function with null

--- a/datafusion/sqllogictest/test_files/vector_functions.slt
+++ b/datafusion/sqllogictest/test_files/vector_functions.slt
@@ -1,0 +1,302 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#############
+## Vector Distance and Array Math Functions Tests
+#############
+
+# ============================================================================
+# cosine_distance
+# ============================================================================
+
+# orthogonal vectors -> distance 1.0
+query R
+select cosine_distance([1.0, 0.0], [0.0, 1.0]);
+----
+1
+
+# identical vectors -> distance 0.0
+query R
+select cosine_distance([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]);
+----
+0
+
+# opposite vectors -> distance 2.0
+query R
+select cosine_distance([1.0, 0.0], [-1.0, 0.0]);
+----
+2
+
+# alias: list_cosine_distance
+query R
+select list_cosine_distance([1.0, 0.0], [0.0, 1.0]);
+----
+1
+
+# null elements inside array
+query R
+select cosine_distance([1.0, NULL], [1.0, 2.0]);
+----
+NULL
+
+# mismatched lengths
+query error
+select cosine_distance([1.0, 2.0], [1.0]);
+
+# ============================================================================
+# inner_product / dot_product
+# ============================================================================
+
+# basic dot product: 1*4 + 2*5 + 3*6 = 32
+query R
+select inner_product([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]);
+----
+32
+
+# orthogonal vectors -> 0
+query R
+select inner_product([1.0, 0.0], [0.0, 1.0]);
+----
+0
+
+# alias: list_inner_product
+query R
+select list_inner_product([1.0, 2.0], [3.0, 4.0]);
+----
+11
+
+# alias: dot_product
+query R
+select dot_product([1.0, 2.0], [3.0, 4.0]);
+----
+11
+
+# null elements inside array
+query R
+select inner_product([1.0, NULL], [1.0, 2.0]);
+----
+NULL
+
+# mismatched lengths
+query error
+select inner_product([1.0, 2.0], [1.0]);
+
+# empty arrays
+query R
+select inner_product(ARRAY[]::DOUBLE[], ARRAY[]::DOUBLE[]);
+----
+0
+
+# ============================================================================
+# array_normalize
+# ============================================================================
+
+# 3-4-5 triangle: [3/5, 4/5] = [0.6, 0.8]
+query ?
+select array_normalize([3.0, 4.0]);
+----
+[0.6, 0.8]
+
+# unit vector stays unit
+query ?
+select array_normalize([1.0, 0.0]);
+----
+[1.0, 0.0]
+
+# alias: list_normalize
+query ?
+select list_normalize([3.0, 4.0]);
+----
+[0.6, 0.8]
+
+# null elements
+query ?
+select array_normalize([1.0, NULL, 2.0]);
+----
+NULL
+
+# zero vector -> null (undefined direction)
+query ?
+select array_normalize([0.0, 0.0]);
+----
+NULL
+
+# ============================================================================
+# array_add
+# ============================================================================
+
+query ?
+select array_add([1.0, 2.0], [3.0, 4.0]);
+----
+[4.0, 6.0]
+
+# alias: list_add
+query ?
+select list_add([1.0, 2.0], [3.0, 4.0]);
+----
+[4.0, 6.0]
+
+# mismatched lengths
+query error
+select array_add([1.0, 2.0], [1.0]);
+
+# empty arrays
+query ?
+select array_add(ARRAY[]::DOUBLE[], ARRAY[]::DOUBLE[]);
+----
+[]
+
+# ============================================================================
+# array_subtract
+# ============================================================================
+
+query ?
+select array_subtract([5.0, 3.0], [1.0, 2.0]);
+----
+[4.0, 1.0]
+
+# alias: list_subtract
+query ?
+select list_subtract([5.0, 3.0], [1.0, 2.0]);
+----
+[4.0, 1.0]
+
+# mismatched lengths
+query error
+select array_subtract([1.0], [1.0, 2.0]);
+
+# ============================================================================
+# array_scale
+# ============================================================================
+
+query ?
+select array_scale([1.0, 2.0, 3.0], 2.0);
+----
+[2.0, 4.0, 6.0]
+
+# alias: list_scale
+query ?
+select list_scale([1.0, 2.0], 3.0);
+----
+[3.0, 6.0]
+
+# scale by zero
+query ?
+select array_scale([1.0, 2.0], 0.0);
+----
+[0.0, 0.0]
+
+# negative scale
+query ?
+select array_scale([1.0, 2.0], -1.0);
+----
+[-1.0, -2.0]
+
+# ============================================================================
+# Column-based null tests (NULL via column data, not bare SQL NULL literal)
+# ============================================================================
+
+statement ok
+CREATE TABLE null_test (a DOUBLE[], b DOUBLE[]) AS VALUES
+  ([1.0, 2.0], [3.0, 4.0]),
+  (NULL, [1.0, 2.0]),
+  ([1.0, 2.0], NULL);
+
+query R
+select cosine_distance(a, b) from null_test;
+----
+0.0161300899
+NULL
+NULL
+
+query R
+select inner_product(a, b) from null_test;
+----
+11
+NULL
+NULL
+
+query ?
+select array_normalize(a) from null_test;
+----
+[0.4472135954999579, 0.8944271909999159]
+NULL
+[0.4472135954999579, 0.8944271909999159]
+
+query ?
+select array_add(a, b) from null_test;
+----
+[4.0, 6.0]
+NULL
+NULL
+
+query ?
+select array_subtract(a, b) from null_test;
+----
+[-2.0, -2.0]
+NULL
+NULL
+
+statement ok
+DROP TABLE null_test;
+
+# ============================================================================
+# Vector search pattern: cosine distance ranking
+# ============================================================================
+
+statement ok
+CREATE TABLE embeddings (id INT, emb DOUBLE[]) AS VALUES
+  (1, [1.0, 0.0, 0.0]),
+  (2, [0.0, 1.0, 0.0]),
+  (3, [0.707, 0.707, 0.0]),
+  (4, [0.0, 0.0, 1.0]),
+  (5, [0.577, 0.577, 0.577]);
+
+# Find nearest neighbors by cosine distance
+query IR
+select id, round(cosine_distance(emb, [1.0, 0.0, 0.0]), 6) as dist from embeddings order by dist limit 3;
+----
+1 0
+3 0.292893
+5 0.42265
+
+# Rank by inner product (higher = more similar)
+query IR
+select id, round(inner_product(emb, [1.0, 0.0, 0.0]), 6) as score from embeddings order by score desc limit 3;
+----
+1 1
+3 0.707
+5 0.577
+
+# Normalize then compute cosine distance (should give same results)
+query IR
+select id, round(cosine_distance(array_normalize(emb), [1.0, 0.0, 0.0]), 6) as dist from embeddings order by dist limit 3;
+----
+1 0
+3 0.292893
+5 0.42265
+
+# Combine array math: subtract query vector, get L2 distance of difference
+query IR
+select id, round(array_distance(array_subtract(emb, [1.0, 0.0, 0.0]), [0.0, 0.0, 0.0]), 6) as l2_diff from embeddings order by l2_diff limit 3;
+----
+1 0
+3 0.765309
+5 0.919123
+
+statement ok
+DROP TABLE embeddings;


### PR DESCRIPTION
## Which issue does this PR close?

Closes gaps in DataFusion's array function coverage compared to DuckDB (`list_sum`, `list_aggregate`) and Trino (`reduce`).

## Rationale for this change

DataFusion has `array_min` and `array_max` but no `array_sum`, `array_product`, or `array_avg`. These are common operations on array columns that currently require verbose workarounds (`UNNEST` + aggregate + `ARRAY_AGG`).

## What changes are included in this PR?

**New functions:**
- `array_sum` / `list_sum` — sum of all elements in an array (same return type as element)
- `array_product` / `list_product` — product of all elements (rejects Decimal types where raw integer multiplication produces incorrect results due to scale)
- `array_avg` / `list_avg` — arithmetic mean, always returns Float64

**Bug fixes:**
- Added missing `list_min` alias to `ArrayMin` (parity with `list_max` on `ArrayMax`)
- Extended `convert_to_f64_array` in `vector_math.rs` to handle Int8, Int16, UInt8, UInt16, UInt32, UInt64

**Implementation:**
- `array_sum` and `array_product` use the same `downcast_primitive!` + offset-window pattern as `array_min`/`array_max` for zero-copy performance
- `array_avg` converts elements to Float64 via the shared `convert_to_f64_array` primitive
- All functions: NULL elements skipped, all-NULL/empty arrays return NULL, List and LargeList supported, FixedSizeList coerced automatically

**Dependencies:** Builds on #21371 (vector distance + array math functions) for shared `vector_math.rs` primitives.

## Are these changes tested?

Yes — 41 new sqllogictest cases covering:
- Integer, float, unsigned integer inputs
- NULL element handling (skip NULLs, all-NULL → NULL)
- Empty array and NULL input
- LargeList support
- Multi-row queries
- Alias tests (`list_sum`, `list_product`, `list_avg`, `list_min`)
- Type preservation (`arrow_typeof` assertions)
- Error cases (string input, Decimal rejection, no arguments)

All existing tests pass (79 unit tests + 2 doctests + sqllogictests).

## Are there any user-facing changes?

Yes — three new SQL functions available:
```sql
SELECT array_sum([1, 2, 3, 4]);        -- 10
SELECT array_product([2, 3, 4]);       -- 24
SELECT array_avg([1, 2, 3, 4]);        -- 2.5
SELECT list_min([3, 1, 4, 2]);         -- 1 (new alias)
```