### PR TITLE
fix: Prevent CLI crash on wide tables

### DIFF
--- a/datafusion-cli/src/print_format.rs
+++ b/datafusion-cli/src/print_format.rs
@@ -97,7 +97,7 @@ fn keep_only_maxrows(s: &str, maxrows: usize) -> String {
     let last_line = &lines[lines.len() - 1]; // bottom border line
 
     let spaces = last_line.len().saturating_sub(4);
-    let dotted_line = format!("| .{:<spaces$}|", "", spaces = spaces);
+    let dotted_line = format!("| .{}|", " ".repeat(spaces));
 
     let mut result = lines[0..(maxrows + 3)].to_vec(); // Keep top border and `maxrows` lines
     result.extend(vec![dotted_line; 3]); // Append ... lines
@@ -630,6 +630,41 @@ mod tests {
             vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
         )
         .unwrap()
+    }
+
+    #[test]
+    fn print_maxrows_limited_wide_table() {
+        let output = PrintBatchesTest::new()
+            .with_format(PrintFormat::Table)
+            .with_batches(vec![wide_column_batch()])
+            .with_maxrows(MaxRows::Limited(1))
+            .run();
+        assert_snapshot!(output, @r"
+        +----+----+----+----+----+----+----+----+----+----+
+        | c0 | c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 |
+        +----+----+----+----+----+----+----+----+----+----+
+        | 0  | 0  | 0  | 0  | 0  | 0  | 0  | 0  | 0  | 0  |
+        | .                                               |
+        | .                                               |
+        | .                                               |
+        +----+----+----+----+----+----+----+----+----+----+
+        ");
+    }
+
+    /// return a schema with many columns (to exercise wide table formatting)
+    fn wide_column_schema() -> SchemaRef {
+        let fields: Vec<Field> = (0..10)
+            .map(|i| Field::new(format!("c{i}"), DataType::Int32, false))
+            .collect();
+        Arc::new(Schema::new(fields))
+    }
+
+    /// return a batch with many columns and three rows
+    fn wide_column_batch() -> RecordBatch {
+        let arrays: Vec<Arc<dyn arrow::array::Array>> = (0..10)
+            .map(|_| Arc::new(Int32Array::from(vec![0, 1, 2])) as _)
+            .collect();
+        RecordBatch::try_new(wide_column_schema(), arrays).unwrap()
     }
 
     /// Slice the record batch into 2 batches

--- a/datafusion-cli/tests/cli_integration.rs
+++ b/datafusion-cli/tests/cli_integration.rs
@@ -287,6 +287,23 @@ fn test_cli_with_unbounded_memory_pool() {
     assert_cmd_snapshot!(cmd);
 }
 
+#[test]
+fn test_cli_wide_result_set_no_crash() {
+    let mut settings = make_settings();
+
+    settings.set_snapshot_suffix("wide_result_set");
+
+    let _bound = settings.bind_to_scope();
+
+    let mut cmd = cli();
+    let sql = "SELECT v1 as c0, v1+1 as c1, v1+2 as c2, v1+3 as c3, v1+4 as c4, \
+               v1+5 as c5, v1+6 as c6, v1+7 as c7, v1+8 as c8, v1+9 as c9 \
+               FROM generate_series(1, 100) as t1(v1);";
+    cmd.args(["--maxrows", "5", "--command", sql]);
+
+    assert_cmd_snapshot!(cmd);
+}
+
 #[tokio::test]
 async fn test_cli() {
     if env::var("TEST_STORAGE_INTEGRATION").is_err() {

--- a/datafusion-cli/tests/snapshots/cli_wide_result_set_no_crash@wide_result_set.snap
+++ b/datafusion-cli/tests/snapshots/cli_wide_result_set_no_crash@wide_result_set.snap
@@ -1,0 +1,32 @@
+---
+source: datafusion-cli/tests/cli_integration.rs
+assertion_line: 307
+info:
+  program: datafusion-cli
+  args:
+    - "--maxrows"
+    - "5"
+    - "--command"
+    - "SELECT v1 as c0, v1+1 as c1, v1+2 as c2, v1+3 as c3, v1+4 as c4, v1+5 as c5, v1+6 as c6, v1+7 as c7, v1+8 as c8, v1+9 as c9 FROM generate_series(1, 100) as t1(v1);"
+---
+success: true
+exit_code: 0
+----- stdout -----
+[CLI_VERSION]
++----+----+----+----+----+----+----+----+----+----+
+| c0 | c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 |
++----+----+----+----+----+----+----+----+----+----+
+| 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 |
+| 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 |
+| 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 | 12 |
+| 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 | 12 | 13 |
+| 5  | 6  | 7  | 8  | 9  | 10 | 11 | 12 | 13 | 14 |
+| .                                               |
+| .                                               |
+| .                                               |
++----+----+----+----+----+----+----+----+----+----+
+100 row(s) fetched. (First 5 displayed. Use --maxrows to adjust)
+[ELAPSED]
+
+
+----- stderr -----


### PR DESCRIPTION
## Which issue does this PR close?
 
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #21709 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The `keep_only_maxrows` function panics on wide tables, format string treats the spaces variable as an index and the new code repeats the space character directly. This prevents the format argument error.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- replaces the format string in `keep_only_maxrows`.
- adds `print_maxrows_limited_wide_table` unit test.
- adds `test_cli_wide_result_set_no_crash` integration test.
- adds a wide result set snapshot file.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes. I added unit and integration tests. The unit test passes a ten column schema to `keep_only_maxrows` and the integration test runs a wide query with a small row limit. These tests verify your format bug fix.

## Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
