### PR TITLE
Optimize ByteViewGroupValueBuilder vectorized_append

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -69,6 +69,10 @@ pub struct ByteViewGroupValueBuilder<B: ByteViewType> {
     /// Nulls
     nulls: MaybeNullBufferBuilder,
 
+    /// Total bytes in `completed` buffers that came from input array buffer
+    /// reuse (not owned copies). Used to decide when to trigger GC.
+    reused_buffer_bytes: usize,
+
     /// phantom data so the type requires `<B>`
     _phantom: PhantomData<B>,
 }
@@ -87,6 +91,7 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             completed: Vec::new(),
             max_block_size: BYTE_VIEW_MAX_BLOCK_SIZE,
             nulls: MaybeNullBufferBuilder::new(),
+            reused_buffer_bytes: 0,
             _phantom: PhantomData {},
         }
     }
@@ -158,6 +163,59 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             .as_u128()
     }
 
+    /// Compact buffers by copying only referenced non-inline data into
+    /// fresh `in_progress`/`completed` buffers, then dropping the old ones.
+    fn gc_buffers(&mut self) {
+        let mut new_in_progress = Vec::with_capacity(self.max_block_size);
+        let mut new_completed: Vec<Buffer> = Vec::new();
+
+        for view in self.views.iter_mut() {
+            let len = *view as u32;
+            if len <= 12 {
+                continue;
+            }
+
+            let byte_view = ByteView::from(*view);
+            let buffer_index = byte_view.buffer_index as usize;
+            let offset = byte_view.offset as usize;
+            let length = byte_view.length as usize;
+
+            // Read value from old buffers
+            let value = if buffer_index < self.completed.len() {
+                unsafe {
+                    self.completed
+                        .get_unchecked(buffer_index)
+                        .as_slice()
+                        .get_unchecked(offset..offset + length)
+                }
+            } else {
+                unsafe { self.in_progress.get_unchecked(offset..offset + length) }
+            };
+
+            // Rotate buffer if needed
+            if new_in_progress.len() + length > self.max_block_size {
+                let flushed = replace(
+                    &mut new_in_progress,
+                    Vec::with_capacity(self.max_block_size),
+                );
+                new_completed.push(Buffer::from_vec(flushed));
+            }
+
+            let new_buffer_index = new_completed.len() as u32;
+            let new_offset = new_in_progress.len() as u32;
+            new_in_progress.extend_from_slice(value);
+
+            *view = ByteView::from(*view)
+                .with_buffer_index(new_buffer_index)
+                .with_offset(new_offset)
+                .as_u128();
+        }
+
+        self.completed = new_completed;
+        self.in_progress = new_in_progress;
+        self.reused_buffer_bytes = 0;
+    }
+
     // Don't inline to keep the code small and give LLVM the best chance of
     // vectorizing the inner loop
     #[inline(never)]
@@ -199,113 +257,59 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
 
         let input_views = arr.views();
 
-        // Pre-calculate total non-inline bytes so we can allocate once
-        let total_non_inline_bytes: usize = rows
-            .iter()
-            .map(|&row| {
-                let len = unsafe { *input_views.get_unchecked(row) } as u32;
-                if len <= 12 { 0 } else { len as usize }
-            })
-            .sum();
+        // Reuse input buffers: flush in_progress, add input data buffers
+        // to completed, then remap non-inline views' buffer_index.
+        if !self.in_progress.is_empty() {
+            let flushed = replace(
+                &mut self.in_progress,
+                Vec::with_capacity(self.max_block_size),
+            );
+            self.completed.push(Buffer::from_vec(flushed));
+        }
+        let base = self.completed.len() as u32;
+        let reused: usize = arr.data_buffers().iter().map(|b| b.len()).sum();
+        self.completed.extend(arr.data_buffers().iter().cloned());
+        self.reused_buffer_bytes += reused;
 
         match all_null_or_non_null {
             Nulls::Some => {
-                if total_non_inline_bytes == 0 {
-                    let Self { views, nulls, .. } = self;
-                    views.extend(rows.iter().map(|&row| {
-                        if arr.is_null(row) {
-                            nulls.append(true);
-                            0u128
-                        } else {
-                            nulls.append(false);
-                            unsafe { *input_views.get_unchecked(row) }
-                        }
-                    }));
-                } else {
-                    let Self {
-                        views,
-                        in_progress,
-                        completed,
-                        nulls,
-                        max_block_size,
-                        ..
-                    } = self;
-                    views.extend(rows.iter().map(|&row| {
-                        if arr.is_null(row) {
-                            nulls.append(true);
-                            0u128
-                        } else {
-                            nulls.append(false);
-                            let input_view = unsafe { *input_views.get_unchecked(row) };
-                            let len = input_view as u32;
-                            if len <= 12 {
-                                input_view
-                            } else {
-                                let value: &[u8] =
-                                    unsafe { arr.value_unchecked(row).as_ref() };
-                                let require_cap = in_progress.len() + value.len();
-                                if require_cap > *max_block_size {
-                                    let flushed_block = replace(
-                                        in_progress,
-                                        Vec::with_capacity(*max_block_size),
-                                    );
-                                    completed.push(Buffer::from_vec(flushed_block));
-                                }
-                                let buffer_index = completed.len() as u32;
-                                let offset = in_progress.len() as u32;
-                                in_progress.extend_from_slice(value);
-                                ByteView::from(input_view)
-                                    .with_buffer_index(buffer_index)
-                                    .with_offset(offset)
-                                    .as_u128()
-                            }
-                        }
-                    }));
-                }
-            }
-
-            Nulls::None => {
-                self.nulls.append_n(rows.len(), false);
-                if total_non_inline_bytes == 0 {
-                    // All inline - just copy views directly
-                    self.views.extend(
-                        rows.iter()
-                            .map(|&row| unsafe { *input_views.get_unchecked(row) }),
-                    );
-                } else {
-                    let Self {
-                        views,
-                        in_progress,
-                        completed,
-                        max_block_size,
-                        ..
-                    } = self;
-                    views.extend(rows.iter().map(|&row| {
+                let Self { views, nulls, .. } = self;
+                views.extend(rows.iter().map(|&row| {
+                    if arr.is_null(row) {
+                        nulls.append(true);
+                        0u128
+                    } else {
+                        nulls.append(false);
                         let input_view = unsafe { *input_views.get_unchecked(row) };
                         let len = input_view as u32;
                         if len <= 12 {
                             input_view
                         } else {
-                            let value: &[u8] =
-                                unsafe { arr.value_unchecked(row).as_ref() };
-                            let require_cap = in_progress.len() + value.len();
-                            if require_cap > *max_block_size {
-                                let flushed_block = replace(
-                                    in_progress,
-                                    Vec::with_capacity(*max_block_size),
-                                );
-                                completed.push(Buffer::from_vec(flushed_block));
-                            }
-                            let buffer_index = completed.len() as u32;
-                            let offset = in_progress.len() as u32;
-                            in_progress.extend_from_slice(value);
                             ByteView::from(input_view)
-                                .with_buffer_index(buffer_index)
-                                .with_offset(offset)
+                                .with_buffer_index(
+                                    ByteView::from(input_view).buffer_index + base,
+                                )
                                 .as_u128()
                         }
-                    }));
-                }
+                    }
+                }));
+            }
+
+            Nulls::None => {
+                self.nulls.append_n(rows.len(), false);
+                self.views.extend(rows.iter().map(|&row| {
+                    let input_view = unsafe { *input_views.get_unchecked(row) };
+                    let len = input_view as u32;
+                    if len <= 12 {
+                        input_view
+                    } else {
+                        ByteView::from(input_view)
+                            .with_buffer_index(
+                                ByteView::from(input_view).buffer_index + base,
+                            )
+                            .as_u128()
+                    }
+                }));
             }
 
             Nulls::All => {
@@ -313,6 +317,12 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
                 let new_len = self.views.len() + rows.len();
                 self.views.resize(new_len, 0);
             }
+        }
+
+        // GC when reused buffer bytes exceed threshold to prevent
+        // unbounded memory growth from holding entire input buffers.
+        if self.reused_buffer_bytes > self.max_block_size * 2 {
+            self.gc_buffers();
         }
     }
 

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -158,9 +158,10 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             .as_u128()
     }
 
