### PR TITLE
Add configurable UTF8 payload profiles to string_agg benchmarks and parameterize benchmark matrix

### DIFF
--- a/datafusion/core/benches/aggregate_query_sql.rs
+++ b/datafusion/core/benches/aggregate_query_sql.rs
@@ -18,9 +18,7 @@
 mod data_utils;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use data_utils::{
-    Utf8PayloadProfile, create_table_provider, create_table_provider_with_payload,
-};
+use data_utils::{Utf8PayloadProfile, create_table_provider_with_payload};
 use datafusion::error::Result;
 use datafusion::execution::context::SessionContext;
 use parking_lot::Mutex;
@@ -54,26 +52,20 @@ fn create_context_with_payload(
     utf8_payload_profile: Utf8PayloadProfile,
 ) -> Result<Arc<Mutex<SessionContext>>> {
     let ctx = SessionContext::new();
-    let provider = if matches!(utf8_payload_profile, Utf8PayloadProfile::Small) {
-        create_table_provider(partitions_len, array_len, batch_size)?
-    } else {
-        create_table_provider_with_payload(
-            partitions_len,
-            array_len,
-            batch_size,
-            utf8_payload_profile,
-        )?
-    };
+    let provider = create_table_provider_with_payload(
+        partitions_len,
+        array_len,
+        batch_size,
+        utf8_payload_profile,
+    )?;
     ctx.register_table("t", provider)?;
     Ok(Arc::new(Mutex::new(ctx)))
 }
 
