### PR TITLE
fix: import from `datafusion_expr` in `make_valid_utf8`

### DIFF
--- a/datafusion/spark/src/function/string/make_valid_utf8.rs
+++ b/datafusion/spark/src/function/string/make_valid_utf8.rs
@@ -17,13 +17,15 @@
 
 use arrow::array::{ArrayRef, LargeStringArray, StringArray};
 use arrow::datatypes::{DataType, Field, FieldRef};
-use datafusion::logical_expr::{ColumnarValue, Signature, Volatility};
 use datafusion_common::cast::{
     as_binary_array, as_binary_view_array, as_large_binary_array,
 };
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{Result, internal_err};
-use datafusion_expr::{ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl};
+use datafusion_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    Volatility,
+};
 use datafusion_functions::utils::make_scalar_function;
 use std::sync::Arc;
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21685.

## Rationale for this change

Per issue. `make_valid_utf8.rs` imports from `datafusion::logical_expr`, but `datafusion` is only a dep of `datafusion-spark` behind the `core` feature, so `cargo check -p datafusion-spark` and `cargo bench -p datafusion-spark` both fail without `--all-features`. CI doesn't catch it because `datafusion-sqllogictest` pins `datafusion-spark` with `core` on.

## What changes are included in this PR?

Move the `ColumnarValue`, `Signature`, `Volatility` imports from `datafusion::logical_expr` to `datafusion_expr`, which is already imported a few lines below.

## Are these changes tested?

Covered by existing tests. Verified `cargo check -p datafusion-spark`, `cargo check -p datafusion-spark --all-targets`, and `cargo bench -p datafusion-spark` all succeed after the change, and `./dev/rust_lint.sh` passes.

## Are there any user-facing changes?

No.