### PR TITLE
feat: Add memory-limited execution for NestedLoopJoinExec

### DIFF
--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -66,6 +66,7 @@ use datafusion_common::{
     internal_datafusion_err, internal_err, project_schema, unwrap_or_internal_err,
 };
 use datafusion_execution::TaskContext;
+use datafusion_execution::disk_manager::RefCountedTempFile;
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion_expr::JoinType;
 use datafusion_physical_expr::equivalence::{
@@ -76,6 +77,10 @@ use datafusion_physical_expr::projection::{ProjectionRef, combine_projections};
 use futures::{Stream, StreamExt, TryStreamExt};
 use log::debug;
 use parking_lot::Mutex;
+
+use crate::metrics::SpillMetrics;
+use crate::spill::in_progress_spill_file::InProgressSpillFile;
+use crate::spill::spill_manager::SpillManager;
 
 #[expect(rustdoc::private_intra_doc_links)]
 /// NestedLoopJoinExec is a build-probe join operator designed for joins that
@@ -160,10 +165,16 @@ use parking_lot::Mutex;
 /// - The design try to minimize the intermediate data size to approximately
 ///   1 batch, for better cache locality and memory efficiency.
 ///
-/// # TODO: Memory-limited Execution
-/// If the memory budget is exceeded during left-side buffering, fallback
-/// strategies such as streaming left batches and re-scanning the right side
-/// may be implemented in the future.
+/// # Memory-limited Execution
+/// When the memory budget is exceeded during left-side buffering, the operator
+/// falls back to a multi-pass strategy:
+/// 1. Buffer as many left rows as fit in memory (one "chunk")
+/// 2. On the first pass, the right side is both processed and spilled to disk
+/// 3. For each subsequent left chunk, the right side is re-read from the spill file
+///
+/// This is enabled automatically when disk spilling is available and the right
+/// side has a single partition. Currently supports INNER, LEFT, LEFT SEMI,
+/// LEFT ANTI, and LEFT MARK join types in multi-pass mode.
 ///
 /// Tracking issue: <https://github.com/apache/datafusion/issues/15760>
 ///
@@ -594,27 +605,7 @@ impl ExecutionPlan for NestedLoopJoinExec {
         );
 
         let metrics = NestedLoopJoinMetrics::new(&self.metrics, partition);
-
-        // Initialization reservation for load of inner table
-        let load_reservation =
-            MemoryConsumer::new(format!("NestedLoopJoinLoad[{partition}]"))
-                .register(context.memory_pool());
-
-        let build_side_data = self.build_side_data.try_once(|| {
-            let stream = self.left.execute(0, Arc::clone(&context))?;
-
-            Ok(collect_left_input(
-                stream,
-                metrics.join_metrics.clone(),
-                load_reservation,
-                need_produce_result_in_final(self.join_type),
-                self.right().output_partitioning().partition_count(),
-            ))
-        })?;
-
         let batch_size = context.session_config().batch_size();
-
-        let probe_side_data = self.right.execute(partition, context)?;
 
         // update column indices to reflect the projection
         let column_indices_after_projection = match self.projection.as_ref() {
@@ -625,16 +616,74 @@ impl ExecutionPlan for NestedLoopJoinExec {
             None => self.column_indices.clone(),
         };
 
-        Ok(Box::pin(NestedLoopJoinStream::new(
-            self.schema(),
-            self.filter.clone(),
-            self.join_type,
-            probe_side_data,
-            build_side_data,
-            column_indices_after_projection,
-            metrics,
-            batch_size,
-        )))
+        let right_partition_count = self.right().output_partitioning().partition_count();
+
+        // Use memory-limited mode when:
+        // 1. Right side has single partition (so we can spill and re-scan)
+        // 2. Disk manager supports temp files
+        let use_memory_limited = right_partition_count == 1
+            && context.runtime_env().disk_manager.tmp_files_enabled();
+
+        if use_memory_limited {
+            let left_stream = self.left.execute(0, Arc::clone(&context))?;
+            let probe_side_data = self.right.execute(partition, Arc::clone(&context))?;
+
+            let reservation =
+                MemoryConsumer::new(format!("NestedLoopJoinLoad[{partition}]"))
+                    .with_can_spill(true)
+                    .register(context.memory_pool());
+
+            let right_schema = probe_side_data.schema();
+            let spill_manager = SpillManager::new(
+                context.runtime_env(),
+                metrics.spill_metrics.clone(),
+                right_schema,
+            )
+            .with_compression_type(context.session_config().spill_compression());
+
+            Ok(Box::pin(NestedLoopJoinStream::new_memory_limited(
+                self.schema(),
+                self.filter.clone(),
+                self.join_type,
+                probe_side_data,
+                left_stream,
+                column_indices_after_projection,
+                metrics,
+                batch_size,
+                reservation,
+                spill_manager,
+            )))
+        } else {
+            // Standard path: buffer all left data via OnceFut
+            let load_reservation =
+                MemoryConsumer::new(format!("NestedLoopJoinLoad[{partition}]"))
+                    .register(context.memory_pool());
+
+            let build_side_data = self.build_side_data.try_once(|| {
+                let stream = self.left.execute(0, Arc::clone(&context))?;
+
+                Ok(collect_left_input(
+                    stream,
+                    metrics.join_metrics.clone(),
+                    load_reservation,
+                    need_produce_result_in_final(self.join_type),
+                    right_partition_count,
+                ))
+            })?;
+
+            let probe_side_data = self.right.execute(partition, context)?;
+
+            Ok(Box::pin(NestedLoopJoinStream::new(
+                self.schema(),
+                self.filter.clone(),
+                self.join_type,
+                probe_side_data,
+                build_side_data,
+                column_indices_after_projection,
+                metrics,
+                batch_size,
+            )))
+        }
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -892,9 +941,7 @@ pub(crate) struct NestedLoopJoinStream {
     /// Should we go back to `BufferingLeft` state again after `EmitLeftUnmatched`
     /// state is over.
     left_exhausted: bool,
-    /// If we can buffer all left data in one pass
-    /// TODO(now): this is for the (unimplemented) memory-limited execution
-    #[expect(dead_code)]
+    /// If we can buffer all left data in one pass (false means memory-limited multi-pass)
     left_buffered_in_one_pass: bool,
 
     // Probe(right) side
@@ -904,6 +951,36 @@ pub(crate) struct NestedLoopJoinStream {
     // For right join, keep track of matched rows in `current_right_batch`
     // Constructed when fetching each new incoming right batch in `FetchingRight` state.
     current_right_batch_matched: Option<BooleanArray>,
+
+    // ========================================================================
+    // MEMORY-LIMITED EXECUTION FIELDS:
+    // Used when left-side data exceeds the memory budget. In this mode,
+    // left data is loaded in chunks, and the right side is spilled to disk
+    // so it can be re-scanned for each left chunk.
+    // ========================================================================
+    /// Left input stream for incremental buffering (memory-limited mode only).
+    /// None when using the standard OnceFut path.
+    left_stream: Option<SendableRecordBatchStream>,
+    /// Memory reservation for left-side buffering in memory-limited mode
+    left_reservation: Option<MemoryReservation>,
+    /// A batch that couldn't be added to the current chunk due to memory limit.
+    /// It will be the first batch in the next chunk.
+    left_stashed_batch: Option<RecordBatch>,
+    /// Accumulated left batches for the current chunk (memory-limited mode)
+    left_pending_batches: Vec<RecordBatch>,
+    /// Left-side schema (for concat_batches in memory-limited mode)
+    left_schema: Option<SchemaRef>,
+
+    /// SpillManager for right-side spilling
+    spill_manager: Option<SpillManager>,
+    /// In-progress spill file for writing right batches during first pass
+    right_spill_in_progress: Option<InProgressSpillFile>,
+    /// Completed right-side spill file (available after first pass)
+    right_spill_file: Option<RefCountedTempFile>,
+    /// Max right batch memory size (for read_spill_as_stream)
+    right_max_batch_memory: usize,
+    /// Whether this is the first right-side pass (need to spill while reading)
+    is_first_right_pass: bool,
 }
 
 pub(crate) struct NestedLoopJoinMetrics {
@@ -911,6 +988,8 @@ pub(crate) struct NestedLoopJoinMetrics {
     pub(crate) join_metrics: BuildProbeJoinMetrics,
     /// Selectivity of the join: output_rows / (left_rows * right_rows)
     pub(crate) selectivity: RatioMetrics,
+    /// Spill metrics for memory-limited execution
+    pub(crate) spill_metrics: SpillMetrics,
 }
 
 impl NestedLoopJoinMetrics {
@@ -920,6 +999,7 @@ impl NestedLoopJoinMetrics {
             selectivity: MetricBuilder::new(metrics)
                 .with_type(MetricType::Summary)
                 .ratio_metrics("selectivity", partition),
+            spill_metrics: SpillMetrics::new(metrics, partition),
         }
     }
 }
@@ -1079,9 +1159,9 @@ impl Stream for NestedLoopJoinStream {
                 // 3. --> Done
                 //    It has processed all data, go to the final state and ready
                 //    to exit.
-                //
-                // TODO: For memory-limited case, go back to `BufferingLeft`
-                // state again.
+                // 4. --> BufferingLeft (memory-limited mode only)
+                //    When left data was loaded in chunks and more chunks remain,
+                //    go back to BufferingLeft to load the next chunk.
                 NLJState::EmitLeftUnmatched => {
                     debug!("[NLJState] Entering: {:?}", self.state);
 
@@ -1153,31 +1233,293 @@ impl NestedLoopJoinStream {
             left_buffered_in_one_pass: true,
             handled_empty_output: false,
             should_track_unmatched_right: need_produce_right_in_final(join_type),
+            // Memory-limited fields (inactive in standard mode)
+            left_stream: None,
+            left_reservation: None,
+            left_stashed_batch: None,
+            left_pending_batches: Vec::new(),
+            left_schema: None,
+            spill_manager: None,
+            right_spill_in_progress: None,
+            right_spill_file: None,
+            right_max_batch_memory: 0,
+            is_first_right_pass: true,
         }
+    }
+
+    /// Create a new NestedLoopJoinStream in memory-limited mode.
+    ///
+    /// In this mode, left-side data is loaded incrementally in chunks,
+    /// and the right side is spilled to disk so it can be re-scanned
+    /// for each left chunk.
+    #[expect(clippy::too_many_arguments)]
+    fn new_memory_limited(
+        schema: Arc<Schema>,
+        filter: Option<JoinFilter>,
+        join_type: JoinType,
+        right_data: SendableRecordBatchStream,
+        left_stream: SendableRecordBatchStream,
+        column_indices: Vec<ColumnIndex>,
+        metrics: NestedLoopJoinMetrics,
+        batch_size: usize,
+        reservation: MemoryReservation,
+        spill_manager: SpillManager,
+    ) -> Self {
+        let left_schema = left_stream.schema();
+        // In memory-limited mode, left_data is unused (use a dummy OnceFut)
+        let dummy_left_data = OnceFut::new(async {
+            internal_err!("OnceFut should not be used in memory-limited mode")
+        });
+        Self {
+            output_schema: Arc::clone(&schema),
+            join_filter: filter,
+            join_type,
+            right_data,
+            column_indices,
+            left_data: dummy_left_data,
+            metrics,
+            buffered_left_data: None,
+            output_buffer: Box::new(BatchCoalescer::new(schema, batch_size)),
+            batch_size,
+            current_right_batch: None,
+            current_right_batch_matched: None,
+            state: NLJState::BufferingLeft,
+            left_probe_idx: 0,
+            left_emit_idx: 0,
+            left_exhausted: false,
+            left_buffered_in_one_pass: true,
+            handled_empty_output: false,
+            should_track_unmatched_right: need_produce_right_in_final(join_type),
+            // Memory-limited fields (active)
+            left_stream: Some(left_stream),
+            left_reservation: Some(reservation),
+            left_stashed_batch: None,
+            left_pending_batches: Vec::new(),
+            left_schema: Some(left_schema),
+            spill_manager: Some(spill_manager),
+            right_spill_in_progress: None,
+            right_spill_file: None,
+            right_max_batch_memory: 0,
+            is_first_right_pass: true,
+        }
+    }
+
+    /// Returns true if this stream is operating in memory-limited mode
+    fn is_memory_limited(&self) -> bool {
+        self.left_stream.is_some() || self.left_reservation.is_some()
     }
 
     // ==== State handler functions ====
 
-    /// Handle BufferingLeft state - prepare left side batches
+    /// Handle BufferingLeft state - prepare left side batches.
+    ///
+    /// In standard mode, uses OnceFut to load all left data at once.
+    /// In memory-limited mode, incrementally buffers left batches until the
+    /// memory budget is reached or the left stream is exhausted.
     fn handle_buffering_left(
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> ControlFlow<Poll<Option<Result<RecordBatch>>>> {
-        match self.left_data.get_shared(cx) {
-            Poll::Ready(Ok(left_data)) => {
-                self.buffered_left_data = Some(left_data);
-                // TODO: implement memory-limited case
-                self.left_exhausted = true;
-                self.state = NLJState::FetchingRight;
-                // Continue to next state immediately
-                ControlFlow::Continue(())
+        if self.is_memory_limited() {
+            self.handle_buffering_left_memory_limited(cx)
+        } else {
+            // Standard path: use OnceFut
+            match self.left_data.get_shared(cx) {
+                Poll::Ready(Ok(left_data)) => {
+                    self.buffered_left_data = Some(left_data);
+                    self.left_exhausted = true;
+                    self.state = NLJState::FetchingRight;
+                    ControlFlow::Continue(())
+                }
+                Poll::Ready(Err(e)) => ControlFlow::Break(Poll::Ready(Some(Err(e)))),
+                Poll::Pending => ControlFlow::Break(Poll::Pending),
             }
-            Poll::Ready(Err(e)) => ControlFlow::Break(Poll::Ready(Some(Err(e)))),
-            Poll::Pending => ControlFlow::Break(Poll::Pending),
         }
     }
 
-    /// Handle FetchingRight state - fetch next right batch and prepare for processing
+    /// Memory-limited path for handle_buffering_left.
+    ///
+    /// Incrementally polls the left stream and accumulates batches until:
+    /// - Memory reservation fails (chunk is full, more data remains)
+    /// - Left stream is exhausted (this is the last/only chunk)
+    fn handle_buffering_left_memory_limited(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> ControlFlow<Poll<Option<Result<RecordBatch>>>> {
+        let reservation = self
+            .left_reservation
+            .as_ref()
+            .expect("left_reservation must be set in memory-limited mode");
+
+        // First, try to re-insert the stashed batch from a previous iteration
+        if let Some(stashed) = self.left_stashed_batch.take() {
+            let batch_size = stashed.get_array_memory_size();
+            if reservation.try_grow(batch_size).is_err() {
+                // Still can't fit even after freeing the previous chunk.
+                // This batch alone exceeds the memory budget.
+                // Buffer it anyway (we must make progress) using infallible grow.
+                reservation.grow(batch_size);
+            }
+            self.metrics.join_metrics.build_mem_used.add(batch_size);
+            self.metrics.join_metrics.build_input_batches.add(1);
+            self.metrics
+                .join_metrics
+                .build_input_rows
+                .add(stashed.num_rows());
+            self.left_pending_batches.push(stashed);
+        }
+
+        // Poll left stream for more batches
+        loop {
+            let left_stream = self
+                .left_stream
+                .as_mut()
+                .expect("left_stream must be set in memory-limited mode");
+
+            match left_stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(batch))) => {
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+                    let batch_size = batch.get_array_memory_size();
+                    let can_grow = reservation.try_grow(batch_size).is_ok();
+
+                    if !can_grow {
+                        if !self.left_pending_batches.is_empty() {
+                            // Memory limit reached and we already have data.
+                            // Stash this batch for the next chunk.
+                            self.left_stashed_batch = Some(batch);
+                            self.left_exhausted = false;
+                            self.left_buffered_in_one_pass = false;
+                            break;
+                        }
+                        // No pending batches yet — we must accept this batch
+                        // to make progress, even if it exceeds the budget.
+                        reservation.grow(batch_size);
+                    }
+
+                    self.metrics.join_metrics.build_mem_used.add(batch_size);
+                    self.metrics.join_metrics.build_input_batches.add(1);
+                    self.metrics
+                        .join_metrics
+                        .build_input_rows
+                        .add(batch.num_rows());
+                    self.left_pending_batches.push(batch);
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    return ControlFlow::Break(Poll::Ready(Some(Err(e))));
+                }
+                Poll::Ready(None) => {
+                    // Left stream exhausted
+                    self.left_exhausted = true;
+                    self.left_stream = None;
+                    break;
+                }
+                Poll::Pending => {
+                    if self.left_pending_batches.is_empty() {
+                        return ControlFlow::Break(Poll::Pending);
+                    }
+                    // We have some batches, proceed with what we have.
+                    // The stashed approach will handle the rest.
+                    // Actually we should wait for more data.
+                    return ControlFlow::Break(Poll::Pending);
+                }
+            }
+        }
+
+        // Build JoinLeftData from the accumulated batches
+        let schema = self
+            .left_schema
+            .as_ref()
+            .expect("left_schema must be set in memory-limited mode");
+
+        if self.left_pending_batches.is_empty() {
+            // No data at all — go directly to Done
+            self.left_exhausted = true;
+            self.state = NLJState::Done;
+            return ControlFlow::Continue(());
+        }
+
+        let merged_batch = match concat_batches(schema, &self.left_pending_batches) {
+            Ok(batch) => batch,
+            Err(e) => {
+                return ControlFlow::Break(Poll::Ready(Some(Err(e.into()))));
+            }
+        };
+        self.left_pending_batches.clear();
+
+        // Build visited bitmap if needed for this join type
+        let with_visited = need_produce_result_in_final(self.join_type);
+        let n_rows = merged_batch.num_rows();
+        let visited_left_side = if with_visited {
+            let buffer_size = n_rows.div_ceil(8);
+            // Use infallible grow for bitmap — it's small
+            reservation.grow(buffer_size);
+            self.metrics.join_metrics.build_mem_used.add(buffer_size);
+            let mut buffer = BooleanBufferBuilder::new(n_rows);
+            buffer.append_n(n_rows, false);
+            buffer
+        } else {
+            BooleanBufferBuilder::new(0)
+        };
+
+        // Create an empty reservation for JoinLeftData's RAII field.
+        // The actual memory tracking is managed by self.left_reservation.
+        let dummy_reservation = reservation.new_empty();
+
+        let left_data = JoinLeftData::new(
+            merged_batch,
+            Mutex::new(visited_left_side),
+            // In memory-limited mode, only 1 probe thread per chunk
+            AtomicUsize::new(1),
+            dummy_reservation,
+        );
+
+        self.buffered_left_data = Some(Arc::new(left_data));
+
+        // If not the first pass, re-open the right spill file as a new stream
+        if !self.is_first_right_pass {
+            if let Some(spill_file) = &self.right_spill_file {
+                let spill_manager = self
+                    .spill_manager
+                    .as_ref()
+                    .expect("spill_manager must be set in memory-limited mode");
+                match spill_manager.read_spill_as_stream(
+                    spill_file.clone(),
+                    Some(self.right_max_batch_memory),
+                ) {
+                    Ok(stream) => {
+                        self.right_data = stream;
+                    }
+                    Err(e) => {
+                        return ControlFlow::Break(Poll::Ready(Some(Err(e))));
+                    }
+                }
+            }
+        } else {
+            // First pass: create InProgressSpillFile for right side
+            let spill_manager = self
+                .spill_manager
+                .as_ref()
+                .expect("spill_manager must be set in memory-limited mode");
+            match spill_manager.create_in_progress_file("NestedLoopJoin right spill") {
+                Ok(spill_file) => {
+                    self.right_spill_in_progress = Some(spill_file);
+                }
+                Err(e) => {
+                    return ControlFlow::Break(Poll::Ready(Some(Err(e))));
+                }
+            }
+        }
+
+        self.state = NLJState::FetchingRight;
+        ControlFlow::Continue(())
+    }
+
+    /// Handle FetchingRight state - fetch next right batch and prepare for processing.
+    ///
+    /// In memory-limited mode during the first pass, each right batch is also
+    /// written to a spill file so it can be re-read on subsequent passes.
     fn handle_fetching_right(
         &mut self,
         cx: &mut std::task::Context<'_>,
@@ -1186,20 +1528,33 @@ impl NestedLoopJoinStream {
             Poll::Ready(result) => match result {
                 Some(Ok(right_batch)) => {
                     // Update metrics
-                    let right_batch_size = right_batch.num_rows();
-                    self.metrics.join_metrics.input_rows.add(right_batch_size);
+                    let right_batch_rows = right_batch.num_rows();
+                    self.metrics.join_metrics.input_rows.add(right_batch_rows);
                     self.metrics.join_metrics.input_batches.add(1);
 
                     // Skip the empty batch
-                    if right_batch_size == 0 {
+                    if right_batch_rows == 0 {
                         return ControlFlow::Continue(());
+                    }
+
+                    // In memory-limited mode, spill right batch to disk on first pass
+                    if self.is_first_right_pass
+                        && let Some(spill_file) = self.right_spill_in_progress.as_mut()
+                    {
+                        if let Err(e) = spill_file.append_batch(&right_batch) {
+                            return ControlFlow::Break(Poll::Ready(Some(Err(e))));
+                        }
+                        // Track max batch memory for read_spill_as_stream
+                        self.right_max_batch_memory = self
+                            .right_max_batch_memory
+                            .max(right_batch.get_array_memory_size());
                     }
 
                     self.current_right_batch = Some(right_batch);
 
                     // Prepare right bitmap
                     if self.should_track_unmatched_right {
-                        let zeroed_buf = BooleanBuffer::new_unset(right_batch_size);
+                        let zeroed_buf = BooleanBuffer::new_unset(right_batch_rows);
                         self.current_right_batch_matched =
                             Some(BooleanArray::new(zeroed_buf, None));
                     }
@@ -1210,7 +1565,27 @@ impl NestedLoopJoinStream {
                 }
                 Some(Err(e)) => ControlFlow::Break(Poll::Ready(Some(Err(e)))),
                 None => {
-                    // Right stream exhausted
+                    // Right stream exhausted.
+                    // In memory-limited mode, finalize the spill file after first pass.
+                    if self.is_first_right_pass {
+                        if let Some(mut spill_in_progress) =
+                            self.right_spill_in_progress.take()
+                        {
+                            match spill_in_progress.finish() {
+                                Ok(Some(file)) => {
+                                    self.right_spill_file = Some(file);
+                                }
+                                Ok(None) => {
+                                    // No data was spilled (right side was empty)
+                                }
+                                Err(e) => {
+                                    return ControlFlow::Break(Poll::Ready(Some(Err(e))));
+                                }
+                            }
+                        }
+                        self.is_first_right_pass = false;
+                    }
+
                     self.state = NLJState::EmitLeftUnmatched;
                     ControlFlow::Continue(())
                 }
@@ -1304,7 +1679,11 @@ impl NestedLoopJoinStream {
         }
     }
 
-    /// Handle EmitLeftUnmatched state - emit unmatched left rows
+    /// Handle EmitLeftUnmatched state - emit unmatched left rows.
+    ///
+    /// In memory-limited mode, after processing all unmatched rows for the
+    /// current left chunk, transitions back to `BufferingLeft` to load the
+    /// next chunk (if the left stream is not yet exhausted).
     fn handle_emit_left_unmatched(
         &mut self,
     ) -> ControlFlow<Poll<Option<Result<RecordBatch>>>> {
@@ -1318,11 +1697,22 @@ impl NestedLoopJoinStream {
             // State unchanged (EmitLeftUnmatched)
             // Continue processing until we have processed all unmatched rows
             Ok(true) => ControlFlow::Continue(()),
-            // To Done state
-            // We have finished processing all unmatched rows
+            // We have finished processing all unmatched rows for this chunk
             Ok(false) => match self.output_buffer.finish_buffered_batch() {
                 Ok(()) => {
-                    self.state = NLJState::Done;
+                    if !self.left_exhausted && self.is_memory_limited() {
+                        // More left data to process — free current chunk and
+                        // go back to BufferingLeft for the next chunk
+                        if let Some(reservation) = self.left_reservation.as_ref() {
+                            reservation.resize(0);
+                        }
+                        self.buffered_left_data = None;
+                        self.left_probe_idx = 0;
+                        self.left_emit_idx = 0;
+                        self.state = NLJState::BufferingLeft;
+                    } else {
+                        self.state = NLJState::Done;
+                    }
                     ControlFlow::Continue(())
                 }
                 Err(e) => ControlFlow::Break(Poll::Ready(Some(arrow_err!(e)))),
@@ -2905,5 +3295,217 @@ pub(crate) mod tests {
     /// Returns the column names on the schema
     fn columns(schema: &Schema) -> Vec<String> {
         schema.fields().iter().map(|f| f.name().clone()).collect()
+    }
+
+    // ========================================================================
+    // Memory-limited execution tests
+    // ========================================================================
+
+    /// Helper to run a single-partition NLJ with a memory limit.
+    /// Right side has 1 partition to enable memory-limited mode.
+    async fn single_partition_join_collect(
+        left: Arc<dyn ExecutionPlan>,
+        right: Arc<dyn ExecutionPlan>,
+        join_type: &JoinType,
+        join_filter: Option<JoinFilter>,
+        context: Arc<TaskContext>,
+    ) -> Result<(Vec<String>, Vec<RecordBatch>)> {
+        let nested_loop_join =
+            NestedLoopJoinExec::try_new(left, right, join_filter, join_type, None)?;
+        let columns = columns(&nested_loop_join.schema());
+        let stream = nested_loop_join.execute(0, context)?;
+        let batches: Vec<RecordBatch> = common::collect(stream)
+            .await?
+            .into_iter()
+            .filter(|b| b.num_rows() > 0)
+            .collect();
+        Ok((columns, batches))
+    }
+
+    /// Create a TaskContext with tight memory limit and disk spilling enabled.
+    fn task_ctx_with_memory_limit(
+        memory_limit: usize,
+        batch_size: usize,
+    ) -> Result<Arc<TaskContext>> {
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_limit(memory_limit, 1.0)
+            .build_arc()?;
+        let cfg = TaskContext::default()
+            .session_config()
+            .clone()
+            .with_batch_size(batch_size);
+        let task_ctx = TaskContext::default()
+            .with_runtime(runtime)
+            .with_session_config(cfg);
+        Ok(Arc::new(task_ctx))
+    }
+
+    /// Helper: run NLJ inner join and return sorted result string.
+    /// Uses memory-limited path (single-partition right, with disk).
+    async fn run_memory_limited_inner_join(
+        memory_limit: usize,
+        batch_size: usize,
+    ) -> Result<(Vec<String>, String)> {
+        let task_ctx = task_ctx_with_memory_limit(memory_limit, batch_size)?;
+        let left = build_left_table();
+        let right = build_right_table();
+        let filter = prepare_join_filter();
+        let (columns, batches) = single_partition_join_collect(
+            left,
+            right,
+            &JoinType::Inner,
+            Some(filter),
+            task_ctx,
+        )
+        .await?;
+        Ok((columns, batches_to_sort_string(&batches)))
+    }
+
+    #[tokio::test]
+    async fn test_nlj_memory_limited_inner_join() -> Result<()> {
+        // Use a very small memory limit to force multi-pass execution.
+        // Each i32 column batch of 3 rows is ~24 bytes, left table has 3 columns
+        // = ~72 bytes. Set limit to ~50 bytes to force splitting.
+        let (columns, result) = run_memory_limited_inner_join(50, 16).await?;
+        assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
+
+        // The result should be identical to the non-memory-limited case:
+        // left.b1 != 8 AND right.b2 != 10 → only (a1=5, b1=5, c1=50) x (a2=2, b2=2, c2=80)
+        allow_duplicates!(assert_snapshot!(result, @r"
+        +----+----+----+----+----+----+
+        | a1 | b1 | c1 | a2 | b2 | c2 |
+        +----+----+----+----+----+----+
+        | 5  | 5  | 50 | 2  | 2  | 80 |
+        +----+----+----+----+----+----+
+        "));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nlj_memory_limited_left_join() -> Result<()> {
+        let task_ctx = task_ctx_with_memory_limit(50, 16)?;
+        let left = build_left_table();
+        let right = build_right_table();
+        let filter = prepare_join_filter();
+        let (columns, batches) = single_partition_join_collect(
+            left,
+            right,
+            &JoinType::Left,
+            Some(filter),
+            task_ctx,
+        )
+        .await?;
+        assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
+
+        // Left join: all left rows appear. Unmatched left rows get NULLs on right.
+        // Matched: (5, 5, 50, 2, 2, 80)
+        // Unmatched: (9, 8, 90, NULL, NULL, NULL) and (11, 8, 110, NULL, NULL, NULL)
+        allow_duplicates!(assert_snapshot!(batches_to_sort_string(&batches), @r"
+        +----+----+-----+----+----+----+
+        | a1 | b1 | c1  | a2 | b2 | c2 |
+        +----+----+-----+----+----+----+
+        | 11 | 8  | 110 |    |    |    |
+        | 5  | 5  | 50  | 2  | 2  | 80 |
+        | 9  | 8  | 90  |    |    |    |
+        +----+----+-----+----+----+----+
+        "));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nlj_fits_in_memory_no_spill() -> Result<()> {
+        // Use a large memory limit — everything fits in one pass.
+        let (columns, result) = run_memory_limited_inner_join(10_000_000, 16).await?;
+        assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
+        allow_duplicates!(assert_snapshot!(result, @r"
+        +----+----+----+----+----+----+
+        | a1 | b1 | c1 | a2 | b2 | c2 |
+        +----+----+----+----+----+----+
+        | 5  | 5  | 50 | 2  | 2  | 80 |
+        +----+----+----+----+----+----+
+        "));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nlj_memory_limited_empty_inputs() -> Result<()> {
+        let task_ctx = task_ctx_with_memory_limit(50, 16)?;
+
+        // Empty left table
+        let empty_left = build_table(
+            ("a1", &vec![]),
+            ("b1", &vec![]),
+            ("c1", &vec![]),
+            None,
+            Vec::new(),
+        );
+        let right = build_right_table();
+        let filter = prepare_join_filter();
+
+        let (_columns, batches) = single_partition_join_collect(
+            empty_left,
+            right,
+            &JoinType::Inner,
+            Some(filter),
+            task_ctx,
+        )
+        .await?;
+        assert!(batches.is_empty() || batches.iter().all(|b| b.num_rows() == 0));
+
+        // Empty right table
+        let task_ctx2 = task_ctx_with_memory_limit(50, 16)?;
+        let left = build_left_table();
+        let empty_right = build_table(
+            ("a2", &vec![]),
+            ("b2", &vec![]),
+            ("c2", &vec![]),
+            None,
+            Vec::new(),
+        );
+        let filter2 = prepare_join_filter();
+
+        let (_columns, batches) = single_partition_join_collect(
+            left,
+            empty_right,
+            &JoinType::Inner,
+            Some(filter2),
+            task_ctx2,
+        )
+        .await?;
+        assert!(batches.is_empty() || batches.iter().all(|b| b.num_rows() == 0));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nlj_memory_limited_no_disk_falls_back_to_oom() -> Result<()> {
+        // When disk is disabled and right has multi partitions,
+        // memory-limited mode is not used and OOM should occur.
+        use datafusion_execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
+
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_limit(100, 1.0)
+            .with_disk_manager_builder(
+                DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled),
+            )
+            .build_arc()?;
+        let task_ctx = Arc::new(TaskContext::default().with_runtime(runtime));
+
+        let left = build_left_table();
+        let right = build_right_table();
+        let filter = prepare_join_filter();
+
+        let err = single_partition_join_collect(
+            left,
+            right,
+            &JoinType::Inner,
+            Some(filter),
+            task_ctx,
+        )
+        .await
+        .unwrap_err();
+
+        assert_contains!(err.to_string(), "Resources exhausted");
+        Ok(())
     }
 }

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -621,8 +621,14 @@ impl ExecutionPlan for NestedLoopJoinExec {
         // Use memory-limited mode when:
         // 1. Right side has single partition (so we can spill and re-scan)
         // 2. Disk manager supports temp files
+        // 3. Join type does not require tracking right-side matched state
+        //    across multiple left chunks. RIGHT/FULL/RIGHT SEMI/RIGHT ANTI/
+        //    RIGHT MARK joins need a global right bitmap that spans all left
+        //    chunks — not yet implemented (Phase 3).
+        let join_type_supports_multi_pass = !need_produce_right_in_final(self.join_type);
         let use_memory_limited = right_partition_count == 1
-            && context.runtime_env().disk_manager.tmp_files_enabled();
+            && context.runtime_env().disk_manager.tmp_files_enabled()
+            && join_type_supports_multi_pass;
 
         if use_memory_limited {
             let left_stream = self.left.execute(0, Arc::clone(&context))?;

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -1383,6 +1383,7 @@ impl NestedLoopJoinStream {
                     if batch.num_rows() == 0 {
                         continue;
                     }
+                    let batch_rows = batch.num_rows();
                     let batch_size = batch.get_array_memory_size();
                     let can_grow = reservation.try_grow(batch_size).is_ok();
 
@@ -1402,10 +1403,7 @@ impl NestedLoopJoinStream {
 
                     self.metrics.join_metrics.build_mem_used.add(batch_size);
                     self.metrics.join_metrics.build_input_batches.add(1);
-                    self.metrics
-                        .join_metrics
-                        .build_input_rows
-                        .add(batch.num_rows());
+                    self.metrics.join_metrics.build_input_rows.add(batch_rows);
                     self.left_pending_batches.push(batch);
                 }
                 Poll::Ready(Some(Err(e))) => {
@@ -1702,6 +1700,14 @@ impl NestedLoopJoinStream {
             // We have finished processing all unmatched rows for this chunk
             Ok(false) => match self.output_buffer.finish_buffered_batch() {
                 Ok(()) => {
+                    // Flush any completed batch before transitioning.
+                    // This is critical for the memory-limited path: the
+                    // ProbeRight results must be emitted before we discard
+                    // the current chunk and load the next one.
+                    if let Some(poll) = self.maybe_flush_ready_batch() {
+                        return ControlFlow::Break(poll);
+                    }
+
                     if !self.left_exhausted && self.is_memory_limited() {
                         // More left data to process — free current chunk and
                         // go back to BufferingLeft for the next chunk

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -172,9 +172,14 @@ use crate::spill::spill_manager::SpillManager;
 /// 2. On the first pass, the right side is both processed and spilled to disk
 /// 3. For each subsequent left chunk, the right side is re-read from the spill file
 ///
-/// This is enabled automatically when disk spilling is available and the right
-/// side has a single partition. Currently supports INNER, LEFT, LEFT SEMI,
-/// LEFT ANTI, and LEFT MARK join types in multi-pass mode.
+/// The fallback is triggered automatically when the initial in-memory load
+/// fails with `ResourcesExhausted` and disk spilling is available. Each
+/// output partition independently re-executes the left child and manages
+/// its own spill state.
+///
+/// Currently supports INNER, LEFT, LEFT SEMI, LEFT ANTI, and LEFT MARK
+/// join types. RIGHT/FULL joins require a global right-side bitmap across
+/// all left chunks, which is not yet implemented.
 ///
 /// Tracking issue: <https://github.com/apache/datafusion/issues/15760>
 ///
@@ -618,78 +623,53 @@ impl ExecutionPlan for NestedLoopJoinExec {
 
         let right_partition_count = self.right().output_partitioning().partition_count();
 
-        // Use memory-limited mode when:
-        // 1. Right side has single partition (so we can spill and re-scan)
-        // 2. Disk manager supports temp files
-        // 3. Join type does not require tracking right-side matched state
-        //    across multiple left chunks. RIGHT/FULL/RIGHT SEMI/RIGHT ANTI/
-        //    RIGHT MARK joins need a global right bitmap that spans all left
-        //    chunks — not yet implemented (Phase 3).
-        let join_type_supports_multi_pass = !need_produce_right_in_final(self.join_type);
-        let use_memory_limited = right_partition_count == 1
-            && context.runtime_env().disk_manager.tmp_files_enabled()
-            && join_type_supports_multi_pass;
+        // Always try to buffer all left data in memory via OnceFut.
+        // If that fails with OOM, the stream will fallback to memory-limited
+        // mode (if conditions allow).
+        let load_reservation =
+            MemoryConsumer::new(format!("NestedLoopJoinLoad[{partition}]"))
+                .register(context.memory_pool());
 
-        if use_memory_limited {
-            let left_stream = self.left.execute(0, Arc::clone(&context))?;
-            let probe_side_data = self.right.execute(partition, Arc::clone(&context))?;
+        let build_side_data = self.build_side_data.try_once(|| {
+            let stream = self.left.execute(0, Arc::clone(&context))?;
 
-            let reservation =
-                MemoryConsumer::new(format!("NestedLoopJoinLoad[{partition}]"))
-                    .with_can_spill(true)
-                    .register(context.memory_pool());
+            Ok(collect_left_input(
+                stream,
+                metrics.join_metrics.clone(),
+                load_reservation,
+                need_produce_result_in_final(self.join_type),
+                right_partition_count,
+            ))
+        })?;
 
-            let right_schema = probe_side_data.schema();
-            let spill_manager = SpillManager::new(
-                context.runtime_env(),
-                metrics.spill_metrics.clone(),
-                right_schema,
-            )
-            .with_compression_type(context.session_config().spill_compression());
+        let probe_side_data = self.right.execute(partition, Arc::clone(&context))?;
 
-            Ok(Box::pin(NestedLoopJoinStream::new_memory_limited(
-                self.schema(),
-                self.filter.clone(),
-                self.join_type,
-                probe_side_data,
-                left_stream,
-                column_indices_after_projection,
-                metrics,
-                batch_size,
-                reservation,
-                spill_manager,
-            )))
+        // Determine if OOM fallback to memory-limited mode is possible.
+        // Conditions:
+        // 1. Disk manager supports temp files (needed for right-side spilling)
+        // 2. Join type does not require tracking right-side matched state
+        //    across multiple left chunks (RIGHT/FULL joins not yet supported)
+        let can_fallback = context.runtime_env().disk_manager.tmp_files_enabled()
+            && !need_produce_right_in_final(self.join_type);
+
+        let (left_plan, task_context) = if can_fallback {
+            (Some(Arc::clone(&self.left)), Some(Arc::clone(&context)))
         } else {
-            // Standard path: buffer all left data via OnceFut
-            let load_reservation =
-                MemoryConsumer::new(format!("NestedLoopJoinLoad[{partition}]"))
-                    .register(context.memory_pool());
+            (None, None)
+        };
 
-            let build_side_data = self.build_side_data.try_once(|| {
-                let stream = self.left.execute(0, Arc::clone(&context))?;
-
-                Ok(collect_left_input(
-                    stream,
-                    metrics.join_metrics.clone(),
-                    load_reservation,
-                    need_produce_result_in_final(self.join_type),
-                    right_partition_count,
-                ))
-            })?;
-
-            let probe_side_data = self.right.execute(partition, context)?;
-
-            Ok(Box::pin(NestedLoopJoinStream::new(
-                self.schema(),
-                self.filter.clone(),
-                self.join_type,
-                probe_side_data,
-                build_side_data,
-                column_indices_after_projection,
-                metrics,
-                batch_size,
-            )))
-        }
+        Ok(Box::pin(NestedLoopJoinStream::new(
+            self.schema(),
+            self.filter.clone(),
+            self.join_type,
+            probe_side_data,
+            build_side_data,
+            column_indices_after_projection,
+            metrics,
+            batch_size,
+            left_plan,
+            task_context,
+        )))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -987,6 +967,16 @@ pub(crate) struct NestedLoopJoinStream {
     right_max_batch_memory: usize,
     /// Whether this is the first right-side pass (need to spill while reading)
     is_first_right_pass: bool,
+
+    // ========================================================================
+    // FALLBACK CONTEXT:
+    // Stored at execute() time so that handle_buffering_left can initiate
+    // a fallback to memory-limited mode if OnceFut fails with OOM.
+    // ========================================================================
+    /// Left child plan for re-execution on OOM fallback
+    left_plan: Option<Arc<dyn ExecutionPlan>>,
+    /// TaskContext for re-execution and SpillManager creation
+    task_context: Option<Arc<TaskContext>>,
 }
 
 pub(crate) struct NestedLoopJoinMetrics {
@@ -1218,6 +1208,8 @@ impl NestedLoopJoinStream {
         column_indices: Vec<ColumnIndex>,
         metrics: NestedLoopJoinMetrics,
         batch_size: usize,
+        left_plan: Option<Arc<dyn ExecutionPlan>>,
+        task_context: Option<Arc<TaskContext>>,
     ) -> Self {
         Self {
             output_schema: Arc::clone(&schema),
@@ -1239,7 +1231,7 @@ impl NestedLoopJoinStream {
             left_buffered_in_one_pass: true,
             handled_empty_output: false,
             should_track_unmatched_right: need_produce_right_in_final(join_type),
-            // Memory-limited fields (inactive in standard mode)
+            // Memory-limited fields (inactive until OOM fallback)
             left_stream: None,
             left_reservation: None,
             left_stashed_batch: None,
@@ -1250,69 +1242,79 @@ impl NestedLoopJoinStream {
             right_spill_file: None,
             right_max_batch_memory: 0,
             is_first_right_pass: true,
-        }
-    }
-
-    /// Create a new NestedLoopJoinStream in memory-limited mode.
-    ///
-    /// In this mode, left-side data is loaded incrementally in chunks,
-    /// and the right side is spilled to disk so it can be re-scanned
-    /// for each left chunk.
-    #[expect(clippy::too_many_arguments)]
-    fn new_memory_limited(
-        schema: Arc<Schema>,
-        filter: Option<JoinFilter>,
-        join_type: JoinType,
-        right_data: SendableRecordBatchStream,
-        left_stream: SendableRecordBatchStream,
-        column_indices: Vec<ColumnIndex>,
-        metrics: NestedLoopJoinMetrics,
-        batch_size: usize,
-        reservation: MemoryReservation,
-        spill_manager: SpillManager,
-    ) -> Self {
-        let left_schema = left_stream.schema();
-        // In memory-limited mode, left_data is unused (use a dummy OnceFut)
-        let dummy_left_data = OnceFut::new(async {
-            internal_err!("OnceFut should not be used in memory-limited mode")
-        });
-        Self {
-            output_schema: Arc::clone(&schema),
-            join_filter: filter,
-            join_type,
-            right_data,
-            column_indices,
-            left_data: dummy_left_data,
-            metrics,
-            buffered_left_data: None,
-            output_buffer: Box::new(BatchCoalescer::new(schema, batch_size)),
-            batch_size,
-            current_right_batch: None,
-            current_right_batch_matched: None,
-            state: NLJState::BufferingLeft,
-            left_probe_idx: 0,
-            left_emit_idx: 0,
-            left_exhausted: false,
-            left_buffered_in_one_pass: true,
-            handled_empty_output: false,
-            should_track_unmatched_right: need_produce_right_in_final(join_type),
-            // Memory-limited fields (active)
-            left_stream: Some(left_stream),
-            left_reservation: Some(reservation),
-            left_stashed_batch: None,
-            left_pending_batches: Vec::new(),
-            left_schema: Some(left_schema),
-            spill_manager: Some(spill_manager),
-            right_spill_in_progress: None,
-            right_spill_file: None,
-            right_max_batch_memory: 0,
-            is_first_right_pass: true,
+            // Fallback context
+            left_plan,
+            task_context,
         }
     }
 
     /// Returns true if this stream is operating in memory-limited mode
     fn is_memory_limited(&self) -> bool {
         self.left_stream.is_some() || self.left_reservation.is_some()
+    }
+
+    /// Check if we can fall back to memory-limited mode on this error.
+    fn can_fallback_to_spill(&self, error: &datafusion_common::DataFusionError) -> bool {
+        self.left_plan.is_some()
+            && self.task_context.is_some()
+            && !self.is_memory_limited() // avoid infinite loop
+            && matches!(
+                error.find_root(),
+                datafusion_common::DataFusionError::ResourcesExhausted(_)
+            )
+    }
+
+    /// Switch from the standard OnceFut path to memory-limited mode.
+    ///
+    /// Re-executes the left child to get a fresh stream, creates a
+    /// SpillManager for right-side spilling, and sets up all the
+    /// memory-limited fields. The next call to `handle_buffering_left`
+    /// will dispatch to `handle_buffering_left_memory_limited`.
+    fn initiate_fallback(&mut self) -> Result<()> {
+        let left_plan = self
+            .left_plan
+            .as_ref()
+            .expect("left_plan must be set for fallback");
+        let context = self
+            .task_context
+            .as_ref()
+            .expect("task_context must be set for fallback");
+
+        // Re-execute left child to get a fresh stream
+        let left_stream = left_plan.execute(0, Arc::clone(context))?;
+        let left_schema = left_stream.schema();
+
+        // Create reservation with can_spill for fair memory allocation
+        let reservation = MemoryConsumer::new("NestedLoopJoinLoad[fallback]".to_string())
+            .with_can_spill(true)
+            .register(context.memory_pool());
+
+        // Create SpillManager for right-side spilling
+        let right_schema = self.right_data.schema();
+        let spill_manager = SpillManager::new(
+            context.runtime_env(),
+            self.metrics.spill_metrics.clone(),
+            right_schema,
+        )
+        .with_compression_type(context.session_config().spill_compression());
+
+        // Populate memory-limited fields
+        self.left_stream = Some(left_stream);
+        self.left_schema = Some(left_schema);
+        self.left_reservation = Some(reservation);
+        self.left_stashed_batch = None;
+        self.left_pending_batches = Vec::new();
+        self.spill_manager = Some(spill_manager);
+        self.right_spill_in_progress = None;
+        self.right_spill_file = None;
+        self.right_max_batch_memory = 0;
+        self.is_first_right_pass = true;
+
+        // State stays BufferingLeft — next poll will enter
+        // handle_buffering_left_memory_limited via is_memory_limited() check
+        self.state = NLJState::BufferingLeft;
+
+        Ok(())
     }
 
     // ==== State handler functions ====
@@ -1337,7 +1339,22 @@ impl NestedLoopJoinStream {
                     self.state = NLJState::FetchingRight;
                     ControlFlow::Continue(())
                 }
-                Poll::Ready(Err(e)) => ControlFlow::Break(Poll::Ready(Some(Err(e)))),
+                Poll::Ready(Err(e)) => {
+                    if self.can_fallback_to_spill(&e) {
+                        debug!(
+                            "NestedLoopJoin: OnceFut failed with OOM, \
+                             falling back to memory-limited mode"
+                        );
+                        match self.initiate_fallback() {
+                            Ok(()) => ControlFlow::Continue(()),
+                            Err(fallback_err) => {
+                                ControlFlow::Break(Poll::Ready(Some(Err(fallback_err))))
+                            }
+                        }
+                    } else {
+                        ControlFlow::Break(Poll::Ready(Some(Err(e))))
+                    }
+                }
                 Poll::Pending => ControlFlow::Break(Poll::Pending),
             }
         }
@@ -3259,20 +3276,44 @@ pub(crate) mod tests {
         );
         let filter = prepare_join_filter();
 
-        let join_types = vec![
+        // Join types that support memory-limited fallback should succeed
+        // even under tight memory limits (they spill to disk instead of OOM).
+        let fallback_join_types = vec![
             JoinType::Inner,
             JoinType::Left,
-            JoinType::Right,
-            JoinType::Full,
             JoinType::LeftSemi,
             JoinType::LeftAnti,
             JoinType::LeftMark,
+        ];
+
+        for join_type in &fallback_join_types {
+            let runtime = RuntimeEnvBuilder::new()
+                .with_memory_limit(100, 1.0)
+                .build_arc()?;
+            let task_ctx = TaskContext::default().with_runtime(runtime);
+            let task_ctx = Arc::new(task_ctx);
+
+            // Should succeed via spill fallback, not OOM
+            let _result = multi_partitioned_join_collect(
+                Arc::clone(&left),
+                Arc::clone(&right),
+                join_type,
+                Some(filter.clone()),
+                task_ctx,
+            )
+            .await?;
+        }
+
+        // Join types that do NOT support fallback should still OOM.
+        let no_fallback_join_types = vec![
+            JoinType::Right,
+            JoinType::Full,
             JoinType::RightSemi,
             JoinType::RightAnti,
             JoinType::RightMark,
         ];
 
-        for join_type in join_types {
+        for join_type in &no_fallback_join_types {
             let runtime = RuntimeEnvBuilder::new()
                 .with_memory_limit(100, 1.0)
                 .build_arc()?;
@@ -3282,17 +3323,14 @@ pub(crate) mod tests {
             let err = multi_partitioned_join_collect(
                 Arc::clone(&left),
                 Arc::clone(&right),
-                &join_type,
+                join_type,
                 Some(filter.clone()),
                 task_ctx,
             )
             .await
             .unwrap_err();
 
-            assert_contains!(
-                err.to_string(),
-                "Resources exhausted: Additional allocation failed for NestedLoopJoinLoad[0] with top memory consumers (across reservations) as:\n  NestedLoopJoinLoad[0]"
-            );
+            assert_contains!(err.to_string(), "Resources exhausted");
         }
 
         Ok(())
@@ -3307,15 +3345,14 @@ pub(crate) mod tests {
     // Memory-limited execution tests
     // ========================================================================
 
-    /// Helper to run a single-partition NLJ with a memory limit.
-    /// Right side has 1 partition to enable memory-limited mode.
-    async fn single_partition_join_collect(
+    /// Helper to run a NLJ using partition 0 and collect results + metrics.
+    async fn join_collect(
         left: Arc<dyn ExecutionPlan>,
         right: Arc<dyn ExecutionPlan>,
         join_type: &JoinType,
         join_filter: Option<JoinFilter>,
         context: Arc<TaskContext>,
-    ) -> Result<(Vec<String>, Vec<RecordBatch>)> {
+    ) -> Result<(Vec<String>, Vec<RecordBatch>, MetricsSet)> {
         let nested_loop_join =
             NestedLoopJoinExec::try_new(left, right, join_filter, join_type, None)?;
         let columns = columns(&nested_loop_join.schema());
@@ -3325,7 +3362,8 @@ pub(crate) mod tests {
             .into_iter()
             .filter(|b| b.num_rows() > 0)
             .collect();
-        Ok((columns, batches))
+        let metrics = nested_loop_join.metrics().unwrap();
+        Ok((columns, batches, metrics))
     }
 
     /// Create a TaskContext with tight memory limit and disk spilling enabled.
@@ -3346,38 +3384,27 @@ pub(crate) mod tests {
         Ok(Arc::new(task_ctx))
     }
 
-    /// Helper: run NLJ inner join and return sorted result string.
-    /// Uses memory-limited path (single-partition right, with disk).
-    async fn run_memory_limited_inner_join(
-        memory_limit: usize,
-        batch_size: usize,
-    ) -> Result<(Vec<String>, String)> {
-        let task_ctx = task_ctx_with_memory_limit(memory_limit, batch_size)?;
+    #[tokio::test]
+    async fn test_nlj_memory_limited_inner_join() -> Result<()> {
+        // Use a very small memory limit to force OOM → fallback to spill.
+        let task_ctx = task_ctx_with_memory_limit(50, 16)?;
         let left = build_left_table();
         let right = build_right_table();
         let filter = prepare_join_filter();
-        let (columns, batches) = single_partition_join_collect(
-            left,
-            right,
-            &JoinType::Inner,
-            Some(filter),
-            task_ctx,
-        )
-        .await?;
-        Ok((columns, batches_to_sort_string(&batches)))
-    }
 
-    #[tokio::test]
-    async fn test_nlj_memory_limited_inner_join() -> Result<()> {
-        // Use a very small memory limit to force multi-pass execution.
-        // Each i32 column batch of 3 rows is ~24 bytes, left table has 3 columns
-        // = ~72 bytes. Set limit to ~50 bytes to force splitting.
-        let (columns, result) = run_memory_limited_inner_join(50, 16).await?;
+        let (columns, batches, metrics) =
+            join_collect(left, right, &JoinType::Inner, Some(filter), task_ctx).await?;
+
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
 
-        // The result should be identical to the non-memory-limited case:
-        // left.b1 != 8 AND right.b2 != 10 → only (a1=5, b1=5, c1=50) x (a2=2, b2=2, c2=80)
-        allow_duplicates!(assert_snapshot!(result, @r"
+        // Verify spill actually occurred (memory-limited path was taken)
+        assert!(
+            metrics.spill_count().unwrap_or(0) > 0,
+            "Expected spilling to occur under tight memory limit"
+        );
+
+        // Result should be identical to the non-memory-limited case
+        allow_duplicates!(assert_snapshot!(batches_to_sort_string(&batches), @r"
         +----+----+----+----+----+----+
         | a1 | b1 | c1 | a2 | b2 | c2 |
         +----+----+----+----+----+----+
@@ -3393,19 +3420,18 @@ pub(crate) mod tests {
         let left = build_left_table();
         let right = build_right_table();
         let filter = prepare_join_filter();
-        let (columns, batches) = single_partition_join_collect(
-            left,
-            right,
-            &JoinType::Left,
-            Some(filter),
-            task_ctx,
-        )
-        .await?;
+
+        let (columns, batches, metrics) =
+            join_collect(left, right, &JoinType::Left, Some(filter), task_ctx).await?;
+
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
 
-        // Left join: all left rows appear. Unmatched left rows get NULLs on right.
-        // Matched: (5, 5, 50, 2, 2, 80)
-        // Unmatched: (9, 8, 90, NULL, NULL, NULL) and (11, 8, 110, NULL, NULL, NULL)
+        // Verify spill actually occurred
+        assert!(
+            metrics.spill_count().unwrap_or(0) > 0,
+            "Expected spilling to occur under tight memory limit"
+        );
+
         allow_duplicates!(assert_snapshot!(batches_to_sort_string(&batches), @r"
         +----+----+-----+----+----+----+
         | a1 | b1 | c1  | a2 | b2 | c2 |
@@ -3420,10 +3446,25 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_nlj_fits_in_memory_no_spill() -> Result<()> {
-        // Use a large memory limit — everything fits in one pass.
-        let (columns, result) = run_memory_limited_inner_join(10_000_000, 16).await?;
+        // Use a large memory limit — everything fits, no spilling needed.
+        let task_ctx = task_ctx_with_memory_limit(10_000_000, 16)?;
+        let left = build_left_table();
+        let right = build_right_table();
+        let filter = prepare_join_filter();
+
+        let (columns, batches, metrics) =
+            join_collect(left, right, &JoinType::Inner, Some(filter), task_ctx).await?;
+
         assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
-        allow_duplicates!(assert_snapshot!(result, @r"
+
+        // Verify no spilling occurred (standard OnceFut path was used)
+        assert_eq!(
+            metrics.spill_count().unwrap_or(0),
+            0,
+            "Expected no spilling with generous memory limit"
+        );
+
+        allow_duplicates!(assert_snapshot!(batches_to_sort_string(&batches), @r"
         +----+----+----+----+----+----+
         | a1 | b1 | c1 | a2 | b2 | c2 |
         +----+----+----+----+----+----+
@@ -3448,14 +3489,9 @@ pub(crate) mod tests {
         let right = build_right_table();
         let filter = prepare_join_filter();
 
-        let (_columns, batches) = single_partition_join_collect(
-            empty_left,
-            right,
-            &JoinType::Inner,
-            Some(filter),
-            task_ctx,
-        )
-        .await?;
+        let (_columns, batches, _metrics) =
+            join_collect(empty_left, right, &JoinType::Inner, Some(filter), task_ctx)
+                .await?;
         assert!(batches.is_empty() || batches.iter().all(|b| b.num_rows() == 0));
 
         // Empty right table
@@ -3470,7 +3506,7 @@ pub(crate) mod tests {
         );
         let filter2 = prepare_join_filter();
 
-        let (_columns, batches) = single_partition_join_collect(
+        let (_columns, batches, _metrics) = join_collect(
             left,
             empty_right,
             &JoinType::Inner,
@@ -3485,8 +3521,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_nlj_memory_limited_no_disk_falls_back_to_oom() -> Result<()> {
-        // When disk is disabled and right has multi partitions,
-        // memory-limited mode is not used and OOM should occur.
+        // When disk is disabled, fallback is not possible and OOM should occur.
         use datafusion_execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
 
         let runtime = RuntimeEnvBuilder::new()
@@ -3501,15 +3536,26 @@ pub(crate) mod tests {
         let right = build_right_table();
         let filter = prepare_join_filter();
 
-        let err = single_partition_join_collect(
-            left,
-            right,
-            &JoinType::Inner,
-            Some(filter),
-            task_ctx,
-        )
-        .await
-        .unwrap_err();
+        let err = join_collect(left, right, &JoinType::Inner, Some(filter), task_ctx)
+            .await
+            .unwrap_err();
+
+        assert_contains!(err.to_string(), "Resources exhausted");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nlj_right_join_no_fallback_on_oom() -> Result<()> {
+        // RIGHT JOIN does not support multi-pass fallback (needs global right
+        // bitmap). OOM should propagate as an error.
+        let task_ctx = task_ctx_with_memory_limit(50, 16)?;
+        let left = build_left_table();
+        let right = build_right_table();
+        let filter = prepare_join_filter();
+
+        let err = join_collect(left, right, &JoinType::Right, Some(filter), task_ctx)
+            .await
+            .unwrap_err();
 
         assert_contains!(err.to_string(), "Resources exhausted");
         Ok(())

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -949,9 +949,6 @@ pub(crate) struct NestedLoopJoinStream {
     left_stream: Option<SendableRecordBatchStream>,
     /// Memory reservation for left-side buffering in memory-limited mode
     left_reservation: Option<MemoryReservation>,
-    /// A batch that couldn't be added to the current chunk due to memory limit.
-    /// It will be the first batch in the next chunk.
-    left_stashed_batch: Option<RecordBatch>,
     /// Accumulated left batches for the current chunk (memory-limited mode)
     left_pending_batches: Vec<RecordBatch>,
     /// Left-side schema (for concat_batches in memory-limited mode)
@@ -1234,7 +1231,6 @@ impl NestedLoopJoinStream {
             // Memory-limited fields (inactive until OOM fallback)
             left_stream: None,
             left_reservation: None,
-            left_stashed_batch: None,
             left_pending_batches: Vec::new(),
             left_schema: None,
             spill_manager: None,
@@ -1302,7 +1298,6 @@ impl NestedLoopJoinStream {
         self.left_stream = Some(left_stream);
         self.left_schema = Some(left_schema);
         self.left_reservation = Some(reservation);
-        self.left_stashed_batch = None;
         self.left_pending_batches = Vec::new();
         self.spill_manager = Some(spill_manager);
         self.right_spill_in_progress = None;
@@ -1374,25 +1369,9 @@ impl NestedLoopJoinStream {
             .as_ref()
             .expect("left_reservation must be set in memory-limited mode");
 
-        // First, try to re-insert the stashed batch from a previous iteration
-        if let Some(stashed) = self.left_stashed_batch.take() {
-            let batch_size = stashed.get_array_memory_size();
-            if reservation.try_grow(batch_size).is_err() {
-                // Still can't fit even after freeing the previous chunk.
-                // This batch alone exceeds the memory budget.
-                // Buffer it anyway (we must make progress) using infallible grow.
-                reservation.grow(batch_size);
-            }
-            self.metrics.join_metrics.build_mem_used.add(batch_size);
-            self.metrics.join_metrics.build_input_batches.add(1);
-            self.metrics
-                .join_metrics
-                .build_input_rows
-                .add(stashed.num_rows());
-            self.left_pending_batches.push(stashed);
-        }
-
-        // Poll left stream for more batches
+        // Poll left stream for more batches.
+        // Note: left_pending_batches may already contain a batch from the
+        // previous chunk iteration (the batch that triggered the memory limit).
         loop {
             let left_stream = self
                 .left_stream
@@ -1407,15 +1386,15 @@ impl NestedLoopJoinStream {
                     let batch_size = batch.get_array_memory_size();
                     let can_grow = reservation.try_grow(batch_size).is_ok();
 
-                    if !can_grow {
-                        if !self.left_pending_batches.is_empty() {
-                            // Memory limit reached and we already have data.
-                            // Stash this batch for the next chunk.
-                            self.left_stashed_batch = Some(batch);
-                            self.left_exhausted = false;
-                            self.left_buffered_in_one_pass = false;
-                            break;
-                        }
+                    if !can_grow && !self.left_pending_batches.is_empty() {
+                        // Memory limit reached and we already have data.
+                        // Push this batch into pending (it's already in memory)
+                        // and stop buffering for this chunk.
+                        self.left_pending_batches.push(batch);
+                        self.left_exhausted = false;
+                        self.left_buffered_in_one_pass = false;
+                        break;
+                    } else if !can_grow {
                         // No pending batches yet — we must accept this batch
                         // to make progress, even if it exceeds the budget.
                         reservation.grow(batch_size);

--- a/datafusion/sqllogictest/test_files/nested_loop_join_spill.slt
+++ b/datafusion/sqllogictest/test_files/nested_loop_join_spill.slt
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for NestedLoopJoinExec memory-limited execution (spill to disk).
+# When the left (build) side exceeds the memory budget, the operator falls
+# back to a multi-pass strategy that spills the right side to disk.
+
+# Use a single target partition to avoid repartitioning.
+statement ok
+SET datafusion.execution.target_partitions = 1
+
+# Set a memory limit small enough to force OOM on the left-side buffering
+# (100K rows × 8 bytes ≈ 800KB > 150KB limit), triggering spill fallback.
+statement ok
+SET datafusion.runtime.memory_limit = '150K'
+
+# --- INNER JOIN with non-equijoin predicate (forces NestedLoopJoinExec) ---
+# Verify query succeeds and produces correct results under tight memory.
+query III nosort
+SELECT count(*) as cnt, min(v1) as mn, max(v1) as mx
+FROM generate_series(1, 100000) AS t1(v1)
+INNER JOIN generate_series(1, 1) AS t2(v2)
+  ON (t1.v1 + t2.v2) > 0
+----
+100000 1 100000
+
+# --- Verify spill metrics via EXPLAIN ANALYZE ---
+# The NestedLoopJoinExec line should show spill_count=1, confirming
+# the memory-limited fallback path was taken and right side was spilled.
+query TT
+EXPLAIN ANALYZE SELECT count(*)
+FROM generate_series(1, 100000) AS t1(v1)
+INNER JOIN generate_series(1, 1) AS t2(v2)
+  ON (t1.v1 + t2.v2) > 0
+----
+Plan with Metrics
+01)ProjectionExec: expr=[count(Int64(1))@0 as count(*)], metrics=[<slt:ignore>]
+02)--AggregateExec: mode=Single, gby=[], aggr=[count(Int64(1))], metrics=[<slt:ignore>]
+03)----NestedLoopJoinExec: join_type=Inner, filter=v1@0 + v2@1 > 0, projection=[], metrics=[output_rows=100.0 K, <slt:ignore> spill_count=1, <slt:ignore>]
+04)------ProjectionExec: expr=[value@0 as v1], metrics=[<slt:ignore>]
+05)--------LazyMemoryExec: partitions=1, batch_generators=[generate_series: start=1, end=100000, batch_size=8192], metrics=[<slt:ignore>]
+06)------ProjectionExec: expr=[value@0 as v2], metrics=[<slt:ignore>]
+07)--------LazyMemoryExec: partitions=1, batch_generators=[generate_series: start=1, end=1, batch_size=8192], metrics=[<slt:ignore>]
+
+# Restore settings to slt runner defaults
+statement ok
+RESET datafusion.runtime.memory_limit
+
+statement ok
+SET datafusion.execution.target_partitions = 4
+
+statement ok
+RESET datafusion.catalog.create_default_catalog_and_schema


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

NestedLoopJoinExec currently fails with an OOM error when the left (build) side exceeds the memory budget. This PR adds a spill-to-disk fallback so the query can complete instead of crashing.

## What changes are included in this PR?

When collect_left_input via OnceFut fails with ResourcesExhausted, each partition independently falls back to a memory-limited multi-pass strategy:

1. Re-executes the left child to get a fresh stream
2. Buffers left data in memory-sized chunks
3. Spills the right side to disk on the first pass, re-reads it for subsequent passes

The fallback is transparent — if memory is sufficient, the existing OnceFut path is used with zero overhead. It is currently gated to join types that don't require global right-side bitmap tracking (INNER, LEFT, LEFT SEMI, LEFT ANTI, LEFT MARK). RIGHT/FULL joins retain the existing OOM behavior until adding a cross-chunk right bitmap.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Unit tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
