### PR TITLE
Adds dynamic filter support for NestedLoopJoinExec

### DIFF
--- a/datafusion/physical-plan/src/joins/mod.rs
+++ b/datafusion/physical-plan/src/joins/mod.rs
@@ -46,6 +46,7 @@ mod join_filter;
 /// Note: This module is public for internal testing purposes only
 /// and is not guaranteed to be stable across versions.
 pub mod join_hash_map;
+mod nlj_filter_analysis;
 
 use array_map::ArrayMap;
 use utils::JoinHashMapType;

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -17,7 +17,7 @@
 
 //! [`NestedLoopJoinExec`]: joins without equijoin (equality predicates).
 
-use std::fmt::Formatter;
+use std::fmt::{self, Formatter};
 use std::ops::{BitOr, ControlFlow};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -194,7 +194,6 @@ use crate::spill::spill_manager::SpillManager;
 /// Note this structure includes a [`OnceAsync`] that is used to coordinate the
 /// loading of the left side with the processing in each output stream.
 /// Therefore it can not be [`Clone`]
-#[derive(Debug)]
 pub struct NestedLoopJoinExec {
     /// left side
     pub(crate) left: Arc<dyn ExecutionPlan>,
@@ -242,10 +241,23 @@ pub(crate) struct NLJDynamicFilter {
     bound_pairs: Vec<BoundPair>,
 }
 
-impl std::fmt::Debug for NLJDynamicFilter {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        f.debug_struct("NLJDynamicFilter")
-            .field("bound_pairs_count", &self.bound_pairs.len())
+/// Custom Debug that omits `dynamic_filter` — it is optimizer-injected runtime state
+/// (contains `Arc<Mutex<SharedBuildAccumulator>>`) that is not preserved by proto
+/// serialization and would cause roundtrip tests to diverge.
+impl fmt::Debug for NestedLoopJoinExec {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("NestedLoopJoinExec")
+            .field("left", &self.left)
+            .field("right", &self.right)
+            .field("filter", &self.filter)
+            .field("join_type", &self.join_type)
+            .field("join_schema", &self.join_schema)
+            .field("build_side_data", &self.build_side_data)
+            .field("left_spill_data", &self.left_spill_data)
+            .field("column_indices", &self.column_indices)
+            .field("projection", &self.projection)
+            .field("metrics", &self.metrics)
+            .field("cache", &self.cache)
             .finish()
     }
 }
@@ -548,7 +560,7 @@ impl NestedLoopJoinExec {
 }
 
 impl DisplayAs for NestedLoopJoinExec {
-    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
                 let display_filter = self.filter.as_ref().map_or_else(

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -23,12 +23,17 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::Poll;
 
+use super::nlj_filter_analysis::{self, BoundPair};
 use super::utils::{
     asymmetric_join_output_partitioning, need_produce_result_in_final,
     reorder_output_after_swap, swap_join_projection,
 };
 use crate::common::can_project;
 use crate::execution_plan::{EmissionType, boundedness_from_children};
+use crate::filter_pushdown::{
+    ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
+    FilterPushdownPropagation,
+};
 use crate::joins::SharedBitmapBuilder;
 use crate::joins::utils::{
     BuildProbeJoinMetrics, ColumnIndex, JoinFilter, OnceAsync, OnceFut,
@@ -60,6 +65,7 @@ use arrow::datatypes::{Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use arrow_schema::DataType;
 use datafusion_common::cast::as_boolean_array;
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{
     JoinSide, Result, ScalarValue, Statistics, arrow_err, assert_eq_or_internal_err,
@@ -72,6 +78,7 @@ use datafusion_expr::JoinType;
 use datafusion_physical_expr::equivalence::{
     ProjectionMapping, join_equivalence_properties,
 };
+use datafusion_physical_expr::expressions::{DynamicFilterPhysicalExpr, lit};
 
 use datafusion_physical_expr::projection::{ProjectionRef, combine_projections};
 use futures::{Stream, StreamExt, TryStreamExt};
@@ -223,6 +230,24 @@ pub struct NestedLoopJoinExec {
     metrics: ExecutionPlanMetricsSet,
     /// Cache holding plan properties like equivalences, output partitioning etc.
     cache: Arc<PlanProperties>,
+    /// Dynamic filter for pushing build-side bounds to probe scan
+    dynamic_filter: Option<NLJDynamicFilter>,
+}
+
+/// Holds the dynamic filter and extracted bound pairs for NLJ.
+#[derive(Clone)]
+pub(crate) struct NLJDynamicFilter {
+    filter: Arc<DynamicFilterPhysicalExpr>,
+    /// Extracted (probe_col, operator, build_col) pairs from JoinFilter
+    bound_pairs: Vec<BoundPair>,
+}
+
+impl std::fmt::Debug for NLJDynamicFilter {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        f.debug_struct("NLJDynamicFilter")
+            .field("bound_pairs_count", &self.bound_pairs.len())
+            .finish()
+    }
 }
 
 /// Helps to build [`NestedLoopJoinExec`].
@@ -302,6 +327,7 @@ impl NestedLoopJoinExecBuilder {
             projection,
             metrics: Default::default(),
             cache: Arc::new(cache),
+            dynamic_filter: None,
         })
     }
 }
@@ -507,7 +533,17 @@ impl NestedLoopJoinExec {
             join_schema: Arc::clone(&self.join_schema),
             column_indices: self.column_indices.clone(),
             projection: self.projection.clone(),
+            dynamic_filter: self.dynamic_filter.clone(),
         }
+    }
+}
+
+impl NestedLoopJoinExec {
+    /// Check if dynamic filter pushdown is allowed for this join.
+    fn allow_dynamic_filter_pushdown(&self, config: &ConfigOptions) -> bool {
+        self.filter.is_some()
+            && matches!(self.join_type, JoinType::Inner)
+            && config.optimizer.enable_join_dynamic_filter_pushdown
     }
 }
 
@@ -680,11 +716,192 @@ impl ExecutionPlan for NestedLoopJoinExec {
             metrics,
             batch_size,
             spill_state,
+            self.dynamic_filter.clone(),
+            self.right.schema(),
         )))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
