### PR TITLE
fix: remove unnecessary `as_any()` to fix compilation error

### DIFF
--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -312,7 +312,7 @@ pub fn serialize_physical_expr_with_converter(
         let mut operand_refs: Vec<&Arc<dyn PhysicalExpr>> = vec![expr.right()];
         let mut current_expr: &BinaryExpr = expr;
         loop {
-            match current_expr.left().as_any().downcast_ref::<BinaryExpr>() {
+            match current_expr.left().downcast_ref::<BinaryExpr>() {
                 Some(bin) if bin.op() == op => {
                     operand_refs.push(bin.right());
                     current_expr = bin;


### PR DESCRIPTION
Merging in https://github.com/apache/datafusion/pull/21031 broke main due to https://github.com/apache/datafusion/pull/21573 landing before it