### PR TITLE
feat: LogicalPlanningPipeline

### DIFF
--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -749,10 +749,9 @@ impl SessionContext {
                     Arc::clone(self.state().config().options()),
                 )
                 .without_query_execution_start_time();
-                let plan = self.state().optimizer().optimize(
+                let plan = self.state().optimize_with_config(
                     Arc::unwrap_or_clone(input),
                     &optimizer_context,
-                    |_1, _2| {},
                 )?;
                 self.state
                     .write()

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -1073,8 +1073,6 @@ pub struct SessionStateBuilder {
     cache_factory: Option<Arc<dyn CacheFactory>>,
     statistics_registry: Option<StatisticsRegistry>,
     // fields to support convenience functions
-    analyzer_rules: Option<Vec<Arc<dyn AnalyzerRule + Send + Sync>>>,
-    optimizer_rules: Option<Vec<Arc<dyn OptimizerRule + Send + Sync>>>,
     physical_optimizer_rules: Option<Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>>>,
     function_rewrites: Option<Vec<Arc<dyn FunctionRewrite + Send + Sync>>>,
 }
@@ -1115,8 +1113,6 @@ impl SessionStateBuilder {
             cache_factory: None,
             statistics_registry: None,
             // fields to support convenience functions
-            analyzer_rules: None,
-            optimizer_rules: None,
             physical_optimizer_rules: None,
             function_rewrites: None,
         }
@@ -1172,8 +1168,6 @@ impl SessionStateBuilder {
             cache_factory: existing.cache_factory,
             statistics_registry: existing.statistics_registry,
             // fields to support convenience functions
-            analyzer_rules: None,
-            optimizer_rules: None,
             physical_optimizer_rules: None,
             function_rewrites: Some(existing.function_rewrites),
         }
@@ -1266,9 +1260,12 @@ impl SessionStateBuilder {
         mut self,
         analyzer_rule: Arc<dyn AnalyzerRule + Send + Sync>,
     ) -> Self {
-        let mut rules = self.analyzer_rules.unwrap_or_default();
-        rules.push(analyzer_rule);
-        self.analyzer_rules = Some(rules);
+        let pipeline = self
+            .logical_pipeline
+            .get_or_insert_with(LogicalPlanningPipeline::default);
+        if let Some(Phase::SyncAnalysis(p)) = pipeline.phase_mut(DEFAULT_ANALYSIS_PHASE) {
+            p.rules.push(analyzer_rule);
+        }
         self
     }
 
@@ -1294,9 +1291,14 @@ impl SessionStateBuilder {
         mut self,
         optimizer_rule: Arc<dyn OptimizerRule + Send + Sync>,
     ) -> Self {
-        let mut rules = self.optimizer_rules.unwrap_or_default();
-        rules.push(optimizer_rule);
-        self.optimizer_rules = Some(rules);
+        let pipeline = self
+            .logical_pipeline
+            .get_or_insert_with(LogicalPlanningPipeline::default);
+        if let Some(Phase::SyncOptimization(p)) =
+            pipeline.phase_mut(DEFAULT_OPTIMIZATION_PHASE)
+        {
+            p.rules.push(optimizer_rule);
+        }
         self
     }
 
@@ -1632,8 +1634,6 @@ impl SessionStateBuilder {
             function_factory,
             cache_factory,
             statistics_registry,
-            analyzer_rules,
-            optimizer_rules,
             physical_optimizer_rules,
             function_rewrites,
         } = self;
@@ -1763,24 +1763,6 @@ impl SessionStateBuilder {
                 .extend(state.function_rewrites.iter().map(Arc::clone));
         }
 
-        if let (Some(rules), Some(Phase::SyncAnalysis(p))) = (
-            analyzer_rules,
-            state.logical_pipeline.phase_mut(DEFAULT_ANALYSIS_PHASE),
-        ) {
-            for rule in rules {
-                p.rules.push(rule);
-            }
-        }
-
-        if let (Some(rules), Some(Phase::SyncOptimization(p))) = (
-            optimizer_rules,
-            state.logical_pipeline.phase_mut(DEFAULT_OPTIMIZATION_PHASE),
-        ) {
-            for rule in rules {
-                p.rules.push(rule);
-            }
-        }
-
         if let Some(physical_optimizer_rules) = physical_optimizer_rules {
             for physical_optimizer_rule in physical_optimizer_rules {
                 state
@@ -1904,20 +1886,6 @@ impl SessionStateBuilder {
         &mut self.cache_factory
     }
 
-    /// Returns the current analyzer_rules value
-    pub fn analyzer_rules(
-        &mut self,
-    ) -> &mut Option<Vec<Arc<dyn AnalyzerRule + Send + Sync>>> {
-        &mut self.analyzer_rules
-    }
-
-    /// Returns the current optimizer_rules value
-    pub fn optimizer_rules(
-        &mut self,
-    ) -> &mut Option<Vec<Arc<dyn OptimizerRule + Send + Sync>>> {
-        &mut self.optimizer_rules
-    }
-
     /// Returns the current physical_optimizer_rules value
     pub fn physical_optimizer_rules(
         &mut self,
@@ -1948,8 +1916,6 @@ impl Debug for SessionStateBuilder {
         let ret = ret.field("type_planner", &self.type_planner);
         ret.field("query_planners", &self.query_planner)
             .field("logical_pipeline", &self.logical_pipeline)
-            .field("analyzer_rules", &self.analyzer_rules)
-            .field("optimizer_rules", &self.optimizer_rules)
             .field("physical_optimizer_rules", &self.physical_optimizer_rules)
             .field("physical_optimizers", &self.physical_optimizers)
             .field("table_functions", &self.table_functions)

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -140,8 +140,6 @@ pub struct SessionState {
     session_id: String,
     /// Ordered pipeline of named analysis and optimization phases.
     logical_pipeline: LogicalPlanningPipeline,
-    /// Expression-level function rewrites applied before physical expr creation.
-    function_rewrites: Vec<Arc<dyn FunctionRewrite + Send + Sync>>,
     /// Provides support for customizing the SQL planner, e.g. to add support for custom operators like `->>` or `?`
     expr_planners: Vec<Arc<dyn ExprPlanner>>,
     #[cfg(feature = "sql")]
@@ -813,7 +811,18 @@ impl SessionState {
         let mut expr = simplifier.coerce(expr, df_schema)?;
 
         // rewrite Exprs to functions if necessary
-        for rewrite in &self.function_rewrites {
+        let function_rewrites = self
+            .logical_pipeline
+            .phase(DEFAULT_ANALYSIS_PHASE)
+            .and_then(|p| {
+                if let Phase::SyncAnalysis(a) = p {
+                    Some(a.function_rewrites.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+        for rewrite in &function_rewrites {
             expr = expr
                 .transform_up(|expr| rewrite.rewrite(expr, df_schema, config_options))?
                 .data;
@@ -1074,7 +1083,6 @@ pub struct SessionStateBuilder {
     statistics_registry: Option<StatisticsRegistry>,
     // fields to support convenience functions
     physical_optimizer_rules: Option<Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>>>,
-    function_rewrites: Option<Vec<Arc<dyn FunctionRewrite + Send + Sync>>>,
 }
 
 impl SessionStateBuilder {
@@ -1114,7 +1122,6 @@ impl SessionStateBuilder {
             statistics_registry: None,
             // fields to support convenience functions
             physical_optimizer_rules: None,
-            function_rewrites: None,
         }
     }
 
@@ -1169,7 +1176,6 @@ impl SessionStateBuilder {
             statistics_registry: existing.statistics_registry,
             // fields to support convenience functions
             physical_optimizer_rules: None,
-            function_rewrites: Some(existing.function_rewrites),
         }
     }
 
@@ -1635,7 +1641,6 @@ impl SessionStateBuilder {
             cache_factory,
             statistics_registry,
             physical_optimizer_rules,
-            function_rewrites,
         } = self;
 
         let config = config.unwrap_or_default();
@@ -1644,7 +1649,6 @@ impl SessionStateBuilder {
         let mut state = SessionState {
             session_id: session_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
             logical_pipeline: logical_pipeline.unwrap_or_default(),
-            function_rewrites: function_rewrites.unwrap_or_default(),
             expr_planners: expr_planners.unwrap_or_default(),
             #[cfg(feature = "sql")]
             relation_planners: relation_planners.unwrap_or_default(),
@@ -1750,17 +1754,6 @@ impl SessionStateBuilder {
             if existing_default_catalog.is_some() {
                 debug!("Overwrote the default catalog");
             }
-        }
-
-        // Sync function_rewrites into the analysis phase so they run before
-        // TypeCoercion (matches original Analyzer::execute_and_check behavior).
-        // Always overwrite to avoid duplication when rebuilding from an existing state.
-        if let Some(Phase::SyncAnalysis(p)) =
-            state.logical_pipeline.phase_mut(DEFAULT_ANALYSIS_PHASE)
-        {
-            p.function_rewrites.clear();
-            p.function_rewrites
-                .extend(state.function_rewrites.iter().map(Arc::clone));
         }
 
         if let Some(physical_optimizer_rules) = physical_optimizer_rules {
@@ -2197,7 +2190,6 @@ impl FunctionRegistry for SessionState {
         &mut self,
         rewrite: Arc<dyn FunctionRewrite + Send + Sync>,
     ) -> datafusion_common::Result<()> {
-        self.function_rewrites.push(Arc::clone(&rewrite));
         if let Some(Phase::SyncAnalysis(p)) =
             self.logical_pipeline.phase_mut(DEFAULT_ANALYSIS_PHASE)
         {

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -624,19 +624,24 @@ impl SessionState {
     }
 
     /// Returns the [`Analyzer`] for this session, reconstructed from the DEFAULT_ANALYSIS_PHASE pipeline phase.
+    ///
+    /// Both the analysis rules and the function rewrites registered on the phase
+    /// are included so that the returned [`Analyzer`] behaves identically to the
+    /// pipeline phase when run directly.
     pub fn analyzer(&self) -> Analyzer {
-        let rules = self
-            .logical_pipeline
+        self.logical_pipeline
             .phase(DEFAULT_ANALYSIS_PHASE)
             .and_then(|p| {
                 if let Phase::SyncAnalysis(a) = p {
-                    Some(a.rules.clone())
+                    Some(Analyzer {
+                        function_rewrites: a.function_rewrites.clone(),
+                        rules: a.rules.clone(),
+                    })
                 } else {
                     None
                 }
             })
-            .unwrap_or_default();
-        Analyzer::with_rules(rules)
+            .unwrap_or_default()
     }
 
     /// Returns the [`Optimizer`] for this session, reconstructed from the DEFAULT_OPTIMIZATION_PHASE pipeline phase.

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -40,7 +40,6 @@ use datafusion_common::alias::AliasGenerator;
 #[cfg(feature = "sql")]
 use datafusion_common::config::Dialect;
 use datafusion_common::config::{ConfigExtension, ConfigOptions, TableOptions};
-use datafusion_common::display::{PlanType, StringifiedPlan, ToStringifiedPlan};
 use datafusion_common::tree_node::TreeNode;
 use datafusion_common::{
     DFSchema, DataFusionError, ResolvedTableReference, TableReference, config_err,
@@ -61,10 +60,11 @@ use datafusion_expr::registry::{
     SerializerRegistry,
 };
 use datafusion_expr::simplify::SimplifyContext;
-use datafusion_expr::{AggregateUDF, Explain, Expr, LogicalPlan, ScalarUDF, WindowUDF};
+use datafusion_expr::{AggregateUDF, Expr, LogicalPlan, ScalarUDF, WindowUDF};
 use datafusion_optimizer::simplify_expressions::ExprSimplifier;
 use datafusion_optimizer::{
-    Analyzer, AnalyzerRule, Optimizer, OptimizerConfig, OptimizerRule,
+    Analyzer, AnalyzerRule, DEFAULT_ANALYSIS_PHASE, DEFAULT_OPTIMIZATION_PHASE,
+    LogicalPlanningPipeline, Optimizer, OptimizerConfig, OptimizerRule, Phase,
 };
 use datafusion_physical_expr::create_physical_expr;
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
@@ -138,8 +138,10 @@ use uuid::Uuid;
 pub struct SessionState {
     /// A unique UUID that identifies the session
     session_id: String,
-    /// Responsible for analyzing and rewrite a logical plan before optimization
-    analyzer: Analyzer,
+    /// Ordered pipeline of named analysis and optimization phases.
+    logical_pipeline: LogicalPlanningPipeline,
+    /// Expression-level function rewrites applied before physical expr creation.
+    function_rewrites: Vec<Arc<dyn FunctionRewrite + Send + Sync>>,
     /// Provides support for customizing the SQL planner, e.g. to add support for custom operators like `->>` or `?`
     expr_planners: Vec<Arc<dyn ExprPlanner>>,
     #[cfg(feature = "sql")]
@@ -147,8 +149,6 @@ pub struct SessionState {
     /// Provides support for customizing the SQL type planning
     #[cfg(feature = "sql")]
     type_planner: Option<Arc<dyn TypePlanner>>,
-    /// Responsible for optimizing a logical plan
-    optimizer: Optimizer,
     /// Responsible for optimizing a physical execution plan
     physical_optimizers: PhysicalOptimizer,
     /// Responsible for planning `LogicalPlan`s, and `ExecutionPlan`
@@ -240,8 +240,7 @@ impl Debug for SessionState {
         let ret = ret.field("type_planner", &self.type_planner);
 
         ret.field("query_planners", &self.query_planner)
-            .field("analyzer", &self.analyzer)
-            .field("optimizer", &self.optimizer)
+            .field("logical_pipeline", &self.logical_pipeline)
             .field("physical_optimizers", &self.physical_optimizers)
             .field("table_functions", &self.table_functions)
             .field("scalar_functions", &self.scalar_functions)
@@ -357,31 +356,40 @@ impl SessionState {
             })
     }
 
-    /// Add `analyzer_rule` to the end of the list of
-    /// [`AnalyzerRule`]s used to rewrite queries.
+    /// Add `analyzer_rule` to the end of the DEFAULT_ANALYSIS_PHASE phase in the pipeline.
     pub fn add_analyzer_rule(
         &mut self,
         analyzer_rule: Arc<dyn AnalyzerRule + Send + Sync>,
     ) -> &Self {
-        self.analyzer.rules.push(analyzer_rule);
+        if let Some(Phase::SyncAnalysis(p)) =
+            self.logical_pipeline.phase_mut(DEFAULT_ANALYSIS_PHASE)
+        {
+            p.rules.push(analyzer_rule);
+        }
         self
     }
 
-    // the add_optimizer_rule takes an owned reference
-    // it should probably be renamed to `with_optimizer_rule` to follow builder style
-    // and `add_optimizer_rule` that takes &mut self added instead of this
     pub(crate) fn append_optimizer_rule(
         &mut self,
         optimizer_rule: Arc<dyn OptimizerRule + Send + Sync>,
     ) {
-        self.optimizer.rules.push(optimizer_rule);
+        if let Some(Phase::SyncOptimization(p)) =
+            self.logical_pipeline.phase_mut(DEFAULT_OPTIMIZATION_PHASE)
+        {
+            p.rules.push(optimizer_rule);
+        }
     }
 
-    /// Removes an optimizer rule by name, returning `true` if it existed.
+    /// Removes an optimizer rule by name from the DEFAULT_OPTIMIZATION_PHASE phase, returning `true` if it existed.
     pub(crate) fn remove_optimizer_rule(&mut self, name: &str) -> bool {
-        let original_len = self.optimizer.rules.len();
-        self.optimizer.rules.retain(|r| r.name() != name);
-        self.optimizer.rules.len() < original_len
+        if let Some(Phase::SyncOptimization(p)) =
+            self.logical_pipeline.phase_mut(DEFAULT_OPTIMIZATION_PHASE)
+        {
+            let before = p.rules.len();
+            p.rules.retain(|r| r.name() != name);
+            return p.rules.len() < before;
+        }
+        false
     }
 
     /// Registers a [`FunctionFactory`] to handle `CREATE FUNCTION` statements
@@ -615,14 +623,46 @@ impl SessionState {
         query.sql_to_expr_with_alias(sql_expr, df_schema, &mut PlannerContext::new())
     }
 
-    /// Returns the [`Analyzer`] for this session
-    pub fn analyzer(&self) -> &Analyzer {
-        &self.analyzer
+    /// Returns the [`Analyzer`] for this session, reconstructed from the DEFAULT_ANALYSIS_PHASE pipeline phase.
+    pub fn analyzer(&self) -> Analyzer {
+        let rules = self
+            .logical_pipeline
+            .phase(DEFAULT_ANALYSIS_PHASE)
+            .and_then(|p| {
+                if let Phase::SyncAnalysis(a) = p {
+                    Some(a.rules.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+        Analyzer::with_rules(rules)
     }
 
-    /// Returns the [`Optimizer`] for this session
-    pub fn optimizer(&self) -> &Optimizer {
-        &self.optimizer
+    /// Returns the [`Optimizer`] for this session, reconstructed from the DEFAULT_OPTIMIZATION_PHASE pipeline phase.
+    pub fn optimizer(&self) -> Optimizer {
+        let rules = self
+            .logical_pipeline
+            .phase(DEFAULT_OPTIMIZATION_PHASE)
+            .and_then(|p| {
+                if let Phase::SyncOptimization(o) = p {
+                    Some(o.rules.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+        Optimizer { rules }
+    }
+
+    /// Returns the logical planning pipeline for this session.
+    pub fn logical_pipeline(&self) -> &LogicalPlanningPipeline {
+        &self.logical_pipeline
+    }
+
+    /// Returns a mutable reference to the logical planning pipeline.
+    pub fn logical_pipeline_mut(&mut self) -> &mut LogicalPlanningPipeline {
+        &mut self.logical_pipeline
     }
 
     /// Returns the [`ExprPlanner`]s for this session
@@ -653,80 +693,47 @@ impl SessionState {
         &self.query_planner
     }
 
-    /// Optimizes the logical plan by applying optimizer rules.
+    /// Optimizes the logical plan by running all sync phases in the pipeline.
+    ///
+    /// Returns an error if any enabled async phase is encountered; use
+    /// [`Self::create_physical_plan`] instead when async phases are registered.
+    ///
     pub fn optimize(&self, plan: &LogicalPlan) -> datafusion_common::Result<LogicalPlan> {
         if let LogicalPlan::Explain(e) = plan {
             let mut stringified_plans = e.stringified_plans.clone();
-
-            // analyze & capture output of each rule
-            let analyzer_result = self.analyzer.execute_and_check(
-                e.plan.as_ref().clone(),
-                &self.options(),
-                |analyzed_plan, analyzer| {
-                    let analyzer_name = analyzer.name().to_string();
-                    let plan_type = PlanType::AnalyzedLogicalPlan { analyzer_name };
-                    stringified_plans.push(analyzed_plan.to_stringified(plan_type));
+            let (inner, new_stringified) = self
+                .logical_pipeline
+                .apply_sync_explained(e.plan.as_ref().clone(), self)?;
+            stringified_plans.extend(new_stringified);
+            return Ok(LogicalPlan::Explain(
+                datafusion_expr::logical_plan::Explain {
+                    verbose: e.verbose,
+                    explain_format: e.explain_format.clone(),
+                    plan: Arc::new(inner),
+                    stringified_plans,
+                    schema: Arc::clone(&e.schema),
+                    logical_optimization_succeeded: true,
                 },
-            );
-            let analyzed_plan = match analyzer_result {
-                Ok(plan) => plan,
-                Err(DataFusionError::Context(analyzer_name, err)) => {
-                    let plan_type = PlanType::AnalyzedLogicalPlan { analyzer_name };
-                    stringified_plans
-                        .push(StringifiedPlan::new(plan_type, err.to_string()));
+            ));
+        }
+        self.logical_pipeline.apply_sync(plan.clone(), self)
+    }
 
-                    return Ok(LogicalPlan::Explain(Explain {
-                        verbose: e.verbose,
-                        plan: Arc::clone(&e.plan),
-                        explain_format: e.explain_format.clone(),
-                        stringified_plans,
-                        schema: Arc::clone(&e.schema),
-                        logical_optimization_succeeded: false,
-                    }));
-                }
-                Err(e) => return Err(e),
-            };
-
-            // to delineate the analyzer & optimizer phases in explain output
-            stringified_plans
-                .push(analyzed_plan.to_stringified(PlanType::FinalAnalyzedLogicalPlan));
-
-            // optimize the child plan, capturing the output of each optimizer
-            let optimized_plan = self.optimizer.optimize(
-                analyzed_plan,
-                self,
-                |optimized_plan, optimizer| {
-                    let optimizer_name = optimizer.name().to_string();
-                    let plan_type = PlanType::OptimizedLogicalPlan { optimizer_name };
-                    stringified_plans.push(optimized_plan.to_stringified(plan_type));
-                },
-            );
-            let (plan, logical_optimization_succeeded) = match optimized_plan {
-                Ok(plan) => (Arc::new(plan), true),
-                Err(DataFusionError::Context(optimizer_name, err)) => {
-                    let plan_type = PlanType::OptimizedLogicalPlan { optimizer_name };
-                    stringified_plans
-                        .push(StringifiedPlan::new(plan_type, err.to_string()));
-                    (Arc::clone(&e.plan), false)
-                }
-                Err(e) => return Err(e),
-            };
-
-            Ok(LogicalPlan::Explain(Explain {
-                verbose: e.verbose,
-                explain_format: e.explain_format.clone(),
-                plan,
-                stringified_plans,
-                schema: Arc::clone(&e.schema),
-                logical_optimization_succeeded,
-            }))
+    /// Run only the optimization phase with a custom [`OptimizerConfig`].
+    ///
+    /// Skips the analysis phase. Used when the plan is already analyzed and the
+    /// caller needs a different config (e.g. PREPARE without `now()` evaluation).
+    pub fn optimize_with_config(
+        &self,
+        plan: LogicalPlan,
+        config: &dyn OptimizerConfig,
+    ) -> datafusion_common::Result<LogicalPlan> {
+        if let Some(Phase::SyncOptimization(p)) =
+            self.logical_pipeline.phase(DEFAULT_OPTIMIZATION_PHASE)
+        {
+            p.apply(plan, config)
         } else {
-            let analyzed_plan = self.analyzer.execute_and_check(
-                plan.clone(),
-                &self.options(),
-                |_, _| {},
-            )?;
-            self.optimizer.optimize(analyzed_plan, self, |_, _| {})
+            Ok(plan)
         }
     }
 
@@ -744,10 +751,16 @@ impl SessionState {
         &self,
         logical_plan: &LogicalPlan,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        let logical_plan = self.optimize(logical_plan)?;
-        self.query_planner
-            .create_physical_plan(&logical_plan, self)
-            .await
+        // Explain nodes require special per-rule capturing via the sync path.
+        // Non-explain plans use the async path so async phases can run.
+        let plan = if matches!(logical_plan, LogicalPlan::Explain(_)) {
+            self.optimize(logical_plan)?
+        } else {
+            self.logical_pipeline
+                .apply(logical_plan.clone(), self)
+                .await?
+        };
+        self.query_planner.create_physical_plan(&plan, self).await
     }
 
     /// Create a [`PhysicalExpr`] from an [`Expr`] after applying type
@@ -782,7 +795,7 @@ impl SessionState {
         let mut expr = simplifier.coerce(expr, df_schema)?;
 
         // rewrite Exprs to functions if necessary
-        for rewrite in self.analyzer.function_rewrites() {
+        for rewrite in &self.function_rewrites {
             expr = expr
                 .transform_up(|expr| rewrite.rewrite(expr, df_schema, config_options))?
                 .data;
@@ -820,9 +833,18 @@ impl SessionState {
         &mut self.config
     }
 
-    /// Return the logical optimizers
+    /// Return the logical optimizers from the DEFAULT_OPTIMIZATION_PHASE pipeline phase.
     pub fn optimizers(&self) -> &[Arc<dyn OptimizerRule + Send + Sync>] {
-        &self.optimizer.rules
+        self.logical_pipeline
+            .phase(DEFAULT_OPTIMIZATION_PHASE)
+            .and_then(|p| {
+                if let Phase::SyncOptimization(o) = p {
+                    Some(o.rules.as_slice())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(&[])
     }
 
     /// Return the physical optimizers
@@ -1008,13 +1030,12 @@ impl SessionState {
 #[derive(Clone)]
 pub struct SessionStateBuilder {
     session_id: Option<String>,
-    analyzer: Option<Analyzer>,
+    logical_pipeline: Option<LogicalPlanningPipeline>,
     expr_planners: Option<Vec<Arc<dyn ExprPlanner>>>,
     #[cfg(feature = "sql")]
     relation_planners: Option<Vec<Arc<dyn RelationPlanner>>>,
     #[cfg(feature = "sql")]
     type_planner: Option<Arc<dyn TypePlanner>>,
-    optimizer: Option<Optimizer>,
     physical_optimizers: Option<PhysicalOptimizer>,
     query_planner: Option<Arc<dyn QueryPlanner + Send + Sync>>,
     catalog_list: Option<Arc<dyn CatalogProviderList>>,
@@ -1037,6 +1058,7 @@ pub struct SessionStateBuilder {
     analyzer_rules: Option<Vec<Arc<dyn AnalyzerRule + Send + Sync>>>,
     optimizer_rules: Option<Vec<Arc<dyn OptimizerRule + Send + Sync>>>,
     physical_optimizer_rules: Option<Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>>>,
+    function_rewrites: Option<Vec<Arc<dyn FunctionRewrite + Send + Sync>>>,
 }
 
 impl SessionStateBuilder {
@@ -1050,13 +1072,12 @@ impl SessionStateBuilder {
     pub fn new() -> Self {
         Self {
             session_id: None,
-            analyzer: None,
+            logical_pipeline: None,
             expr_planners: None,
             #[cfg(feature = "sql")]
             relation_planners: None,
             #[cfg(feature = "sql")]
             type_planner: None,
-            optimizer: None,
             physical_optimizers: None,
             query_planner: None,
             catalog_list: None,
@@ -1079,6 +1100,7 @@ impl SessionStateBuilder {
             analyzer_rules: None,
             optimizer_rules: None,
             physical_optimizer_rules: None,
+            function_rewrites: None,
         }
     }
 
@@ -1105,13 +1127,12 @@ impl SessionStateBuilder {
             .with_create_default_catalog_and_schema(create_default_catalog_and_schema);
         Self {
             session_id: None,
-            analyzer: Some(existing.analyzer),
+            logical_pipeline: Some(existing.logical_pipeline),
             expr_planners: Some(existing.expr_planners),
             #[cfg(feature = "sql")]
             relation_planners: Some(existing.relation_planners),
             #[cfg(feature = "sql")]
             type_planner: existing.type_planner,
-            optimizer: Some(existing.optimizer),
             physical_optimizers: Some(existing.physical_optimizers),
             query_planner: Some(existing.query_planner),
             catalog_list: Some(existing.catalog_list),
@@ -1136,6 +1157,7 @@ impl SessionStateBuilder {
             analyzer_rules: None,
             optimizer_rules: None,
             physical_optimizer_rules: None,
+            function_rewrites: Some(existing.function_rewrites),
         }
     }
 
@@ -1206,12 +1228,17 @@ impl SessionStateBuilder {
         self
     }
 
-    /// Set the [`AnalyzerRule`]s optimizer plan rules.
+    /// Replace the analysis-phase rules with the given set.
     pub fn with_analyzer_rules(
         mut self,
         rules: Vec<Arc<dyn AnalyzerRule + Send + Sync>>,
     ) -> Self {
-        self.analyzer = Some(Analyzer::with_rules(rules));
+        let pipeline = self
+            .logical_pipeline
+            .get_or_insert_with(LogicalPlanningPipeline::default);
+        if let Some(Phase::SyncAnalysis(p)) = pipeline.phase_mut(DEFAULT_ANALYSIS_PHASE) {
+            p.rules = rules;
+        }
         self
     }
 
@@ -1227,12 +1254,19 @@ impl SessionStateBuilder {
         self
     }
 
-    /// Set the [`OptimizerRule`]s used to optimize plans.
+    /// Replace the optimization-phase rules with the given set.
     pub fn with_optimizer_rules(
         mut self,
         rules: Vec<Arc<dyn OptimizerRule + Send + Sync>>,
     ) -> Self {
-        self.optimizer = Some(Optimizer::with_rules(rules));
+        let pipeline = self
+            .logical_pipeline
+            .get_or_insert_with(LogicalPlanningPipeline::default);
+        if let Some(Phase::SyncOptimization(p)) =
+            pipeline.phase_mut(DEFAULT_OPTIMIZATION_PHASE)
+        {
+            p.rules = rules;
+        }
         self
     }
 
@@ -1293,6 +1327,38 @@ impl SessionStateBuilder {
         let mut rules = self.physical_optimizer_rules.unwrap_or_default();
         rules.push(physical_optimizer_rule);
         self.physical_optimizer_rules = Some(rules);
+        self
+    }
+
+    /// Replace the entire logical planning pipeline.
+    pub fn with_logical_pipeline(mut self, pipeline: LogicalPlanningPipeline) -> Self {
+        self.logical_pipeline = Some(pipeline);
+        self
+    }
+
+    /// Append a phase to the end of the pipeline.
+    pub fn with_phase(mut self, phase: Phase) -> Self {
+        self.logical_pipeline
+            .get_or_insert_with(LogicalPlanningPipeline::default)
+            .push(phase);
+        self
+    }
+
+    /// Insert a phase immediately before the named anchor phase.
+    pub fn with_phase_before(mut self, anchor: &str, phase: Phase) -> Self {
+        let pipeline = self
+            .logical_pipeline
+            .get_or_insert_with(LogicalPlanningPipeline::default);
+        pipeline.insert_before(anchor, phase);
+        self
+    }
+
+    /// Insert a phase immediately after the named anchor phase.
+    pub fn with_phase_after(mut self, anchor: &str, phase: Phase) -> Self {
+        let pipeline = self
+            .logical_pipeline
+            .get_or_insert_with(LogicalPlanningPipeline::default);
+        pipeline.insert_after(anchor, phase);
         self
     }
 
@@ -1506,13 +1572,12 @@ impl SessionStateBuilder {
     pub fn build(self) -> SessionState {
         let Self {
             session_id,
-            analyzer,
+            logical_pipeline,
             expr_planners,
             #[cfg(feature = "sql")]
             relation_planners,
             #[cfg(feature = "sql")]
             type_planner,
-            optimizer,
             physical_optimizers,
             query_planner,
             catalog_list,
@@ -1534,6 +1599,7 @@ impl SessionStateBuilder {
             analyzer_rules,
             optimizer_rules,
             physical_optimizer_rules,
+            function_rewrites,
         } = self;
 
         let config = config.unwrap_or_default();
@@ -1541,13 +1607,13 @@ impl SessionStateBuilder {
 
         let mut state = SessionState {
             session_id: session_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
-            analyzer: analyzer.unwrap_or_default(),
+            logical_pipeline: logical_pipeline.unwrap_or_default(),
+            function_rewrites: function_rewrites.unwrap_or_default(),
             expr_planners: expr_planners.unwrap_or_default(),
             #[cfg(feature = "sql")]
             relation_planners: relation_planners.unwrap_or_default(),
             #[cfg(feature = "sql")]
             type_planner,
-            optimizer: optimizer.unwrap_or_default(),
             physical_optimizers: physical_optimizers.unwrap_or_default(),
             query_planner: query_planner
                 .unwrap_or_else(|| Arc::new(DefaultQueryPlanner {})),
@@ -1650,15 +1716,32 @@ impl SessionStateBuilder {
             }
         }
 
-        if let Some(analyzer_rules) = analyzer_rules {
-            for analyzer_rule in analyzer_rules {
-                state.analyzer.rules.push(analyzer_rule);
+        // Sync function_rewrites into the analysis phase so they run before
+        // TypeCoercion (matches original Analyzer::execute_and_check behavior).
+        // Always overwrite to avoid duplication when rebuilding from an existing state.
+        if let Some(Phase::SyncAnalysis(p)) =
+            state.logical_pipeline.phase_mut(DEFAULT_ANALYSIS_PHASE)
+        {
+            p.function_rewrites.clear();
+            p.function_rewrites
+                .extend(state.function_rewrites.iter().map(Arc::clone));
+        }
+
+        if let (Some(rules), Some(Phase::SyncAnalysis(p))) = (
+            analyzer_rules,
+            state.logical_pipeline.phase_mut(DEFAULT_ANALYSIS_PHASE),
+        ) {
+            for rule in rules {
+                p.rules.push(rule);
             }
         }
 
-        if let Some(optimizer_rules) = optimizer_rules {
-            for optimizer_rule in optimizer_rules {
-                state.optimizer.rules.push(optimizer_rule);
+        if let (Some(rules), Some(Phase::SyncOptimization(p))) = (
+            optimizer_rules,
+            state.logical_pipeline.phase_mut(DEFAULT_OPTIMIZATION_PHASE),
+        ) {
+            for rule in rules {
+                p.rules.push(rule);
             }
         }
 
@@ -1679,9 +1762,9 @@ impl SessionStateBuilder {
         &self.session_id
     }
 
-    /// Returns the current analyzer value
-    pub fn analyzer(&mut self) -> &mut Option<Analyzer> {
-        &mut self.analyzer
+    /// Returns the logical planning pipeline for direct mutation.
+    pub fn logical_pipeline(&mut self) -> &mut Option<LogicalPlanningPipeline> {
+        &mut self.logical_pipeline
     }
 
     /// Returns the current expr_planners value
@@ -1699,11 +1782,6 @@ impl SessionStateBuilder {
     #[cfg(feature = "sql")]
     pub fn type_planner(&mut self) -> &mut Option<Arc<dyn TypePlanner>> {
         &mut self.type_planner
-    }
-
-    /// Returns the current optimizer value
-    pub fn optimizer(&mut self) -> &mut Option<Optimizer> {
-        &mut self.optimizer
     }
 
     /// Returns the current physical_optimizers value
@@ -1833,10 +1911,9 @@ impl Debug for SessionStateBuilder {
         #[cfg(feature = "sql")]
         let ret = ret.field("type_planner", &self.type_planner);
         ret.field("query_planners", &self.query_planner)
+            .field("logical_pipeline", &self.logical_pipeline)
             .field("analyzer_rules", &self.analyzer_rules)
-            .field("analyzer", &self.analyzer)
             .field("optimizer_rules", &self.optimizer_rules)
-            .field("optimizer", &self.optimizer)
             .field("physical_optimizer_rules", &self.physical_optimizer_rules)
             .field("physical_optimizers", &self.physical_optimizers)
             .field("table_functions", &self.table_functions)
@@ -2118,7 +2195,12 @@ impl FunctionRegistry for SessionState {
         &mut self,
         rewrite: Arc<dyn FunctionRewrite + Send + Sync>,
     ) -> datafusion_common::Result<()> {
-        self.analyzer.add_function_rewrite(rewrite);
+        self.function_rewrites.push(Arc::clone(&rewrite));
+        if let Some(Phase::SyncAnalysis(p)) =
+            self.logical_pipeline.phase_mut(DEFAULT_ANALYSIS_PHASE)
+        {
+            p.function_rewrites.push(rewrite);
+        }
         Ok(())
     }
 

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -746,14 +746,30 @@ impl SessionState {
     /// `CREATE TABLE`, which do not have corresponding physical plans and must
     /// be handled by another layer, typically [`SessionContext`].
     ///
+    /// # EXPLAIN and async phases
+    ///
+    /// `EXPLAIN` queries require per-rule plan capture (see
+    /// [`LogicalPlanningPipeline::apply_sync_explained`]), which is only
+    /// available on the synchronous path. If any enabled async phase is
+    /// registered, `EXPLAIN` will return an error rather than silently
+    /// skipping those phases. Non-`EXPLAIN` queries always use the async
+    /// path, so all phases run normally.
+    ///
     /// [`SessionContext`]: crate::execution::context::SessionContext
     pub async fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        // Explain nodes require special per-rule capturing via the sync path.
-        // Non-explain plans use the async path so async phases can run.
         let plan = if matches!(logical_plan, LogicalPlan::Explain(_)) {
+            // EXPLAIN uses the sync path to capture per-rule StringifiedPlans.
+            // Fail fast if async phases are registered: they cannot be captured
+            // and silently skipping them would produce misleading EXPLAIN output.
+            if self.logical_pipeline.has_async() {
+                return datafusion_common::plan_err!(
+                    "EXPLAIN is not supported when async pipeline phases are registered; \
+                     disable async phases or use a non-EXPLAIN query"
+                );
+            }
             self.optimize(logical_plan)?
         } else {
             self.logical_pipeline

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -1345,20 +1345,38 @@ impl SessionStateBuilder {
     }
 
     /// Insert a phase immediately before the named anchor phase.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no phase named `anchor` exists in the pipeline. Use
+    /// [`LogicalPlanningPipeline::insert_before`] directly if you need to
+    /// handle the not-found case without panicking.
     pub fn with_phase_before(mut self, anchor: &str, phase: Phase) -> Self {
         let pipeline = self
             .logical_pipeline
             .get_or_insert_with(LogicalPlanningPipeline::default);
-        pipeline.insert_before(anchor, phase);
+        assert!(
+            pipeline.insert_before(anchor, phase),
+            "with_phase_before: no phase named '{anchor}' found in the pipeline",
+        );
         self
     }
 
     /// Insert a phase immediately after the named anchor phase.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no phase named `anchor` exists in the pipeline. Use
+    /// [`LogicalPlanningPipeline::insert_after`] directly if you need to
+    /// handle the not-found case without panicking.
     pub fn with_phase_after(mut self, anchor: &str, phase: Phase) -> Self {
         let pipeline = self
             .logical_pipeline
             .get_or_insert_with(LogicalPlanningPipeline::default);
-        pipeline.insert_after(anchor, phase);
+        assert!(
+            pipeline.insert_after(anchor, phase),
+            "with_phase_after: no phase named '{anchor}' found in the pipeline",
+        );
         self
     }
 

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -746,31 +746,28 @@ impl SessionState {
     /// `CREATE TABLE`, which do not have corresponding physical plans and must
     /// be handled by another layer, typically [`SessionContext`].
     ///
-    /// # EXPLAIN and async phases
-    ///
-    /// `EXPLAIN` queries require per-rule plan capture (see
-    /// [`LogicalPlanningPipeline::apply_sync_explained`]), which is only
-    /// available on the synchronous path. If any enabled async phase is
-    /// registered, `EXPLAIN` will return an error rather than silently
-    /// skipping those phases. Non-`EXPLAIN` queries always use the async
-    /// path, so all phases run normally.
-    ///
     /// [`SessionContext`]: crate::execution::context::SessionContext
     pub async fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        let plan = if matches!(logical_plan, LogicalPlan::Explain(_)) {
-            // EXPLAIN uses the sync path to capture per-rule StringifiedPlans.
-            // Fail fast if async phases are registered: they cannot be captured
-            // and silently skipping them would produce misleading EXPLAIN output.
-            if self.logical_pipeline.has_async() {
-                return datafusion_common::plan_err!(
-                    "EXPLAIN is not supported when async pipeline phases are registered; \
-                     disable async phases or use a non-EXPLAIN query"
-                );
-            }
-            self.optimize(logical_plan)?
+        let plan = if let LogicalPlan::Explain(e) = logical_plan {
+            // EXPLAIN uses apply_explained so per-rule StringifiedPlans are
+            // captured across both sync and async phases.
+            let mut stringified_plans = e.stringified_plans.clone();
+            let (inner, new_stringified) = self
+                .logical_pipeline
+                .apply_explained(e.plan.as_ref().clone(), self)
+                .await?;
+            stringified_plans.extend(new_stringified);
+            LogicalPlan::Explain(datafusion_expr::logical_plan::Explain {
+                verbose: e.verbose,
+                explain_format: e.explain_format.clone(),
+                plan: Arc::new(inner),
+                stringified_plans,
+                schema: Arc::clone(&e.schema),
+                logical_optimization_succeeded: true,
+            })
         } else {
             self.logical_pipeline
                 .apply(logical_plan.clone(), self)

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -53,6 +53,7 @@ recursive_protection = ["dep:recursive"]
 # traits).
 [dependencies]
 arrow = { workspace = true }
+async-trait = { workspace = true }
 chrono = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
@@ -61,7 +62,6 @@ datafusion-physical-expr = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-async-trait = { workspace = true }
 recursive = { workspace = true, optional = true }
 regex = { workspace = true }
 regex-syntax = "0.8.9"

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -61,12 +61,13 @@ datafusion-physical-expr = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
+async-trait = { workspace = true }
 recursive = { workspace = true, optional = true }
 regex = { workspace = true }
 regex-syntax = "0.8.9"
 
 [dev-dependencies]
-async-trait = { workspace = true }
+
 criterion = { workspace = true }
 ctor = { workspace = true }
 datafusion-functions-aggregate = { workspace = true }

--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -69,6 +69,15 @@ pub trait AnalyzerRule: Debug {
 /// [`SessionState::create_physical_plan`], before the synchronous [`Analyzer`].
 /// By default no rules are registered, so the phase is a no-op.
 ///
+/// # Limitations
+///
+/// `analyze` receives [`ConfigOptions`] rather than [`OptimizerConfig`], so
+/// `query_execution_start_time`, `alias_generator`, and `function_registry`
+/// are not available. Async rules that need those should be registered as
+/// async optimization rules or re-expressed as sync rules.
+///
+/// [`ConfigOptions`]: datafusion_common::config::ConfigOptions
+/// [`OptimizerConfig`]: crate::optimizer::OptimizerConfig
 /// [`SessionState::create_physical_plan`]: https://docs.rs/datafusion/latest/datafusion/execution/session_state/struct.SessionState.html#method.create_physical_plan
 #[async_trait]
 pub trait AsyncAnalyzerRule: Debug + Send + Sync {

--- a/datafusion/optimizer/src/analyzer/mod.rs
+++ b/datafusion/optimizer/src/analyzer/mod.rs
@@ -20,6 +20,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use log::debug;
 
 use datafusion_common::Result;
@@ -58,6 +59,27 @@ pub trait AnalyzerRule: Debug {
     fn analyze(&self, plan: LogicalPlan, config: &ConfigOptions) -> Result<LogicalPlan>;
 
     /// A human readable name for this analyzer rule
+    fn name(&self) -> &str;
+}
+
+/// Like [`AnalyzerRule`], but may perform async operations (e.g. remote catalog
+/// lookups, schema resolution) during analysis.
+///
+/// Async analyzer rules run as a pre-analysis phase in
+/// [`SessionState::create_physical_plan`], before the synchronous [`Analyzer`].
+/// By default no rules are registered, so the phase is a no-op.
+///
+/// [`SessionState::create_physical_plan`]: https://docs.rs/datafusion/latest/datafusion/execution/session_state/struct.SessionState.html#method.create_physical_plan
+#[async_trait]
+pub trait AsyncAnalyzerRule: Debug + Send + Sync {
+    /// Rewrite `plan`, possibly performing async I/O.
+    async fn analyze(
+        &self,
+        plan: LogicalPlan,
+        config: &ConfigOptions,
+    ) -> Result<LogicalPlan>;
+
+    /// A human readable name for this rule.
     fn name(&self) -> &str;
 }
 

--- a/datafusion/optimizer/src/lib.rs
+++ b/datafusion/optimizer/src/lib.rs
@@ -75,9 +75,17 @@ pub mod utils;
 #[cfg(test)]
 pub mod test;
 
-pub use analyzer::{Analyzer, AnalyzerRule};
+pub mod logical_pipeline;
+
+pub use analyzer::{Analyzer, AnalyzerRule, AsyncAnalyzerRule};
+pub use logical_pipeline::{
+    AsyncAnalysisPhase, AsyncOptimizationPhase, AsyncPhase, DEFAULT_ANALYSIS_PHASE,
+    DEFAULT_OPTIMIZATION_PHASE, LogicalPlanningPipeline, Phase, Strategy,
+    SyncAnalysisPhase, SyncOptimizationPhase, SyncPhase,
+};
 pub use optimizer::{
-    ApplyOrder, Optimizer, OptimizerConfig, OptimizerContext, OptimizerRule,
+    ApplyOrder, AsyncOptimizerRule, Optimizer, OptimizerConfig, OptimizerContext,
+    OptimizerRule,
 };
 
 pub(crate) mod join_key_set;

--- a/datafusion/optimizer/src/logical_pipeline/async_phase.rs
+++ b/datafusion/optimizer/src/logical_pipeline/async_phase.rs
@@ -98,6 +98,32 @@ impl AsyncPhase<dyn AsyncAnalyzerRule + Send + Sync> {
         }
         Ok(plan)
     }
+
+    /// Like [`Self::apply`] but calls `observer` after each rule for EXPLAIN output.
+    pub async fn apply_observed(
+        &self,
+        plan: LogicalPlan,
+        config: &ConfigOptions,
+        observer: &mut (dyn FnMut(&LogicalPlan, &str) + Send),
+    ) -> Result<LogicalPlan> {
+        if !self.enabled || self.rules.is_empty() {
+            return Ok(plan);
+        }
+        let passes = match &self.strategy {
+            Strategy::Once => 1,
+            Strategy::FixedPoint { max_passes } => {
+                max_passes.unwrap_or_else(|| config.optimizer.max_passes)
+            }
+        };
+        let mut plan = plan;
+        for _ in 0..passes {
+            for rule in &self.rules {
+                plan = rule.analyze(plan, config).await?;
+                observer(&plan, rule.name());
+            }
+        }
+        Ok(plan)
+    }
 }
 
 impl AsyncPhase<dyn AsyncOptimizerRule + Send + Sync> {
@@ -119,6 +145,32 @@ impl AsyncPhase<dyn AsyncOptimizerRule + Send + Sync> {
         for _ in 0..passes {
             for rule in &self.rules {
                 plan = rule.rewrite(plan, config).await?;
+            }
+        }
+        Ok(plan)
+    }
+
+    /// Like [`Self::apply`] but calls `observer` after each rule for EXPLAIN output.
+    pub async fn apply_observed(
+        &self,
+        plan: LogicalPlan,
+        config: &ConfigOptions,
+        observer: &mut (dyn FnMut(&LogicalPlan, &str) + Send),
+    ) -> Result<LogicalPlan> {
+        if !self.enabled || self.rules.is_empty() {
+            return Ok(plan);
+        }
+        let passes = match &self.strategy {
+            Strategy::Once => 1,
+            Strategy::FixedPoint { max_passes } => {
+                max_passes.unwrap_or_else(|| config.optimizer.max_passes)
+            }
+        };
+        let mut plan = plan;
+        for _ in 0..passes {
+            for rule in &self.rules {
+                plan = rule.rewrite(plan, config).await?;
+                observer(&plan, rule.name());
             }
         }
         Ok(plan)

--- a/datafusion/optimizer/src/logical_pipeline/async_phase.rs
+++ b/datafusion/optimizer/src/logical_pipeline/async_phase.rs
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use datafusion_common::Result;
+use datafusion_common::config::ConfigOptions;
+use datafusion_expr::LogicalPlan;
+
+use crate::analyzer::AsyncAnalyzerRule;
+use crate::optimizer::AsyncOptimizerRule;
+
+use super::Strategy;
+
+/// A named, activatable phase whose rules are applied asynchronously.
+///
+/// Use [`AsyncAnalysisPhase`] for [`AsyncAnalyzerRule`]s and
+/// [`AsyncOptimizationPhase`] for [`AsyncOptimizerRule`]s.
+pub struct AsyncPhase<T: ?Sized> {
+    pub(super) name: String,
+    pub enabled: bool,
+    pub strategy: Strategy,
+    pub rules: Vec<Arc<T>>,
+}
+
+impl<T: ?Sized> Clone for AsyncPhase<T> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            enabled: self.enabled,
+            strategy: self.strategy.clone(),
+            rules: self.rules.clone(),
+        }
+    }
+}
+
+impl<T: ?Sized + Debug> Debug for AsyncPhase<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsyncPhase")
+            .field("name", &self.name)
+            .field("enabled", &self.enabled)
+            .field("strategy", &self.strategy)
+            .field("rules", &self.rules)
+            .finish()
+    }
+}
+
+impl<T: ?Sized> AsyncPhase<T> {
+    pub fn new(name: impl Into<String>, strategy: Strategy) -> Self {
+        Self {
+            name: name.into(),
+            enabled: true,
+            strategy,
+            rules: Vec::new(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl AsyncPhase<dyn AsyncAnalyzerRule + Send + Sync> {
+    pub async fn apply(
+        &self,
+        plan: LogicalPlan,
+        config: &ConfigOptions,
+    ) -> Result<LogicalPlan> {
+        if !self.enabled || self.rules.is_empty() {
+            return Ok(plan);
+        }
+        let passes = match &self.strategy {
+            Strategy::Once => 1,
+            Strategy::FixedPoint { max_passes } => {
+                max_passes.unwrap_or_else(|| config.optimizer.max_passes)
+            }
+        };
+        let mut plan = plan;
+        for _ in 0..passes {
+            for rule in &self.rules {
+                plan = rule.analyze(plan, config).await?;
+            }
+        }
+        Ok(plan)
+    }
+}
+
+impl AsyncPhase<dyn AsyncOptimizerRule + Send + Sync> {
+    pub async fn apply(
+        &self,
+        plan: LogicalPlan,
+        config: &ConfigOptions,
+    ) -> Result<LogicalPlan> {
+        if !self.enabled || self.rules.is_empty() {
+            return Ok(plan);
+        }
+        let passes = match &self.strategy {
+            Strategy::Once => 1,
+            Strategy::FixedPoint { max_passes } => {
+                max_passes.unwrap_or_else(|| config.optimizer.max_passes)
+            }
+        };
+        let mut plan = plan;
+        for _ in 0..passes {
+            for rule in &self.rules {
+                plan = rule.rewrite(plan, config).await?;
+            }
+        }
+        Ok(plan)
+    }
+}
+
+pub type AsyncAnalysisPhase = AsyncPhase<dyn AsyncAnalyzerRule + Send + Sync>;
+pub type AsyncOptimizationPhase = AsyncPhase<dyn AsyncOptimizerRule + Send + Sync>;

--- a/datafusion/optimizer/src/logical_pipeline/mod.rs
+++ b/datafusion/optimizer/src/logical_pipeline/mod.rs
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`LogicalPlanningPipeline`]: an ordered sequence of named [`Phase`]s that
+//! transform a [`LogicalPlan`] before physical planning.
+//!
+//! Inspired by Spark SQL's `Batch(name, strategy, rules)` model.
+
+mod async_phase;
+mod pipeline;
+mod sync_phase;
+
+pub use async_phase::{AsyncAnalysisPhase, AsyncOptimizationPhase, AsyncPhase};
+pub use pipeline::LogicalPlanningPipeline;
+pub use sync_phase::{SyncAnalysisPhase, SyncOptimizationPhase, SyncPhase};
+
+/// Name of the default synchronous analysis phase.
+pub const DEFAULT_ANALYSIS_PHASE: &str = "analysis";
+
+/// Name of the default synchronous optimization phase.
+pub const DEFAULT_OPTIMIZATION_PHASE: &str = "optimization";
+
+/// How many times a phase's rules are applied.
+///
+/// # Choosing a strategy
+///
+/// Use [`Strategy::Once`] when rules are idempotent and a single pass always
+/// suffices (e.g. a post-processing cleanup that must run exactly one time).
+///
+/// Use [`Strategy::FixedPoint`] when rules interact: one rule's output may
+/// unlock another rule's pattern. The phase repeats until the plan signature
+/// stops changing or the pass limit is hit. This is the correct choice for
+/// both the default analysis and optimization phases.
+///
+/// Note: `FixedPoint { max_passes: Some(1) }` is mechanically equivalent to
+/// `Once` (both execute rules exactly one time), but carries different intent.
+/// `Once` means "one pass by design"; `FixedPoint { max_passes: Some(1) }`
+/// means "convergence loop, hard-capped at one iteration."
+#[derive(Clone, Debug)]
+pub enum Strategy {
+    /// Apply each rule exactly once. No convergence check is performed.
+    Once,
+    /// Repeat until the plan stops changing or `max_passes` iterations are
+    /// reached. Convergence is detected via [`LogicalPlanSignature`] so the
+    /// loop exits early as soon as a full pass produces no change.
+    ///
+    /// `max_passes: None` defers to `config.optimizer.max_passes` at runtime.
+    ///
+    /// [`LogicalPlanSignature`]: crate::plan_signature::LogicalPlanSignature
+    FixedPoint { max_passes: Option<usize> },
+}
+
+/// One step in a [`LogicalPlanningPipeline`].
+#[derive(Clone, Debug)]
+pub enum Phase {
+    SyncAnalysis(SyncAnalysisPhase),
+    SyncOptimization(SyncOptimizationPhase),
+    AsyncAnalysis(AsyncAnalysisPhase),
+    AsyncOptimization(AsyncOptimizationPhase),
+}
+
+impl Phase {
+    pub fn name(&self) -> &str {
+        match self {
+            Phase::SyncAnalysis(p) => p.name(),
+            Phase::SyncOptimization(p) => p.name(),
+            Phase::AsyncAnalysis(p) => p.name(),
+            Phase::AsyncOptimization(p) => p.name(),
+        }
+    }
+
+    pub fn is_async(&self) -> bool {
+        matches!(self, Phase::AsyncAnalysis(_) | Phase::AsyncOptimization(_))
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        match self {
+            Phase::SyncAnalysis(p) => p.enabled,
+            Phase::SyncOptimization(p) => p.enabled,
+            Phase::AsyncAnalysis(p) => p.enabled,
+            Phase::AsyncOptimization(p) => p.enabled,
+        }
+    }
+}

--- a/datafusion/optimizer/src/logical_pipeline/mod.rs
+++ b/datafusion/optimizer/src/logical_pipeline/mod.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 //! [`LogicalPlanningPipeline`]: an ordered sequence of named [`Phase`]s that
-//! transform a [`LogicalPlan`] before physical planning.
+//! transform a `LogicalPlan` before physical planning.
 //!
 //! Inspired by Spark SQL's `Batch(name, strategy, rules)` model.
 
@@ -55,12 +55,10 @@ pub enum Strategy {
     /// Apply each rule exactly once. No convergence check is performed.
     Once,
     /// Repeat until the plan stops changing or `max_passes` iterations are
-    /// reached. Convergence is detected via [`LogicalPlanSignature`] so the
+    /// reached. Convergence is detected via a plan signature hash so the
     /// loop exits early as soon as a full pass produces no change.
     ///
     /// `max_passes: None` defers to `config.optimizer.max_passes` at runtime.
-    ///
-    /// [`LogicalPlanSignature`]: crate::plan_signature::LogicalPlanSignature
     FixedPoint { max_passes: Option<usize> },
 }
 

--- a/datafusion/optimizer/src/logical_pipeline/pipeline.rs
+++ b/datafusion/optimizer/src/logical_pipeline/pipeline.rs
@@ -247,4 +247,89 @@ impl LogicalPlanningPipeline {
         }
         Ok(plan)
     }
+
+    /// Run all phases (including async), capturing per-rule intermediate plans
+    /// for EXPLAIN output.
+    ///
+    /// Returns `(optimized_plan, stringified_plans)` where `stringified_plans`
+    /// contains [`PlanType::AnalyzedLogicalPlan`], [`PlanType::FinalAnalyzedLogicalPlan`],
+    /// and [`PlanType::OptimizedLogicalPlan`] entries in application order across
+    /// both sync and async phases.
+    pub async fn apply_explained(
+        &self,
+        plan: LogicalPlan,
+        config: &(dyn OptimizerConfig + Sync),
+    ) -> Result<(LogicalPlan, Vec<StringifiedPlan>)> {
+        let config_opts = config.options();
+        let mut plan = plan;
+        let mut stringified: Vec<StringifiedPlan> = Vec::new();
+        let mut pending_final_analyzed = false;
+
+        for phase in &self.phases {
+            if !phase.is_enabled() {
+                continue;
+            }
+            match phase {
+                Phase::SyncAnalysis(p) => {
+                    plan =
+                        p.apply_observed(plan, &config_opts, &mut |p, rule_name| {
+                            stringified.push(p.to_stringified(
+                                PlanType::AnalyzedLogicalPlan {
+                                    analyzer_name: rule_name.to_string(),
+                                },
+                            ));
+                        })?;
+                    pending_final_analyzed = true;
+                }
+                Phase::AsyncAnalysis(p) => {
+                    plan = p
+                        .apply_observed(plan, &config_opts, &mut |p, rule_name| {
+                            stringified.push(p.to_stringified(
+                                PlanType::AnalyzedLogicalPlan {
+                                    analyzer_name: rule_name.to_string(),
+                                },
+                            ));
+                        })
+                        .await?;
+                    pending_final_analyzed = true;
+                }
+                Phase::SyncOptimization(p) => {
+                    if pending_final_analyzed {
+                        stringified.push(
+                            plan.to_stringified(PlanType::FinalAnalyzedLogicalPlan),
+                        );
+                        pending_final_analyzed = false;
+                    }
+                    plan = p.apply_observed(plan, config, &mut |p, rule_name| {
+                        stringified.push(p.to_stringified(
+                            PlanType::OptimizedLogicalPlan {
+                                optimizer_name: rule_name.to_string(),
+                            },
+                        ));
+                    })?;
+                }
+                Phase::AsyncOptimization(p) => {
+                    if pending_final_analyzed {
+                        stringified.push(
+                            plan.to_stringified(PlanType::FinalAnalyzedLogicalPlan),
+                        );
+                        pending_final_analyzed = false;
+                    }
+                    plan = p
+                        .apply_observed(plan, &config_opts, &mut |p, rule_name| {
+                            stringified.push(p.to_stringified(
+                                PlanType::OptimizedLogicalPlan {
+                                    optimizer_name: rule_name.to_string(),
+                                },
+                            ));
+                        })
+                        .await?;
+                }
+            }
+        }
+        if pending_final_analyzed {
+            stringified.push(plan.to_stringified(PlanType::FinalAnalyzedLogicalPlan));
+        }
+        Ok((plan, stringified))
+    }
 }

--- a/datafusion/optimizer/src/logical_pipeline/pipeline.rs
+++ b/datafusion/optimizer/src/logical_pipeline/pipeline.rs
@@ -88,7 +88,10 @@ impl LogicalPlanningPipeline {
     }
 
     /// Insert `phase` immediately before the phase named `anchor`.
-    /// Returns `false` if `anchor` is not found.
+    ///
+    /// Returns `false` if `anchor` is not found; the phase is not inserted.
+    /// Use the return value to detect misconfiguration.
+    #[must_use]
     pub fn insert_before(&mut self, anchor: &str, phase: Phase) -> bool {
         if let Some(pos) = self.phases.iter().position(|p| p.name() == anchor) {
             self.phases.insert(pos, phase);
@@ -99,7 +102,10 @@ impl LogicalPlanningPipeline {
     }
 
     /// Insert `phase` immediately after the phase named `anchor`.
-    /// Returns `false` if `anchor` is not found.
+    ///
+    /// Returns `false` if `anchor` is not found; the phase is not inserted.
+    /// Use the return value to detect misconfiguration.
+    #[must_use]
     pub fn insert_after(&mut self, anchor: &str, phase: Phase) -> bool {
         if let Some(pos) = self.phases.iter().position(|p| p.name() == anchor) {
             self.phases.insert(pos + 1, phase);

--- a/datafusion/optimizer/src/logical_pipeline/pipeline.rs
+++ b/datafusion/optimizer/src/logical_pipeline/pipeline.rs
@@ -1,0 +1,244 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion_common::display::{PlanType, StringifiedPlan, ToStringifiedPlan};
+use datafusion_common::{Result, plan_err};
+use datafusion_expr::LogicalPlan;
+
+use crate::optimizer::OptimizerConfig;
+use crate::{Analyzer, Optimizer};
+
+use super::sync_phase::{SyncAnalysisPhase, SyncOptimizationPhase};
+use super::{DEFAULT_ANALYSIS_PHASE, DEFAULT_OPTIMIZATION_PHASE, Phase, Strategy};
+
+/// An ordered sequence of named [`Phase`]s that transform a [`LogicalPlan`].
+///
+/// The default pipeline mirrors the existing DataFusion behavior:
+/// an analysis phase followed by an optimization phase, both sync.
+///
+/// Users can inject custom phases (including async ones) at any position.
+/// When any enabled async phase is present, use
+/// [`LogicalPlanningPipeline::apply`] (requires an async context). The sync
+/// [`LogicalPlanningPipeline::apply_sync`] returns an error if an enabled
+/// async phase is encountered.
+#[derive(Clone, Debug)]
+pub struct LogicalPlanningPipeline {
+    phases: Vec<Phase>,
+}
+
+impl Default for LogicalPlanningPipeline {
+    fn default() -> Self {
+        let mut analysis = SyncAnalysisPhase::new(
+            DEFAULT_ANALYSIS_PHASE,
+            Strategy::FixedPoint { max_passes: None },
+        );
+        for rule in Analyzer::new().rules {
+            analysis.rules.push(rule);
+        }
+
+        let mut optimization = SyncOptimizationPhase::new(
+            DEFAULT_OPTIMIZATION_PHASE,
+            Strategy::FixedPoint { max_passes: None },
+        );
+        for rule in Optimizer::new().rules {
+            optimization.rules.push(rule);
+        }
+
+        Self::new(vec![
+            Phase::SyncAnalysis(analysis),
+            Phase::SyncOptimization(optimization),
+        ])
+    }
+}
+
+impl LogicalPlanningPipeline {
+    pub fn new(phases: Vec<Phase>) -> Self {
+        Self { phases }
+    }
+
+    pub fn phases(&self) -> &[Phase] {
+        &self.phases
+    }
+
+    pub fn phase(&self, name: &str) -> Option<&Phase> {
+        self.phases.iter().find(|p| p.name() == name)
+    }
+
+    pub fn phase_mut(&mut self, name: &str) -> Option<&mut Phase> {
+        self.phases.iter_mut().find(|p| p.name() == name)
+    }
+
+    /// Append a phase to the end of the pipeline.
+    pub fn push(&mut self, phase: Phase) {
+        self.phases.push(phase);
+    }
+
+    /// Insert `phase` immediately before the phase named `anchor`.
+    /// Returns `false` if `anchor` is not found.
+    pub fn insert_before(&mut self, anchor: &str, phase: Phase) -> bool {
+        if let Some(pos) = self.phases.iter().position(|p| p.name() == anchor) {
+            self.phases.insert(pos, phase);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Insert `phase` immediately after the phase named `anchor`.
+    /// Returns `false` if `anchor` is not found.
+    pub fn insert_after(&mut self, anchor: &str, phase: Phase) -> bool {
+        if let Some(pos) = self.phases.iter().position(|p| p.name() == anchor) {
+            self.phases.insert(pos + 1, phase);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns `true` if any enabled phase is async.
+    pub fn has_async(&self) -> bool {
+        self.phases.iter().any(|p| p.is_enabled() && p.is_async())
+    }
+
+    /// Run all phases synchronously.
+    ///
+    /// Returns an error if an enabled async phase is encountered. Callers
+    /// that may have async phases registered should use
+    /// [`LogicalPlanningPipeline::apply`] from an async context instead.
+    pub fn apply_sync(
+        &self,
+        plan: LogicalPlan,
+        config: &dyn OptimizerConfig,
+    ) -> Result<LogicalPlan> {
+        let config_opts = config.options();
+        let mut plan = plan;
+        for phase in &self.phases {
+            if !phase.is_enabled() {
+                continue;
+            }
+            plan = match phase {
+                Phase::SyncAnalysis(p) => p.apply(plan, &config_opts)?,
+                Phase::SyncOptimization(p) => p.apply(plan, config)?,
+                Phase::AsyncAnalysis(p) => {
+                    return plan_err!(
+                        "pipeline has async analysis phase '{}'; \
+                         use create_physical_plan() instead of optimize()",
+                        p.name()
+                    );
+                }
+                Phase::AsyncOptimization(p) => {
+                    return plan_err!(
+                        "pipeline has async optimization phase '{}'; \
+                         use create_physical_plan() instead of optimize()",
+                        p.name()
+                    );
+                }
+            };
+        }
+        Ok(plan)
+    }
+
+    /// Run all phases, capturing per-rule intermediate plans for EXPLAIN output.
+    ///
+    /// Returns `(optimized_plan, stringified_plans)` where `stringified_plans`
+    /// contains [`PlanType::AnalyzedLogicalPlan`], [`PlanType::FinalAnalyzedLogicalPlan`],
+    /// and [`PlanType::OptimizedLogicalPlan`] entries in application order.
+    pub fn apply_sync_explained(
+        &self,
+        plan: LogicalPlan,
+        config: &dyn OptimizerConfig,
+    ) -> Result<(LogicalPlan, Vec<StringifiedPlan>)> {
+        let config_opts = config.options();
+        let mut plan = plan;
+        let mut stringified: Vec<StringifiedPlan> = Vec::new();
+        let mut pending_final_analyzed = false;
+
+        for phase in &self.phases {
+            if !phase.is_enabled() {
+                continue;
+            }
+            match phase {
+                Phase::SyncAnalysis(p) => {
+                    plan =
+                        p.apply_observed(plan, &config_opts, &mut |p, rule_name| {
+                            stringified.push(p.to_stringified(
+                                PlanType::AnalyzedLogicalPlan {
+                                    analyzer_name: rule_name.to_string(),
+                                },
+                            ));
+                        })?;
+                    pending_final_analyzed = true;
+                }
+                Phase::SyncOptimization(p) => {
+                    if pending_final_analyzed {
+                        stringified.push(
+                            plan.to_stringified(PlanType::FinalAnalyzedLogicalPlan),
+                        );
+                        pending_final_analyzed = false;
+                    }
+                    plan = p.apply_observed(plan, config, &mut |p, rule_name| {
+                        stringified.push(p.to_stringified(
+                            PlanType::OptimizedLogicalPlan {
+                                optimizer_name: rule_name.to_string(),
+                            },
+                        ));
+                    })?;
+                }
+                Phase::AsyncAnalysis(p) => {
+                    return plan_err!(
+                        "pipeline has async analysis phase '{}'; \
+                         use create_physical_plan() instead of optimize()",
+                        p.name()
+                    );
+                }
+                Phase::AsyncOptimization(p) => {
+                    return plan_err!(
+                        "pipeline has async optimization phase '{}'; \
+                         use create_physical_plan() instead of optimize()",
+                        p.name()
+                    );
+                }
+            }
+        }
+        if pending_final_analyzed {
+            stringified.push(plan.to_stringified(PlanType::FinalAnalyzedLogicalPlan));
+        }
+        Ok((plan, stringified))
+    }
+
+    /// Run all phases, awaiting async ones.
+    pub async fn apply(
+        &self,
+        plan: LogicalPlan,
+        config: &(dyn OptimizerConfig + Sync),
+    ) -> Result<LogicalPlan> {
+        let config_opts = config.options();
+        let mut plan = plan;
+        for phase in &self.phases {
+            if !phase.is_enabled() {
+                continue;
+            }
+            plan = match phase {
+                Phase::SyncAnalysis(p) => p.apply(plan, &config_opts)?,
+                Phase::SyncOptimization(p) => p.apply(plan, config)?,
+                Phase::AsyncAnalysis(p) => p.apply(plan, &config_opts).await?,
+                Phase::AsyncOptimization(p) => p.apply(plan, &config_opts).await?,
+            };
+        }
+        Ok(plan)
+    }
+}

--- a/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
+++ b/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
@@ -1,0 +1,371 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use datafusion_common::Result;
+use datafusion_common::config::ConfigOptions;
+use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
+use datafusion_expr::expr_rewriter::FunctionRewrite;
+use datafusion_expr::{InvariantLevel, LogicalPlan, assert_expected_schema};
+
+use crate::analyzer::AnalyzerRule;
+use crate::analyzer::function_rewrite::ApplyFunctionRewrites;
+use crate::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
+use crate::plan_signature::LogicalPlanSignature;
+
+use super::Strategy;
+
+/// A named, activatable phase whose rules are applied synchronously.
+///
+/// Use [`SyncAnalysisPhase`] for [`AnalyzerRule`]s and
+/// [`SyncOptimizationPhase`] for [`OptimizerRule`]s.
+pub struct SyncPhase<T: ?Sized> {
+    pub(super) name: String,
+    pub enabled: bool,
+    pub strategy: Strategy,
+    pub rules: Vec<Arc<T>>,
+    /// [`FunctionRewrite`]s applied before analysis rules (only used by [`SyncAnalysisPhase`]).
+    pub function_rewrites: Vec<Arc<dyn FunctionRewrite + Send + Sync>>,
+}
+
+impl<T: ?Sized> Clone for SyncPhase<T> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            enabled: self.enabled,
+            strategy: self.strategy.clone(),
+            rules: self.rules.clone(),
+            function_rewrites: self.function_rewrites.clone(),
+        }
+    }
+}
+
+impl<T: ?Sized + Debug> Debug for SyncPhase<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyncPhase")
+            .field("name", &self.name)
+            .field("enabled", &self.enabled)
+            .field("strategy", &self.strategy)
+            .field("rules", &self.rules)
+            .field("function_rewrites", &self.function_rewrites)
+            .finish()
+    }
+}
+
+impl<T: ?Sized> SyncPhase<T> {
+    pub fn new(name: impl Into<String>, strategy: Strategy) -> Self {
+        Self {
+            name: name.into(),
+            enabled: true,
+            strategy,
+            rules: Vec::new(),
+            function_rewrites: Vec::new(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl SyncPhase<dyn AnalyzerRule + Send + Sync> {
+    /// Apply all analysis rules in order, repeating per [`Strategy`].
+    ///
+    /// Checks plan invariants before and after applying rules.
+    /// [`FunctionRewrite`]s in `self.function_rewrites` run first so that
+    /// `TypeCoercion` operates on already-rewritten expressions.
+    pub fn apply(
+        &self,
+        plan: LogicalPlan,
+        config: &ConfigOptions,
+    ) -> Result<LogicalPlan> {
+        if !self.enabled || (self.rules.is_empty() && self.function_rewrites.is_empty()) {
+            return Ok(plan);
+        }
+
+        plan.check_invariants(InvariantLevel::Always)
+            .map_err(|e| e.context("Invalid input plan passed to analysis phase"))?;
+
+        let passes = match &self.strategy {
+            Strategy::Once => 1,
+            Strategy::FixedPoint { max_passes } => max_passes.unwrap_or(8),
+        };
+
+        // Prepend function rewrites as an analyzer rule when present.
+        let fn_rewrite_rule: Option<Arc<dyn AnalyzerRule + Send + Sync>> =
+            if self.function_rewrites.is_empty() {
+                None
+            } else {
+                Some(Arc::new(ApplyFunctionRewrites::new(
+                    self.function_rewrites.clone(),
+                )))
+            };
+
+        let mut plan = plan;
+        let mut previous_plans = HashSet::with_capacity(16);
+        previous_plans.insert(LogicalPlanSignature::new(&plan));
+
+        'outer: for _ in 0..passes {
+            if let Some(rule) = &fn_rewrite_rule {
+                plan = rule.analyze(plan, config)?;
+            }
+            for rule in &self.rules {
+                plan = rule.analyze(plan, config)?;
+            }
+            if !previous_plans.insert(LogicalPlanSignature::new(&plan)) {
+                break 'outer;
+            }
+        }
+
+        plan.check_invariants(InvariantLevel::Executable)
+            .map_err(|e| e.context("Invalid plan after analysis phase"))?;
+
+        Ok(plan)
+    }
+
+    /// Like [`Self::apply`] but calls `observer` after each rule for EXPLAIN output.
+    pub fn apply_observed(
+        &self,
+        plan: LogicalPlan,
+        config: &ConfigOptions,
+        observer: &mut dyn FnMut(&LogicalPlan, &str),
+    ) -> Result<LogicalPlan> {
+        if !self.enabled || (self.rules.is_empty() && self.function_rewrites.is_empty()) {
+            return Ok(plan);
+        }
+
+        plan.check_invariants(InvariantLevel::Always)
+            .map_err(|e| e.context("Invalid input plan passed to analysis phase"))?;
+
+        let passes = match &self.strategy {
+            Strategy::Once => 1,
+            Strategy::FixedPoint { max_passes } => max_passes.unwrap_or(8),
+        };
+
+        let fn_rewrite_rule: Option<Arc<dyn AnalyzerRule + Send + Sync>> =
+            if self.function_rewrites.is_empty() {
+                None
+            } else {
+                Some(Arc::new(ApplyFunctionRewrites::new(
+                    self.function_rewrites.clone(),
+                )))
+            };
+
+        let mut plan = plan;
+        let mut previous_plans = HashSet::with_capacity(16);
+        previous_plans.insert(LogicalPlanSignature::new(&plan));
+
+        'outer: for _ in 0..passes {
+            if let Some(rule) = &fn_rewrite_rule {
+                plan = rule.analyze(plan, config)?;
+                observer(&plan, rule.name());
+            }
+            for rule in &self.rules {
+                plan = rule.analyze(plan, config)?;
+                observer(&plan, rule.name());
+            }
+            if !previous_plans.insert(LogicalPlanSignature::new(&plan)) {
+                break 'outer;
+            }
+        }
+
+        plan.check_invariants(InvariantLevel::Executable)
+            .map_err(|e| e.context("Invalid plan after analysis phase"))?;
+
+        Ok(plan)
+    }
+}
+
+impl SyncPhase<dyn OptimizerRule + Send + Sync> {
+    /// Apply all optimization rules in order, respecting [`ApplyOrder`] recursion.
+    ///
+    /// Uses [`LogicalPlanSignature`] to detect fixpoint convergence early.
+    /// Checks plan invariants before the first pass and schema invariants after
+    /// each rule.
+    pub fn apply(
+        &self,
+        plan: LogicalPlan,
+        config: &dyn OptimizerConfig,
+    ) -> Result<LogicalPlan> {
+        if !self.enabled || self.rules.is_empty() {
+            return Ok(plan);
+        }
+
+        plan.check_invariants(InvariantLevel::Executable)
+            .map_err(|e| e.context("Invalid input plan passed to optimization phase"))?;
+
+        let passes = match &self.strategy {
+            Strategy::Once => 1,
+            Strategy::FixedPoint { max_passes } => {
+                max_passes.unwrap_or_else(|| config.options().optimizer.max_passes)
+            }
+        };
+
+        let mut plan = plan;
+        let starting_schema = Arc::clone(plan.schema());
+        let mut previous_plans = HashSet::with_capacity(16);
+        previous_plans.insert(LogicalPlanSignature::new(&plan));
+
+        'outer: for _ in 0..passes {
+            for rule in &self.rules {
+                let rule_starting_schema = Arc::clone(plan.schema());
+                let result: Transformed<LogicalPlan> = match rule.apply_order() {
+                    Some(order) => plan.rewrite_with_subqueries(
+                        &mut RuleRewriter::new(order, rule.as_ref(), config),
+                    )?,
+                    None => rule.rewrite(plan, config)?,
+                };
+                plan = result.data;
+                assert_expected_schema(&rule_starting_schema, &plan).map_err(|e| {
+                    e.context(format!(
+                        "Optimizer rule '{}' changed the schema",
+                        rule.name()
+                    ))
+                })?;
+                #[cfg(debug_assertions)]
+                plan.check_invariants(InvariantLevel::Executable)
+                    .map_err(|e| {
+                        e.context(format!(
+                            "Invalid plan after optimizer rule '{}'",
+                            rule.name()
+                        ))
+                    })?;
+            }
+            let plan_is_fresh = previous_plans.insert(LogicalPlanSignature::new(&plan));
+            if !plan_is_fresh {
+                break 'outer;
+            }
+        }
+
+        assert_expected_schema(&starting_schema, &plan)
+            .map_err(|e| e.context("Optimizer changed top-level schema"))?;
+
+        Ok(plan)
+    }
+
+    /// Like [`Self::apply`] but calls `observer` after each rule for EXPLAIN output.
+    pub fn apply_observed(
+        &self,
+        plan: LogicalPlan,
+        config: &dyn OptimizerConfig,
+        observer: &mut dyn FnMut(&LogicalPlan, &str),
+    ) -> Result<LogicalPlan> {
+        if !self.enabled || self.rules.is_empty() {
+            return Ok(plan);
+        }
+
+        plan.check_invariants(InvariantLevel::Executable)
+            .map_err(|e| e.context("Invalid input plan passed to optimization phase"))?;
+
+        let passes = match &self.strategy {
+            Strategy::Once => 1,
+            Strategy::FixedPoint { max_passes } => {
+                max_passes.unwrap_or_else(|| config.options().optimizer.max_passes)
+            }
+        };
+
+        let mut plan = plan;
+        let starting_schema = Arc::clone(plan.schema());
+        let mut previous_plans = HashSet::with_capacity(16);
+        previous_plans.insert(LogicalPlanSignature::new(&plan));
+
+        'outer: for _ in 0..passes {
+            for rule in &self.rules {
+                let rule_starting_schema = Arc::clone(plan.schema());
+                let result: Transformed<LogicalPlan> = match rule.apply_order() {
+                    Some(order) => plan.rewrite_with_subqueries(
+                        &mut RuleRewriter::new(order, rule.as_ref(), config),
+                    )?,
+                    None => rule.rewrite(plan, config)?,
+                };
+                plan = result.data;
+                assert_expected_schema(&rule_starting_schema, &plan).map_err(|e| {
+                    e.context(format!(
+                        "Optimizer rule '{}' changed the schema",
+                        rule.name()
+                    ))
+                })?;
+                #[cfg(debug_assertions)]
+                plan.check_invariants(InvariantLevel::Executable)
+                    .map_err(|e| {
+                        e.context(format!(
+                            "Invalid plan after optimizer rule '{}'",
+                            rule.name()
+                        ))
+                    })?;
+                observer(&plan, rule.name());
+            }
+            let plan_is_fresh = previous_plans.insert(LogicalPlanSignature::new(&plan));
+            if !plan_is_fresh {
+                break 'outer;
+            }
+        }
+
+        assert_expected_schema(&starting_schema, &plan)
+            .map_err(|e| e.context("Optimizer changed top-level schema"))?;
+
+        Ok(plan)
+    }
+}
+
+pub type SyncAnalysisPhase = SyncPhase<dyn AnalyzerRule + Send + Sync>;
+pub type SyncOptimizationPhase = SyncPhase<dyn OptimizerRule + Send + Sync>;
+
+/// [`TreeNodeRewriter`] wrapper that applies a single [`OptimizerRule`] with
+/// the correct traversal order. Mirrors the `Rewriter` in `optimizer.rs`.
+struct RuleRewriter<'a> {
+    apply_order: ApplyOrder,
+    rule: &'a dyn OptimizerRule,
+    config: &'a dyn OptimizerConfig,
+}
+
+impl<'a> RuleRewriter<'a> {
+    fn new(
+        apply_order: ApplyOrder,
+        rule: &'a dyn OptimizerRule,
+        config: &'a dyn OptimizerConfig,
+    ) -> Self {
+        Self {
+            apply_order,
+            rule,
+            config,
+        }
+    }
+}
+
+impl TreeNodeRewriter for RuleRewriter<'_> {
+    type Node = LogicalPlan;
+
+    fn f_down(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+        if self.apply_order == ApplyOrder::TopDown {
+            self.rule.rewrite(node, self.config)
+        } else {
+            Ok(Transformed::no(node))
+        }
+    }
+
+    fn f_up(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+        if self.apply_order == ApplyOrder::BottomUp {
+            self.rule.rewrite(node, self.config)
+        } else {
+            Ok(Transformed::no(node))
+        }
+    }
+}

--- a/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
+++ b/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
@@ -131,7 +131,7 @@ impl SyncAnalysisPhase {
         }
 
         plan.check_invariants(InvariantLevel::Always)
-            .map_err(|e| e.context("Invalid input plan passed to analysis phase"))?;
+            .map_err(|e| e.context("Invalid input plan passed to Analyzer"))?;
 
         let passes = match &self.strategy {
             Strategy::Once => 1,
@@ -168,7 +168,7 @@ impl SyncAnalysisPhase {
         }
 
         plan.check_invariants(InvariantLevel::Executable)
-            .map_err(|e| e.context("Invalid plan after analysis phase"))?;
+            .map_err(|e| e.context("Invalid (non-executable) plan after Analyzer"))?;
 
         Ok(plan)
     }
@@ -185,7 +185,7 @@ impl SyncAnalysisPhase {
         }
 
         plan.check_invariants(InvariantLevel::Always)
-            .map_err(|e| e.context("Invalid input plan passed to analysis phase"))?;
+            .map_err(|e| e.context("Invalid input plan passed to Analyzer"))?;
 
         let passes = match &self.strategy {
             Strategy::Once => 1,
@@ -224,7 +224,7 @@ impl SyncAnalysisPhase {
         }
 
         plan.check_invariants(InvariantLevel::Executable)
-            .map_err(|e| e.context("Invalid plan after analysis phase"))?;
+            .map_err(|e| e.context("Invalid (non-executable) plan after Analyzer"))?;
 
         Ok(plan)
     }

--- a/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
+++ b/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
@@ -24,6 +24,7 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
 use datafusion_expr::expr_rewriter::FunctionRewrite;
 use datafusion_expr::{InvariantLevel, LogicalPlan, assert_expected_schema};
+use log::warn;
 
 use crate::analyzer::AnalyzerRule;
 use crate::analyzer::function_rewrite::ApplyFunctionRewrites;
@@ -261,28 +262,58 @@ impl SyncPhase<dyn OptimizerRule + Send + Sync> {
 
         'outer: for _ in 0..passes {
             for rule in &self.rules {
+                let prev_plan = config
+                    .options()
+                    .optimizer
+                    .skip_failed_rules
+                    .then(|| plan.clone());
+
                 let rule_starting_schema = Arc::clone(plan.schema());
-                let result: Transformed<LogicalPlan> = match rule.apply_order() {
-                    Some(order) => plan.rewrite_with_subqueries(
-                        &mut RuleRewriter::new(order, rule.as_ref(), config),
-                    )?,
-                    None => rule.rewrite(plan, config)?,
-                };
-                plan = result.data;
-                assert_expected_schema(&rule_starting_schema, &plan).map_err(|e| {
-                    e.context(format!(
-                        "Optimizer rule '{}' changed the schema",
-                        rule.name()
-                    ))
-                })?;
-                #[cfg(debug_assertions)]
-                plan.check_invariants(InvariantLevel::Executable)
-                    .map_err(|e| {
-                        e.context(format!(
-                            "Invalid plan after optimizer rule '{}'",
+                let result =
+                    match rule.apply_order() {
+                        Some(order) => plan.rewrite_with_subqueries(
+                            &mut RuleRewriter::new(order, rule.as_ref(), config),
+                        ),
+                        None => rule.rewrite(plan, config),
+                    }
+                    .and_then(|t| {
+                        assert_expected_schema(&rule_starting_schema, &t.data).map_err(
+                            |e| {
+                                e.context(format!(
+                                    "Optimizer rule '{}' changed the schema",
+                                    rule.name()
+                                ))
+                            },
+                        )?;
+                        #[cfg(debug_assertions)]
+                        t.data
+                            .check_invariants(InvariantLevel::Executable)
+                            .map_err(|e| {
+                                e.context(format!(
+                                    "Invalid plan after optimizer rule '{}'",
+                                    rule.name()
+                                ))
+                            })?;
+                        Ok(t)
+                    });
+
+                match (result, prev_plan) {
+                    (Ok(t), _) => plan = t.data,
+                    (Err(e), Some(orig)) => {
+                        warn!(
+                            "Skipping optimizer rule '{}' due to unexpected error: {}",
+                            rule.name(),
+                            e
+                        );
+                        plan = orig;
+                    }
+                    (Err(e), None) => {
+                        return Err(e.context(format!(
+                            "Optimizer rule '{}' failed",
                             rule.name()
-                        ))
-                    })?;
+                        )));
+                    }
+                }
             }
             let plan_is_fresh = previous_plans.insert(LogicalPlanSignature::new(&plan));
             if !plan_is_fresh {
@@ -324,29 +355,61 @@ impl SyncPhase<dyn OptimizerRule + Send + Sync> {
 
         'outer: for _ in 0..passes {
             for rule in &self.rules {
+                let prev_plan = config
+                    .options()
+                    .optimizer
+                    .skip_failed_rules
+                    .then(|| plan.clone());
+
                 let rule_starting_schema = Arc::clone(plan.schema());
-                let result: Transformed<LogicalPlan> = match rule.apply_order() {
-                    Some(order) => plan.rewrite_with_subqueries(
-                        &mut RuleRewriter::new(order, rule.as_ref(), config),
-                    )?,
-                    None => rule.rewrite(plan, config)?,
-                };
-                plan = result.data;
-                assert_expected_schema(&rule_starting_schema, &plan).map_err(|e| {
-                    e.context(format!(
-                        "Optimizer rule '{}' changed the schema",
-                        rule.name()
-                    ))
-                })?;
-                #[cfg(debug_assertions)]
-                plan.check_invariants(InvariantLevel::Executable)
-                    .map_err(|e| {
-                        e.context(format!(
-                            "Invalid plan after optimizer rule '{}'",
+                let result =
+                    match rule.apply_order() {
+                        Some(order) => plan.rewrite_with_subqueries(
+                            &mut RuleRewriter::new(order, rule.as_ref(), config),
+                        ),
+                        None => rule.rewrite(plan, config),
+                    }
+                    .and_then(|t| {
+                        assert_expected_schema(&rule_starting_schema, &t.data).map_err(
+                            |e| {
+                                e.context(format!(
+                                    "Optimizer rule '{}' changed the schema",
+                                    rule.name()
+                                ))
+                            },
+                        )?;
+                        #[cfg(debug_assertions)]
+                        t.data
+                            .check_invariants(InvariantLevel::Executable)
+                            .map_err(|e| {
+                                e.context(format!(
+                                    "Invalid plan after optimizer rule '{}'",
+                                    rule.name()
+                                ))
+                            })?;
+                        Ok(t)
+                    });
+
+                match (result, prev_plan) {
+                    (Ok(t), _) => {
+                        plan = t.data;
+                        observer(&plan, rule.name());
+                    }
+                    (Err(e), Some(orig)) => {
+                        warn!(
+                            "Skipping optimizer rule '{}' due to unexpected error: {}",
+                            rule.name(),
+                            e
+                        );
+                        plan = orig;
+                    }
+                    (Err(e), None) => {
+                        return Err(e.context(format!(
+                            "Optimizer rule '{}' failed",
                             rule.name()
-                        ))
-                    })?;
-                observer(&plan, rule.name());
+                        )));
+                    }
+                }
             }
             let plan_is_fresh = previous_plans.insert(LogicalPlanSignature::new(&plan));
             if !plan_is_fresh {

--- a/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
+++ b/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
@@ -34,15 +34,15 @@ use super::Strategy;
 
 /// A named, activatable phase whose rules are applied synchronously.
 ///
-/// Use [`SyncAnalysisPhase`] for [`AnalyzerRule`]s and
-/// [`SyncOptimizationPhase`] for [`OptimizerRule`]s.
+/// Use [`SyncOptimizationPhase`] for [`OptimizerRule`]s.
+/// For analysis rules use [`SyncAnalysisPhase`], which is a concrete struct
+/// rather than a type alias so it can carry its own `function_rewrites` field
+/// without polluting this generic type.
 pub struct SyncPhase<T: ?Sized> {
     pub(super) name: String,
     pub enabled: bool,
     pub strategy: Strategy,
     pub rules: Vec<Arc<T>>,
-    /// [`FunctionRewrite`]s applied before analysis rules (only used by [`SyncAnalysisPhase`]).
-    pub function_rewrites: Vec<Arc<dyn FunctionRewrite + Send + Sync>>,
 }
 
 impl<T: ?Sized> Clone for SyncPhase<T> {
@@ -52,7 +52,6 @@ impl<T: ?Sized> Clone for SyncPhase<T> {
             enabled: self.enabled,
             strategy: self.strategy.clone(),
             rules: self.rules.clone(),
-            function_rewrites: self.function_rewrites.clone(),
         }
     }
 }
@@ -64,12 +63,44 @@ impl<T: ?Sized + Debug> Debug for SyncPhase<T> {
             .field("enabled", &self.enabled)
             .field("strategy", &self.strategy)
             .field("rules", &self.rules)
-            .field("function_rewrites", &self.function_rewrites)
             .finish()
     }
 }
 
 impl<T: ?Sized> SyncPhase<T> {
+    pub fn new(name: impl Into<String>, strategy: Strategy) -> Self {
+        Self {
+            name: name.into(),
+            enabled: true,
+            strategy,
+            rules: Vec::new(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Synchronous analysis phase: runs [`AnalyzerRule`]s and optional
+/// [`FunctionRewrite`]s in order.
+///
+/// This is a concrete struct rather than a type alias over [`SyncPhase`] so
+/// that `function_rewrites` lives here exclusively and does not appear on the
+/// generic [`SyncPhase<T>`] (which is also used for optimization rules that
+/// have no need for function rewrites).
+#[derive(Clone, Debug)]
+pub struct SyncAnalysisPhase {
+    pub(super) name: String,
+    pub enabled: bool,
+    pub strategy: Strategy,
+    pub rules: Vec<Arc<dyn AnalyzerRule + Send + Sync>>,
+    /// [`FunctionRewrite`]s prepended before analysis rules each pass so that
+    /// `TypeCoercion` operates on already-rewritten expressions.
+    pub function_rewrites: Vec<Arc<dyn FunctionRewrite + Send + Sync>>,
+}
+
+impl SyncAnalysisPhase {
     pub fn new(name: impl Into<String>, strategy: Strategy) -> Self {
         Self {
             name: name.into(),
@@ -83,19 +114,13 @@ impl<T: ?Sized> SyncPhase<T> {
     pub fn name(&self) -> &str {
         &self.name
     }
-}
 
-impl SyncPhase<dyn AnalyzerRule + Send + Sync> {
     /// Apply all analysis rules in order, repeating per [`Strategy`].
     ///
     /// Checks plan invariants before and after applying rules.
-    /// [`FunctionRewrite`]s in `self.function_rewrites` run first so that
-    /// `TypeCoercion` operates on already-rewritten expressions.
-    pub fn apply(
-        &self,
-        plan: LogicalPlan,
-        config: &ConfigOptions,
-    ) -> Result<LogicalPlan> {
+    /// [`FunctionRewrite`]s run first each pass so that `TypeCoercion`
+    /// operates on already-rewritten expressions.
+    pub fn apply(&self, plan: LogicalPlan, config: &ConfigOptions) -> Result<LogicalPlan> {
         if !self.enabled || (self.rules.is_empty() && self.function_rewrites.is_empty()) {
             return Ok(plan);
         }
@@ -108,7 +133,6 @@ impl SyncPhase<dyn AnalyzerRule + Send + Sync> {
             Strategy::FixedPoint { max_passes } => max_passes.unwrap_or(8),
         };
 
-        // Prepend function rewrites as an analyzer rule when present.
         let fn_rewrite_rule: Option<Arc<dyn AnalyzerRule + Send + Sync>> =
             if self.function_rewrites.is_empty() {
                 None
@@ -325,7 +349,6 @@ impl SyncPhase<dyn OptimizerRule + Send + Sync> {
     }
 }
 
-pub type SyncAnalysisPhase = SyncPhase<dyn AnalyzerRule + Send + Sync>;
 pub type SyncOptimizationPhase = SyncPhase<dyn OptimizerRule + Send + Sync>;
 
 /// [`TreeNodeRewriter`] wrapper that applies a single [`OptimizerRule`] with

--- a/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
+++ b/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
@@ -152,10 +152,14 @@ impl SyncAnalysisPhase {
 
         'outer: for _ in 0..passes {
             if let Some(rule) = &fn_rewrite_rule {
-                plan = rule.analyze(plan, config)?;
+                plan = rule
+                    .analyze(plan, config)
+                    .map_err(|e| e.context(rule.name()))?;
             }
             for rule in &self.rules {
-                plan = rule.analyze(plan, config)?;
+                plan = rule
+                    .analyze(plan, config)
+                    .map_err(|e| e.context(rule.name()))?;
             }
             if !previous_plans.insert(LogicalPlanSignature::new(&plan)) {
                 break 'outer;
@@ -202,11 +206,15 @@ impl SyncAnalysisPhase {
 
         'outer: for _ in 0..passes {
             if let Some(rule) = &fn_rewrite_rule {
-                plan = rule.analyze(plan, config)?;
+                plan = rule
+                    .analyze(plan, config)
+                    .map_err(|e| e.context(rule.name()))?;
                 observer(&plan, rule.name());
             }
             for rule in &self.rules {
-                plan = rule.analyze(plan, config)?;
+                plan = rule
+                    .analyze(plan, config)
+                    .map_err(|e| e.context(rule.name()))?;
                 observer(&plan, rule.name());
             }
             if !previous_plans.insert(LogicalPlanSignature::new(&plan)) {
@@ -224,7 +232,7 @@ impl SyncAnalysisPhase {
 impl SyncPhase<dyn OptimizerRule + Send + Sync> {
     /// Apply all optimization rules in order, respecting [`ApplyOrder`] recursion.
     ///
-    /// Uses [`LogicalPlanSignature`] to detect fixpoint convergence early.
+    /// Uses a plan signature hash to detect fixpoint convergence early.
     /// Checks plan invariants before the first pass and schema invariants after
     /// each rule.
     pub fn apply(

--- a/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
+++ b/datafusion/optimizer/src/logical_pipeline/sync_phase.rs
@@ -120,7 +120,11 @@ impl SyncAnalysisPhase {
     /// Checks plan invariants before and after applying rules.
     /// [`FunctionRewrite`]s run first each pass so that `TypeCoercion`
     /// operates on already-rewritten expressions.
-    pub fn apply(&self, plan: LogicalPlan, config: &ConfigOptions) -> Result<LogicalPlan> {
+    pub fn apply(
+        &self,
+        plan: LogicalPlan,
+        config: &ConfigOptions,
+    ) -> Result<LogicalPlan> {
         if !self.enabled || (self.rules.is_empty() && self.function_rewrites.is_empty()) {
             return Ok(plan);
         }

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -20,6 +20,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use datafusion_expr::registry::FunctionRegistry;
 use datafusion_expr::{InvariantLevel, assert_expected_schema};
@@ -129,6 +130,30 @@ pub trait OptimizerRule: Debug {
     ) -> Result<Transformed<LogicalPlan>, DataFusionError> {
         internal_err!("rewrite is not implemented for {}", self.name())
     }
+}
+
+/// Like [`OptimizerRule`], but may perform async operations during optimization.
+///
+/// Async optimizer rules run as a post-optimization phase in
+/// [`SessionState::create_physical_plan`], after the synchronous [`Optimizer`]
+/// has finished all its passes. By default no rules are registered, so the
+/// phase is a no-op.
+///
+/// Unlike the sync [`Optimizer`], async rules run exactly once (no fixed-point
+/// loop).
+///
+/// [`SessionState::create_physical_plan`]: https://docs.rs/datafusion/latest/datafusion/execution/session_state/struct.SessionState.html#method.create_physical_plan
+#[async_trait]
+pub trait AsyncOptimizerRule: Debug + Send + Sync {
+    /// Try to rewrite `plan`. Called exactly once per query.
+    async fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        config: &ConfigOptions,
+    ) -> Result<LogicalPlan>;
+
+    /// A human readable name for this rule.
+    fn name(&self) -> &str;
 }
 
 /// Options to control the DataFusion Optimizer.

--- a/datafusion/optimizer/src/optimizer.rs
+++ b/datafusion/optimizer/src/optimizer.rs
@@ -142,10 +142,21 @@ pub trait OptimizerRule: Debug {
 /// Unlike the sync [`Optimizer`], async rules run exactly once (no fixed-point
 /// loop).
 ///
+/// # Limitations
+///
+/// `rewrite` receives [`ConfigOptions`] rather than [`OptimizerConfig`], so
+/// the following are unavailable to async rules:
+/// - `query_execution_start_time` — the timestamp used to evaluate `now()`.
+/// - `alias_generator` — the shared alias counter for deterministic subquery names.
+/// - `function_registry` — access to registered UDFs.
+///
+/// If any of these are required, implement [`OptimizerRule`] instead and
+/// register it in the synchronous optimization phase.
+///
 /// [`SessionState::create_physical_plan`]: https://docs.rs/datafusion/latest/datafusion/execution/session_state/struct.SessionState.html#method.create_physical_plan
 #[async_trait]
 pub trait AsyncOptimizerRule: Debug + Send + Sync {
-    /// Try to rewrite `plan`. Called exactly once per query.
+    /// Try to rewrite `plan`.
     async fn rewrite(
         &self,
         plan: LogicalPlan,


### PR DESCRIPTION
> **POC for design validation only — not ready for review or merge. Will open a proper issue when the design is more stable.**

## Why

DataFusion's planning architecture has two constraints that limit certain use cases:

**1. All rules are synchronous.**

The existing async support in `CatalogProvider` covers many remote catalog scenarios well. The gap is specifically **predicate-dependent schema resolution**: cases where the set of columns (or streams, or partitions) that need to be opened cannot be determined without first seeing the filter predicates in the query.

Consider a wide schema-on-read store where columns are backed by individually opened streams. Opening all streams upfront to resolve the schema is prohibitively expensive. The right set of streams depends on the predicates the user wrote. Pre-resolving before planning means either opening everything (expensive, defeats pruning) or blocking on a call that itself needs to peek at the predicate — at which point you have re-implemented an analysis rule, outside the planner.

What you need is a rule that sees the partially-analyzed plan (including predicates), does async I/O to resolve schema or open the right streams, and rewrites scan nodes in place. That is the core motivation for `AsyncAnalyzerRule`.

**2. The pipeline is a closed two-slot system.**

Engines and frameworks built on DataFusion have no way to inject custom planning stages without replacing the entire `Analyzer` or `Optimizer`. There is no named hook, no ordering guarantee, no enable/disable per phase.

## What

**1. Add async rule variants**

New traits alongside the existing sync ones:

```rust
// analysis
pub trait AsyncAnalyzerRule { async fn analyze(...) }

// optimization
pub trait AsyncOptimizerRule { async fn rewrite(...) }
```

**2. Unify everything into an extensible pipeline**

Replaces the two hardcoded slots with a single `LogicalPlanningPipeline` — an ordered `Vec<Phase>` where each phase is named, can be enabled/disabled, carries a `Strategy` (`Once` or `FixedPoint`), and holds rules of one type:

| Phase variant | Rule type |
|---|---|
| `SyncAnalysis` | `AnalyzerRule` |
| `SyncOptimization` | `OptimizerRule` |
| `AsyncAnalysis` | `AsyncAnalyzerRule` |
| `AsyncOptimization` | `AsyncOptimizerRule` |

The design is directly inspired by **Spark SQL's** `Batch(name, strategy, rules*)` and **Apache Calcite's** `HepPlanner` batches: named, ordered phases with explicit iteration strategy, strict analysis/optimization separation.

The default pipeline has two phases that replicate existing behavior exactly:

```
"analysis"      SyncAnalysis     FixedPoint  ← Analyzer::new().rules
"optimization"  SyncOptimization FixedPoint  ← Optimizer::new().rules
```

`SessionState` replaces `analyzer: Analyzer` and `optimizer: Optimizer` with `logical_pipeline: LogicalPlanningPipeline`. Users can inject custom phases (including async ones) at any position:

```rust
let mut phase = AsyncAnalysisPhase::new("my-async-phase", Strategy::Once);
phase.rules.push(Arc::new(MyAsyncRule));

let state = SessionStateBuilder::new()
    .with_phase_before(DEFAULT_ANALYSIS_PHASE, Phase::AsyncAnalysis(phase))
    .build();
```

The sync `optimize()` path (`DataFrame` API, `PREPARE`) fails fast with a clear error if an async phase is registered. The async `create_physical_plan()` path handles all four variants, including EXPLAIN output that captures per-rule intermediate plans across both sync and async phases.

## Known gaps

- `SessionState::analyzer()` / `optimizer()` now return owned values instead of references.