### PR TITLE
test: Add test for computing min/max values for expresions

### DIFF
--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -8951,3 +8951,33 @@ GROUP BY id ORDER BY id;
 
 statement ok
 DROP TABLE first_last_value_str_tests;
+
+# Regression test for incorrect MIN/MAX folding from projected expression
+# statistics. The PR branch `aggregate-stats-single-mode-and-cast` rewrites this
+# query to unattainable literals using parquet min/max envelopes for UserID and
+# ClientIP.
+statement ok
+SET datafusion.execution.target_partitions = 1;
+
+statement ok
+CREATE EXTERNAL TABLE hits_raw
+STORED AS PARQUET
+LOCATION '../core/tests/data/clickbench_hits_10.parquet';
+
+query II
+SELECT MIN(delta), MAX(delta)
+FROM (
+  SELECT "UserID" - CAST("ClientIP" AS BIGINT) AS delta
+  FROM hits_raw
+);
+----
+-2461439044872611287 7418527518698834918
+
+statement ok
+SET datafusion.execution.target_partitions = 4;
+
+statement ok
+RESET datafusion.catalog.create_default_catalog_and_schema;
+
+statement ok
+DROP TABLE hits_raw;


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/pull/21651

## Rationale for this change

This test shows a bug in https://github.com/apache/datafusion/pull/21651 

The test passes on main but fails on that PR like this

```sql
andrewlamb@Andrews-MacBook-Pro-3:~/Software/datafusion3$ cargo test --profile=ci --test sqllogictests
    Finished `ci` profile [unoptimized] target(s) in 0.22s
     Running bin/sqllogictests.rs (target/ci/deps/sqllogictests-d8b84848b1385364)
Running with 16 test threads (available parallelism: 16)
Completed 428 test files in 4 seconds                                                                                                       External error: 1 errors in file /Users/andrewlamb/Software/datafusion3/datafusion/sqllogictest/test_files/aggregate.slt

1. query result mismatch:
[SQL] SELECT MIN(delta), MAX(delta)
FROM (
  SELECT "UserID" - CAST("ClientIP" AS BIGINT) AS delta
  FROM hits_raw
);
[Diff] (-expected|+actual)
-   -2461439044872611287 7418527518698834918
+   -2461439047704734435 7418527521343057109
at /Users/andrewlamb/Software/datafusion3/datafusion/sqllogictest/test_files/aggregate.slt:8951



Error: Execution("1 failures")
error: test failed, to rerun pass `-p datafusion-sqllogictest --test sqllogictests`

Caused by:
  process didn't exit successfully: `/Users/andrewlamb/Software/datafusion3/target/ci/deps/sqllogictests-d8b84848b1385364` (exit status: 1)
```

## What changes are included in this PR?

Add a new test

## Are these changes tested?

They are all tests
## Are there any user-facing changes?

No