### PR TITLE
Improve ergonomics for ExecutionPlanMetricsSet and MetricsSet

### DIFF
--- a/datafusion/physical-expr-common/src/metrics/mod.rs
+++ b/datafusion/physical-expr-common/src/metrics/mod.rs
@@ -26,6 +26,7 @@ mod value;
 use datafusion_common::HashMap;
 pub use datafusion_common::format::{MetricCategory, MetricType};
 use parking_lot::Mutex;
+use std::vec::IntoIter;
 use std::{
     borrow::Cow,
     fmt::{self, Debug, Display},
@@ -223,6 +224,11 @@ impl MetricsSet {
     /// Add the specified metric
     pub fn push(&mut self, metric: Arc<Metric>) {
         self.metrics.push(metric)
+    }
+
+    /// Extends the current list of metrics with the provided ones
+    pub fn extend(&mut self, metrics: impl Iterator<Item = Arc<Metric>>) {
+        self.metrics.extend(metrics)
     }
 
     /// Returns an iterator across all metrics
@@ -432,6 +438,15 @@ impl Display for MetricsSet {
     }
 }
 
+impl IntoIterator for MetricsSet {
+    type Item = Arc<Metric>;
+    type IntoIter = IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.metrics.into_iter()
+    }
+}
+
 /// A set of [`Metric`]s for an individual operator.
 ///
 /// This structure is intended as a convenience for execution plan
@@ -462,6 +477,14 @@ impl ExecutionPlanMetricsSet {
     pub fn clone_inner(&self) -> MetricsSet {
         let guard = self.inner.lock();
         (*guard).clone()
+    }
+}
+
+impl From<MetricsSet> for ExecutionPlanMetricsSet {
+    fn from(metrics: MetricsSet) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(metrics)),
+        }
     }
 }
 

--- a/datafusion/physical-expr-common/src/metrics/mod.rs
+++ b/datafusion/physical-expr-common/src/metrics/mod.rs
@@ -26,11 +26,11 @@ mod value;
 use datafusion_common::HashMap;
 pub use datafusion_common::format::{MetricCategory, MetricType};
 use parking_lot::Mutex;
-use std::vec::IntoIter;
 use std::{
     borrow::Cow,
     fmt::{self, Debug, Display},
     sync::Arc,
+    vec::IntoIter,
 };
 
 // public exports
@@ -227,7 +227,7 @@ impl MetricsSet {
     }
 
     /// Extends the current list of metrics with the provided ones
-    pub fn extend(&mut self, metrics: impl Iterator<Item = Arc<Metric>>) {
+    pub fn extend(&mut self, metrics: impl IntoIterator<Item = Arc<Metric>>) {
         self.metrics.extend(metrics)
     }
 
@@ -444,6 +444,14 @@ impl IntoIterator for MetricsSet {
 
     fn into_iter(self) -> Self::IntoIter {
         self.metrics.into_iter()
+    }
+}
+
+impl FromIterator<Arc<Metric>> for MetricsSet {
+    fn from_iter<T: IntoIterator<Item = Arc<Metric>>>(iter: T) -> Self {
+        Self {
+            metrics: iter.into_iter().collect(),
+        }
     }
 }
 

--- a/datafusion/physical-expr-common/src/metrics/mod.rs
+++ b/datafusion/physical-expr-common/src/metrics/mod.rs
@@ -226,11 +226,6 @@ impl MetricsSet {
         self.metrics.push(metric)
     }
 
-    /// Extends the current list of metrics with the provided ones
-    pub fn extend(&mut self, metrics: impl IntoIterator<Item = Arc<Metric>>) {
-        self.metrics.extend(metrics)
-    }
-
     /// Returns an iterator across all metrics
     pub fn iter(&self) -> impl Iterator<Item = &Arc<Metric>> {
         self.metrics.iter()
@@ -444,6 +439,21 @@ impl IntoIterator for MetricsSet {
 
     fn into_iter(self) -> Self::IntoIter {
         self.metrics.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a MetricsSet {
+    type Item = &'a Arc<Metric>;
+    type IntoIter = std::slice::Iter<'a, Arc<Metric>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.metrics.iter()
+    }
+}
+
+impl Extend<Arc<Metric>> for MetricsSet {
+    fn extend<I: IntoIterator<Item = Arc<Metric>>>(&mut self, iter: I) {
+        self.metrics.extend(iter);
     }
 }
 
@@ -781,6 +791,52 @@ mod tests {
                 panic!("Not a timestamp");
             }
         };
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut metrics = MetricsSet::new();
+        let m1 = Arc::new(Metric::new(MetricValue::OutputRows(Count::new()), None));
+        let m2 = Arc::new(Metric::new(MetricValue::SpillCount(Count::new()), None));
+
+        metrics.extend([Arc::clone(&m1), Arc::clone(&m2)]);
+        assert_eq!(metrics.iter().count(), 2);
+
+        let m3 = Arc::new(Metric::new(MetricValue::SpilledBytes(Count::new()), None));
+        metrics.extend(std::iter::once(Arc::clone(&m3)));
+        assert_eq!(metrics.iter().count(), 3);
+    }
+
+    #[test]
+    fn test_collect() {
+        let m1 = Arc::new(Metric::new(MetricValue::OutputRows(Count::new()), None));
+        let m2 = Arc::new(Metric::new(MetricValue::SpillCount(Count::new()), None));
+
+        let metrics: MetricsSet =
+            vec![Arc::clone(&m1), Arc::clone(&m2)].into_iter().collect();
+        assert_eq!(metrics.iter().count(), 2);
+
+        let empty: MetricsSet = std::iter::empty().collect();
+        assert_eq!(empty.iter().count(), 0);
+    }
+
+    #[test]
+    fn test_into_iterator_by_ref() {
+        let mut metrics = MetricsSet::new();
+        metrics.push(Arc::new(Metric::new(
+            MetricValue::OutputRows(Count::new()),
+            None,
+        )));
+        metrics.push(Arc::new(Metric::new(
+            MetricValue::SpillCount(Count::new()),
+            None,
+        )));
+
+        let mut count = 0;
+        for _m in &metrics {
+            count += 1;
+        }
+        assert_eq!(count, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- None

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Sometimes, when an `ExecutionPlan` implementation is complex, different metrics are collected from different structs that compose the whole execution plan. 

These metrics need to eventually be served from the single entrypoint `ExecutionPlan::metrics()` or `DataSource::metrics()`, and the current api does not have good methods for merging several `ExecutionPlanMetricsSet` coming from different sources into a single one.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add some basic conversion and iteration methods for `MetricsSet` and `ExecutionPlanMetricsSet`, in order to improve ergonomics around these structs.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

This is purely just basic std trait implementations and method exposure, so as long as the code compiles, I don't think it needs further tests.

## Are there any user-facing changes?

People will see some more available methods in the `MetricsSet` and `ExecutionPlanMetricsSet` structs for ergonomics.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