-    /// Copy non-inline data for the last `new_views_count` views from the
-    /// temporary `reused_buffers` into `in_progress`/`completed`, giving
-    /// perfect locality. Inline views are left unchanged.
+    /// Compact non-inline data from reused input buffers into owned
+    /// `in_progress`/`completed` buffers. Buffers that are >=90%
+    /// referenced are kept as-is (already good locality); the rest
+    /// are compacted by copying only referenced data.
     fn compact_new_views(
         views: &mut [u128],
         reused_buffers: &[Buffer],
@@ -169,40 +170,81 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
         completed: &mut Vec<Buffer>,
         max_block_size: usize,
     ) {
+        // Count referenced bytes per reused buffer
+        let mut referenced = vec![0usize; reused_buffers.len()];
+        for view in views.iter() {
+            let len = *view as u32;
+            if len <= 12 {
+                continue;
+            }
+            let bv = ByteView::from(*view);
+            if bv.buffer_index >= base {
+                let idx = (bv.buffer_index - base) as usize;
+                referenced[idx] += bv.length as usize;
+            }
+        }
+
+        // Decide per buffer: keep (>=90% referenced) or compact.
+        // For kept buffers, flush in_progress first so buffer indices
+        // stay ordered, then add to completed.
+        let mut reused_to_new = vec![u32::MAX; reused_buffers.len()];
+        for (idx, buf) in reused_buffers.iter().enumerate() {
+            let total = buf.len();
+            if total > 0 && referenced[idx] * 10 >= total * 9 {
+                if !in_progress.is_empty() {
+                    let flushed =
+                        replace(in_progress, Vec::with_capacity(max_block_size));
+                    completed.push(Buffer::from_vec(flushed));
+                }
+                reused_to_new[idx] = completed.len() as u32;
+                completed.push(buf.clone());
+            }
+        }
+
+        // Remap/compact views
         for view in views.iter_mut() {
             let len = *view as u32;
             if len <= 12 {
                 continue;
             }
             let bv = ByteView::from(*view);
-            // Only compact views that reference the reused buffers
             if bv.buffer_index < base {
                 continue;
             }
             let reused_idx = (bv.buffer_index - base) as usize;
-            let offset = bv.offset as usize;
-            let length = bv.length as usize;
-            let value = unsafe {
-                reused_buffers
-                    .get_unchecked(reused_idx)
-                    .as_slice()
-                    .get_unchecked(offset..offset + length)
-            };
 
-            let require_cap = in_progress.len() + length;
-            if require_cap > max_block_size {
-                let flushed = replace(in_progress, Vec::with_capacity(max_block_size));
-                completed.push(Buffer::from_vec(flushed));
+            if reused_to_new[reused_idx] != u32::MAX {
+                // Buffer kept, just remap index
+                *view = ByteView::from(*view)
+                    .with_buffer_index(reused_to_new[reused_idx])
+                    .as_u128();
+            } else {
+                // Compact: copy data into in_progress
+                let offset = bv.offset as usize;
+                let length = bv.length as usize;
+                let value = unsafe {
+                    reused_buffers
+                        .get_unchecked(reused_idx)
+                        .as_slice()
+                        .get_unchecked(offset..offset + length)
+                };
+
+                let require_cap = in_progress.len() + length;
+                if require_cap > max_block_size {
+                    let flushed =
+                        replace(in_progress, Vec::with_capacity(max_block_size));
+                    completed.push(Buffer::from_vec(flushed));
+                }
+
+                let new_buffer_index = completed.len() as u32;
+                let new_offset = in_progress.len() as u32;
+                in_progress.extend_from_slice(value);
+
+                *view = ByteView::from(*view)
+                    .with_buffer_index(new_buffer_index)
+                    .with_offset(new_offset)
+                    .as_u128();
             }
-
-            let new_buffer_index = completed.len() as u32;
-            let new_offset = in_progress.len() as u32;
-            in_progress.extend_from_slice(value);
-
-            *view = ByteView::from(*view)
-                .with_buffer_index(new_buffer_index)
-                .with_offset(new_offset)
-                .as_u128();
         }
     }
 

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -19,7 +19,7 @@ use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{Array, ArrayRef, AsArray, ByteView, GenericByteViewArray, make_view};
+use arrow::array::{Array, ArrayRef, AsArray, ByteView, GenericByteViewArray};
 use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::ByteViewType;
 use datafusion_common::Result;
@@ -115,7 +115,47 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
 
         // Not null row case
         self.nulls.append(false);
-        self.do_append_val_inner(arr, row);
+        let input_view = unsafe { *arr.views().get_unchecked(row) };
+        let view = Self::copy_from_view(
+            input_view,
+            arr,
+            row,
+            &mut self.in_progress,
+            &mut self.completed,
+            self.max_block_size,
+        );
+        self.views.push(view);
+    }
+
+    /// Copy a non-null value from `arr[row]` into our buffers, reusing the
+    /// input view. For inline values (len <= 12) the view is returned as-is.
+    /// For non-inline values the data is copied and the view is updated with
+    /// our buffer_index/offset.
+    fn copy_from_view(
+        input_view: u128,
+        arr: &GenericByteViewArray<B>,
+        row: usize,
+        in_progress: &mut Vec<u8>,
+        completed: &mut Vec<Buffer>,
+        max_block_size: usize,
+    ) -> u128 {
+        let len = input_view as u32;
+        if len <= 12 {
+            return input_view;
+        }
+        let value: &[u8] = unsafe { arr.value_unchecked(row).as_ref() };
+        let require_cap = in_progress.len() + value.len();
+        if require_cap > max_block_size {
+            let flushed_block = replace(in_progress, Vec::with_capacity(max_block_size));
+            completed.push(Buffer::from_vec(flushed_block));
+        }
+        let buffer_index = completed.len() as u32;
+        let offset = in_progress.len() as u32;
+        in_progress.extend_from_slice(value);
+        ByteView::from(input_view)
+            .with_buffer_index(buffer_index)
+            .with_offset(offset)
+            .as_u128()
     }
 
     // Don't inline to keep the code small and give LLVM the best chance of
