### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/docs/source/contributor-guide/inviting.md
+++ b/docs/source/contributor-guide/inviting.md
@@ -95,7 +95,7 @@ Your Name
 [1] LINK TO DISCUSSION THREAD (e.g. https://lists.apache.org/thread/7rocc026wckknrjt9j6bsqk3z4c0g5yf)
 ```
 
-If the vote passes (requires 3 `+1`, and no `-1` voites) , send a result email
+If the vote passes (requires 3 `+1`, and no `-1` votes) , send a result email
 like the following (substitute `N` with the number of `+1` votes)
 
 ```
@@ -296,14 +296,14 @@ Subject: [DISCUSS] $NEW_PMC_MEMBER for PMC
 
 I would like to propose adding $NEW_PMC_MEMBER[1] to the DataFusion PMC.
 
-$NEW_PMC_MEMBMER has been a committer since $COMMITTER_MONTH [2], has a
+$NEW_PMC_MEMBER has been a committer since $COMMITTER_MONTH [2], has a
 strong and sustained contribution record for more than a year, and focused on
 helping the community and the project grow[3].
 
 Are there any thoughts about inviting $NEW_PMC_MEMBER to become a PMC member?
 
 [1] https://github.com/$NEW_PMC_MEMBERS_GITHUB_ACCOUNT
-[2] LINK TO COMMMITER VOTE RESULT THREAD (e.g. https://lists.apache.org/thread/ovgp8z97l1vh0wzjkgn0ktktggomxq9t)
+[2] LINK TO COMMITTER VOTE RESULT THREAD (e.g. https://lists.apache.org/thread/ovgp8z97l1vh0wzjkgn0ktktggomxq9t)
 [3]: https://github.com/apache/datafusion/pulls?q=commenter%3A<$NEW_PMC_MEMBERS_GITHUB_ACCOUNT>+
 
 Thanks,

--- a/docs/source/contributor-guide/specification/output-field-name-semantic.md
+++ b/docs/source/contributor-guide/specification/output-field-name-semantic.md
@@ -20,7 +20,7 @@
 # Output field name semantics
 
 This specification documents how field names in output record batches should be
-generated based on given user queries. The filed name rules apply to
+generated based on given user queries. The field name rules apply to
 DataFusion queries planned from both SQL queries and Dataframe APIs.
 
 ## Field name rules

--- a/docs/source/user-guide/crate-configuration.md
+++ b/docs/source/user-guide/crate-configuration.md
@@ -54,7 +54,7 @@ More on [Cargo dependencies](https://doc.rust-lang.org/cargo/reference/specifyin
 
 ## Optimizing Builds
 
-Here are several suggestions to get the Rust compler to produce faster code when
+Here are several suggestions to get the Rust compiler to produce faster code when
 compiling DataFusion. Note that these changes may increase compile time and
 binary size.
 

--- a/docs/source/user-guide/explain-usage.md
+++ b/docs/source/user-guide/explain-usage.md
@@ -159,7 +159,7 @@ next section)
 ## More Debugging Information: `EXPLAIN VERBOSE`
 
 If the plan has to read too many files, not all of them will be shown in the
-`EXPLAIN`. To see them, use `EXPLAIN VEBOSE`. Like `EXPLAIN`, `EXPLAIN VERBOSE`
+`EXPLAIN`. To see them, use `EXPLAIN VERBOSE`. Like `EXPLAIN`, `EXPLAIN VERBOSE`
 does not run the query. Instead it shows the full explain plan, with information
 that is omitted from the default explain, as well as all intermediate physical
 plans DataFusion generates before returning. This mode can be very helpful for

--- a/docs/source/user-guide/expressions.md
+++ b/docs/source/user-guide/expressions.md
@@ -287,7 +287,7 @@ select log(-1), log(0), sqrt(-1);
 
 | Syntax                                                                          | Description                                                                                                                                              |
 | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| avg(expr)                                                                       | Сalculates the average value for `expr`.                                                                                                                 |
+| avg(expr)                                                                       | Calculates the average value for `expr`.                                                                                                                 |
 | avg_distinct(expr)                                                              | Creates an expression to represent the avg(distinct) aggregate function                                                                                  |
 | approx_distinct(expr)                                                           | Calculates an approximate count of the number of distinct values for `expr`.                                                                             |
 | approx_median(expr)                                                             | Calculates an approximation of the median for `expr`.                                                                                                    |
@@ -303,10 +303,10 @@ select log(-1), log(0), sqrt(-1);
 | cube(exprs)                                                                     | Creates a grouping set for all combination of `exprs`                                                                                                    |
 | grouping_set(exprs)                                                             | Create a grouping set.                                                                                                                                   |
 | max(expr)                                                                       | Finds the maximum value of `expr`.                                                                                                                       |
-| median(expr)                                                                    | Сalculates the median of `expr`.                                                                                                                         |
+| median(expr)                                                                    | Calculates the median of `expr`.                                                                                                                         |
 | min(expr)                                                                       | Finds the minimum value of `expr`.                                                                                                                       |
 | rollup(exprs)                                                                   | Creates a grouping set for rollup sets.                                                                                                                  |
-| sum(expr)                                                                       | Сalculates the sum of `expr`.                                                                                                                            |
+| sum(expr)                                                                       | Calculates the sum of `expr`.                                                                                                                            |
 | sum_distinct(expr)                                                              | Creates an expression to represent the sum(distinct) aggregate function                                                                                  |
 
 ## Aggregate Function Builder


### PR DESCRIPTION
## Which issue does this PR close?

- None.

## Rationale for this change

Fix a handful of small typos in the contributor and user documentation.

## What changes are included in this PR?

- Correct spelling mistakes in several docs pages
- Replace a Cyrillic `С` with an ASCII `C` in aggregate function descriptions

## Are these changes tested?

- `rustup run stable cargo fmt --all -- --check`
- Attempted `PATH="$HOME/Library/Python/3.9/bin:$PATH" rustup run stable cargo clippy --all-targets --all-features -- -D warnings`, which hit an existing clippy failure in `datafusion/expr/src/logical_plan/plan.rs:3775` unrelated to this docs-only change

## Are there any user-facing changes?

- Documentation text only.
