### PR TITLE
sql: render PostgreSQL array literals as ARRAY[...] in unparser

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -51,6 +51,11 @@ pub trait Dialect: Send + Sync {
     /// Return the character used to quote identifiers.
     fn identifier_quote_style(&self, _identifier: &str) -> Option<char>;
 
+    /// Whether array literals should be rendered with the `ARRAY[...]` keyword.
+    fn array_keyword(&self) -> bool {
+        false
+    }
+
     /// Does the dialect support specifying `NULLS FIRST/LAST` in `ORDER BY` clauses?
     fn supports_nulls_first_in_sort(&self) -> bool {
         true
@@ -321,6 +326,10 @@ impl Dialect for DefaultDialect {
 pub struct PostgreSqlDialect {}
 
 impl Dialect for PostgreSqlDialect {
+    fn array_keyword(&self) -> bool {
+        true
+    }
+
     fn supports_qualify(&self) -> bool {
         false
     }

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -52,7 +52,7 @@ pub trait Dialect: Send + Sync {
     fn identifier_quote_style(&self, _identifier: &str) -> Option<char>;
 
     /// Whether array literals should be rendered with the `ARRAY[...]` keyword.
-    fn array_keyword(&self) -> bool {
+    fn use_array_keyword_for_array_literals(&self) -> bool {
         false
     }
 
@@ -326,7 +326,7 @@ impl Dialect for DefaultDialect {
 pub struct PostgreSqlDialect {}
 
 impl Dialect for PostgreSqlDialect {
-    fn array_keyword(&self) -> bool {
+    fn use_array_keyword_for_array_literals(&self) -> bool {
         true
     }
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -3074,26 +3074,18 @@ mod tests {
         let unparser = Unparser::new(dialect.as_ref());
 
         let inner_type = DataType::Int32;
-        let nested_type = DataType::List(Arc::new(Field::new_list_field(
-            inner_type.clone(),
-            true,
-        )));
+        let nested_type =
+            DataType::List(Arc::new(Field::new_list_field(inner_type.clone(), true)));
 
         let expr = Expr::Literal(
             ScalarValue::List(ScalarValue::new_list_nullable(
                 &[
                     ScalarValue::List(ScalarValue::new_list_nullable(
-                        &[
-                            ScalarValue::Int32(Some(1)),
-                            ScalarValue::Int32(Some(2)),
-                        ],
+                        &[ScalarValue::Int32(Some(1)), ScalarValue::Int32(Some(2))],
                         &inner_type,
                     )),
                     ScalarValue::List(ScalarValue::new_list_nullable(
-                        &[
-                            ScalarValue::Int32(Some(3)),
-                            ScalarValue::Int32(Some(4)),
-                        ],
+                        &[ScalarValue::Int32(Some(3)), ScalarValue::Int32(Some(4))],
                         &inner_type,
                     )),
                 ],

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -604,7 +604,7 @@ impl Unparser<'_> {
             .collect::<Result<Vec<_>>>()?;
         Ok(ast::Expr::Array(Array {
             elem: args,
-            named: false,
+            named: self.dialect.array_keyword(),
         }))
     }
 
@@ -615,7 +615,10 @@ impl Unparser<'_> {
             elem.push(self.scalar_to_sql(&value)?);
         }
 
-        Ok(ast::Expr::Array(Array { elem, named: false }))
+        Ok(ast::Expr::Array(Array {
+            elem,
+            named: self.dialect.array_keyword(),
+        }))
     }
 
     fn array_element_to_sql(&self, args: &[Expr]) -> Result<ast::Expr> {

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -604,7 +604,7 @@ impl Unparser<'_> {
             .collect::<Result<Vec<_>>>()?;
         Ok(ast::Expr::Array(Array {
             elem: args,
-            named: self.dialect.array_keyword(),
+            named: self.dialect.use_array_keyword_for_array_literals(),
         }))
     }
 
@@ -617,7 +617,7 @@ impl Unparser<'_> {
 
         Ok(ast::Expr::Array(Array {
             elem,
-            named: self.dialect.array_keyword(),
+            named: self.dialect.use_array_keyword_for_array_literals(),
         }))
     }
 
@@ -3043,6 +3043,69 @@ mod tests {
 
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn test_array_literal_scalar_value_to_sql_postgres() -> Result<()> {
+        let dialect: Arc<dyn Dialect> = Arc::new(PostgreSqlDialect {});
+        let unparser = Unparser::new(dialect.as_ref());
+
+        let expr = Expr::Literal(
+            ScalarValue::List(ScalarValue::new_list_nullable(
+                &[
+                    ScalarValue::Int32(Some(1)),
+                    ScalarValue::Int32(Some(2)),
+                    ScalarValue::Int32(Some(3)),
+                ],
+                &DataType::Int32,
+            )),
+            None,
+        );
+
+        let ast = unparser.expr_to_sql(&expr)?;
+        assert_eq!(ast.to_string(), "ARRAY[1, 2, 3]");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nested_array_literal_scalar_value_to_sql_postgres() -> Result<()> {
+        let dialect: Arc<dyn Dialect> = Arc::new(PostgreSqlDialect {});
+        let unparser = Unparser::new(dialect.as_ref());
+
+        let inner_type = DataType::Int32;
+        let nested_type = DataType::List(Arc::new(Field::new_list_field(
+            inner_type.clone(),
+            true,
+        )));
+
+        let expr = Expr::Literal(
+            ScalarValue::List(ScalarValue::new_list_nullable(
+                &[
+                    ScalarValue::List(ScalarValue::new_list_nullable(
+                        &[
+                            ScalarValue::Int32(Some(1)),
+                            ScalarValue::Int32(Some(2)),
+                        ],
+                        &inner_type,
+                    )),
+                    ScalarValue::List(ScalarValue::new_list_nullable(
+                        &[
+                            ScalarValue::Int32(Some(3)),
+                            ScalarValue::Int32(Some(4)),
+                        ],
+                        &inner_type,
+                    )),
+                ],
+                &nested_type,
+            )),
+            None,
+        );
+
+        let ast = unparser.expr_to_sql(&expr)?;
+        assert_eq!(ast.to_string(), "ARRAY[ARRAY[1, 2], ARRAY[3, 4]]");
+
+        Ok(())
     }
 
     #[test]

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2729,6 +2729,17 @@ fn test_unparse_window() -> Result<()> {
 }
 
 #[test]
+fn test_array_to_sql_postgres() -> Result<(), DataFusionError> {
+    roundtrip_statement_with_dialect_helper!(
+        sql: "SELECT [1, 2, 3, 4, 5]",
+        parser_dialect: GenericDialect {},
+        unparser_dialect: UnparserPostgreSqlDialect {},
+        expected: @"SELECT ARRAY[1, 2, 3, 4, 5]",
+    );
+    Ok(())
+}
+
+#[test]
 fn test_like_filter() {
     let statement = generate_round_trip_statement(
         GenericDialect {},


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

PostgreSQL array literals should be rendered using `ARRAY[...]` syntax when unparsing SQL. Without this, roundtripped PostgreSQL SQL can lose the dialect-specific array form and emit a plain bracketed array literal instead.

## What changes are included in this PR?

- Added a dialect hook to indicate whether array literals should render as `ARRAY[...]`.
- Enabled that behavior for `PostgreSqlDialect`.
- Updated the SQL unparser to honor the dialect setting when rendering array expressions.
- Adjusted the PostgreSQL roundtrip test to expect `ARRAY[1, 2, 3, 4, 5]`.

## Are these changes tested?

Yes. The PostgreSQL roundtrip test in plan_to_sql.rs covers the array literal case and verifies the unparsed SQL now uses `ARRAY[...]`.

## Are there any user-facing changes?

Yes. PostgreSQL SQL generated by DataFusion will now emit array literals in `ARRAY[...]` form instead of plain bracketed form.