### PR TITLE
[branch-52] fix: Fix panic in regexp_like() (#20200)

### DIFF
--- a/datafusion/functions/src/regex/regexplike.rs
+++ b/datafusion/functions/src/regex/regexplike.rs
@@ -356,7 +356,7 @@ fn handle_regexp_like(
                 .map_err(|e| arrow_datafusion_err!(e))?
         }
         (Utf8, LargeUtf8) => {
-            let value = values.as_string_view();
+            let value = values.as_string::<i32>();
             let pattern = patterns.as_string::<i64>();
 
             regexp::regexp_is_match(value, pattern, flags)

--- a/datafusion/sqllogictest/test_files/regexp/regexp_like.slt
+++ b/datafusion/sqllogictest/test_files/regexp/regexp_like.slt
@@ -334,5 +334,10 @@ true true
 false false
 false false
 
+query TT
+select * from regexp_test where regexp_like('f', regexp_replace((('v\r') like ('f_*sP6H1*')), '339629555', '-1459539013'));
+----
+
+
 statement ok
 drop table if exists dict_table;


### PR DESCRIPTION
- Part of https://github.com/apache/datafusion/issues/21078
- Closes https://github.com/apache/datafusion/pull/20200 on branch-52

This PR:
- Backports https://github.com/apache/datafusion/pull/20200 from @neilconway to the branch-52 line