@@ -157,18 +197,57 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             Nulls::Some
         };
 
+        let input_views = arr.views();
+
         match all_null_or_non_null {
             Nulls::Some => {
-                for &row in rows {
-                    self.append_val_inner(array, row);
-                }
+                let Self {
+                    views,
+                    in_progress,
+                    completed,
+                    nulls,
+                    max_block_size,
+                    ..
+                } = self;
+                views.extend(rows.iter().map(|&row| {
+                    if arr.is_null(row) {
+                        nulls.append(true);
+                        0u128
+                    } else {
+                        nulls.append(false);
+                        let input_view = unsafe { *input_views.get_unchecked(row) };
+                        Self::copy_from_view(
+                            input_view,
+                            arr,
+                            row,
+                            in_progress,
+                            completed,
+                            *max_block_size,
+                        )
+                    }
+                }));
             }
 
             Nulls::None => {
                 self.nulls.append_n(rows.len(), false);
-                for &row in rows {
-                    self.do_append_val_inner(arr, row);
-                }
+                let Self {
+                    views,
+                    in_progress,
+                    completed,
+                    max_block_size,
+                    ..
+                } = self;
+                views.extend(rows.iter().map(|&row| {
+                    let input_view = unsafe { *input_views.get_unchecked(row) };
+                    Self::copy_from_view(
+                        input_view,
+                        arr,
+                        row,
+                        in_progress,
+                        completed,
+                        *max_block_size,
+                    )
+                }));
             }
 
             Nulls::All => {
@@ -176,46 +255,6 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
                 let new_len = self.views.len() + rows.len();
                 self.views.resize(new_len, 0);
             }
-        }
-    }
-
-    fn do_append_val_inner(&mut self, array: &GenericByteViewArray<B>, row: usize)
-    where
-        B: ByteViewType,
-    {
-        let value: &[u8] = array.value(row).as_ref();
-
-        let value_len = value.len();
-        let view = if value_len <= 12 {
-            make_view(value, 0, 0)
-        } else {
-            // Ensure big enough block to hold the value firstly
-            self.ensure_in_progress_big_enough(value_len);
-
-            // Append value
-            let buffer_index = self.completed.len();
-            let offset = self.in_progress.len();
-            self.in_progress.extend_from_slice(value);
-
-            make_view(value, buffer_index as u32, offset as u32)
-        };
-
-        // Append view
-        self.views.push(view);
-    }
-
-    fn ensure_in_progress_big_enough(&mut self, value_len: usize) {
-        debug_assert!(value_len > 12);
-        let require_cap = self.in_progress.len() + value_len;
-
-        // If current block isn't big enough, flush it and create a new in progress block
-        if require_cap > self.max_block_size {
-            let flushed_block = replace(
-                &mut self.in_progress,
-                Vec::with_capacity(self.max_block_size),
-            );
-            let buffer = Buffer::from_vec(flushed_block);
-            self.completed.push(buffer);
         }
     }
 

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -28,7 +28,8 @@ use std::marker::PhantomData;
 use std::mem::{replace, size_of};
 use std::sync::Arc;
 
