### PR TITLE
port 52.5.0 changelog to main

### DIFF
--- a/dev/changelog/52.5.0.md
+++ b/dev/changelog/52.5.0.md
@@ -1,0 +1,45 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Apache DataFusion 52.5.0 Changelog
+
+This release consists of 8 commits from 3 contributors. See credits at the end of this changelog for more information.
+
+See the [upgrade guide](https://datafusion.apache.org/library-user-guide/upgrading.html) for information on how to upgrade from previous versions.
+
+**Other:**
+
+- [branch-52] Fix push_down_filter for children with non-empty fetch fields (#21057) [#21141](https://github.com/apache/datafusion/pull/21141) (hareshkh)
+- [branch-52] Substrait join consumer should not merge nullability of join keys (#21121) [#21161](https://github.com/apache/datafusion/pull/21161) (hareshkh)
+- [branch-52] Fix incorrect regex pattern in regex_replace_posix_groups (#19827) [#21396](https://github.com/apache/datafusion/pull/21396) (alamb)
+- [branch-52] fix: Fix panic in regexp_like() (#20200) [#21397](https://github.com/apache/datafusion/pull/21397) (alamb)
+- [branch-52] fix: use spill writer's schema instead of the first batch schema for spill files (#21293) [#21403](https://github.com/apache/datafusion/pull/21403) (alamb)
+- [branch-52] chore: update deps for cargo audit [#21415](https://github.com/apache/datafusion/pull/21415) (alamb)
+- [branch-52] Restore Sort unparser guard for correct ORDER BY placement (#20658) [#21358](https://github.com/apache/datafusion/pull/21358) (alamb)
+- [BRANCH-52] fix: foreign inner ffi types [#21439](https://github.com/apache/datafusion/pull/21439) (timsaucer)
+
+Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
+
+```
+     5  Andrew Lamb
+     2  Haresh Khanna
+     1  Tim Saucer
+```
+
+Thank you also to everyone who contributed in other ways such as filing issues, reviewing PRs, and providing feedback on this release.


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #21078.

## Rationale for this change

The `branch-52` release work added the `52.5.0` changelog in #21407, and that changelog should also be present on `main`.

## What changes are included in this PR?

This PR ports `dev/changelog/52.5.0.md` from #21407 onto `main`.

Implementation note: I used `git cherry-pick -n` of the merged `branch-52` commit and kept only the changelog file, discarding the version and config changes that do not belong on `main`.

## Are these changes tested?

This is a documentation-only chabge

## Are there any user-facing changes?

Yes. The `52.5.0` changelog is now available on `main`.
