### PR TITLE
Feat/map sql extension types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -123,7 +123,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -258,7 +258,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "comfy-table",
  "half",
@@ -312,7 +312,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "arrow-string",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures",
  "once_cell",
@@ -945,12 +945,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1032,7 +1026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
- "base64 0.22.1",
+ "base64",
  "bitflags",
  "bollard-buildkit-proto",
  "bollard-stubs",
@@ -1089,7 +1083,7 @@ version = "1.52.1-rc.29.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bollard-buildkit-proto",
  "bytes",
  "prost",
@@ -1175,9 +1169,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1582,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
+checksum = "e2049d5ec0c16ffe3815be58fe6966159a0f37dcf16ae1c7330808ed7c9b71a1"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -1846,7 +1840,7 @@ dependencies = [
  "criterion",
  "foldhash 0.2.0",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "hex",
  "indexmap 2.14.0",
  "insta",
@@ -2037,7 +2031,7 @@ dependencies = [
  "arrow-flight",
  "arrow-schema",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "dashmap",
  "datafusion",
@@ -2170,7 +2164,7 @@ version = "53.1.0"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64 0.22.1",
+ "base64",
  "blake2",
  "blake3",
  "chrono",
@@ -2249,7 +2243,7 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
  "itoa",
  "log",
@@ -2343,7 +2337,7 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",
@@ -2377,7 +2371,7 @@ dependencies = [
  "criterion",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
@@ -2430,7 +2424,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",
@@ -2556,6 +2550,7 @@ name = "datafusion-sql"
 version = "53.1.0"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "bigdecimal",
  "chrono",
  "ctor",
@@ -2681,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
@@ -2709,7 +2704,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2731,11 +2726,11 @@ checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "docker_credential"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+checksum = "a4564c274ebf369f501de192b02a0b81a5c4bda375abfe526aa70fc702fa6fa0"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "serde",
  "serde_json",
 ]
@@ -2838,7 +2833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2916,13 +2911,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -3182,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3247,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3274,7 +3268,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3361,9 +3355,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -3440,7 +3434,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -3603,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3629,7 +3623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3685,16 +3679,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3762,9 +3746,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3905,10 +3889,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3925,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.13.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2c24837c4fd5ab6a31d64133eae954f5199247523cf29586117e85245c0dd3"
+checksum = "e19299f36b28d94bcf0d8b913305e2b79bd5cb53f981e3855968abfd177379cd"
 
 [[package]]
 name = "linktime-proc-macro"
@@ -3970,9 +3951,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -4000,7 +3981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4106,7 +4087,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4233,7 +4214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "form_urlencoded",
@@ -4344,7 +4325,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -4362,14 +4343,14 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.22.1",
+ "base64",
  "brotli",
  "bytes",
  "chrono",
  "flate2",
  "futures",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",
@@ -4423,7 +4404,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "898bac3fa00d0ba57a4e8289837e965baa2dee8c3749f3b11d45a64b4223d9c3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde",
 ]
 
@@ -4433,7 +4414,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8edd1efdd8ab23ba9cb9ace3d9987a72663d5d7c9f74fa00b51d6213645cf6c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde",
 ]
 
@@ -4570,12 +4551,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4636,7 +4611,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -4795,9 +4770,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -5025,15 +5000,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5121,7 +5087,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5236,14 +5202,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5534,11 +5500,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5553,9 +5519,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5595,7 +5561,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5606,7 +5572,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5660,9 +5626,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -5707,7 +5673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5808,7 +5774,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5978,7 +5944,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6149,9 +6115,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6289,13 +6255,13 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http 1.4.0",
@@ -6318,9 +6284,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -6348,20 +6314,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6573,7 +6539,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "log",
  "percent-encoding",
  "rustls",
@@ -6588,7 +6554,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http 1.4.0",
  "httparse",
  "log",
