### PR TITLE
chore: fix cargo audit and dependencies check on main

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -48,4 +48,4 @@ jobs:
       - name: Run audit check
         # Note: you can ignore specific RUSTSEC issues using the `--ignore` flag ,for example:
         # run: cargo audit --ignore RUSTSEC-2026-0001
-        run: cargo audit --ignore RUSTSEC-2024-0014
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4321,7 +4321,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest",
  "ring",
  "rustls-pki-types",
@@ -4984,9 +4984,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -5360,9 +5360,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6006,7 +6006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6225,7 +6225,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.10.0",
+ "rand 0.10.1",
  "socket2",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,6 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
- "pretty_assertions",
  "rand 0.9.2",
  "rand_distr",
  "recursive",

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -172,7 +172,6 @@ bytes = { workspace = true }
 env_logger = { workspace = true }
 glob = { workspace = true }
 insta = { workspace = true }
-pretty_assertions = "1.0"
 rand = { workspace = true, features = ["small_rng"] }
 rand_distr = "0.5"
 recursive = { workspace = true }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -3770,11 +3770,11 @@ impl PartialOrd for Aggregate {
 /// Returns 0 when no grouping set is duplicated.
 fn max_grouping_set_duplicate_ordinal(group_expr: &[Expr]) -> usize {
     if let Some(Expr::GroupingSet(GroupingSet::GroupingSets(sets))) = group_expr.first() {
-        sets.iter()
-            .map(|set| sets.iter().filter(|other| *other == set).count())
-            .max()
-            .unwrap_or(0)
-            .saturating_sub(1)
+        let mut counts: HashMap<&[Expr], usize> = HashMap::new();
+        for set in sets {
+            *counts.entry(set).or_insert(0) += 1;
+        }
+        counts.into_values().max().unwrap_or(0).saturating_sub(1)
     } else {
         0
     }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -3770,11 +3770,11 @@ impl PartialOrd for Aggregate {
 /// Returns 0 when no grouping set is duplicated.
 fn max_grouping_set_duplicate_ordinal(group_expr: &[Expr]) -> usize {
     if let Some(Expr::GroupingSet(GroupingSet::GroupingSets(sets))) = group_expr.first() {
-        let mut counts: HashMap<&[Expr], usize> = HashMap::new();
-        for set in sets {
-            *counts.entry(set).or_insert(0) += 1;
-        }
-        counts.into_values().max().unwrap_or(0).saturating_sub(1)
+        sets.iter()
+            .map(|set| sets.iter().filter(|other| *other == set).count())
+            .max()
+            .unwrap_or(0)
+            .saturating_sub(1)
     } else {
         0
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21652.
- Closes https://github.com/apache/datafusion/issues/21656

## Rationale for this change

`cargo audit` started failing on `main` due to newly published advisories 

Dependencies check is also failing

## What changes are included in this PR?

- update `rustls-webpki` from `0.103.10` to `0.103.12`
- update `rand` from `0.10.0` to `0.10.1`
- Remove unecessary ignore
- Remove unused dep

## Are these changes tested?

Yes.

By CI

## Are there any user-facing changes?

No.