### PR TITLE
Add ClickBench extended URL prefix filter benchmark

### DIFF
--- a/benchmarks/queries/clickbench/README.md
+++ b/benchmarks/queries/clickbench/README.md
@@ -241,8 +241,24 @@ These queries test the performance of the `FIRST_VALUE` aggregation function wit
 | Q12   | `WatchID`            | `Int64`     | `OS`            | `Int16`       | 91               |
 
 
+### Q13: Filter-only URL prefix match
 
+**Question**: "Which counters have the most page views with URLs that look like HTTP URLs?"
 
+**Important Query Properties**: Filter-only string prefix match. The `URL`
+column is used only by the pushed-down filter and is not projected or
+aggregated. This makes the query useful for measuring optimizations that can
+skip RowFilter evaluation when Parquet row group statistics prove that all rows
+in a row group satisfy the prefix predicate.
+
+```sql
+SELECT "CounterID", COUNT(*) AS page_views
+FROM hits
+WHERE "URL" LIKE 'http%'
+GROUP BY "CounterID"
+ORDER BY page_views DESC
+LIMIT 10;
+```
 
 ## Data Notes
 

--- a/benchmarks/queries/clickbench/extended/q13.sql
+++ b/benchmarks/queries/clickbench/extended/q13.sql
@@ -1,0 +1,4 @@
+-- Must set for ClickBench hits_partitioned dataset. See https://github.com/apache/datafusion/issues/16591
+-- set datafusion.execution.parquet.binary_as_string = true
+
+SELECT "CounterID", COUNT(*) AS page_views FROM hits WHERE "URL" LIKE 'http%' GROUP BY "CounterID" ORDER BY page_views DESC LIMIT 10;


### PR DESCRIPTION
## Which issue does this PR close?

Split from #21637.

## Rationale for this change

This adds a ClickBench extended query that can be used to measure filter-only string prefix matching on Parquet data. It is intended to help evaluate optimizations that skip RowFilter evaluation when row group statistics prove the predicate fully matches a row group.

## What changes are included in this PR?

- Adds `benchmarks/queries/clickbench/extended/q13.sql`
- Documents the new extended query in the ClickBench README

The query filters on `URL LIKE 'http%'` but only projects and aggregates `CounterID`, so the URL column is only needed for filter evaluation.

## Are these changes tested?


## Are there any user-facing changes?

No. This only adds a benchmark query.