### PR TITLE
feat: substrait support of  `Decimal32` & `Decimal64`

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer/expr/literal.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/expr/literal.rs
@@ -21,6 +21,8 @@ use crate::logical_plan::consumer::utils::{DEFAULT_TIMEZONE, next_struct_field_n
 use crate::variation_const::FLOAT_16_TYPE_NAME;
 #[expect(deprecated)]
 use crate::variation_const::{
+    DECIMAL_32_TYPE_VARIATION_REF, DECIMAL_64_TYPE_VARIATION_REF,
+    DECIMAL_128_TYPE_VARIATION_REF, DECIMAL_256_TYPE_VARIATION_REF,
     DEFAULT_CONTAINER_TYPE_VARIATION_REF, DEFAULT_TYPE_VARIATION_REF,
     INTERVAL_DAY_TIME_TYPE_REF, INTERVAL_MONTH_DAY_NANO_TYPE_NAME,
     INTERVAL_MONTH_DAY_NANO_TYPE_REF, INTERVAL_YEAR_MONTH_TYPE_REF,
@@ -32,7 +34,7 @@ use crate::variation_const::{
 };
 use datafusion::arrow::array::{AsArray, MapArray, new_empty_array};
 use datafusion::arrow::buffer::OffsetBuffer;
-use datafusion::arrow::datatypes::{Field, IntervalDayTime, IntervalMonthDayNano};
+use datafusion::arrow::datatypes::{Field, IntervalDayTime, IntervalMonthDayNano, i256};
 use datafusion::arrow::temporal_conversions::NANOSECONDS;
 use datafusion::common::scalar::ScalarStructBuilder;
 use datafusion::common::{
@@ -220,18 +222,50 @@ pub(crate) fn from_substrait_literal(
             ScalarValue::FixedSizeBinary(b.len() as _, Some(b.clone()))
         }
         Some(LiteralType::Decimal(d)) => {
-            let value: [u8; 16] = d
-                .value
-                .clone()
-                .try_into()
-                .or(substrait_err!("Failed to parse decimal value"))?;
             let p = d.precision.try_into().map_err(|e| {
                 substrait_datafusion_err!("Failed to parse decimal precision: {e}")
             })?;
             let s = d.scale.try_into().map_err(|e| {
                 substrait_datafusion_err!("Failed to parse decimal scale: {e}")
             })?;
-            ScalarValue::Decimal128(Some(i128::from_le_bytes(value)), p, s)
+
+            match lit.type_variation_reference {
+                DECIMAL_32_TYPE_VARIATION_REF => {
+                    let value: [u8; 4] = d
+                        .value
+                        .clone()
+                        .try_into()
+                        .or(substrait_err!("Failed to parse decimal value"))?;
+                    ScalarValue::Decimal32(Some(i32::from_le_bytes(value)), p, s)
+                }
+                DECIMAL_64_TYPE_VARIATION_REF => {
+                    let value: [u8; 8] = d
+                        .value
+                        .clone()
+                        .try_into()
+                        .or(substrait_err!("Failed to parse decimal value"))?;
+                    ScalarValue::Decimal64(Some(i64::from_le_bytes(value)), p, s)
+                }
+                DECIMAL_128_TYPE_VARIATION_REF => {
+                    let value: [u8; 16] = d
+                        .value
+                        .clone()
+                        .try_into()
+                        .or(substrait_err!("Failed to parse decimal value"))?;
+                    ScalarValue::Decimal128(Some(i128::from_le_bytes(value)), p, s)
+                }
+                DECIMAL_256_TYPE_VARIATION_REF => {
+                    let value: [u8; 32] = d
+                        .value
+                        .clone()
+                        .try_into()
+                        .or(substrait_err!("Failed to parse decimal value"))?;
+                    ScalarValue::Decimal256(Some(i256::from_le_bytes(value)), p, s)
+                }
+                others => {
+                    return substrait_err!("Unknown type variation reference {others}");
+                }
+            }
         }
         Some(LiteralType::List(l)) => {
             // Each element should start the name index from the same value, then we increase it

--- a/datafusion/substrait/src/logical_plan/consumer/types.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/types.rs
@@ -20,6 +20,7 @@ use super::utils::{DEFAULT_TIMEZONE, from_substrait_precision, next_struct_field
 #[expect(deprecated)]
 use crate::variation_const::{
     DATE_32_TYPE_VARIATION_REF, DATE_64_TYPE_VARIATION_REF,
+    DECIMAL_32_TYPE_VARIATION_REF, DECIMAL_64_TYPE_VARIATION_REF,
     DECIMAL_128_TYPE_VARIATION_REF, DECIMAL_256_TYPE_VARIATION_REF,
     DEFAULT_CONTAINER_TYPE_VARIATION_REF, DEFAULT_INTERVAL_DAY_TYPE_VARIATION_REF,
     DEFAULT_MAP_TYPE_VARIATION_REF, DEFAULT_TYPE_VARIATION_REF,
@@ -226,6 +227,12 @@ pub fn from_substrait_type(
                 }
             }
             r#type::Kind::Decimal(d) => match d.type_variation_reference {
+                DECIMAL_32_TYPE_VARIATION_REF => {
+                    Ok(DataType::Decimal32(d.precision as u8, d.scale as i8))
+                }
+                DECIMAL_64_TYPE_VARIATION_REF => {
+                    Ok(DataType::Decimal64(d.precision as u8, d.scale as i8))
+                }
                 DECIMAL_128_TYPE_VARIATION_REF => {
                     Ok(DataType::Decimal128(d.precision as u8, d.scale as i8))
                 }

--- a/datafusion/substrait/src/logical_plan/producer/expr/literal.rs
+++ b/datafusion/substrait/src/logical_plan/producer/expr/literal.rs
@@ -17,7 +17,8 @@
 
 use crate::logical_plan::producer::{SubstraitProducer, to_substrait_type};
 use crate::variation_const::{
-    DATE_32_TYPE_VARIATION_REF, DECIMAL_128_TYPE_VARIATION_REF,
+    DATE_32_TYPE_VARIATION_REF, DECIMAL_32_TYPE_VARIATION_REF,
+    DECIMAL_64_TYPE_VARIATION_REF, DECIMAL_128_TYPE_VARIATION_REF,
     DEFAULT_CONTAINER_TYPE_VARIATION_REF, DEFAULT_TYPE_VARIATION_REF, FLOAT_16_TYPE_NAME,
     LARGE_CONTAINER_TYPE_VARIATION_REF, TIME_32_TYPE_VARIATION_REF,
     TIME_64_TYPE_VARIATION_REF, UNSIGNED_INTEGER_TYPE_VARIATION_REF,
@@ -259,6 +260,22 @@ pub(crate) fn to_substrait_literal(
             LiteralType::String(s.clone()),
             VIEW_CONTAINER_TYPE_VARIATION_REF,
         ),
+        ScalarValue::Decimal32(v, p, s) if v.is_some() => (
+            LiteralType::Decimal(Decimal {
+                value: v.unwrap().to_le_bytes().to_vec(),
+                precision: *p as i32,
+                scale: *s as i32,
+            }),
+            DECIMAL_32_TYPE_VARIATION_REF,
+        ),
+        ScalarValue::Decimal64(v, p, s) if v.is_some() => (
+            LiteralType::Decimal(Decimal {
+                value: v.unwrap().to_le_bytes().to_vec(),
+                precision: *p as i32,
+                scale: *s as i32,
+            }),
+            DECIMAL_64_TYPE_VARIATION_REF,
+        ),
         ScalarValue::Decimal128(v, p, s) if v.is_some() => (
             LiteralType::Decimal(Decimal {
                 value: v.unwrap().to_le_bytes().to_vec(),
@@ -475,6 +492,11 @@ mod tests {
         round_trip_literal(ScalarValue::Time64Microsecond(None))?;
         round_trip_literal(ScalarValue::Time64Nanosecond(Some(45296789123000)))?;
         round_trip_literal(ScalarValue::Time64Nanosecond(None))?;
+
+        round_trip_literal(ScalarValue::Decimal32(Some(12345), 9, 2))?;
+        round_trip_literal(ScalarValue::Decimal32(None, 9, 2))?;
+        round_trip_literal(ScalarValue::Decimal64(Some(1234567890123456), 18, 2))?;
+        round_trip_literal(ScalarValue::Decimal64(None, 18, 2))?;
 
         round_trip_literal(ScalarValue::List(ScalarValue::new_list_nullable(
             &[ScalarValue::Float32(Some(1.0))],

--- a/datafusion/substrait/src/logical_plan/producer/types.rs
+++ b/datafusion/substrait/src/logical_plan/producer/types.rs
@@ -19,6 +19,7 @@ use crate::logical_plan::producer::utils::flatten_names;
 use crate::logical_plan::producer::{SubstraitProducer, to_substrait_precision};
 use crate::variation_const::{
     DATE_32_TYPE_VARIATION_REF, DATE_64_TYPE_VARIATION_REF,
+    DECIMAL_32_TYPE_VARIATION_REF, DECIMAL_64_TYPE_VARIATION_REF,
     DECIMAL_128_TYPE_VARIATION_REF, DECIMAL_256_TYPE_VARIATION_REF,
     DEFAULT_CONTAINER_TYPE_VARIATION_REF, DEFAULT_INTERVAL_DAY_TYPE_VARIATION_REF,
     DEFAULT_MAP_TYPE_VARIATION_REF, DEFAULT_TYPE_VARIATION_REF,
@@ -340,6 +341,22 @@ pub(crate) fn to_substrait_type_from_field(
                 })),
             })
         }
+        DataType::Decimal32(p, s) => Ok(substrait::proto::Type {
+            kind: Some(r#type::Kind::Decimal(r#type::Decimal {
+                type_variation_reference: DECIMAL_32_TYPE_VARIATION_REF,
+                nullability,
+                scale: *s as i32,
+                precision: *p as i32,
+            })),
+        }),
+        DataType::Decimal64(p, s) => Ok(substrait::proto::Type {
+            kind: Some(r#type::Kind::Decimal(r#type::Decimal {
+                type_variation_reference: DECIMAL_64_TYPE_VARIATION_REF,
+                nullability,
+                scale: *s as i32,
+                precision: *p as i32,
+            })),
+        }),
         DataType::Decimal128(p, s) => Ok(substrait::proto::Type {
             kind: Some(r#type::Kind::Decimal(r#type::Decimal {
                 type_variation_reference: DECIMAL_128_TYPE_VARIATION_REF,
@@ -434,6 +451,8 @@ mod tests {
         round_trip_type(DataType::Utf8)?;
         round_trip_type(DataType::LargeUtf8)?;
         round_trip_type(DataType::Utf8View)?;
+        round_trip_type(DataType::Decimal32(9, 2))?;
+        round_trip_type(DataType::Decimal64(18, 2))?;
         round_trip_type(DataType::Decimal128(10, 2))?;
         round_trip_type(DataType::Decimal256(30, 2))?;
 

--- a/datafusion/substrait/src/variation_const.rs
+++ b/datafusion/substrait/src/variation_const.rs
@@ -59,6 +59,8 @@ pub const DEFAULT_MAP_TYPE_VARIATION_REF: u32 = 0;
 pub const DICTIONARY_MAP_TYPE_VARIATION_REF: u32 = 1;
 pub const DECIMAL_128_TYPE_VARIATION_REF: u32 = 0;
 pub const DECIMAL_256_TYPE_VARIATION_REF: u32 = 1;
+pub const DECIMAL_32_TYPE_VARIATION_REF: u32 = 2;
+pub const DECIMAL_64_TYPE_VARIATION_REF: u32 = 3;
 /// Used for the arrow type [`DataType::Interval`] with [`IntervalUnit::DayTime`].
 ///
 /// [`DataType::Interval`]: datafusion::arrow::datatypes::DataType::Interval


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #21779

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Added support of `Decimal32` and `Decimal64` types for serialization/deserialization of substrait plans.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
