### PR TITLE
perf: Tweak vec capacity in `project_statistics`

### DIFF
--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -656,7 +656,7 @@ impl ProjectionExprs {
         mut stats: Statistics,
         output_schema: &Schema,
     ) -> Result<Statistics> {
-        let mut column_statistics = vec![];
+        let mut column_statistics = Vec::with_capacity(self.exprs.len());
 
         for proj_expr in self.exprs.iter() {
             let expr = &proj_expr.expr;


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

We can easily specify the correct capacity for the result vector in `project_statistics`. Profiling shows that this reduces total allocated bytes for planning TPC-H Q13 by ~1.7%, or ~17 kB out of ~1.03MB of allocations.

Probably too small to show up in a measurement of elapsed duration, but doesn't hurt.

## What changes are included in this PR?

* Specify vector capacity in `project_statistics`

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
