### PR TITLE
Fix #21864: Use the correct capacity value in `StringViewArrayBuilder::with_capacity`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7482,3 +7482,31 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "arrow"
+version = "58.1.0"
+
+[[patch.unused]]
+name = "arrow-buffer"
+version = "58.1.0"
+
+[[patch.unused]]
+name = "arrow-flight"
+version = "58.1.0"
+
+[[patch.unused]]
+name = "arrow-ipc"
+version = "58.1.0"
+
+[[patch.unused]]
+name = "arrow-ord"
+version = "58.1.0"
+
+[[patch.unused]]
+name = "arrow-schema"
+version = "58.1.0"
+
+[[patch.unused]]
+name = "parquet"
+version = "58.1.0"

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -133,8 +133,8 @@ pub struct StringViewArrayBuilder {
 }
 
 impl StringViewArrayBuilder {
-    pub fn with_capacity(_item_capacity: usize, data_capacity: usize) -> Self {
-        let builder = StringViewBuilder::with_capacity(data_capacity);
+    pub fn with_capacity(item_capacity: usize, _data_capacity: usize) -> Self {
+        let builder = StringViewBuilder::with_capacity(item_capacity);
         Self {
             builder,
             block: String::new(),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #21864.

## Rationale for this change

Fixes a performance bug by reserving the correct amount of space when calling `StringViewBuilder::with_capacity`.

## What changes are included in this PR?

Single-line change to the body of `StringViewArrayBuilder::with_capacity`.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