-fn payload_label(profile: Utf8PayloadProfile) -> &'static str {
-    match profile {
-        Utf8PayloadProfile::Small => "small_3b",
-        Utf8PayloadProfile::Medium => "medium_64b",
-        Utf8PayloadProfile::Large => "large_1024b",
-    }
+fn string_agg_sql(group_by_column: &str) -> String {
+    format!(
+        "SELECT {group_by_column}, string_agg(utf8, ',') FROM t GROUP BY {group_by_column}"
+    )
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -335,14 +327,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     // - medium_64b makes copy costs measurable without overwhelming the query
     // - large_1024b stresses both CPU and memory behavior
     let string_agg_profiles = [
-        Utf8PayloadProfile::Small,
-        Utf8PayloadProfile::Medium,
-        Utf8PayloadProfile::Large,
+        (Utf8PayloadProfile::Small, "small_3b"),
+        (Utf8PayloadProfile::Medium, "medium_64b"),
+        (Utf8PayloadProfile::Large, "large_1024b"),
     ]
     .into_iter()
-    .map(|profile| {
+    .map(|(profile, label)| {
         (
-            payload_label(profile),
+            label,
             create_context_with_payload(partitions_len, array_len, batch_size, profile)
                 .unwrap(),
         )
@@ -350,25 +342,16 @@ fn criterion_benchmark(c: &mut Criterion) {
     .collect::<Vec<_>>();
 
     let string_agg_queries = [
-        (
-            "few_groups",
-            "SELECT u64_narrow, string_agg(utf8, ',') FROM t GROUP BY u64_narrow",
-        ),
-        (
-            "mid_groups",
-            "SELECT u64_mid, string_agg(utf8, ',') FROM t GROUP BY u64_mid",
-        ),
-        (
-            "many_groups",
-            "SELECT u64_wide, string_agg(utf8, ',') FROM t GROUP BY u64_wide",
-        ),
+        ("few_groups", string_agg_sql("u64_narrow")),
+        ("mid_groups", string_agg_sql("u64_mid")),
+        ("many_groups", string_agg_sql("u64_wide")),
     ];
 
     let mut string_agg_group = c.benchmark_group("string_agg_payloads");
-    for (query_name, sql) in string_agg_queries {
+    for (query_name, sql) in &string_agg_queries {
         for (payload_name, payload_ctx) in &string_agg_profiles {
             string_agg_group
-                .bench_function(BenchmarkId::new(query_name, payload_name), |b| {
+                .bench_function(BenchmarkId::new(*query_name, *payload_name), |b| {
                     b.iter(|| query(payload_ctx.clone(), &rt, sql))
                 });
         }

--- a/datafusion/core/benches/aggregate_query_sql.rs
+++ b/datafusion/core/benches/aggregate_query_sql.rs
@@ -17,8 +17,10 @@
 
 mod data_utils;
 
-use criterion::{Criterion, criterion_group, criterion_main};
-use data_utils::create_table_provider;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use data_utils::{
+    Utf8PayloadProfile, create_table_provider, create_table_provider_with_payload,
+};
 use datafusion::error::Result;
 use datafusion::execution::context::SessionContext;
 use parking_lot::Mutex;
@@ -37,10 +39,41 @@ fn create_context(
     array_len: usize,
     batch_size: usize,
 ) -> Result<Arc<Mutex<SessionContext>>> {
+    create_context_with_payload(
+        partitions_len,
+        array_len,
+        batch_size,
+        Utf8PayloadProfile::Small,
+    )
+}
+
+fn create_context_with_payload(
+    partitions_len: usize,
+    array_len: usize,
+    batch_size: usize,
+    utf8_payload_profile: Utf8PayloadProfile,
+) -> Result<Arc<Mutex<SessionContext>>> {
     let ctx = SessionContext::new();
-    let provider = create_table_provider(partitions_len, array_len, batch_size)?;
+    let provider = if matches!(utf8_payload_profile, Utf8PayloadProfile::Small) {
+        create_table_provider(partitions_len, array_len, batch_size)?
+    } else {
+        create_table_provider_with_payload(
+            partitions_len,
+            array_len,
+            batch_size,
+            utf8_payload_profile,
+        )?
+    };
     ctx.register_table("t", provider)?;
     Ok(Arc::new(Mutex::new(ctx)))
+}
+
+fn payload_label(profile: Utf8PayloadProfile) -> &'static str {
+    match profile {
+        Utf8PayloadProfile::Small => "small_3b",
+        Utf8PayloadProfile::Medium => "medium_64b",
+        Utf8PayloadProfile::Large => "large_1024b",
+    }
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -296,38 +329,51 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("string_agg_query_group_by_few_groups", |b| {
-        b.iter(|| {
-            query(
-                ctx.clone(),
-                &rt,
-                "SELECT u64_narrow, string_agg(utf8, ',') \
-                 FROM t GROUP BY u64_narrow",
-            )
-        })
-    });
+    // These payload sizes keep the original 4-value cardinality while changing
+    // only the bytes copied into grouped `string_agg` state:
+    // - small_3b preserves the existing `hi0`..`hi3` baseline
+    // - medium_64b makes copy costs measurable without overwhelming the query
+    // - large_1024b stresses both CPU and memory behavior
+    let string_agg_profiles = [
+        Utf8PayloadProfile::Small,
+        Utf8PayloadProfile::Medium,
+        Utf8PayloadProfile::Large,
+    ]
+    .into_iter()
+    .map(|profile| {
+        (
+            payload_label(profile),
+            create_context_with_payload(partitions_len, array_len, batch_size, profile)
+                .unwrap(),
+        )
+    })
+    .collect::<Vec<_>>();
 
-    c.bench_function("string_agg_query_group_by_mid_groups", |b| {
-        b.iter(|| {
-            query(
-                ctx.clone(),
-                &rt,
-                "SELECT u64_mid, string_agg(utf8, ',') \
-                 FROM t GROUP BY u64_mid",
-            )
-        })
-    });
+    let string_agg_queries = [
+        (
+            "few_groups",
+            "SELECT u64_narrow, string_agg(utf8, ',') FROM t GROUP BY u64_narrow",
+        ),
+        (
+            "mid_groups",
+            "SELECT u64_mid, string_agg(utf8, ',') FROM t GROUP BY u64_mid",
+        ),
+        (
+            "many_groups",
+            "SELECT u64_wide, string_agg(utf8, ',') FROM t GROUP BY u64_wide",
+        ),
+    ];
 
-    c.bench_function("string_agg_query_group_by_many_groups", |b| {
-        b.iter(|| {
-            query(
-                ctx.clone(),
-                &rt,
-                "SELECT u64_wide, string_agg(utf8, ',') \
-                 FROM t GROUP BY u64_wide",
-            )
-        })
-    });
+    let mut string_agg_group = c.benchmark_group("string_agg_payloads");
+    for (query_name, sql) in string_agg_queries {
+        for (payload_name, payload_ctx) in &string_agg_profiles {
+            string_agg_group
+                .bench_function(BenchmarkId::new(query_name, payload_name), |b| {
+                    b.iter(|| query(payload_ctx.clone(), &rt, sql))
+                });
+        }
+    }
+    string_agg_group.finish();
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/datafusion/core/benches/data_utils/mod.rs
+++ b/datafusion/core/benches/data_utils/mod.rs
@@ -41,7 +41,6 @@ use std::sync::Arc;
 /// large profiles keep the same low cardinality but scale each value's byte
 /// width so string aggregation can expose the cost of copying larger payloads.
 #[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
 pub enum Utf8PayloadProfile {
     /// 3-byte baseline values such as `hi0`.
     Small,
@@ -79,6 +78,7 @@ pub fn create_table_provider_with_payload(
     batch_size: usize,
     utf8_payload_profile: Utf8PayloadProfile,
 ) -> Result<Arc<MemTable>> {
+    let _ = Utf8PayloadProfile::all();
     let schema = Arc::new(create_schema());
     let partitions = create_record_batches(
         &schema,
@@ -212,6 +212,10 @@ pub fn create_record_batches(
 }
 
 impl Utf8PayloadProfile {
+    fn all() -> [Self; 3] {
+        [Self::Small, Self::Medium, Self::Large]
+    }
+
     fn payloads(self) -> [String; 4] {
         std::array::from_fn(|idx| match self {
             Self::Small => format!("hi{idx}"),

--- a/datafusion/core/benches/data_utils/mod.rs
+++ b/datafusion/core/benches/data_utils/mod.rs
@@ -130,11 +130,10 @@ fn create_record_batch(
     rng: &mut StdRng,
     batch_size: usize,
     batch_index: usize,
-    utf8_payload_profile: Utf8PayloadProfile,
+    payloads: &[String; 4],
 ) -> RecordBatch {
     // Randomly choose from 4 distinct key values; a higher number increases sparseness.
     let key_suffixes = [0, 1, 2, 3];
-    let payloads = utf8_payload_profile.payloads();
     let keys = StringArray::from_iter_values((0..batch_size).map(|_| {
         let suffix = *key_suffixes.choose(rng).unwrap();
         payloads[suffix].as_str()
@@ -193,6 +192,7 @@ pub fn create_record_batches(
     let mut rng = StdRng::seed_from_u64(42);
     let mut partitions = Vec::with_capacity(partitions_len);
     let batches_per_partition = array_len / batch_size / partitions_len;
+    let payloads = utf8_payload_profile.payloads();
 
     for _ in 0..partitions_len {
         let mut batches = Vec::with_capacity(batches_per_partition);
@@ -202,7 +202,7 @@ pub fn create_record_batches(
                 &mut rng,
                 batch_size,
                 batch_index,
-                utf8_payload_profile,
+                &payloads,
             ));
         }
         partitions.push(batches);
@@ -212,30 +212,21 @@ pub fn create_record_batches(
 
 impl Utf8PayloadProfile {
     fn payloads(self) -> [String; 4] {
-        match self {
-            Self::Small => [
-                "hi0".to_string(),
-                "hi1".to_string(),
-                "hi2".to_string(),
-                "hi3".to_string(),
-            ],
-            Self::Medium => std::array::from_fn(|idx| payload_string("mid", idx, 64)),
-            Self::Large => std::array::from_fn(|idx| payload_string("large", idx, 1024)),
-        }
+        std::array::from_fn(|idx| match self {
+            Self::Small => format!("hi{idx}"),
+            Self::Medium => payload_string("mid", idx, 64),
+            Self::Large => payload_string("large", idx, 1024),
+        })
     }
 }
 
 fn payload_string(prefix: &str, suffix: usize, target_len: usize) -> String {
     let mut value = format!("{prefix}{suffix}_");
     value.extend(std::iter::repeat_n(
-        ascii_fill(suffix),
+        (b'a' + suffix as u8) as char,
         target_len - value.len(),
     ));
     value
-}
-
-fn ascii_fill(suffix: usize) -> char {
-    (b'a' + suffix as u8) as char
 }
 
 /// An enum that wraps either a regular StringBuilder or a GenericByteViewBuilder

--- a/datafusion/core/benches/data_utils/mod.rs
+++ b/datafusion/core/benches/data_utils/mod.rs
@@ -41,6 +41,7 @@ use std::sync::Arc;
 /// large profiles keep the same low cardinality but scale each value's byte
 /// width so string aggregation can expose the cost of copying larger payloads.
 #[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
 pub enum Utf8PayloadProfile {
     /// 3-byte baseline values such as `hi0`.
     Small,

--- a/datafusion/core/benches/data_utils/mod.rs
+++ b/datafusion/core/benches/data_utils/mod.rs
@@ -35,6 +35,23 @@ use rand_distr::{Normal, Pareto};
 use std::fmt::Write;
 use std::sync::Arc;
 
+/// Payload profile for the benchmark `utf8` column.
+///
+/// The small profile preserves the existing `hi0`..`hi3` baseline. Medium and
+/// large profiles keep the same low cardinality but scale each value's byte
+/// width so string aggregation can expose the cost of copying larger payloads.
+#[derive(Clone, Copy, Debug)]
+pub enum Utf8PayloadProfile {
+    /// 3-byte baseline values such as `hi0`.
+    Small,
+    /// 64-byte payloads that are large enough to make copying noticeable
+    /// without dominating the benchmark with allocator churn.
+    Medium,
+    /// 1024-byte payloads that amplify both CPU and memory pressure in
+    /// grouped `string_agg` workloads.
+    Large,
+}
+
 /// create an in-memory table given the partition len, array len, and batch size,
 /// and the result table will be of array_len in total, and then partitioned, and batched.
 #[expect(clippy::allow_attributes)] // some issue where expect(dead_code) doesn't fire properly
@@ -44,9 +61,31 @@ pub fn create_table_provider(
     array_len: usize,
     batch_size: usize,
 ) -> Result<Arc<MemTable>> {
+    create_table_provider_with_payload(
+        partitions_len,
+        array_len,
+        batch_size,
+        Utf8PayloadProfile::Small,
+    )
+}
+
+/// Create an in-memory table with a configurable `utf8` payload size.
+#[expect(clippy::allow_attributes)] // some issue where expect(dead_code) doesn't fire properly
+#[allow(dead_code)]
+pub fn create_table_provider_with_payload(
+    partitions_len: usize,
+    array_len: usize,
+    batch_size: usize,
+    utf8_payload_profile: Utf8PayloadProfile,
+) -> Result<Arc<MemTable>> {
     let schema = Arc::new(create_schema());
-    let partitions =
-        create_record_batches(&schema, array_len, partitions_len, batch_size);
+    let partitions = create_record_batches(
+        &schema,
+        array_len,
+        partitions_len,
+        batch_size,
+        utf8_payload_profile,
+    );
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     MemTable::try_new(schema, partitions).map(Arc::new)
 }
@@ -91,12 +130,15 @@ fn create_record_batch(
     rng: &mut StdRng,
     batch_size: usize,
     batch_index: usize,
+    utf8_payload_profile: Utf8PayloadProfile,
 ) -> RecordBatch {
     // Randomly choose from 4 distinct key values; a higher number increases sparseness.
     let key_suffixes = [0, 1, 2, 3];
-    let keys = StringArray::from_iter_values(
-        (0..batch_size).map(|_| format!("hi{}", key_suffixes.choose(rng).unwrap())),
-    );
+    let payloads = utf8_payload_profile.payloads();
+    let keys = StringArray::from_iter_values((0..batch_size).map(|_| {
+        let suffix = *key_suffixes.choose(rng).unwrap();
+        payloads[suffix].as_str()
+    }));
 
     let values = create_data(rng, batch_size, 0.5);
 
@@ -146,6 +188,7 @@ pub fn create_record_batches(
     array_len: usize,
     partitions_len: usize,
     batch_size: usize,
+    utf8_payload_profile: Utf8PayloadProfile,
 ) -> Vec<Vec<RecordBatch>> {
     let mut rng = StdRng::seed_from_u64(42);
     let mut partitions = Vec::with_capacity(partitions_len);
@@ -159,11 +202,40 @@ pub fn create_record_batches(
                 &mut rng,
                 batch_size,
                 batch_index,
+                utf8_payload_profile,
             ));
         }
         partitions.push(batches);
     }
     partitions
+}
+
+impl Utf8PayloadProfile {
+    fn payloads(self) -> [String; 4] {
+        match self {
+            Self::Small => [
+                "hi0".to_string(),
+                "hi1".to_string(),
+                "hi2".to_string(),
+                "hi3".to_string(),
+            ],
+            Self::Medium => std::array::from_fn(|idx| payload_string("mid", idx, 64)),
+            Self::Large => std::array::from_fn(|idx| payload_string("large", idx, 1024)),
+        }
+    }
+}
+
+fn payload_string(prefix: &str, suffix: usize, target_len: usize) -> String {
+    let mut value = format!("{prefix}{suffix}_");
+    value.extend(std::iter::repeat_n(
+        ascii_fill(suffix),
+        target_len - value.len(),
+    ));
+    value
+}
+
+fn ascii_fill(suffix: usize) -> char {
+    (b'a' + suffix as u8) as char
 }
 
 /// An enum that wraps either a regular StringBuilder or a GenericByteViewBuilder


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #21156

---

## Rationale for this change

The current `string_agg` benchmarks use very small (≈3-byte) string payloads (e.g., `hi0`..`hi3`). This makes it difficult to observe the real cost of string aggregation in scenarios where payload sizes are larger, particularly the cost of copying and memory pressure during grouped aggregation.

This PR introduces configurable UTF-8 payload sizes so benchmarks can better reflect realistic workloads and expose CPU and memory behavior differences across payload sizes.

---

## What changes are included in this PR?

* Introduced a new `Utf8PayloadProfile` enum with three profiles:

  * `Small` (≈3 bytes, existing baseline)
  * `Medium` (≈64 bytes)
  * `Large` (≈1024 bytes)

* Added `create_table_provider_with_payload` to allow generating tables with configurable string payload sizes.

* Refactored record batch generation to use precomputed payload arrays instead of formatting strings per row.

* Added helper:

  * `payload_string` for generating fixed-size string payloads
  * `Utf8PayloadProfile::payloads()` for producing 4-value low-cardinality payload sets

* Updated benchmark setup:

  * Introduced `create_context_with_payload`
  * Parameterized `string_agg` queries across:

    * group cardinality (`few`, `mid`, `many`)
    * payload size (`small_3b`, `medium_64b`, `large_1024b`)

* Replaced individual benchmark functions with a `criterion` benchmark group using `BenchmarkId` to produce a matrix of results.

---

## Are these changes tested?

No new unit tests were added.

Reason:

* This change only affects benchmark utilities and benchmark definitions.
* Existing functionality remains unchanged for default (`Small`) payload profile.
* Benchmarks themselves act as validation for correctness and performance behavior.

---

## Are there any user-facing changes?

No.

This PR only impacts internal benchmarking infrastructure and does not modify public APIs or query behavior.

---

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.

---

## Additional Notes

* The benchmark matrix now isolates the impact of payload size while preserving low cardinality (4 distinct values), ensuring that observed differences are primarily due to string size rather than grouping distribution.
* Medium payloads aim to expose copy costs without excessive allocator overhead, while large payloads stress both CPU and memory behavior.

---

