### PR TITLE
fix: allow coercion from Binary and LargeBinary into BinaryView

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -886,6 +886,8 @@ fn coerced_from<'a>(
         (Interval(_), Null | Utf8 | LargeUtf8) => Some(type_into.clone()),
         // We can go into a Utf8View from a Utf8 or LargeUtf8
         (Utf8View, Utf8 | LargeUtf8 | Null) => Some(type_into.clone()),
+        // We can go into a BinaryView from a Binary or LargeBinary
+        (BinaryView, Binary | LargeBinary | Null) => Some(type_into.clone()),
         // Any type can be coerced into strings
         (Utf8 | LargeUtf8, _) => Some(type_into.clone()),
         (Null, _) if can_cast_types(type_from, type_into) => Some(type_into.clone()),
@@ -956,10 +958,38 @@ mod tests {
         let cases = vec![
             (DataType::Utf8View, DataType::Utf8),
             (DataType::Utf8View, DataType::LargeUtf8),
+            (DataType::Utf8View, DataType::Null),
+            (DataType::BinaryView, DataType::Binary),
+            (DataType::BinaryView, DataType::LargeBinary),
+            (DataType::BinaryView, DataType::Null),
         ];
 
         for case in cases {
             assert_eq!(coerced_from(&case.0, &case.1), Some(case.0));
+        }
+    }
+
+    #[test]
+    fn test_binaryview_signature_accepts_binary_columns() {
+        // A scalar UDF declared with `Signature::exact(vec![BinaryView], ...)`
+        // must accept `Binary`, `LargeBinary`, and `Null` arguments via
+        // coercion, matching the behaviour already in place for `Utf8View`.
+        let signature =
+            Signature::exact(vec![DataType::BinaryView], Volatility::Immutable);
+
+        for input in [DataType::Binary, DataType::LargeBinary, DataType::Null] {
+            let current_fields = vec![Arc::new(Field::new("f", input.clone(), true))];
+            let coerced = fields_with_udf(&current_fields, &MockUdf(signature.clone()))
+                .unwrap_or_else(|e| {
+                    panic!("failed to coerce {input:?} into BinaryView: {e}")
+                });
+            assert_eq!(
+                coerced
+                    .iter()
+                    .map(|f| f.data_type().clone())
+                    .collect::<Vec<_>>(),
+                vec![DataType::BinaryView]
+            );
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21798.

## Rationale for this change

`coerced_from` in `datafusion/expr/src/type_coercion/functions.rs` handles
`(Utf8View, Utf8 | LargeUtf8 | Null)` but the symmetric arm for `BinaryView`
was missing. That meant a scalar UDF declared with

```rust
Signature::exact(vec![DataType::BinaryView], Volatility::Immutable)
```

would reject `Binary`/`LargeBinary` columns (and untyped `Null` placeholders)
during planning, even though the analogous Utf8View-family call works fine.

### Before

```text
Error: type_coercion
caused by
Error during planning: Failed to coerce arguments to satisfy a call to 'my_udf' function:
coercion from [Binary] to the signature Exact([BinaryView]) failed.
```

### After

```text
# Binary / LargeBinary / Null all coerce into BinaryView
[BinaryView]
```

## What changes are included in this PR?

- Add `(BinaryView, Binary | LargeBinary | Null) => Some(type_into.clone())`
  in `coerced_from`, directly mirroring the Utf8View arm above it.
- Extend `test_string_conversion` to cover the three new BinaryView cases and
  the previously uncovered `Utf8View <- Null` case.
- Add `test_binaryview_signature_accepts_binary_columns`, which exercises the
  fix through `fields_with_udf` with a real `Signature::exact(vec![BinaryView], ...)`
  so regressions show up at the coercion-entry level, not just inside
  `coerced_from`.

## Are these changes tested?

Yes:

- `cargo test -p datafusion-expr` (all 18 functions::tests pass, including the
  new `test_binaryview_signature_accepts_binary_columns`).
- `cargo fmt --all --check`.
- `cargo clippy --all-targets --workspace --features "avro,integration-tests,extended_tests" -- -D warnings`.

## Are there any user-facing changes?

Yes, but strictly additive: existing call sites keep compiling, and calls that
used to fail planning with a `BinaryView` signature now succeed by coercing
`Binary`/`LargeBinary`/`Null` arguments into `BinaryView`. No public API is
changed and no breaking behaviour is introduced.