### PR TITLE
perf: Use bulk-NULL string builder in `initcap`

### DIFF
--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -604,7 +604,17 @@ impl StringViewArrayBuilder {
         let offset: u32 = i32::try_from(self.in_progress.len())
             .expect("offset exceeds i32::MAX") as u32;
         self.in_progress.extend_from_slice(v);
-        self.views.push(make_view(v, buffer_index, offset));
+
+        // Build the ByteView inline rather than going through `make_view`,
+        // which is marked as `[inline(never)]`.
+        let view = ByteView {
+            length,
+            // SAFETY: length > 12 here, so v has at least 4 bytes.
+            prefix: u32::from_le_bytes(v[0..4].try_into().unwrap()),
+            buffer_index,
+            offset,
+        };
+        self.views.push(view.into());
     }
 
     /// Append an empty placeholder row. The corresponding slot must be

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -17,13 +17,11 @@
 
 use std::sync::Arc;
 
-use arrow::array::{
-    Array, ArrayRef, GenericStringArray, GenericStringBuilder, OffsetSizeTrait,
-    StringViewBuilder,
-};
+use arrow::array::{Array, ArrayRef, GenericStringArray, OffsetSizeTrait};
 use arrow::buffer::{Buffer, OffsetBuffer};
 use arrow::datatypes::DataType;
 
+use crate::strings::{GenericStringArrayBuilder, StringViewArrayBuilder};
 use crate::utils::{make_scalar_function, utf8_to_str_type};
 use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
 use datafusion_common::types::logical_string;
@@ -157,21 +155,35 @@ fn initcap<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
         return Ok(initcap_ascii_array(string_array));
     }
 
-    let mut builder = GenericStringBuilder::<T>::with_capacity(
-        string_array.len(),
+    let len = string_array.len();
+    let mut builder = GenericStringArrayBuilder::<T>::with_capacity(
+        len,
         string_array.value_data().len(),
     );
 
     let mut container = String::new();
-    string_array.iter().for_each(|str| match str {
-        Some(s) => {
+    let nulls = string_array.nulls().cloned();
+    if let Some(ref n) = nulls {
+        for i in 0..len {
+            if n.is_null(i) {
+                builder.append_placeholder();
+            } else {
+                // SAFETY: not null per check above.
+                let s = unsafe { string_array.value_unchecked(i) };
+                initcap_string(s, &mut container);
+                builder.append_value(&container);
+            }
+        }
+    } else {
+        for i in 0..len {
+            // SAFETY: no null buffer means every index is valid.
+            let s = unsafe { string_array.value_unchecked(i) };
             initcap_string(s, &mut container);
             builder.append_value(&container);
         }
-        None => builder.append_null(),
-    });
+    }
 
-    Ok(Arc::new(builder.finish()) as ArrayRef)
+    Ok(Arc::new(builder.finish(nulls)?) as ArrayRef)
 }
 
 /// Fast path for `Utf8` or `LargeUtf8` arrays that are ASCII-only. We can use a
@@ -232,18 +244,32 @@ fn initcap_ascii_array<T: OffsetSizeTrait>(
 
 fn initcap_utf8view(args: &[ArrayRef]) -> Result<ArrayRef> {
     let string_view_array = as_string_view_array(&args[0])?;
-    let mut builder = StringViewBuilder::with_capacity(string_view_array.len());
+    let len = string_view_array.len();
+    let mut builder = StringViewArrayBuilder::with_capacity(len);
     let mut container = String::new();
 
-    string_view_array.iter().for_each(|str| match str {
-        Some(s) => {
+    let nulls = string_view_array.nulls().cloned();
+    if let Some(ref n) = nulls {
+        for i in 0..len {
+            if n.is_null(i) {
+                builder.append_placeholder();
+            } else {
+                // SAFETY: not null per check above.
+                let s = unsafe { string_view_array.value_unchecked(i) };
+                initcap_string(s, &mut container);
+                builder.append_value(&container);
+            }
+        }
+    } else {
+        for i in 0..len {
+            // SAFETY: no null buffer means every index is valid.
+            let s = unsafe { string_view_array.value_unchecked(i) };
             initcap_string(s, &mut container);
             builder.append_value(&container);
         }
-        None => builder.append_null(),
-    });
+    }
 
-    Ok(Arc::new(builder.finish()) as ArrayRef)
+    Ok(Arc::new(builder.finish(nulls)?) as ArrayRef)
 }
 
 fn initcap_string(input: &str, container: &mut String) {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21862.

## Rationale for this change

Similar to other recent changes, we can use the bulk-NULL string builders to avoid per-row NULL handling overhead.

Benchmarks:

  - scalar/scalar_utf8: 227.4ns → 228.6ns (+0.53%)
  - scalar/scalar_utf8view: 227.9ns → 229.2ns (+0.57%)
  - size=1024 str_len=128/array_utf8: 276.5µs → 277.7µs (+0.43%)
  - size=1024 str_len=128/array_utf8view: 223.3µs → 222.4µs (−0.40%)
  - size=1024 str_len=16/array_utf8: 37.5µs → 37.4µs (−0.27%)
  - size=1024 str_len=16/array_utf8view: 41.9µs → 39.3µs (−6.21%)
  - size=4096 str_len=128/array_utf8: 1115.4µs → 1109.2µs (−0.56%)
  - size=4096 str_len=128/array_utf8view: 900.2µs → 895.2µs (−0.56%)
  - size=4096 str_len=16/array_utf8: 148.3µs → 148.4µs (+0.07%)
  - size=4096 str_len=16/array_utf8view: 164.2µs → 153.8µs (−6.33%)
  - size=8192 str_len=128/array_utf8: 2.2ms → 2.2ms (0.00%)
  - size=8192 str_len=128/array_utf8view: 1811.2µs → 1819.2µs (+0.44%)
  - size=8192 str_len=16/array_utf8: 299.0µs → 299.3µs (+0.10%)
  - size=8192 str_len=16/array_utf8view: 330.6µs → 310.2µs (−6.17%)
  - unicode size=1024/array_utf8: 772.2µs → 769.2µs (−0.39%)
  - unicode size=1024/array_utf8view: 777.8µs → 779.2µs (+0.18%)
  - unicode size=4096/array_utf8: 3.1ms → 3.1ms (0.00%)
  - unicode size=4096/array_utf8view: 3.1ms → 3.1ms (0.00%)
  - unicode size=8192/array_utf8: 6.2ms → 6.1ms (−1.61%)
  - unicode size=8192/array_utf8view: 6.2ms → 6.2ms (0.00%)

## What changes are included in this PR?

* Switch to bulk-NULL string builders
* Optimize `StringViewArrayBuilder::append_value()` by inlining the view construction for > 12 byte strings. Empirically this improved performance, probably because `make_view` can't be inlined. This should also help other PRs in this series.

## Are these changes tested?

Yes, covered by existing tests.

## Are there any user-facing changes?

No.
