### PR TITLE
fix: fix elapsed_compute metric in ParquetSink to report encoding time only 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,6 +2118,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
+ "pin-project",
  "tempfile",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,6 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
- "pin-project",
  "tempfile",
  "tokio",
 ]
@@ -2476,6 +2475,7 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
+ "pin-project",
  "rand 0.9.4",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,8 +179,8 @@ parquet = { version = "58.1.0", default-features = false, features = [
     "object_store",
 ] }
 pbjson = { version = "0.9.0" }
-pin-project = "1"
 pbjson-types = "0.9"
+pin-project = "1"
 # Should match arrow-flight's version of prost.
 prost = "0.14.1"
 rand = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ parquet = { version = "58.1.0", default-features = false, features = [
     "object_store",
 ] }
 pbjson = { version = "0.9.0" }
+pin-project = "1"
 pbjson-types = "0.9"
 # Should match arrow-flight's version of prost.
 prost = "0.14.1"

--- a/datafusion/core/src/dataframe/parquet.rs
+++ b/datafusion/core/src/dataframe/parquet.rs
@@ -558,6 +558,66 @@ mod tests {
 
         assert_eq!(metric_usize(&aggregated, "rows_written"), 50);
         assert!(metric_usize(&aggregated, "bytes_written") > 0);
+        assert!(
+            metric_usize(&aggregated, "elapsed_compute") > 0,
+            "expected elapsed_compute > 0 on parallel path"
+        );
+
+        Ok(())
+    }
+
+    /// Test that ParquetSink reports a non-zero elapsed_compute on the sequential
+    /// write path (allow_single_file_parallelism = false), where elapsed_compute
+    /// is computed as total_write_time - io_time via TimingWriter.
+    #[tokio::test]
+    async fn test_parquet_sink_metrics_sequential() -> Result<()> {
+        use arrow::array::Int32Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+        use arrow::record_batch::RecordBatch;
+        use datafusion_execution::TaskContext;
+
+        use futures::TryStreamExt;
+
+        let ctx = SessionContext::new();
+        ctx.sql("SET datafusion.execution.parquet.allow_single_file_parallelism = false")
+            .await?
+            .collect()
+            .await?;
+
+        let tmp_dir = TempDir::new()?;
+        let output_path = tmp_dir.path().join("metrics_sequential.parquet");
+        let output_path_str = output_path.to_str().unwrap();
+
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let ids: Vec<i32> = (0..50).collect();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(ids))],
+        )?;
+        ctx.register_batch("source_seq", batch)?;
+
+        let df = ctx
+            .sql(&format!(
+                "COPY source_seq TO '{output_path_str}' STORED AS PARQUET"
+            ))
+            .await?;
+        let plan = df.create_physical_plan().await?;
+        let task_ctx = Arc::new(TaskContext::from(&ctx.state()));
+        let stream = plan.execute(0, task_ctx)?;
+        let _batches: Vec<_> = stream.try_collect().await?;
+
+        let metrics = plan
+            .metrics()
+            .expect("DataSinkExec should return metrics from ParquetSink");
+        let aggregated = metrics.aggregate_by_name();
+
+        assert_eq!(metric_usize(&aggregated, "rows_written"), 50);
+        assert!(metric_usize(&aggregated, "bytes_written") > 0);
+        assert!(
+            metric_usize(&aggregated, "elapsed_compute") > 0,
+            "expected elapsed_compute > 0 on sequential path"
+        );
 
         Ok(())
     }

--- a/datafusion/datasource-parquet/Cargo.toml
+++ b/datafusion/datasource-parquet/Cargo.toml
@@ -53,7 +53,6 @@ log = { workspace = true }
 object_store = { workspace = true }
 parking_lot = { workspace = true }
 parquet = { workspace = true }
-pin-project = "1"
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/datafusion/datasource-parquet/Cargo.toml
+++ b/datafusion/datasource-parquet/Cargo.toml
@@ -53,6 +53,7 @@ log = { workspace = true }
 object_store = { workspace = true }
 parking_lot = { workspace = true }
 parquet = { workspace = true }
+pin-project = "1"
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -22,6 +22,7 @@ use std::fmt::Debug;
 use std::ops::Range;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 use std::{fmt, vec};
 
 use arrow::array::RecordBatch;
@@ -55,7 +56,7 @@ use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::dml::InsertOp;
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, LexRequirement};
 use datafusion_physical_plan::metrics::{
-    ExecutionPlanMetricsSet, MetricBuilder, MetricCategory, MetricsSet,
+    ExecutionPlanMetricsSet, MetricBuilder, MetricCategory, MetricsSet, Time,
 };
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
 use datafusion_session::Session;
@@ -78,6 +79,7 @@ use parquet::arrow::arrow_writer::{
     ArrowWriterOptions, compute_leaves,
 };
 use parquet::arrow::async_reader::MetadataFetch;
+use parquet::arrow::async_writer::AsyncFileWriter;
 use parquet::arrow::{ArrowWriter, AsyncArrowWriter};
 use parquet::basic::Type;
 #[cfg(feature = "parquet_encryption")]
@@ -1175,6 +1177,35 @@ impl DisplayAs for ParquetSink {
     }
 }
 
