### PR TITLE
Update 53 upgrade guide to note release, other changes

### DIFF
--- a/docs/source/library-user-guide/upgrading/53.0.0.md
+++ b/docs/source/library-user-guide/upgrading/53.0.0.md
@@ -158,7 +158,7 @@ flag is used for null-aware anti joins, such as plans generated for `NOT IN`
 subqueries.
 
 Most callers should pass `false`, the previous behavior. Pass `true` only for null-aware
-`JoinType::LeftAnti` joins. 
+`JoinType::LeftAnti` joins.
 
 ### `FileSinkConfig` adds `file_output_mode`
 


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/19692

## Rationale for this change

@rluvaton  noted some issues with the 53 upgrade guide https://github.com/apache/datafusion/issues/19692#issuecomment-4198963869: 

 > FYI, the migration guide says 53.0.0 was not released yet and it miss the following breaking changes:
> 
> https://github.com/apache/datafusion/pull/20319 - removed deprecated function from ExecutionPlan trait
> https://github.com/apache/datafusion/pull/19635 - added argument to HashJoinExec::try_new function

## What changes are included in this PR?

Fix the above

## Are these changes tested?
Yes by CI

## Are there any user-facing changes?

Better docs