### PR TITLE
chore: bump API limit for stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -37,3 +37,4 @@ jobs:
           days-before-issue-stale: -1
           days-before-issue-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 150


### PR DESCRIPTION
Last few runs for stale workflow is running into limit of `operations-per-run` which by default is 30

- https://github.com/actions/stale#operations-per-run

See:

- https://github.com/apache/datafusion/actions/runs/24868809436
- https://github.com/apache/datafusion/actions/runs/24920208039
- https://github.com/apache/datafusion/actions/runs/24946087481
- https://github.com/apache/datafusion/actions/runs/24973415001

I don't think we're in danger of being rate limited by GitHub if we bump to 150 (from 30)