### PR TITLE
chore: Fix `typo` problems

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -900,7 +900,7 @@ data_imdb() {
                 if [ "${DOWNLOADED_SIZE}" != "${expected_size}" ]; then
                     echo "Error: Download size mismatch"
                     echo "Expected: ${expected_size}"
-                    echo "Got: ${DOWNLADED_SIZE}"
+                    echo "Got: ${DOWNLOADED_SIZE}"
                     echo "Please re-initiate the download"
                     return 1
                 fi

--- a/benchmarks/lineprotocol.py
+++ b/benchmarks/lineprotocol.py
@@ -164,12 +164,12 @@ def lineformat(
 ) -> None:
     baseline = BenchmarkRun.load_from_file(baseline)
     context = baseline.context
-    benchamrk_str = f"benchmark,name={context.name},version={context.benchmark_version},datafusion_version={context.datafusion_version},num_cpus={context.num_cpus}"
+    benchmark_str = f"benchmark,name={context.name},version={context.benchmark_version},datafusion_version={context.datafusion_version},num_cpus={context.num_cpus}"
     for query in baseline.queries:
         query_str = f"query=\"{query.query}\""
         timestamp = f"{query.start_time*10**9}"
         for iter_num, result in enumerate(query.iterations):
-            print(f"{benchamrk_str} {query_str},iteration={iter_num},row_count={result.row_count},elapsed_ms={result.elapsed*1000:.0f} {timestamp}\n")
+            print(f"{benchmark_str} {query_str},iteration={iter_num},row_count={result.row_count},elapsed_ms={result.elapsed*1000:.0f} {timestamp}\n")
     
 def main() -> None:
     parser = ArgumentParser()

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -254,7 +254,7 @@ where
 /// let state = SessionStateBuilder::new()
 ///     .with_config(config)
 ///     .with_runtime_env(runtime_env)
-///     // include support for built in functions and configurations
+///     // include support for built-in functions and configurations
 ///     .with_default_features()
 ///     .build();
 ///
@@ -1087,8 +1087,8 @@ impl SessionContext {
         }
     }
 
-    fn schema_doesnt_exist_err(&self, schemaref: &SchemaReference) -> Result<DataFrame> {
-        exec_err!("Schema '{schemaref}' doesn't exist.")
+    fn schema_doesnt_exist_err(&self, schema_ref: &SchemaReference) -> Result<DataFrame> {
+        exec_err!("Schema '{schema_ref}' doesn't exist.")
     }
 
     async fn set_variable(&self, stmt: SetVariable) -> Result<()> {

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -587,7 +587,7 @@ pub trait ScalarUDFImpl: Debug + DynEq + DynHash + Send + Sync + Any {
     ///
     /// If you provide an implementation for [`Self::return_field_from_args`],
     /// DataFusion will not call `return_type` (this function). While it is
-    /// valid to to put [`unimplemented!()`] or [`unreachable!()`], it is
+    /// valid to put [`unimplemented!()`] or [`unreachable!()`], it is
     /// recommended to return [`DataFusionError::Internal`] instead, which
     /// reduces the severity of symptoms if bugs occur (an error rather than a
     /// panic).

--- a/datafusion/functions-nested/src/range.rs
+++ b/datafusion/functions-nested/src/range.rs
@@ -289,7 +289,7 @@ impl Range {
     ///
     /// # Arguments
     ///
-    /// * `args` - An array of 1 to 3 ArrayRefs representing start, stop, and step(step value can not be zero.) values.
+    /// * `args` - An array of 1 to 3 ArrayRefs representing start, stop, and step (step value can not be zero) values.
     ///
     /// # Examples
     ///

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -496,7 +496,7 @@ impl Optimizer {
 /// These are invariants which should hold true before and after [`LogicalPlan`] optimization.
 ///
 /// This differs from [`LogicalPlan::check_invariants`], which addresses if a singular
-/// LogicalPlan is valid. Instead this address if the optimization was valid based upon permitted changes.
+/// LogicalPlan is valid. Instead, this address if the optimization was valid based upon permitted changes.
 fn assert_valid_optimization(
     plan: &LogicalPlan,
     prev_schema: &Arc<DFSchema>,

--- a/datafusion/physical-optimizer/src/optimizer.rs
+++ b/datafusion/physical-optimizer/src/optimizer.rs
@@ -163,7 +163,7 @@ impl PhysicalOptimizer {
             Arc::new(PushdownSort::new()),
             Arc::new(EnsureCooperative::new()),
             // This FilterPushdown handles dynamic filters that may have references to the source ExecutionPlan.
-            // Therefore it should be run at the end of the optimization process since any changes to the plan may break the dynamic filter's references.
+            // Therefore, it should be run at the end of the optimization process since any changes to the plan may break the dynamic filter's references.
             // See `FilterPushdownPhase` for more details.
             Arc::new(FilterPushdown::new_post_optimization()),
             // The SanityCheckPlan rule checks whether the order and

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -1867,7 +1867,7 @@ impl NestedLoopJoinStream {
             bitmap.set_bit(l_index, true);
         }
 
-        // 2. Maybe updateh the right bitmap
+        // 2. Maybe update the right bitmap
         if self.should_track_unmatched_right {
             debug_assert!(self.current_right_batch_matched.is_some());
             // after bit-wise or, it will be put back
@@ -2198,7 +2198,7 @@ fn build_unmatched_batch(
             // 2. Fill left side with nulls
             let flipped_bitmap = not(&batch_bitmap)?;
 
-            // create a recordbatch, with left_schema, of only one row of all nulls
+            // create a record batch, with left_schema, of only one row of all nulls
             let left_null_columns: Vec<Arc<dyn Array>> = another_side_schema
                 .fields()
                 .iter()

--- a/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/normalize.rs
@@ -253,7 +253,7 @@ pub fn cell_to_string(col: &ArrayRef, row: usize, is_spark_path: bool) -> Result
     }
 }
 
-/// Converts columns to a result as expected by sqllogicteset.
+/// Converts columns to a result as expected by sqllogictest.
 pub fn convert_schema_to_types(columns: &Fields) -> Vec<DFColumnType> {
     columns
         .iter()

--- a/datafusion/sqllogictest/test_files/repartition.slt
+++ b/datafusion/sqllogictest/test_files/repartition.slt
@@ -123,7 +123,7 @@ physical_plan
 03)----RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
 04)------StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true
 
-# Start repratition on empty column test.
+# Start repartition on empty column test.
 # See https://github.com/apache/datafusion/issues/12057
 
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #21494.

## Rationale for this change
There are typo problems on following source-files and some of them were being highlighted by IntelliJ (CLion). It is useful to fix them:
```
datafusion/
     benchmarks/bench.sh
     benchmarks/lineprotocol.py
     core/src/execution/context/mod.rs
     expr/src/udf.rs
     functions-nested/src/range.rs
     optimizer/src/optimizer.rs
     optimizer/src/optimizer.rs
     physical-plan/src/joins/nested_loop_join.rs
     sqllogictest/src/engines/datafusion_engine/normalize.rs
     sqllogictest/test_files/repartition.slt
```

## What changes are included in this PR?
This PR aims to fix found typo problems.

## Are these changes tested?
Not required.

## Are there any user-facing changes?
No
