### PR TITLE
Skip type erasure in trace_future/trace_block when no tracer is set

### DIFF
--- a/datafusion/common-runtime/src/trace_utils.rs
+++ b/datafusion/common-runtime/src/trace_utils.rs
@@ -132,21 +132,24 @@ where
     F: Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
-    // Erase the future’s output type first:
+    // Fast path: if no custom tracer is set, avoid type erasure overhead
+    if GLOBAL_TRACER.get().is_none() {
+        return future.boxed();
+    }
+
+    // Slow path: erase the future's output type, pass through tracer, then downcast
     let erased_future = async move {
         let result = future.await;
         Box::new(result) as Box<dyn Any + Send>
     }
     .boxed();
 
-    // Forward through the global tracer:
     get_tracer()
         .trace_future(erased_future)
-        // Downcast from `Box<dyn Any + Send>` back to `T`:
         .map(|any_box| {
             *any_box
                 .downcast::<T>()
-                .expect("Tracer must preserve the future’s output type!")
+                .expect("Tracer must preserve the future's output type!")
         })
         .boxed()
 }
@@ -169,20 +172,23 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    // Erase the closure’s return type first:
+    // Fast path: if no custom tracer is set, avoid type erasure overhead
+    if GLOBAL_TRACER.get().is_none() {
+        return Box::new(f);
+    }
+
+    // Slow path: erase, trace, downcast
     let erased_closure = Box::new(|| {
         let result = f();
         Box::new(result) as Box<dyn Any + Send>
     });
 
-    // Forward through the global tracer:
     let traced_closure = get_tracer().trace_block(erased_closure);
 
-    // Downcast from `Box<dyn Any + Send>` back to `T`:
     Box::new(move || {
         let any_box = traced_closure();
         *any_box
             .downcast::<T>()
-            .expect("Tracer must preserve the closure’s return type!")
+            .expect("Tracer must preserve the closure's return type!")
     })
 }


### PR DESCRIPTION
## Summary

- Add fast path to `trace_future` and `trace_block` that skips the `Box<dyn Any + Send>` type erasure and downcast pipeline when no custom `JoinSetTracer` is registered (the common case)
- When `GLOBAL_TRACER` is not set, returns the future/closure directly with minimal boxing overhead

## Background

Profiling ClickBench queries showed `trace_future`'s type erasure overhead accounted for ~12% of total CPU time. Even with the `NoopTracer`, every spawned task was paying the cost of:
1. Boxing the result as `Box<dyn Any + Send>` (type erasure)
2. Passing through the tracer (noop)
3. Downcasting back from `Box<dyn Any + Send>` to `T`
4. Double-boxing the future with `.boxed()`

## Benchmark results (ClickBench, single iteration)

Notable improvements:
| Query | Before (ms) | After (ms) | Change |
|-------|------------|-----------|--------|
| Q3 | 74.9 | 48.0 | -36.0% |
| Q18 | 2517.5 | 2032.8 | -19.3% |
| Q19 | 54.9 | 43.2 | -21.3% |
| Q32 | 4497.6 | 4225.1 | -6.1% |
| Q33 | 2671.2 | 2497.9 | -6.5% |
| **Total** | **43272.9** | **42092.2** | **-2.7%** |

## Test plan

- [x] `cargo test -p datafusion-common-runtime` passes
- [x] `cargo clippy -p datafusion-common-runtime --all-targets --all-features -- -D warnings` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)