### PR TITLE
chore: bump `sha` & `md-5` to `0.11.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2 0.11.0",
+ "sha2",
  "time",
  "tracing",
 ]
@@ -2283,12 +2283,12 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "memchr",
  "num-traits",
  "rand 0.9.4",
  "regex",
- "sha2 0.10.9",
+ "sha2",
  "tokio",
  "uuid",
 ]
@@ -2639,7 +2639,7 @@ dependencies = [
  "rand 0.9.4",
  "serde_json",
  "sha1 0.11.0",
- "sha2 0.10.9",
+ "sha2",
  "url",
 ]
 
@@ -4756,7 +4756,7 @@ dependencies = [
  "md-5 0.11.0",
  "memchr",
  "rand 0.10.1",
- "sha2 0.11.0",
+ "sha2",
  "stringprep",
 ]
 
@@ -5708,17 +5708,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ recursive = "0.1.1"
 regex = "1.12"
 rstest = "0.26.1"
 serde_json = "1"
-sha2 = "^0.10.9"
+sha2 = "^0.11.0"
 sqlparser = { version = "0.61.0", default-features = false, features = ["std", "visitor"] }
 strum = "0.28.0"
 strum_macros = "0.28.0"

--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -68,7 +68,7 @@ name = "datafusion_functions"
 arrow = { workspace = true }
 arrow-buffer = { workspace = true }
 base64 = { version = "0.22", optional = true }
-blake2 = { version = "^0.10.2", optional = true }
+blake2 = { version = "^0.10.6", optional = true }
 blake3 = { version = "1.8", optional = true }
 chrono = { workspace = true }
 chrono-tz = { version = "0.10.4", optional = true }
@@ -81,7 +81,7 @@ datafusion-macros = { workspace = true }
 hex = { workspace = true, optional = true }
 itertools = { workspace = true }
 log = { workspace = true }
-md-5 = { version = "^0.10.0", optional = true }
+md-5 = { version = "^0.11.0", optional = true }
 memchr = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true }

--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -68,7 +68,7 @@ name = "datafusion_functions"
 arrow = { workspace = true }
 arrow-buffer = { workspace = true }
 base64 = { version = "0.22", optional = true }
-blake2 = { version = "^0.10.6", optional = true }
+blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.8", optional = true }
 chrono = { workspace = true }
 chrono-tz = { version = "0.10.4", optional = true }

--- a/datafusion/functions/src/crypto/basic.rs
+++ b/datafusion/functions/src/crypto/basic.rs
@@ -19,7 +19,7 @@
 
 use arrow::array::{Array, ArrayRef, AsArray, BinaryArray, BinaryArrayType};
 use arrow::datatypes::DataType;
-use blake2::{Blake2b512, Blake2s256, Digest};
+use blake2::{Blake2b512, Blake2s256};
 use blake3::Hasher as Blake3;
 
 use arrow::compute::StringArrayType;
@@ -85,7 +85,8 @@ impl fmt::Display for DigestAlgorithm {
 }
 
 macro_rules! digest_to_array {
-    ($METHOD:ident, $INPUT:expr) => {{
+    ($MODULE:ident, $METHOD:ident, $INPUT:expr) => {{
+        use $MODULE::Digest;
         let binary_array: BinaryArray = $INPUT
             .iter()
             .map(|x| x.map(|x| $METHOD::digest(x)))
@@ -95,20 +96,23 @@ macro_rules! digest_to_array {
 }
 
 macro_rules! digest_to_scalar {
-    ($METHOD: ident, $INPUT:expr) => {{ ScalarValue::Binary($INPUT.map(|v| $METHOD::digest(v).as_slice().to_vec())) }};
+    ($MODULE: ident, $METHOD: ident, $INPUT:expr) => {{
+        use $MODULE::Digest;
+        ScalarValue::Binary($INPUT.map(|v| $METHOD::digest(v).as_slice().to_vec()))
+    }};
 }
 
 impl DigestAlgorithm {
     /// digest an optional string to its hash value, null values are returned as is
     fn digest_scalar(self, value: Option<&[u8]>) -> ColumnarValue {
         ColumnarValue::Scalar(match self {
-            Self::Md5 => digest_to_scalar!(Md5, value),
-            Self::Sha224 => digest_to_scalar!(Sha224, value),
-            Self::Sha256 => digest_to_scalar!(Sha256, value),
-            Self::Sha384 => digest_to_scalar!(Sha384, value),
-            Self::Sha512 => digest_to_scalar!(Sha512, value),
-            Self::Blake2b => digest_to_scalar!(Blake2b512, value),
-            Self::Blake2s => digest_to_scalar!(Blake2s256, value),
+            Self::Md5 => digest_to_scalar!(md5, Md5, value),
+            Self::Sha224 => digest_to_scalar!(sha2, Sha224, value),
+            Self::Sha256 => digest_to_scalar!(sha2, Sha256, value),
+            Self::Sha384 => digest_to_scalar!(sha2, Sha384, value),
+            Self::Sha512 => digest_to_scalar!(sha2, Sha512, value),
+            Self::Blake2b => digest_to_scalar!(blake2, Blake2b512, value),
+            Self::Blake2s => digest_to_scalar!(blake2, Blake2s256, value),
             Self::Blake3 => ScalarValue::Binary(value.map(|v| {
                 let mut digest = Blake3::default();
                 digest.update(v);
@@ -125,13 +129,13 @@ impl DigestAlgorithm {
         StringArrType: StringArrayType<'a>,
     {
         match self {
-            Self::Md5 => digest_to_array!(Md5, input_value),
-            Self::Sha224 => digest_to_array!(Sha224, input_value),
-            Self::Sha256 => digest_to_array!(Sha256, input_value),
-            Self::Sha384 => digest_to_array!(Sha384, input_value),
-            Self::Sha512 => digest_to_array!(Sha512, input_value),
-            Self::Blake2b => digest_to_array!(Blake2b512, input_value),
-            Self::Blake2s => digest_to_array!(Blake2s256, input_value),
+            Self::Md5 => digest_to_array!(md5, Md5, input_value),
+            Self::Sha224 => digest_to_array!(sha2, Sha224, input_value),
+            Self::Sha256 => digest_to_array!(sha2, Sha256, input_value),
+            Self::Sha384 => digest_to_array!(sha2, Sha384, input_value),
+            Self::Sha512 => digest_to_array!(sha2, Sha512, input_value),
+            Self::Blake2b => digest_to_array!(blake2, Blake2b512, input_value),
+            Self::Blake2s => digest_to_array!(blake2, Blake2s256, input_value),
             Self::Blake3 => {
                 let binary_array: BinaryArray = input_value
                     .iter()
@@ -156,13 +160,13 @@ impl DigestAlgorithm {
         BinaryArrType: BinaryArrayType<'a>,
     {
         match self {
-            Self::Md5 => digest_to_array!(Md5, input_value),
-            Self::Sha224 => digest_to_array!(Sha224, input_value),
-            Self::Sha256 => digest_to_array!(Sha256, input_value),
-            Self::Sha384 => digest_to_array!(Sha384, input_value),
-            Self::Sha512 => digest_to_array!(Sha512, input_value),
-            Self::Blake2b => digest_to_array!(Blake2b512, input_value),
-            Self::Blake2s => digest_to_array!(Blake2s256, input_value),
+            Self::Md5 => digest_to_array!(md5, Md5, input_value),
+            Self::Sha224 => digest_to_array!(sha2, Sha224, input_value),
+            Self::Sha256 => digest_to_array!(sha2, Sha256, input_value),
+            Self::Sha384 => digest_to_array!(sha2, Sha384, input_value),
+            Self::Sha512 => digest_to_array!(sha2, Sha512, input_value),
+            Self::Blake2b => digest_to_array!(blake2, Blake2b512, input_value),
+            Self::Blake2s => digest_to_array!(blake2, Blake2s256, input_value),
             Self::Blake3 => {
                 let binary_array: BinaryArray = input_value
                     .iter()


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #21279
- Closes #21281

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Keep dependencies up to date.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

We used to use `Digest` from `blake2`, which was a common dependency used by `md5` and `sha2`; however `blake2` doesn't have a `0.11.0` release so we were blocked because of incompatible dependencies when trying to upgrade `sha2` or `md5`. Fix code to use their own `Digest` (e.g. `md5::Digest`, `sha2::Digest`) instead of relying on `blake2::Digest` which should prevent such issues from occurring again and allows us to bump their versions independently.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
