### PR TITLE
Gene.bordegaray/2026/04/partition routed dynamic filters

### DIFF
--- a/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
@@ -37,14 +37,17 @@ use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::datasource::physical_plan::{CsvSource, ParquetSource};
 use datafusion::datasource::source::DataSourceExec;
 use datafusion::prelude::{SessionConfig, SessionContext};
-use datafusion_common::ScalarValue;
 use datafusion_common::config::CsvOptions;
 use datafusion_common::error::Result;
 use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
 };
+use datafusion_common::{NullEquality, ScalarValue};
+use datafusion_datasource::TableSchema;
 use datafusion_datasource::file_groups::FileGroup;
-use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
+use datafusion_datasource::file_scan_config::{
+    FileScanConfigBuilder, wrap_partition_type_in_dict, wrap_partition_value_in_dict,
+};
 use datafusion_expr::{JoinType, Operator};
 use datafusion_functions_aggregate::count::count_udaf;
 use datafusion_physical_expr::aggregate::AggregateExprBuilder;
@@ -67,12 +70,17 @@ use datafusion_physical_plan::execution_plan::ExecutionPlan;
 use datafusion_physical_plan::expressions::col;
 use datafusion_physical_plan::filter::FilterExec;
 use datafusion_physical_plan::joins::utils::JoinOn;
+use datafusion_physical_plan::joins::{
+    DynamicFilterRoutingMode, HashJoinExec, PartitionMode,
+};
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion_physical_plan::projection::{ProjectionExec, ProjectionExpr};
+use datafusion_physical_plan::repartition::RepartitionExec;
 use datafusion_physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion_physical_plan::union::UnionExec;
 use datafusion_physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlanProperties, PlanProperties, displayable,
+    DisplayAs, DisplayFormatType, ExecutionPlanProperties, Partitioning, PlanProperties,
+    displayable,
 };
 use insta::Settings;
 
@@ -537,6 +545,76 @@ fn hash_join_exec(
     .unwrap()
 }
 
