### PR TITLE
chore: download tpch data without docker

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -612,7 +612,11 @@ data_tpch() {
     else
         echo " Copying answers to ${TPCH_DIR}/answers"
         mkdir -p "${TPCH_DIR}/answers"
-        docker run -v "${TPCH_DIR}":/data -it --entrypoint /bin/bash --rm ghcr.io/scalytics/tpch-docker:main  -c "cp -f /opt/tpch/2.18.0_rc2/dbgen/answers/* /data/answers/"
+        BASE_GH_URL="https://raw.githubusercontent.com/scalytics/TPCH-Docker/refs/heads/main/data/tpch/2.18.0_rc2/dbgen/answers"
+        for i in $(seq 1 22); do
+            OUT_FILE="q${i}.out"
+            wget -q --timeout=30 --tries=3 -O "${TPCH_DIR}/answers/${OUT_FILE}" "${BASE_GH_URL}/${OUT_FILE}"
+        done
     fi
 
     if [ "$FORMAT" = "parquet" ]; then


### PR DESCRIPTION
## Rationale for this change

Instead of using `scalytics/tpch-docker` image to download the TPC-H data, which requires Docker on the system, go to the GitHub repo directly and download from there.

## Are these changes tested?

Successful run of
```
$ ./bench.sh data tpch
$ ./bench.sh run tpch
```

## Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
