### PR TITLE
ci: improve caches in rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Rust Dependency Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          shared-key: "amd-ci-check" # this job uses it's own cache becase check has a separate cache and we need it to be fast as it blocks other jobs
+          shared-key: "amd-ci"
           save-if: ${{ github.ref_name == 'main' }}
       - name: Prepare cargo build
         run: |
@@ -147,6 +147,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - name: Check datafusion-proto (default features)
         run: cargo check --profile ci --all-targets -p datafusion-proto
       #
@@ -244,6 +249,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - name: Check datafusion-functions (default features)
         run: cargo check --profile ci --all-targets -p datafusion-functions
       #
@@ -367,8 +377,8 @@ jobs:
       - name: Rust Dependency Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          save-if: ${{ github.ref_name == 'main' }}
-          shared-key: "amd-ci-linux-test-example"
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - name: Run examples
         run: |
           # test datafusion-sql examples
@@ -395,6 +405,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - name: Run doctests
         run: cargo test --profile ci --doc --features avro,json
       - name: Verify Working Directory Clean
@@ -414,6 +429,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - name: Run cargo doc
         run: ci/scripts/rust_docs.sh
 
@@ -458,7 +478,21 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
+      - name: Cache TPCH data
+        id: cache-tpch-data
+        uses: actions/cache@v4
+        with:
+          path: datafusion/sqllogictest/test_files/tpch/data
+          # Bump the suffix (e.g. v1 -> v2) to force regeneration
+          # if the dbgen source or scale factor below changes.
+          key: tpch-data-databricks-dbgen-sf0.1-v1
       - name: Generate benchmark data and expected query results
+        if: steps.cache-tpch-data.outputs.cache-hit != 'true'
         run: |
           mkdir -p datafusion/sqllogictest/test_files/tpch/data
           git clone https://github.com/databricks/tpch-dbgen.git
@@ -506,6 +540,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - name: Run sqllogictest
         run: |
           cd datafusion/sqllogictest
@@ -531,6 +570,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - name: Run sqllogictest
         # TODO: Right now several tests are failing in Substrait round-trip mode, so this
         #  command cannot be run for all the .slt files. Run it for just one that works (limit.slt)
@@ -582,6 +626,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - name: Run gen
         run: ./regen.sh
         working-directory: ./datafusion/proto
@@ -667,8 +716,8 @@ jobs:
       - name: Rust Dependency Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          save-if: ${{ github.ref_name == 'main' }}
-          shared-key: "amd-ci-clippy"
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - name: Run clippy
         run: ci/scripts/rust_clippy.sh
 
@@ -688,7 +737,9 @@ jobs:
         with:
           rust-version: stable
       - name: Install taplo
-        run: cargo +stable install taplo-cli --version ^0.9 --locked
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486  # v2.75.18
+        with:
+          tool: taplo-cli
       # if you encounter an error, try running 'taplo format' to fix the formatting automatically.
       - name: Check Cargo.toml formatting
         run: taplo format --check
@@ -709,6 +760,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          save-if: false # set in linux-test
+          shared-key: "amd-ci"
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
         with:
           node-version: "20"


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21818.

## Rationale for this change

Several jobs in `.github/workflows/rust.yml` rebuild dependencies cold on every run because they don't attach `Swatinem/rust-cache`. The workflow also maintained four separate cache keys covering roughly the same workspace, and `taplo-cli` was still being installed from source on every run. Part of #13813.

## What changes are included in this PR?

1. Add read-only `Swatinem/rust-cache@v2` (`shared-key: amd-ci`, `save-if: false`) to the jobs that previously had no dep cache: `linux-datafusion-proto-features`, `linux-cargo-check-datafusion-functions`, `linux-test-doc`, `linux-rustdoc`, `verify-benchmark-results`, `sqllogictest-postgres`, `sqllogictest-substrait`, `config-docs-check`, `vendor`.

`msrv` is intentionally excluded — `cargo msrv verify` builds against MSRV rust versions, so the `amd-ci` cache (built with stable) wouldn't match and would just add download overhead.

2. Consolidate `amd-ci-check`, `amd-ci-linux-test-example`, and `amd-ci-clippy` onto the shared `amd-ci` key. `linux-test-example` and `clippy` now use `save-if: false`; `linux-build-lib` and `linux-test` remain the savers.

3. Replace `cargo install taplo-cli` in `cargo-toml-formatting-checks` with `taiki-e/install-action`, matching the pattern already used for `wasm-pack` and `cargo-msrv`.

4. Cache the deterministic `tpch-dbgen` output in `verify-benchmark-results` keyed on the dbgen fork and scale factor, skipping the clone + `make` + `dbgen` on cache hits.

No `needs:` graph or coverage changes.

## Are these changes tested?

Validated locally with `actionlint`; pre-existing warnings in untouched shell blocks are unchanged. The actual cache behaviour needs to be observed on real CI runs across multiple pushes.

### Test Evidence

<details><summary>rust.yml Performance (Cold)</summary>

<img width="1550" height="1400" alt="image" src="https://github.com/user-attachments/assets/02b9ad37-0b8e-4c15-8988-be1c9df467c5" />

</details>


<details><summary>rust.yml Performance (Warm)</summary>

</details>

## Are there any user-facing changes?

No — this is CI infrastructure only.

Made with [Cursor](https://cursor.com)