+    }
+
+    /// Forward path (top-down): Route parent filters to children and create
+    /// dynamic filters for probe-side scan optimization.
+    ///
+    /// # What it does
+    ///
+    /// 1. **Route parent filters**: Uses `column_indices` to determine which
+    ///    output columns belong to which side (left/right). Parent filters
+    ///    referencing only left columns go to the left child, and vice versa.
+    ///
+    /// 2. **Create dynamic filter (Post phase only)**: Analyzes the `JoinFilter`
+    ///    expression to extract `(probe_col, operator, build_col)` pairs, then
+    ///    creates a `DynamicFilterPhysicalExpr` targeting the probe-side columns.
+    ///    This filter starts as `lit(true)` and gets updated with actual bounds
+    ///    at runtime after the build side is collected.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// SQL: SELECT * FROM events e JOIN windows w ON e.ts BETWEEN w.start AND w.end
+    ///
+    /// Plan BEFORE this function:
+    ///   NestedLoopJoinExec [filter: e.ts >= w.start AND e.ts <= w.end]
+    ///   ├── left (build): DataSourceExec [windows.parquet]
+    ///   └── right (probe): DataSourceExec [events.parquet]  ← no filter
+    ///
+    /// This function (Post phase):
+    ///   1. extract_bound_pairs(filter) → [ProbeGtEq(ts, start), ProbeLtEq(ts, end)]
+    ///   2. Creates DynamicFilterPhysicalExpr(children=[Column("ts")], lit(true))
+    ///   3. Adds as self_filter to right child
+    ///
+    /// After recursive pushdown, the plan becomes:
+    ///   NestedLoopJoinExec [filter: e.ts >= w.start AND e.ts <= w.end]
+    ///   ├── left (build): DataSourceExec [windows.parquet]
+    ///   └── right (probe): DataSourceExec [events.parquet]
+    ///                        filter: DynamicFilterPhysicalExpr(ts, lit(true))
+    ///                                  ↑ placeholder, updated at runtime
+    /// ```
+    fn gather_filters_for_pushdown(
+        &self,
+        phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn crate::PhysicalExpr>>,
+        config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        let (left_preserved, right_preserved) = self.join_type.on_lr_is_preserved();
+
+        // If a projection is applied (e.g., SELECT col_a, col_c instead of SELECT *),
+        // the output schema has fewer columns than the full join schema.
+        // Parent filters reference positions in the projected output, so we must
+        // use the projected column_indices for routing — not the full list.
+        // Without this, a parent filter on output position 1 would map to the
+        // wrong column (position 1 in the full schema vs the projected schema).
+        let column_indices_for_routing = match self.projection.as_ref() {
+            Some(projection) => projection
+                .iter()
+                .map(|i| self.column_indices[*i].clone())
+                .collect(),
+            None => self.column_indices.clone(),
+        };
+
+        // Map each output column position to its source side (Left or Right).
+        // Parent filters reference output positions (e.g., Column("ts", 2)).
+        // We need to know which side each position comes from so we can route
+        // the filter to the correct child.
+        // Example: output [start, end_val, ts, payload]
+        //   left_allowed  = {0, 1}  (start, end_val from left)
+        //   right_allowed = {2, 3}  (ts, payload from right)
+        let (mut left_allowed, mut right_allowed) = (
+            std::collections::HashSet::new(),
+            std::collections::HashSet::new(),
+        );
+        column_indices_for_routing
+            .iter()
+            .enumerate()
+            .for_each(|(output_idx, ci)| {
+                match ci.side {
+                    JoinSide::Left => left_allowed.insert(output_idx),
+                    JoinSide::Right => right_allowed.insert(output_idx),
+                    JoinSide::None => false,
+                };
+            });
+
+        let left_child = if left_preserved {
+            ChildFilterDescription::from_child_with_allowed_indices(
+                &parent_filters,
+                left_allowed,
+                self.left(),
+            )?
+        } else {
+            ChildFilterDescription::all_unsupported(&parent_filters)
+        };
+
+        let mut right_child = if right_preserved {
+            ChildFilterDescription::from_child_with_allowed_indices(
+                &parent_filters,
+                right_allowed,
+                self.right(),
+            )?
+        } else {
+            ChildFilterDescription::all_unsupported(&parent_filters)
+        };
+
+        // In Post phase, create dynamic filter for the probe (right) side
+        if phase == FilterPushdownPhase::Post
+            && self.allow_dynamic_filter_pushdown(config)
+            && let Some(join_filter) = &self.filter
+        {
+            let bound_pairs = nlj_filter_analysis::extract_bound_pairs(join_filter);
+            if !bound_pairs.is_empty() {
+                let probe_cols = nlj_filter_analysis::probe_columns_from_pairs(
+                    &bound_pairs,
+                    &self.right.schema(),
+                );
+                let dynamic_filter =
+                    Arc::new(DynamicFilterPhysicalExpr::new(probe_cols, lit(true)));
+                right_child = right_child.with_self_filter(dynamic_filter);
+            }
+        }
+
+        Ok(FilterDescription::new()
+            .with_child(left_child)
+            .with_child(right_child))
+    }
+
+    /// Return path (bottom-up): Capture the `DynamicFilterPhysicalExpr` Arc
+    /// reference so we can update it at runtime with actual build-side bounds.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// After gather + recursive pushdown:
+    ///   DataSourceExec stores Arc<DynamicFilterPhysicalExpr> (reference #1)
+    ///   ChildPushdownResult reports it back via self_filters
+    ///
+    /// This function:
+    ///   1. Detects DynamicFilterPhysicalExpr in right child's self_filters
+    ///   2. Downcasts to Arc<DynamicFilterPhysicalExpr>
+    ///   3. Stores in NLJDynamicFilter { filter: Arc (reference #2), bound_pairs }
+    ///   4. Returns updated NestedLoopJoinExec
+    ///
+    /// Now both NLJ (producer) and DataSourceExec (consumer) hold the same Arc:
+    ///   NLJ calls filter.update(bounds) → DataSourceExec sees it immediately
+    /// ```
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        let mut result = FilterPushdownPropagation::if_any(child_pushdown_result.clone());
+
+        // Check if our dynamic filter was pushed to the right (probe) child
+        let right_self_filters = &child_pushdown_result.self_filters[1];
+
+        if let Some(filter_result) = right_self_filters.first() {
+            let predicate = Arc::clone(&filter_result.predicate);
+            if let Ok(dynamic_filter) =
+                Arc::downcast::<DynamicFilterPhysicalExpr>(predicate)
+            {
+                // Extract bound pairs again (same analysis as in gather_filters)
+                let bound_pairs = self
+                    .filter
+                    .as_ref()
+                    .map(nlj_filter_analysis::extract_bound_pairs)
+                    .unwrap_or_default();
+
+                // Build updated node with dynamic filter stored
+                let builder = NestedLoopJoinExecBuilder::from(self);
+                let mut new_node = builder.build()?;
+                new_node.dynamic_filter = Some(NLJDynamicFilter {
+                    filter: dynamic_filter,
+                    bound_pairs,
+                });
+                result = result
+                    .with_updated_node(Arc::new(new_node) as Arc<dyn ExecutionPlan>);
+            }
+        }
+        Ok(result)
     }
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
@@ -1014,6 +1231,11 @@ pub(crate) struct NestedLoopJoinStream {
 
     /// Memory-limited spill fallback state. See [`SpillState`] for details.
     spill_state: SpillState,
+
+    /// Dynamic filter info for pushing build-side bounds to probe scan
+    dynamic_filter_info: Option<NLJDynamicFilter>,
+    /// Schema of the probe (right) side, for building predicate expressions
+    probe_schema: SchemaRef,
 }
 
 pub(crate) struct NestedLoopJoinMetrics {
@@ -1246,6 +1468,8 @@ impl NestedLoopJoinStream {
         metrics: NestedLoopJoinMetrics,
         batch_size: usize,
         spill_state: SpillState,
+        dynamic_filter_info: Option<NLJDynamicFilter>,
+        probe_schema: SchemaRef,
     ) -> Self {
         Self {
             output_schema: Arc::clone(&schema),
@@ -1268,6 +1492,8 @@ impl NestedLoopJoinStream {
             handled_empty_output: false,
             should_track_unmatched_right: need_produce_right_in_final(join_type),
             spill_state,
+            dynamic_filter_info,
+            probe_schema,
         }
     }
 
@@ -1402,6 +1628,27 @@ impl NestedLoopJoinStream {
             // Standard path: use OnceFut
             match self.left_data.get_shared(cx) {
                 Poll::Ready(Ok(left_data)) => {
+                    // Compute and push dynamic filter bounds before probing starts
+                    if let Some(df_info) = &self.dynamic_filter_info
+                        && !df_info.bound_pairs.is_empty()
+                    {
+                        if let Ok((mins, maxes)) =
+                            nlj_filter_analysis::compute_build_bounds(
+                                left_data.batch(),
+                                &df_info.bound_pairs,
+                            )
+                            && let Some(predicate) =
+                                nlj_filter_analysis::build_probe_predicate(
+                                    &df_info.bound_pairs,
+                                    &mins,
+                                    &maxes,
+                                    &self.probe_schema,
+                                )
+                        {
+                            let _ = df_info.filter.update(predicate);
+                        }
+                        df_info.filter.mark_complete();
+                    }
                     self.buffered_left_data = Some(left_data);
                     self.left_exhausted = true;
                     self.state = NLJState::FetchingRight;
@@ -3588,5 +3835,569 @@ pub(crate) mod tests {
 
         assert_contains!(err.to_string(), "Resources exhausted");
         Ok(())
+    }
+
+    // ================================================================
+    // Dynamic filter expression analysis tests
+    // ================================================================
+
+    mod dynamic_filter_tests {
+        use super::*;
+        use crate::joins::nlj_filter_analysis::{self, BoundPair, BoundType};
+        use std::collections::HashMap;
+
+        /// Helper: build a JoinFilter with the given expression and column indices.
+        fn make_filter(
+            expr: Arc<dyn PhysicalExpr>,
+            left_indices: Vec<usize>,
+            right_indices: Vec<usize>,
+            fields: Vec<Field>,
+        ) -> JoinFilter {
+            let column_indices =
+                JoinFilter::build_column_indices(left_indices, right_indices);
+            let schema = Arc::new(Schema::new(fields));
+            JoinFilter::new(expr, column_indices, schema)
+        }
+
+        #[test]
+        fn test_extract_bound_pairs_range_join() {
+            // e.ts >= w.start AND e.ts <= w.end
+            // build_column_indices puts left first, then right:
+            //   column_indices[0] = Left(0)  → w.start
+            //   column_indices[1] = Left(1)  → w.end
+            //   column_indices[2] = Right(0) → e.ts
+            // So intermediate schema: Col(0)=Left(start), Col(1)=Left(end), Col(2)=Right(ts)
+            let start = Arc::new(Column::new("start", 0)) as Arc<dyn PhysicalExpr>;
+            let end = Arc::new(Column::new("end", 1)) as Arc<dyn PhysicalExpr>;
+            let ts = Arc::new(Column::new("ts", 2)) as Arc<dyn PhysicalExpr>;
+
+            // ts >= start → Col(2) >= Col(0)
+            let ge_expr = Arc::new(BinaryExpr::new(
+                Arc::clone(&ts),
+                Operator::GtEq,
+                Arc::clone(&start),
+            )) as Arc<dyn PhysicalExpr>;
+            // ts <= end → Col(2) <= Col(1)
+            let le_expr = Arc::new(BinaryExpr::new(
+                Arc::clone(&ts),
+                Operator::LtEq,
+                Arc::clone(&end),
+            )) as Arc<dyn PhysicalExpr>;
+            let combined = Arc::new(BinaryExpr::new(ge_expr, Operator::And, le_expr))
+                as Arc<dyn PhysicalExpr>;
+
+            let filter = make_filter(
+                combined,
+                vec![0, 1], // left indices: start(0), end(1)
+                vec![0],    // right index: ts(0)
+                vec![
+                    Field::new("start", DataType::Int64, true),
+                    Field::new("end", DataType::Int64, true),
+                    Field::new("ts", DataType::Int64, true),
+                ],
+            );
+
+            let pairs = nlj_filter_analysis::extract_bound_pairs(&filter);
+            assert_eq!(pairs.len(), 2);
+
+            // ts >= start → probe(ts=0) >= build(start=0) → ProbeGtEq
+            assert_eq!(pairs[0].probe_col_idx, 0); // ts in right schema
+            assert_eq!(pairs[0].build_col_idx, 0); // start in left schema
+            assert_eq!(pairs[0].bound_type, BoundType::ProbeGtEq);
+
+            // ts <= end → probe(ts=0) <= build(end=1) → ProbeLtEq
+            assert_eq!(pairs[1].probe_col_idx, 0); // ts in right schema
+            assert_eq!(pairs[1].build_col_idx, 1); // end in left schema
+            assert_eq!(pairs[1].bound_type, BoundType::ProbeLtEq);
+        }
+
+        #[test]
+        fn test_extract_bound_pairs_flipped_operator() {
+            // build.start <= probe.ts  (build on left in expression)
+            // Should flip to: probe.ts >= build.start → ProbeGtEq
+            // column_indices: [Left(0)=start, Right(0)=ts]
+            let start = Arc::new(Column::new("start", 0)) as Arc<dyn PhysicalExpr>;
+            let ts = Arc::new(Column::new("ts", 1)) as Arc<dyn PhysicalExpr>;
+
+            let expr = Arc::new(BinaryExpr::new(start, Operator::LtEq, ts))
+                as Arc<dyn PhysicalExpr>;
+
+            let filter = make_filter(
+                expr,
+                vec![0], // left: start(0)
+                vec![0], // right: ts(0)
+                vec![
+                    Field::new("start", DataType::Int64, true),
+                    Field::new("ts", DataType::Int64, true),
+                ],
+            );
+
+            let pairs = nlj_filter_analysis::extract_bound_pairs(&filter);
+            assert_eq!(pairs.len(), 1);
+            assert_eq!(pairs[0].probe_col_idx, 0);
+            assert_eq!(pairs[0].build_col_idx, 0);
+            // build <= probe flips to probe >= build
+            assert_eq!(pairs[0].bound_type, BoundType::ProbeGtEq);
+        }
+
+        #[test]
+        fn test_extract_bound_pairs_equality() {
+            // probe.id = build.id → ProbeEq
+            // column_indices: [Left(0)=build.id, Right(0)=probe.id]
+            let build_id = Arc::new(Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
+            let probe_id = Arc::new(Column::new("id", 1)) as Arc<dyn PhysicalExpr>;
+
+            let expr = Arc::new(BinaryExpr::new(probe_id, Operator::Eq, build_id))
+                as Arc<dyn PhysicalExpr>;
+
+            let filter = make_filter(
+                expr,
+                vec![0],
+                vec![0],
+                vec![
+                    Field::new("id", DataType::Int32, true),
+                    Field::new("id", DataType::Int32, true),
+                ],
+            );
+
+            let pairs = nlj_filter_analysis::extract_bound_pairs(&filter);
+            assert_eq!(pairs.len(), 1);
+            assert_eq!(pairs[0].bound_type, BoundType::ProbeEq);
+        }
+
+        #[test]
+        fn test_extract_bound_pairs_no_cross_side() {
+            // left.a > left.b (both same side) → should return empty
+            let a = Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>;
+            let b = Arc::new(Column::new("b", 1)) as Arc<dyn PhysicalExpr>;
+
+            let expr =
+                Arc::new(BinaryExpr::new(a, Operator::Gt, b)) as Arc<dyn PhysicalExpr>;
+
+            // column_indices: [Left(0), Left(1)]
+            let filter = make_filter(
+                expr,
+                vec![0, 1],
+                vec![],
+                vec![
+                    Field::new("a", DataType::Int32, true),
+                    Field::new("b", DataType::Int32, true),
+                ],
+            );
+
+            let pairs = nlj_filter_analysis::extract_bound_pairs(&filter);
+            assert!(pairs.is_empty());
+        }
+
+        #[test]
+        fn test_extract_bound_pairs_non_comparison_skipped() {
+            // probe.a + build.b (Plus, not comparison) → should return empty
+            let a = Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>;
+            let b = Arc::new(Column::new("b", 1)) as Arc<dyn PhysicalExpr>;
+
+            let expr =
+                Arc::new(BinaryExpr::new(a, Operator::Plus, b)) as Arc<dyn PhysicalExpr>;
+
+            let filter = make_filter(
+                expr,
+                vec![0],
+                vec![0],
+                vec![
+                    Field::new("a", DataType::Int32, true),
+                    Field::new("b", DataType::Int32, true),
+                ],
+            );
+
+            let pairs = nlj_filter_analysis::extract_bound_pairs(&filter);
+            assert!(pairs.is_empty());
+        }
+
+        #[test]
+        fn test_compute_build_bounds() {
+            // Build batch: start=[100, 200, 300], end=[150, 250, 400]
+            let start = Arc::new(arrow::array::Int64Array::from(vec![100, 200, 300]));
+            let end = Arc::new(arrow::array::Int64Array::from(vec![150, 250, 400]));
+            let batch = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("start", DataType::Int64, false),
+                    Field::new("end", DataType::Int64, false),
+                ])),
+                vec![start, end],
+            )
+            .unwrap();
+
+            let pairs = vec![
+                BoundPair {
+                    probe_col_idx: 0,
+                    build_col_idx: 0,
+                    bound_type: BoundType::ProbeGtEq,
+                },
+                BoundPair {
+                    probe_col_idx: 0,
+                    build_col_idx: 1,
+                    bound_type: BoundType::ProbeLtEq,
+                },
+            ];
+
+            let (mins, maxes) =
+                nlj_filter_analysis::compute_build_bounds(&batch, &pairs).unwrap();
+
+            assert_eq!(mins[&0], ScalarValue::Int64(Some(100))); // min(start)
+            assert_eq!(maxes[&0], ScalarValue::Int64(Some(300))); // max(start)
+            assert_eq!(mins[&1], ScalarValue::Int64(Some(150))); // min(end)
+            assert_eq!(maxes[&1], ScalarValue::Int64(Some(400))); // max(end)
+        }
+
+        #[test]
+        fn test_compute_build_bounds_with_nulls() {
+            // Build batch with nulls: val=[None, 200, None, 400]
+            let val = Arc::new(arrow::array::Int64Array::from(vec![
+                None,
+                Some(200),
+                None,
+                Some(400),
+            ]));
+            let batch = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new("val", DataType::Int64, true)])),
+                vec![val],
+            )
+            .unwrap();
+
+            let pairs = vec![BoundPair {
+                probe_col_idx: 0,
+                build_col_idx: 0,
+                bound_type: BoundType::ProbeGtEq,
+            }];
+
+            let (mins, maxes) =
+                nlj_filter_analysis::compute_build_bounds(&batch, &pairs).unwrap();
+
+            // Nulls should be skipped
+            assert_eq!(mins[&0], ScalarValue::Int64(Some(200)));
+            assert_eq!(maxes[&0], ScalarValue::Int64(Some(400)));
+        }
+
+        #[test]
+        fn test_build_probe_predicate_range() {
+            // pairs: ts >= min(start), ts <= max(end)
+            let pairs = vec![
+                BoundPair {
+                    probe_col_idx: 0,
+                    build_col_idx: 0,
+                    bound_type: BoundType::ProbeGtEq,
+                },
+                BoundPair {
+                    probe_col_idx: 0,
+                    build_col_idx: 1,
+                    bound_type: BoundType::ProbeLtEq,
+                },
+            ];
+            let mut mins = HashMap::new();
+            mins.insert(0, ScalarValue::Int64(Some(100)));
+            mins.insert(1, ScalarValue::Int64(Some(150)));
+            let mut maxes = HashMap::new();
+            maxes.insert(0, ScalarValue::Int64(Some(300)));
+            maxes.insert(1, ScalarValue::Int64(Some(400)));
+
+            let probe_schema = Schema::new(vec![Field::new("ts", DataType::Int64, true)]);
+
+            let predicate = nlj_filter_analysis::build_probe_predicate(
+                &pairs,
+                &mins,
+                &maxes,
+                &probe_schema,
+            );
+
+            assert!(predicate.is_some());
+            let pred = predicate.unwrap();
+            // Should be: ts >= 100 AND ts <= 400
+            let display = format!("{pred}");
+            assert!(
+                display.contains(">="),
+                "Expected >= in predicate: {display}"
+            );
+            assert!(
+                display.contains("<="),
+                "Expected <= in predicate: {display}"
+            );
+        }
+
+        #[test]
+        fn test_build_probe_predicate_equality() {
+            // probe.id = build.id → probe >= min AND probe <= max
+            let pairs = vec![BoundPair {
+                probe_col_idx: 0,
+                build_col_idx: 0,
+                bound_type: BoundType::ProbeEq,
+            }];
+            let mut mins = HashMap::new();
+            mins.insert(0, ScalarValue::Int32(Some(10)));
+            let mut maxes = HashMap::new();
+            maxes.insert(0, ScalarValue::Int32(Some(30)));
+
+            let probe_schema = Schema::new(vec![Field::new("id", DataType::Int32, true)]);
+
+            let predicate = nlj_filter_analysis::build_probe_predicate(
+                &pairs,
+                &mins,
+                &maxes,
+                &probe_schema,
+            );
+
+            assert!(predicate.is_some());
+            let pred = predicate.unwrap();
+            // ProbeEq should generate both >= and <= bounds
+            let display = format!("{pred}");
+            assert!(
+                display.contains(">="),
+                "Expected >= for Eq bound: {display}"
+            );
+            assert!(
+                display.contains("<="),
+                "Expected <= for Eq bound: {display}"
+            );
+        }
+
+        #[test]
+        fn test_build_probe_predicate_empty_pairs() {
+            let pairs = vec![];
+            let mins = HashMap::new();
+            let maxes = HashMap::new();
+            let probe_schema = Schema::new(vec![Field::new("id", DataType::Int32, true)]);
+
+            let predicate = nlj_filter_analysis::build_probe_predicate(
+                &pairs,
+                &mins,
+                &maxes,
+                &probe_schema,
+            );
+
+            assert!(predicate.is_none());
+        }
+
+        #[test]
+        fn test_extract_bound_pairs_multi_column() {
+            // Two separate cross-side comparisons on different columns:
+            // probe.ts >= build.start AND probe.amount <= build.max_amount
+            // column_indices: [Left(0)=start, Left(1)=max_amount, Right(0)=ts, Right(1)=amount]
+            let start = Arc::new(Column::new("start", 0)) as Arc<dyn PhysicalExpr>;
+            let max_amt = Arc::new(Column::new("max_amount", 1)) as Arc<dyn PhysicalExpr>;
+            let ts = Arc::new(Column::new("ts", 2)) as Arc<dyn PhysicalExpr>;
+            let amount = Arc::new(Column::new("amount", 3)) as Arc<dyn PhysicalExpr>;
+
+            let ge_expr = Arc::new(BinaryExpr::new(
+                Arc::clone(&ts),
+                Operator::GtEq,
+                Arc::clone(&start),
+            )) as Arc<dyn PhysicalExpr>;
+            let le_expr = Arc::new(BinaryExpr::new(
+                Arc::clone(&amount),
+                Operator::LtEq,
+                Arc::clone(&max_amt),
+            )) as Arc<dyn PhysicalExpr>;
+            let combined = Arc::new(BinaryExpr::new(ge_expr, Operator::And, le_expr))
+                as Arc<dyn PhysicalExpr>;
+
+            let filter = make_filter(
+                combined,
+                vec![0, 1], // left: start(0), max_amount(1)
+                vec![0, 1], // right: ts(0), amount(1)
+                vec![
+                    Field::new("start", DataType::Int64, true),
+                    Field::new("max_amount", DataType::Int64, true),
+                    Field::new("ts", DataType::Int64, true),
+                    Field::new("amount", DataType::Int64, true),
+                ],
+            );
+
+            let pairs = nlj_filter_analysis::extract_bound_pairs(&filter);
+            assert_eq!(pairs.len(), 2);
+
+            // ts >= start
+            assert_eq!(pairs[0].probe_col_idx, 0); // ts
+            assert_eq!(pairs[0].build_col_idx, 0); // start
+            assert_eq!(pairs[0].bound_type, BoundType::ProbeGtEq);
+
+            // amount <= max_amount
+            assert_eq!(pairs[1].probe_col_idx, 1); // amount
+            assert_eq!(pairs[1].build_col_idx, 1); // max_amount
+            assert_eq!(pairs[1].bound_type, BoundType::ProbeLtEq);
+        }
+
+        #[test]
+        fn test_extract_bound_pairs_mixed_cross_and_same_side() {
+            // probe.ts >= build.start AND build.x != build.y (same-side, should skip)
+            // Only the cross-side comparison should be extracted
+            let start = Arc::new(Column::new("start", 0)) as Arc<dyn PhysicalExpr>;
+            let x = Arc::new(Column::new("x", 1)) as Arc<dyn PhysicalExpr>;
+            let ts = Arc::new(Column::new("ts", 2)) as Arc<dyn PhysicalExpr>;
+
+            let ge_expr = Arc::new(BinaryExpr::new(
+                Arc::clone(&ts),
+                Operator::GtEq,
+                Arc::clone(&start),
+            )) as Arc<dyn PhysicalExpr>;
+            // Same-side comparison: build.start != build.x (both Left)
+            let ne_expr = Arc::new(BinaryExpr::new(
+                Arc::clone(&start),
+                Operator::NotEq,
+                Arc::clone(&x),
+            )) as Arc<dyn PhysicalExpr>;
+            let combined = Arc::new(BinaryExpr::new(ge_expr, Operator::And, ne_expr))
+                as Arc<dyn PhysicalExpr>;
+
+            let filter = make_filter(
+                combined,
+                vec![0, 1], // left: start(0), x(1)
+                vec![0],    // right: ts(0)
+                vec![
+                    Field::new("start", DataType::Int64, true),
+                    Field::new("x", DataType::Int64, true),
+                    Field::new("ts", DataType::Int64, true),
+                ],
+            );
+
+            let pairs = nlj_filter_analysis::extract_bound_pairs(&filter);
+            // Only the cross-side GtEq should be extracted, NotEq is skipped
+            assert_eq!(pairs.len(), 1);
+            assert_eq!(pairs[0].bound_type, BoundType::ProbeGtEq);
+        }
+
+        #[test]
+        fn test_extract_bound_pairs_all_operators() {
+            // Test all 5 comparison operators from probe perspective:
+            // probe > build, probe >= build, probe < build, probe <= build, probe = build
+            let build_col = |idx: usize, name: &str| -> Arc<dyn PhysicalExpr> {
+                Arc::new(Column::new(name, idx))
+            };
+            let probe_col = |idx: usize, name: &str| -> Arc<dyn PhysicalExpr> {
+                Arc::new(Column::new(name, idx))
+            };
+
+            // Each comparison: probe_col(right) <op> build_col(left)
+            // column_indices layout: [Left(0), Right(0), Left(1), Right(1), ...]
+            let exprs: Vec<(Operator, BoundType)> = vec![
+                (Operator::Gt, BoundType::ProbeGt),
+                (Operator::GtEq, BoundType::ProbeGtEq),
+                (Operator::Lt, BoundType::ProbeLt),
+                (Operator::LtEq, BoundType::ProbeLtEq),
+                (Operator::Eq, BoundType::ProbeEq),
+            ];
+
+            for (op, expected_bound) in exprs {
+                // Intermediate schema: [Left(0)=build_val, Right(0)=probe_val]
+                let b = build_col(0, "b");
+                let p = probe_col(1, "p");
+                let expr = Arc::new(BinaryExpr::new(p, op, b)) as Arc<dyn PhysicalExpr>;
+
+                let filter = make_filter(
+                    expr,
+                    vec![0],
+                    vec![0],
+                    vec![
+                        Field::new("b", DataType::Int32, true),
+                        Field::new("p", DataType::Int32, true),
+                    ],
+                );
+
+                let pairs = nlj_filter_analysis::extract_bound_pairs(&filter);
+                assert_eq!(pairs.len(), 1, "Failed for operator {op:?}");
+                assert_eq!(
+                    pairs[0].bound_type, expected_bound,
+                    "Failed for operator {op:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn test_build_probe_predicate_multi_column() {
+            // Two probe columns: ts >= min(start) AND amount <= max(max_amount)
+            let pairs = vec![
+                BoundPair {
+                    probe_col_idx: 0,
+                    build_col_idx: 0,
+                    bound_type: BoundType::ProbeGtEq,
+                },
+                BoundPair {
+                    probe_col_idx: 1,
+                    build_col_idx: 1,
+                    bound_type: BoundType::ProbeLtEq,
+                },
+            ];
+            let mut mins = HashMap::new();
+            mins.insert(0, ScalarValue::Int64(Some(100)));
+            mins.insert(1, ScalarValue::Int64(Some(50)));
+            let mut maxes = HashMap::new();
+            maxes.insert(0, ScalarValue::Int64(Some(300)));
+            maxes.insert(1, ScalarValue::Int64(Some(500)));
+
+            let probe_schema = Schema::new(vec![
+                Field::new("ts", DataType::Int64, true),
+                Field::new("amount", DataType::Int64, true),
+            ]);
+
+            let predicate = nlj_filter_analysis::build_probe_predicate(
+                &pairs,
+                &mins,
+                &maxes,
+                &probe_schema,
+            );
+
+            assert!(predicate.is_some());
+            let display = format!("{}", predicate.unwrap());
+            // Should contain: ts >= 100 AND amount <= 500
+            assert!(
+                display.contains("ts"),
+                "Expected ts in predicate: {display}"
+            );
+            assert!(
+                display.contains("amount"),
+                "Expected amount in predicate: {display}"
+            );
+            assert!(
+                display.contains(">="),
+                "Expected >= in predicate: {display}"
+            );
+            assert!(
+                display.contains("<="),
+                "Expected <= in predicate: {display}"
+            );
+        }
+
+        #[test]
+        fn test_compute_build_bounds_multi_column() {
+            // Two build columns: start=[100, 200, 300], max_amount=[50, 500, 250]
+            let start = Arc::new(arrow::array::Int64Array::from(vec![100, 200, 300]));
+            let max_amt = Arc::new(arrow::array::Int64Array::from(vec![50, 500, 250]));
+            let batch = RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("start", DataType::Int64, false),
+                    Field::new("max_amount", DataType::Int64, false),
+                ])),
+                vec![start, max_amt],
+            )
+            .unwrap();
+
+            let pairs = vec![
+                BoundPair {
+                    probe_col_idx: 0,
+                    build_col_idx: 0,
+                    bound_type: BoundType::ProbeGtEq,
+                },
+                BoundPair {
+                    probe_col_idx: 1,
+                    build_col_idx: 1,
+                    bound_type: BoundType::ProbeLtEq,
+                },
+            ];
+
+            let (mins, maxes) =
+                nlj_filter_analysis::compute_build_bounds(&batch, &pairs).unwrap();
+
+            assert_eq!(mins[&0], ScalarValue::Int64(Some(100)));
+            assert_eq!(maxes[&0], ScalarValue::Int64(Some(300)));
+            assert_eq!(mins[&1], ScalarValue::Int64(Some(50)));
+            assert_eq!(maxes[&1], ScalarValue::Int64(Some(500)));
+        }
     }
 }

