### PR TITLE
perf(repartition): drive input + completion from a single task

### DIFF
--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -382,13 +382,15 @@ impl RepartitionExecState {
                 })
                 .collect();
 
-            // Extract senders for wait_for_task before moving txs
+            // Clone outbound senders so the same task that drives the input
+            // can forward EOS/error/panic markers after `pull_from_input`
+            // returns or unwinds.
             let senders: HashMap<_, _> = txs
                 .iter()
                 .map(|(partition, channel)| (*partition, channel.sender.clone()))
                 .collect();
 
-            let input_task = SpawnedTask::spawn(RepartitionExec::pull_from_input(
+            let input_task = SpawnedTask::spawn(RepartitionExec::drive_input(
                 stream,
                 txs,
                 partitioning.clone(),
@@ -396,13 +398,9 @@ impl RepartitionExecState {
                 // preserve_order depends on partition index to start from 0
                 if preserve_order { 0 } else { i },
                 num_input_partitions,
+                senders,
             ));
-
-            // In a separate task, wait for each input to be done
-            // (and pass along any errors, including panic!s)
-            let wait_for_task =
-                SpawnedTask::spawn(RepartitionExec::wait_for_task(input_task, senders));
-            spawned_tasks.push(wait_for_task);
+            spawned_tasks.push(input_task);
         }
         *self = Self::ConsumingInputStreams(ConsumingInputStreamsState {
             channels,
@@ -1456,47 +1454,67 @@ impl RepartitionExec {
         Ok(())
     }
 
-    /// Waits for `input_task` which is consuming one of the inputs to
-    /// complete. Upon each successful completion, sends a `None` to
-    /// each of the output tx channels to signal one of the inputs is
-    /// complete. Upon error, propagates the errors to all output tx
-    /// channels.
-    async fn wait_for_task(
-        input_task: SpawnedTask<Result<()>>,
-        txs: HashMap<usize, DistributionSender<MaybeBatch>>,
+    /// Drives `pull_from_input` for a single input partition and forwards
+    /// its completion, error, or panic to all output senders. Running the
+    /// forwarder in the same spawned task (rather than a separate
+    /// `wait_for_task` shepherd) halves the number of tokio tasks created
+    /// per `RepartitionExec`. Panic safety is preserved by wrapping the
+    /// inner future in `AssertUnwindSafe(..).catch_unwind()`.
+    ///
+    /// Send errors on the output channels are ignored (`.ok()`) because
+    /// they indicate the receiver has already shut down (e.g. from LIMIT).
+    async fn drive_input(
+        stream: SendableRecordBatchStream,
+        txs: HashMap<usize, OutputChannel>,
+        partitioning: Partitioning,
+        metrics: RepartitionMetrics,
+        input_partition: usize,
+        num_input_partitions: usize,
+        senders: HashMap<usize, DistributionSender<MaybeBatch>>,
     ) {
-        // wait for completion, and propagate error
-        // note we ignore errors on send (.ok) as that means the receiver has already shutdown.
+        let result = std::panic::AssertUnwindSafe(Self::pull_from_input(
+            stream,
+            txs,
+            partitioning,
+            metrics,
+            input_partition,
+            num_input_partitions,
+        ))
+        .catch_unwind()
+        .await;
 
-        match input_task.join().await {
-            // Error in joining task
-            Err(e) => {
-                let e = Arc::new(e);
-
-                for (_, tx) in txs {
-                    let err = Err(DataFusionError::Context(
-                        "Join Error".to_string(),
-                        Box::new(DataFusionError::External(Box::new(Arc::clone(&e)))),
-                    ));
-                    tx.send(Some(err)).await.ok();
+        match result {
+            // Input task completed successfully
+            Ok(Ok(())) => {
+                for (_partition, tx) in senders {
+                    tx.send(None).await.ok();
                 }
             }
-            // Error from running input task
+            // Error returned from pull_from_input
             Ok(Err(e)) => {
-                // send the same Arc'd error to all output partitions
                 let e = Arc::new(e);
-
-                for (_, tx) in txs {
-                    // wrap it because need to send error to all output partitions
+                for (_, tx) in senders {
                     let err = Err(DataFusionError::from(&e));
                     tx.send(Some(err)).await.ok();
                 }
             }
-            // Input task completed successfully
-            Ok(Ok(())) => {
-                // notify each output partition that this input partition has no more data
-                for (_partition, tx) in txs {
-                    tx.send(None).await.ok();
+            // pull_from_input panicked
+            Err(panic) => {
+                let msg = if let Some(s) = panic.downcast_ref::<&'static str>() {
+                    (*s).to_string()
+                } else if let Some(s) = panic.downcast_ref::<String>() {
+                    s.clone()
+                } else {
+                    "unknown panic".to_string()
+                };
+                for (_, tx) in senders {
+                    let err = Err(DataFusionError::Context(
+                        "Join Error".to_string(),
+                        Box::new(DataFusionError::Execution(format!(
+                            "task panicked: {msg}"
+                        ))),
+                    ));
+                    tx.send(Some(err)).await.ok();
                 }
             }
         }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

Each `RepartitionExec` input partition currently spawns **two** tokio tasks:

1. `pull_from_input` — the worker that pulls batches from the input stream and routes them to per-output senders.
2. `wait_for_task` — a shepherd that only awaits the worker's `JoinHandle` and forwards EOS (`None`) or the joined error to each output sender.

Observing a ClickBench run under `tokio-console` shows the shepherd is pure overhead: on ~300 captured `SpawnedTask` rows, it's an exact 1:1 split between workers (polls ≈ 300–600, busy ≈ hundreds of ms) and shepherds (polls ≈ 3–5, busy ≈ 4–30 µs). That doubles the number of tokio tasks created per `RepartitionExec` and adds a cross-task waker round-trip per partition for no useful work.

Example paired rows from the capture (same total lifetime, radically different workload):

| task     | total | busy  | polls |
|----------|-------|-------|-------|
| worker   | 615ms | 391ms | 349   |
| shepherd | 615ms | 22µs  | 4     |

## What changes are included in this PR?

- Introduce `RepartitionExec::drive_input` that wraps `pull_from_input` in `AssertUnwindSafe(..).catch_unwind()` and, after the inner future resolves, forwards `None` / error / a synthesized panic error to each output sender from the *same* task.
- Remove `RepartitionExec::wait_for_task`.
- The outer spawn loop in `RepartitionExecState::consume_input_streams` now spawns exactly one task per input partition.

Panic safety is preserved: a panic from `pull_from_input` is surfaced as `DataFusionError::Context("Join Error", Execution("task panicked: …"))`, mirroring the previous `JoinError`-wrapping path closely enough for existing callers.

**Net effect:** tokio tasks spawned per `RepartitionExec` drops from `2 · N` to `N` (where `N` = input partitions), with one fewer cross-task waker hop per partition.

## Are these changes tested?

Yes — covered by existing repartition tests in `datafusion/physical-plan/src/repartition/mod.rs`:

- `cargo test -p datafusion-physical-plan --lib repartition::` → **41/41 pass**, including:
  - `error_for_input_exec` (exercises panic propagation from input)
  - `repartition_with_error_in_stream` (exercises error propagation)
  - All spilling / ordering / drop-cancel tests.
- `cargo clippy -p datafusion-physical-plan --all-targets -- -D warnings` → clean.
- `cargo fmt --check` → clean.

## Are there any user-facing changes?

No public API changes. The only behavior difference is the wording of panic errors surfaced through repartition: they now carry `"task panicked: {msg}"` (synthesized from the panic payload via `downcast_ref`) instead of the exact `JoinError` `Display`, but remain wrapped in `DataFusionError::Context("Join Error", …)` as before.