### PR TITLE
fix: UNIQUE constraint with NULLs incorrectly collapses GROUP BY groups

### DIFF
--- a/datafusion/common/src/functional_dependencies.rs
+++ b/datafusion/common/src/functional_dependencies.rs
@@ -137,12 +137,15 @@ pub struct FunctionalDependence {
     // Column indices of dependent column(s):
     pub target_indices: Vec<usize>,
     /// Flag indicating whether one of the `source_indices` can receive NULL values.
-    /// For a data source, if the constraint in question is `Constraint::Unique`,
-    /// this flag is `true`. If the constraint in question is `Constraint::PrimaryKey`,
-    /// this flag is `false`.
-    /// Note that as the schema changes between different stages in a plan,
-    /// such as after LEFT JOIN or RIGHT JOIN operations, this property may
-    /// change.
+    ///
+    /// Base-table constraints only produce a functional dependency when all
+    /// determinant columns are non-nullable, so dependencies derived directly
+    /// from `Constraint::PrimaryKey` or `Constraint::Unique` start with this
+    /// flag set to `false`.
+    ///
+    /// As the schema changes between different stages in a plan, null-introducing
+    /// operators such as LEFT JOIN or RIGHT JOIN may conservatively downgrade an
+    /// existing dependency by setting this flag to `true`.
     pub nullable: bool,
     // The functional dependency mode:
     pub mode: Dependency,
@@ -196,15 +199,25 @@ impl FunctionalDependencies {
     }
 
     /// Creates a new `FunctionalDependencies` object from the given constraints.
+    ///
+    /// `nullable_flags` must contain one entry per field in the relation,
+    /// indicating whether that field is nullable.  A `UNIQUE` constraint whose
+    /// source columns include any nullable field is **not** a functional
+    /// dependency — because SQL treats `NULL` values as distinct, multiple rows
+    /// may carry `NULL` in a unique-key column without violating the constraint.
+    /// Such constraints are therefore omitted entirely.  When all source columns
+    /// are non-nullable a `UNIQUE` constraint is equivalent to a primary key and
+    /// is recorded with `nullable = false`.
     pub fn new_from_constraints(
         constraints: Option<&Constraints>,
-        n_field: usize,
+        nullable_flags: &[bool],
     ) -> Self {
+        let n_field = nullable_flags.len();
         if let Some(Constraints { inner: constraints }) = constraints {
             // Construct dependency objects based on each individual constraint:
             let dependencies = constraints
                 .iter()
-                .map(|constraint| {
+                .filter_map(|constraint| {
                     // All the field indices are associated with the whole table
                     // since we are dealing with table level constraints:
                     let dependency = match constraint {
@@ -213,15 +226,27 @@ impl FunctionalDependencies {
                             (0..n_field).collect::<Vec<_>>(),
                             false,
                         ),
-                        Constraint::Unique(indices) => FunctionalDependence::new(
-                            indices.to_vec(),
-                            (0..n_field).collect::<Vec<_>>(),
-                            true,
-                        ),
+                        Constraint::Unique(indices) => {
+                            // A UNIQUE constraint where any source column is
+                            // nullable is not a functional dependency: SQL does
+                            // not consider NULLs equal, so two rows may both
+                            // have NULL in the key and still satisfy the
+                            // constraint.  Only emit an FD when all source
+                            // columns are non-nullable, in which case it is
+                            // equivalent to a primary key.
+                            if indices.iter().any(|&i| nullable_flags[i]) {
+                                return None;
+                            }
+                            FunctionalDependence::new(
+                                indices.to_vec(),
+                                (0..n_field).collect::<Vec<_>>(),
+                                false,
+                            )
+                        }
                     };
                     // As primary keys are guaranteed to be unique, set the
                     // functional dependency mode to `Dependency::Single`:
-                    dependency.with_mode(Dependency::Single)
+                    Some(dependency.with_mode(Dependency::Single))
                 })
                 .collect::<Vec<_>>();
             Self::new(dependencies)
@@ -422,7 +447,6 @@ pub fn aggregate_functional_dependencies(
 ) -> FunctionalDependencies {
     let mut aggregate_func_dependencies = vec![];
     let aggr_input_fields = aggr_input_schema.field_names();
-    let aggr_fields = aggr_schema.fields();
     // Association covers the whole table:
     let target_indices = (0..aggr_schema.fields().len()).collect::<Vec<_>>();
     // Get functional dependencies of the schema:
@@ -484,9 +508,12 @@ pub fn aggregate_functional_dependencies(
     if !group_by_expr_names.is_empty() {
         let count = group_by_expr_names.len();
         let source_indices = (0..count).collect::<Vec<_>>();
-        let nullable = source_indices
-            .iter()
-            .any(|idx| aggr_fields[*idx].is_nullable());
+        // Aggregation with GROUP BY always produces unique output rows for
+        // each distinct combination of GROUP BY keys. The nullable flag is
+        // set to false here so that subsequent expansion (e.g. a second
+        // GROUP BY on the aggregate output) is never blocked by source
+        // field nullability.
+        let nullable = false;
         // If GROUP BY expressions do not already act as a determinant:
         if !aggregate_func_dependencies.iter().any(|item| {
             // If `item.source_indices` is a subset of GROUP BY expressions, we shouldn't add

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -192,12 +192,14 @@ impl LogicalPlanBuilder {
         // Ensure that the recursive term has the same field types as the static term
         let coerced_recursive_term =
             coerce_plan_expr_for_schema(recursive_term, self.plan.schema())?;
-        Ok(Self::from(LogicalPlan::RecursiveQuery(RecursiveQuery {
-            name,
-            static_term: self.plan,
-            recursive_term: Arc::new(coerced_recursive_term),
-            is_distinct,
-        })))
+        Ok(Self::from(LogicalPlan::RecursiveQuery(
+            RecursiveQuery::try_new(
+                name,
+                self.plan,
+                Arc::new(coerced_recursive_term),
+                is_distinct,
+            )?,
+        )))
     }
 
     /// Create a values list based relation, and the schema is inferred from data, consuming
@@ -2890,6 +2892,32 @@ mod tests {
         assert_snapshot!(plan, @r"
         Aggregate: groupBy=[[employee_csv.id, employee_csv.state, employee_csv.salary]], aggr=[[sum(employee_csv.salary)]]
           TableScan: employee_csv projection=[id, state, salary]
+        ");
+
+        Ok(())
+    }
+
+    #[test]
+    fn plan_builder_aggregate_does_not_expand_nullable_unique_group_by_exprs()
+    -> Result<()> {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("state", DataType::Utf8, false),
+            Field::new("salary", DataType::Int32, false),
+        ]);
+        let constraints = Constraints::new_unverified(vec![Constraint::Unique(vec![0])]);
+        let table_source = table_source_with_constraints(&schema, constraints);
+
+        let options =
+            LogicalPlanBuilderOptions::new().with_add_implicit_group_by_exprs(true);
+        let plan = LogicalPlanBuilder::scan("employee_csv", table_source, None)?
+            .with_options(options)
+            .aggregate(vec![col("id")], vec![sum(col("salary"))])?
+            .build()?;
+
+        assert_snapshot!(plan, @r"
+        Aggregate: groupBy=[[employee_csv.id]], aggr=[[sum(employee_csv.salary)]]
+          TableScan: employee_csv
         ");
 
         Ok(())

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -354,9 +354,12 @@ impl LogicalPlan {
             LogicalPlan::Copy(CopyTo { output_schema, .. }) => output_schema,
             LogicalPlan::Ddl(ddl) => ddl.schema(),
             LogicalPlan::Unnest(Unnest { schema, .. }) => schema,
-            LogicalPlan::RecursiveQuery(RecursiveQuery { static_term, .. }) => {
-                // we take the schema of the static term as the schema of the entire recursive query
-                static_term.schema()
+            LogicalPlan::RecursiveQuery(RecursiveQuery { schema, .. }) => {
+                // Recursive queries expose the static term's field layout as
+                // their output schema, but their functional dependencies are
+                // computed separately because the recursive term can violate
+                // those of the anchor.
+                schema
             }
         }
     }
@@ -1081,12 +1084,12 @@ impl LogicalPlan {
             }) => {
                 self.assert_no_expressions(expr)?;
                 let (static_term, recursive_term) = self.only_two_inputs(inputs)?;
-                Ok(LogicalPlan::RecursiveQuery(RecursiveQuery {
-                    name: name.clone(),
-                    static_term: Arc::new(static_term),
-                    recursive_term: Arc::new(recursive_term),
-                    is_distinct: *is_distinct,
-                }))
+                Ok(LogicalPlan::RecursiveQuery(RecursiveQuery::try_new(
+                    name.clone(),
+                    Arc::new(static_term),
+                    Arc::new(recursive_term),
+                    *is_distinct,
+                )?))
             }
             LogicalPlan::Analyze(a) => {
                 self.assert_no_expressions(expr)?;
@@ -2258,10 +2261,12 @@ impl PartialOrd for EmptyRelation {
 ///   intermediate table, then empty the intermediate table.
 ///
 /// [Postgres Docs]: https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RecursiveQuery {
     /// Name of the query
     pub name: String,
+    /// Output schema for the recursive query.
+    pub schema: DFSchemaRef,
     /// The static term (initial contents of the working table)
     pub static_term: Arc<LogicalPlan>,
     /// The recursive term (evaluated on the contents of the working table until
@@ -2270,6 +2275,49 @@ pub struct RecursiveQuery {
     /// Should the output of the recursive term be deduplicated (`UNION`) or
     /// not (`UNION ALL`).
     pub is_distinct: bool,
+}
+
+impl RecursiveQuery {
+    pub fn try_new(
+        name: String,
+        static_term: Arc<LogicalPlan>,
+        recursive_term: Arc<LogicalPlan>,
+        is_distinct: bool,
+    ) -> Result<Self> {
+        let schema = Arc::new(
+            static_term
+                .schema()
+                .as_ref()
+                .clone()
+                .with_functional_dependencies(FunctionalDependencies::empty())?,
+        );
+
+        Ok(Self {
+            name,
+            schema,
+            static_term,
+            recursive_term,
+            is_distinct,
+        })
+    }
+}
+
+impl PartialOrd for RecursiveQuery {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (
+            &self.name,
+            &self.static_term,
+            &self.recursive_term,
+            &self.is_distinct,
+        )
+            .partial_cmp(&(
+                &other.name,
+                &other.static_term,
+                &other.recursive_term,
+                &other.is_distinct,
+            ))
+            .filter(|cmp| *cmp != Ordering::Equal || self == other)
+    }
 }
 
 /// Values expression. See
@@ -2966,9 +3014,11 @@ impl TableScanBuilder {
             return plan_err!("table_name cannot be empty");
         }
         let schema = source.schema();
+        let nullable_flags: Vec<bool> =
+            schema.fields().iter().map(|f| f.is_nullable()).collect();
         let func_dependencies = FunctionalDependencies::new_from_constraints(
             source.constraints(),
-            schema.fields.len(),
+            &nullable_flags,
         );
         let projected_schema = projection
             .as_ref()
@@ -5271,7 +5321,7 @@ mod tests {
                         Some(&Constraints::new_unverified(vec![Constraint::Unique(
                             vec![0],
                         )])),
-                        1,
+                        &[false],
                     ),
                 )
                 .unwrap(),

--- a/datafusion/expr/src/logical_plan/tree_node.rs
+++ b/datafusion/expr/src/logical_plan/tree_node.rs
@@ -329,14 +329,18 @@ impl TreeNode for LogicalPlan {
                 static_term,
                 recursive_term,
                 is_distinct,
+                ..
             }) => (static_term, recursive_term).map_elements(f)?.update_data(
                 |(static_term, recursive_term)| {
-                    LogicalPlan::RecursiveQuery(RecursiveQuery {
-                        name,
-                        static_term,
-                        recursive_term,
-                        is_distinct,
-                    })
+                    LogicalPlan::RecursiveQuery(
+                        RecursiveQuery::try_new(
+                            name,
+                            static_term,
+                            recursive_term,
+                            is_distinct,
+                        )
+                        .expect("recursive query schema should remain valid"),
+                    )
                 },
             ),
             LogicalPlan::Statement(stmt) => match stmt {

--- a/datafusion/optimizer/src/eliminate_duplicated_expr.rs
+++ b/datafusion/optimizer/src/eliminate_duplicated_expr.rs
@@ -145,7 +145,12 @@ mod tests {
     use crate::OptimizerContext;
     use crate::assert_optimized_plan_eq_snapshot;
     use crate::test::*;
-    use datafusion_expr::{col, logical_plan::builder::LogicalPlanBuilder};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::{Constraint, Constraints};
+    use datafusion_expr::{
+        col, logical_plan::builder::LogicalPlanBuilder,
+        logical_plan::builder::table_source_with_constraints,
+    };
     use std::sync::Arc;
 
     macro_rules! assert_optimized_plan_equal {
@@ -198,6 +203,50 @@ mod tests {
         Limit: skip=5, fetch=10
           Sort: test.a ASC NULLS FIRST, test.b ASC NULLS LAST
             TableScan: test
+        ")
+    }
+
+    #[test]
+    fn eliminate_sort_exprs_pk_removes_dependent_key() -> Result<()> {
+        // When `id` is a PRIMARY KEY (non-nullable), it uniquely determines
+        // `val`, so `ORDER BY id, val` can safely be reduced to `ORDER BY id`.
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("val", DataType::Int32, false),
+        ]);
+        let constraints =
+            Constraints::new_unverified(vec![Constraint::PrimaryKey(vec![0])]);
+        let source = table_source_with_constraints(&schema, constraints);
+        let plan = LogicalPlanBuilder::scan("t", source, None)?
+            .sort_by(vec![col("t.id"), col("t.val")])?
+            .build()?;
+
+        assert_optimized_plan_equal!(plan, @r"
+        Sort: t.id ASC NULLS LAST
+          TableScan: t
+        ")
+    }
+
+    #[test]
+    fn eliminate_sort_exprs_nullable_unique_keeps_dependent_key() -> Result<()> {
+        // When `id` is a nullable UNIQUE column, SQL allows multiple NULL
+        // values in `id`.  Because NULLs are not considered equal, multiple
+        // rows may share `id = NULL` with different `val` values, so `id`
+        // does NOT functionally determine `val`.  `ORDER BY id, val` must
+        // therefore keep both keys.
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, true), // nullable
+            Field::new("val", DataType::Int32, false),
+        ]);
+        let constraints = Constraints::new_unverified(vec![Constraint::Unique(vec![0])]);
+        let source = table_source_with_constraints(&schema, constraints);
+        let plan = LogicalPlanBuilder::scan("t", source, None)?
+            .sort_by(vec![col("t.id"), col("t.val")])?
+            .build()?;
+
+        assert_optimized_plan_equal!(plan, @r"
+        Sort: t.id ASC NULLS LAST, t.val ASC NULLS LAST
+          TableScan: t
         ")
     }
 }

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1086,12 +1086,12 @@ impl AsLogicalPlan for LogicalPlanNode {
                     ))?
                     .try_into_logical_plan(ctx, extension_codec)?;
 
-                Ok(LogicalPlan::RecursiveQuery(RecursiveQuery {
-                    name: recursive_query_node.name.clone(),
-                    static_term: Arc::new(static_term),
-                    recursive_term: Arc::new(recursive_term),
-                    is_distinct: recursive_query_node.is_distinct,
-                }))
+                Ok(LogicalPlan::RecursiveQuery(RecursiveQuery::try_new(
+                    recursive_query_node.name.clone(),
+                    Arc::new(static_term),
+                    Arc::new(recursive_term),
+                    recursive_query_node.is_distinct,
+                )?))
             }
             LogicalPlanType::CteWorkTableScan(cte_work_table_scan_node) => {
                 let CteWorkTableScanNode { name, schema } = cte_work_table_scan_node;

--- a/datafusion/sqllogictest/test_files/cte.slt
+++ b/datafusion/sqllogictest/test_files/cte.slt
@@ -1319,3 +1319,35 @@ RESET datafusion.execution.enable_recursive_ctes;
 
 statement ok
 RESET datafusion.sql_parser.enable_ident_normalization;
+
+# Regression test: functional dependencies from the static (anchor) term of a
+# recursive CTE must NOT be propagated to the outer SubqueryAlias.  The
+# recursive term can produce rows that violate any uniqueness constraint that
+# holds for the anchor alone.  Without this guard, the anchor's PRIMARY KEY FD
+# leaks into the SubqueryAlias schema; the replace_distinct_aggregate optimizer
+# rule then sees `id` as already unique and incorrectly eliminates DISTINCT,
+# returning duplicate rows instead of a deduplicated result.
+statement ok
+CREATE TABLE pk_table(id INT NOT NULL, val INT NOT NULL, PRIMARY KEY(id));
+
+statement ok
+INSERT INTO pk_table VALUES (1, 100), (2, 200);
+
+# Without the FD fix, the anchor's PRIMARY KEY FD propagates to SubqueryAlias:
+# nodes, making the optimizer believe id is unique across the whole CTE output.
+# The replace_distinct_aggregate rule then eliminates DISTINCT (id appears
+# unique), returning two rows of `1` instead of one.
+query I
+WITH RECURSIVE nodes AS (
+    SELECT id, val FROM pk_table
+    UNION ALL
+    SELECT 1 AS id, 300 AS val
+    FROM nodes
+    WHERE nodes.id = 2
+)
+SELECT DISTINCT id FROM nodes WHERE id = 1
+----
+1
+
+statement ok
+DROP TABLE pk_table;

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -3399,6 +3399,22 @@ CREATE TABLE sales_global_with_unique (zip_code INT,
           (1, 'TUR', 4, '2022-01-03 10:00:00'::timestamp, 'TRY', 100.0),
           (1, 'TUR', NULL, '2022-01-03 10:00:00'::timestamp, 'TRY', 100.0)
 
+# create a table for testing, where sn is a non-null unique key
+statement ok
+CREATE TABLE sales_global_with_not_null_unique (zip_code INT,
+          country VARCHAR(3),
+          sn INT NOT NULL,
+          ts TIMESTAMP,
+          currency VARCHAR(3),
+          amount FLOAT,
+          unique(sn)
+        ) as VALUES
+          (0, 'GRC', 0, '2022-01-01 06:00:00'::timestamp, 'EUR', 30.0),
+          (1, 'FRA', 1, '2022-01-01 08:00:00'::timestamp, 'EUR', 50.0),
+          (1, 'TUR', 2, '2022-01-01 11:30:00'::timestamp, 'TRY', 75.0),
+          (1, 'FRA', 3, '2022-01-02 12:00:00'::timestamp, 'EUR', 200.0),
+          (1, 'TUR', 4, '2022-01-03 10:00:00'::timestamp, 'TRY', 100.0)
+
 # when group by contains primary key expression
 # we can use all the expressions in the table during selection
 # (not just group by expressions + aggregation result)
@@ -3565,12 +3581,13 @@ SELECT r.sn, r.amount, SUM(r.amount)
   GROUP BY r.sn
 ORDER BY r.sn
 
-# left semi join should propagate constraint of left side as is.
+# left semi join should preserve the left-side constraint when the UNIQUE key
+# is also NOT NULL, so the grouped column can still determine the rest.
 query IRR
 SELECT l.sn, l.amount, SUM(l.amount)
   FROM (SELECT *
-    FROM sales_global_with_unique as l
-    LEFT SEMI JOIN sales_global_with_unique as r
+    FROM sales_global_with_not_null_unique as l
+    LEFT SEMI JOIN sales_global_with_not_null_unique as r
     ON l.amount >= r.amount + 10)
   GROUP BY l.sn
 ORDER BY l.sn
@@ -3579,10 +3596,34 @@ ORDER BY l.sn
 2 75 75
 3 200 200
 4 100 100
-NULL 100 100
 
-# Similarly, left anti join should propagate constraint of left side as is.
+# left semi join with a nullable UNIQUE key cannot safely propagate the
+# constraint for expansion, because UNIQUE allows multiple NULLs.
+statement error DataFusion error: Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: While expanding wildcard, column "l\.amount" must appear in the GROUP BY clause or must be part of an aggregate function, currently only "l\.sn, sum\(l\.amount\)" appears in the SELECT clause satisfies this requirement
+SELECT l.sn, l.amount, SUM(l.amount)
+  FROM (SELECT *
+    FROM sales_global_with_unique as l
+    LEFT SEMI JOIN sales_global_with_unique as r
+    ON l.amount >= r.amount + 10)
+  GROUP BY l.sn
+ORDER BY l.sn
+
+# left anti join should likewise preserve the left-side constraint when the
+# UNIQUE key is also NOT NULL.
 query IRR
+SELECT l.sn, l.amount, SUM(l.amount)
+  FROM (SELECT *
+    FROM sales_global_with_not_null_unique as l
+    LEFT ANTI JOIN sales_global_with_not_null_unique as r
+    ON l.amount >= r.amount + 10)
+  GROUP BY l.sn
+ORDER BY l.sn
+----
+0 30 30
+
+# Similarly, left anti join with a nullable UNIQUE key cannot safely propagate
+# the constraint for expansion.
+statement error DataFusion error: Error during planning: Column in SELECT must be in GROUP BY or an aggregate function: While expanding wildcard, column "l\.amount" must appear in the GROUP BY clause or must be part of an aggregate function, currently only "l\.sn, sum\(l\.amount\)" appears in the SELECT clause satisfies this requirement
 SELECT l.sn, l.amount, SUM(l.amount)
   FROM (SELECT *
     FROM sales_global_with_unique as l
@@ -3590,8 +3631,6 @@ SELECT l.sn, l.amount, SUM(l.amount)
     ON l.amount >= r.amount + 10)
   GROUP BY l.sn
 ORDER BY l.sn
-----
-0 30 30
 
 # Should support grouping by list column
 query ?I
@@ -5641,3 +5680,32 @@ set datafusion.execution.target_partitions = 4;
 
 statement count 0
 drop table t;
+
+# Test that GROUP BY with a UNIQUE constraint does not incorrectly collapse
+# NULL rows. UNIQUE allows multiple NULLs (NULLs are not equal in SQL), so
+# a UNIQUE column cannot be used to eliminate other GROUP BY columns.
+# Regression test for https://github.com/apache/datafusion/issues/21507
+
+statement ok
+CREATE TABLE t_unique_null(a INT, b INT, c INT, UNIQUE(a));
+
+statement ok
+INSERT INTO t_unique_null VALUES (1, 10, 100), (NULL, 20, 200), (NULL, 30, 300);
+
+# The two NULL rows must stay in separate groups (grouped by b as well).
+query II rowsort
+SELECT a, SUM(c) AS total FROM t_unique_null GROUP BY a, b;
+----
+1 100
+NULL 200
+NULL 300
+
+# GROUP BY on the UNIQUE column alone must still merge the NULL rows into one group.
+query II rowsort
+SELECT a, SUM(c) AS total FROM t_unique_null GROUP BY a;
+----
+1 100
+NULL 500
+
+statement ok
+DROP TABLE t_unique_null;

--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -652,6 +652,33 @@ See [PR #21803](https://github.com/apache/datafusion/pull/21803) for details.
 
 [20047]: https://github.com/apache/datafusion/pull/20047
 
+### `FunctionalDependencies::new_from_constraints` now requires nullable flags
+
+`FunctionalDependencies::new_from_constraints` has a new second parameter,
+`nullable_flags: &[bool]`, which must contain one entry per field in the
+relation indicating whether that field is nullable.
+
+Previously, `UNIQUE` constraints were always emitted as functional dependencies
+with `nullable = true`. Now, a `UNIQUE` constraint whose source columns include
+any nullable field is omitted entirely (SQL treats `NULL` as distinct, so the
+constraint does not guarantee uniqueness). When all source columns are
+non-nullable, the `UNIQUE` constraint is treated as equivalent to a primary key
+(`nullable = false`).
+
+**Before:**
+
+```rust,ignore
+let fd = FunctionalDependencies::new_from_constraints(Some(&constraints));
+```
+
+**After:**
+
+```rust,ignore
+// Collect the nullability of each field in the relation:
+let nullable_flags: Vec<bool> = schema.fields().iter().map(|f| f.is_nullable()).collect();
+let fd = FunctionalDependencies::new_from_constraints(Some(&constraints), &nullable_flags);
+```
+
 ### File statistics cache is now memory-limited and managed by the `CacheManager`
 
 The file statistics cache used by `ListingTable` is now memory-limited and


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21507

## Rationale for this change

DataFusion was deriving functional dependencies too aggressively in two cases:

1. `UNIQUE` constraints were being treated as functional dependencies even when one or more key columns were nullable. Under SQL semantics, `UNIQUE` allows multiple `NULL` values, so such constraints do not guarantee row-level uniqueness and cannot be used to eliminate `GROUP BY` expressions safely.

2. Recursive CTEs could inherit functional dependencies from the static term (anchor) even though the recursive term may produce rows that violate those dependencies. This could cause downstream optimizer rules to make incorrect uniqueness-based rewrites.

## What changes are included in this PR?

This PR tightens functional-dependency derivation and propagation:

- `FunctionalDependencies::new_from_constraints` now takes per-field nullability and only derives a functional dependency from a `UNIQUE` constraint when all determinant columns are non-nullable.
- Nullable `UNIQUE` constraints are omitted entirely instead of being recorded as nullable functional dependencies.
- Aggregate output functional dependencies for `GROUP BY` are preserved so they can still be used safely by later planning stages.
- Recursive CTE plans now clear inherited functional dependencies from the anchor schema, so outer consumers do not assume uniqueness that the recursive term may break.
- Added regression coverage for:
  - `GROUP BY` over nullable `UNIQUE` columns with multiple `NULL` values
  - join cases where non-null unique keys can still support expansion, but nullable unique keys cannot
  - recursive CTEs where anchor-term uniqueness must not leak into the full recursive result
- Added an upgrade note for the `FunctionalDependencies::new_from_constraints` API change.

## Are these changes tested?

Yes. This PR adds regression coverage for nullable-`UNIQUE` `GROUP BY` cases, recursive CTE functional-dependency propagation, and join cases that distinguish nullable from non-null unique keys.

## Are there any user-facing changes?

Yes. Queries that rely on grouping or distinctness analysis will no longer assume uniqueness from nullable `UNIQUE` constraints, and recursive CTE outputs will no longer inherit invalid functional dependencies from the anchor term. This prevents incorrect optimizer rewrites and fixes wrong results in affected queries.