### PR TITLE
fix(spark): add custom nullability to SparkMakeInterval

### DIFF
--- a/datafusion/spark/src/function/datetime/make_interval.rs
+++ b/datafusion/spark/src/function/datetime/make_interval.rs
@@ -20,12 +20,14 @@ use std::sync::Arc;
 use arrow::array::{Array, ArrayRef, IntervalMonthDayNanoBuilder, PrimitiveArray};
 use arrow::datatypes::DataType::Interval;
 use arrow::datatypes::IntervalUnit::MonthDayNano;
-use arrow::datatypes::{DataType, IntervalMonthDayNano};
+use arrow::datatypes::{DataType, Field, FieldRef, IntervalMonthDayNano};
 use datafusion_common::types::{NativeType, logical_float64, logical_int32};
-use datafusion_common::{DataFusionError, Result, ScalarValue, plan_datafusion_err};
+use datafusion_common::{
+    DataFusionError, Result, ScalarValue, internal_err, plan_datafusion_err,
+};
 use datafusion_expr::{
-    Coercion, ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
-    TypeSignatureClass, Volatility,
+    Coercion, ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl,
+    Signature, TypeSignature, TypeSignatureClass, Volatility,
 };
 use datafusion_functions::utils::make_scalar_function;
 
@@ -114,7 +116,28 @@ impl ScalarUDFImpl for SparkMakeInterval {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(Interval(MonthDayNano))
+        internal_err!("return_field_from_args should be used instead")
+    }
+
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+        let has_non_finite_secs = args
+            .scalar_arguments
+            .get(6)
+            .and_then(|arg| {
+                arg.map(|scalar| match scalar {
+                    ScalarValue::Float64(Some(v)) => !v.is_finite(),
+                    ScalarValue::Float32(Some(v)) => !v.is_finite(),
+                    _ => false,
+                })
+            })
+            .unwrap_or(false);
+        let nullable =
+            has_non_finite_secs || args.arg_fields.iter().any(|f| f.is_nullable());
+        Ok(Arc::new(Field::new(
+            self.name(),
+            Interval(MonthDayNano),
+            nullable,
+        )))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -271,6 +294,7 @@ mod tests {
     use datafusion_common::{
         Result, assert_eq_or_internal_err, internal_datafusion_err, internal_err,
     };
+    use datafusion_expr::ReturnFieldArgs;
 
     use super::*;
     fn run_make_interval_month_day_nano(arrs: Vec<ArrayRef>) -> Result<ArrayRef> {
@@ -598,6 +622,72 @@ mod tests {
                 );
             }
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn return_field_respects_nullability() -> Result<()> {
+        let udf = SparkMakeInterval::new();
+
+        // All nullable inputs -> nullable output
+        let arg_fields = vec![
+            Arc::new(Field::new("years", DataType::Int32, true)),
+            Arc::new(Field::new("months", DataType::Int32, true)),
+            Arc::new(Field::new("weeks", DataType::Int32, true)),
+            Arc::new(Field::new("days", DataType::Int32, true)),
+            Arc::new(Field::new("hours", DataType::Int32, true)),
+            Arc::new(Field::new("mins", DataType::Int32, true)),
+            Arc::new(Field::new("secs", DataType::Float64, true)),
+        ];
+
+        let out = udf.return_field_from_args(ReturnFieldArgs {
+            arg_fields: &arg_fields,
+            scalar_arguments: &[None, None, None, None, None, None, None],
+        })?;
+        assert!(out.is_nullable());
+        assert_eq!(out.data_type(), &Interval(MonthDayNano));
+
+        // Non-nullable inputs -> non-nullable output
+        let non_nullable_arg_fields = vec![
+            Arc::new(Field::new("years", DataType::Int32, false)),
+            Arc::new(Field::new("months", DataType::Int32, false)),
+            Arc::new(Field::new("weeks", DataType::Int32, false)),
+            Arc::new(Field::new("days", DataType::Int32, false)),
+            Arc::new(Field::new("hours", DataType::Int32, false)),
+            Arc::new(Field::new("mins", DataType::Int32, false)),
+            Arc::new(Field::new("secs", DataType::Float64, false)),
+        ];
+
+        let out = udf.return_field_from_args(ReturnFieldArgs {
+            arg_fields: &non_nullable_arg_fields,
+            scalar_arguments: &[None, None, None, None, None, None, None],
+        })?;
+        assert!(!out.is_nullable());
+
+        // Non-finite secs scalar should force nullable even if fields are non-nullable
+        let scalar_values = [
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(ScalarValue::Float64(Some(f64::NAN))),
+        ];
+        let scalar_refs = scalar_values.iter().map(|v| v.as_ref()).collect::<Vec<_>>();
+        let out = udf.return_field_from_args(ReturnFieldArgs {
+            arg_fields: &non_nullable_arg_fields,
+            scalar_arguments: &scalar_refs,
+        })?;
+        assert!(out.is_nullable());
+
+        // Zero-arg call (defaults) should be non-nullable
+        let out = udf.return_field_from_args(ReturnFieldArgs {
+            arg_fields: &[],
+            scalar_arguments: &[],
+        })?;
+        assert!(!out.is_nullable());
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #19155.

## Rationale for this change

SparkMakeInterval uses the default is_nullable which always returns true. Spark derives nullability from inputs: nullable only if any input is nullable or seconds contains non-finite values.

## What changes are included in this PR?

Add return_field_from_args() matching the pattern in SparkMakeDtInterval.

## Are these changes tested?

Yes, added return_field_respects_nullability test.

## Are there any user-facing changes?

No.