### PR TITLE
Update documentation for PhysicalExpr::evaluate_bounds

### DIFF
--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -181,10 +181,18 @@ pub trait PhysicalExpr: Any + Send + Sync + Display + Debug + DynEq + DynHash {
     /// A `Result` containing the output interval for the expression in
     /// case of success, or an error object in case of failure.
     ///
+    /// Note the output bounds must form an **envelope** that contains all
+    /// possible outputs of the expression given the input bounds. While
+    /// expressions should output the tightest possible bounds, they do not need
+    /// to be exact and can be conservative.
+    ///
     /// # Example
     ///
     /// If the expression is `a + b`, and the input intervals are `a: [1, 2]`
     /// and `b: [3, 4]`, then the output interval would be `[4, 6]`.
+    ///
+    /// If the expression is `sin(a)`, it is correct (though not precise) to
+    /// produce an output interval `[-1, 1]` for all inputs a.
     fn evaluate_bounds(&self, _children: &[&Interval]) -> Result<Interval> {
         not_impl_err!("Not implemented for {self}")
     }

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -181,7 +181,7 @@ pub trait PhysicalExpr: Any + Send + Sync + Display + Debug + DynEq + DynHash {
     /// A `Result` containing the output interval for the expression in
     /// case of success, or an error object in case of failure.
     ///
-    /// Note the output bounds must form an **envelope** that contains all
+    /// Note that the output bounds must form an **envelope** that contains all
     /// possible outputs of the expression given the input bounds. While
     /// expressions should output the tightest possible bounds, they do not need
     /// to be exact and can be conservative.
@@ -192,7 +192,7 @@ pub trait PhysicalExpr: Any + Send + Sync + Display + Debug + DynEq + DynHash {
     /// and `b: [3, 4]`, then the output interval would be `[4, 6]`.
     ///
     /// If the expression is `sin(a)`, it is correct (though not precise) to
-    /// produce an output interval `[-1, 1]` for all inputs a.
+    /// produce the interval `[-1, 1]` for any input interval for `a`.
     fn evaluate_bounds(&self, _children: &[&Interval]) -> Result<Interval> {
         not_impl_err!("Not implemented for {self}")
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/pull/21651 from @Dandandan 

## Rationale for this change

While reviewing https://github.com/apache/datafusion/pull/21651 I found that `sin(x)` is hard coded to always return `[-1, 1]` as its bounds regardless of its input:

https://github.com/apache/datafusion/blob/5901df58b21b8b4e36011744e7ddc17bcb6a37b3/datafusion/functions/src/math/bounds.rs#L27-L32

This is not clear from the docs and https://github.com/apache/datafusion/pull/21651  was assuming something different

## What changes are included in this PR?

1. Update the documentation to reflect the current state of the code (the bound are not exact)

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
