### PR TITLE
Enable logical planning for `UPDATE ... FROM` and preserve joined assignment qualifiers

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2332,16 +2332,30 @@ fn collect_target_refs(
     target: &TableReference,
 ) -> Result<Vec<TableReference>> {
     let mut target_refs = vec![target.clone()];
-    input.apply(|node| {
-        if let LogicalPlan::SubqueryAlias(alias) = node
-            && let LogicalPlan::TableScan(scan) = alias.input.as_ref()
-            && scan.table_name.resolved_eq(target)
-        {
-            target_refs.push(TableReference::bare(alias.alias.to_string()));
-        }
-        Ok(TreeNodeRecursion::Continue)
-    })?;
+    collect_target_refs_from_target_branch(input, &mut target_refs)?;
     Ok(target_refs)
+}
+
+fn collect_target_refs_from_target_branch(
+    input: &Arc<LogicalPlan>,
+    target_refs: &mut Vec<TableReference>,
+) -> Result<()> {
+    match input.as_ref() {
+        LogicalPlan::Projection(projection) => {
+            collect_target_refs_from_target_branch(&projection.input, target_refs)
+        }
+        LogicalPlan::Filter(filter) => {
+            collect_target_refs_from_target_branch(&filter.input, target_refs)
+        }
+        LogicalPlan::Join(join) => {
+            collect_target_refs_from_target_branch(&join.left, target_refs)
+        }
+        LogicalPlan::SubqueryAlias(alias) => {
+            target_refs.push(TableReference::bare(alias.alias.to_string()));
+            collect_target_refs_from_target_branch(&alias.input, target_refs)
+        }
+        _ => Ok(()),
+    }
 }
 
 fn normalize_update_assignment_expr(expr: Expr, strip_qualifiers: bool) -> Result<Expr> {
@@ -4904,6 +4918,22 @@ digraph {
         assert_eq!(
             assignments.get("b").map(ToString::to_string).as_deref(),
             Some("t1.a")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_update_assignments_preserves_self_join_source_alias() {
+        let assignments = update_assignments_for_sql(
+            "UPDATE t1 AS target SET a = src.a FROM t1 AS src \
+             WHERE target.id = src.id",
+        )
+        .await
+        .unwrap();
+
+        let assignments: HashMap<_, _> = assignments.into_iter().collect();
+        assert_eq!(
+            assignments.get("a").map(ToString::to_string).as_deref(),
+            Some("src.a")
         );
     }
 

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -777,6 +777,13 @@ impl DefaultPhysicalPlanner {
                 input,
                 ..
             }) => {
+                // TODO: remove this guard once UPDATE ... FROM routing via
+                // TableProvider::update_from(...) and joined assignment handling land.
+                // See https://github.com/apache/datafusion/issues/19950.
+                if update_uses_joined_input(input)? {
+                    return not_impl_err!("UPDATE ... FROM is not supported");
+                }
+
                 if let Some(provider) =
                     target.as_any().downcast_ref::<DefaultTableSource>()
                 {
@@ -2192,6 +2199,18 @@ fn extract_dml_filters(
             }
             Ok(deduped)
         })
+}
+
+fn update_uses_joined_input(input: &Arc<LogicalPlan>) -> Result<bool> {
+    let mut has_join = false;
+    input.apply(|node| {
+        if matches!(node, LogicalPlan::Join(_)) {
+            has_join = true;
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(has_join)
 }
 
 /// Determine whether a predicate references only columns from the target table

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -791,7 +791,7 @@ impl DefaultPhysicalPlanner {
                     // We pass the filters and let the provider handle the projection
                     let filters = extract_dml_filters(input, table_name)?;
                     // Extract assignments from the projection in input plan
-                    let assignments = extract_update_assignments(input)?;
+                    let assignments = extract_update_assignments(input, table_name)?;
                     provider
                         .table_provider
                         .update(session_state, assignments, filters)
@@ -2261,7 +2261,10 @@ fn strip_column_qualifiers(expr: Expr) -> Result<Expr> {
 /// over the source table. This function extracts column name and expression pairs
 /// from the projection. Column qualifiers are stripped from the expressions.
 ///
-fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, Expr)>> {
+fn extract_update_assignments(
+    input: &Arc<LogicalPlan>,
+    target: &TableReference,
+) -> Result<Vec<(String, Expr)>> {
     // The UPDATE input plan structure is:
     // Projection(updated columns as expressions with aliases)
     //   Filter(optional WHERE clause)
@@ -2269,6 +2272,8 @@ fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, E
     //
     // Each projected expression has an alias matching the column name
     let mut assignments = Vec::new();
+    let strip_qualifiers = !update_uses_joined_input(input)?;
+    let target_refs = collect_target_refs(input, target)?;
 
     // Find the top-level projection
     if let LogicalPlan::Projection(projection) = input.as_ref() {
@@ -2279,10 +2284,12 @@ fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, E
                 let column_name = alias.name.clone();
                 // Only include if it's not just a column reference to itself
                 // (those are columns that aren't being updated)
-                if !is_identity_assignment(&alias.expr, &column_name) {
-                    // Strip qualifiers from the assignment expression
-                    let stripped_expr = strip_column_qualifiers((*alias.expr).clone())?;
-                    assignments.push((column_name, stripped_expr));
+                if !is_identity_assignment(&alias.expr, &column_name, &target_refs) {
+                    let assignment_expr = normalize_update_assignment_expr(
+                        (*alias.expr).clone(),
+                        strip_qualifiers,
+                    )?;
+                    assignments.push((column_name, assignment_expr));
                 }
             }
         }
@@ -2293,10 +2300,16 @@ fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, E
                 for expr in &projection.expr {
                     if let Expr::Alias(alias) = expr {
                         let column_name = alias.name.clone();
-                        if !is_identity_assignment(&alias.expr, &column_name) {
-                            let stripped_expr =
-                                strip_column_qualifiers((*alias.expr).clone())?;
-                            assignments.push((column_name, stripped_expr));
+                        if !is_identity_assignment(
+                            &alias.expr,
+                            &column_name,
+                            &target_refs,
+                        ) {
+                            let assignment_expr = normalize_update_assignment_expr(
+                                (*alias.expr).clone(),
+                                strip_qualifiers,
+                            )?;
+                            assignments.push((column_name, assignment_expr));
                         }
                     }
                 }
@@ -2309,11 +2322,47 @@ fn extract_update_assignments(input: &Arc<LogicalPlan>) -> Result<Vec<(String, E
     Ok(assignments)
 }
 
+fn collect_target_refs(
+    input: &Arc<LogicalPlan>,
+    target: &TableReference,
+) -> Result<Vec<TableReference>> {
+    let mut target_refs = vec![target.clone()];
+    input.apply(|node| {
+        if let LogicalPlan::SubqueryAlias(alias) = node
+            && let LogicalPlan::TableScan(scan) = alias.input.as_ref()
+            && scan.table_name.resolved_eq(target)
+        {
+            target_refs.push(TableReference::bare(alias.alias.to_string()));
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(target_refs)
+}
+
+fn normalize_update_assignment_expr(expr: Expr, strip_qualifiers: bool) -> Result<Expr> {
+    if strip_qualifiers {
+        strip_column_qualifiers(expr)
+    } else {
+        Ok(expr)
+    }
+}
+
 /// Check if an assignment is an identity assignment (column = column)
 /// These are columns that are not being modified in the UPDATE
-fn is_identity_assignment(expr: &Expr, column_name: &str) -> bool {
+fn is_identity_assignment(
+    expr: &Expr,
+    column_name: &str,
+    target_refs: &[TableReference],
+) -> bool {
     match expr {
-        Expr::Column(col) => col.name == column_name,
+        Expr::Column(col) => {
+            col.name == column_name
+                && col.relation.as_ref().is_none_or(|relation| {
+                    target_refs
+                        .iter()
+                        .any(|target_ref| relation.resolved_eq(target_ref))
+                })
+        }
         _ => false,
     }
 }
@@ -3133,6 +3182,7 @@ impl<'n> TreeNodeVisitor<'n> for InvariantChecker {
 mod tests {
     use std::any::Any;
     use std::cmp::Ordering;
+    use std::collections::HashMap;
     use std::fmt::{self, Debug};
     use std::ops::{BitAnd, Not};
 
@@ -3184,6 +3234,39 @@ mod tests {
         planner
             .create_physical_plan(&logical_plan, &session_state)
             .await
+    }
+
+    fn make_test_mem_table(schema: SchemaRef) -> Arc<MemTable> {
+        Arc::new(MemTable::try_new(schema, vec![vec![]]).unwrap())
+    }
+
+    async fn update_assignments_for_sql(sql: &str) -> Result<Vec<(String, Expr)>> {
+        let ctx = SessionContext::new();
+        let t1_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let t2_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        ctx.register_table("t1", make_test_mem_table(t1_schema))?;
+        ctx.register_table("t2", make_test_mem_table(t2_schema))?;
+
+        let df = ctx.sql(sql).await?;
+        let (table_name, input) = match df.logical_plan() {
+            LogicalPlan::Dml(DmlStatement {
+                op: WriteOp::Update,
+                table_name,
+                input,
+                ..
+            }) => (table_name.clone(), Arc::clone(input)),
+            plan => panic!("expected update plan, got {plan:?}"),
+        };
+
+        extract_update_assignments(&input, &table_name)
     }
 
     #[tokio::test]
@@ -4767,5 +4850,69 @@ digraph {
 
         assert_eq!(plan.schema(), schema);
         assert!(plan.is::<EmptyExec>());
+    }
+
+    #[tokio::test]
+    async fn test_extract_update_assignments_preserves_joined_source_qualifiers() {
+        let assignments = update_assignments_for_sql(
+            "UPDATE t1 SET b = t2.b FROM t2 WHERE t1.id = t2.id",
+        )
+        .await
+        .unwrap();
+
+        let assignments: HashMap<_, _> = assignments.into_iter().collect();
+        assert_eq!(
+            assignments.get("b").map(ToString::to_string).as_deref(),
+            Some("t2.b")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_update_assignments_preserves_alias_qualified_sources() {
+        let assignments = update_assignments_for_sql(
+            "UPDATE t1 AS target SET b = source.b FROM t2 AS source \
+             WHERE target.id = source.id",
+        )
+        .await
+        .unwrap();
+
+        let assignments: HashMap<_, _> = assignments.into_iter().collect();
+        assert_eq!(
+            assignments.get("b").map(ToString::to_string).as_deref(),
+            Some("source.b")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_update_assignments_distinguishes_same_name_join_columns() {
+        let assignments = update_assignments_for_sql(
+            "UPDATE t1 SET a = t2.a, b = t1.a FROM t2 WHERE t1.id = t2.id",
+        )
+        .await
+        .unwrap();
+
+        let assignments: HashMap<_, _> = assignments.into_iter().collect();
+        assert_eq!(
+            assignments.get("a").map(ToString::to_string).as_deref(),
+            Some("t2.a")
+        );
+        assert_eq!(
+            assignments.get("b").map(ToString::to_string).as_deref(),
+            Some("t1.a")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_update_assignments_strips_single_table_target_qualifiers() {
+        let assignments =
+            update_assignments_for_sql("UPDATE t1 SET b = t1.a WHERE t1.id = 1")
+                .await
+                .unwrap();
+
+        let assignments: HashMap<_, _> = assignments.into_iter().collect();
+        assert_eq!(
+            assignments.get("b").map(ToString::to_string).as_deref(),
+            Some("a")
+        );
     }
 }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -790,9 +790,11 @@ impl DefaultPhysicalPlanner {
                 {
                     // For UPDATE, the assignments are encoded in the projection of input
                     // We pass the filters and let the provider handle the projection
-                    let filters = extract_dml_filters(input, table_name)?;
+                    let filters =
+                        extract_dml_filters_with_analysis(input, table_name, &analysis)?;
                     // Extract assignments from the projection in input plan
-                    let assignments = extract_update_assignments(input, table_name)?;
+                    let assignments =
+                        extract_update_assignments_with_analysis(input, &analysis)?;
                     provider
                         .table_provider
                         .update(session_state, assignments, filters)
@@ -2107,6 +2109,15 @@ fn extract_dml_filters(
     target: &TableReference,
 ) -> Result<Vec<Expr>> {
     let analysis = analyze_dml_input(input, target)?;
+    extract_dml_filters_with_analysis(input, target, &analysis)
+}
+
+#[allow(clippy::allow_attributes, clippy::mutable_key_type)] // Expr contains Arc with interior mutability but is intentionally used as hash key
+fn extract_dml_filters_with_analysis(
+    input: &Arc<LogicalPlan>,
+    target: &TableReference,
+    analysis: &DmlInputAnalysis,
+) -> Result<Vec<Expr>> {
     let mut filters = Vec::new();
 
     input.apply(|node| {
@@ -2204,30 +2215,28 @@ fn analyze_dml_input(
         has_joined_input: false,
         target_refs: vec![target.clone()],
     };
-    analyze_target_branch(input, &mut analysis)?;
+    analyze_target_branch(input, &mut analysis);
     Ok(analysis)
 }
 
-fn analyze_target_branch(
-    input: &Arc<LogicalPlan>,
-    analysis: &mut DmlInputAnalysis,
-) -> Result<()> {
-    match input.as_ref() {
-        LogicalPlan::Projection(projection) => {
-            analyze_target_branch(&projection.input, analysis)
+fn analyze_target_branch(input: &Arc<LogicalPlan>, analysis: &mut DmlInputAnalysis) {
+    let mut current = input;
+    loop {
+        match current.as_ref() {
+            LogicalPlan::Projection(projection) => current = &projection.input,
+            LogicalPlan::Filter(filter) => current = &filter.input,
+            LogicalPlan::SubqueryAlias(alias) => {
+                analysis
+                    .target_refs
+                    .push(TableReference::bare(alias.alias.to_string()));
+                current = &alias.input;
+            }
+            LogicalPlan::Join(join) => {
+                analysis.has_joined_input = true;
+                current = &join.left;
+            }
+            _ => return,
         }
-        LogicalPlan::Filter(filter) => analyze_target_branch(&filter.input, analysis),
-        LogicalPlan::SubqueryAlias(alias) => {
-            analysis
-                .target_refs
-                .push(TableReference::bare(alias.alias.to_string()));
-            analyze_target_branch(&alias.input, analysis)
-        }
-        LogicalPlan::Join(join) => {
-            analysis.has_joined_input = true;
-            analyze_target_branch(&join.left, analysis)
-        }
-        _ => Ok(()),
     }
 }
 
@@ -2280,6 +2289,7 @@ fn strip_column_qualifiers(expr: Expr) -> Result<Expr> {
 /// from the projection. Column qualifiers are stripped only for single-table
 /// updates so provider-facing expressions remain resolvable.
 ///
+#[cfg(test)]
 fn extract_update_assignments(
     input: &Arc<LogicalPlan>,
     target: &TableReference,
@@ -2291,67 +2301,65 @@ fn extract_update_assignments(
     //
     // Each projected expression has an alias matching the column name
     let analysis = analyze_dml_input(input, target)?;
-    let mut assignments = Vec::new();
-    let strip_qualifiers = !analysis.has_joined_input;
+    extract_update_assignments_with_analysis(input, &analysis)
+}
 
-    // Find the top-level projection
+fn extract_update_assignments_with_analysis(
+    input: &Arc<LogicalPlan>,
+    analysis: &DmlInputAnalysis,
+) -> Result<Vec<(String, Expr)>> {
+    find_update_projection(input)?
+        .map(|projection| {
+            append_update_assignments(
+                projection,
+                &analysis.target_refs,
+                !analysis.has_joined_input,
+            )
+        })
+        .transpose()
+        .map(|assignments| assignments.unwrap_or_default())
+}
+
+fn find_update_projection(input: &Arc<LogicalPlan>) -> Result<Option<&Projection>> {
     if let LogicalPlan::Projection(projection) = input.as_ref() {
-        append_update_assignments(
-            &mut assignments,
-            projection,
-            &analysis.target_refs,
-            strip_qualifiers,
-        )?;
-    } else {
-        // Try to find projection deeper in the plan
-        input.apply(|node| {
-            if let LogicalPlan::Projection(projection) = node {
-                append_update_assignments(
-                    &mut assignments,
-                    projection,
-                    &analysis.target_refs,
-                    strip_qualifiers,
-                )?;
-                return Ok(TreeNodeRecursion::Stop);
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })?;
+        return Ok(Some(projection));
     }
 
-    Ok(assignments)
+    let mut found_projection = None;
+    input.apply(|node| {
+        if let LogicalPlan::Projection(projection) = node {
+            found_projection = Some(projection);
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(found_projection)
 }
 
 fn append_update_assignments(
-    assignments: &mut Vec<(String, Expr)>,
     projection: &Projection,
     target_refs: &[TableReference],
     strip_qualifiers: bool,
-) -> Result<()> {
-    for expr in &projection.expr {
-        if let Expr::Alias(alias) = expr {
-            // The alias name is the column name being updated
-            // The inner expression is the new value
-            let column_name = alias.name.clone();
-            // Only include if it's not just a column reference to itself
-            // (those are columns that aren't being updated)
-            if !is_identity_assignment(&alias.expr, &column_name, target_refs) {
-                let assignment_expr = normalize_update_assignment_expr(
-                    (*alias.expr).clone(),
-                    strip_qualifiers,
-                )?;
-                assignments.push((column_name, assignment_expr));
+) -> Result<Vec<(String, Expr)>> {
+    projection
+        .expr
+        .iter()
+        .filter_map(|expr| match expr {
+            Expr::Alias(alias)
+                if !is_identity_assignment(&alias.expr, &alias.name, target_refs) =>
+            {
+                Some(
+                    if strip_qualifiers {
+                        strip_column_qualifiers((*alias.expr).clone())
+                    } else {
+                        Ok((*alias.expr).clone())
+                    }
+                    .map(|assignment_expr| (alias.name.clone(), assignment_expr)),
+                )
             }
-        }
-    }
-    Ok(())
-}
-
-fn normalize_update_assignment_expr(expr: Expr, strip_qualifiers: bool) -> Result<Expr> {
-    if strip_qualifiers {
-        strip_column_qualifiers(expr)
-    } else {
-        Ok(expr)
-    }
+            _ => None,
+        })
+        .collect()
 }
 
 /// Check if an assignment is an identity assignment (column = column)
@@ -3247,20 +3255,19 @@ mod tests {
         Arc::new(MemTable::try_new(schema, vec![vec![]]).unwrap())
     }
 
+    fn test_update_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]))
+    }
+
     async fn update_assignments_for_sql(sql: &str) -> Result<Vec<(String, Expr)>> {
         let ctx = SessionContext::new();
-        let t1_schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Int32, false),
-        ]));
-        let t2_schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Int32, false),
-        ]));
-        ctx.register_table("t1", make_test_mem_table(t1_schema))?;
-        ctx.register_table("t2", make_test_mem_table(t2_schema))?;
+        let schema = test_update_schema();
+        ctx.register_table("t1", make_test_mem_table(Arc::clone(&schema)))?;
+        ctx.register_table("t2", make_test_mem_table(schema))?;
 
         let df = ctx.sql(sql).await?;
         let (table_name, input) = match df.logical_plan() {
@@ -3274,6 +3281,16 @@ mod tests {
         };
 
         extract_update_assignments(&input, &table_name)
+    }
+
+    async fn assert_update_assignment(sql: &str, column: &str, expected: &str) {
+        let assignments: HashMap<_, _> = update_assignments_for_sql(sql)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(name, expr)| (name, expr.to_string()))
+            .collect();
+        assert_eq!(assignments.get(column).map(String::as_str), Some(expected));
     }
 
     #[tokio::test]
@@ -4861,81 +4878,53 @@ digraph {
 
     #[tokio::test]
     async fn test_extract_update_assignments_preserves_joined_source_qualifiers() {
-        let assignments = update_assignments_for_sql(
+        assert_update_assignment(
             "UPDATE t1 SET b = t2.b FROM t2 WHERE t1.id = t2.id",
+            "b",
+            "t2.b",
         )
-        .await
-        .unwrap();
-
-        let assignments: HashMap<_, _> = assignments.into_iter().collect();
-        assert_eq!(
-            assignments.get("b").map(ToString::to_string).as_deref(),
-            Some("t2.b")
-        );
+        .await;
     }
 
     #[tokio::test]
     async fn test_extract_update_assignments_preserves_alias_qualified_sources() {
-        let assignments = update_assignments_for_sql(
+        assert_update_assignment(
             "UPDATE t1 AS target SET b = source.b FROM t2 AS source \
              WHERE target.id = source.id",
+            "b",
+            "source.b",
         )
-        .await
-        .unwrap();
-
-        let assignments: HashMap<_, _> = assignments.into_iter().collect();
-        assert_eq!(
-            assignments.get("b").map(ToString::to_string).as_deref(),
-            Some("source.b")
-        );
+        .await;
     }
 
     #[tokio::test]
     async fn test_extract_update_assignments_distinguishes_same_name_join_columns() {
-        let assignments = update_assignments_for_sql(
+        let assignments: HashMap<_, _> = update_assignments_for_sql(
             "UPDATE t1 SET a = t2.a, b = t1.a FROM t2 WHERE t1.id = t2.id",
         )
         .await
-        .unwrap();
-
-        let assignments: HashMap<_, _> = assignments.into_iter().collect();
-        assert_eq!(
-            assignments.get("a").map(ToString::to_string).as_deref(),
-            Some("t2.a")
-        );
-        assert_eq!(
-            assignments.get("b").map(ToString::to_string).as_deref(),
-            Some("t1.a")
-        );
+        .unwrap()
+        .into_iter()
+        .map(|(name, expr)| (name, expr.to_string()))
+        .collect();
+        assert_eq!(assignments.get("a").map(String::as_str), Some("t2.a"));
+        assert_eq!(assignments.get("b").map(String::as_str), Some("t1.a"));
     }
 
     #[tokio::test]
     async fn test_extract_update_assignments_preserves_self_join_source_alias() {
-        let assignments = update_assignments_for_sql(
+        assert_update_assignment(
             "UPDATE t1 AS target SET a = src.a FROM t1 AS src \
              WHERE target.id = src.id",
+            "a",
+            "src.a",
         )
-        .await
-        .unwrap();
-
-        let assignments: HashMap<_, _> = assignments.into_iter().collect();
-        assert_eq!(
-            assignments.get("a").map(ToString::to_string).as_deref(),
-            Some("src.a")
-        );
+        .await;
     }
 
     #[tokio::test]
     async fn test_extract_update_assignments_strips_single_table_target_qualifiers() {
-        let assignments =
-            update_assignments_for_sql("UPDATE t1 SET b = t1.a WHERE t1.id = 1")
-                .await
-                .unwrap();
-
-        let assignments: HashMap<_, _> = assignments.into_iter().collect();
-        assert_eq!(
-            assignments.get("b").map(ToString::to_string).as_deref(),
-            Some("a")
-        );
+        assert_update_assignment("UPDATE t1 SET b = t1.a WHERE t1.id = 1", "b", "a")
+            .await;
     }
 }

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2277,42 +2277,22 @@ fn extract_update_assignments(
 
     // Find the top-level projection
     if let LogicalPlan::Projection(projection) = input.as_ref() {
-        for expr in &projection.expr {
-            if let Expr::Alias(alias) = expr {
-                // The alias name is the column name being updated
-                // The inner expression is the new value
-                let column_name = alias.name.clone();
-                // Only include if it's not just a column reference to itself
-                // (those are columns that aren't being updated)
-                if !is_identity_assignment(&alias.expr, &column_name, &target_refs) {
-                    let assignment_expr = normalize_update_assignment_expr(
-                        (*alias.expr).clone(),
-                        strip_qualifiers,
-                    )?;
-                    assignments.push((column_name, assignment_expr));
-                }
-            }
-        }
+        append_update_assignments(
+            &mut assignments,
+            projection,
+            &target_refs,
+            strip_qualifiers,
+        )?;
     } else {
         // Try to find projection deeper in the plan
         input.apply(|node| {
             if let LogicalPlan::Projection(projection) = node {
-                for expr in &projection.expr {
-                    if let Expr::Alias(alias) = expr {
-                        let column_name = alias.name.clone();
-                        if !is_identity_assignment(
-                            &alias.expr,
-                            &column_name,
-                            &target_refs,
-                        ) {
-                            let assignment_expr = normalize_update_assignment_expr(
-                                (*alias.expr).clone(),
-                                strip_qualifiers,
-                            )?;
-                            assignments.push((column_name, assignment_expr));
-                        }
-                    }
-                }
+                append_update_assignments(
+                    &mut assignments,
+                    projection,
+                    &target_refs,
+                    strip_qualifiers,
+                )?;
                 return Ok(TreeNodeRecursion::Stop);
             }
             Ok(TreeNodeRecursion::Continue)
@@ -2320,6 +2300,31 @@ fn extract_update_assignments(
     }
 
     Ok(assignments)
+}
+
+fn append_update_assignments(
+    assignments: &mut Vec<(String, Expr)>,
+    projection: &Projection,
+    target_refs: &[TableReference],
+    strip_qualifiers: bool,
+) -> Result<()> {
+    for expr in &projection.expr {
+        if let Expr::Alias(alias) = expr {
+            // The alias name is the column name being updated
+            // The inner expression is the new value
+            let column_name = alias.name.clone();
+            // Only include if it's not just a column reference to itself
+            // (those are columns that aren't being updated)
+            if !is_identity_assignment(&alias.expr, &column_name, target_refs) {
+                let assignment_expr = normalize_update_assignment_expr(
+                    (*alias.expr).clone(),
+                    strip_qualifiers,
+                )?;
+                assignments.push((column_name, assignment_expr));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn collect_target_refs(

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -777,10 +777,11 @@ impl DefaultPhysicalPlanner {
                 input,
                 ..
             }) => {
+                let analysis = analyze_dml_input(input, table_name)?;
                 // TODO: remove this guard once UPDATE ... FROM routing via
                 // TableProvider::update_from(...) and joined assignment handling land.
                 // See https://github.com/apache/datafusion/issues/19950.
-                if update_uses_joined_input(input)? {
+                if analysis.has_joined_input {
                     return not_impl_err!("UPDATE ... FROM is not supported");
                 }
 
@@ -2105,27 +2106,15 @@ fn extract_dml_filters(
     input: &Arc<LogicalPlan>,
     target: &TableReference,
 ) -> Result<Vec<Expr>> {
+    let analysis = analyze_dml_input(input, target)?;
     let mut filters = Vec::new();
-    let mut allowed_refs = vec![target.clone()];
-
-    // First pass: collect any alias references to the target table
-    input.apply(|node| {
-        if let LogicalPlan::SubqueryAlias(alias) = node
-            // Check if this alias points to the target table
-            && let LogicalPlan::TableScan(scan) = alias.input.as_ref()
-            && scan.table_name.resolved_eq(target)
-        {
-            allowed_refs.push(TableReference::bare(alias.alias.to_string()));
-        }
-        Ok(TreeNodeRecursion::Continue)
-    })?;
 
     input.apply(|node| {
         match node {
             LogicalPlan::Filter(filter) => {
                 // Split AND predicates into individual expressions
                 for predicate in split_conjunction(&filter.predicate) {
-                    if predicate_is_on_target_multi(predicate, &allowed_refs)? {
+                    if predicate_is_on_target_multi(predicate, &analysis.target_refs)? {
                         filters.push(predicate.clone());
                     }
                 }
@@ -2201,16 +2190,45 @@ fn extract_dml_filters(
         })
 }
 
-fn update_uses_joined_input(input: &Arc<LogicalPlan>) -> Result<bool> {
-    let mut has_join = false;
-    input.apply(|node| {
-        if matches!(node, LogicalPlan::Join(_)) {
-            has_join = true;
-            return Ok(TreeNodeRecursion::Stop);
+#[derive(Debug)]
+struct DmlInputAnalysis {
+    has_joined_input: bool,
+    target_refs: Vec<TableReference>,
+}
+
+fn analyze_dml_input(
+    input: &Arc<LogicalPlan>,
+    target: &TableReference,
+) -> Result<DmlInputAnalysis> {
+    let mut analysis = DmlInputAnalysis {
+        has_joined_input: false,
+        target_refs: vec![target.clone()],
+    };
+    analyze_target_branch(input, &mut analysis)?;
+    Ok(analysis)
+}
+
+fn analyze_target_branch(
+    input: &Arc<LogicalPlan>,
+    analysis: &mut DmlInputAnalysis,
+) -> Result<()> {
+    match input.as_ref() {
+        LogicalPlan::Projection(projection) => {
+            analyze_target_branch(&projection.input, analysis)
         }
-        Ok(TreeNodeRecursion::Continue)
-    })?;
-    Ok(has_join)
+        LogicalPlan::Filter(filter) => analyze_target_branch(&filter.input, analysis),
+        LogicalPlan::SubqueryAlias(alias) => {
+            analysis
+                .target_refs
+                .push(TableReference::bare(alias.alias.to_string()));
+            analyze_target_branch(&alias.input, analysis)
+        }
+        LogicalPlan::Join(join) => {
+            analysis.has_joined_input = true;
+            analyze_target_branch(&join.left, analysis)
+        }
+        _ => Ok(()),
+    }
 }
 
 /// Determine whether a predicate references only columns from the target table
@@ -2259,7 +2277,8 @@ fn strip_column_qualifiers(expr: Expr) -> Result<Expr> {
 /// Extract column assignments from an UPDATE input plan.
 /// For UPDATE statements, the SQL planner encodes assignments as a projection
 /// over the source table. This function extracts column name and expression pairs
-/// from the projection. Column qualifiers are stripped from the expressions.
+/// from the projection. Column qualifiers are stripped only for single-table
+/// updates so provider-facing expressions remain resolvable.
 ///
 fn extract_update_assignments(
     input: &Arc<LogicalPlan>,
@@ -2271,16 +2290,16 @@ fn extract_update_assignments(
     //     TableScan
     //
     // Each projected expression has an alias matching the column name
+    let analysis = analyze_dml_input(input, target)?;
     let mut assignments = Vec::new();
-    let strip_qualifiers = !update_uses_joined_input(input)?;
-    let target_refs = collect_target_refs(input, target)?;
+    let strip_qualifiers = !analysis.has_joined_input;
 
     // Find the top-level projection
     if let LogicalPlan::Projection(projection) = input.as_ref() {
         append_update_assignments(
             &mut assignments,
             projection,
-            &target_refs,
+            &analysis.target_refs,
             strip_qualifiers,
         )?;
     } else {
@@ -2290,7 +2309,7 @@ fn extract_update_assignments(
                 append_update_assignments(
                     &mut assignments,
                     projection,
-                    &target_refs,
+                    &analysis.target_refs,
                     strip_qualifiers,
                 )?;
                 return Ok(TreeNodeRecursion::Stop);
@@ -2325,37 +2344,6 @@ fn append_update_assignments(
         }
     }
     Ok(())
-}
-
-fn collect_target_refs(
-    input: &Arc<LogicalPlan>,
-    target: &TableReference,
-) -> Result<Vec<TableReference>> {
-    let mut target_refs = vec![target.clone()];
-    collect_target_refs_from_target_branch(input, &mut target_refs)?;
-    Ok(target_refs)
-}
-
-fn collect_target_refs_from_target_branch(
-    input: &Arc<LogicalPlan>,
-    target_refs: &mut Vec<TableReference>,
-) -> Result<()> {
-    match input.as_ref() {
-        LogicalPlan::Projection(projection) => {
-            collect_target_refs_from_target_branch(&projection.input, target_refs)
-        }
-        LogicalPlan::Filter(filter) => {
-            collect_target_refs_from_target_branch(&filter.input, target_refs)
-        }
-        LogicalPlan::Join(join) => {
-            collect_target_refs_from_target_branch(&join.left, target_refs)
-        }
-        LogicalPlan::SubqueryAlias(alias) => {
-            target_refs.push(TableReference::bare(alias.alias.to_string()));
-            collect_target_refs_from_target_branch(&alias.input, target_refs)
-        }
-        _ => Ok(()),
-    }
 }
 
 fn normalize_update_assignment_expr(expr: Expr, strip_qualifiers: bool) -> Result<Expr> {

--- a/datafusion/core/tests/custom_sources_cases/dml_planning.rs
+++ b/datafusion/core/tests/custom_sources_cases/dml_planning.rs
@@ -725,8 +725,6 @@ async fn test_delete_target_table_scoping() -> Result<()> {
 
 #[tokio::test]
 async fn test_update_from_drops_non_target_predicates() -> Result<()> {
-    // UPDATE ... FROM is currently not working
-    // TODO fix https://github.com/apache/datafusion/issues/19950
     let target_provider = Arc::new(CaptureUpdateProvider::new_with_filter_pushdown(
         test_schema(),
         TableProviderFilterPushDown::Exact,
@@ -743,17 +741,19 @@ async fn test_update_from_drops_non_target_predicates() -> Result<()> {
     let source_table = datafusion::datasource::empty::EmptyTable::new(source_schema);
     ctx.register_table("t2", Arc::new(source_table))?;
 
-    let result = ctx
+    let df = ctx
         .sql(
             "UPDATE t1 SET value = 1 FROM t2 \
              WHERE t1.id = t2.id AND t2.src_only = 'active' AND t1.value > 10",
         )
-        .await;
+        .await?;
 
-    // Verify UPDATE ... FROM is rejected with appropriate error
-    // TODO fix https://github.com/apache/datafusion/issues/19950
-    assert!(result.is_err());
-    let err = result.unwrap_err();
+    // Verify UPDATE ... FROM reaches logical planning but still fails closed
+    // before the unsafe single-table update runtime path can execute.
+    let err = df
+        .collect()
+        .await
+        .expect_err("UPDATE ... FROM should fail closed");
     assert!(
         err.to_string().contains("UPDATE ... FROM is not supported"),
         "Expected 'UPDATE ... FROM is not supported' error, got: {err}"

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1084,12 +1084,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
                 let update_from = from_clauses.and_then(|mut f| f.pop());
 
-                // UPDATE ... FROM is currently not working
-                // TODO fix https://github.com/apache/datafusion/issues/19950
-                if update_from.is_some() {
-                    return not_impl_err!("UPDATE ... FROM is not supported");
-                }
-
                 if returning.is_some() {
                     plan_err!("Update-returning clause not yet supported")?;
                 }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -32,6 +32,7 @@ use crate::utils::normalize_ident;
 use arrow::datatypes::{Field, FieldRef, Fields};
 use datafusion_common::error::_plan_err;
 use datafusion_common::parsers::CompressionTypeVariant;
+use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion_common::{
     Column, Constraint, Constraints, DFSchema, DFSchemaRef, DataFusionError, Result,
     ScalarValue, SchemaError, SchemaReference, TableReference, ToDFSchema, exec_err,
@@ -1912,6 +1913,12 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         statement: DFStatement,
     ) -> Result<LogicalPlan> {
         let plan = self.statement_to_plan(statement)?;
+        // TODO: remove this guard once UPDATE ... FROM routing via
+        // TableProvider::update_from(...) and joined assignment handling land.
+        // See https://github.com/apache/datafusion/issues/19950.
+        if update_uses_joined_input(&plan)? {
+            return not_impl_err!("UPDATE ... FROM is not supported");
+        }
         if matches!(plan, LogicalPlan::Explain(_)) {
             return plan_err!("Nested EXPLAINs are not supported");
         }
@@ -2565,4 +2572,25 @@ ON p.function_name = r.routine_name
             }
         }
     }
+}
+
+fn update_uses_joined_input(plan: &LogicalPlan) -> Result<bool> {
+    let LogicalPlan::Dml(DmlStatement {
+        op: WriteOp::Update,
+        input,
+        ..
+    }) = plan
+    else {
+        return Ok(false);
+    };
+
+    let mut has_join = false;
+    input.apply(|node| {
+        if matches!(node, LogicalPlan::Join(_)) {
+            has_join = true;
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(has_join)
 }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -32,7 +32,6 @@ use crate::utils::normalize_ident;
 use arrow::datatypes::{Field, FieldRef, Fields};
 use datafusion_common::error::_plan_err;
 use datafusion_common::parsers::CompressionTypeVariant;
-use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion_common::{
     Column, Constraint, Constraints, DFSchema, DFSchemaRef, DataFusionError, Result,
     ScalarValue, SchemaError, SchemaReference, TableReference, ToDFSchema, exec_err,
@@ -1913,12 +1912,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         statement: DFStatement,
     ) -> Result<LogicalPlan> {
         let plan = self.statement_to_plan(statement)?;
-        // TODO: remove this guard once UPDATE ... FROM routing via
-        // TableProvider::update_from(...) and joined assignment handling land.
-        // See https://github.com/apache/datafusion/issues/19950.
-        if update_uses_joined_input(&plan)? {
-            return not_impl_err!("UPDATE ... FROM is not supported");
-        }
         if matches!(plan, LogicalPlan::Explain(_)) {
             return plan_err!("Nested EXPLAINs are not supported");
         }
@@ -2572,25 +2565,4 @@ ON p.function_name = r.routine_name
             }
         }
     }
-}
-
-fn update_uses_joined_input(plan: &LogicalPlan) -> Result<bool> {
-    let LogicalPlan::Dml(DmlStatement {
-        op: WriteOp::Update,
-        input,
-        ..
-    }) = plan
-    else {
-        return Ok(false);
-    };
-
-    let mut has_join = false;
-    input.apply(|node| {
-        if matches!(node, LogicalPlan::Join(_)) {
-            has_join = true;
-            return Ok(TreeNodeRecursion::Stop);
-        }
-        Ok(TreeNodeRecursion::Continue)
-    })?;
-    Ok(has_join)
 }

--- a/datafusion/sql/tests/common/mod.rs
+++ b/datafusion/sql/tests/common/mod.rs
@@ -124,6 +124,18 @@ impl ContextProvider for MockContextProvider {
                 Field::new("id", DataType::Int32, false),
                 Field::new("price", DataType::Decimal128(10, 2), false),
             ])),
+            "t1" => Ok(Schema::new(vec![
+                Field::new("a", DataType::Int32, false),
+                Field::new("b", DataType::Utf8, false),
+                Field::new("c", DataType::Float64, false),
+                Field::new("d", DataType::Int32, false),
+            ])),
+            "t2" => Ok(Schema::new(vec![
+                Field::new("a", DataType::Int32, false),
+                Field::new("b", DataType::Utf8, false),
+                Field::new("c", DataType::Float64, false),
+                Field::new("d", DataType::Int32, false),
+            ])),
             "person" => Ok(Schema::new(vec![
                 Field::new("id", DataType::UInt32, false),
                 Field::new("first_name", DataType::Utf8, false),

--- a/datafusion/sql/tests/common/mod.rs
+++ b/datafusion/sql/tests/common/mod.rs
@@ -124,18 +124,6 @@ impl ContextProvider for MockContextProvider {
                 Field::new("id", DataType::Int32, false),
                 Field::new("price", DataType::Decimal128(10, 2), false),
             ])),
-            "t1" => Ok(Schema::new(vec![
-                Field::new("a", DataType::Int32, false),
-                Field::new("b", DataType::Utf8, false),
-                Field::new("c", DataType::Float64, false),
-                Field::new("d", DataType::Int32, false),
-            ])),
-            "t2" => Ok(Schema::new(vec![
-                Field::new("a", DataType::Int32, false),
-                Field::new("b", DataType::Utf8, false),
-                Field::new("c", DataType::Float64, false),
-                Field::new("d", DataType::Int32, false),
-            ])),
             "person" => Ok(Schema::new(vec![
                 Field::new("id", DataType::UInt32, false),
                 Field::new("first_name", DataType::Utf8, false),

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -29,8 +29,8 @@ use common::MockContextProvider;
 use datafusion_common::file_options::file_type::FileType;
 use datafusion_common::{DataFusionError, Result, TableReference, assert_contains};
 use datafusion_expr::{
-    ColumnarValue, CreateIndex, DdlStatement, ScalarFunctionArgs, ScalarUDF,
-    ScalarUDFImpl, Signature, TableSource, Volatility, col,
+    AggregateUDF, ColumnarValue, CreateIndex, DdlStatement, ScalarFunctionArgs,
+    ScalarUDF, ScalarUDFImpl, Signature, TableSource, Volatility, WindowUDF, col,
     logical_plan::LogicalPlan, planner::ExprPlanner, planner::TypePlanner,
     test::function_stub::sum_udaf,
 };
@@ -81,20 +81,26 @@ impl TableSource for SqlTestTableSource {
 
 struct UpdatePlanningContextProvider {
     inner: MockContextProvider,
+    update_schema: SchemaRef,
 }
 
 impl UpdatePlanningContextProvider {
     fn new(state: MockSessionState) -> Self {
         Self {
             inner: MockContextProvider { state },
+            update_schema: update_test_schema(),
         }
+    }
+
+    fn get_update_table_source(&self) -> Arc<dyn TableSource> {
+        Arc::new(SqlTestTableSource::new(Arc::clone(&self.update_schema)))
     }
 }
 
 impl ContextProvider for UpdatePlanningContextProvider {
     fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
         match name.table() {
-            "t1" | "t2" => Ok(Arc::new(SqlTestTableSource::new(update_test_schema()))),
+            "t1" | "t2" => Ok(self.get_update_table_source()),
             _ => self.inner.get_table_source(name),
         }
     }
@@ -123,11 +129,11 @@ impl ContextProvider for UpdatePlanningContextProvider {
         self.inner.get_function_meta(name)
     }
 
-    fn get_aggregate_meta(&self, name: &str) -> Option<Arc<datafusion_expr::AggregateUDF>> {
+    fn get_aggregate_meta(&self, name: &str) -> Option<Arc<AggregateUDF>> {
         self.inner.get_aggregate_meta(name)
     }
 
-    fn get_window_meta(&self, name: &str) -> Option<Arc<datafusion_expr::WindowUDF>> {
+    fn get_window_meta(&self, name: &str) -> Option<Arc<WindowUDF>> {
         self.inner.get_window_meta(name)
     }
 
@@ -3629,10 +3635,7 @@ fn logical_plan_with_dialect_and_options(
 ) -> Result<LogicalPlan> {
     let state = sql_test_state();
     let context = MockContextProvider { state };
-    let planner = SqlToRel::new_with_options(&context, options);
-    let result = DFParser::parse_sql_with_dialect(sql, dialect);
-    let mut ast = result?;
-    planner.statement_to_plan(ast.pop_front().unwrap())
+    plan_sql_with_options(sql, dialect, options, &context)
 }
 
 fn update_logical_plan_with_options(
@@ -3642,9 +3645,17 @@ fn update_logical_plan_with_options(
     let dialect = &GenericDialect {};
     let state = sql_test_state();
     let context = UpdatePlanningContextProvider::new(state);
-    let planner = SqlToRel::new_with_options(&context, options);
-    let result = DFParser::parse_sql_with_dialect(sql, dialect);
-    let mut ast = result?;
+    plan_sql_with_options(sql, dialect, options, &context)
+}
+
+fn plan_sql_with_options<S: ContextProvider>(
+    sql: &str,
+    dialect: &dyn Dialect,
+    options: ParserOptions,
+    context: &S,
+) -> Result<LogicalPlan> {
+    let planner = SqlToRel::new_with_options(context, options);
+    let mut ast = DFParser::parse_sql_with_dialect(sql, dialect)?;
     planner.statement_to_plan(ast.pop_front().unwrap())
 }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -760,6 +760,17 @@ fn plan_update_from_with_aliases() {
     );
 }
 
+#[test]
+fn explain_update_from_is_rejected() {
+    let sql = "EXPLAIN UPDATE t1 SET b = t2.b, c = t2.a, d = 1 \
+               FROM t2 WHERE t1.a = t2.a AND t1.b > 'foo' AND t2.c > 1.0";
+    let err = logical_plan(sql).expect_err("EXPLAIN UPDATE ... FROM should fail");
+    assert_snapshot!(
+        err.strip_backtrace(),
+        @r#"This feature is not implemented: UPDATE ... FROM is not supported"#
+    );
+}
+
 #[rstest]
 #[case::missing_assignment_target("UPDATE person SET doesnotexist = true")]
 #[case::missing_assignment_expression("UPDATE person SET age = doesnotexist + 42")]

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -761,13 +761,21 @@ fn plan_update_from_with_aliases() {
 }
 
 #[test]
-fn explain_update_from_is_rejected() {
+fn plan_explain_update_from() {
     let sql = "EXPLAIN UPDATE t1 SET b = t2.b, c = t2.a, d = 1 \
                FROM t2 WHERE t1.a = t2.a AND t1.b > 'foo' AND t2.c > 1.0";
-    let err = logical_plan(sql).expect_err("EXPLAIN UPDATE ... FROM should fail");
+    let plan = logical_plan(sql).unwrap();
     assert_snapshot!(
-        err.strip_backtrace(),
-        @r#"This feature is not implemented: UPDATE ... FROM is not supported"#
+        plan,
+        @r#"
+    Explain
+      Dml: op=[Update] table=[t1]
+        Projection: t1.a AS a, t2.b AS b, CAST(t2.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d
+          Filter: t1.a = t2.a AND t1.b > Utf8("foo") AND t2.c > Float64(1)
+            Cross Join:
+              TableScan: t1
+              TableScan: t2
+    "#
     );
 }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -738,6 +738,28 @@ fn plan_update() {
     );
 }
 
+#[test]
+fn plan_update_from_with_aliases() {
+    let sql = "UPDATE t1 AS target \
+               SET b = source.b, c = source.a, d = 1 \
+               FROM t2 AS source \
+               WHERE target.a = source.a AND target.b > 'foo' AND source.c > 1.0";
+    let plan = logical_plan(sql).unwrap();
+    assert_snapshot!(
+        plan,
+        @r#"
+    Dml: op=[Update] table=[t1]
+      Projection: target.a AS a, source.b AS b, CAST(source.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d
+        Filter: target.a = source.a AND target.b > Utf8("foo") AND source.c > Float64(1)
+          Cross Join:
+            SubqueryAlias: target
+              TableScan: t1
+            SubqueryAlias: source
+              TableScan: t2
+    "#
+    );
+}
+
 #[rstest]
 #[case::missing_assignment_target("UPDATE person SET doesnotexist = true")]
 #[case::missing_assignment_expression("UPDATE person SET age = doesnotexist + 42")]

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -26,16 +26,18 @@ use std::vec;
 
 use arrow::datatypes::{TimeUnit::Nanosecond, *};
 use common::MockContextProvider;
-use datafusion_common::{DataFusionError, Result, assert_contains};
+use datafusion_common::file_options::file_type::FileType;
+use datafusion_common::{DataFusionError, Result, TableReference, assert_contains};
 use datafusion_expr::{
     ColumnarValue, CreateIndex, DdlStatement, ScalarFunctionArgs, ScalarUDF,
-    ScalarUDFImpl, Signature, Volatility, col, logical_plan::LogicalPlan,
+    ScalarUDFImpl, Signature, TableSource, Volatility, col,
+    logical_plan::LogicalPlan, planner::ExprPlanner, planner::TypePlanner,
     test::function_stub::sum_udaf,
 };
 use datafusion_functions::{string, unicode};
 use datafusion_sql::{
     parser::DFParser,
-    planner::{NullOrdering, ParserOptions, SqlToRel},
+    planner::{ContextProvider, NullOrdering, ParserOptions, SqlToRel},
 };
 
 use crate::common::{CustomExprPlanner, CustomTypePlanner, MockSessionState};
@@ -55,6 +57,109 @@ use sqlparser::dialect::{Dialect, GenericDialect, HiveDialect, MySqlDialect};
 
 mod cases;
 mod common;
+
+#[derive(Debug)]
+struct SqlTestTableSource {
+    schema: SchemaRef,
+}
+
+impl SqlTestTableSource {
+    fn new(schema: SchemaRef) -> Self {
+        Self { schema }
+    }
+}
+
+impl TableSource for SqlTestTableSource {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}
+
+struct UpdatePlanningContextProvider {
+    inner: MockContextProvider,
+}
+
+impl UpdatePlanningContextProvider {
+    fn new(state: MockSessionState) -> Self {
+        Self {
+            inner: MockContextProvider { state },
+        }
+    }
+}
+
+impl ContextProvider for UpdatePlanningContextProvider {
+    fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
+        match name.table() {
+            "t1" | "t2" => Ok(Arc::new(SqlTestTableSource::new(update_test_schema()))),
+            _ => self.inner.get_table_source(name),
+        }
+    }
+
+    fn get_file_type(&self, ext: &str) -> Result<Arc<dyn FileType>> {
+        self.inner.get_file_type(ext)
+    }
+
+    fn create_cte_work_table(
+        &self,
+        name: &str,
+        schema: SchemaRef,
+    ) -> Result<Arc<dyn TableSource>> {
+        self.inner.create_cte_work_table(name, schema)
+    }
+
+    fn get_expr_planners(&self) -> &[Arc<dyn ExprPlanner>] {
+        self.inner.get_expr_planners()
+    }
+
+    fn get_type_planner(&self) -> Option<Arc<dyn TypePlanner>> {
+        self.inner.get_type_planner()
+    }
+
+    fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>> {
+        self.inner.get_function_meta(name)
+    }
+
+    fn get_aggregate_meta(&self, name: &str) -> Option<Arc<datafusion_expr::AggregateUDF>> {
+        self.inner.get_aggregate_meta(name)
+    }
+
+    fn get_window_meta(&self, name: &str) -> Option<Arc<datafusion_expr::WindowUDF>> {
+        self.inner.get_window_meta(name)
+    }
+
+    fn get_variable_type(&self, variable_names: &[String]) -> Option<DataType> {
+        self.inner.get_variable_type(variable_names)
+    }
+
+    fn options(&self) -> &datafusion_common::config::ConfigOptions {
+        self.inner.options()
+    }
+
+    fn udf_names(&self) -> Vec<String> {
+        self.inner.udf_names()
+    }
+
+    fn udaf_names(&self) -> Vec<String> {
+        self.inner.udaf_names()
+    }
+
+    fn udwf_names(&self) -> Vec<String> {
+        self.inner.udwf_names()
+    }
+}
+
+fn update_test_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, false),
+        Field::new("c", DataType::Float64, false),
+        Field::new("d", DataType::Int32, false),
+    ]))
+}
 
 #[test]
 fn parse_decimals_1() {
@@ -744,7 +849,7 @@ fn plan_update_from_with_aliases() {
                SET b = source.b, c = source.a, d = 1 \
                FROM t2 AS source \
                WHERE target.a = source.a AND target.b > 'foo' AND source.c > 1.0";
-    let plan = logical_plan(sql).unwrap();
+    let plan = update_logical_plan(sql).unwrap();
     assert_snapshot!(
         plan,
         @r#"
@@ -764,7 +869,7 @@ fn plan_update_from_with_aliases() {
 fn plan_explain_update_from() {
     let sql = "EXPLAIN UPDATE t1 SET b = t2.b, c = t2.a, d = 1 \
                FROM t2 WHERE t1.a = t2.a AND t1.b > 'foo' AND t2.c > 1.0";
-    let plan = logical_plan(sql).unwrap();
+    let plan = update_logical_plan(sql).unwrap();
     assert_snapshot!(
         plan,
         @r#"
@@ -3499,6 +3604,10 @@ fn logical_plan(sql: &str) -> Result<LogicalPlan> {
     logical_plan_with_options(sql, ParserOptions::default())
 }
 
+fn update_logical_plan(sql: &str) -> Result<LogicalPlan> {
+    update_logical_plan_with_options(sql, ParserOptions::default())
+}
+
 fn logical_plan_with_options(sql: &str, options: ParserOptions) -> Result<LogicalPlan> {
     let dialect = &GenericDialect {};
     logical_plan_with_dialect_and_options(sql, dialect, options)
@@ -3518,7 +3627,29 @@ fn logical_plan_with_dialect_and_options(
     dialect: &dyn Dialect,
     options: ParserOptions,
 ) -> Result<LogicalPlan> {
-    let state = MockSessionState::default()
+    let state = sql_test_state();
+    let context = MockContextProvider { state };
+    let planner = SqlToRel::new_with_options(&context, options);
+    let result = DFParser::parse_sql_with_dialect(sql, dialect);
+    let mut ast = result?;
+    planner.statement_to_plan(ast.pop_front().unwrap())
+}
+
+fn update_logical_plan_with_options(
+    sql: &str,
+    options: ParserOptions,
+) -> Result<LogicalPlan> {
+    let dialect = &GenericDialect {};
+    let state = sql_test_state();
+    let context = UpdatePlanningContextProvider::new(state);
+    let planner = SqlToRel::new_with_options(&context, options);
+    let result = DFParser::parse_sql_with_dialect(sql, dialect);
+    let mut ast = result?;
+    planner.statement_to_plan(ast.pop_front().unwrap())
+}
+
+fn sql_test_state() -> MockSessionState {
+    MockSessionState::default()
         .with_scalar_function(Arc::new(unicode::character_length().as_ref().clone()))
         .with_scalar_function(Arc::new(string::concat().as_ref().clone()))
         .with_scalar_function(Arc::new(make_udf(
@@ -3555,13 +3686,7 @@ fn logical_plan_with_dialect_and_options(
         .with_aggregate_function(grouping_udaf())
         .with_window_function(rank_udwf())
         .with_window_function(row_number_udwf())
-        .with_expr_planner(Arc::new(CoreFunctionPlanner::default()));
-
-    let context = MockContextProvider { state };
-    let planner = SqlToRel::new_with_options(&context, options);
-    let result = DFParser::parse_sql_with_dialect(sql, dialect);
-    let mut ast = result?;
-    planner.statement_to_plan(ast.pop_front().unwrap())
+        .with_expr_planner(Arc::new(CoreFunctionPlanner::default()))
 }
 
 fn make_udf(name: &'static str, args: Vec<DataType>, return_type: DataType) -> ScalarUDF {

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -67,10 +67,19 @@ logical_plan
 physical_plan_error This feature is not implemented: Physical plan does not support logical expression ScalarSubquery(<subquery>)
 
 # set from other table
-# UPDATE ... FROM is currently unsupported
-# TODO fix https://github.com/apache/datafusion/issues/19950
-query error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+# UPDATE ... FROM now reaches logical planning, but the physical planner
+# still fails closed until joined update provider support lands.
+query TT
 explain update t1 set b = t2.b, c = t2.a, d = 1 from t2 where t1.a = t2.a and t1.b > 'foo' and t2.c > 1.0;
+----
+logical_plan
+01)Dml: op=[Update] table=[t1]
+02)--Projection: t1.a AS a, t2.b AS b, CAST(t2.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d
+03)----Filter: t1.a = t2.a AND t1.b > CAST(Utf8("foo") AS Utf8View) AND t2.c > Float64(1)
+04)------Cross Join:
+05)--------TableScan: t1
+06)--------TableScan: t2
+physical_plan_error This feature is not implemented: UPDATE ... FROM is not supported
 
 # test update from other table with actual data
 statement ok
@@ -90,10 +99,20 @@ statement error DataFusion error: This feature is not implemented: Multiple tabl
 explain update t1 set b = t2.b, c = t3.a, d = 1 from t2, t3 where t1.a = t2.a and t1.a = t3.a;
 
 # test table alias
-# UPDATE ... FROM is currently unsupported
-# TODO fix https://github.com/apache/datafusion/issues/19950
-statement error DataFusion error: This feature is not implemented: UPDATE ... FROM is not supported
+# UPDATE ... FROM with aliases also reaches logical planning, but execution
+# remains blocked in the physical planner for now.
+query TT
 explain update t1 as T set b = t2.b, c = t.a, d = 1 from t2 where t.a = t2.a and t.b > 'foo' and t2.c > 1.0;
+----
+logical_plan
+01)Dml: op=[Update] table=[t1]
+02)--Projection: t.a AS a, t2.b AS b, CAST(t.a AS Float64) AS c, CAST(Int64(1) AS Int32) AS d
+03)----Filter: t.a = t2.a AND t.b > CAST(Utf8("foo") AS Utf8View) AND t2.c > Float64(1)
+04)------Cross Join:
+05)--------SubqueryAlias: t
+06)----------TableScan: t1
+07)--------TableScan: t2
+physical_plan_error This feature is not implemented: UPDATE ... FROM is not supported
 
 # test update with table alias with actual data
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #19950

---

## Rationale for this change

Previously, `UPDATE ... FROM` statements were rejected early in the SQL planner, preventing even valid single-target update cases from reaching logical planning. This blocked progress toward full support for joined updates and made it difficult to incrementally implement the feature.

Additionally, the existing assignment extraction logic stripped column qualifiers unconditionally, which caused incorrect expressions when updates referenced joined sources (e.g. `SET t1.a = t2.b`).

This PR enables logical planning for `UPDATE ... FROM` and introduces a more precise analysis of the input plan so that assignment expressions and filters are handled correctly depending on whether joins are present.

---

## What changes are included in this PR?

* **Planner enablement**

  * Removed the early rejection of `UPDATE ... FROM` in the SQL layer.
  * Logical planner now produces joined update plans (e.g. via `Cross Join` + `Filter`).

* **Fail-closed physical planning**

  * Added a guard in the physical planner to reject joined updates (`UPDATE ... FROM`) until execution support is implemented.
  * Ensures correctness by preventing unsafe execution paths.

* **DML input analysis**

  * Introduced `DmlInputAnalysis` to:

    * Detect whether the input contains joins
    * Track valid target table references and aliases
  * Added `analyze_dml_input` and `analyze_target_branch` helpers.

* **Filter extraction improvements**

  * Reworked filter extraction to use analysis-driven target reference tracking.
  * Ensures only predicates relevant to the target table are pushed down.

* **Assignment extraction overhaul**

  * Refactored assignment extraction into:

    * `find_update_projection`
    * `append_update_assignments`
    * `extract_update_assignments_with_analysis`
  * Preserves qualifiers for joined-source expressions.
  * Strips qualifiers only for single-table updates to maintain provider compatibility.
  * Improved identity-assignment detection to respect table references.

* **SQL planning tests**

  * Added logical plan tests verifying:

    * `UPDATE ... FROM` with joins
    * Alias handling
    * `EXPLAIN UPDATE ... FROM`

* **Physical planner and DML tests**

  * Updated tests to assert fail-closed behavior for joined updates.
  * Added coverage for:

    * joined assignment preservation (`t2.col`)
    * alias-qualified references
    * same-name column disambiguation
    * self-joins
    * single-table qualifier stripping

---

## Are these changes tested?

Yes.

This PR adds and updates comprehensive test coverage across both SQL and physical planning layers:

* Logical plan tests confirm that `UPDATE ... FROM` is now accepted and produces the expected plan structure.
* Physical planner tests verify that execution still fails with a clear error (`UPDATE ... FROM is not supported`).
* Unit tests validate assignment extraction behavior for:

  * joined sources
  * aliases
  * column name conflicts
  * self-joins
  * single-table updates

These tests ensure both correctness and safe incremental rollout of the feature.

---

## Are there any user-facing changes?

Yes.

* `UPDATE ... FROM` is no longer rejected during SQL parsing/planning.
* Users can now run `EXPLAIN UPDATE ... FROM` and inspect logical plans.
* Execution of such queries still fails with:

  ```
  This feature is not implemented: UPDATE ... FROM is not supported
  ```

This provides improved visibility while maintaining safe behavior until full execution support is implemented.

---

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