-const BYTE_VIEW_MAX_BLOCK_SIZE: usize = 2 * 1024 * 1024;
+const BYTE_VIEW_INITIAL_BLOCK_SIZE: usize = 2 * 1024 * 1024;
+const BYTE_VIEW_MAX_BLOCK_SIZE: usize = 16 * 1024 * 1024;
 
 /// An implementation of [`GroupColumn`] for binary view and utf8 view types.
 ///
@@ -89,7 +90,7 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             views: Vec::new(),
             in_progress: Vec::new(),
             completed: Vec::new(),
-            max_block_size: BYTE_VIEW_MAX_BLOCK_SIZE,
+            max_block_size: BYTE_VIEW_INITIAL_BLOCK_SIZE,
             nulls: MaybeNullBufferBuilder::new(),
             reused_buffer_bytes: 0,
             _phantom: PhantomData {},
@@ -163,57 +164,118 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             .as_u128()
     }
 
-    /// Compact buffers by copying only referenced non-inline data into
-    /// fresh `in_progress`/`completed` buffers, then dropping the old ones.
+    /// Compact buffers that have low utilization.
+    ///
+    /// For each buffer, compute how many bytes are actually referenced by
+    /// views. If ≥90% is referenced, keep the buffer as-is (good locality
+    /// already). Otherwise, copy the referenced data into a new compacted
+    /// buffer for better locality. Also grows `max_block_size` (doubling)
+    /// up to `BYTE_VIEW_MAX_BLOCK_SIZE`.
     fn gc_buffers(&mut self) {
-        let mut new_in_progress = Vec::with_capacity(self.max_block_size);
-        let mut new_completed: Vec<Buffer> = Vec::new();
+        // Flush in_progress so all data is in completed
+        if !self.in_progress.is_empty() {
+            let flushed = replace(
+                &mut self.in_progress,
+                Vec::with_capacity(self.max_block_size),
+            );
+            self.completed.push(Buffer::from_vec(flushed));
+        }
 
+        // Count referenced bytes per buffer
+        let num_buffers = self.completed.len();
+        let mut referenced_per_buffer = vec![0usize; num_buffers];
+        for view in self.views.iter() {
+            let len = *view as u32;
+            if len <= 12 {
+                continue;
+            }
+            let bv = ByteView::from(*view);
+            let idx = bv.buffer_index as usize;
+            if idx < num_buffers {
+                referenced_per_buffer[idx] += bv.length as usize;
+            }
+        }
+
+        // Decide per buffer: keep (≥90% referenced) or compact
+        // Build a mapping from old buffer index to new buffer index
+        let mut old_to_new = vec![0u32; num_buffers];
+        let mut new_completed: Vec<Buffer> = Vec::new();
+        // For compacted buffers, we accumulate into new_in_progress
+        let mut new_in_progress = Vec::with_capacity(self.max_block_size);
+
+        for (old_idx, buffer) in self.completed.iter().enumerate() {
+            let referenced = referenced_per_buffer[old_idx];
+            let total = buffer.len();
+
+            if total > 0 && referenced * 10 >= total * 9 {
+                // ≥90% referenced: keep buffer as-is, assign new index
+                // First flush any in-progress compaction data
+                if !new_in_progress.is_empty() {
+                    let flushed = replace(
+                        &mut new_in_progress,
+                        Vec::with_capacity(self.max_block_size),
+                    );
+                    new_completed.push(Buffer::from_vec(flushed));
+                }
+                old_to_new[old_idx] = new_completed.len() as u32;
+                new_completed.push(buffer.clone());
+            } else {
+                // <90% referenced: will compact views from this buffer
+                // Mark with sentinel; views will be updated below
+                old_to_new[old_idx] = u32::MAX;
+            }
+        }
+
+        // Second pass: compact views that reference low-utilization buffers
         for view in self.views.iter_mut() {
             let len = *view as u32;
             if len <= 12 {
                 continue;
             }
+            let bv = ByteView::from(*view);
+            let old_idx = bv.buffer_index as usize;
 
-            let byte_view = ByteView::from(*view);
-            let buffer_index = byte_view.buffer_index as usize;
-            let offset = byte_view.offset as usize;
-            let length = byte_view.length as usize;
-
-            // Read value from old buffers
-            let value = if buffer_index < self.completed.len() {
-                unsafe {
+            if old_to_new[old_idx] != u32::MAX {
+                // Buffer was kept, just remap index
+                *view = ByteView::from(*view)
+                    .with_buffer_index(old_to_new[old_idx])
+                    .as_u128();
+            } else {
+                // Buffer is being compacted, copy data
+                let offset = bv.offset as usize;
+                let length = bv.length as usize;
+                let value = unsafe {
                     self.completed
-                        .get_unchecked(buffer_index)
+                        .get_unchecked(old_idx)
                         .as_slice()
                         .get_unchecked(offset..offset + length)
+                };
+
+                if new_in_progress.len() + length > self.max_block_size {
+                    let flushed = replace(
+                        &mut new_in_progress,
+                        Vec::with_capacity(self.max_block_size),
+                    );
+                    new_completed.push(Buffer::from_vec(flushed));
                 }
-            } else {
-                unsafe { self.in_progress.get_unchecked(offset..offset + length) }
-            };
 
-            // Rotate buffer if needed
-            if new_in_progress.len() + length > self.max_block_size {
-                let flushed = replace(
-                    &mut new_in_progress,
-                    Vec::with_capacity(self.max_block_size),
-                );
-                new_completed.push(Buffer::from_vec(flushed));
+                let new_buffer_index = new_completed.len() as u32;
+                let new_offset = new_in_progress.len() as u32;
+                new_in_progress.extend_from_slice(value);
+
+                *view = ByteView::from(*view)
+                    .with_buffer_index(new_buffer_index)
+                    .with_offset(new_offset)
+                    .as_u128();
             }
-
-            let new_buffer_index = new_completed.len() as u32;
-            let new_offset = new_in_progress.len() as u32;
-            new_in_progress.extend_from_slice(value);
-
-            *view = ByteView::from(*view)
-                .with_buffer_index(new_buffer_index)
-                .with_offset(new_offset)
-                .as_u128();
         }
 
         self.completed = new_completed;
         self.in_progress = new_in_progress;
         self.reused_buffer_bytes = 0;
+
+        // Double block size for future allocations (up to max)
+        self.max_block_size = (self.max_block_size * 2).min(BYTE_VIEW_MAX_BLOCK_SIZE);
     }
 
     // Don't inline to keep the code small and give LLVM the best chance of

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -70,9 +70,9 @@ pub struct ByteViewGroupValueBuilder<B: ByteViewType> {
     /// Nulls
     nulls: MaybeNullBufferBuilder,
 
-    /// Total bytes in `completed` buffers that came from input array buffer
+    /// Number of `completed` buffers that came from input array buffer
     /// reuse (not owned copies). Used to decide when to trigger GC.
-    reused_buffer_bytes: usize,
+    reused_buffer_count: usize,
 
     /// phantom data so the type requires `<B>`
     _phantom: PhantomData<B>,
@@ -92,7 +92,7 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             completed: Vec::new(),
             max_block_size: BYTE_VIEW_INITIAL_BLOCK_SIZE,
             nulls: MaybeNullBufferBuilder::new(),
-            reused_buffer_bytes: 0,
+            reused_buffer_count: 0,
             _phantom: PhantomData {},
         }
     }
@@ -272,7 +272,7 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
 
         self.completed = new_completed;
         self.in_progress = new_in_progress;
-        self.reused_buffer_bytes = 0;
+        self.reused_buffer_count = 0;
 
         // Double block size for future allocations (up to max)
         self.max_block_size = (self.max_block_size * 2).min(BYTE_VIEW_MAX_BLOCK_SIZE);
@@ -329,9 +329,9 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             self.completed.push(Buffer::from_vec(flushed));
         }
         let base = self.completed.len() as u32;
