### PR TITLE
feat: add is_nullable scalar UDF

### DIFF
--- a/datafusion/functions/src/core/is_nullable.rs
+++ b/datafusion/functions/src/core/is_nullable.rs
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::DataType;
+use datafusion_common::{Result, ScalarValue, utils::take_function_args};
+use datafusion_expr::{ColumnarValue, Documentation, ScalarFunctionArgs};
+use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
+use datafusion_macros::user_doc;
+
+#[user_doc(
+    doc_section(label = "Other Functions"),
+    description = "Returns true if the expression's field is nullable, false otherwise. This reflects the schema-level nullability, not whether a specific runtime value is NULL.",
+    syntax_example = "is_nullable(expression)",
+    sql_example = r#"```sql
+> select is_nullable(name), is_nullable(ts) from table_with_metadata limit 1;
++----------------------------+------------------------+
+| is_nullable(table_with_metadata.name) | is_nullable(table_with_metadata.ts) |
++----------------------------+------------------------+
+| true                       | false                  |
++----------------------------+------------------------+
+```
+"#,
+    argument(
+        name = "expression",
+        description = "Expression to evaluate. The expression can be a constant, column, or function, and any combination of operators."
+    )
+)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct IsNullableFunc {
+    signature: Signature,
+}
+
+impl Default for IsNullableFunc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IsNullableFunc {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for IsNullableFunc {
+    fn name(&self) -> &str {
+        "is_nullable"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let [_arg] = take_function_args(self.name(), args.args)?;
+        let nullable = args.arg_fields[0].is_nullable();
+        Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(nullable))))
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        self.doc()
+    }
+}

--- a/datafusion/functions/src/core/mod.rs
+++ b/datafusion/functions/src/core/mod.rs
@@ -29,6 +29,7 @@ pub mod expr_ext;
 pub mod getfield;
 pub mod greatest;
 mod greatest_least_utils;
+pub mod is_nullable;
 pub mod least;
 pub mod named_struct;
 pub mod nullif;
@@ -59,6 +60,7 @@ make_udf_function!(union_extract::UnionExtractFun, union_extract);
 make_udf_function!(union_tag::UnionTagFunc, union_tag);
 make_udf_function!(version::VersionFunc, version);
 make_udf_function!(arrow_metadata::ArrowMetadataFunc, arrow_metadata);
+make_udf_function!(is_nullable::IsNullableFunc, is_nullable);
 
 pub mod expr_fn {
     use datafusion_expr::{Expr, Literal};
@@ -119,6 +121,10 @@ pub mod expr_fn {
         union_tag,
         "Returns the name of the currently selected field in the union",
         arg1
+    ),(
+        is_nullable,
+        "Returns whether the input expression is nullable",
+        arg1
     ));
 
     #[doc = "Returns the value of the field with the given name from the struct"]
@@ -168,5 +174,6 @@ pub fn functions() -> Vec<Arc<ScalarUDF>> {
         union_tag(),
         version(),
         r#struct(),
+        is_nullable(),
     ]
 }

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -137,7 +137,7 @@ impl TestContext {
                 info!("Registering table with many types");
                 register_table_with_many_types(test_ctx.session_ctx()).await;
             }
-            "metadata.slt" => {
+            "metadata.slt" | "is_nullable.slt" => {
                 info!("Registering metadata table tables");
                 register_metadata_tables(test_ctx.session_ctx()).await;
             }

--- a/datafusion/sqllogictest/test_files/is_nullable.slt
+++ b/datafusion/sqllogictest/test_files/is_nullable.slt
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+## Tests for the is_nullable function
+##########
+
+# Literals are not nullable
+query B
+select is_nullable(1);
+----
+false
+
+query B
+select is_nullable('hello');
+----
+false
+
+# NULL literal is nullable
+query B
+select is_nullable(NULL);
+----
+true
+
+# Nullable columns from table_with_metadata
+query B
+select is_nullable(id) from table_with_metadata limit 1;
+----
+true
+
+query B
+select is_nullable(name) from table_with_metadata limit 1;
+----
+true
+
+# Non-nullable columns
+query B
+select is_nullable(ts) from table_with_metadata limit 1;
+----
+false
+
+query B
+select is_nullable(nonnull_name) from table_with_metadata limit 1;
+----
+false
+
+# Expressions propagate nullability
+query B
+select is_nullable(id + 1) from table_with_metadata limit 1;
+----
+true

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -5286,6 +5286,7 @@ union_tag(union_expression)
 - [arrow_try_cast](#arrow_try_cast)
 - [arrow_typeof](#arrow_typeof)
 - [get_field](#get_field)
+- [is_nullable](#is_nullable)
 - [version](#version)
 
 ### `arrow_cast`
@@ -5455,6 +5456,29 @@ get_field(expression, field_name[, field_name2, ...])
 +--------+
 | 42     |
 +--------+
+```
+
+### `is_nullable`
+
+Returns true if the expression's field is nullable, false otherwise. This reflects the schema-level nullability, not whether a specific runtime value is NULL.
+
+```sql
+is_nullable(expression)
+```
+
+#### Arguments
+
+- **expression**: Expression to evaluate. The expression can be a constant, column, or function, and any combination of operators.
+
+#### Example
+
+```sql
+> select is_nullable(name), is_nullable(ts) from table_with_metadata limit 1;
++----------------------------+------------------------+
+| is_nullable(table_with_metadata.name) | is_nullable(table_with_metadata.ts) |
++----------------------------+------------------------+
+| true                       | false                  |
++----------------------------+------------------------+
 ```
 
 ### `version`


### PR DESCRIPTION
## Summary

- Adds `is_nullable(expression)` scalar UDF that returns the schema-level nullability of the input expression as a boolean
- Completes the Arrow field introspection set alongside `arrow_typeof` and `arrow_metadata`
- Returns `true` for nullable columns/expressions, `false` for non-nullable ones (NOT NULL columns, concrete literals)

## Test plan

- [x] Added sqllogictest (`is_nullable.slt`) covering:
  - Literal expressions (non-nullable: `is_nullable(1)` → false)
  - NULL literal (nullable: `is_nullable(NULL)` → true)
  - Nullable columns (`id`, `name` from `table_with_metadata`)
  - Non-nullable columns (`ts`, `nonnull_name` from `table_with_metadata`)
  - Expression nullability propagation (`id + 1` inherits nullable)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy` passes
- [x] Regenerated `scalar_functions.md` docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)