--- a/datafusion/physical-plan/src/joins/nlj_filter_analysis.rs
+++ b/datafusion/physical-plan/src/joins/nlj_filter_analysis.rs
@@ -1,0 +1,456 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Expression analysis for dynamic filter pushdown in Nested Loop Joins.
+//!
+//! Unlike HashJoin which has explicit equi-join keys (`on: JoinOn`), NLJ only has
+//! a `JoinFilter` with arbitrary expressions. This module walks the filter expression
+//! to extract `(probe_col, operator, build_col)` pairs that can be converted into
+//! bounds-based dynamic filters.
+//!
+//! For example, `e.ts BETWEEN w.start AND w.end` (which expands to
+//! `e.ts >= w.start AND e.ts <= w.end`) yields two bound pairs:
+//! - probe.ts >= build.start → push `probe.ts >= min(build.start)`
+//! - probe.ts <= build.end   → push `probe.ts <= max(build.end)`
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::joins::join_filter::JoinFilter;
+use crate::joins::utils::ColumnIndex;
+
+use arrow::datatypes::Schema;
+use datafusion_common::{JoinSide, Result, ScalarValue};
+use datafusion_expr::Operator;
+use datafusion_physical_expr::expressions::{BinaryExpr, Column, lit};
+use datafusion_physical_expr::utils::split_conjunction;
+use datafusion_physical_expr::{PhysicalExpr, PhysicalExprRef};
+
+/// How to derive the probe-side bound from a build-side column's min/max.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(clippy::enum_variant_names)]
+pub(crate) enum BoundType {
+    /// probe >= build → push `probe >= min(build)`
+    ProbeGtEq,
+    /// probe > build → push `probe > min(build)`
+    ProbeGt,
+    /// probe <= build → push `probe <= max(build)`
+    ProbeLtEq,
+    /// probe < build → push `probe < max(build)`
+    ProbeLt,
+    /// probe = build → push `probe >= min(build) AND probe <= max(build)`
+    ProbeEq,
+}
+
+/// A pair linking a probe-side column to a build-side column with a derivation rule.
+#[derive(Debug, Clone)]
+pub(crate) struct BoundPair {
+    /// Column index in the probe (right) child's schema
+    pub probe_col_idx: usize,
+    /// Column index in the build (left) child's schema
+    pub build_col_idx: usize,
+    /// How to derive the probe-side bound
+    pub bound_type: BoundType,
+}
+
+/// Walk the JoinFilter expression tree and extract bound pairs.
+///
+/// Only handles top-level AND conjuncts that are simple BinaryExpr comparisons
+/// between a build-side column and a probe-side column. Skips OR, function calls,
+/// nested expressions, and literal comparisons.
+///
+/// # How it works
+///
+/// The JoinFilter expression uses an **intermediate schema** where column positions
+/// map to actual left/right columns via `column_indices`. For example:
+///
+/// ```text
+/// SQL: SELECT * FROM events e JOIN windows w ON e.ts BETWEEN w.start AND w.end
+///
+/// JoinFilter:
+///   expression: Col(0) >= Col(1) AND Col(0) <= Col(2)
+///   column_indices: [
+///     0 → ColumnIndex { index: 0, side: Right }  // e.ts (probe)
+///     1 → ColumnIndex { index: 0, side: Left  }  // w.start (build)
+///     2 → ColumnIndex { index: 1, side: Left  }  // w.end (build)
+///   ]
+///
+/// Step 1: split_conjunction → [Col(0) >= Col(1), Col(0) <= Col(2)]
+///
+/// Step 2: For "Col(0) >= Col(1)":
+///   Col(0) → column_indices[0] → Right (probe), original index 0 (e.ts)
+///   Col(1) → column_indices[1] → Left (build), original index 0 (w.start)
+///   Pattern: probe >= build → BoundType::ProbeGtEq
+///   Result: BoundPair { probe_col_idx: 0, build_col_idx: 0, ProbeGtEq }
+///
+/// Step 3: For "Col(0) <= Col(2)":
+///   Col(0) → Right (probe), e.ts
+///   Col(2) → Left (build), original index 1 (w.end)
+///   Pattern: probe <= build → BoundType::ProbeLtEq
+///   Result: BoundPair { probe_col_idx: 0, build_col_idx: 1, ProbeLtEq }
+///
+/// Output: [
+///   BoundPair { probe=e.ts, build=w.start, ProbeGtEq },
+///   BoundPair { probe=e.ts, build=w.end,   ProbeLtEq },
+/// ]
+/// ```
+///
+/// At runtime, these pairs tell us:
+/// - Collect min(w.start), max(w.end) from build batch
+/// - Push to probe scan: `e.ts >= min(w.start) AND e.ts <= max(w.end)`
+pub(crate) fn extract_bound_pairs(filter: &JoinFilter) -> Vec<BoundPair> {
+    let expr = filter.expression();
+    let column_indices = filter.column_indices();
+    let conjuncts = split_conjunction(expr);
+
+    let mut pairs = Vec::new();
+    for conjunct in conjuncts {
+        if let Some(pair) = try_extract_bound_pair(conjunct.as_ref(), column_indices) {
+            pairs.push(pair);
+        }
+    }
+    pairs
+}
+
+/// Try to extract a BoundPair from a single expression.
+/// Returns Some if the expression is `Column <cmp_op> Column` where one side is
+/// build (Left) and the other is probe (Right).
+fn try_extract_bound_pair(
+    expr: &dyn PhysicalExpr,
+    column_indices: &[ColumnIndex],
+) -> Option<BoundPair> {
+    let binary = expr.downcast_ref::<BinaryExpr>()?;
+    let op = *binary.op();
+
+    // Only handle comparison operators
+    if !matches!(
+        op,
+        Operator::Eq | Operator::Gt | Operator::GtEq | Operator::Lt | Operator::LtEq
+    ) {
+        return None;
+    }
+
+    // Both children must be Column references into the intermediate schema
+    let left_col = binary.left().downcast_ref::<Column>()?;
+    let right_col = binary.right().downcast_ref::<Column>()?;
+
+    let left_idx = left_col.index();
+    let right_idx = right_col.index();
+
+    // Look up which side each column belongs to
+    let left_ci = column_indices.get(left_idx)?;
+    let right_ci = column_indices.get(right_idx)?;
+
+    // We need one build (Left) and one probe (Right)
+    match (left_ci.side, right_ci.side) {
+        (JoinSide::Left, JoinSide::Right) => {
+            // Expression: build_col <op> probe_col
+            // Flip to probe perspective: probe_col <flipped_op> build_col
+            let bound_type = flip_operator_to_probe_perspective(op)?;
+            Some(BoundPair {
+                probe_col_idx: right_ci.index,
+                build_col_idx: left_ci.index,
+                bound_type,
+            })
+        }
+        (JoinSide::Right, JoinSide::Left) => {
+            // Expression: probe_col <op> build_col (already in probe perspective)
+            let bound_type = operator_to_bound_type(op)?;
+            Some(BoundPair {
+                probe_col_idx: left_ci.index,
+                build_col_idx: right_ci.index,
+                bound_type,
+            })
+        }
+        _ => None, // Both same side, or JoinSide::None
+    }
+}
+
+/// Convert operator to BoundType when expression is `probe <op> build`.
+fn operator_to_bound_type(op: Operator) -> Option<BoundType> {
+    match op {
+        Operator::Eq => Some(BoundType::ProbeEq),
+        Operator::Gt => Some(BoundType::ProbeGt),
+        Operator::GtEq => Some(BoundType::ProbeGtEq),
+        Operator::Lt => Some(BoundType::ProbeLt),
+        Operator::LtEq => Some(BoundType::ProbeLtEq),
+        _ => None,
+    }
+}
+
+/// Flip operator when expression is `build <op> probe` to probe perspective.
+///
+/// When the JoinFilter expression has the build column on the left and probe on
+/// the right, we need to flip the operator to express it from the probe's point
+/// of view, since the pushed predicate applies to the probe side.
+///
+/// # Examples
+///
+/// ```text
+/// Expression: w.start <= e.ts   (build <= probe)
+/// Flipped:    e.ts >= w.start   (probe >= build)
+/// → BoundType::ProbeGtEq → push: e.ts >= min(w.start)
+///
+/// Expression: w.end > e.ts      (build > probe)
+/// Flipped:    e.ts < w.end      (probe < build)
+/// → BoundType::ProbeLt → push: e.ts < max(w.end)
+///
+/// Expression: w.id = e.id       (build = probe)
+/// Flipped:    e.id = w.id       (equality is symmetric)
+/// → BoundType::ProbeEq → push: e.id >= min(w.id) AND e.id <= max(w.id)
+/// ```
+fn flip_operator_to_probe_perspective(op: Operator) -> Option<BoundType> {
+    match op {
+        Operator::Eq => Some(BoundType::ProbeEq),
+        Operator::Gt => Some(BoundType::ProbeLt), // build > probe ≡ probe < build
+        Operator::GtEq => Some(BoundType::ProbeLtEq), // build >= probe ≡ probe <= build
+        Operator::Lt => Some(BoundType::ProbeGt), // build < probe ≡ probe > build
+        Operator::LtEq => Some(BoundType::ProbeGtEq), // build <= probe ≡ probe >= build
+        _ => None,
+    }
+}
+
+/// Compute min/max values for build-side columns referenced by bound pairs.
+///
+/// Called after the build side is fully collected into a single merged batch.
+/// Only computes min/max for columns actually referenced in the bound pairs
+/// (avoids unnecessary work for columns not involved in cross-side comparisons).
+///
+/// # Example
+///
+/// ```text
+/// Build batch (windows table):
+///   col 0 (start): [100, 200, 300]
+///   col 1 (end):   [150, 250, 400]
+///   col 2 (name):  ["a", "b", "c"]   ← not referenced in any BoundPair
+///
+/// Bound pairs: [
+///   BoundPair { build_col_idx: 0, ... },  // references w.start
+///   BoundPair { build_col_idx: 1, ... },  // references w.end
+/// ]
+///
+/// Result:
+///   mins  = { 0 → ScalarValue::Int32(100), 1 → ScalarValue::Int32(150) }
+///   maxes = { 0 → ScalarValue::Int32(300), 1 → ScalarValue::Int32(400) }
+///
+/// col 2 (name) is skipped — not in any BoundPair.
+/// ```
+///
+/// Returns two maps: `build_col_idx → min_value` and `build_col_idx → max_value`.
+/// Null values are skipped during min/max computation.
+pub(crate) fn compute_build_bounds(
+    batch: &arrow::record_batch::RecordBatch,
+    bound_pairs: &[BoundPair],
+) -> Result<(HashMap<usize, ScalarValue>, HashMap<usize, ScalarValue>)> {
+    let mut mins = HashMap::new();
+    let mut maxes = HashMap::new();
+
+    // Collect unique build column indices that need min/max
+    let build_cols: std::collections::HashSet<usize> =
+        bound_pairs.iter().map(|p| p.build_col_idx).collect();
+
+    for &col_idx in &build_cols {
+        let col = batch.column(col_idx);
+        let num_rows = col.len();
+
+        if num_rows == 0 {
+            continue;
+        }
+
+        // Find min and max by iterating through non-null values
+        let mut min_val: Option<ScalarValue> = None;
+        let mut max_val: Option<ScalarValue> = None;
+
+        for row in 0..num_rows {
+            if col.is_null(row) {
+                continue;
+            }
+            let val = ScalarValue::try_from_array(col, row)?;
+            min_val = Some(match min_val {
+                None => val.clone(),
+                Some(current) => {
+                    if val.partial_cmp(&current) == Some(std::cmp::Ordering::Less) {
+                        val.clone()
+                    } else {
+                        current
+                    }
+                }
+            });
+            max_val = Some(match max_val {
+                None => val,
+                Some(current) => {
+                    if val.partial_cmp(&current) == Some(std::cmp::Ordering::Greater) {
+                        val
+                    } else {
+                        current
+                    }
+                }
+            });
+        }
+
+        if let (Some(min), Some(max)) = (min_val, max_val) {
+            mins.insert(col_idx, min);
+            maxes.insert(col_idx, max);
+        }
+    }
+
+    Ok((mins, maxes))
+}
+
+/// Build a probe-side predicate from BoundPairs and computed min/max values.
+///
+/// Combines the bound pairs with actual min/max values to produce a filter
+/// expression that can be pushed to the probe-side scan for row group pruning.
+///
+/// # Example
+///
+/// ```text
+/// Input:
+///   pairs = [
+///     BoundPair { probe_col_idx: 0 (e.ts), build_col_idx: 0 (w.start), ProbeGtEq },
+///     BoundPair { probe_col_idx: 0 (e.ts), build_col_idx: 1 (w.end),   ProbeLtEq },
+///   ]
+///   build_mins  = { 0 → 100, 1 → 150 }
+///   build_maxes = { 0 → 300, 1 → 400 }
+///
+/// Processing:
+///   Pair 1 (ProbeGtEq): e.ts >= min(w.start) → e.ts >= 100
+///   Pair 2 (ProbeLtEq): e.ts <= max(w.end)   → e.ts <= 400
+///
+/// Output: e.ts >= 100 AND e.ts <= 400
+/// ```
+///
+/// This predicate is pushed to the probe scan via `DynamicFilterPhysicalExpr::update()`.
+/// The scan uses it for Parquet row group pruning (skip groups where
+/// `ts_max < 100` or `ts_min > 400`).
+///
+/// Returns None if no predicates can be built (e.g., all build columns are null).
+pub(crate) fn build_probe_predicate(
+    pairs: &[BoundPair],
+    build_mins: &HashMap<usize, ScalarValue>,
+    build_maxes: &HashMap<usize, ScalarValue>,
+    probe_schema: &Schema,
+) -> Option<Arc<dyn PhysicalExpr>> {
+    let mut predicates: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
+
+    for pair in pairs {
+        let probe_col: Arc<dyn PhysicalExpr> = Arc::new(Column::new(
+            probe_schema.field(pair.probe_col_idx).name(),
+            pair.probe_col_idx,
+        ));
+
+        match pair.bound_type {
+            BoundType::ProbeGtEq => {
+                if let Some(min_val) = build_mins.get(&pair.build_col_idx)
+                    && !min_val.is_null()
+                {
+                    predicates.push(Arc::new(BinaryExpr::new(
+                        probe_col,
+                        Operator::GtEq,
+                        lit(min_val.clone()),
+                    )));
+                }
+            }
+            BoundType::ProbeGt => {
+                if let Some(min_val) = build_mins.get(&pair.build_col_idx)
+                    && !min_val.is_null()
+                {
+                    predicates.push(Arc::new(BinaryExpr::new(
+                        probe_col,
+                        Operator::Gt,
+                        lit(min_val.clone()),
+                    )));
+                }
+            }
+            BoundType::ProbeLtEq => {
+                if let Some(max_val) = build_maxes.get(&pair.build_col_idx)
+                    && !max_val.is_null()
+                {
+                    predicates.push(Arc::new(BinaryExpr::new(
+                        probe_col,
+                        Operator::LtEq,
+                        lit(max_val.clone()),
+                    )));
+                }
+            }
+            BoundType::ProbeLt => {
+                if let Some(max_val) = build_maxes.get(&pair.build_col_idx)
+                    && !max_val.is_null()
+                {
+                    predicates.push(Arc::new(BinaryExpr::new(
+                        probe_col,
+                        Operator::Lt,
+                        lit(max_val.clone()),
+                    )));
+                }
+            }
+            BoundType::ProbeEq => {
+                if let Some(min_val) = build_mins.get(&pair.build_col_idx)
+                    && !min_val.is_null()
+                {
+                    predicates.push(Arc::new(BinaryExpr::new(
+                        Arc::clone(&probe_col),
+                        Operator::GtEq,
+                        lit(min_val.clone()),
+                    )));
+                }
+                if let Some(max_val) = build_maxes.get(&pair.build_col_idx)
+                    && !max_val.is_null()
+                {
+                    predicates.push(Arc::new(BinaryExpr::new(
+                        probe_col,
+                        Operator::LtEq,
+                        lit(max_val.clone()),
+                    )));
+                }
+            }
+        }
+    }
+
+    if predicates.is_empty() {
+        None
+    } else {
+        Some(
+            predicates
+                .into_iter()
+                .reduce(|acc, pred| {
+                    Arc::new(BinaryExpr::new(acc, Operator::And, pred))
+                        as Arc<dyn PhysicalExpr>
+                })
+                .unwrap(),
+        )
+    }
+}
+
+/// Get the unique probe-side column indices referenced by the bound pairs.
+/// Used to create DynamicFilterPhysicalExpr children.
+pub(crate) fn probe_columns_from_pairs(
+    pairs: &[BoundPair],
+    probe_schema: &Schema,
+) -> Vec<PhysicalExprRef> {
+    let mut seen = std::collections::HashSet::new();
+    let mut cols = Vec::new();
+    for pair in pairs {
+        if seen.insert(pair.probe_col_idx) {
+            cols.push(Arc::new(Column::new(
+                probe_schema.field(pair.probe_col_idx).name(),
+                pair.probe_col_idx,
+            )) as PhysicalExprRef);
+        }
+    }
+    cols
+}

