### PR TITLE
Fix: allow coercion from Binary and LargeBinary into BinaryView

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -888,6 +888,8 @@ fn coerced_from<'a>(
         (Utf8View, Utf8 | LargeUtf8 | Null) => Some(type_into.clone()),
         // Any type can be coerced into strings
         (Utf8 | LargeUtf8, _) => Some(type_into.clone()),
+        // We can go into a BinaryView from a Binary or LargeBinary
+        (BinaryView, Binary | LargeBinary | Null) => Some(type_into.clone()),
         (Null, _) if can_cast_types(type_from, type_into) => Some(type_into.clone()),
 
         (List(_), FixedSizeList(_, _)) => Some(type_into.clone()),
@@ -956,6 +958,20 @@ mod tests {
         let cases = vec![
             (DataType::Utf8View, DataType::Utf8),
             (DataType::Utf8View, DataType::LargeUtf8),
+            (DataType::Utf8View, DataType::Null),
+        ];
+
+        for case in cases {
+            assert_eq!(coerced_from(&case.0, &case.1), Some(case.0));
+        }
+    }
+
+    #[test]
+    fn test_binary_conversion() {
+        let cases = vec![
+            (DataType::BinaryView, DataType::Binary),
+            (DataType::BinaryView, DataType::LargeBinary),
+            (DataType::BinaryView, DataType::Null),
         ];
 
         for case in cases {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21798

## Rationale for this change

The coercion should take place in the same way as is foreseen already for the string datatypes (Utf8, LargeUtf8, Null -> Utf8View)

## What changes are included in this PR?

The coerced_from function in datafusion/expr/src/type_coercion/functions.rs was missing a match arm for (BinaryView, Binary | LargeBinary | Null).

## Are these changes tested?

Additional unit test written : `test_binary_conversion`

## Are there any user-facing changes?

No


