### PR TITLE
chore: re-enable `add_months` overflow test

### DIFF
--- a/datafusion/sqllogictest/test_files/spark/datetime/add_months.slt
+++ b/datafusion/sqllogictest/test_files/spark/datetime/add_months.slt
@@ -31,11 +31,8 @@ SELECT add_months('2016-07-30'::date, 10000::int);
 2849-11-30
 
 # Test integer overflow
-# TODO: Enable with next arrow upgrade (>=58.0.0)
-# query D
-# SELECT add_months('2016-07-30'::date, 2147483647::int);
-# ----
-# NULL
+query error DataFusion error: Arrow error: Compute error: Date arithmetic overflow: 17012 \+ 2147483647 months
+SELECT add_months('2016-07-30'::date, 2147483647::int);
 
 query D
 SELECT add_months('2016-07-30'::date, -5::int);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- From this discussion: https://github.com/apache/datafusion/pull/19711#discussion_r2676319850

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In above PR we didn't enable a test because upstream arrow-rs had a panic bug. This is now fixed:

- https://github.com/apache/arrow-rs/pull/9144

So now we can enable this test again to assert expected error.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
