### PR TITLE
feat[expr-common]: support regex and LIKE coercion on REE and Dict value types that require an extra coercion step

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1766,7 +1766,7 @@ fn binary_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType>
 pub fn like_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     string_coercion(lhs_type, rhs_type)
         .or_else(|| binary_to_string_coercion(lhs_type, rhs_type))
-        .or_else(|| dictionary_coercion(lhs_type, rhs_type, false, string_coercion))
+        .or_else(|| dictionary_coercion(lhs_type, rhs_type, false, like_coercion))
         .or_else(|| ree_coercion(lhs_type, rhs_type, false, like_coercion))
         .or_else(|| regex_null_coercion(lhs_type, rhs_type))
         .or_else(|| null_coercion(lhs_type, rhs_type))
@@ -1787,7 +1787,7 @@ fn regex_null_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataT
 /// This is a union of string coercion rules, dictionary coercion rules, and REE coercion rules.
 pub fn regex_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     string_coercion(lhs_type, rhs_type)
-        .or_else(|| dictionary_coercion(lhs_type, rhs_type, false, string_coercion))
+        .or_else(|| dictionary_coercion(lhs_type, rhs_type, false, regex_coercion))
         .or_else(|| ree_coercion(lhs_type, rhs_type, false, regex_coercion))
         .or_else(|| regex_null_coercion(lhs_type, rhs_type))
 }

--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1767,7 +1767,7 @@ pub fn like_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataTyp
     string_coercion(lhs_type, rhs_type)
         .or_else(|| binary_to_string_coercion(lhs_type, rhs_type))
         .or_else(|| dictionary_coercion(lhs_type, rhs_type, false, string_coercion))
-        .or_else(|| ree_coercion(lhs_type, rhs_type, false, string_coercion))
+        .or_else(|| ree_coercion(lhs_type, rhs_type, false, like_coercion))
         .or_else(|| regex_null_coercion(lhs_type, rhs_type))
         .or_else(|| null_coercion(lhs_type, rhs_type))
 }
@@ -1788,7 +1788,7 @@ fn regex_null_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataT
 pub fn regex_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     string_coercion(lhs_type, rhs_type)
         .or_else(|| dictionary_coercion(lhs_type, rhs_type, false, string_coercion))
-        .or_else(|| ree_coercion(lhs_type, rhs_type, false, string_coercion))
+        .or_else(|| ree_coercion(lhs_type, rhs_type, false, regex_coercion))
         .or_else(|| regex_null_coercion(lhs_type, rhs_type))
 }
 

--- a/datafusion/sqllogictest/test_files/regexp/regexp_like.slt
+++ b/datafusion/sqllogictest/test_files/regexp/regexp_like.slt
@@ -277,6 +277,23 @@ drop table strings
 statement ok
 drop table dict_table
 
+# Dict value types that themselves need further coercion against the literal
+statement ok
+create table dict_inner as
+select arrow_cast(arrow_cast(c, 'Binary'), 'Dictionary(UInt32, Binary)') as bin_col,
+       arrow_cast(arrow_cast(c, 'Dictionary(UInt32, Utf8)'),
+                  'Dictionary(Int32, Dictionary(UInt32, Utf8))') as nested_col
+from (values ('foo'), ('bar')) as t(c);
+
+query BB
+select bin_col LIKE 'foo', nested_col ~ 'foo' from dict_inner;
+----
+true true
+false false
+
+statement ok
+drop table dict_inner
+
 # Ensure that regexp_like is rewritten to use the (more optimized) regex operators
 statement ok
 create table regexp_test as values

--- a/datafusion/sqllogictest/test_files/run_end_encoded.slt
+++ b/datafusion/sqllogictest/test_files/run_end_encoded.slt
@@ -67,3 +67,21 @@ FROM sensor_readings;
 23 23
 24 24
 25 25
+
+# Regex / LIKE match against an REE column whose values are themselves Dictionary-encoded
+query BB rowsort
+SELECT
+    arrow_cast(
+        arrow_cast(sensor_id, 'Dictionary(UInt32, Utf8)'),
+        'RunEndEncoded("run_ends": non-null Int32, "values": Dictionary(UInt32, Utf8))'
+    ) ~ 'sensor_A',
+    arrow_cast(
+        arrow_cast(sensor_id, 'Dictionary(UInt32, Utf8)'),
+        'RunEndEncoded("run_ends": non-null Int32, "values": Dictionary(UInt32, Utf8))'
+    ) LIKE 'sensor_A'
+FROM sensor_readings;
+----
+false false
+true true
+true true
+true true


### PR DESCRIPTION
The coerce_fn applied to REE values needs to be the higher-level coerce function so that any REE value can be coerced (not just primitive types).

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #21923 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Queries were failing

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Correct unwrapping of REE values for regex/LIKE coercion

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes, with slt tests.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Queries that would previously error now pass.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