+/// Wraps an [`AsyncFileWriter`] and records the wall-clock time spent in I/O
+/// calls (`write` and `complete`). Used by the sequential write path to isolate
+/// I/O time so it can be subtracted from the total write time, yielding a clean
+/// `elapsed_compute` that covers only Arrow→Parquet encoding.
+///
+/// `io_time` is backed by `Arc<AtomicUsize>`, so clones share the same counter.
+/// This type is an internal implementation detail and is not registered in any
+/// `MetricsSet`.
+struct TimingWriter<W> {
+    inner: W,
+    io_time: Time,
+}
+
+impl<W: AsyncFileWriter> AsyncFileWriter for TimingWriter<W> {
+    fn write(&mut self, bs: Bytes) -> BoxFuture<'_, parquet::errors::Result<()>> {
+        Box::pin(async move {
+            let _timer = self.io_time.timer();
+            self.inner.write(bs).await
+        })
+    }
+
+    fn complete(&mut self) -> BoxFuture<'_, parquet::errors::Result<()>> {
+        Box::pin(async move {
+            let _timer = self.io_time.timer();
+            self.inner.complete().await
+        })
+    }
+}
+
 impl ParquetSink {
     /// Create from config.
     pub fn new(config: FileSinkConfig, parquet_options: TableParquetOptions) -> Self {
@@ -1244,7 +1275,8 @@ impl ParquetSink {
         object_store: Arc<dyn ObjectStore>,
         context: &Arc<TaskContext>,
         parquet_props: WriterProperties,
-    ) -> Result<AsyncArrowWriter<BufWriter>> {
+        io_time: Time,
+    ) -> Result<AsyncArrowWriter<TimingWriter<BufWriter>>> {
         let buf_writer = BufWriter::with_capacity(
             object_store,
             location.clone(),
@@ -1254,12 +1286,16 @@ impl ParquetSink {
                 .execution
                 .objectstore_writer_buffer_size,
         );
+        let timing_writer = TimingWriter {
+            inner: buf_writer,
+            io_time,
+        };
         let options = ArrowWriterOptions::new()
             .with_properties(parquet_props)
             .with_skip_arrow_metadata(self.parquet_options.global.skip_arrow_metadata);
 
         let writer = AsyncArrowWriter::try_new_with_options(
-            buf_writer,
+            timing_writer,
             get_writer_schema(&self.config),
             options,
         )?;
@@ -1339,8 +1375,10 @@ impl FileSink for ParquetSink {
             .with_category(MetricCategory::Bytes)
             .global_counter("bytes_written");
         let elapsed_compute = MetricBuilder::new(&self.metrics).elapsed_compute(0);
-
-        let write_start = datafusion_common::instant::Instant::now();
+        // Sequential path only: not registered in MetricsSet — used internally to
+        // compute elapsed_compute = total_write_time - io_time.
+        let total_write_time = Time::new();
+        let io_time = Time::new();
 
         let parquet_opts = &self.parquet_options;
 
@@ -1371,15 +1409,19 @@ impl FileSink for ParquetSink {
                         Arc::clone(&object_store),
                         context,
                         parquet_props.clone(),
+                        io_time.clone(),
                     )
                     .await?;
                 let reservation = MemoryConsumer::new(format!("ParquetSink[{path}]"))
                     .register(context.memory_pool());
+                let total_write_time_task = total_write_time.clone();
                 file_write_tasks.spawn(async move {
                     while let Some(batch) = rx.recv().await {
+                        let _timer = total_write_time_task.timer();
                         writer.write(&batch).await?;
                         reservation.try_resize(writer.memory_size())?;
                     }
+                    let _timer = total_write_time_task.timer();
                     let parquet_meta_data = writer
                         .close()
                         .await
@@ -1407,6 +1449,7 @@ impl FileSink for ParquetSink {
                 let skip_arrow_metadata = self.parquet_options.global.skip_arrow_metadata;
                 let parallel_options_clone = parallel_options.clone();
                 let pool = Arc::clone(context.memory_pool());
+                let encoding_time = elapsed_compute.clone();
                 file_write_tasks.spawn(async move {
                     let parquet_meta_data = output_single_parquet_file_parallelized(
                         writer,
@@ -1416,6 +1459,7 @@ impl FileSink for ParquetSink {
                         skip_arrow_metadata,
                         parallel_options_clone,
                         pool,
+                        encoding_time,
                     )
                     .await?;
                     Ok((path, parquet_meta_data))
@@ -1456,7 +1500,8 @@ impl FileSink for ParquetSink {
             .await
             .map_err(|e| DataFusionError::ExecutionJoin(Box::new(e)))??;
 
-        elapsed_compute.add_elapsed(write_start);
+        let encoding_nanos = total_write_time.value().saturating_sub(io_time.value());
+        elapsed_compute.add_duration(Duration::from_nanos(encoding_nanos as u64));
 
         Ok(rows_written_counter.value() as u64)
     }
@@ -1487,8 +1532,10 @@ async fn column_serializer_task(
     mut rx: Receiver<ArrowLeafColumn>,
     mut writer: ArrowColumnWriter,
     reservation: MemoryReservation,
+    encoding_time: Time,
 ) -> Result<(ArrowColumnWriter, MemoryReservation)> {
     while let Some(col) = rx.recv().await {
+        let _timer = encoding_time.timer();
         writer.write(&col)?;
         reservation.try_resize(writer.memory_size())?;
     }
@@ -1505,6 +1552,7 @@ fn spawn_column_parallel_row_group_writer(
     col_writers: Vec<ArrowColumnWriter>,
     max_buffer_size: usize,
     pool: &Arc<dyn MemoryPool>,
+    encoding_time: &Time,
 ) -> Result<(Vec<ColumnWriterTask>, Vec<ColSender>)> {
     let num_columns = col_writers.len();
 
@@ -1522,6 +1570,7 @@ fn spawn_column_parallel_row_group_writer(
             receive_array,
             writer,
             reservation,
+            encoding_time.clone(),
         ));
         col_writer_tasks.push(task);
     }
@@ -1570,6 +1619,7 @@ fn spawn_rg_join_and_finalize_task(
     column_writer_tasks: Vec<ColumnWriterTask>,
     rg_rows: usize,
     pool: &Arc<dyn MemoryPool>,
+    encoding_time: Time,
 ) -> SpawnedTask<RBStreamSerializeResult> {
     let rg_reservation =
         MemoryConsumer::new("ParquetSink(SerializedRowGroupWriter)").register(pool);
@@ -1584,6 +1634,7 @@ fn spawn_rg_join_and_finalize_task(
                 .map_err(|e| DataFusionError::ExecutionJoin(Box::new(e)))??;
             let encoded_size = writer.get_estimated_total_bytes();
             rg_reservation.grow(encoded_size);
+            let _timer = encoding_time.timer();
             finalized_rg.push(writer.close()?);
         }
 
@@ -1599,6 +1650,7 @@ fn spawn_rg_join_and_finalize_task(
 /// on the next row group in parallel. So, parquet serialization is parallelized
 /// across both columns and row_groups, with a theoretical max number of parallel tasks
 /// given by n_columns * num_row_groups.
+#[expect(clippy::too_many_arguments)]
 fn spawn_parquet_parallel_serialization_task(
     row_group_writer_factory: ArrowRowGroupWriterFactory,
     mut data: Receiver<RecordBatch>,
@@ -1607,6 +1659,7 @@ fn spawn_parquet_parallel_serialization_task(
     writer_props: Arc<WriterProperties>,
     parallel_options: Arc<ParallelParquetWriterOptions>,
     pool: Arc<dyn MemoryPool>,
+    encoding_time: Time,
 ) -> SpawnedTask<Result<(), DataFusionError>> {
     SpawnedTask::spawn(async move {
         let max_buffer_rb = parallel_options.max_buffered_record_batches_per_stream;
@@ -1617,7 +1670,12 @@ fn spawn_parquet_parallel_serialization_task(
         let col_writers =
             row_group_writer_factory.create_column_writers(row_group_index)?;
         let (mut column_writer_handles, mut col_array_channels) =
-            spawn_column_parallel_row_group_writer(col_writers, max_buffer_rb, &pool)?;
+            spawn_column_parallel_row_group_writer(
+                col_writers,
+                max_buffer_rb,
+                &pool,
+                &encoding_time,
+            )?;
         let mut current_rg_rows = 0;
 
         while let Some(mut rb) = data.recv().await {
@@ -1652,6 +1710,7 @@ fn spawn_parquet_parallel_serialization_task(
                         column_writer_handles,
                         max_row_group_rows,
                         &pool,
+                        encoding_time.clone(),
                     );
 
                     // Do not surface error from closed channel (means something
@@ -1671,6 +1730,7 @@ fn spawn_parquet_parallel_serialization_task(
                             col_writers,
                             max_buffer_rb,
                             &pool,
+                            &encoding_time,
                         )?;
                 }
             }
@@ -1683,6 +1743,7 @@ fn spawn_parquet_parallel_serialization_task(
                 column_writer_handles,
                 current_rg_rows,
                 &pool,
+                encoding_time.clone(),
             );
 
             // Do not surface error from closed channel (means something
@@ -1746,6 +1807,7 @@ async fn concatenate_parallel_row_groups(
 /// independent RecordBatch streams in parallel to RowGroups in memory. Another
 /// task then stitches these independent RowGroups together and streams this large
 /// single parquet file to an ObjectStore in multiple parts.
+#[expect(clippy::too_many_arguments)]
 async fn output_single_parquet_file_parallelized(
     object_store_writer: Box<dyn AsyncWrite + Send + Unpin>,
     data: Receiver<RecordBatch>,
@@ -1754,6 +1816,7 @@ async fn output_single_parquet_file_parallelized(
     skip_arrow_metadata: bool,
     parallel_options: ParallelParquetWriterOptions,
     pool: Arc<dyn MemoryPool>,
+    encoding_time: Time,
 ) -> Result<ParquetMetaData> {
     let max_rowgroups = parallel_options.max_parallel_row_groups;
     // Buffer size of this channel limits maximum number of RowGroups being worked on in parallel
@@ -1780,6 +1843,7 @@ async fn output_single_parquet_file_parallelized(
         Arc::clone(&arc_props),
         parallel_options.into(),
         Arc::clone(&pool),
+        encoding_time,
     );
     let parquet_meta_data = concatenate_parallel_row_groups(
         writer,

--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -19,13 +19,9 @@
 
 use std::cell::RefCell;
 use std::fmt::Debug;
-use std::future::Future;
 use std::ops::Range;
-use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
 use std::{fmt, vec};
 
 use arrow::array::RecordBatch;
@@ -43,7 +39,6 @@ use datafusion_datasource::write::demux::DemuxedStreamReceiver;
 use arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::config::{ConfigField, ConfigFileType, TableParquetOptions};
 use datafusion_common::encryption::FileDecryptionProperties;
-use datafusion_common::instant::Instant;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{
     DEFAULT_PARQUET_EXTENSION, DataFusionError, GetExt, HashSet, Result,
@@ -60,7 +55,8 @@ use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::dml::InsertOp;
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, LexRequirement};
 use datafusion_physical_plan::metrics::{
-    ExecutionPlanMetricsSet, MetricBuilder, MetricCategory, MetricsSet, Time,
+    ElapsedComputeFutureExt, ExecutionPlanMetricsSet, MetricBuilder, MetricCategory,
+    MetricsSet, Time,
 };
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
 use datafusion_session::Session;
@@ -94,7 +90,6 @@ use parquet::file::properties::{
 };
 use parquet::file::writer::SerializedFileWriter;
 use parquet::schema::types::SchemaDescriptor;
-use pin_project::{pin_project, pinned_drop};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
@@ -1177,70 +1172,6 @@ impl DisplayAs for ParquetSink {
                 // TODO: collect info
                 write!(f, "")
             }
-        }
-    }
-}
-
-/// Wraps any [`Future`] and accumulates the time spent actively executing
-/// inside `poll()` calls into `elapsed_compute`. Time between polls (when
-/// the future is suspended waiting for I/O or an upstream channel) is not
-/// measured, so only CPU time is captured.
-///
-/// Used by the sequential write path so that `elapsed_compute` reflects
-/// pure Arrow→Parquet encoding time, automatically excluding object-store
-/// I/O latency without requiring a separate subtraction step.
-///
-/// Note: uses `pin-project` rather than `pin-project-lite` in order to
-/// support `PinnedDrop`, which ensures accumulated time is flushed even
-/// if the future is cancelled (dropped before completion).
-#[pin_project(PinnedDrop)]
-struct ElapsedComputeFuture<T> {
-    #[pin]
-    inner: T,
-    curr: Duration,
-    elapsed_compute: Time,
-}
-
-#[pinned_drop]
-impl<T> PinnedDrop for ElapsedComputeFuture<T> {
-    fn drop(self: Pin<&mut Self>) {
-        if self.curr > Duration::default() {
-            let self_projected = self.project();
-            self_projected
-                .elapsed_compute
-                .add_duration(*self_projected.curr);
-        }
-    }
-}
-
-impl<O, F: Future<Output = O>> Future for ElapsedComputeFuture<F> {
-    type Output = O;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let self_projected = self.project();
-        let start = Instant::now();
-        let result = self_projected.inner.poll(cx);
-        *self_projected.curr += start.elapsed();
-        if result.is_ready() {
-            self_projected
-                .elapsed_compute
-                .add_duration(*self_projected.curr);
-            *self_projected.curr = Duration::default();
-        }
-        result
-    }
-}
-
-trait ElapsedComputeFutureExt: Future + Sized {
-    fn with_elapsed_compute(self, elapsed_compute: Time) -> ElapsedComputeFuture<Self>;
-}
-
-impl<O, F: Future<Output = O>> ElapsedComputeFutureExt for F {
-    fn with_elapsed_compute(self, elapsed_compute: Time) -> ElapsedComputeFuture<Self> {
-        ElapsedComputeFuture {
-            inner: self,
-            curr: Duration::default(),
-            elapsed_compute,
         }
     }
 }

--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -1473,21 +1473,19 @@ impl FileSink for ParquetSink {
                         .objectstore_writer_buffer_size,
                 ))
                 .build()?;
-                let schema = get_writer_schema(&self.config);
-                let props = parquet_props.clone();
-                let skip_arrow_metadata = self.parquet_options.global.skip_arrow_metadata;
-                let parallel_options_clone = parallel_options.clone();
-                let pool = Arc::clone(context.memory_pool());
+                let ctx = ParquetFileWriteContext {
+                    schema: get_writer_schema(&self.config),
+                    props: Arc::new(parquet_props),
+                    skip_arrow_metadata: self.parquet_options.global.skip_arrow_metadata,
+                    parallel_options: Arc::new(parallel_options.clone()),
+                    pool: Arc::clone(context.memory_pool()),
+                };
                 let encoding_time = elapsed_compute.clone();
                 file_write_tasks.spawn(async move {
                     let parquet_meta_data = output_single_parquet_file_parallelized(
                         writer,
                         rx,
-                        schema,
-                        &props,
-                        skip_arrow_metadata,
-                        parallel_options_clone,
-                        pool,
+                        ctx,
                         encoding_time,
                     )
                     .await?;
@@ -1611,6 +1609,22 @@ struct ParallelParquetWriterOptions {
     max_buffered_record_batches_per_stream: usize,
 }
 
+/// Write configuration inputs shared across all parallel tasks that encode a
+/// single Parquet file. These values are invariant for the duration of one file
+/// write and do not change per row-group or per column.
+///
+/// Separating these from per-call parameters (`object_store_writer`, `data`,
+/// `encoding_time`) keeps the deep parallel call chain below the argument-count
+/// limit without mixing configuration with runtime state.
+#[derive(Clone)]
+struct ParquetFileWriteContext {
+    schema: Arc<Schema>,
+    props: Arc<WriterProperties>,
+    skip_arrow_metadata: bool,
+    parallel_options: Arc<ParallelParquetWriterOptions>,
+    pool: Arc<dyn MemoryPool>,
+}
+
 /// This is the return type of calling [ArrowColumnWriter].close() on each column
 /// i.e. the Vec of encoded columns which can be appended to a row group
 type RBStreamSerializeResult = Result<(Vec<ArrowColumnChunk>, MemoryReservation, usize)>;
@@ -1676,20 +1690,17 @@ fn spawn_rg_join_and_finalize_task(
 /// on the next row group in parallel. So, parquet serialization is parallelized
 /// across both columns and row_groups, with a theoretical max number of parallel tasks
 /// given by n_columns * num_row_groups.
-#[expect(clippy::too_many_arguments)]
 fn spawn_parquet_parallel_serialization_task(
     row_group_writer_factory: ArrowRowGroupWriterFactory,
     mut data: Receiver<RecordBatch>,
     serialize_tx: Sender<SpawnedTask<RBStreamSerializeResult>>,
-    schema: Arc<Schema>,
-    writer_props: Arc<WriterProperties>,
-    parallel_options: Arc<ParallelParquetWriterOptions>,
-    pool: Arc<dyn MemoryPool>,
+    ctx: ParquetFileWriteContext,
     encoding_time: Time,
 ) -> SpawnedTask<Result<(), DataFusionError>> {
     SpawnedTask::spawn(async move {
-        let max_buffer_rb = parallel_options.max_buffered_record_batches_per_stream;
-        let max_row_group_rows = writer_props
+        let max_buffer_rb = ctx.parallel_options.max_buffered_record_batches_per_stream;
+        let max_row_group_rows = ctx
+            .props
             .max_row_group_row_count()
             .unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT);
         let mut row_group_index = 0;
@@ -1699,7 +1710,7 @@ fn spawn_parquet_parallel_serialization_task(
             spawn_column_parallel_row_group_writer(
                 col_writers,
                 max_buffer_rb,
-                &pool,
+                &ctx.pool,
                 &encoding_time,
             )?;
         let mut current_rg_rows = 0;
@@ -1713,7 +1724,7 @@ fn spawn_parquet_parallel_serialization_task(
                     send_arrays_to_col_writers(
                         &col_array_channels,
                         &rb,
-                        Arc::clone(&schema),
+                        Arc::clone(&ctx.schema),
                     )
                     .await?;
                     current_rg_rows += rb.num_rows();
@@ -1724,7 +1735,7 @@ fn spawn_parquet_parallel_serialization_task(
                     send_arrays_to_col_writers(
                         &col_array_channels,
                         &a,
-                        Arc::clone(&schema),
+                        Arc::clone(&ctx.schema),
                     )
                     .await?;
 
@@ -1735,7 +1746,7 @@ fn spawn_parquet_parallel_serialization_task(
                     let finalize_rg_task = spawn_rg_join_and_finalize_task(
                         column_writer_handles,
                         max_row_group_rows,
-                        &pool,
+                        &ctx.pool,
                         encoding_time.clone(),
                     );
 
@@ -1755,7 +1766,7 @@ fn spawn_parquet_parallel_serialization_task(
                         spawn_column_parallel_row_group_writer(
                             col_writers,
                             max_buffer_rb,
-                            &pool,
+                            &ctx.pool,
                             &encoding_time,
                         )?;
                 }
@@ -1768,7 +1779,7 @@ fn spawn_parquet_parallel_serialization_task(
             let finalize_rg_task = spawn_rg_join_and_finalize_task(
                 column_writer_handles,
                 current_rg_rows,
-                &pool,
+                &ctx.pool,
                 encoding_time.clone(),
             );
 
@@ -1833,42 +1844,34 @@ async fn concatenate_parallel_row_groups(
 /// independent RecordBatch streams in parallel to RowGroups in memory. Another
 /// task then stitches these independent RowGroups together and streams this large
 /// single parquet file to an ObjectStore in multiple parts.
-#[expect(clippy::too_many_arguments)]
 async fn output_single_parquet_file_parallelized(
     object_store_writer: Box<dyn AsyncWrite + Send + Unpin>,
     data: Receiver<RecordBatch>,
-    output_schema: Arc<Schema>,
-    parquet_props: &WriterProperties,
-    skip_arrow_metadata: bool,
-    parallel_options: ParallelParquetWriterOptions,
-    pool: Arc<dyn MemoryPool>,
+    ctx: ParquetFileWriteContext,
     encoding_time: Time,
 ) -> Result<ParquetMetaData> {
-    let max_rowgroups = parallel_options.max_parallel_row_groups;
+    let max_rowgroups = ctx.parallel_options.max_parallel_row_groups;
     // Buffer size of this channel limits maximum number of RowGroups being worked on in parallel
     let (serialize_tx, serialize_rx) =
         mpsc::channel::<SpawnedTask<RBStreamSerializeResult>>(max_rowgroups);
 
-    let arc_props = Arc::new(parquet_props.clone());
     let merged_buff = SharedBuffer::new(INITIAL_BUFFER_BYTES);
     let options = ArrowWriterOptions::new()
-        .with_properties(parquet_props.clone())
-        .with_skip_arrow_metadata(skip_arrow_metadata);
+        .with_properties((*ctx.props).clone())
+        .with_skip_arrow_metadata(ctx.skip_arrow_metadata);
     let writer = ArrowWriter::try_new_with_options(
         merged_buff.clone(),
-        Arc::clone(&output_schema),
+        Arc::clone(&ctx.schema),
         options,
     )?;
     let (writer, row_group_writer_factory) = writer.into_serialized_writer()?;
 
+    let pool = Arc::clone(&ctx.pool);
     let launch_serialization_task = spawn_parquet_parallel_serialization_task(
         row_group_writer_factory,
         data,
         serialize_tx,
-        Arc::clone(&output_schema),
-        Arc::clone(&arc_props),
-        parallel_options.into(),
-        Arc::clone(&pool),
+        ctx,
         encoding_time,
     );
     let parquet_meta_data = concatenate_parallel_row_groups(

--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -19,9 +19,12 @@
 
 use std::cell::RefCell;
 use std::fmt::Debug;
+use std::future::Future;
 use std::ops::Range;
+use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 use std::{fmt, vec};
 
@@ -40,6 +43,7 @@ use datafusion_datasource::write::demux::DemuxedStreamReceiver;
 use arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::config::{ConfigField, ConfigFileType, TableParquetOptions};
 use datafusion_common::encryption::FileDecryptionProperties;
+use datafusion_common::instant::Instant;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{
     DEFAULT_PARQUET_EXTENSION, DataFusionError, GetExt, HashSet, Result,
@@ -79,7 +83,6 @@ use parquet::arrow::arrow_writer::{
     ArrowWriterOptions, compute_leaves,
 };
 use parquet::arrow::async_reader::MetadataFetch;
-use parquet::arrow::async_writer::AsyncFileWriter;
 use parquet::arrow::{ArrowWriter, AsyncArrowWriter};
 use parquet::basic::Type;
 #[cfg(feature = "parquet_encryption")]
@@ -91,6 +94,7 @@ use parquet::file::properties::{
 };
 use parquet::file::writer::SerializedFileWriter;
 use parquet::schema::types::SchemaDescriptor;
+use pin_project::{pin_project, pinned_drop};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
@@ -1177,32 +1181,67 @@ impl DisplayAs for ParquetSink {
     }
 }
 
-/// Wraps an [`AsyncFileWriter`] and records the wall-clock time spent in I/O
-/// calls (`write` and `complete`). Used by the sequential write path to isolate
-/// I/O time so it can be subtracted from the total write time, yielding a clean
-/// `elapsed_compute` that covers only Arrow→Parquet encoding.
+/// Wraps any [`Future`] and accumulates the time spent actively executing
+/// inside `poll()` calls into `elapsed_compute`. Time between polls (when
+/// the future is suspended waiting for I/O or an upstream channel) is not
+/// measured, so only CPU time is captured.
 ///
-/// `io_time` is backed by `Arc<AtomicUsize>`, so clones share the same counter.
-/// This type is an internal implementation detail and is not registered in any
-/// `MetricsSet`.
-struct TimingWriter<W> {
-    inner: W,
-    io_time: Time,
+/// Used by the sequential write path so that `elapsed_compute` reflects
+/// pure Arrow→Parquet encoding time, automatically excluding object-store
+/// I/O latency without requiring a separate subtraction step.
+///
+/// Note: uses `pin-project` rather than `pin-project-lite` in order to
+/// support `PinnedDrop`, which ensures accumulated time is flushed even
+/// if the future is cancelled (dropped before completion).
+#[pin_project(PinnedDrop)]
+struct ElapsedComputeFuture<T> {
+    #[pin]
+    inner: T,
+    curr: Duration,
+    elapsed_compute: Time,
 }
 
-impl<W: AsyncFileWriter> AsyncFileWriter for TimingWriter<W> {
-    fn write(&mut self, bs: Bytes) -> BoxFuture<'_, parquet::errors::Result<()>> {
-        Box::pin(async move {
-            let _timer = self.io_time.timer();
-            self.inner.write(bs).await
-        })
+#[pinned_drop]
+impl<T> PinnedDrop for ElapsedComputeFuture<T> {
+    fn drop(self: Pin<&mut Self>) {
+        if self.curr > Duration::default() {
+            let self_projected = self.project();
+            self_projected
+                .elapsed_compute
+                .add_duration(*self_projected.curr);
+        }
     }
+}
 
-    fn complete(&mut self) -> BoxFuture<'_, parquet::errors::Result<()>> {
-        Box::pin(async move {
-            let _timer = self.io_time.timer();
-            self.inner.complete().await
-        })
+impl<O, F: Future<Output = O>> Future for ElapsedComputeFuture<F> {
+    type Output = O;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let self_projected = self.project();
+        let start = Instant::now();
+        let result = self_projected.inner.poll(cx);
+        *self_projected.curr += start.elapsed();
+        if result.is_ready() {
+            self_projected
+                .elapsed_compute
+                .add_duration(*self_projected.curr);
+            *self_projected.curr = Duration::default();
+        }
+        result
+    }
+}
+
+trait ElapsedComputeFutureExt: Future + Sized {
+    fn with_elapsed_compute(self, elapsed_compute: Time) -> ElapsedComputeFuture<Self>;
+}
+
+impl<O, F: Future<Output = O>> ElapsedComputeFutureExt for F {
+    fn with_elapsed_compute(self, elapsed_compute: Time) -> ElapsedComputeFuture<Self> {
+        ElapsedComputeFuture {
+            inner: self,
+            curr: Duration::default(),
+            elapsed_compute,
+        }
     }
 }
 
@@ -1275,8 +1314,7 @@ impl ParquetSink {
         object_store: Arc<dyn ObjectStore>,
         context: &Arc<TaskContext>,
         parquet_props: WriterProperties,
-        io_time: Time,
-    ) -> Result<AsyncArrowWriter<TimingWriter<BufWriter>>> {
+    ) -> Result<AsyncArrowWriter<BufWriter>> {
         let buf_writer = BufWriter::with_capacity(
             object_store,
             location.clone(),
@@ -1286,16 +1324,12 @@ impl ParquetSink {
                 .execution
                 .objectstore_writer_buffer_size,
         );
-        let timing_writer = TimingWriter {
-            inner: buf_writer,
-            io_time,
-        };
         let options = ArrowWriterOptions::new()
             .with_properties(parquet_props)
             .with_skip_arrow_metadata(self.parquet_options.global.skip_arrow_metadata);
 
         let writer = AsyncArrowWriter::try_new_with_options(
-            timing_writer,
+            buf_writer,
             get_writer_schema(&self.config),
             options,
         )?;
@@ -1375,10 +1409,6 @@ impl FileSink for ParquetSink {
             .with_category(MetricCategory::Bytes)
             .global_counter("bytes_written");
         let elapsed_compute = MetricBuilder::new(&self.metrics).elapsed_compute(0);
-        // Sequential path only: not registered in MetricsSet — used internally to
-        // compute elapsed_compute = total_write_time - io_time.
-        let total_write_time = Time::new();
-        let io_time = Time::new();
 
         let parquet_opts = &self.parquet_options;
 
@@ -1409,25 +1439,24 @@ impl FileSink for ParquetSink {
                         Arc::clone(&object_store),
                         context,
                         parquet_props.clone(),
-                        io_time.clone(),
                     )
                     .await?;
                 let reservation = MemoryConsumer::new(format!("ParquetSink[{path}]"))
                     .register(context.memory_pool());
-                let total_write_time_task = total_write_time.clone();
-                file_write_tasks.spawn(async move {
-                    while let Some(batch) = rx.recv().await {
-                        let _timer = total_write_time_task.timer();
-                        writer.write(&batch).await?;
-                        reservation.try_resize(writer.memory_size())?;
+                file_write_tasks.spawn(
+                    async move {
+                        while let Some(batch) = rx.recv().await {
+                            writer.write(&batch).await?;
+                            reservation.try_resize(writer.memory_size())?;
+                        }
+                        let parquet_meta_data = writer
+                            .close()
+                            .await
+                            .map_err(|e| DataFusionError::ParquetError(Box::new(e)))?;
+                        Ok((path, parquet_meta_data))
                     }
-                    let _timer = total_write_time_task.timer();
-                    let parquet_meta_data = writer
-                        .close()
-                        .await
-                        .map_err(|e| DataFusionError::ParquetError(Box::new(e)))?;
-                    Ok((path, parquet_meta_data))
-                });
+                    .with_elapsed_compute(elapsed_compute.clone()),
+                );
             } else {
                 let writer = ObjectWriterBuilder::new(
                     // Parquet files as a whole are never compressed, since they
@@ -1499,9 +1528,6 @@ impl FileSink for ParquetSink {
             .join_unwind()
             .await
             .map_err(|e| DataFusionError::ExecutionJoin(Box::new(e)))??;
-
-        let encoding_nanos = total_write_time.value().saturating_sub(io_time.value());
-        elapsed_compute.add_duration(Duration::from_nanos(encoding_nanos as u64));
 
         Ok(rows_written_counter.value() as u64)
     }

--- a/datafusion/physical-expr-common/Cargo.toml
+++ b/datafusion/physical-expr-common/Cargo.toml
@@ -49,6 +49,7 @@ hashbrown = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 parking_lot = { workspace = true }
+pin-project = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/datafusion/physical-expr-common/src/metrics/elapsed_compute.rs
+++ b/datafusion/physical-expr-common/src/metrics/elapsed_compute.rs
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use datafusion_common::instant::Instant;
+use pin_project::{pin_project, pinned_drop};
+
+use super::Time;
+
+/// Wraps any [`Future`] and accumulates the wall-clock time spent inside
+/// each [`Future::poll`] call into `elapsed_compute`. Everything that
+/// executes synchronously within a `poll()` scope is measured — including
+/// CPU-bound work, memory copies, and any blocking the future performs
+/// before returning. Time between polls (when the runtime has suspended the
+/// future waiting for I/O, a channel, or a waker) is not measured.
+///
+/// For futures that mix synchronous CPU work with async I/O this gives a
+/// good approximation of CPU time: async I/O causes the future to yield
+/// (`Poll::Pending`), so the I/O latency is excluded automatically.
+///
+/// Note: uses `pin-project` rather than `pin-project-lite` in order to
+/// support `PinnedDrop`, which ensures accumulated time is flushed even
+/// if the future is cancelled (dropped before completion).
+#[pin_project(PinnedDrop)]
+pub struct ElapsedComputeFuture<T> {
+    #[pin]
+    inner: T,
+    /// Local accumulator: elapsed time is collected here during each `poll()`
+    /// and only flushed to `elapsed_compute` on completion (`Poll::Ready`) or
+    /// on drop (`PinnedDrop`). Keeping a separate local `Duration` avoids
+    /// performing an atomic operation on every `poll()` call, at the cost of
+    /// the reported metric value being unavailable until the future finishes.
+    curr: Duration,
+    elapsed_compute: Time,
+}
+
+#[pinned_drop]
+impl<T> PinnedDrop for ElapsedComputeFuture<T> {
+    fn drop(self: Pin<&mut Self>) {
+        if self.curr > Duration::default() {
+            let self_projected = self.project();
+            self_projected
+                .elapsed_compute
+                .add_duration(*self_projected.curr);
+        }
+    }
+}
+
+impl<O, F: Future<Output = O>> Future for ElapsedComputeFuture<F> {
+    type Output = O;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let self_projected = self.project();
+        let start = Instant::now();
+        let result = self_projected.inner.poll(cx);
+        *self_projected.curr += start.elapsed();
+        if result.is_ready() {
+            self_projected
+                .elapsed_compute
+                .add_duration(*self_projected.curr);
+            *self_projected.curr = Duration::default();
+        }
+        result
+    }
+}
+
+/// Extension trait that wraps any [`Future`] with [`ElapsedComputeFuture`].
+pub trait ElapsedComputeFutureExt: Future + Sized {
+    /// Wraps this future so that the time spent inside each [`Future::poll`]
+    /// call is accumulated into `elapsed_compute`. See [`ElapsedComputeFuture`]
+    /// for a full description of what is and is not measured.
+    fn with_elapsed_compute(self, elapsed_compute: Time) -> ElapsedComputeFuture<Self>;
+}
+
+impl<O, F: Future<Output = O>> ElapsedComputeFutureExt for F {
+    fn with_elapsed_compute(self, elapsed_compute: Time) -> ElapsedComputeFuture<Self> {
+        ElapsedComputeFuture {
+            inner: self,
+            curr: Duration::default(),
+            elapsed_compute,
+        }
+    }
+}

--- a/datafusion/physical-expr-common/src/metrics/mod.rs
+++ b/datafusion/physical-expr-common/src/metrics/mod.rs
@@ -20,6 +20,7 @@
 mod baseline;
 mod builder;
 mod custom;
+mod elapsed_compute;
 mod expression;
 mod value;
 
@@ -38,6 +39,7 @@ use std::{
 pub use baseline::{BaselineMetrics, RecordOutput, SpillMetrics, SplitMetrics};
 pub use builder::MetricBuilder;
 pub use custom::CustomMetricValue;
+pub use elapsed_compute::{ElapsedComputeFuture, ElapsedComputeFutureExt};
 pub use expression::ExpressionEvaluatorMetrics;
 pub use value::{
     Count, Gauge, MetricValue, PruningMetrics, RatioMergeStrategy, RatioMetrics,


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21797.

## Rationale for this change

`ParquetSink` registered an `elapsed_compute` metric using a single wall-clock timer that spanned the entire write operation — upstream batch wait, CPU Arrow→Parquet encoding, and object-store I/O all rolled into one number. This
made the metric misleading: it inflated `elapsed_compute` with I/O latency, which is inconsistent with how every other operator in DataFusion reports this metric (CPU time only).

## What changes are included in this PR?

Two write paths are fixed independently:

**Sequential path** (`allow_single_file_parallelism = false` or CDC enabled):
- A new `TimingWriter<W>` wrapper implements `AsyncFileWriter` and records wall-clock time spent in I/O calls (`write` / `complete`).
- The total time inside `writer.write()` and `writer.close()` is accumulated in `total_write_time`. After all tasks join, `elapsed_compute` is set to `total_write_time − io_time`, isolating pure Arrow→Parquet encoding time.

**Parallel path** (`allow_single_file_parallelism = true`, default):
- `encoding_time: Time` (a clone of the registered `elapsed_compute` metric) is threaded through the five-function call chain down to the two leaf sites: `writer.write()` in `column_serializer_task` and `writer.close()` in `spawn_rg_join_and_finalize_task`. Since `Time` is `Arc<AtomicUsize>`, all concurrent column tasks accumulate directly into the registered metric.
- Note: on the parallel path, `append_to_row_group()` in `concatenate_parallel_row_groups` is interleaved with I/O and cannot be cleanly isolated. It is excluded from `elapsed_compute`. This is acceptable since it operates on already-encoded data and represents a small fraction of total encoding CPU time.

## Are these changes tested?

Yes. Two tests are added/extended in `datafusion/core/src/dataframe/parquet.rs`:
- `test_parquet_sink_metrics_sequential` (new): verifies `elapsed_compute > 0` with `allow_single_file_parallelism = false`.
- `test_parquet_sink_metrics_parallel`: extended with an `elapsed_compute > 0` assertion (was previously missing for the parallel path).

The existing `test_parquet_sink_metrics` test (parallel path, default config) already asserted `elapsed_compute > 0` and continues to pass.

## Are there any user-facing changes?

No API changes. The `elapsed_compute` metric was already surfaced — this PR makes its value accurate rather than introducing a new metric.