--- a/datafusion/sqllogictest/test_files/nlj_dynamic_filter.slt
+++ b/datafusion/sqllogictest/test_files/nlj_dynamic_filter.slt
@@ -1,0 +1,387 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for dynamic filter pushdown in NestedLoopJoinExec.
+#
+# NLJ handles non-equijoin predicates (range, temporal, inequality).
+# Dynamic filters extract build-side bounds from the JoinFilter expression
+# and push them to the probe-side scan for Parquet row group pruning.
+#
+# For example, `events JOIN windows ON e.ts BETWEEN w.start AND w.end`
+# derives `e.ts >= min(w.start) AND e.ts <= max(w.end)` from the build
+# side and pushes it to the events scan.
+
+# Setup: enable filter pushdown and collect statistics
+statement ok
+set datafusion.execution.parquet.pushdown_filters = true;
+
+statement ok
+set datafusion.execution.parquet.reorder_filters = true;
+
+# Use small row groups so pruning is visible in tests
+statement ok
+set datafusion.execution.parquet.max_row_group_size = 5;
+
+statement ok
+set datafusion.explain.physical_plan_only = true;
+
+# ================================================================
+# Create test data
+# ================================================================
+
+# Build side (windows): small table with narrow ranges
+# start: [100, 200, 300], end: [150, 250, 400]
+statement ok
+CREATE TABLE windows_mem(start INT, end_val INT) AS VALUES
+(100, 150),
+(200, 250),
+(300, 400);
+
+query I
+COPY windows_mem TO 'test_files/scratch/nlj_dynamic_filter/windows.parquet'
+STORED AS PARQUET;
+----
+3
+
+statement ok
+CREATE EXTERNAL TABLE windows_parquet(start INT, end_val INT)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/nlj_dynamic_filter/windows.parquet';
+
+# Probe side (events): larger table with timestamps spanning wide range
+# 50 rows: ts = [1, 2, 3, ..., 50] * 10 = [10, 20, 30, ..., 500]
+# With row_group_size=5, this creates 10 row groups
+statement ok
+CREATE TABLE events_mem(ts INT, payload VARCHAR) AS
+SELECT value * 10 AS ts, 'data_' || CAST(value AS VARCHAR) AS payload
+FROM generate_series(1, 50) AS t(value);
+
+query I
+COPY events_mem TO 'test_files/scratch/nlj_dynamic_filter/events.parquet'
+STORED AS PARQUET;
+----
+50
+
+statement ok
+CREATE EXTERNAL TABLE events_parquet(ts INT, payload VARCHAR)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/nlj_dynamic_filter/events.parquet';
+
+# ================================================================
+# Test 1: Correctness — range join results
+# ================================================================
+# events.ts BETWEEN windows.start AND windows.end_val
+# Matching events:
+#   window (100, 150): ts in {100, 110, 120, 130, 140, 150}
+#   window (200, 250): ts in {200, 210, 220, 230, 240, 250}
+#   window (300, 400): ts in {300, 310, 320, 330, 340, 350, 360, 370, 380, 390, 400}
+
+query III rowsort
+SELECT e.ts, w.start, w.end_val
+FROM events_parquet e
+INNER JOIN windows_parquet w
+  ON e.ts >= w.start AND e.ts <= w.end_val
+ORDER BY e.ts, w.start;
+----
+100 100 150
+110 100 150
+120 100 150
+130 100 150
+140 100 150
+150 100 150
+200 200 250
+210 200 250
+220 200 250
+230 200 250
+240 200 250
+250 200 250
+300 300 400
+310 300 400
+320 300 400
+330 300 400
+340 300 400
+350 300 400
+360 300 400
+370 300 400
+380 300 400
+390 300 400
+400 300 400
+
+# ================================================================
+# Test 2: EXPLAIN shows NestedLoopJoinExec with DynamicFilter
+# ================================================================
+
+query TT
+EXPLAIN
+SELECT e.ts, w.start, w.end_val
+FROM events_parquet e
+INNER JOIN windows_parquet w
+  ON e.ts >= w.start AND e.ts <= w.end_val;
+----
+physical_plan
+01)NestedLoopJoinExec: join_type=Inner, filter=ts@0 >= start@1 AND ts@0 <= end_val@2, projection=[ts@2, start@0, end_val@1]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/nlj_dynamic_filter/windows.parquet]]}, projection=[start, end_val], file_type=parquet
+03)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/nlj_dynamic_filter/events.parquet]]}, projection=[ts], file_type=parquet, predicate=DynamicFilter [ empty ]
+
+# ================================================================
+# Test 3: DynamicFilter disabled when config is off
+# ================================================================
+
+statement ok
+SET datafusion.optimizer.enable_join_dynamic_filter_pushdown = false;
+
+query TT
+EXPLAIN
+SELECT e.ts, w.start, w.end_val
+FROM events_parquet e
+INNER JOIN windows_parquet w
+  ON e.ts >= w.start AND e.ts <= w.end_val;
+----
+physical_plan
+01)NestedLoopJoinExec: join_type=Inner, filter=ts@0 >= start@1 AND ts@0 <= end_val@2, projection=[ts@2, start@0, end_val@1]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/nlj_dynamic_filter/windows.parquet]]}, projection=[start, end_val], file_type=parquet
+03)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/nlj_dynamic_filter/events.parquet]]}, projection=[ts], file_type=parquet
+
+# Re-enable for remaining tests
+statement ok
+SET datafusion.optimizer.enable_join_dynamic_filter_pushdown = true;
+
+# ================================================================
+# Test 4: Correctness with inequality join (probe > build)
+# ================================================================
+
+query II rowsort
+SELECT e.ts, w.start
+FROM events_parquet e
+INNER JOIN windows_parquet w
+  ON e.ts > w.start
+WHERE w.start = 300
+ORDER BY e.ts;
+----
+310 300
+320 300
+330 300
+340 300
+350 300
+360 300
+370 300
+380 300
+390 300
+400 300
+410 300
+420 300
+430 300
+440 300
+450 300
+460 300
+470 300
+480 300
+490 300
+500 300
+
+# ================================================================
+# Test 5: Correctness with BETWEEN expression
+# ================================================================
+# BETWEEN expands to >= AND <=, which our expression analysis handles.
+# events.ts BETWEEN windows.start AND windows.end_val
+# Same results as Test 1 (BETWEEN is syntactic sugar for >= AND <=)
+
+query III rowsort
+SELECT e.ts, w.start, w.end_val
+FROM events_parquet e
+INNER JOIN windows_parquet w
+  ON e.ts BETWEEN w.start AND w.end_val
+ORDER BY e.ts, w.start;
+----
+100 100 150
+110 100 150
+120 100 150
+130 100 150
+140 100 150
+150 100 150
+200 200 250
+210 200 250
+220 200 250
+230 200 250
+240 200 250
+250 200 250
+300 300 400
+310 300 400
+320 300 400
+330 300 400
+340 300 400
+350 300 400
+360 300 400
+370 300 400
+380 300 400
+390 300 400
+400 300 400
+
+# ================================================================
+# Test 6: Multi-column range join
+# ================================================================
+# Create tables with two range columns for multi-column bound derivation
+
+statement ok
+CREATE TABLE tiers_mem(min_amount INT, max_amount INT, tier VARCHAR) AS VALUES
+(0, 100, 'bronze'),
+(101, 300, 'silver'),
+(301, 500, 'gold');
+
+query I
+COPY tiers_mem TO 'test_files/scratch/nlj_dynamic_filter/tiers.parquet'
+STORED AS PARQUET;
+----
+3
+
+statement ok
+CREATE EXTERNAL TABLE tiers_parquet(min_amount INT, max_amount INT, tier VARCHAR)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/nlj_dynamic_filter/tiers.parquet';
+
+# orders: amount = [10, 20, ..., 500]
+statement ok
+CREATE TABLE orders_mem(amount INT, order_id INT) AS
+SELECT value * 10 AS amount, value AS order_id
+FROM generate_series(1, 50) AS t(value);
+
+query I
+COPY orders_mem TO 'test_files/scratch/nlj_dynamic_filter/orders.parquet'
+STORED AS PARQUET;
+----
+50
+
+statement ok
+CREATE EXTERNAL TABLE orders_parquet(amount INT, order_id INT)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/nlj_dynamic_filter/orders.parquet';
+
+# Multi-column range join: amount >= min_amount AND amount <= max_amount
+# bronze (0-100): amounts 10,20,...,100 = 10 rows
+# silver (101-300): amounts 110,120,...,300 = 20 rows
+# gold (301-500): amounts 310,320,...,500 = 20 rows
+
+query I
+SELECT count(*)
+FROM orders_parquet o
+INNER JOIN tiers_parquet t
+  ON o.amount >= t.min_amount AND o.amount <= t.max_amount;
+----
+50
+
+query TI rowsort
+SELECT t.tier, o.amount
+FROM orders_parquet o
+INNER JOIN tiers_parquet t
+  ON o.amount >= t.min_amount AND o.amount <= t.max_amount
+WHERE t.tier = 'gold'
+ORDER BY o.amount;
+----
+gold 310
+gold 320
+gold 330
+gold 340
+gold 350
+gold 360
+gold 370
+gold 380
+gold 390
+gold 400
+gold 410
+gold 420
+gold 430
+gold 440
+gold 450
+gold 460
+gold 470
+gold 480
+gold 490
+gold 500
+
+# ================================================================
+# Test 7: Combination of cross-side and same-side predicates
+# ================================================================
+# e.ts >= w.start AND e.ts <= w.end_val AND w.start > 150
+# The same-side predicate (w.start > 150) is not extractable as a bound pair
+# but should not break the cross-side extraction
+
+query III rowsort
+SELECT e.ts, w.start, w.end_val
+FROM events_parquet e
+INNER JOIN windows_parquet w
+  ON e.ts >= w.start AND e.ts <= w.end_val
+WHERE w.start > 150
+ORDER BY e.ts, w.start;
+----
+200 200 250
+210 200 250
+220 200 250
+230 200 250
+240 200 250
+250 200 250
+300 300 400
+310 300 400
+320 300 400
+330 300 400
+340 300 400
+350 300 400
+360 300 400
+370 300 400
+380 300 400
+390 300 400
+400 300 400
+
+# ================================================================
+# Cleanup
+# ================================================================
+
+statement ok
+DROP TABLE windows_mem;
+
+statement ok
+DROP TABLE events_mem;
+
+statement ok
+DROP TABLE windows_parquet;
+
+statement ok
+DROP TABLE events_parquet;
+
+statement ok
+DROP TABLE tiers_mem;
+
+statement ok
+DROP TABLE orders_mem;
+
+statement ok
+DROP TABLE tiers_parquet;
+
+statement ok
+DROP TABLE orders_parquet;
+
+# Reset configuration
+statement ok
+set datafusion.execution.parquet.pushdown_filters = false;
+
+statement ok
+set datafusion.execution.parquet.reorder_filters = false;
+
+statement ok
+set datafusion.execution.parquet.max_row_group_size = 1048576;
+
+statement ok
+set datafusion.explain.physical_plan_only = false;