@@ -6723,9 +6689,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6736,9 +6702,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6746,9 +6712,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6756,9 +6722,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6769,18 +6735,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.68"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
+checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
 dependencies = [
  "async-trait",
  "cast",
@@ -6800,9 +6766,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.68"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
+checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6811,9 +6777,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
+checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
 
 [[package]]
 name = "wasm-encoder"
@@ -6864,9 +6830,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6884,9 +6850,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
  "libc",
  "libredox",
@@ -6917,7 +6883,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -300,7 +300,7 @@ impl LogicalPlanBuilder {
                         )?;
                     } else if !can_cast_types(&value_type, field_type) {
                         return plan_err!(
-                            "Cannot cast {} to extension type at column {}",
+                            "Cannot cast {} to extension type at {}",
                             value_type,
                             column_name
                         );
@@ -311,7 +311,7 @@ impl LogicalPlanBuilder {
                         && !can_cast_types(&value_type, field_type)
                     {
                         return plan_err!(
-                            "Cannot cast {} to {} for column {}",
+                            "Cannot cast {} to {} for {}",
                             value_type,
                             field_type,
                             column_name

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -17,12 +17,12 @@
 
 //! This module provides a builder for creating LogicalPlans
 
+use datafusion_common::metadata::check_metadata_with_storage_equal;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::iter::once;
 use std::sync::Arc;
-use datafusion_common::metadata::check_metadata_with_storage_equal;
 
 use crate::dml::CopyTo;
 use crate::expr::{Alias, PlannedReplaceSelectItem, Sort as SortExpr};
@@ -276,17 +276,21 @@ impl LogicalPlanBuilder {
             let field = schema.field(j);
             let field_type = field.data_type();
             let field_metadata = field.metadata();
-            let is_target_ext = field_metadata.contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
+            let is_target_ext = field_metadata
+                .contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
             let column_name = format!("column {}", j);
             for row in values.iter() {
                 let value = &row[j];
                 let value_type = value.get_type(schema)?;
-                if value_type == DataType::Null { continue; }
+                if value_type == DataType::Null {
+                    continue;
+                }
 
                 if is_target_ext {
                     let value_meta = value.metadata(schema)?;
                     let value_meta_map = value_meta.to_hashmap();
-                    let is_value_ext = value_meta_map.contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
+                    let is_value_ext = value_meta_map
+                        .contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
 
                     if is_value_ext && value_type == *field_type {
                         check_metadata_with_storage_equal(
@@ -296,20 +300,31 @@ impl LogicalPlanBuilder {
                             " in VALUES list",
                         )?;
                     } else if !can_cast_types(&value_type, field_type) {
-                        return plan_err!("Cannot cast {} to extension type at column {}", value_type, column_name);
+                        return plan_err!(
+                            "Cannot cast {} to extension type at column {}",
+                            value_type,
+                            column_name
+                        );
                     }
                 } else {
                     // Optimized path for standard types
-                    if !value_type.equals_datatype(field_type) && !can_cast_types(&value_type, field_type) {
-                        return plan_err!("Cannot cast {} to {} for column {}", value_type, field_type, column_name);
+                    if !value_type.equals_datatype(field_type)
+                        && !can_cast_types(&value_type, field_type)
+                    {
+                        return plan_err!(
+                            "Cannot cast {} to {} for column {}",
+                            value_type,
+                            field_type,
+                            column_name
+                        );
                     }
                 }
             }
 
             fields.push_with_metadata(
-                field_type.clone(), 
-                field.is_nullable(), 
-                Some(FieldMetadata::new_from_field(field))
+                field_type.clone(),
+                field.is_nullable(),
+                Some(FieldMetadata::new_from_field(field)),
             );
         }
 

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -56,7 +56,7 @@ use datafusion_common::file_options::file_type::FileType;
 use datafusion_common::metadata::FieldMetadata;
 use datafusion_common::{
     Column, Constraints, DFSchema, DFSchemaRef, NullEquality, Result, ScalarValue,
-    TableReference, ToDFSchema, UnnestOptions, exec_err,
+    TableReference, ToDFSchema, UnnestOptions,
     get_target_functional_dependencies, internal_datafusion_err, plan_datafusion_err,
     plan_err,
 };
@@ -278,7 +278,7 @@ impl LogicalPlanBuilder {
             let field_metadata = field.metadata();
             let is_target_ext = field_metadata
                 .contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
-            let column_name = format!("column {}", j);
+            let column_name = format!("column {j}");
             for row in values.iter() {
                 let value = &row[j];
                 let value_type = value.get_type(schema)?;

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -22,6 +22,7 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::iter::once;
 use std::sync::Arc;
+use datafusion_common::metadata::check_metadata_with_storage_equal;
 
 use crate::dml::CopyTo;
 use crate::expr::{Alias, PlannedReplaceSelectItem, Sort as SortExpr};
@@ -274,28 +275,42 @@ impl LogicalPlanBuilder {
         for j in 0..n_cols {
             let field = schema.field(j);
             let field_type = field.data_type();
-            let field_nullable = field.is_nullable();
-            let field_metadata = FieldMetadata::new_from_field(field);
+            let field_metadata = field.metadata();
+            let is_target_ext = field_metadata.contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
+            let column_name = format!("column {}", j);
             for row in values.iter() {
                 let value = &row[j];
-                let data_type = value.get_type(schema)?;
+                let value_type = value.get_type(schema)?;
+                if value_type == DataType::Null { continue; }
 
-                if !data_type.equals_datatype(field_type)
-                    && !can_cast_types(&data_type, field_type)
-                {
-                    return exec_err!(
-                        "type mismatch and can't cast to got {} and {}",
-                        data_type,
-                        field_type
-                    );
+                if is_target_ext {
+                    let value_meta = value.metadata(schema)?;
+                    let value_meta_map = value_meta.to_hashmap();
+                    let is_value_ext = value_meta_map.contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
+
+                    if is_value_ext && value_type == *field_type {
+                        check_metadata_with_storage_equal(
+                            (&value_type, Some(&value_meta_map)),
+                            (field_type, Some(field_metadata)),
+                            &column_name,
+                            " in VALUES list",
+                        )?;
+                    } else if !can_cast_types(&value_type, field_type) {
+                        return plan_err!("Cannot cast {} to extension type at column {}", value_type, column_name);
+                    }
+                } else {
+                    // Optimized path for standard types
+                    if !value_type.equals_datatype(field_type) && !can_cast_types(&value_type, field_type) {
+                        return plan_err!("Cannot cast {} to {} for column {}", value_type, field_type, column_name);
+                    }
                 }
             }
-            let metadata = if field_metadata.is_empty() {
-                None
-            } else {
-                Some(field_metadata)
-            };
-            fields.push_with_metadata(field_type.to_owned(), field_nullable, metadata);
+
+            fields.push_with_metadata(
+                field_type.clone(), 
+                field.is_nullable(), 
+                Some(FieldMetadata::new_from_field(field))
+            );
         }
 
         Self::infer_inner(values, fields, schema)

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -56,9 +56,8 @@ use datafusion_common::file_options::file_type::FileType;
 use datafusion_common::metadata::FieldMetadata;
 use datafusion_common::{
     Column, Constraints, DFSchema, DFSchemaRef, NullEquality, Result, ScalarValue,
-    TableReference, ToDFSchema, UnnestOptions,
-    get_target_functional_dependencies, internal_datafusion_err, plan_datafusion_err,
-    plan_err,
+    TableReference, ToDFSchema, UnnestOptions, get_target_functional_dependencies,
+    internal_datafusion_err, plan_datafusion_err, plan_err,
 };
 use datafusion_expr_common::type_coercion::binary::type_union_resolution;
 

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -272,8 +272,10 @@ impl LogicalPlanBuilder {
         let n_cols = values[0].len();
         let mut fields = ValuesFields::new();
         for j in 0..n_cols {
-            let field_type = schema.field(j).data_type();
-            let field_nullable = schema.field(j).is_nullable();
+            let field = schema.field(j);
+            let field_type = field.data_type();
+            let field_nullable = field.is_nullable();
+            let field_metadata = FieldMetadata::new_from_field(field);
             for row in values.iter() {
                 let value = &row[j];
                 let data_type = value.get_type(schema)?;
@@ -288,7 +290,12 @@ impl LogicalPlanBuilder {
                     );
                 }
             }
-            fields.push(field_type.to_owned(), field_nullable);
+            let metadata = if field_metadata.is_empty() {
+                None
+            } else {
+                Some(field_metadata)
+            };
+            fields.push_with_metadata(field_type.to_owned(), field_nullable, metadata);
         }
 
         Self::infer_inner(values, fields, schema)
@@ -1565,10 +1572,6 @@ struct ValuesFields {
 impl ValuesFields {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub fn push(&mut self, data_type: DataType, nullable: bool) {
-        self.push_with_metadata(data_type, nullable, None);
     }
 
     pub fn push_with_metadata(

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -52,6 +52,7 @@ recursive_protection = ["dep:recursive"]
 # They are used for testing purposes only, so they are in the dev-dependencies section.
 [dependencies]
 arrow = { workspace = true }
+arrow-schema = { workspace = true }
 bigdecimal = { workspace = true }
 chrono = { workspace = true }
 datafusion-common = { workspace = true, features = ["sql"] }

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -23,6 +23,9 @@ use std::vec;
 
 use crate::utils::make_decimal_type;
 use arrow::datatypes::*;
+use arrow_schema::extension::{
+    EXTENSION_TYPE_METADATA_KEY, EXTENSION_TYPE_NAME_KEY, ExtensionType, Json, Uuid,
+};
 use datafusion_common::TableReference;
 use datafusion_common::config::SqlParserOptions;
 use datafusion_common::datatype::{DataTypeExt, FieldExt};
@@ -658,6 +661,21 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         // If no type_planner can handle this type, use the default conversion
         match sql_type {
+            // Canonical Arrow extension types
+            SQLDataType::Uuid => Ok(Arc::new(
+                Field::new("", DataType::FixedSizeBinary(16), true).with_metadata(
+                    HashMap::from([(
+                        EXTENSION_TYPE_NAME_KEY.to_string(),
+                        Uuid::NAME.to_string(),
+                    )]),
+                ),
+            )),
+            SQLDataType::JSON => Ok(Arc::new(
+                Field::new("", DataType::Utf8, true).with_metadata(HashMap::from([
+                    (EXTENSION_TYPE_NAME_KEY.to_string(), Json::NAME.to_string()),
+                    (EXTENSION_TYPE_METADATA_KEY.to_string(), "".to_string()),
+                ])),
+            )),
             SQLDataType::Array(ArrayElemTypeDef::AngleBracket(inner_sql_type)) => {
                 // Arrays may be multi-dimensional.
                 Ok(self.convert_data_type_to_field(inner_sql_type)?.into_list())

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -27,8 +27,8 @@ use arrow_schema::extension::{ExtensionType, Json, Uuid};
 use datafusion_common::TableReference;
 use datafusion_common::config::SqlParserOptions;
 use datafusion_common::datatype::{DataTypeExt, FieldExt};
-use datafusion_common::types::{DFJson, DFUuid, DFExtensionType};
 use datafusion_common::error::add_possible_columns_to_diag;
+use datafusion_common::types::{DFExtensionType, DFJson, DFUuid};
 use datafusion_common::{DFSchema, DataFusionError, Result, not_impl_err, plan_err};
 use datafusion_common::{
     DFSchemaRef, Diagnostic, SchemaError, field_not_found, internal_err,
@@ -664,32 +664,27 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             SQLDataType::Uuid => {
                 let data_type = DataType::FixedSizeBinary(16);
                 let df_uuid = DFUuid::try_new(&data_type, Default::default())?;
-                
+
                 // Re-construct the Arrow Uuid using the validated data from df_uuid
-                let arrow_uuid = Uuid::try_new(
-                    &df_uuid.storage_type().clone(),
-                    (),
-                ).map_err(|e| DataFusionError::External(Box::new(e)))?;
+                let arrow_uuid = Uuid::try_new(&df_uuid.storage_type().clone(), ())
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
                 Ok(Arc::new(
-                    Field::new("", data_type, true)
-                        .with_extension_type(arrow_uuid)
+                    Field::new("", data_type, true).with_extension_type(arrow_uuid),
                 ))
-        },
+            }
             SQLDataType::JSON => {
                 let data_type = DataType::Utf8;
                 let df_json = DFJson::try_new(&data_type, Default::default())?;
 
-                let arrow_json = Json::try_new(
-                    &df_json.storage_type().clone(),
-                    Default::default(),
-                ).map_err(|e| DataFusionError::External(Box::new(e)))?;
+                let arrow_json =
+                    Json::try_new(&df_json.storage_type().clone(), Default::default())
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
                 Ok(Arc::new(
-                    Field::new("", data_type, true)
-                        .with_extension_type(arrow_json)
+                    Field::new("", data_type, true).with_extension_type(arrow_json),
                 ))
-            },
+            }
             SQLDataType::Array(ArrayElemTypeDef::AngleBracket(inner_sql_type)) => {
                 // Arrays may be multi-dimensional.
                 Ok(self.convert_data_type_to_field(inner_sql_type)?.into_list())

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -23,12 +23,11 @@ use std::vec;
 
 use crate::utils::make_decimal_type;
 use arrow::datatypes::*;
-use arrow_schema::extension::{
-    EXTENSION_TYPE_METADATA_KEY, EXTENSION_TYPE_NAME_KEY, ExtensionType, Json, Uuid,
-};
+use arrow_schema::extension::{ExtensionType, Json, Uuid};
 use datafusion_common::TableReference;
 use datafusion_common::config::SqlParserOptions;
 use datafusion_common::datatype::{DataTypeExt, FieldExt};
+use datafusion_common::types::{DFJson, DFUuid, DFExtensionType};
 use datafusion_common::error::add_possible_columns_to_diag;
 use datafusion_common::{DFSchema, DataFusionError, Result, not_impl_err, plan_err};
 use datafusion_common::{
@@ -662,20 +661,35 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // If no type_planner can handle this type, use the default conversion
         match sql_type {
             // Canonical Arrow extension types
-            SQLDataType::Uuid => Ok(Arc::new(
-                Field::new("", DataType::FixedSizeBinary(16), true).with_metadata(
-                    HashMap::from([(
-                        EXTENSION_TYPE_NAME_KEY.to_string(),
-                        Uuid::NAME.to_string(),
-                    )]),
-                ),
-            )),
-            SQLDataType::JSON => Ok(Arc::new(
-                Field::new("", DataType::Utf8, true).with_metadata(HashMap::from([
-                    (EXTENSION_TYPE_NAME_KEY.to_string(), Json::NAME.to_string()),
-                    (EXTENSION_TYPE_METADATA_KEY.to_string(), "".to_string()),
-                ])),
-            )),
+            SQLDataType::Uuid => {
+                let data_type = DataType::FixedSizeBinary(16);
+                let df_uuid = DFUuid::try_new(&data_type, Default::default())?;
+                
+                // Re-construct the Arrow Uuid using the validated data from df_uuid
+                let arrow_uuid = Uuid::try_new(
+                    &df_uuid.storage_type().clone(),
+                    (),
+                ).map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+                Ok(Arc::new(
+                    Field::new("", data_type, true)
+                        .with_extension_type(arrow_uuid)
+                ))
+        },
+            SQLDataType::JSON => {
+                let data_type = DataType::Utf8;
+                let df_json = DFJson::try_new(&data_type, Default::default())?;
+
+                let arrow_json = Json::try_new(
+                    &df_json.storage_type().clone(),
+                    Default::default(),
+                ).map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+                Ok(Arc::new(
+                    Field::new("", data_type, true)
+                        .with_extension_type(arrow_json)
+                ))
+            },
             SQLDataType::Array(ArrayElemTypeDef::AngleBracket(inner_sql_type)) => {
                 // Arrays may be multi-dimensional.
                 Ok(self.convert_data_type_to_field(inner_sql_type)?.into_list())

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -31,6 +31,7 @@ use crate::utils::normalize_ident;
 
 use arrow::datatypes::{Field, FieldRef, Fields};
 use datafusion_common::error::_plan_err;
+use datafusion_common::metadata::FieldMetadata;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{
     Column, Constraint, Constraints, DFSchema, DFSchemaRef, DataFusionError, Result,
@@ -44,7 +45,7 @@ use datafusion_expr::logical_plan::DdlStatement;
 use datafusion_expr::logical_plan::builder::project;
 use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{
-    Analyze, CreateCatalog, CreateCatalogSchema,
+    Analyze, Cast, CreateCatalog, CreateCatalogSchema,
     CreateExternalTable as PlanCreateExternalTable, CreateFunction, CreateFunctionBody,
     CreateIndex as PlanCreateIndex, CreateMemoryTable, CreateView, Deallocate,
     DescribeTable, DmlStatement, DropCatalogSchema, DropFunction, DropTable, DropView,
@@ -52,7 +53,7 @@ use datafusion_expr::{
     LogicalPlan, LogicalPlanBuilder, OperateFunctionArg, PlanType, Prepare,
     ResetVariable, SetVariable, SortExpr, Statement as PlanStatement, ToStringifiedPlan,
     TransactionAccessMode, TransactionConclusion, TransactionEnd,
-    TransactionIsolationLevel, TransactionStart, Volatility, WriteOp, cast, col,
+    TransactionIsolationLevel, TransactionStart, Volatility, WriteOp, col,
 };
 use sqlparser::ast::{
     self, BeginTransactionKind, CheckConstraint, ForeignKeyConstraint, IndexColumn,
@@ -530,11 +531,26 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 .iter()
                                 .zip(input_fields)
                                 .map(|(field, input_field)| {
-                                    cast(
-                                        col(input_field.name()),
-                                        field.data_type().clone(),
-                                    )
-                                    .alias(field.name())
+                                    let target_field = Arc::new(
+                                        Field::new(
+                                            field.name(),
+                                            field.data_type().clone(),
+                                            field.is_nullable(),
+                                        )
+                                        .with_metadata(field.metadata().clone()),
+                                    );
+                                    let metadata =
+                                        FieldMetadata::new_from_field(field.as_ref());
+                                    let alias_metadata = if metadata.is_empty() {
+                                        None
+                                    } else {
+                                        Some(metadata)
+                                    };
+                                    Expr::Cast(Cast::new_from_field(
+                                        Box::new(col(input_field.name())),
+                                        target_field,
+                                    ))
+                                    .alias_with_metadata(field.name(), alias_metadata)
                                 })
                                 .collect::<Vec<_>>();
 

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -31,7 +31,6 @@ use crate::utils::normalize_ident;
 
 use arrow::datatypes::{Field, FieldRef, Fields};
 use datafusion_common::error::_plan_err;
-use datafusion_common::metadata::FieldMetadata;
 use datafusion_common::metadata::check_metadata_with_storage_equal;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{
@@ -46,7 +45,7 @@ use datafusion_expr::logical_plan::DdlStatement;
 use datafusion_expr::logical_plan::builder::project;
 use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{
-    Analyze, Cast, CreateCatalog, CreateCatalogSchema,
+    Analyze, CreateCatalog, CreateCatalogSchema,
     CreateExternalTable as PlanCreateExternalTable, CreateFunction, CreateFunctionBody,
     CreateIndex as PlanCreateIndex, CreateMemoryTable, CreateView, Deallocate,
     DescribeTable, DmlStatement, DropCatalogSchema, DropFunction, DropTable, DropView,

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -32,6 +32,7 @@ use crate::utils::normalize_ident;
 use arrow::datatypes::{Field, FieldRef, Fields};
 use datafusion_common::error::_plan_err;
 use datafusion_common::metadata::FieldMetadata;
+use datafusion_common::metadata::check_metadata_with_storage_equal;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{
     Column, Constraint, Constraints, DFSchema, DFSchemaRef, DataFusionError, Result,
@@ -43,7 +44,6 @@ use datafusion_expr::dml::{CopyTo, InsertOp};
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas_and_ambiguity_check;
 use datafusion_expr::logical_plan::DdlStatement;
 use datafusion_expr::logical_plan::builder::project;
-use datafusion_common::metadata::check_metadata_with_storage_equal;
 use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{
     Analyze, Cast, CreateCatalog, CreateCatalogSchema,
@@ -534,13 +534,20 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 .map(|(field, input_field)| -> Result<Expr> {
                                     let input_meta = input_field.metadata();
                                     let target_meta = field.metadata();
-                                    
-                                    let is_target_ext = target_meta.contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
-                                    let is_input_ext = input_meta.contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
+
+                                    let is_target_ext = target_meta.contains_key(
+                                        arrow_schema::extension::EXTENSION_TYPE_NAME_KEY,
+                                    );
+                                    let is_input_ext = input_meta.contains_key(
+                                        arrow_schema::extension::EXTENSION_TYPE_NAME_KEY,
+                                    );
 
                                     if !is_target_ext && !is_input_ext {
-                                        return if input_field.data_type() == field.data_type() {
-                                            Ok(col(input_field.name()).alias(field.name()))
+                                        return if input_field.data_type()
+                                            == field.data_type()
+                                        {
+                                            Ok(col(input_field.name())
+                                                .alias(field.name()))
                                         } else {
                                             Ok(col(input_field.name())
                                                 .cast_to(field.data_type(), input_schema)?
@@ -548,23 +555,30 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                         };
                                     }
 
-                                    let metadata_matches = check_metadata_with_storage_equal(
-                                        (input_field.data_type(), Some(input_meta)),
-                                        (field.data_type(), Some(target_meta)),
-                                        "input", "target"
-                                    ).is_ok();
+                                    let metadata_matches =
+                                        check_metadata_with_storage_equal(
+                                            (input_field.data_type(), Some(input_meta)),
+                                            (field.data_type(), Some(target_meta)),
+                                            "input",
+                                            "target",
+                                        )
+                                        .is_ok();
 
                                     if metadata_matches {
                                         Ok(col(input_field.name()).alias(field.name()))
                                     } else {
-                                        Ok(Expr::Cast(datafusion_expr::Cast::new_from_field(
-                                            Box::new(col(input_field.name())),
-                                            Arc::clone(field),
-                                        )).alias(field.name()))
+                                        Ok(Expr::Cast(
+                                            datafusion_expr::Cast::new_from_field(
+                                                Box::new(col(input_field.name())),
+                                                Arc::clone(field),
+                                            ),
+                                        )
+                                        .alias(field.name()))
                                     }
-                                }).collect::<Result<Vec<_>>>()?;
+                                })
+                                .collect::<Result<Vec<_>>>()?;
 
-                                LogicalPlanBuilder::from(plan.clone())
+                            LogicalPlanBuilder::from(plan.clone())
                                 .project(project_exprs)?
                                 .build()?
                         } else {

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -531,14 +531,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 .iter()
                                 .zip(input_fields)
                                 .map(|(field, input_field)| {
-                                    let target_field = Arc::new(
-                                        Field::new(
-                                            field.name(),
-                                            field.data_type().clone(),
-                                            field.is_nullable(),
-                                        )
-                                        .with_metadata(field.metadata().clone()),
-                                    );
                                     let metadata =
                                         FieldMetadata::new_from_field(field.as_ref());
                                     let alias_metadata = if metadata.is_empty() {
@@ -548,7 +540,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                     };
                                     Expr::Cast(Cast::new_from_field(
                                         Box::new(col(input_field.name())),
-                                        target_field,
+                                        Arc::clone(field),
                                     ))
                                     .alias_with_metadata(field.name(), alias_metadata)
                                 })

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -43,6 +43,7 @@ use datafusion_expr::dml::{CopyTo, InsertOp};
 use datafusion_expr::expr_rewriter::normalize_col_with_schemas_and_ambiguity_check;
 use datafusion_expr::logical_plan::DdlStatement;
 use datafusion_expr::logical_plan::builder::project;
+use datafusion_common::metadata::check_metadata_with_storage_equal;
 use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{
     Analyze, Cast, CreateCatalog, CreateCatalogSchema,
@@ -530,23 +531,40 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 .fields()
                                 .iter()
                                 .zip(input_fields)
-                                .map(|(field, input_field)| {
-                                    let metadata =
-                                        FieldMetadata::new_from_field(field.as_ref());
-                                    let alias_metadata = if metadata.is_empty() {
-                                        None
-                                    } else {
-                                        Some(metadata)
-                                    };
-                                    Expr::Cast(Cast::new_from_field(
-                                        Box::new(col(input_field.name())),
-                                        Arc::clone(field),
-                                    ))
-                                    .alias_with_metadata(field.name(), alias_metadata)
-                                })
-                                .collect::<Vec<_>>();
+                                .map(|(field, input_field)| -> Result<Expr> {
+                                    let input_meta = input_field.metadata();
+                                    let target_meta = field.metadata();
+                                    
+                                    let is_target_ext = target_meta.contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
+                                    let is_input_ext = input_meta.contains_key(arrow_schema::extension::EXTENSION_TYPE_NAME_KEY);
 
-                            LogicalPlanBuilder::from(plan.clone())
+                                    if !is_target_ext && !is_input_ext {
+                                        return if input_field.data_type() == field.data_type() {
+                                            Ok(col(input_field.name()).alias(field.name()))
+                                        } else {
+                                            Ok(col(input_field.name())
+                                                .cast_to(field.data_type(), input_schema)?
+                                                .alias(field.name()))
+                                        };
+                                    }
+
+                                    let metadata_matches = check_metadata_with_storage_equal(
+                                        (input_field.data_type(), Some(input_meta)),
+                                        (field.data_type(), Some(target_meta)),
+                                        "input", "target"
+                                    ).is_ok();
+
+                                    if metadata_matches {
+                                        Ok(col(input_field.name()).alias(field.name()))
+                                    } else {
+                                        Ok(Expr::Cast(datafusion_expr::Cast::new_from_field(
+                                            Box::new(col(input_field.name())),
+                                            Arc::clone(field),
+                                        )).alias(field.name()))
+                                    }
+                                }).collect::<Result<Vec<_>>>()?;
+
+                                LogicalPlanBuilder::from(plan.clone())
                                 .project(project_exprs)?
                                 .build()?
                         } else {

--- a/datafusion/sql/tests/common/mod.rs
+++ b/datafusion/sql/tests/common/mod.rs
@@ -380,12 +380,6 @@ impl TypePlanner for CustomTypePlanner {
         sql_type: &sqlparser::ast::DataType,
     ) -> Result<Option<FieldRef>> {
         match sql_type {
-            sqlparser::ast::DataType::Uuid => Ok(Some(Arc::new(
-                Field::new("", DataType::FixedSizeBinary(16), true).with_metadata(
-                    [("ARROW:extension:name".to_string(), "arrow.uuid".to_string())]
-                        .into(),
-                ),
-            ))),
             sqlparser::ast::DataType::Datetime(precision) => {
                 let precision = match precision {
                     Some(0) => TimeUnit::Second,

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -39,7 +39,6 @@ use datafusion::catalog::{
 use datafusion::common::{DataFusionError, Result, not_impl_err};
 use datafusion::functions::math::abs;
 use datafusion::logical_expr::async_udf::{AsyncScalarUDF, AsyncScalarUDFImpl};
-use datafusion::logical_expr::planner::TypePlanner;
 use datafusion::logical_expr::{
     ColumnarValue, Expr, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
     Volatility, create_udf,
@@ -58,7 +57,6 @@ use datafusion::common::cast::as_float64_array;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use log::info;
-use sqlparser::ast;
 use tempfile::TempDir;
 
 /// Context for running tests
@@ -67,23 +65,6 @@ pub struct TestContext {
     ctx: SessionContext,
     /// Temporary directory created and cleared at the end of the test
     test_dir: Option<TempDir>,
-}
-
-#[derive(Debug)]
-struct SqlLogicTestTypePlanner;
-
-impl TypePlanner for SqlLogicTestTypePlanner {
-    fn plan_type_field(&self, sql_type: &ast::DataType) -> Result<Option<FieldRef>> {
-        match sql_type {
-            ast::DataType::Uuid => Ok(Some(Arc::new(
-                Field::new("", DataType::FixedSizeBinary(16), true).with_metadata(
-                    [("ARROW:extension:name".to_string(), "arrow.uuid".to_string())]
-                        .into(),
-                ),
-            ))),
-            _ => Ok(None),
-        }
-    }
 }
 
 impl TestContext {
@@ -112,14 +93,6 @@ impl TestContext {
 
         if is_spark_path(relative_path) {
             state_builder = state_builder.with_spark_features();
-        }
-
-        if matches!(
-            relative_path.file_name().and_then(|name| name.to_str()),
-            Some("cast_extension_type_metadata.slt")
-        ) {
-            state_builder =
-                state_builder.with_type_planner(Arc::new(SqlLogicTestTypePlanner));
         }
 
         let state = state_builder.build();

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -29,7 +29,7 @@ use arrow::array::{
 };
 use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::{
-    DataType, Field, FieldRef, Fields, Schema, SchemaRef, TimeUnit, UInt32Type,
+    DataType, Field, Fields, Schema, SchemaRef, TimeUnit, UInt32Type,
     UnionFields,
 };
 use arrow::record_batch::RecordBatch;

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -29,8 +29,7 @@ use arrow::array::{
 };
 use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::{
-    DataType, Field, Fields, Schema, SchemaRef, TimeUnit, UInt32Type,
-    UnionFields,
+    DataType, Field, Fields, Schema, SchemaRef, TimeUnit, UInt32Type, UnionFields,
 };
 use arrow::record_batch::RecordBatch;
 use datafusion::catalog::{

--- a/datafusion/sqllogictest/test_files/sql_extension_types.slt
+++ b/datafusion/sqllogictest/test_files/sql_extension_types.slt
@@ -64,6 +64,14 @@ arrow.uuid
 statement ok
 DROP TABLE test_uuid2;
 
+# Error: Cannot cast an integer to UUID
+statement error Unsupported CAST from Int64 to FixedSizeBinary\(16\)
+SELECT CAST(12345 AS UUID);
+
+# Error: Cannot cast a short string to UUID
+statement error Unsupported CAST from Utf8 to FixedSizeBinary\(16\)
+SELECT CAST('too-short' AS UUID);
+
 #######
 # JSON Extension Type
 #######

--- a/datafusion/sqllogictest/test_files/sql_extension_types.slt
+++ b/datafusion/sqllogictest/test_files/sql_extension_types.slt
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for built-in mapping of SQL types to Arrow canonical extension types.
+# See: https://arrow.apache.org/docs/format/CanonicalExtensions.html
+
+#######
+# UUID Extension Type
+#######
+
+# CAST to UUID preserves extension metadata
+query ?T
+SELECT CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID),
+       arrow_metadata(CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID), 'ARROW:extension:name');
+----
+00010203040506070809000102030506 arrow.uuid
+
+# CREATE TABLE with UUID column preserves extension metadata through VALUES
+statement ok
+CREATE TABLE test_uuid (
+    value UUID
+) AS VALUES
+    (NULL);
+
+query TTT
+DESCRIBE test_uuid;
+----
+value FixedSizeBinary(16) YES
+
+query T
+SELECT arrow_metadata(value, 'ARROW:extension:name') FROM test_uuid;
+----
+arrow.uuid
+
+statement ok
+DROP TABLE test_uuid;
+
+# UUID column with non-null binary value
+statement ok
+CREATE TABLE test_uuid2 (
+    id UUID
+) AS VALUES
+    (CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID));
+
+query T
+SELECT arrow_metadata(id, 'ARROW:extension:name') FROM test_uuid2;
+----
+arrow.uuid
+
+statement ok
+DROP TABLE test_uuid2;
+
+#######
+# JSON Extension Type
+#######
+
+# CAST to JSON preserves extension metadata
+query TT
+SELECT CAST('{"a": 1}' AS JSON),
+       arrow_metadata(CAST('{"a": 1}' AS JSON), 'ARROW:extension:name');
+----
+{"a": 1} arrow.json
+
+# CREATE TABLE with JSON column preserves extension metadata
+statement ok
+CREATE TABLE test_json (
+    data JSON
+) AS VALUES
+    (NULL);
+
+query TTT
+DESCRIBE test_json;
+----
+data Utf8 YES
+
+query T
+SELECT arrow_metadata(data, 'ARROW:extension:name') FROM test_json;
+----
+arrow.json
+
+statement ok
+DROP TABLE test_json;
+
+# JSON column with non-null value
+statement ok
+CREATE TABLE test_json2 (
+    data JSON
+) AS VALUES
+    (CAST('{"hello": "world"}' AS JSON));
+
+query T
+SELECT arrow_metadata(data, 'ARROW:extension:name') FROM test_json2;
+----
+arrow.json
+
+statement ok
+DROP TABLE test_json2;

--- a/datafusion/sqllogictest/test_files/sql_extension_types.slt
+++ b/datafusion/sqllogictest/test_files/sql_extension_types.slt
@@ -29,48 +29,36 @@ SELECT CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)
 ----
 00010203040506070809000102030506 arrow.uuid
 
-# CREATE TABLE with UUID column preserves extension metadata through VALUES
+# Test table creation and various insertion methods (Null, Naked Binary, and Cast)
 statement ok
-CREATE TABLE test_uuid (
-    value UUID
-) AS VALUES
-    (NULL);
+CREATE TABLE test_uuid (value UUID);
 
 query TTT
 DESCRIBE test_uuid;
 ----
 value FixedSizeBinary(16) YES
 
+# 1. NULL insertion
+statement ok
+INSERT INTO test_uuid VALUES (NULL);
+
+# 2. Exercises Implicit Promotion to UUID from binary
+statement ok
+INSERT INTO test_uuid VALUES (X'00010203040506070809000102030506');
+
+# 3. Explicit CAST
+statement ok
+INSERT INTO test_uuid VALUES (CAST(arrow_cast(X'00010203040506070809000102030507', 'FixedSizeBinary(16)') AS UUID));
+
 query T
 SELECT arrow_metadata(value, 'ARROW:extension:name') FROM test_uuid;
 ----
 arrow.uuid
-
-statement ok
-DROP TABLE test_uuid;
-
-# UUID column with non-null binary value
-statement ok
-CREATE TABLE test_uuid2 (
-    id UUID
-) AS VALUES
-    (CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID));
-
-query T
-SELECT arrow_metadata(id, 'ARROW:extension:name') FROM test_uuid2;
-----
+arrow.uuid
 arrow.uuid
 
 statement ok
-DROP TABLE test_uuid2;
-
-# Error: Cannot cast an integer to UUID
-statement error Unsupported CAST from Int64 to FixedSizeBinary\(16\)
-SELECT CAST(12345 AS UUID);
-
-# Error: Cannot cast a short string to UUID
-statement error Unsupported CAST from Utf8 to FixedSizeBinary\(16\)
-SELECT CAST('too-short' AS UUID);
+DROP TABLE test_uuid;
 
 #######
 # JSON Extension Type
@@ -83,37 +71,207 @@ SELECT CAST('{"a": 1}' AS JSON),
 ----
 {"a": 1} arrow.json
 
-# CREATE TABLE with JSON column preserves extension metadata
 statement ok
-CREATE TABLE test_json (
-    data JSON
-) AS VALUES
-    (NULL);
+CREATE TABLE test_json (data JSON);
 
 query TTT
 DESCRIBE test_json;
 ----
 data Utf8 YES
 
+# 1. NULL insertion
+statement ok
+INSERT INTO test_json VALUES (NULL);
+
+# 2. Bare string literal (Implicit Promotion)
+statement ok
+INSERT INTO test_json VALUES ('{"bare": "literal"}');
+
+# 3. Explicit CAST
+statement ok
+INSERT INTO test_json VALUES (CAST('{"hello": "world"}' AS JSON));
+
 query T
 SELECT arrow_metadata(data, 'ARROW:extension:name') FROM test_json;
 ----
 arrow.json
+arrow.json
+arrow.json
+
+# Verify Type Decay: Concatenation results in a bare Utf8 string
+query T
+SELECT arrow_metadata(data || '{"extra": 1}', 'ARROW:extension:name') FROM test_json;
+----
+NULL
+NULL
+NULL
 
 statement ok
 DROP TABLE test_json;
 
-# JSON column with non-null value
+#######
+# Error Handling
+#######
+
+# Error: Cannot cast an integer to UUID
+statement error Unsupported CAST from Int64 to FixedSizeBinary\(16\)
+SELECT CAST(12345 AS UUID);
+
+# Error: Cannot cast a short string to UUID
+statement error Unsupported CAST from Utf8 to FixedSizeBinary\(16\)
+SELECT CAST('too-short' AS UUID);
+
+# This should trigger cast plan_err: "Cannot cast Utf8 to extension type at column 0"
+# Because 'not-a-uuid' is Utf8, and it's being compared to a UUID target in a VALUES list.
 statement ok
-CREATE TABLE test_json2 (
-    data JSON
-) AS VALUES
-    (CAST('{"hello": "world"}' AS JSON));
+CREATE TABLE t1 (id UUID);
+
+# Then, try to insert the invalid type
+statement error Cannot cast Utf8 to extension type at column 0
+INSERT INTO t1 VALUES ('not-a-uuid');
+
+statement ok
+INSERT INTO t1 VALUES (NULL);
+
+statement ok
+DROP TABLE t1;
+
+# Error: Cannot mix different extension types
+statement ok
+CREATE TABLE mix_types (id UUID);
+
+# Even if the JSON string is 16 bytes, it lacks the arrow.uuid metadata
+statement error Cannot cast Utf8 to extension type at column 0
+INSERT INTO mix_types VALUES (CAST('{"key": "value"}' AS JSON));
+
+statement ok
+DROP TABLE mix_types;
+
+statement ok
+CREATE TABLE multi_col (info JSON, id UUID);
+
+# Succeed with valid types
+statement ok
+INSERT INTO multi_col VALUES 
+  (CAST('{"a":1}' AS JSON), CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID));
+
+# This will fail because a Boolean cannot be cast to FixedSizeBinary(16)
+statement error Cannot cast Boolean to extension type at column 1
+INSERT INTO multi_col VALUES 
+  (CAST('{"a":1}' AS JSON), true);
+
+statement ok
+DROP TABLE multi_col;
+
+statement ok
+CREATE TABLE bulk_uuid (id UUID);
+
+# Batch of multiple values (some NULL)
+statement ok
+INSERT INTO bulk_uuid VALUES 
+  (CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID)),
+  (NULL),
+  (CAST(arrow_cast(X'00010203040506070809000102030507', 'FixedSizeBinary(16)') AS UUID));
+
+query I
+SELECT COUNT(*) FROM bulk_uuid;
+----
+3
+
+statement ok
+DROP TABLE bulk_uuid;
+
+#######
+# Relational Integration
+#######
+
+# UNION preserves extension metadata
+statement ok
+CREATE TABLE u1 (id UUID) AS VALUES (CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID));
+
+statement ok
+CREATE TABLE u2 (id UUID) AS VALUES (CAST(arrow_cast(X'00010203040506070809000102030507', 'FixedSizeBinary(16)') AS UUID));
 
 query T
-SELECT arrow_metadata(data, 'ARROW:extension:name') FROM test_json2;
+SELECT arrow_metadata(id, 'ARROW:extension:name') FROM (
+    SELECT id FROM u1
+    UNION ALL
+    SELECT id FROM u2
+) LIMIT 1;
 ----
-arrow.json
+arrow.uuid
 
 statement ok
-DROP TABLE test_json2;
+DROP TABLE u1;
+
+statement ok
+DROP TABLE u2;
+
+# JOIN on UUID columns
+statement ok
+CREATE TABLE j1 (id UUID, val INT) AS VALUES (CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID), 1);
+
+statement ok
+CREATE TABLE j2 (id UUID, name TEXT) AS VALUES (CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID), 'DataFusion');
+
+query IT
+SELECT j1.val, j2.name 
+FROM j1 
+JOIN j2 ON j1.id = j2.id;
+----
+1 DataFusion
+
+statement ok
+DROP TABLE j1;
+
+statement ok
+DROP TABLE j2;
+
+# CASE preserves extension metadata
+statement ok
+CREATE TABLE c1 (id UUID) AS VALUES 
+  (CAST(arrow_cast(X'00010203040506070809000102030506', 'FixedSizeBinary(16)') AS UUID)),
+  (CAST(arrow_cast(X'00010203040506070809000102030507', 'FixedSizeBinary(16)') AS UUID));
+
+query T
+SELECT arrow_metadata(CASE WHEN 1=1 THEN id ELSE id END, 'ARROW:extension:name') FROM c1;
+----
+arrow.uuid
+arrow.uuid
+
+# This forces the engine to evaluate the condition row-by-row - type coersion drops metadata
+query T
+SELECT arrow_metadata(CASE WHEN id IS NOT NULL THEN id ELSE id END, 'ARROW:extension:name') FROM c1;
+----
+NULL
+NULL
+
+# Force the CASE result to be treated as a UUID explicitly
+query T
+SELECT arrow_metadata(CAST((CASE WHEN id IS NOT NULL THEN id ELSE id END) AS UUID), 'ARROW:extension:name') FROM c1;
+----
+arrow.uuid
+arrow.uuid
+
+# COALESCE often drops metadata because it resolves to the common physical type
+query T
+SELECT arrow_metadata(COALESCE(id, id), 'ARROW:extension:name') FROM c1;
+----
+NULL
+NULL
+
+# Window functions might drop metadata during result materialization
+query T
+SELECT arrow_metadata(FIRST_VALUE(id) OVER(), 'ARROW:extension:name') FROM c1;
+----
+NULL
+NULL
+
+# Aggregates return the physical type, losing the extension tag
+query T
+SELECT arrow_metadata(MAX(id), 'ARROW:extension:name') FROM c1;
+----
+NULL
+
+statement ok
+DROP TABLE c1;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21626

## Rationale for this change
Ensures that DataFusion natively maps SQL UUID and JSON types to their respective Arrow Canonical Extension Types. This standardizes how these types are stored and metadata-tagged, allowing for seamless interoperability with other Arrow-native tools.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Updated planner.rs to map UUID to FixedSizeBinary(16) and JSON to Utf8 with official arrow.uuid and arrow.json metadata keys.
- Arrow Standards: Integrated arrow-schema extension constants (EXTENSION_TYPE_NAME_KEY, Uuid::NAME, etc.) and included the required empty string metadata for JSON types.
- Metadata Preservation in Statements: Refactored statement.rs to use alias_with_metadata. This ensures that in CREATE TABLE ... AS SELECT (CTAS) operations, the extension metadata survives the projection and is applied to the new table schema.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes,
- Added sql_extension_types.slt which performs end-to-end testing of CAST and CREATE TABLE for both UUID and JSON.
- Existing SQL logic tests pass, confirming no regressions in standard type handling.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

Yes. UUID and JSON are now officially recognized SQL keywords in DataFusion DDL and Casts, automatically resulting in Arrow-compliant canonical extension types.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
