### PR TITLE
ci: permit stale workflow to delete cache

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,7 @@ jobs:
   close-stale-prs:
     runs-on: ubuntu-slim
     permissions:
+      actions: write
       issues: write
       pull-requests: write
     steps:


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Some PRs are being omitted from stale check because they were in a cache, and the workflow appears to not have permission to delete cache so they are forever stuck as unprocessed.

For example in this run: https://github.com/apache/datafusion/actions/runs/24756695077/job/72431314533

Seeing this in logs:

```
[#20473]            issue skipped due being processed during the previous run
[#20460]            pull request skipped due being processed during the previous run
[#20448]            issue skipped due being processed during the previous run
[#20443]            issue skipped due being processed during the previous run
[#20435]            issue skipped due being processed during the previous run
[#20418]            issue skipped due being processed during the previous run
[#20417]            pull request skipped due being processed during the previous run
[#20416]            pull request skipped due being processed during the previous run
[#20403]            pull request skipped due being processed during the previous run
```

And at the end we see this warning:

```
Warning: Error delete _state: [403] Resource not accessible by integration - https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key
```

stale workflow uses a cache in case it hits the `operations-per-run` limit meant to prevent API rate limiting (we have default of 30), so it seems we previously hit this limit and some issues/PRs were cached, and have never been uncached since so are never processed again. See: https://github.com/actions/stale#operations-per-run

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Give permission to stale workflow to run github actions (like delete cache). See recommended permissions:

https://github.com/actions/stale#recommended-permissions

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