### PR DESCRIPTION
## Which issue does this PR close?     
                                                              
  - Closes [#16973](https://github.com/apache/datafusion/issues/16973) (partial — adds dynamic filter support for NestedLoopJoinExec)
                                                           
  ## Rationale for this change                                           
                                                           
  NestedLoopJoinExec handles non-equi joins (range, temporal, inequality) but currently reads ALL probe-side data even
  when the build side has a narrow range. For example:                       
                                                                         
  ```sql                                                                                                                 
  SELECT * FROM events e JOIN windows w ON e.ts BETWEEN w.start AND w.end
 ```
                                                                                                                         
  If the build side (windows) has start values in [100, 300] and end values in [150, 400], the probe scan reads all
  events even though only events with ts in [100, 400] can possibly match. With dynamic filters, the probe scan can skip 
  row groups outside this range.                                                   
                                                                                                                         
  HashJoinExec already supports dynamic filter pushdown for equi-joins. This PR extends the same mechanism to NLJ for
  non-equi joins by analyzing the JoinFilter expression to derive bounds from build-side data.                           
                                                                                                                         
  ## What changes are included in this PR?                                   
                                                                                                                         
  New: nlj_filter_analysis.rs — Expression analysis module that walks the JoinFilter expression tree to extract          
  (probe_col, operator, build_col) pairs and derive probe-side bounds:                                                   
  - extract_bound_pairs() — finds BinaryExpr comparisons between build and probe columns                                 
  - compute_build_bounds() — computes min/max from the merged build batch               
  - build_probe_predicate() — converts bounds into probe-side filter (e.g., ts >= 100 AND ts <= 400)                     
                                                                                                    
  Modified: nested_loop_join.rs:                                                                                         
  - NLJDynamicFilter struct holding DynamicFilterPhysicalExpr and extracted bound pairs                                  
  - gather_filters_for_pushdown() — creates dynamic filter in Post phase, routes parent filters
  - handle_child_pushdown_result() — captures the filter Arc reference                                                   
  - handle_buffering_left() — after build data is ready, computes bounds and pushes filter before probe starts

 ## Are these changes tested? 

Yes, with UT

 ## Are there any user-facing changes?                                                                                     
                                                                                   
  No.