### PR TITLE
perf: Optimize `DFSchema::qualified_name`

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -1355,7 +1355,7 @@ pub fn qualified_name(qualifier: Option<&TableReference>, name: &str) -> String 
         }) => (catalog.as_ref(), schema.as_ref(), table.as_ref()),
     };
 
-    // Reserve capacity for at most 3 separators; this might slighty over-allocate.
+    // Reserve capacity for at most 3 separators; this might slightly over-allocate.
     let mut s = String::with_capacity(a.len() + b.len() + c.len() + 3 + name.len());
     s.push_str(a);
     if !b.is_empty() {

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -1342,27 +1342,34 @@ impl SchemaExt for Schema {
 /// `format!("{q}.{name}")` when `qualifier` is `Some`, or just `name` when
 /// `None`. We avoid going through the `fmt` machinery for performance reasons.
 pub fn qualified_name(qualifier: Option<&TableReference>, name: &str) -> String {
-    let (a, b, c) = match qualifier {
+    let qualifier = match qualifier {
         None => return name.to_string(),
-        Some(TableReference::Bare { table }) => (table.as_ref(), "", ""),
-        Some(TableReference::Partial { schema, table }) => {
-            (schema.as_ref(), table.as_ref(), "")
+        Some(q) => q,
+    };
+    let (a, b, c) = match qualifier {
+        TableReference::Bare { table } => (table.as_ref(), None, None),
+        TableReference::Partial { schema, table } => {
+            (schema.as_ref(), Some(table.as_ref()), None)
         }
-        Some(TableReference::Full {
+        TableReference::Full {
             catalog,
             schema,
             table,
-        }) => (catalog.as_ref(), schema.as_ref(), table.as_ref()),
+        } => (
+            catalog.as_ref(),
+            Some(schema.as_ref()),
+            Some(table.as_ref()),
+        ),
     };
 
-    // Reserve capacity for at most 3 separators; this might slightly over-allocate.
-    let mut s = String::with_capacity(a.len() + b.len() + c.len() + 3 + name.len());
+    let extra = b.unwrap_or("").len() + c.unwrap_or("").len();
+    let mut s = String::with_capacity(a.len() + extra + 3 + name.len());
     s.push_str(a);
-    if !b.is_empty() {
+    if let Some(b) = b {
         s.push('.');
         s.push_str(b);
     }
-    if !c.is_empty() {
+    if let Some(c) = c {
         s.push('.');
         s.push_str(c);
     }
@@ -1387,6 +1394,15 @@ mod tests {
             (Some(TableReference::partial("s", "t")), "c0"),
             (Some(TableReference::full("c", "s", "t")), "c0"),
             (Some(TableReference::bare("mytable")), "some_column_name"),
+            // Empty segments must be preserved so that distinct qualified
+            // fields don't collide in `DFSchema::field_names()`.
+            (Some(TableReference::bare("")), "col"),
+            (Some(TableReference::partial("s", "")), "col"),
+            (Some(TableReference::partial("", "t")), "col"),
+            (Some(TableReference::full("c", "", "t")), "col"),
+            (Some(TableReference::full("", "s", "t")), "col"),
+            (Some(TableReference::full("c", "s", "")), "col"),
+            (Some(TableReference::full("", "", "")), "col"),
         ];
         for (qualifier, name) in cases {
             let actual = qualified_name(qualifier.as_ref(), name);

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -1338,11 +1338,37 @@ impl SchemaExt for Schema {
     }
 }
 
+/// Build a fully-qualified field name string. This is equivalent to
+/// `format!("{q}.{name}")` when `qualifier` is `Some`, or just `name` when
+/// `None`. We avoid going through the `fmt` machinery for performance reasons.
 pub fn qualified_name(qualifier: Option<&TableReference>, name: &str) -> String {
-    match qualifier {
-        Some(q) => format!("{q}.{name}"),
-        None => name.to_string(),
+    let (a, b, c) = match qualifier {
+        None => return name.to_string(),
+        Some(TableReference::Bare { table }) => (table.as_ref(), "", ""),
+        Some(TableReference::Partial { schema, table }) => {
+            (schema.as_ref(), table.as_ref(), "")
+        }
+        Some(TableReference::Full {
+            catalog,
+            schema,
+            table,
+        }) => (catalog.as_ref(), schema.as_ref(), table.as_ref()),
+    };
+
+    // Reserve capacity for at most 3 separators; this might slighty over-allocate.
+    let mut s = String::with_capacity(a.len() + b.len() + c.len() + 3 + name.len());
+    s.push_str(a);
+    if !b.is_empty() {
+        s.push('.');
+        s.push_str(b);
     }
+    if !c.is_empty() {
+        s.push('.');
+        s.push_str(c);
+    }
+    s.push('.');
+    s.push_str(name);
+    s
 }
 
 #[cfg(test)]
@@ -1350,6 +1376,27 @@ mod tests {
     use crate::assert_contains;
 
     use super::*;
+
+    /// `qualified_name` doesn't use `TableReference::Display` for performance
+    /// reasons, but check that the output is consistent.
+    #[test]
+    fn qualified_name_agrees_with_display() {
+        let cases: &[(Option<TableReference>, &str)] = &[
+            (None, "col"),
+            (Some(TableReference::bare("t")), "c0"),
+            (Some(TableReference::partial("s", "t")), "c0"),
+            (Some(TableReference::full("c", "s", "t")), "c0"),
+            (Some(TableReference::bare("mytable")), "some_column_name"),
+        ];
+        for (qualifier, name) in cases {
+            let actual = qualified_name(qualifier.as_ref(), name);
+            let expected = match qualifier {
+                Some(q) => format!("{q}.{name}"),
+                None => name.to_string(),
+            };
+            assert_eq!(actual, expected, "qualifier={qualifier:?} name={name}");
+        }
+    }
 
     #[test]
     fn qualifier_in_name() -> Result<()> {

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -1346,7 +1346,7 @@ pub fn qualified_name(qualifier: Option<&TableReference>, name: &str) -> String 
         None => return name.to_string(),
         Some(q) => q,
     };
-    let (a, b, c) = match qualifier {
+    let (first, second, third) = match qualifier {
         TableReference::Bare { table } => (table.as_ref(), None, None),
         TableReference::Partial { schema, table } => {
             (schema.as_ref(), Some(table.as_ref()), None)
@@ -1362,16 +1362,16 @@ pub fn qualified_name(qualifier: Option<&TableReference>, name: &str) -> String 
         ),
     };
 
-    let extra = b.unwrap_or("").len() + c.unwrap_or("").len();
-    let mut s = String::with_capacity(a.len() + extra + 3 + name.len());
-    s.push_str(a);
-    if let Some(b) = b {
+    let extra = second.map_or(0, str::len) + third.map_or(0, str::len);
+    let mut s = String::with_capacity(first.len() + extra + 3 + name.len());
+    s.push_str(first);
+    if let Some(second) = second {
         s.push('.');
-        s.push_str(b);
+        s.push_str(second);
     }
-    if let Some(c) = c {
+    if let Some(third) = third {
         s.push('.');
-        s.push_str(c);
+        s.push_str(third);
     }
     s.push('.');
     s.push_str(name);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21723

## Rationale for this change

`DFSchema::qualified_name` shows up as a hotspot when profiling the planner. It currently goes through the `fmt` machinery, which is fairly slow; it is reasonably simple to avoid that and `write_str()` to a preallocated string.

On the `sql_planner` benchmark, this yields 1-5% improvements for most benchmarks, with no significant regressions.

## What changes are included in this PR?

* Implement optimization
* Add unit test to ensure that we preserve compatibility between `qualified_name` and `TableReference::Display`

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