+fn parquet_exec_with_date_partition(
+    partitioned_by_file_group: bool,
+) -> Arc<DataSourceExec> {
+    let table_schema = TableSchema::new(
+        schema(),
+        vec![Arc::new(Field::new(
+            "date",
+            wrap_partition_type_in_dict(DataType::Utf8),
+            false,
+        ))],
+    );
+    let partition_values: &[&str] = if partitioned_by_file_group {
+        &["2026-04-21", "2026-04-22"]
+    } else {
+        &["2026-04-21"]
+    };
+    let file_groups = partition_values
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| {
+            FileGroup::new(vec![
+                PartitionedFile::new(format!("partition_{idx}.parquet"), 100)
+                    .with_partition_values(vec![wrap_partition_value_in_dict(
+                        ScalarValue::Utf8(Some((*value).to_string())),
+                    )]),
+            ])
+        })
+        .collect::<Vec<_>>();
+
+    let builder = FileScanConfigBuilder::new(
+        ObjectStoreUrl::parse("test:///").unwrap(),
+        Arc::new(ParquetSource::new(table_schema)),
+    )
+    .with_file_groups(file_groups);
+
+    let builder = if partitioned_by_file_group {
+        builder.with_partitioned_by_file_group(true)
+    } else {
+        builder
+    };
+
+    DataSourceExec::from_data_source(builder.build())
+}
+
+fn join_on_column(
+    left: &dyn ExecutionPlan,
+    right: &dyn ExecutionPlan,
+    column_name: &str,
+) -> JoinOn {
+    vec![(
+        Arc::new(Column::new_with_schema(column_name, &left.schema()).unwrap())
+            as Arc<dyn PhysicalExpr>,
+        Arc::new(Column::new_with_schema(column_name, &right.schema()).unwrap())
+            as Arc<dyn PhysicalExpr>,
+    )]
+}
+
+fn add_hash_repartition(
+    input: Arc<dyn ExecutionPlan>,
+    column_name: &str,
+    partition_count: usize,
+) -> Arc<dyn ExecutionPlan> {
+    let expr = Arc::new(Column::new_with_schema(column_name, &input.schema()).unwrap())
+        as Arc<dyn PhysicalExpr>;
+    Arc::new(
+        RepartitionExec::try_new(input, Partitioning::Hash(vec![expr], partition_count))
+            .unwrap(),
+    )
+}
+
 fn filter_exec(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
     let predicate = Arc::new(BinaryExpr::new(
         col("c", &schema()).unwrap(),
@@ -574,6 +652,26 @@ fn ensure_distribution_helper(
     config.optimizer.repartition_file_min_size = 1024;
     config.optimizer.prefer_existing_sort = prefer_existing_sort;
     ensure_distribution(distribution_context, &config).map(|item| item.data.plan)
+}
+
+fn dynamic_filter_routing_mode(
+    plan: Arc<dyn ExecutionPlan>,
+    target_partitions: usize,
+) -> Result<DynamicFilterRoutingMode> {
+    let distribution_context = DistributionContext::new_default(plan);
+    let mut config = ConfigOptions::new();
+    config.execution.target_partitions = target_partitions;
+    config.optimizer.enable_round_robin_repartition = false;
+    config.optimizer.repartition_file_scans = false;
+    config.optimizer.repartition_file_min_size = 1024;
+    config.optimizer.prefer_existing_sort = false;
+    let optimized = distribution_context
+        .transform_up(|node| ensure_distribution(node, &config))
+        .map(|item| item.data.plan)?;
+    let hash_join = optimized
+        .downcast_ref::<HashJoinExec>()
+        .expect("expected HashJoinExec");
+    Ok(hash_join.dynamic_filter_routing_mode)
 }
 
 fn test_suite_default_config_options() -> ConfigOptions {
@@ -1089,6 +1187,133 @@ fn join_after_agg_alias() -> Result<()> {
     assert_plan!(plan_distrib, plan_sort);
 
     Ok(())
+}
+
+#[test]
+fn partitioned_hash_join_uses_partition_index_for_file_groups() -> Result<()> {
+    let left = parquet_exec_with_date_partition(true);
+    let right = parquet_exec_with_date_partition(true);
+    let join_on = join_on_column(left.as_ref(), right.as_ref(), "date");
+
+    let join = hash_join_exec(left, right, &join_on, &JoinType::Inner);
+    assert_eq!(
+        dynamic_filter_routing_mode(join, 2)?,
+        DynamicFilterRoutingMode::PartitionIndex,
+    );
+    Ok(())
+}
+
+#[test]
+fn partitioned_hash_join_uses_case_hash_for_repartitioned_inputs() -> Result<()> {
+    let direct_left = add_hash_repartition(parquet_exec(), "a", 4);
+    let direct_right = add_hash_repartition(parquet_exec(), "a", 4);
+    let projected_left = projection_exec_with_alias(
+        add_hash_repartition(parquet_exec(), "a", 4),
+        vec![("a".to_string(), "a".to_string())],
+    );
+    let projected_right = projection_exec_with_alias(
+        add_hash_repartition(parquet_exec(), "a", 4),
+        vec![("a".to_string(), "a".to_string())],
+    );
+
+    for (left, right) in [
+        (direct_left, direct_right),
+        (projected_left, projected_right),
+    ] {
+        let join_on = join_on_column(left.as_ref(), right.as_ref(), "a");
+        let join = hash_join_exec(left, right, &join_on, &JoinType::Inner);
+        assert_eq!(
+            dynamic_filter_routing_mode(join, 4)?,
+            DynamicFilterRoutingMode::CaseHash,
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn partitioned_hash_join_uses_case_hash_through_collect_left() -> Result<()> {
+    // In `CollectLeft` mode, `RightSemi` preserves the right child's output
+    // partitioning. The parent join should inherit repartition provenance from
+    // that side rather than from child 0.
+    let subtree_left = parquet_exec();
+    let subtree_right = add_hash_repartition(parquet_exec(), "a", 4);
+    let subtree_join_on =
+        join_on_column(subtree_left.as_ref(), subtree_right.as_ref(), "a");
+    let subtree = Arc::new(
+        HashJoinExec::try_new(
+            subtree_left,
+            subtree_right,
+            subtree_join_on,
+            None,
+            &JoinType::RightSemi,
+            None,
+            PartitionMode::CollectLeft,
+            NullEquality::NullEqualsNothing,
+            false,
+        )
+        .unwrap(),
+    );
+
+    let right = add_hash_repartition(parquet_exec(), "a", 4);
+    let join_on = join_on_column(subtree.as_ref(), right.as_ref(), "a");
+
+    let join = hash_join_exec(subtree, right, &join_on, &JoinType::Inner);
+    assert_eq!(
+        dynamic_filter_routing_mode(join, 4)?,
+        DynamicFilterRoutingMode::CaseHash,
+    );
+    Ok(())
+}
+
+#[test]
+fn partitioned_hash_join_uses_case_hash_for_single_partition() -> Result<()> {
+    for (left, right) in [
+        (parquet_exec_multiple(), parquet_exec()),
+        (parquet_exec(), parquet_exec_multiple()),
+    ] {
+        let join_on = join_on_column(left.as_ref(), right.as_ref(), "a");
+        let join = hash_join_exec(left, right, &join_on, &JoinType::Inner);
+        assert_eq!(
+            dynamic_filter_routing_mode(join, 1)?,
+            DynamicFilterRoutingMode::CaseHash,
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn partitioned_hash_join_errors_when_only_one_side_is_file_group_partitioned() {
+    for (left, right, left_repartitioned, right_repartitioned) in [
+        (
+            parquet_exec_with_date_partition(true),
+            parquet_exec_with_date_partition(false),
+            false,
+            true,
+        ),
+        (
+            parquet_exec_with_date_partition(false),
+            parquet_exec_with_date_partition(true),
+            true,
+            false,
+        ),
+    ] {
+        let join_on = join_on_column(left.as_ref(), right.as_ref(), "date");
+        let join = hash_join_exec(left, right, &join_on, &JoinType::Inner);
+        let err = dynamic_filter_routing_mode(join, 2).unwrap_err();
+        let err = err.to_string();
+        assert!(
+            err.contains("Partitioned hash join has misaligned partitioning"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains(&format!("left repartitioned={left_repartitioned}")),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains(&format!("right repartitioned={right_repartitioned}")),
+            "unexpected error: {err}"
+        );
+    }
 }
 
 #[test]
@@ -3883,8 +4108,18 @@ fn test_replace_order_preserving_variants_with_fetch() -> Result<()> {
     // Create distribution context
     let dist_context = DistributionContext::new(
         spm_exec,
-        true,
-        vec![DistributionContext::new(parquet_exec, false, vec![])],
+        DistFlags {
+            dist_changing: true,
+            repartitioned: false,
+        },
+        vec![DistributionContext::new(
+            parquet_exec,
+            DistFlags {
+                dist_changing: false,
+                repartitioned: false,
+            },
+            vec![],
+        )],
     );
 
     // Apply the function

--- a/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
@@ -34,6 +34,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 use datafusion_catalog::memory::DataSourceExec;
+use datafusion_common::JoinType;
 use datafusion_common::config::ConfigOptions;
 use datafusion_datasource::{
     PartitionedFile, file_groups::FileGroup, file_scan_config::FileScanConfigBuilder,
@@ -48,6 +49,9 @@ use datafusion_physical_expr::{
 };
 use datafusion_physical_optimizer::{
     PhysicalOptimizerRule, filter_pushdown::FilterPushdown,
+};
+use datafusion_physical_plan::joins::{
+    DynamicFilterRoutingMode, HashJoinExec, HashJoinExecBuilder, PartitionMode,
 };
 use datafusion_physical_plan::{
     ExecutionPlan,
@@ -825,7 +829,11 @@ async fn test_topk_filter_passes_through_coalesce_partitions() {
     ];
 
     // Create a source that supports all batches
-    let source = Arc::new(TestSource::new(schema(), true, batches));
+    let source = Arc::new(TestSource::new(
+        schema(),
+        true,
+        vec![batches.clone(), batches],
+    ));
 
     let base_config =
         FileScanConfigBuilder::new(ObjectStoreUrl::parse("test://").unwrap(), source)
@@ -880,9 +888,6 @@ async fn test_topk_filter_passes_through_coalesce_partitions() {
 // per-partition CASE filter this test exercises is not reachable via SQL.
 #[tokio::test]
 async fn test_hashjoin_dynamic_filter_pushdown_partitioned() {
-    use datafusion_common::JoinType;
-    use datafusion_physical_plan::joins::{HashJoinExec, PartitionMode};
-
     // Rough sketch of the MRE we're trying to recreate:
     // COPY (select i as k from generate_series(1, 10000000) as t(i))
     // TO 'test_files/scratch/push_down_filter/t1.parquet'
@@ -1127,12 +1132,175 @@ async fn test_hashjoin_dynamic_filter_pushdown_partitioned() {
     );
 }
 
-// Not portable to sqllogictest: this test specifically pins a
-// `RepartitionExec(Hash, 12)` between `HashJoinExec(CollectLeft)` and the
-// probe-side scan to verify the dynamic filter link survives that boundary
-// (regression for #17451). The same CollectLeft filter content and
-// pushdown counters are already covered by the simpler slt port
-// (push_down_filter_parquet.slt::test_hashjoin_dynamic_filter_pushdown).
+// Not portable to sqllogictest: this inspects the in-memory
+// `DynamicFilterPhysicalExpr` to verify both the global fallback expression and
+// the per-partition filters used by `PartitionIndex` routing.
+#[tokio::test]
+async fn test_hashjoin_dynamic_filter_pushdown_partition_index() {
+    let build_side_schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Utf8, false),
+        Field::new("b", DataType::Utf8, false),
+        Field::new("c", DataType::Float64, false),
+    ]));
+    let build_batches = vec![
+        vec![
+            record_batch!(
+                ("a", Utf8, ["aa"]),
+                ("b", Utf8, ["ba"]),
+                ("c", Float64, [1.0])
+            )
+            .unwrap(),
+        ],
+        vec![
+            record_batch!(
+                ("a", Utf8, ["zz"]),
+                ("b", Utf8, ["zy"]),
+                ("c", Float64, [2.0])
+            )
+            .unwrap(),
+        ],
+    ];
+    let build_scan = TestScanBuilder::new(Arc::clone(&build_side_schema))
+        .with_support(true)
+        .with_partition_batches(build_batches)
+        .build();
+
+    let probe_side_schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Utf8, false),
+        Field::new("b", DataType::Utf8, false),
+        Field::new("e", DataType::Float64, false),
+    ]));
+    let probe_batches = vec![
+        vec![
+            record_batch!(
+                ("a", Utf8, ["aa", "ac"]),
+                ("b", Utf8, ["ba", "bc"]),
+                ("e", Float64, [10.0, 30.0])
+            )
+            .unwrap(),
+        ],
+        vec![
+            record_batch!(
+                ("a", Utf8, ["zz", "zx"]),
+                ("b", Utf8, ["zy", "zq"]),
+                ("e", Float64, [20.0, 40.0])
+            )
+            .unwrap(),
+        ],
+    ];
+    let probe_scan = TestScanBuilder::new(Arc::clone(&probe_side_schema))
+        .with_support(true)
+        .with_partition_batches(probe_batches)
+        .build();
+
+    let on = vec![
+        (
+            col("a", &build_side_schema).unwrap(),
+            col("a", &probe_side_schema).unwrap(),
+        ),
+        (
+            col("b", &build_side_schema).unwrap(),
+            col("b", &probe_side_schema).unwrap(),
+        ),
+    ];
+    let hash_join = Arc::new(
+        HashJoinExecBuilder::new(
+            build_scan,
+            Arc::clone(&probe_scan),
+            on,
+            JoinType::Inner,
+        )
+        .with_partition_mode(PartitionMode::Partitioned)
+        .with_null_equality(datafusion_common::NullEquality::NullEqualsNothing)
+        .with_dynamic_filter_routing_mode(DynamicFilterRoutingMode::PartitionIndex)
+        .build()
+        .unwrap(),
+    );
+
+    let cp = Arc::new(CoalescePartitionsExec::new(hash_join)) as Arc<dyn ExecutionPlan>;
+    let plan = Arc::new(SortExec::new(
+        LexOrdering::new(vec![PhysicalSortExpr::new(
+            col("a", &probe_side_schema).unwrap(),
+            SortOptions::new(true, false),
+        )])
+        .unwrap(),
+        cp,
+    )) as Arc<dyn ExecutionPlan>;
+
+    let mut config = ConfigOptions::default();
+    config.execution.parquet.pushdown_filters = true;
+    config.optimizer.enable_dynamic_filter_pushdown = true;
+    let plan = FilterPushdown::new_post_optimization()
+        .optimize(plan, &config)
+        .unwrap();
+
+    let sort = plan.downcast_ref::<SortExec>().expect("expected SortExec");
+    let cp = sort
+        .input()
+        .downcast_ref::<CoalescePartitionsExec>()
+        .expect("expected CoalescePartitionsExec");
+    let hash_join = cp
+        .input()
+        .downcast_ref::<HashJoinExec>()
+        .expect("expected HashJoinExec");
+    assert_eq!(
+        hash_join.dynamic_filter_routing_mode,
+        DynamicFilterRoutingMode::PartitionIndex
+    );
+
+    let config = SessionConfig::new().with_batch_size(10);
+    let session_ctx = SessionContext::new_with_config(config);
+    session_ctx.register_object_store(
+        ObjectStoreUrl::parse("test://").unwrap().as_ref(),
+        Arc::new(InMemory::new()),
+    );
+    let state = session_ctx.state();
+    let task_ctx = state.task_ctx();
+    let batches = collect(Arc::clone(&plan), Arc::clone(&task_ctx))
+        .await
+        .unwrap();
+
+    let dynamic_filter = hash_join
+        .dynamic_filter_for_test()
+        .expect("expected dynamic filter");
+    insta::assert_snapshot!(
+        format!("{}", format_plan_for_test(&plan)),
+        @r"
+    - SortExec: expr=[a@0 DESC NULLS LAST], preserve_partitioning=[false]
+    -   CoalescePartitionsExec
+    -     HashJoinExec: mode=Partitioned, join_type=Inner, on=[(a@0, a@0), (b@1, b@1)]
+    -       DataSourceExec: file_groups={2 groups: [[test_0.parquet], [test_1.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=true
+    -       DataSourceExec: file_groups={2 groups: [[test_0.parquet], [test_1.parquet]]}, projection=[a, b, e], file_type=test, pushdown_supported=true, predicate=DynamicFilter [ a@0 >= aa AND a@0 <= aa AND b@1 >= ba AND b@1 <= ba AND struct(a@0, b@1) IN (SET) ([{c0:aa,c1:ba}]) OR a@0 >= zz AND a@0 <= zz AND b@1 >= zy AND b@1 <= zy AND struct(a@0, b@1) IN (SET) ([{c0:zz,c1:zy}]) ]
+    "
+    );
+    let partition_0_filter = dynamic_filter.partition_filter(0).unwrap().unwrap();
+    let partition_1_filter = dynamic_filter.partition_filter(1).unwrap().unwrap();
+    insta::assert_snapshot!(
+        format!("{partition_0_filter}"),
+        @"a@0 >= aa AND a@0 <= aa AND b@1 >= ba AND b@1 <= ba AND struct(a@0, b@1) IN (SET) ([{c0:aa,c1:ba}])"
+    );
+    insta::assert_snapshot!(
+        format!("{partition_1_filter}"),
+        @"a@0 >= zz AND a@0 <= zz AND b@1 >= zy AND b@1 <= zy AND struct(a@0, b@1) IN (SET) ([{c0:zz,c1:zy}])"
+    );
+
+    let result = format!("{}", pretty_format_batches(&batches).unwrap());
+    let probe_scan_metrics = probe_scan.metrics().unwrap();
+    assert_eq!(probe_scan_metrics.output_rows().unwrap(), 2);
+
+    insta::assert_snapshot!(
+        result,
+        @r"
+    +----+----+-----+----+----+------+
+    | a  | b  | c   | a  | b  | e    |
+    +----+----+-----+----+----+------+
+    | zz | zy | 2.0 | zz | zy | 20.0 |
+    | aa | ba | 1.0 | aa | ba | 10.0 |
+    +----+----+-----+----+----+------+
+    ",
+    );
+}
+
 #[tokio::test]
 async fn test_hashjoin_dynamic_filter_pushdown_collect_left() {
     use datafusion_common::JoinType;

--- a/datafusion/core/tests/physical_optimizer/pushdown_utils.rs
+++ b/datafusion/core/tests/physical_optimizer/pushdown_utils.rs
@@ -21,9 +21,9 @@ use datafusion::{datasource::object_store::ObjectStoreUrl, physical_plan::Physic
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{Result, config::ConfigOptions, internal_err};
 use datafusion_datasource::{
-    PartitionedFile, file::FileSource, file_scan_config::FileScanConfig,
-    file_scan_config::FileScanConfigBuilder, file_stream::FileOpenFuture,
-    file_stream::FileOpener, source::DataSourceExec,
+    PartitionedFile, file::FileSource, file_groups::FileGroup,
+    file_scan_config::FileScanConfig, file_scan_config::FileScanConfigBuilder,
+    file_stream::FileOpenFuture, file_stream::FileOpener, source::DataSourceExec,
 };
 use datafusion_physical_expr::projection::ProjectionExprs;
 use datafusion_physical_expr_common::physical_expr::fmt_sql;
@@ -104,19 +104,23 @@ pub struct TestSource {
     support: bool,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     batch_size: Option<usize>,
-    batches: Vec<RecordBatch>,
+    partition_batches: Vec<Vec<RecordBatch>>,
     metrics: ExecutionPlanMetricsSet,
     projection: Option<ProjectionExprs>,
     table_schema: datafusion_datasource::TableSchema,
 }
 
 impl TestSource {
-    pub fn new(schema: SchemaRef, support: bool, batches: Vec<RecordBatch>) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        support: bool,
+        partition_batches: Vec<Vec<RecordBatch>>,
+    ) -> Self {
         let table_schema = datafusion_datasource::TableSchema::new(schema, vec![]);
         Self {
             support,
             metrics: ExecutionPlanMetricsSet::new(),
-            batches,
+            partition_batches,
             predicate: None,
             batch_size: None,
             projection: None,
@@ -130,10 +134,13 @@ impl FileSource for TestSource {
         &self,
         _object_store: Arc<dyn ObjectStore>,
         _base_config: &FileScanConfig,
-        _partition: usize,
+        partition: usize,
     ) -> Result<Arc<dyn FileOpener>> {
+        let Some(batches) = self.partition_batches.get(partition).cloned() else {
+            return internal_err!("missing test batches for partition {partition}");
+        };
         Ok(Arc::new(TestOpener {
-            batches: self.batches.clone(),
+            batches,
             batch_size: self.batch_size,
             projection: self.projection.clone(),
             predicate: self.predicate.clone(),
@@ -259,7 +266,7 @@ impl FileSource for TestSource {
 #[derive(Debug, Clone)]
 pub struct TestScanBuilder {
     support: bool,
-    batches: Vec<RecordBatch>,
+    partition_batches: Vec<Vec<RecordBatch>>,
     schema: SchemaRef,
 }
 
@@ -267,7 +274,7 @@ impl TestScanBuilder {
     pub fn new(schema: SchemaRef) -> Self {
         Self {
             support: false,
-            batches: vec![],
+            partition_batches: vec![vec![]],
             schema,
         }
     }
@@ -278,20 +285,39 @@ impl TestScanBuilder {
     }
 
     pub fn with_batches(mut self, batches: Vec<RecordBatch>) -> Self {
-        self.batches = batches;
+        self.partition_batches = vec![batches];
+        self
+    }
+
+    pub fn with_partition_batches(
+        mut self,
+        partition_batches: Vec<Vec<RecordBatch>>,
+    ) -> Self {
+        self.partition_batches = partition_batches;
         self
     }
 
     pub fn build(self) -> Arc<dyn ExecutionPlan> {
+        let partition_count = self.partition_batches.len();
         let source = Arc::new(TestSource::new(
             Arc::clone(&self.schema),
             self.support,
-            self.batches,
+            self.partition_batches,
         ));
-        let base_config =
+        let builder =
             FileScanConfigBuilder::new(ObjectStoreUrl::parse("test://").unwrap(), source)
-                .with_file(PartitionedFile::new("test.parquet", 123))
-                .build();
+                .with_partitioned_by_file_group(partition_count > 1);
+        let file_groups = (0..partition_count)
+            .map(|idx| {
+                let path = if partition_count == 1 {
+                    "test.parquet".to_string()
+                } else {
+                    format!("test_{idx}.parquet")
+                };
+                FileGroup::new(vec![PartitionedFile::new(path, 123)])
+            })
+            .collect();
+        let base_config = builder.with_file_groups(file_groups).build();
         DataSourceExec::from_data_source(base_config)
     }
 }

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -43,8 +43,10 @@ use datafusion_common::encryption::FileDecryptionProperties;
 use datafusion_common::stats::Precision;
 use datafusion_common::{
     ColumnStatistics, DataFusionError, Result, ScalarValue, Statistics, exec_err,
+    tree_node::{Transformed, TransformedResult, TreeNode},
 };
 use datafusion_datasource::{PartitionedFile, TableSchema};
+use datafusion_physical_expr::expressions::DynamicFilterPhysicalExpr;
 use datafusion_physical_expr::simplifier::PhysicalExprSimplifier;
 use datafusion_physical_expr_adapter::PhysicalExprAdapterFactory;
 use datafusion_physical_expr_common::physical_expr::{
@@ -76,6 +78,29 @@ use parquet::arrow::push_decoder::{ParquetPushDecoder, ParquetPushDecoderBuilder
 use parquet::basic::Type;
 use parquet::bloom_filter::Sbbf;
 use parquet::file::metadata::{PageIndexPolicy, ParquetMetaDataReader};
+
+// Replace each partition-index dynamic filter with the concrete filter for the
+// execution partition currently opening a file. This must happen before
+// partition-column literal replacement so partition-specific predicates can be
+// simplified against this file's partition values.
+fn rewrite_partition_index_dynamic_filters(
+    predicate: Arc<dyn PhysicalExpr>,
+    partition_index: usize,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    predicate
+        .transform_up(|expr| {
+            let Some(dyn_filter) = expr.downcast_ref::<DynamicFilterPhysicalExpr>()
+            else {
+                return Ok(Transformed::no(expr));
+            };
+
+            match dyn_filter.partition_filter(partition_index)? {
+                Some(partition_expr) => Ok(Transformed::yes(partition_expr)),
+                None => Ok(Transformed::no(expr)),
+            }
+        })
+        .data()
+}
 
 /// Stateless Parquet morselizer implementation.
 ///
@@ -597,7 +622,12 @@ impl ParquetMorselizer {
         ));
 
         let mut projection = self.projection.clone();
-        let mut predicate = self.predicate.clone();
+        let mut predicate = self
+            .predicate
+            .clone()
+            .map(|p| rewrite_partition_index_dynamic_filters(p, self.partition_index))
+            .transpose()?;
+
         if !literal_columns.is_empty() {
             projection = projection.try_map_exprs(|expr| {
                 replace_columns_with_literals(Arc::clone(&expr), &literal_columns)
@@ -1634,10 +1664,10 @@ mod test {
     };
     use datafusion_datasource::morsel::{Morsel, Morselizer};
     use datafusion_datasource::{PartitionedFile, TableSchema};
-    use datafusion_expr::{col, lit};
+    use datafusion_expr::{Operator, col, lit};
     use datafusion_physical_expr::{
         PhysicalExpr,
-        expressions::{Column, DynamicFilterPhysicalExpr, Literal},
+        expressions::{BinaryExpr, Column, DynamicFilterPhysicalExpr, Literal},
         planner::logical2physical,
         projection::ProjectionExprs,
     };
@@ -1732,6 +1762,12 @@ mod test {
         /// Set the predicate.
         fn with_predicate(mut self, predicate: Arc<dyn PhysicalExpr>) -> Self {
             self.predicate = Some(predicate);
+            self
+        }
+
+        /// Set the opener partition index.
+        fn with_partition_index(mut self, partition_index: usize) -> Self {
+            self.partition_index = partition_index;
             self
         }
 
@@ -2009,6 +2045,197 @@ mod test {
             expr.children().into_iter().map(Arc::clone).collect(),
             expr,
         ))
+    }
+
+    fn make_partitioned_dynamic_filter(
+        children: Vec<Arc<dyn PhysicalExpr>>,
+        global_expr: Arc<dyn PhysicalExpr>,
+        partition_exprs: Vec<Option<Arc<dyn PhysicalExpr>>>,
+    ) -> Arc<DynamicFilterPhysicalExpr> {
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            children,
+            datafusion_physical_expr::expressions::lit(true) as Arc<dyn PhysicalExpr>,
+        ));
+        dynamic_filter
+            .update_partitioned(global_expr, partition_exprs)
+            .unwrap();
+        dynamic_filter
+    }
+
+    #[test]
+    fn rewrite_partition_index_dynamic_filters_root() {
+        let col_a = Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>;
+        let part_0 = Arc::new(BinaryExpr::new(
+            Arc::clone(&col_a),
+            Operator::Gt,
+            datafusion_physical_expr::expressions::lit(10i32) as Arc<dyn PhysicalExpr>,
+        )) as Arc<dyn PhysicalExpr>;
+
+        let dynamic_filter = make_partitioned_dynamic_filter(
+            vec![Arc::clone(&col_a)],
+            Arc::clone(&part_0),
+            vec![Some(Arc::clone(&part_0))],
+        );
+
+        let rewritten = rewrite_partition_index_dynamic_filters(
+            dynamic_filter as Arc<dyn PhysicalExpr>,
+            0,
+        )
+        .unwrap();
+
+        assert_eq!(format!("{rewritten}"), format!("{part_0}"));
+    }
+
+    #[test]
+    fn rewrite_partition_index_dynamic_filters_nested() {
+        let col_a = Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>;
+        let static_expr = Arc::new(BinaryExpr::new(
+            Arc::clone(&col_a),
+            Operator::Eq,
+            datafusion_physical_expr::expressions::lit(12i32) as Arc<dyn PhysicalExpr>,
+        )) as Arc<dyn PhysicalExpr>;
+        let part_0 = Arc::new(BinaryExpr::new(
+            Arc::clone(&col_a),
+            Operator::Gt,
+            datafusion_physical_expr::expressions::lit(10i32) as Arc<dyn PhysicalExpr>,
+        )) as Arc<dyn PhysicalExpr>;
+
+        let dynamic_filter = make_partitioned_dynamic_filter(
+            vec![Arc::clone(&col_a)],
+            Arc::clone(&part_0),
+            vec![Some(Arc::clone(&part_0))],
+        );
+        let predicate = Arc::new(BinaryExpr::new(
+            Arc::clone(&static_expr),
+            Operator::And,
+            dynamic_filter as Arc<dyn PhysicalExpr>,
+        )) as Arc<dyn PhysicalExpr>;
+
+        let rewritten = rewrite_partition_index_dynamic_filters(predicate, 0).unwrap();
+        let expected = Arc::new(BinaryExpr::new(static_expr, Operator::And, part_0))
+            as Arc<dyn PhysicalExpr>;
+
+        assert_eq!(format!("{rewritten}"), format!("{expected}"));
+    }
+
+    #[test]
+    fn partition_index_rewrite_happens_before_literal_replacement() {
+        let col_part = Arc::new(Column::new("part", 0)) as Arc<dyn PhysicalExpr>;
+        let col_a = Arc::new(Column::new("a", 1)) as Arc<dyn PhysicalExpr>;
+        let part_0 = Arc::new(BinaryExpr::new(
+            Arc::new(BinaryExpr::new(
+                Arc::clone(&col_part),
+                Operator::Eq,
+                datafusion_physical_expr::expressions::lit(1i32) as Arc<dyn PhysicalExpr>,
+            )) as Arc<dyn PhysicalExpr>,
+            Operator::And,
+            Arc::new(BinaryExpr::new(
+                Arc::clone(&col_a),
+                Operator::Gt,
+                datafusion_physical_expr::expressions::lit(10i32)
+                    as Arc<dyn PhysicalExpr>,
+            )) as Arc<dyn PhysicalExpr>,
+        )) as Arc<dyn PhysicalExpr>;
+
+        let dynamic_filter = make_partitioned_dynamic_filter(
+            vec![Arc::clone(&col_part), Arc::clone(&col_a)],
+            Arc::clone(&part_0),
+            vec![Some(Arc::clone(&part_0))],
+        );
+
+        let rewritten = rewrite_partition_index_dynamic_filters(
+            dynamic_filter as Arc<dyn PhysicalExpr>,
+            0,
+        )
+        .unwrap();
+
+        let mut literal_columns = ConstantColumns::new();
+        literal_columns.insert("part".to_string(), ScalarValue::Int32(Some(1)));
+        let rewritten =
+            replace_columns_with_literals(rewritten, &literal_columns).unwrap();
+        let rewritten_str = format!("{rewritten}");
+
+        assert!(
+            !rewritten_str.contains("part@0"),
+            "partition column should be replaced in rewritten filter: {rewritten_str}"
+        );
+        assert!(
+            rewritten_str.contains("a@1 > 10"),
+            "data filter should remain after literal replacement: {rewritten_str}"
+        );
+    }
+
+    #[test]
+    fn partition_index_rewrite_empty_partition_becomes_false() {
+        let col_a = Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>;
+        let global = Arc::new(BinaryExpr::new(
+            Arc::clone(&col_a),
+            Operator::Gt,
+            datafusion_physical_expr::expressions::lit(10i32) as Arc<dyn PhysicalExpr>,
+        )) as Arc<dyn PhysicalExpr>;
+
+        let dynamic_filter =
+            make_partitioned_dynamic_filter(vec![Arc::clone(&col_a)], global, vec![None]);
+
+        let rewritten = rewrite_partition_index_dynamic_filters(
+            dynamic_filter as Arc<dyn PhysicalExpr>,
+            0,
+        )
+        .unwrap();
+
+        assert_eq!(format!("{rewritten}"), "false");
+    }
+
+    #[tokio::test]
+    async fn test_partition_index_rewrite_in_opener_with_nested_predicate() {
+        let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+
+        let batch = record_batch!(("a", Int32, vec![Some(1), Some(2), Some(3)])).unwrap();
+        let data_size =
+            write_parquet(Arc::clone(&store), "part=1/file.parquet", batch.clone()).await;
+
+        let file_schema = batch.schema();
+        let mut file = PartitionedFile::new(
+            "part=1/file.parquet".to_string(),
+            u64::try_from(data_size).unwrap(),
+        );
+        file.partition_values = vec![ScalarValue::Int32(Some(1))];
+
+        let logical_schema = Arc::new(Schema::new(vec![
+            Field::new("part", DataType::Int32, false),
+            Field::new("a", DataType::Int32, false),
+        ]));
+        let table_schema_for_opener = TableSchema::new(
+            Arc::clone(&file_schema),
+            vec![Arc::new(Field::new("part", DataType::Int32, false))],
+        );
+
+        let child_a = logical2physical(&col("a"), &logical_schema);
+        let partition_expr = logical2physical(&col("a").eq(lit(2)), &logical_schema);
+        let dynamic_filter = make_partitioned_dynamic_filter(
+            vec![child_a],
+            Arc::clone(&partition_expr),
+            vec![Some(partition_expr)],
+        );
+        let static_expr = logical2physical(&col("part").eq(lit(1)), &logical_schema);
+        let predicate = Arc::new(BinaryExpr::new(
+            static_expr,
+            Operator::And,
+            dynamic_filter as Arc<dyn PhysicalExpr>,
+        )) as Arc<dyn PhysicalExpr>;
+
+        let opener = ParquetMorselizerBuilder::new()
+            .with_store(Arc::clone(&store))
+            .with_table_schema(table_schema_for_opener)
+            .with_projection_indices(&[0])
+            .with_partition_index(0)
+            .with_predicate(predicate)
+            .with_pushdown_filters(true)
+            .build();
+
+        let stream = open_file(&opener, file).await.unwrap();
+        let values = collect_int32_values(stream).await;
+        assert_eq!(values, vec![2]);
     }
 
     #[tokio::test]

--- a/datafusion/physical-expr/src/expressions/dynamic_filters.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters.rs
@@ -82,6 +82,11 @@ struct Inner {
     /// This is used for [`PhysicalExpr::snapshot_generation`] to have a cheap check for changes.
     generation: u64,
     expr: Arc<dyn PhysicalExpr>,
+    /// Per-partition filter expressions for partition-index routing.
+    /// When set (via [`DynamicFilterPhysicalExpr::update_partitioned`]), each entry
+    /// corresponds to a build partition. `Some(expr)` means the partition has a filter.
+    /// `None` means the partition was empty.
+    partitioned_exprs: Option<Vec<Option<Arc<dyn PhysicalExpr>>>>,
     /// Flag for quick synchronous check if filter is complete.
     /// This is redundant with the watch channel state, but allows us to return immediately
     /// from `wait_complete()` without subscribing if already complete.
@@ -95,6 +100,7 @@ impl Inner {
             // This is not currently used anywhere but it seems useful to have this simple distinction.
             generation: 1,
             expr,
+            partitioned_exprs: None,
             is_complete: false,
         }
     }
@@ -245,6 +251,7 @@ impl DynamicFilterPhysicalExpr {
         *current = Inner {
             generation: new_generation,
             expr: new_expr,
+            partitioned_exprs: None,
             is_complete: current.is_complete,
         };
         drop(current); // Release the lock before broadcasting
@@ -254,6 +261,58 @@ impl DynamicFilterPhysicalExpr {
             generation: new_generation,
         });
         Ok(())
+    }
+
+    /// Store per-partition filter expressions for partition-index routing.
+    ///
+    /// `global_expr` is the OR of all partition filters, used as the global fallback
+    /// (stored in `Inner.expr`). Each entry in `partition_exprs` corresponds to a build
+    /// partition: `Some(expr)` means the partition has a filter. `None` means it was empty.
+    ///
+    /// Use [`Self::partition_filter`] to retrieve a specific partition's filter.
+    pub fn update_partitioned(
+        &self,
+        global_expr: Arc<dyn PhysicalExpr>,
+        partition_exprs: Vec<Option<Arc<dyn PhysicalExpr>>>,
+    ) -> Result<()> {
+        let mut current = self.inner.write();
+        let new_generation = current.generation + 1;
+        *current = Inner {
+            generation: new_generation,
+            expr: global_expr,
+            partitioned_exprs: Some(partition_exprs),
+            is_complete: current.is_complete,
+        };
+        drop(current);
+
+        let _ = self.state_watch.send(FilterState::InProgress {
+            generation: new_generation,
+        });
+        Ok(())
+    }
+
+    /// Returns the filter expression for a specific partition, with children
+    /// remapped to match any prior [`PhysicalExpr::with_new_children`] calls.
+    ///
+    /// Returns `None` if no per-partition data has been stored (i.e., the filter is
+    /// operating in CaseHash or CollectLeft mode). Returns `Some(lit(false))` if the
+    /// partition was empty (no build-side data).
+    pub fn partition_filter(
+        &self,
+        partition: usize,
+    ) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+        let inner = self.inner.read();
+        let expr = match &inner.partitioned_exprs {
+            Some(exprs) => match exprs.get(partition) {
+                Some(Some(expr)) => Arc::clone(expr),
+                Some(None) => crate::expressions::lit(false),
+                None => return Ok(None),
+            },
+            None => return Ok(None),
+        };
+        drop(inner);
+        Self::remap_children(&self.children, self.remapped_children.as_ref(), expr)
+            .map(Some)
     }
 
     /// Mark this dynamic filter as complete and broadcast to all waiters.
@@ -580,6 +639,152 @@ mod test {
         // Take another snapshot
         let snapshot = dynamic_filter.snapshot().unwrap();
         assert_eq!(snapshot, Some(new_expr));
+    }
+
+    #[test]
+    fn test_partition_filter_none_without_partitioned_state() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let dynamic_filter = DynamicFilterPhysicalExpr::new(
+            vec![col("a", &schema).unwrap()],
+            lit(true) as Arc<dyn PhysicalExpr>,
+        );
+
+        assert!(dynamic_filter.partition_filter(0).unwrap().is_none());
+
+        dynamic_filter
+            .update(Arc::new(BinaryExpr::new(
+                col("a", &schema).unwrap(),
+                datafusion_expr::Operator::Gt,
+                lit(10) as Arc<dyn PhysicalExpr>,
+            )) as Arc<dyn PhysicalExpr>)
+            .unwrap();
+
+        assert!(dynamic_filter.partition_filter(0).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_update_partitioned_and_partition_filter() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let col_a = col("a", &schema).unwrap();
+        let dynamic_filter = DynamicFilterPhysicalExpr::new(
+            vec![Arc::clone(&col_a)],
+            lit(true) as Arc<dyn PhysicalExpr>,
+        );
+
+        let part_0 = Arc::new(BinaryExpr::new(
+            Arc::clone(&col_a),
+            datafusion_expr::Operator::Gt,
+            lit(10) as Arc<dyn PhysicalExpr>,
+        )) as Arc<dyn PhysicalExpr>;
+        let part_2 = Arc::new(BinaryExpr::new(
+            Arc::clone(&col_a),
+            datafusion_expr::Operator::Lt,
+            lit(0) as Arc<dyn PhysicalExpr>,
+        )) as Arc<dyn PhysicalExpr>;
+        let global = Arc::new(BinaryExpr::new(
+            Arc::clone(&part_0),
+            datafusion_expr::Operator::Or,
+            Arc::clone(&part_2),
+        )) as Arc<dyn PhysicalExpr>;
+
+        dynamic_filter
+            .update_partitioned(
+                Arc::clone(&global),
+                vec![Some(Arc::clone(&part_0)), None, Some(Arc::clone(&part_2))],
+            )
+            .unwrap();
+
+        let snapshot = dynamic_filter.snapshot().unwrap().unwrap();
+        assert_eq!(format!("{snapshot:?}"), format!("{global:?}"));
+        let current = dynamic_filter.current().unwrap();
+        assert_eq!(format!("{current}"), format!("{global}"));
+        assert_eq!(
+            format!("{dynamic_filter}"),
+            "DynamicFilter [ a@0 > 10 OR a@0 < 0 ]"
+        );
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![ScalarValue::Int32(Some(15)).to_array_of_size(1).unwrap()],
+        )
+        .unwrap();
+
+        let part_0_expr = dynamic_filter.partition_filter(0).unwrap().unwrap();
+        let ColumnarValue::Array(part_0_result) = part_0_expr.evaluate(&batch).unwrap()
+        else {
+            panic!("Expected ColumnarValue::Array");
+        };
+        assert!(
+            part_0_result.eq(&ScalarValue::Boolean(Some(true))
+                .to_array_of_size(1)
+                .unwrap())
+        );
+
+        let empty_partition_expr = dynamic_filter.partition_filter(1).unwrap().unwrap();
+        let empty_partition_result = empty_partition_expr.evaluate(&batch).unwrap();
+        let ColumnarValue::Scalar(empty_partition_result) = empty_partition_result else {
+            panic!("Expected ColumnarValue::Scalar");
+        };
+        assert_eq!(empty_partition_result, ScalarValue::Boolean(Some(false)));
+
+        let part_2_expr = dynamic_filter.partition_filter(2).unwrap().unwrap();
+        let ColumnarValue::Array(part_2_result) = part_2_expr.evaluate(&batch).unwrap()
+        else {
+            panic!("Expected ColumnarValue::Array");
+        };
+        assert!(
+            part_2_result.eq(&ScalarValue::Boolean(Some(false))
+                .to_array_of_size(1)
+                .unwrap())
+        );
+
+        assert!(dynamic_filter.partition_filter(3).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_partition_filter_remaps_children() {
+        let table_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![col("a", &table_schema).unwrap()],
+            lit(true) as Arc<dyn PhysicalExpr>,
+        ));
+
+        let remapped_schema = Arc::new(Schema::new(vec![
+            Field::new("b", DataType::Int32, false),
+            Field::new("a", DataType::Int32, false),
+        ]));
+        let remapped = reassign_expr_columns(
+            Arc::clone(&dynamic_filter) as Arc<dyn PhysicalExpr>,
+            &remapped_schema,
+        )
+        .unwrap();
+        let remapped = remapped
+            .downcast_ref::<DynamicFilterPhysicalExpr>()
+            .unwrap();
+
+        dynamic_filter
+            .update_partitioned(
+                Arc::new(BinaryExpr::new(
+                    col("a", &table_schema).unwrap(),
+                    datafusion_expr::Operator::Gt,
+                    lit(10) as Arc<dyn PhysicalExpr>,
+                )) as Arc<dyn PhysicalExpr>,
+                vec![Some(Arc::new(BinaryExpr::new(
+                    col("a", &table_schema).unwrap(),
+                    datafusion_expr::Operator::Gt,
+                    lit(10) as Arc<dyn PhysicalExpr>,
+                )) as Arc<dyn PhysicalExpr>)],
+            )
+            .unwrap();
+
+        let partition_expr = remapped.partition_filter(0).unwrap().unwrap();
+        insta::assert_snapshot!(
+            format!("{partition_expr:?}"),
+            @r#"BinaryExpr { left: Column { name: "a", index: 1 }, op: Gt, right: Literal { value: Int32(10), field: Field { name: "lit", data_type: Int32 } }, fail_on_overflow: false }"#
+        );
     }
 
     #[test]

--- a/datafusion/physical-optimizer/src/enforce_distribution.rs
+++ b/datafusion/physical-optimizer/src/enforce_distribution.rs
@@ -31,6 +31,7 @@ use crate::utils::{
     add_sort_above_with_check, is_coalesce_partitions, is_repartition,
     is_sort_preserving_merge,
 };
+use datafusion_common::plan_err;
 
 use arrow::compute::SortOptions;
 use datafusion_common::config::ConfigOptions;
@@ -50,7 +51,8 @@ use datafusion_physical_plan::aggregates::{
 use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion_physical_plan::execution_plan::EmissionType;
 use datafusion_physical_plan::joins::{
-    CrossJoinExec, HashJoinExec, PartitionMode, SortMergeJoinExec,
+    CrossJoinExec, DynamicFilterRoutingMode, HashJoinExec, HashJoinExecBuilder,
+    PartitionMode, SortMergeJoinExec,
 };
 use datafusion_physical_plan::projection::{ProjectionExec, ProjectionExpr};
 use datafusion_physical_plan::repartition::RepartitionExec;
@@ -843,7 +845,14 @@ fn add_roundrobin_on_top(
 
         let new_plan = Arc::new(repartition) as _;
 
-        Ok(DistributionContext::new(new_plan, true, vec![input]))
+        Ok(DistributionContext::new(
+            new_plan,
+            DistFlags {
+                dist_changing: true,
+                repartitioned: true,
+            },
+            vec![input],
+        ))
     } else {
         // Partition is not helpful, we already have desired number of partitions.
         Ok(input)
@@ -912,7 +921,14 @@ fn add_hash_on_top(
                 .with_preserve_order();
         let plan = Arc::new(repartition) as _;
 
-        return Ok(DistributionContext::new(plan, true, vec![input]));
+        return Ok(DistributionContext::new(
+            plan,
+            DistFlags {
+                dist_changing: true,
+                repartitioned: true,
+            },
+            vec![input],
+        ));
     }
 
     Ok(input)
@@ -986,7 +1002,14 @@ fn add_merge_on_top(input: DistributionContext) -> DistributionContext {
             Arc::new(CoalescePartitionsExec::new(Arc::clone(&input.plan))) as _
         };
 
-        DistributionContext::new(new_plan, true, vec![input])
+        DistributionContext::new(
+            new_plan,
+            DistFlags {
+                dist_changing: true,
+                repartitioned: false,
+            },
+            vec![input],
+        )
     } else {
         input
     }
@@ -1050,7 +1073,7 @@ pub fn replace_order_preserving_variants(
         .children
         .into_iter()
         .map(|child| {
-            if child.data {
+            if child.data.dist_changing {
                 replace_order_preserving_variants(child)
             } else {
                 Ok(child)
@@ -1379,7 +1402,7 @@ pub fn ensure_distribution(
                 }
             };
 
-            let streaming_benefit = if child.data {
+            let streaming_benefit = if child.data.dist_changing {
                 preserving_order_enables_streaming(&plan, &child.plan)?
             } else {
                 false
@@ -1398,7 +1421,7 @@ pub fn ensure_distribution(
 
                 if (!ordering_satisfied || !order_preserving_variants_desirable)
                     && !streaming_benefit
-                    && child.data
+                    && child.data.dist_changing
                 {
                     child = replace_order_preserving_variants(child)?;
                     // If ordering requirements were satisfied before repartitioning,
@@ -1415,9 +1438,9 @@ pub fn ensure_distribution(
                     }
                 }
                 // Stop tracking distribution changing operators
-                child.data = false;
+                child.data.dist_changing = false;
             } else {
-                let streaming_benefit = if child.data {
+                let streaming_benefit = if child.data.dist_changing {
                     preserving_order_enables_streaming(&plan, &child.plan)?
                 } else {
                     false
@@ -1484,47 +1507,146 @@ pub fn ensure_distribution(
         plan.with_new_children(children_plans)?
     };
 
+    // For Partitioned hash joins, determine the dynamic filter routing mode
+    // based on whether each side was repartitioned.
+    if let Some(hash_join) = plan.downcast_ref::<HashJoinExec>()
+        && hash_join.mode == PartitionMode::Partitioned
+        && children.len() == 2
+    {
+        let left_repartitioned = children[0].data.repartitioned;
+        let right_repartitioned = children[1].data.repartitioned;
+
+        let routing_mode = match (
+            left_repartitioned,
+            right_repartitioned,
+            plan.output_partitioning().partition_count(),
+        ) {
+            // Hash routing is always safe for a single output partition:
+            // `hash(expr) % 1` routes every row to partition 0, which matches
+            // the only join partition even if one side still has a
+            // RepartitionExec(Hash, 1) above the scan.
+            (true, false, 1) | (false, true, 1) => DynamicFilterRoutingMode::CaseHash,
+            (true, true, _) => DynamicFilterRoutingMode::CaseHash,
+            (false, false, _) => DynamicFilterRoutingMode::PartitionIndex,
+            _ => {
+                return plan_err!(
+                    "Partitioned hash join has misaligned partitioning: \
+                     left repartitioned={left_repartitioned}, \
+                     right repartitioned={right_repartitioned}. \
+                     Both sides must be either repartitioned or not."
+                );
+            }
+        };
+
+        if routing_mode != hash_join.dynamic_filter_routing_mode {
+            plan = Arc::new(
+                HashJoinExecBuilder::from(hash_join)
+                    .with_dynamic_filter_routing_mode(routing_mode)
+                    .build()?,
+            );
+        }
+    }
+
     Ok(Transformed::yes(DistributionContext::new(
         plan, data, children,
     )))
 }
 
-/// Keeps track of distribution changing operators (like `RepartitionExec`,
-/// `SortPreservingMergeExec`, `CoalescePartitionsExec`) and their ancestors.
-/// Using this information, we can optimize distribution of the plan if/when
-/// necessary.
-pub type DistributionContext = PlanContext<bool>;
+/// Tracks distribution-changing operators and repartitioning state through the plan tree.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DistFlags {
+    /// Whether a distribution-changing operator exists in the subtree.
+    pub dist_changing: bool,
+    /// Whether the output partitioning originates from a RepartitionExec.
+    /// Used by partitioned hash joins to choose the dynamic filter routing mode.
+    pub repartitioned: bool,
+}
+
+pub type DistributionContext = PlanContext<DistFlags>;
+
+fn inherits_repartitioned_output(
+    plan: &Arc<dyn ExecutionPlan>,
+    children: &[DistributionContext],
+    is_repartition: bool,
+) -> bool {
+    if is_repartition {
+        return true;
+    }
+
+    if children.is_empty() {
+        return false;
+    }
+
+    if let Some(hash_join) = plan.downcast_ref::<HashJoinExec>() {
+        return match hash_join.mode {
+            PartitionMode::Partitioned => {
+                children.iter().any(|child| child.data.repartitioned)
+            }
+            PartitionMode::CollectLeft => match hash_join.join_type {
+                JoinType::Inner
+                | JoinType::Right
+                | JoinType::RightSemi
+                | JoinType::RightAnti
+                | JoinType::RightMark => children[1].data.repartitioned,
+                JoinType::Left
+                | JoinType::LeftSemi
+                | JoinType::LeftAnti
+                | JoinType::Full
+                | JoinType::LeftMark => false,
+            },
+            PartitionMode::Auto => false,
+        };
+    }
+
+    children[0].data.repartitioned
+}
 
 fn update_children(mut dist_context: DistributionContext) -> Result<DistributionContext> {
     for child_context in dist_context.children.iter_mut() {
-        child_context.data = if let Some(repartition) =
-            child_context.plan.downcast_ref::<RepartitionExec>()
-        {
-            !matches!(
-                repartition.partitioning(),
-                Partitioning::UnknownPartitioning(_)
-            )
+        let is_repartition = child_context
+            .plan
+            .downcast_ref::<RepartitionExec>()
+            .is_some_and(|r| {
+                !matches!(r.partitioning(), Partitioning::UnknownPartitioning(_))
+            });
+
+        let dist_changing = if is_repartition {
+            true
         } else {
             child_context.plan.is::<SortPreservingMergeExec>()
                 || child_context.plan.is::<CoalescePartitionsExec>()
                 || child_context.plan.children().is_empty()
-                || child_context.children[0].data
+                || child_context.children[0].data.dist_changing
                 || child_context
                     .plan
                     .required_input_distribution()
                     .iter()
                     .zip(child_context.children.iter())
                     .any(|(required_dist, child_context)| {
-                        child_context.data
+                        child_context.data.dist_changing
                             && matches!(
                                 required_dist,
                                 Distribution::UnspecifiedDistribution
                             )
                     })
-        }
+        };
+
+        // Track whether this subtree's output partitioning originates from a
+        // RepartitionExec, following the child that actually determines the
+        // node's output partitioning for multi-input operators.
+        let repartitioned = inherits_repartitioned_output(
+            &child_context.plan,
+            &child_context.children,
+            is_repartition,
+        );
+
+        child_context.data = DistFlags {
+            dist_changing,
+            repartitioned,
+        };
     }
 
-    dist_context.data = false;
+    dist_context.data = DistFlags::default();
     Ok(dist_context)
 }
 

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -293,6 +293,7 @@ impl HashJoinExecBuilder {
                 column_indices: vec![],
                 null_equality: NullEquality::NullEqualsNothing,
                 null_aware: false,
+                dynamic_filter_routing_mode: DynamicFilterRoutingMode::CaseHash,
                 dynamic_filter: None,
                 // Will be computed at when plan will be built.
                 cache: stub_properties(),
@@ -358,6 +359,15 @@ impl HashJoinExecBuilder {
     /// Set fetch property.
     pub fn with_fetch(mut self, fetch: Option<usize>) -> Self {
         self.exec.fetch = fetch;
+        self
+    }
+
+    /// Set dynamic filter routing mode for Partitioned joins.
+    pub fn with_dynamic_filter_routing_mode(
+        mut self,
+        mode: DynamicFilterRoutingMode,
+    ) -> Self {
+        self.exec.dynamic_filter_routing_mode = mode;
         self
     }
 
@@ -437,6 +447,7 @@ impl HashJoinExecBuilder {
             null_equality,
             null_aware,
             dynamic_filter,
+            dynamic_filter_routing_mode,
             fetch,
             // Recomputed.
             join_schema: _,
@@ -484,6 +495,7 @@ impl HashJoinExecBuilder {
             column_indices,
             null_equality,
             null_aware,
+            dynamic_filter_routing_mode,
             cache: Arc::new(cache),
             dynamic_filter,
             fetch,
@@ -514,6 +526,7 @@ impl From<&HashJoinExec> for HashJoinExecBuilder {
                 column_indices: exec.column_indices.clone(),
                 null_equality: exec.null_equality,
                 null_aware: exec.null_aware,
+                dynamic_filter_routing_mode: exec.dynamic_filter_routing_mode,
                 cache: Arc::clone(&exec.cache),
                 dynamic_filter: exec.dynamic_filter.clone(),
                 fetch: exec.fetch,
@@ -715,6 +728,17 @@ impl From<&HashJoinExec> for HashJoinExecBuilder {
 /// Note this structure includes a [`OnceAsync`] that is used to coordinate the
 /// loading of the left side with the processing in each output stream.
 /// Therefore it can not be [`Clone`]
+/// Determines how dynamic filters are routed to probe-side partitions in Partitioned mode.
+/// Set by `enforce_distribution` based on whether `RepartitionExec` was inserted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DynamicFilterRoutingMode {
+    /// Route probe rows by hash (CASE expression). Used when both sides are hash-repartitioned.
+    CaseHash,
+    /// Route by partition index. Used when both sides satisfy the
+    /// join's distribution without repartitioning (e.g., file-partitioned data).
+    PartitionIndex,
+}
+
 pub struct HashJoinExec {
     /// left (build) side which gets hashed
     pub left: Arc<dyn ExecutionPlan>,
@@ -750,6 +774,8 @@ pub struct HashJoinExec {
     pub null_equality: NullEquality,
     /// Flag to indicate if this is a null-aware anti join
     pub null_aware: bool,
+    /// How dynamic filters are routed in Partitioned mode.
+    pub dynamic_filter_routing_mode: DynamicFilterRoutingMode,
     /// Cache holding plan properties like equivalences, output partitioning etc.
     cache: Arc<PlanProperties>,
     /// Dynamic filter for pushing down to the probe side
@@ -842,23 +868,7 @@ impl HashJoinExec {
 
     fn allow_join_dynamic_filter_pushdown(&self, config: &ConfigOptions) -> bool {
         let (_, probe_preserved) = self.join_type.on_lr_is_preserved();
-        if !probe_preserved || !config.optimizer.enable_join_dynamic_filter_pushdown {
-            return false;
-        }
-
-        // `preserve_file_partitions` can report Hash partitioning for Hive-style
-        // file groups, but those partitions are not actually hash-distributed.
-        // Partitioned dynamic filters rely on hash routing, so disable them in
-        // this mode to avoid incorrect results. Follow-up work: enable dynamic
-        // filtering for preserve_file_partitioned scans (issue #20195).
-        // https://github.com/apache/datafusion/issues/20195
-        if config.optimizer.preserve_file_partitions > 0
-            && self.mode == PartitionMode::Partitioned
-        {
-            return false;
-        }
-
-        true
+        probe_preserved && config.optimizer.enable_join_dynamic_filter_pushdown
     }
 
     /// left (build) side which gets hashed
@@ -1319,6 +1329,8 @@ impl ExecutionPlan for HashJoinExec {
         // Initialize build_accumulator lazily with runtime partition counts (only if enabled)
         // Use RepartitionExec's random state (seeds: 0,0,0,0) for partition routing
         let repartition_random_state = REPARTITION_RANDOM_STATE;
+        let use_partition_index =
+            self.dynamic_filter_routing_mode == DynamicFilterRoutingMode::PartitionIndex;
         let build_accumulator = enable_dynamic_filter_pushdown
             .then(|| {
                 self.dynamic_filter.as_ref().map(|df| {
@@ -1336,6 +1348,7 @@ impl ExecutionPlan for HashJoinExec {
                             filter,
                             on_right,
                             repartition_random_state,
+                            use_partition_index,
                         ))
                     })))
                 })

--- a/datafusion/physical-plan/src/joins/hash_join/mod.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/mod.rs
@@ -17,7 +17,7 @@
 
 //! [`HashJoinExec`] Partitioned Hash Join Operator
 
-pub use exec::{HashJoinExec, HashJoinExecBuilder};
+pub use exec::{DynamicFilterRoutingMode, HashJoinExec, HashJoinExecBuilder};
 pub use partitioned_hash_eval::{HashExpr, HashTableLookupExpr, SeededRandomState};
 
 mod exec;

--- a/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
@@ -252,6 +252,9 @@ pub(crate) struct SharedBuildAccumulator {
     /// Random state for partitioning (RepartitionExec's hash function with 0,0,0,0 seeds)
     /// Used for PartitionedHashLookupPhysicalExpr
     repartition_random_state: SeededRandomState,
+    /// Whether to use partition-index routing (PartitionIndex mode) instead of
+    /// CASE-hash routing (CaseHash mode) in Partitioned joins.
+    use_partition_index: bool,
     /// Schema of the probe (right) side for evaluating filter expressions
     probe_schema: Arc<Schema>,
 }
@@ -335,15 +338,14 @@ impl SharedBuildAccumulator {
     ///
     /// - **CollectLeft**: Build side is collected ONCE from partition 0 and shared via `OnceFut`
     ///   across all output partitions. Each output partition calls `collect_build_side` to access the shared build data.
-    ///   Although this results in multiple invocations, the  `report_partition_bounds` function contains deduplication logic to handle them safely.
+    ///   Although this results in multiple invocations, the  `report_build_data` function contains deduplication logic to handle them safely.
     ///   Expected calls = number of output partitions.
     ///
     ///
     /// - **Partitioned**: Each partition independently builds its own hash table by calling
     ///   `collect_build_side` once. Expected calls = number of build partitions.
     ///
-    /// - **Auto**: Placeholder mode resolved during optimization. Uses 1 as safe default since
-    ///   the actual mode will be determined and a new accumulator created before execution.
+    /// - **Auto**: Placeholder mode resolved during optimization and must not reach execution.
     ///
     /// ## Why This Matters
     ///
@@ -357,6 +359,7 @@ impl SharedBuildAccumulator {
         dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
         on_right: Vec<PhysicalExprRef>,
         repartition_random_state: SeededRandomState,
+        use_partition_index: bool,
     ) -> Self {
         // Troubleshooting: If partition counts are incorrect, verify this logic matches
         // the actual execution pattern in collect_build_side()
@@ -402,6 +405,7 @@ impl SharedBuildAccumulator {
             dynamic_filter,
             on_right,
             repartition_random_state,
+            use_partition_index,
             probe_schema: right_child.schema(),
         }
     }
@@ -411,7 +415,7 @@ impl SharedBuildAccumulator {
     /// This unified method handles both CollectLeft and Partitioned modes. When all partitions
     /// have reported (barrier wait), the leader builds the appropriate filter expression:
     /// - CollectLeft: Simple conjunction of bounds and membership check
-    /// - Partitioned: CASE expression routing to per-partition filters
+    /// - Partitioned: CASE-hash or partition-index routing, depending on join mode
     ///
     /// # Arguments
     /// * `data` - Build data including hash map, pushdown strategy, and bounds
@@ -593,6 +597,22 @@ impl SharedBuildAccumulator {
                 }
             },
             FinalizeInput::Partitioned(partitions) => {
+                if self.use_partition_index {
+                    let partition_filters: Vec<Option<Arc<dyn PhysicalExpr>>> =
+                        partitions
+                            .iter()
+                            .map(|partition| self.build_partition_filter(partition))
+                            .collect::<Result<_>>()?;
+
+                    let global_expr =
+                        Self::combine_or(partition_filters.iter().flatten().cloned())
+                            .unwrap_or_else(|| lit(false));
+
+                    self.dynamic_filter
+                        .update_partitioned(global_expr, partition_filters)?;
+                    return Ok(());
+                }
+
                 let num_partitions = partitions.len();
                 let routing_hash_expr = Arc::new(HashExpr::new(
                     self.on_right.clone(),
@@ -690,6 +710,63 @@ impl SharedBuildAccumulator {
 
         Ok(())
     }
+
+    /// Build a filter expression for a single partition (bounds AND membership).
+    fn build_filter_expr(
+        &self,
+        pushdown: &PushdownStrategy,
+        bounds: &PartitionBounds,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        let membership_expr = create_membership_predicate(
+            &self.on_right,
+            pushdown.clone(),
+            &HASH_JOIN_SEED,
+            self.probe_schema.as_ref(),
+        )?;
+        let bounds_expr = create_bounds_predicate(&self.on_right, bounds);
+
+        Ok(match (membership_expr, bounds_expr) {
+            (Some(membership), Some(bounds)) => {
+                Arc::new(BinaryExpr::new(bounds, Operator::And, membership))
+                    as Arc<dyn PhysicalExpr>
+            }
+            (Some(membership), None) => membership,
+            (None, Some(bounds)) => bounds,
+            (None, None) => lit(true),
+        })
+    }
+
+    /// Build an optional filter expression for a partition slot.
+    /// Returns None for empty partitions, `lit(true)` for canceled-unknown partitions,
+    /// and errors on pending partitions.
+    fn build_partition_filter(
+        &self,
+        partition: &PartitionStatus,
+    ) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+        match partition {
+            PartitionStatus::Reported(partition)
+                if matches!(partition.pushdown, PushdownStrategy::Empty) =>
+            {
+                Ok(None)
+            }
+            PartitionStatus::Reported(partition) => self
+                .build_filter_expr(&partition.pushdown, &partition.bounds)
+                .map(Some),
+            PartitionStatus::CanceledUnknown => Ok(Some(lit(true))),
+            PartitionStatus::Pending => datafusion_common::internal_err!(
+                "attempted to build partition-index dynamic filter with pending partition"
+            ),
+        }
+    }
+
+    /// Combine filter expressions with OR.
+    fn combine_or(
+        filters: impl Iterator<Item = Arc<dyn PhysicalExpr>>,
+    ) -> Option<Arc<dyn PhysicalExpr>> {
+        filters.reduce(|acc, expr| {
+            Arc::new(BinaryExpr::new(acc, Operator::Or, expr)) as Arc<dyn PhysicalExpr>
+        })
+    }
 }
 
 impl fmt::Debug for SharedBuildAccumulator {
@@ -721,6 +798,7 @@ mod tests {
             dynamic_filter,
             on_right: vec![],
             repartition_random_state: SeededRandomState::with_seed(1),
+            use_partition_index: false,
             probe_schema,
         }
     }

--- a/datafusion/physical-plan/src/joins/mod.rs
+++ b/datafusion/physical-plan/src/joins/mod.rs
@@ -21,7 +21,8 @@ use arrow::array::BooleanBufferBuilder;
 pub use cross_join::CrossJoinExec;
 use datafusion_physical_expr::PhysicalExprRef;
 pub use hash_join::{
-    HashExpr, HashJoinExec, HashJoinExecBuilder, HashTableLookupExpr, SeededRandomState,
+    DynamicFilterRoutingMode, HashExpr, HashJoinExec, HashJoinExecBuilder,
+    HashTableLookupExpr, SeededRandomState,
 };
 pub use nested_loop_join::{NestedLoopJoinExec, NestedLoopJoinExecBuilder};
 use parking_lot::Mutex;

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -1154,6 +1154,11 @@ enum PartitionMode {
   AUTO = 2;
 }
 
+enum DynamicFilterRoutingMode {
+  CASE_HASH = 0;
+  PARTITION_INDEX = 1;
+}
+
 message HashJoinExecNode {
   PhysicalPlanNode left = 1;
   PhysicalPlanNode right = 2;
@@ -1164,6 +1169,7 @@ message HashJoinExecNode {
   JoinFilter filter = 8;
   repeated uint32 projection = 9;
   bool null_aware = 10;
+  DynamicFilterRoutingMode dynamic_filter_routing_mode = 11;
 }
 
 enum StreamPartitionMode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -5731,6 +5731,77 @@ impl<'de> serde::Deserialize<'de> for DropViewNode {
         deserializer.deserialize_struct("datafusion.DropViewNode", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for DynamicFilterRoutingMode {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let variant = match self {
+            Self::CaseHash => "CASE_HASH",
+            Self::PartitionIndex => "PARTITION_INDEX",
+        };
+        serializer.serialize_str(variant)
+    }
+}
+impl<'de> serde::Deserialize<'de> for DynamicFilterRoutingMode {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "CASE_HASH",
+            "PARTITION_INDEX",
+        ];
+
+        struct GeneratedVisitor;
+
+        impl serde::de::Visitor<'_> for GeneratedVisitor {
+            type Value = DynamicFilterRoutingMode;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "expected one of: {:?}", &FIELDS)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                i32::try_from(v)
+                    .ok()
+                    .and_then(|x| x.try_into().ok())
+                    .ok_or_else(|| {
+                        serde::de::Error::invalid_value(serde::de::Unexpected::Signed(v), &self)
+                    })
+            }
+
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                i32::try_from(v)
+                    .ok()
+                    .and_then(|x| x.try_into().ok())
+                    .ok_or_else(|| {
+                        serde::de::Error::invalid_value(serde::de::Unexpected::Unsigned(v), &self)
+                    })
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "CASE_HASH" => Ok(DynamicFilterRoutingMode::CaseHash),
+                    "PARTITION_INDEX" => Ok(DynamicFilterRoutingMode::PartitionIndex),
+                    _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
+                }
+            }
+        }
+        deserializer.deserialize_any(GeneratedVisitor)
+    }
+}
 impl serde::Serialize for EmptyExecNode {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -8674,6 +8745,9 @@ impl serde::Serialize for HashJoinExecNode {
         if self.null_aware {
             len += 1;
         }
+        if self.dynamic_filter_routing_mode != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion.HashJoinExecNode", len)?;
         if let Some(v) = self.left.as_ref() {
             struct_ser.serialize_field("left", v)?;
@@ -8708,6 +8782,11 @@ impl serde::Serialize for HashJoinExecNode {
         if self.null_aware {
             struct_ser.serialize_field("nullAware", &self.null_aware)?;
         }
+        if self.dynamic_filter_routing_mode != 0 {
+            let v = DynamicFilterRoutingMode::try_from(self.dynamic_filter_routing_mode)
+                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.dynamic_filter_routing_mode)))?;
+            struct_ser.serialize_field("dynamicFilterRoutingMode", &v)?;
+        }
         struct_ser.end()
     }
 }
@@ -8731,6 +8810,8 @@ impl<'de> serde::Deserialize<'de> for HashJoinExecNode {
             "projection",
             "null_aware",
             "nullAware",
+            "dynamic_filter_routing_mode",
+            "dynamicFilterRoutingMode",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -8744,6 +8825,7 @@ impl<'de> serde::Deserialize<'de> for HashJoinExecNode {
             Filter,
             Projection,
             NullAware,
+            DynamicFilterRoutingMode,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -8774,6 +8856,7 @@ impl<'de> serde::Deserialize<'de> for HashJoinExecNode {
                             "filter" => Ok(GeneratedField::Filter),
                             "projection" => Ok(GeneratedField::Projection),
                             "nullAware" | "null_aware" => Ok(GeneratedField::NullAware),
+                            "dynamicFilterRoutingMode" | "dynamic_filter_routing_mode" => Ok(GeneratedField::DynamicFilterRoutingMode),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -8802,6 +8885,7 @@ impl<'de> serde::Deserialize<'de> for HashJoinExecNode {
                 let mut filter__ = None;
                 let mut projection__ = None;
                 let mut null_aware__ = None;
+                let mut dynamic_filter_routing_mode__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Left => {
@@ -8861,6 +8945,12 @@ impl<'de> serde::Deserialize<'de> for HashJoinExecNode {
                             }
                             null_aware__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::DynamicFilterRoutingMode => {
+                            if dynamic_filter_routing_mode__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("dynamicFilterRoutingMode"));
+                            }
+                            dynamic_filter_routing_mode__ = Some(map_.next_value::<DynamicFilterRoutingMode>()? as i32);
+                        }
                     }
                 }
                 Ok(HashJoinExecNode {
@@ -8873,6 +8963,7 @@ impl<'de> serde::Deserialize<'de> for HashJoinExecNode {
                     filter: filter__,
                     projection: projection__.unwrap_or_default(),
                     null_aware: null_aware__.unwrap_or_default(),
+                    dynamic_filter_routing_mode: dynamic_filter_routing_mode__.unwrap_or_default(),
                 })
             }
         }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1738,6 +1738,8 @@ pub struct HashJoinExecNode {
     pub projection: ::prost::alloc::vec::Vec<u32>,
     #[prost(bool, tag = "10")]
     pub null_aware: bool,
+    #[prost(enumeration = "DynamicFilterRoutingMode", tag = "11")]
+    pub dynamic_filter_routing_mode: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SymmetricHashJoinExecNode {
@@ -2440,6 +2442,32 @@ impl PartitionMode {
             "COLLECT_LEFT" => Some(Self::CollectLeft),
             "PARTITIONED" => Some(Self::Partitioned),
             "AUTO" => Some(Self::Auto),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum DynamicFilterRoutingMode {
+    CaseHash = 0,
+    PartitionIndex = 1,
+}
+impl DynamicFilterRoutingMode {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::CaseHash => "CASE_HASH",
+            Self::PartitionIndex => "PARTITION_INDEX",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CASE_HASH" => Some(Self::CaseHash),
+            "PARTITION_INDEX" => Some(Self::PartitionIndex),
             _ => None,
         }
     }

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -74,8 +74,9 @@ use datafusion_physical_plan::expressions::PhysicalSortExpr;
 use datafusion_physical_plan::filter::{FilterExec, FilterExecBuilder};
 use datafusion_physical_plan::joins::utils::{ColumnIndex, JoinFilter};
 use datafusion_physical_plan::joins::{
-    CrossJoinExec, HashJoinExec, NestedLoopJoinExec, PartitionMode, SortMergeJoinExec,
-    StreamJoinPartitionMode, SymmetricHashJoinExec,
+    CrossJoinExec, DynamicFilterRoutingMode, HashJoinExec, HashJoinExecBuilder,
+    NestedLoopJoinExec, PartitionMode, SortMergeJoinExec, StreamJoinPartitionMode,
+    SymmetricHashJoinExec,
 };
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion_physical_plan::memory::LazyMemoryExec;
@@ -1397,6 +1398,24 @@ impl protobuf::PhysicalPlanNode {
             protobuf::PartitionMode::Partitioned => PartitionMode::Partitioned,
             protobuf::PartitionMode::Auto => PartitionMode::Auto,
         };
+        let dynamic_filter_routing_mode =
+            protobuf::DynamicFilterRoutingMode::try_from(
+                hashjoin.dynamic_filter_routing_mode,
+            )
+            .map_err(|_| {
+                proto_error(format!(
+                    "Received a HashJoinNode message with unknown DynamicFilterRoutingMode {}",
+                    hashjoin.dynamic_filter_routing_mode
+                ))
+            })?;
+        let dynamic_filter_routing_mode = match dynamic_filter_routing_mode {
+            protobuf::DynamicFilterRoutingMode::CaseHash => {
+                DynamicFilterRoutingMode::CaseHash
+            }
+            protobuf::DynamicFilterRoutingMode::PartitionIndex => {
+                DynamicFilterRoutingMode::PartitionIndex
+            }
+        };
         let projection = if !hashjoin.projection.is_empty() {
             Some(
                 hashjoin
@@ -1408,17 +1427,16 @@ impl protobuf::PhysicalPlanNode {
         } else {
             None
         };
-        Ok(Arc::new(HashJoinExec::try_new(
-            left,
-            right,
-            on,
-            filter,
-            &join_type.into(),
-            projection,
-            partition_mode,
-            null_equality.into(),
-            hashjoin.null_aware,
-        )?))
+        Ok(Arc::new(
+            HashJoinExecBuilder::new(left, right, on, join_type.into())
+                .with_filter(filter)
+                .with_projection(projection)
+                .with_partition_mode(partition_mode)
+                .with_null_equality(null_equality.into())
+                .with_null_aware(hashjoin.null_aware)
+                .with_dynamic_filter_routing_mode(dynamic_filter_routing_mode)
+                .build()?,
+        ))
     }
 
     fn try_into_symmetric_hash_join_physical_plan(
@@ -2465,6 +2483,14 @@ impl protobuf::PhysicalPlanNode {
             PartitionMode::Partitioned => protobuf::PartitionMode::Partitioned,
             PartitionMode::Auto => protobuf::PartitionMode::Auto,
         };
+        let dynamic_filter_routing_mode = match exec.dynamic_filter_routing_mode {
+            DynamicFilterRoutingMode::CaseHash => {
+                protobuf::DynamicFilterRoutingMode::CaseHash
+            }
+            DynamicFilterRoutingMode::PartitionIndex => {
+                protobuf::DynamicFilterRoutingMode::PartitionIndex
+            }
+        };
 
         Ok(protobuf::PhysicalPlanNode {
             physical_plan_type: Some(PhysicalPlanType::HashJoin(Box::new(
@@ -2480,6 +2506,7 @@ impl protobuf::PhysicalPlanNode {
                         v.iter().map(|x| *x as u32).collect::<Vec<u32>>()
                     }),
                     null_aware: exec.null_aware,
+                    dynamic_filter_routing_mode: dynamic_filter_routing_mode.into(),
                 },
             ))),
         })

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -66,8 +66,8 @@ use datafusion::physical_plan::expressions::{
 };
 use datafusion::physical_plan::filter::{FilterExec, FilterExecBuilder};
 use datafusion::physical_plan::joins::{
-    HashJoinExec, NestedLoopJoinExec, PartitionMode, SortMergeJoinExec,
-    StreamJoinPartitionMode, SymmetricHashJoinExec,
+    DynamicFilterRoutingMode, HashJoinExec, HashJoinExecBuilder, NestedLoopJoinExec,
+    PartitionMode, SortMergeJoinExec, StreamJoinPartitionMode, SymmetricHashJoinExec,
 };
 use datafusion::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion::physical_plan::metrics::MetricType;
@@ -305,6 +305,44 @@ fn roundtrip_hash_join() -> Result<()> {
             )?))?;
         }
     }
+    Ok(())
+}
+
+#[test]
+fn roundtrip_hash_join_preserves_dynamic_filter_routing_mode() -> Result<()> {
+    let field = Field::new("col", DataType::Int64, false);
+    let schema_left = Arc::new(Schema::new(vec![field.clone()]));
+    let schema_right = Arc::new(Schema::new(vec![field]));
+    let on = vec![(
+        Arc::new(Column::new("col", schema_left.index_of("col")?)) as _,
+        Arc::new(Column::new("col", schema_right.index_of("col")?)) as _,
+    )];
+
+    let join = Arc::new(
+        HashJoinExecBuilder::new(
+            Arc::new(EmptyExec::new(Arc::clone(&schema_left))),
+            Arc::new(EmptyExec::new(Arc::clone(&schema_right))),
+            on,
+            JoinType::Inner,
+        )
+        .with_partition_mode(PartitionMode::Partitioned)
+        .with_null_equality(NullEquality::NullEqualsNothing)
+        .with_dynamic_filter_routing_mode(DynamicFilterRoutingMode::PartitionIndex)
+        .build()?,
+    );
+
+    let ctx = SessionContext::new();
+    let codec = DefaultPhysicalExtensionCodec {};
+    let proto_converter = DefaultPhysicalProtoConverter {};
+    let roundtripped = roundtrip_test_and_return(join, &ctx, &codec, &proto_converter)?;
+    let hash_join = roundtripped
+        .downcast_ref::<HashJoinExec>()
+        .expect("expected HashJoinExec after roundtrip");
+
+    assert_eq!(
+        hash_join.dynamic_filter_routing_mode,
+        DynamicFilterRoutingMode::PartitionIndex
+    );
     Ok(())
 }
 

--- a/datafusion/sqllogictest/test_files/preserve_file_partitioning.slt
+++ b/datafusion/sqllogictest/test_files/preserve_file_partitioning.slt
@@ -659,8 +659,8 @@ C prod 2017.6
 # TEST 12: Partitioned Join with Matching Partition Counts - With Optimization
 # Both tables have 3 partitions matching target_partitions=3
 # No RepartitionExec needed for join - partitions already satisfy the requirement
-# Dynamic filter pushdown is disabled in this mode because preserve_file_partitions
-# reports Hash partitioning for Hive-style file groups, which are not hash-routed.
+# Dynamic filter pushdown is enabled in this mode because scan partition P maps
+# directly to join partition P, so PartitionIndex routing is safe.
 ##########
 
 statement ok
@@ -686,7 +686,7 @@ physical_plan
 03)----AggregateExec: mode=Partial, gby=[f_dkey@1 as f_dkey, env@2 as env], aggr=[sum(f.value)]
 04)------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(d_dkey@1, f_dkey@1)], projection=[value@2, f_dkey@3, env@0]
 05)--------DataSourceExec: file_groups={3 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/dimension_partitioned/d_dkey=A/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/dimension_partitioned/d_dkey=B/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/dimension_partitioned/d_dkey=C/data.parquet]]}, projection=[env, d_dkey], file_type=parquet
-06)--------DataSourceExec: file_groups={3 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/fact/f_dkey=A/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/fact/f_dkey=B/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/fact/f_dkey=C/data.parquet]]}, projection=[value, f_dkey], file_type=parquet
+06)--------DataSourceExec: file_groups={3 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/fact/f_dkey=A/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/fact/f_dkey=B/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/fact/f_dkey=C/data.parquet]]}, projection=[value, f_dkey], file_type=parquet, predicate=DynamicFilter [ empty ]
 
 query TTR rowsort
 SELECT f.f_dkey, d.env, sum(f.value)
@@ -699,7 +699,48 @@ B prod 614.4
 C prod 2017.6
 
 ##########
-# TEST 13: Partitioned Join where Number of File Groups is less than target_partitions
+# TEST 13: PartitionIndex dynamic filter with an additional static probe predicate
+# The probe-side scan should keep both predicates conjoined and still avoid repartitioning.
+##########
+
+query TT
+EXPLAIN SELECT f.f_dkey, d.env, sum(f.value)
+FROM fact_table f
+INNER JOIN dimension_table_partitioned d ON f.f_dkey = d.d_dkey
+WHERE f.value > 90
+GROUP BY f.f_dkey, d.env;
+----
+logical_plan
+01)Aggregate: groupBy=[[f.f_dkey, d.env]], aggr=[[sum(f.value)]]
+02)--Projection: f.value, f.f_dkey, d.env
+03)----Inner Join: f.f_dkey = d.d_dkey
+04)------SubqueryAlias: f
+05)--------Filter: fact_table.value > Float64(90)
+06)----------TableScan: fact_table projection=[value, f_dkey], partial_filters=[fact_table.value > Float64(90)]
+07)------SubqueryAlias: d
+08)--------TableScan: dimension_table_partitioned projection=[env, d_dkey]
+physical_plan
+01)AggregateExec: mode=FinalPartitioned, gby=[f_dkey@0 as f_dkey, env@1 as env], aggr=[sum(f.value)]
+02)--RepartitionExec: partitioning=Hash([f_dkey@0, env@1], 3), input_partitions=3
+03)----AggregateExec: mode=Partial, gby=[f_dkey@1 as f_dkey, env@2 as env], aggr=[sum(f.value)]
+04)------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(d_dkey@1, f_dkey@1)], projection=[value@2, f_dkey@3, env@0]
+05)--------DataSourceExec: file_groups={3 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/dimension_partitioned/d_dkey=A/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/dimension_partitioned/d_dkey=B/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/dimension_partitioned/d_dkey=C/data.parquet]]}, projection=[env, d_dkey], file_type=parquet
+06)--------FilterExec: value@0 > 90
+07)----------DataSourceExec: file_groups={3 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/fact/f_dkey=A/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/fact/f_dkey=B/data.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/preserve_file_partitioning/fact/f_dkey=C/data.parquet]]}, projection=[value, f_dkey], file_type=parquet, predicate=value@1 > 90 AND DynamicFilter [ empty ], pruning_predicate=value_null_count@1 != row_count@2 AND value_max@0 > 90, required_guarantees=[]
+
+query TTR rowsort
+SELECT f.f_dkey, d.env, sum(f.value)
+FROM fact_table f
+INNER JOIN dimension_table_partitioned d ON f.f_dkey = d.d_dkey
+WHERE f.value > 90
+GROUP BY f.f_dkey, d.env;
+----
+A dev 772.4
+B prod 212.3
+C prod 2017.6
+
+##########
+# TEST 14: Partitioned Join where Number of File Groups is less than target_partitions
 # With preserve_file_partitions enabled, we should still avoid repartitioning
 ##########
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #20195.

I have split it up into three commits to make it easier to review

## Rationale for this change

## What changes are included in this PR?

Extensively covered in #21207 via this comment: https://github.com/apache/datafusion/issues/21207#issuecomment-4254968115


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes:
- Unit
- Integration
- SqlLogic

## Are there any user-facing changes?

Yes:

#### `datafusion_physical_plan::joins::DynamicFilterRoutingMode`
Enum with Variants:
- CaseHash
- PartitionIndex

#### `HashJoinExec`
- Public field: `dynamic_filter_routing_mode: DynamicFilterRoutingMode`

#### `HashJoinExecBuilder`
- New builder method: `with_dynamic_filter_routing_mode`

#### `DynamicFilterPhysicalExpr`
- New public methods: `update_partitioned()`, `partition_filter()`

#### Protos
- `DynamicFilterRoutingMode` -> `dynamic_filter_routing_mode = 11`