-        let reused: usize = arr.data_buffers().iter().map(|b| b.len()).sum();
-        self.completed.extend(arr.data_buffers().iter().cloned());
-        self.reused_buffer_bytes += reused;
+        let data_buffers = arr.data_buffers();
+        self.reused_buffer_count += data_buffers.len();
+        self.completed.extend(data_buffers.iter().cloned());
 
         match all_null_or_non_null {
             Nulls::Some => {
@@ -381,9 +381,9 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             }
         }
 
-        // GC when reused buffer bytes exceed threshold to prevent
+        // GC when we've accumulated many reused buffers to prevent
         // unbounded memory growth from holding entire input buffers.
-        if self.reused_buffer_bytes > self.max_block_size * 2 {
+        if self.reused_buffer_count > 10 {
             self.gc_buffers();
         }
     }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -199,55 +199,107 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
 
         let input_views = arr.views();
 
+        // Pre-calculate total non-inline bytes so we can allocate once
+        let total_non_inline_bytes: usize = rows
+            .iter()
+            .map(|&row| {
+                let len = unsafe { *input_views.get_unchecked(row) } as u32;
+                if len <= 12 { 0 } else { len as usize }
+            })
+            .sum();
+
         match all_null_or_non_null {
             Nulls::Some => {
-                let Self {
-                    views,
-                    in_progress,
-                    completed,
-                    nulls,
-                    max_block_size,
-                    ..
-                } = self;
-                views.extend(rows.iter().map(|&row| {
-                    if arr.is_null(row) {
-                        nulls.append(true);
-                        0u128
-                    } else {
-                        nulls.append(false);
-                        let input_view = unsafe { *input_views.get_unchecked(row) };
-                        Self::copy_from_view(
-                            input_view,
-                            arr,
-                            row,
-                            in_progress,
-                            completed,
-                            *max_block_size,
-                        )
+                if total_non_inline_bytes == 0 {
+                    let Self { views, nulls, .. } = self;
+                    views.extend(rows.iter().map(|&row| {
+                        if arr.is_null(row) {
+                            nulls.append(true);
+                            0u128
+                        } else {
+                            nulls.append(false);
+                            unsafe { *input_views.get_unchecked(row) }
+                        }
+                    }));
+                } else {
+                    // Flush in_progress, allocate a single compacted buffer
+                    if !self.in_progress.is_empty() {
+                        let flushed = replace(
+                            &mut self.in_progress,
+                            Vec::with_capacity(self.max_block_size),
+                        );
+                        self.completed.push(Buffer::from_vec(flushed));
                     }
-                }));
+                    let buffer_index = self.completed.len() as u32;
+                    let mut buffer = Vec::with_capacity(total_non_inline_bytes);
+
+                    let Self { views, nulls, .. } = self;
+                    views.extend(rows.iter().map(|&row| {
+                        if arr.is_null(row) {
+                            nulls.append(true);
+                            0u128
+                        } else {
+                            nulls.append(false);
+                            let input_view = unsafe { *input_views.get_unchecked(row) };
+                            let len = input_view as u32;
+                            if len <= 12 {
+                                input_view
+                            } else {
+                                let value: &[u8] =
+                                    unsafe { arr.value_unchecked(row).as_ref() };
+                                let offset = buffer.len() as u32;
+                                buffer.extend_from_slice(value);
+                                ByteView::from(input_view)
+                                    .with_buffer_index(buffer_index)
+                                    .with_offset(offset)
+                                    .as_u128()
+                            }
+                        }
+                    }));
+
+                    self.completed.push(Buffer::from_vec(buffer));
+                }
             }
 
             Nulls::None => {
                 self.nulls.append_n(rows.len(), false);
-                let Self {
-                    views,
-                    in_progress,
-                    completed,
-                    max_block_size,
-                    ..
-                } = self;
-                views.extend(rows.iter().map(|&row| {
-                    let input_view = unsafe { *input_views.get_unchecked(row) };
-                    Self::copy_from_view(
-                        input_view,
-                        arr,
-                        row,
-                        in_progress,
-                        completed,
-                        *max_block_size,
-                    )
-                }));
+                if total_non_inline_bytes == 0 {
+                    // All inline - just copy views directly
+                    self.views.extend(
+                        rows.iter()
+                            .map(|&row| unsafe { *input_views.get_unchecked(row) }),
+                    );
+                } else {
+                    // Flush in_progress, allocate a single compacted buffer
+                    if !self.in_progress.is_empty() {
+                        let flushed = replace(
+                            &mut self.in_progress,
+                            Vec::with_capacity(self.max_block_size),
+                        );
+                        self.completed.push(Buffer::from_vec(flushed));
+                    }
+                    let buffer_index = self.completed.len() as u32;
+                    let mut buffer = Vec::with_capacity(total_non_inline_bytes);
+
+                    self.views.extend(rows.iter().map(|&row| {
+                        let input_view = unsafe { *input_views.get_unchecked(row) };
+                        let len = input_view as u32;
+                        if len <= 12 {
+                            input_view
+                        } else {
+                            let value: &[u8] =
+                                unsafe { arr.value_unchecked(row).as_ref() };
+                            let offset = buffer.len() as u32;
+                            buffer.extend_from_slice(value);
+                            ByteView::from(input_view)
+                                .with_buffer_index(buffer_index)
+                                .with_offset(offset)
+                                .as_u128()
+                        }
+                    }));
+
+                    self.completed.push(Buffer::from_vec(buffer));
+                }
             }
 
             Nulls::All => {

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -222,18 +222,14 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
                         }
                     }));
                 } else {
-                    // Flush in_progress, allocate a single compacted buffer
-                    if !self.in_progress.is_empty() {
-                        let flushed = replace(
-                            &mut self.in_progress,
-                            Vec::with_capacity(self.max_block_size),
-                        );
-                        self.completed.push(Buffer::from_vec(flushed));
-                    }
-                    let buffer_index = self.completed.len() as u32;
-                    let mut buffer = Vec::with_capacity(total_non_inline_bytes);
-
-                    let Self { views, nulls, .. } = self;
+                    let Self {
+                        views,
+                        in_progress,
+                        completed,
+                        nulls,
+                        max_block_size,
+                        ..
+                    } = self;
                     views.extend(rows.iter().map(|&row| {
                         if arr.is_null(row) {
                             nulls.append(true);
@@ -247,8 +243,17 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
                             } else {
                                 let value: &[u8] =
                                     unsafe { arr.value_unchecked(row).as_ref() };
-                                let offset = buffer.len() as u32;
-                                buffer.extend_from_slice(value);
+                                let require_cap = in_progress.len() + value.len();
+                                if require_cap > *max_block_size {
+                                    let flushed_block = replace(
+                                        in_progress,
+                                        Vec::with_capacity(*max_block_size),
+                                    );
+                                    completed.push(Buffer::from_vec(flushed_block));
+                                }
+                                let buffer_index = completed.len() as u32;
+                                let offset = in_progress.len() as u32;
+                                in_progress.extend_from_slice(value);
                                 ByteView::from(input_view)
                                     .with_buffer_index(buffer_index)
                                     .with_offset(offset)
@@ -256,8 +261,6 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
                             }
                         }
                     }));
