### PR TITLE
Make `test_display_pg_json` pass regardless of build setup and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,6 +2659,7 @@ dependencies = [
  "object_store",
  "postgres-types",
  "regex",
+ "serde_json",
  "sqllogictest",
  "sqlparser",
  "tempfile",

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -66,3 +66,6 @@ sqlparser = { workspace = true, optional = true }
 ctor = { workspace = true }
 env_logger = { workspace = true }
 insta = { workspace = true }
+# Makes sure `test_display_pg_json` behaves in a consistent way regardless of
+# feature unification with dependencies
+serde_json = { workspace = true, features = ["preserve_order"] }

--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -84,6 +84,9 @@ substrait = ["datafusion-substrait"]
 [dev-dependencies]
 env_logger = { workspace = true }
 regex = { workspace = true }
+# Required to make sure tests for pg display behaves consistently
+# regardless of feature unification with dependencies
+serde_json = { workspace = true, features = ["preserve_order"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [[test]]

--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -93,3 +93,8 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 harness = false
 name = "sqllogictests"
 path = "bin/sqllogictests.rs"
+
+# Required because we pull serde_json with a feature to get consistent pg display,
+# but its not directly used.
+[package.metadata.cargo-machete]
+ignored = "serde_json"


### PR DESCRIPTION
## Which issue does this PR close?

- Closes ##21501.

## Rationale for this change

Running tests for `datafusion-expr` currently fails locally, but due to feature unification with the `subtrait` dependency it does pass in CI.

## What changes are included in this PR?

Enables a feature for a dependency during tests.

## Are these changes tested?

Ran tests for the crate directly.

## Are there any user-facing changes?

None.