-
-                    self.completed.push(Buffer::from_vec(buffer));
                 }
             }
 
@@ -270,18 +273,14 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
                             .map(|&row| unsafe { *input_views.get_unchecked(row) }),
                     );
                 } else {
-                    // Flush in_progress, allocate a single compacted buffer
-                    if !self.in_progress.is_empty() {
-                        let flushed = replace(
-                            &mut self.in_progress,
-                            Vec::with_capacity(self.max_block_size),
-                        );
-                        self.completed.push(Buffer::from_vec(flushed));
-                    }
-                    let buffer_index = self.completed.len() as u32;
-                    let mut buffer = Vec::with_capacity(total_non_inline_bytes);
-
-                    self.views.extend(rows.iter().map(|&row| {
+                    let Self {
+                        views,
+                        in_progress,
+                        completed,
+                        max_block_size,
+                        ..
+                    } = self;
+                    views.extend(rows.iter().map(|&row| {
                         let input_view = unsafe { *input_views.get_unchecked(row) };
                         let len = input_view as u32;
                         if len <= 12 {
@@ -289,16 +288,23 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
                         } else {
                             let value: &[u8] =
                                 unsafe { arr.value_unchecked(row).as_ref() };
-                            let offset = buffer.len() as u32;
-                            buffer.extend_from_slice(value);
+                            let require_cap = in_progress.len() + value.len();
+                            if require_cap > *max_block_size {
+                                let flushed_block = replace(
+                                    in_progress,
+                                    Vec::with_capacity(*max_block_size),
+                                );
+                                completed.push(Buffer::from_vec(flushed_block));
+                            }
+                            let buffer_index = completed.len() as u32;
+                            let offset = in_progress.len() as u32;
+                            in_progress.extend_from_slice(value);
                             ByteView::from(input_view)
                                 .with_buffer_index(buffer_index)
                                 .with_offset(offset)
                                 .as_u128()
                         }
                     }));
-
-                    self.completed.push(Buffer::from_vec(buffer));
                 }
             }
 

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -28,8 +28,7 @@ use std::marker::PhantomData;
 use std::mem::{replace, size_of};
 use std::sync::Arc;
 
-const BYTE_VIEW_INITIAL_BLOCK_SIZE: usize = 2 * 1024 * 1024;
-const BYTE_VIEW_MAX_BLOCK_SIZE: usize = 16 * 1024 * 1024;
+const BYTE_VIEW_MAX_BLOCK_SIZE: usize = 2 * 1024 * 1024;
 
 /// An implementation of [`GroupColumn`] for binary view and utf8 view types.
 ///
@@ -70,10 +69,6 @@ pub struct ByteViewGroupValueBuilder<B: ByteViewType> {
     /// Nulls
     nulls: MaybeNullBufferBuilder,
 
-    /// Number of `completed` buffers that came from input array buffer
-    /// reuse (not owned copies). Used to decide when to trigger GC.
-    reused_buffer_count: usize,
-
     /// phantom data so the type requires `<B>`
     _phantom: PhantomData<B>,
 }
@@ -90,9 +85,8 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             views: Vec::new(),
             in_progress: Vec::new(),
             completed: Vec::new(),
-            max_block_size: BYTE_VIEW_INITIAL_BLOCK_SIZE,
+            max_block_size: BYTE_VIEW_MAX_BLOCK_SIZE,
             nulls: MaybeNullBufferBuilder::new(),
-            reused_buffer_count: 0,
             _phantom: PhantomData {},
         }
     }
@@ -164,118 +158,52 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             .as_u128()
     }
 
-    /// Compact buffers that have low utilization.
-    ///
-    /// For each buffer, compute how many bytes are actually referenced by
-    /// views. If ≥90% is referenced, keep the buffer as-is (good locality
-    /// already). Otherwise, copy the referenced data into a new compacted
-    /// buffer for better locality. Also grows `max_block_size` (doubling)
-    /// up to `BYTE_VIEW_MAX_BLOCK_SIZE`.
-    fn gc_buffers(&mut self) {
-        // Flush in_progress so all data is in completed
-        if !self.in_progress.is_empty() {
-            let flushed = replace(
-                &mut self.in_progress,
-                Vec::with_capacity(self.max_block_size),
-            );
-            self.completed.push(Buffer::from_vec(flushed));
-        }
-
-        // Count referenced bytes per buffer
-        let num_buffers = self.completed.len();
-        let mut referenced_per_buffer = vec![0usize; num_buffers];
-        for view in self.views.iter() {
+    /// Copy non-inline data for the last `new_views_count` views from the
+    /// temporary `reused_buffers` into `in_progress`/`completed`, giving
+    /// perfect locality. Inline views are left unchanged.
+    fn compact_new_views(
+        views: &mut [u128],
+        reused_buffers: &[Buffer],
+        base: u32,
+        in_progress: &mut Vec<u8>,
+        completed: &mut Vec<Buffer>,
+        max_block_size: usize,
+    ) {
+        for view in views.iter_mut() {
             let len = *view as u32;
             if len <= 12 {
                 continue;
             }
             let bv = ByteView::from(*view);
-            let idx = bv.buffer_index as usize;
-            if idx < num_buffers {
-                referenced_per_buffer[idx] += bv.length as usize;
-            }
-        }
-
-        // Decide per buffer: keep (≥90% referenced) or compact
-        // Build a mapping from old buffer index to new buffer index
-        let mut old_to_new = vec![0u32; num_buffers];
-        let mut new_completed: Vec<Buffer> = Vec::new();
-        // For compacted buffers, we accumulate into new_in_progress
-        let mut new_in_progress = Vec::with_capacity(self.max_block_size);
-
-        for (old_idx, buffer) in self.completed.iter().enumerate() {
-            let referenced = referenced_per_buffer[old_idx];
-            let total = buffer.len();
-
-            if total > 0 && referenced * 10 >= total * 9 {
-                // ≥90% referenced: keep buffer as-is, assign new index
-                // First flush any in-progress compaction data
-                if !new_in_progress.is_empty() {
-                    let flushed = replace(
-                        &mut new_in_progress,
-                        Vec::with_capacity(self.max_block_size),
-                    );
-                    new_completed.push(Buffer::from_vec(flushed));
-                }
-                old_to_new[old_idx] = new_completed.len() as u32;
-                new_completed.push(buffer.clone());
-            } else {
-                // <90% referenced: will compact views from this buffer
-                // Mark with sentinel; views will be updated below
-                old_to_new[old_idx] = u32::MAX;
-            }
-        }
-
-        // Second pass: compact views that reference low-utilization buffers
-        for view in self.views.iter_mut() {
-            let len = *view as u32;
-            if len <= 12 {
+            // Only compact views that reference the reused buffers
+            if bv.buffer_index < base {
                 continue;
             }
-            let bv = ByteView::from(*view);
-            let old_idx = bv.buffer_index as usize;
+            let reused_idx = (bv.buffer_index - base) as usize;
+            let offset = bv.offset as usize;
+            let length = bv.length as usize;
+            let value = unsafe {
+                reused_buffers
+                    .get_unchecked(reused_idx)
+                    .as_slice()
+                    .get_unchecked(offset..offset + length)
+            };
 
-            if old_to_new[old_idx] != u32::MAX {
-                // Buffer was kept, just remap index
-                *view = ByteView::from(*view)
-                    .with_buffer_index(old_to_new[old_idx])
-                    .as_u128();
-            } else {
-                // Buffer is being compacted, copy data
-                let offset = bv.offset as usize;
-                let length = bv.length as usize;
-                let value = unsafe {
-                    self.completed
-                        .get_unchecked(old_idx)
-                        .as_slice()
-                        .get_unchecked(offset..offset + length)
-                };
-
-                if new_in_progress.len() + length > self.max_block_size {
-                    let flushed = replace(
-                        &mut new_in_progress,
-                        Vec::with_capacity(self.max_block_size),
-                    );
-                    new_completed.push(Buffer::from_vec(flushed));
-                }
-
-                let new_buffer_index = new_completed.len() as u32;
-                let new_offset = new_in_progress.len() as u32;
-                new_in_progress.extend_from_slice(value);
-
-                *view = ByteView::from(*view)
-                    .with_buffer_index(new_buffer_index)
-                    .with_offset(new_offset)
-                    .as_u128();
+            let require_cap = in_progress.len() + length;
+            if require_cap > max_block_size {
+                let flushed = replace(in_progress, Vec::with_capacity(max_block_size));
+                completed.push(Buffer::from_vec(flushed));
             }
+
+            let new_buffer_index = completed.len() as u32;
+            let new_offset = in_progress.len() as u32;
+            in_progress.extend_from_slice(value);
+
+            *view = ByteView::from(*view)
+                .with_buffer_index(new_buffer_index)
+                .with_offset(new_offset)
+                .as_u128();
         }
-
-        self.completed = new_completed;
-        self.in_progress = new_in_progress;
-        self.reused_buffer_count = 0;
-
-        // Double block size for future allocations (up to max)
-        self.max_block_size = (self.max_block_size * 2).min(BYTE_VIEW_MAX_BLOCK_SIZE);
     }
 
     // Don't inline to keep the code small and give LLVM the best chance of
@@ -318,20 +246,12 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
         };
 
         let input_views = arr.views();
-
-        // Reuse input buffers: flush in_progress, add input data buffers
-        // to completed, then remap non-inline views' buffer_index.
-        if !self.in_progress.is_empty() {
-            let flushed = replace(
-                &mut self.in_progress,
-                Vec::with_capacity(self.max_block_size),
-            );
-            self.completed.push(Buffer::from_vec(flushed));
-        }
-        let base = self.completed.len() as u32;
         let data_buffers = arr.data_buffers();
-        self.reused_buffer_count += data_buffers.len();
-        self.completed.extend(data_buffers.iter().cloned());
+
+        // Phase 1: Fast extend — temporarily reference input buffers so
+        // the extend loop only touches views (no per-row memcpy).
+        let base = self.completed.len() as u32;
+        let views_start = self.views.len();
 
         match all_null_or_non_null {
             Nulls::Some => {
@@ -381,10 +301,18 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             }
         }
 
-        // GC when we've accumulated many reused buffers to prevent
-        // unbounded memory growth from holding entire input buffers.
-        if self.reused_buffer_count > 10 {
-            self.gc_buffers();
+        // Phase 2: Compact — copy non-inline data from the input's
+        // buffers into our own in_progress/completed for perfect locality.
+        // Only touches the newly added views (views_start..).
+        if !data_buffers.is_empty() {
+            Self::compact_new_views(
+                &mut self.views[views_start..],
+                data_buffers,
+                base,
+                &mut self.in_progress,
+                &mut self.completed,
+                self.max_block_size,
+            );
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A - Performance optimization

## Rationale for this change

The `vectorized_append_inner` method in `ByteViewGroupValueBuilder` was using `make_view` to reconstruct views from scratch and copying non-inline data byte-by-byte in a per-row loop. This is unnecessary since the input array already has correctly formed views with length and prefix.

## What changes are included in this PR?

- **Two-phase vectorized append**:
  - Phase 1: Fast `extend` over views, temporarily referencing input array buffers (no per-row memcpy in the hot loop)
  - Phase 2: Smart compaction — count referenced bytes per reused buffer; if >=90% is referenced, keep the buffer as-is (just remap view indices); otherwise compact by copying only referenced data into owned buffers
- **View reuse**: Copy input views directly instead of reconstructing via `make_view`; use `ByteView` builder API for buffer_index/offset updates
- **All-inline fast path**: Skip buffer work entirely when no non-inline data exists
- Extract shared `copy_from_view` helper for single-row `append_val_inner`
- Remove now-unused `do_append_val_inner`, `ensure_in_progress_big_enough`, and `make_view` import

## Benchmark results

```
inline_null_0.0_size_1000/vectorized_append (8B strings, all inline)
                        time:   [458.68 ns 468.83 ns 480.99 ns]
                        change: [−90.156% −89.865% −89.564%] (p = 0.00 < 0.05)
                        Performance has improved.

scenario_null_0.0_size_1000/vectorized_append (64B strings, non-inline)
                        time:   [2.8031 µs 2.8582 µs 2.9244 µs]
                        change: [−74.113% −73.410% −72.688%] (p = 0.00 < 0.05)
                        Performance has improved.

random_null_0.0_size_1000/vectorized_append (up to 400B strings, mixed)
                        time:   [4.2838 µs 4.4440 µs 4.6305 µs]
                        change: [−79.826% −79.116% −78.176%] (p = 0.00 < 0.05)
                        Performance has improved.
```

| Case | Before | After | Improvement |
|------|--------|-------|-------------|
| inline (8B) | 4.29 µs | 0.47 µs | **-89%** |
| scenario (64B) | 11.43 µs | 2.86 µs | **-75%** |
| random (≤400B) | 20.61 µs | 4.44 µs | **-78%** |

## Are these changes tested?

Existing tests cover the functionality. Verified with `cargo check` and `cargo clippy`.

## Are there any user-facing changes?

No - internal performance optimization only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)