### PR TITLE
IN LIST: clean up generic static filtering

### DIFF
--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -38,6 +38,7 @@ use datafusion_expr::{ColumnarValue, expr_vec_fmt};
 
 mod array_static_filter;
 mod primitive_filter;
+mod result;
 mod static_filter;
 mod strategy;
 

--- a/datafusion/physical-expr/src/expressions/in_list/array_static_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/array_static_filter.rs
@@ -23,10 +23,9 @@ use arrow::buffer::{BooleanBuffer, NullBuffer};
 use arrow::compute::{SortOptions, take};
 use arrow::datatypes::DataType;
 use arrow::util::bit_iterator::BitIndexIterator;
-use datafusion_common::HashMap;
 use datafusion_common::Result;
 use datafusion_common::hash_utils::{RandomState, with_hashes};
-use hashbrown::hash_map::RawEntryMut;
+use hashbrown::HashTable;
 
 use super::result::build_in_list_result;
 use super::static_filter::StaticFilter;
@@ -36,11 +35,8 @@ use super::static_filter::StaticFilter;
 pub(super) struct ArrayStaticFilter {
     in_array: ArrayRef,
     state: RandomState,
-    /// Used to provide a lookup from value to in list index
-    ///
-    /// Note: usize::hash is not used, instead the raw entry
-    /// API is used to store entries w.r.t their value
-    map: HashMap<usize, (), ()>,
+    /// Stores indices into `in_array` for O(1) lookups.
+    table: HashTable<usize>,
 }
 
 impl ArrayStaticFilter {
@@ -56,36 +52,34 @@ impl ArrayStaticFilter {
             return Ok(ArrayStaticFilter {
                 in_array,
                 state: RandomState::default(),
-                map: HashMap::with_hasher(()),
+                table: HashTable::new(),
             });
         }
 
         let state = RandomState::default();
-        let map = Self::build_haystack_map(&in_array, &state)?;
+        let table = Self::build_haystack_table(&in_array, &state)?;
 
         Ok(Self {
             in_array,
             state,
-            map,
+            table,
         })
     }
 
-    fn build_haystack_map(
+    fn build_haystack_table(
         haystack: &ArrayRef,
         state: &RandomState,
-    ) -> Result<HashMap<usize, (), ()>> {
-        let mut map: HashMap<usize, (), ()> = HashMap::with_hasher(());
+    ) -> Result<HashTable<usize>> {
+        let mut table = HashTable::new();
 
         with_hashes([haystack.as_ref()], state, |hashes| -> Result<()> {
             let cmp = make_comparator(haystack, haystack, SortOptions::default())?;
 
             let insert_value = |idx| {
                 let hash = hashes[idx];
-                if let RawEntryMut::Vacant(v) = map
-                    .raw_entry_mut()
-                    .from_hash(hash, |x| cmp(*x, idx).is_eq())
-                {
-                    v.insert_with_hasher(hash, idx, (), |x| hashes[*x]);
+                // Only insert if not already present (deduplication)
+                if table.find(hash, |&x| cmp(x, idx).is_eq()).is_none() {
+                    table.insert_unique(hash, idx, |&x| hashes[x]);
                 }
             };
 
@@ -100,7 +94,7 @@ impl ArrayStaticFilter {
             Ok(())
         })?;
 
-        Ok(map)
+        Ok(table)
     }
 
     fn find_needles_in_haystack(
@@ -122,10 +116,7 @@ impl ArrayStaticFilter {
                 #[inline(always)]
                 |i| {
                     let hash = needle_hashes[i];
-                    self.map
-                        .raw_entry()
-                        .from_hash(hash, |idx| cmp(i, *idx).is_eq())
-                        .is_some()
+                    self.table.find(hash, |&idx| cmp(i, idx).is_eq()).is_some()
                 },
             ))
         })

--- a/datafusion/physical-expr/src/expressions/in_list/array_static_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/array_static_filter.rs
@@ -42,6 +42,102 @@ pub(super) struct ArrayStaticFilter {
     map: HashMap<usize, (), ()>,
 }
 
+impl ArrayStaticFilter {
+    /// Computes a [`StaticFilter`] for the provided [`Array`] if there
+    /// are nulls present or there are more than the configured number of
+    /// elements.
+    ///
+    /// Note: This is split into a separate function as higher-rank trait bounds currently
+    /// cause type inference to misbehave
+    pub(super) fn try_new(in_array: ArrayRef) -> Result<ArrayStaticFilter> {
+        // Null type has no natural order - return empty hash set
+        if in_array.data_type() == &DataType::Null {
+            return Ok(ArrayStaticFilter {
+                in_array,
+                state: RandomState::default(),
+                map: HashMap::with_hasher(()),
+            });
+        }
+
+        let state = RandomState::default();
+        let map = Self::build_haystack_map(&in_array, &state)?;
+
+        Ok(Self {
+            in_array,
+            state,
+            map,
+        })
+    }
+
+    fn build_haystack_map(
+        haystack: &ArrayRef,
+        state: &RandomState,
+    ) -> Result<HashMap<usize, (), ()>> {
+        let mut map: HashMap<usize, (), ()> = HashMap::with_hasher(());
+
+        with_hashes([haystack.as_ref()], state, |hashes| -> Result<()> {
+            let cmp = make_comparator(haystack, haystack, SortOptions::default())?;
+
+            let insert_value = |idx| {
+                let hash = hashes[idx];
+                if let RawEntryMut::Vacant(v) = map
+                    .raw_entry_mut()
+                    .from_hash(hash, |x| cmp(*x, idx).is_eq())
+                {
+                    v.insert_with_hasher(hash, idx, (), |x| hashes[*x]);
+                }
+            };
+
+            match haystack.nulls() {
+                Some(nulls) => {
+                    BitIndexIterator::new(nulls.validity(), nulls.offset(), nulls.len())
+                        .for_each(insert_value)
+                }
+                None => (0..haystack.len()).for_each(insert_value),
+            }
+
+            Ok(())
+        })?;
+
+        Ok(map)
+    }
+
+    fn find_needles_in_haystack(
+        &self,
+        needles: &dyn Array,
+        negated: bool,
+    ) -> Result<BooleanArray> {
+        let needle_nulls = needles.logical_nulls();
+        let needle_nulls = needle_nulls.as_ref();
+        let haystack_has_nulls = self.in_array.null_count() != 0;
+
+        with_hashes([needles], &self.state, |hashes| {
+            let cmp = make_comparator(needles, &self.in_array, SortOptions::default())?;
+            Ok((0..needles.len())
+                .map(|i| {
+                    // SQL three-valued logic: null IN (...) is always null
+                    if needle_nulls.is_some_and(|nulls| nulls.is_null(i)) {
+                        return None;
+                    }
+
+                    let hash = hashes[i];
+                    let contains = self
+                        .map
+                        .raw_entry()
+                        .from_hash(hash, |idx| cmp(i, *idx).is_eq())
+                        .is_some();
+
+                    match contains {
+                        true => Some(!negated),
+                        false if haystack_has_nulls => None,
+                        false => Some(negated),
+                    }
+                })
+                .collect())
+        })
+    }
+}
+
 impl StaticFilter for ArrayStaticFilter {
     fn null_count(&self) -> usize {
         self.in_array.null_count()
@@ -76,85 +172,6 @@ impl StaticFilter for ArrayStaticFilter {
             _ => {}
         }
 
-        let needle_nulls = v.logical_nulls();
-        let needle_nulls = needle_nulls.as_ref();
-        let haystack_has_nulls = self.in_array.null_count() != 0;
-
-        with_hashes([v], &self.state, |hashes| {
-            let cmp = make_comparator(v, &self.in_array, SortOptions::default())?;
-            Ok((0..v.len())
-                .map(|i| {
-                    // SQL three-valued logic: null IN (...) is always null
-                    if needle_nulls.is_some_and(|nulls| nulls.is_null(i)) {
-                        return None;
-                    }
-
-                    let hash = hashes[i];
-                    let contains = self
-                        .map
-                        .raw_entry()
-                        .from_hash(hash, |idx| cmp(i, *idx).is_eq())
-                        .is_some();
-
-                    match contains {
-                        true => Some(!negated),
-                        false if haystack_has_nulls => None,
-                        false => Some(negated),
-                    }
-                })
-                .collect())
-        })
-    }
-}
-
-impl ArrayStaticFilter {
-    /// Computes a [`StaticFilter`] for the provided [`Array`] if there
-    /// are nulls present or there are more than the configured number of
-    /// elements.
-    ///
-    /// Note: This is split into a separate function as higher-rank trait bounds currently
-    /// cause type inference to misbehave
-    pub(super) fn try_new(in_array: ArrayRef) -> Result<ArrayStaticFilter> {
-        // Null type has no natural order - return empty hash set
-        if in_array.data_type() == &DataType::Null {
-            return Ok(ArrayStaticFilter {
-                in_array,
-                state: RandomState::default(),
-                map: HashMap::with_hasher(()),
-            });
-        }
-
-        let state = RandomState::default();
-        let mut map: HashMap<usize, (), ()> = HashMap::with_hasher(());
-
-        with_hashes([&in_array], &state, |hashes| -> Result<()> {
-            let cmp = make_comparator(&in_array, &in_array, SortOptions::default())?;
-
-            let insert_value = |idx| {
-                let hash = hashes[idx];
-                if let RawEntryMut::Vacant(v) = map
-                    .raw_entry_mut()
-                    .from_hash(hash, |x| cmp(*x, idx).is_eq())
-                {
-                    v.insert_with_hasher(hash, idx, (), |x| hashes[*x]);
-                }
-            };
-
-            match in_array.nulls() {
-                Some(nulls) => {
-                    BitIndexIterator::new(nulls.validity(), nulls.offset(), nulls.len())
-                        .for_each(insert_value)
-                }
-                None => (0..in_array.len()).for_each(insert_value),
-            }
-
-            Ok(())
-        })?;
-
-        Ok(Self {
-            in_array,
-            state,
-            map,
-        })
+        self.find_needles_in_haystack(v, negated)
     }
 }

--- a/datafusion/physical-expr/src/expressions/in_list/array_static_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/array_static_filter.rs
@@ -28,6 +28,7 @@ use datafusion_common::Result;
 use datafusion_common::hash_utils::{RandomState, with_hashes};
 use hashbrown::hash_map::RawEntryMut;
 
+use super::result::build_in_list_result;
 use super::static_filter::StaticFilter;
 
 /// Static filter for InList that stores the array and hash set for O(1) lookups
@@ -108,32 +109,25 @@ impl ArrayStaticFilter {
         negated: bool,
     ) -> Result<BooleanArray> {
         let needle_nulls = needles.logical_nulls();
-        let needle_nulls = needle_nulls.as_ref();
         let haystack_has_nulls = self.in_array.null_count() != 0;
 
-        with_hashes([needles], &self.state, |hashes| {
+        with_hashes([needles], &self.state, |needle_hashes| {
             let cmp = make_comparator(needles, &self.in_array, SortOptions::default())?;
-            Ok((0..needles.len())
-                .map(|i| {
-                    // SQL three-valued logic: null IN (...) is always null
-                    if needle_nulls.is_some_and(|nulls| nulls.is_null(i)) {
-                        return None;
-                    }
 
-                    let hash = hashes[i];
-                    let contains = self
-                        .map
+            Ok(build_in_list_result(
+                needles.len(),
+                needle_nulls.as_ref(),
+                haystack_has_nulls,
+                negated,
+                #[inline(always)]
+                |i| {
+                    let hash = needle_hashes[i];
+                    self.map
                         .raw_entry()
                         .from_hash(hash, |idx| cmp(i, *idx).is_eq())
-                        .is_some();
-
-                    match contains {
-                        true => Some(!negated),
-                        false if haystack_has_nulls => None,
-                        false => Some(negated),
-                    }
-                })
-                .collect())
+                        .is_some()
+                },
+            ))
         })
     }
 }

--- a/datafusion/physical-expr/src/expressions/in_list/result.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/result.rs
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Result building helpers for InList operations.
+//!
+//! This module provides unified logic for building BooleanArray results
+//! from IN list membership tests, handling null propagation correctly
+//! according to SQL three-valued logic.
+
+use arrow::array::BooleanArray;
+use arrow::buffer::{BooleanBuffer, NullBuffer};
+
+// Truth table for (needle_nulls, haystack_has_nulls, negated):
+// (Some, true,  false) => values: valid & contains,  nulls: valid & contains
+// (None, true,  false) => values: contains,          nulls: contains
+// (Some, true,  true)  => values: valid & !contains, nulls: valid & contains
+// (None, true,  true)  => values: !contains,         nulls: contains
+// (Some, false, false) => values: valid & contains,  nulls: valid
+// (Some, false, true)  => values: valid & !contains, nulls: valid
+// (None, false, false) => values: contains,          nulls: none
+// (None, false, true)  => values: !contains,         nulls: none
+
+/// Builds a BooleanArray result for IN list operations.
+///
+/// This function handles the null propagation logic for SQL IN lists:
+/// - If the needle value is null, the result is null
+/// - If the needle is not in the set and the haystack has nulls, the result is null
+/// - Otherwise, the result is true/false based on membership and negation
+///
+/// This version computes contains for all positions, including nulls, then applies
+/// null masking via bitmap operations.
+#[inline]
+pub(crate) fn build_in_list_result<C>(
+    len: usize,
+    needle_nulls: Option<&NullBuffer>,
+    haystack_has_nulls: bool,
+    negated: bool,
+    contains: C,
+) -> BooleanArray
+where
+    C: FnMut(usize) -> bool,
+{
+    let contains_buf = BooleanBuffer::collect_bool(len, contains);
+    build_result_from_contains(needle_nulls, haystack_has_nulls, negated, contains_buf)
+}
+
+/// Builds a BooleanArray result from a pre-computed contains buffer.
+///
+/// This version does not assume contains_buf is pre-masked at null positions.
+/// It handles nulls using bitmap operations.
+#[inline]
+pub(crate) fn build_result_from_contains(
+    needle_nulls: Option<&NullBuffer>,
+    haystack_has_nulls: bool,
+    negated: bool,
+    contains_buf: BooleanBuffer,
+) -> BooleanArray {
+    match (needle_nulls, haystack_has_nulls, negated) {
+        // Haystack has nulls: result is null unless value is found.
+        (Some(v), true, false) => {
+            // values: valid & contains, nulls: valid & contains
+            let values = v.inner() & &contains_buf;
+            BooleanArray::new(values.clone(), Some(NullBuffer::new(values)))
+        }
+        (None, true, false) => {
+            BooleanArray::new(contains_buf.clone(), Some(NullBuffer::new(contains_buf)))
+        }
+        (Some(v), true, true) => {
+            // NOT IN with nulls: false if found, null if not found or needle null.
+            // values: valid & !contains, nulls: valid & contains
+            let valid = v.inner();
+            let values = valid & &(!&contains_buf);
+            let nulls = valid & &contains_buf;
+            BooleanArray::new(values, Some(NullBuffer::new(nulls)))
+        }
+        (None, true, true) => {
+            BooleanArray::new(!&contains_buf, Some(NullBuffer::new(contains_buf)))
+        }
+        // Haystack has no nulls: result validity follows needle validity.
+        (Some(v), false, false) => {
+            // values: valid & contains, nulls: valid
+            BooleanArray::new(v.inner() & &contains_buf, Some(v.clone()))
+        }
+        (Some(v), false, true) => {
+            // values: valid & !contains, nulls: valid
+            BooleanArray::new(v.inner() & &(!&contains_buf), Some(v.clone()))
+        }
+        (None, false, false) => BooleanArray::new(contains_buf, None),
+        (None, false, true) => BooleanArray::new(!&contains_buf, None),
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #19241.
- This PR was originally proposed as the first commit in the broader `IN LIST` optimization series in #19390.
- This PR builds on the refactor extracted in #21649.

## Rationale for this change

After #21649, non-primitive constant `IN LIST` evaluation still uses the extracted `ArrayStaticFilter` fallback path. That path relies on comparator checks for each input row. This PR replaces that fallback lookup with a precomputed hash table and shared result construction so generic constant-list evaluation is cheaper before the later specialized primitive and string optimizations from #19390.

## What changes are included in this PR?

The PR is split so reviewers can separate mechanical cleanup from the behavior/performance changes:

1. `Refactor generic InList static filter helpers`

   Pure refactoring. This moves the existing generic static-filter construction and probe loop into helper methods inside `ArrayStaticFilter`, without changing the lookup data structure or result semantics.

2. `Build InList results from bitmaps`

   Changes how the generic path materializes `BooleanArray` results after membership has been computed. Instead of mixing membership checks and SQL three-valued null handling in the row loop, this builds a contains bitmap first and applies the null/negation rules with bitmap operations. This keeps the same `IN` / `NOT IN` semantics, including the `NULL` cases.

3. `Optimize generic InList static filtering`

   Replaces the fallback lookup storage from a unit-valued raw-entry `HashMap` to `hashbrown::HashTable<usize>`. The table still stores indices into the constant list and still uses Arrow hashing plus `make_comparator` for equality, but avoids the extra map value bookkeeping.

The existing specialized primitive filters and dictionary handling are intentionally left out of scope.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No. This is an internal performance optimization only.

<!-- codex-benchmark-start -->
## Local benchmark snapshot

Benchmark command:

```bash
cargo bench -p datafusion-physical-expr --profile release-nonlto --bench in_list_strategy -- --save-baseline <name>
```

Method: compare adjacent saved baselines using raw Criterion sample minima (`min(time / iters)`). Lower is better; changes within +/-5% are treated as noise.

Compared baselines: merge-base -> [#21927](https://github.com/apache/datafusion/pull/21927)

Relevant scope: generic fallback string/view/binary rows.

Summary: 62 relevant rows, 61 faster, 0 slower, 1 within +/-5%.

Largest relevant deltas:

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `utf8view/short_8b/list=64/match=0%` | 45.55 us | 21.85 us | -52.0% (2.08x faster) |
| `utf8view/short_8b/list=256/match=0%` | 44.34 us | 21.71 us | -51.0% (2.04x faster) |
| `utf8view/short_8b/list=16/match=0%` | 44.03 us | 21.60 us | -50.9% (2.04x faster) |
| `utf8view/short_8b/list=4/match=0%` | 41.54 us | 20.52 us | -50.6% (2.02x faster) |
| `utf8view/len_12b/list=16/match=0%` | 41.43 us | 20.55 us | -50.4% (2.02x faster) |
| `utf8view/len_12b/list=64/match=0%` | 41.59 us | 21.00 us | -49.5% (1.98x faster) |
| `fixed_size_binary/fsb16/list=10000/match=0%` | 58.11 us | 29.36 us | -49.5% (1.98x faster) |
| `fixed_size_binary/fsb16/list=256/match=0%` | 55.49 us | 28.57 us | -48.5% (1.94x faster) |
| `utf8view/shared_prefix/pfx=8/list=16/match=0%` | 57.54 us | 32.07 us | -44.3% (1.79x faster) |
| `utf8view/mixed_len/list=16/match=0%` | 62.86 us | 35.25 us | -43.9% (1.78x faster) |
| `fixed_size_binary/fsb16/list=4/match=0%` | 47.62 us | 27.20 us | -42.9% (1.75x faster) |
| `fixed_size_binary/fsb16/list=64/match=0%` | 47.85 us | 27.45 us | -42.6% (1.74x faster) |
| `utf8view/mixed_len/list=64/match=0%` | 66.09 us | 38.00 us | -42.5% (1.74x faster) |
| `utf8/short_8b/list=256/match=0%` | 52.09 us | 30.49 us | -41.5% (1.71x faster) |
| `utf8view/shared_prefix/pfx=12/list=32/match=0%` | 70.61 us | 42.33 us | -40.1% (1.67x faster) |

<details>
<summary>Full relevant table (62 rows)</summary>

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `fixed_size_binary/fsb16/list=10000/match=0%` | 58.11 us | 29.36 us | -49.5% (1.98x faster) |
| `fixed_size_binary/fsb16/list=10000/match=50%` | 98.77 us | 81.20 us | -17.8% (1.22x faster) |
| `fixed_size_binary/fsb16/list=256/match=0%` | 55.49 us | 28.57 us | -48.5% (1.94x faster) |
| `fixed_size_binary/fsb16/list=256/match=50%` | 96.40 us | 79.32 us | -17.7% (1.22x faster) |
| `fixed_size_binary/fsb16/list=4/match=0%` | 47.62 us | 27.20 us | -42.9% (1.75x faster) |
| `fixed_size_binary/fsb16/list=4/match=50%` | 93.08 us | 75.58 us | -18.8% (1.23x faster) |
| `fixed_size_binary/fsb16/list=64/match=0%` | 47.85 us | 27.45 us | -42.6% (1.74x faster) |
| `fixed_size_binary/fsb16/list=64/match=50%` | 95.20 us | 74.96 us | -21.3% (1.27x faster) |
| `nulls/utf8/long_24b/list=16/match=50%/nulls=20%` | 85.74 us | 74.79 us | -12.8% (1.15x faster) |
| `nulls/utf8/short_8b/list=16/match=50%/nulls=20%` | 80.01 us | 77.30 us | -3.4% (within +/-5%) |
| `nulls/utf8view/long_24b/list=16/match=50%/nulls=20%` | 110.19 us | 96.52 us | -12.4% (1.14x faster) |
| `nulls/utf8view/short_8b/list=16/match=50%/nulls=20%` | 74.78 us | 62.92 us | -15.9% (1.19x faster) |
| `nulls/utf8view/short_8b/list=16/match=50%/nulls=20%/NOT_IN` | 71.24 us | 63.51 us | -10.9% (1.12x faster) |
| `nulls/utf8view/short_8b/list=16/match=50%/nulls=50%` | 83.84 us | 62.11 us | -25.9% (1.35x faster) |
| `utf8/long_24b/list=256/match=0%` | 58.79 us | 37.57 us | -36.1% (1.56x faster) |
| `utf8/long_24b/list=256/match=50%` | 107.85 us | 74.62 us | -30.8% (1.45x faster) |
| `utf8/long_24b/list=4/match=0%` | 56.68 us | 37.64 us | -33.6% (1.51x faster) |
| `utf8/long_24b/list=4/match=50%` | 100.40 us | 79.11 us | -21.2% (1.27x faster) |
| `utf8/long_24b/list=64/match=0%` | 59.39 us | 35.95 us | -39.5% (1.65x faster) |
| `utf8/long_24b/list=64/match=50%` | 101.26 us | 79.59 us | -21.4% (1.27x faster) |
| `utf8/mixed_len/list=16/match=0%` | 60.51 us | 49.06 us | -18.9% (1.23x faster) |
| `utf8/mixed_len/list=16/match=50%` | 154.00 us | 139.13 us | -9.7% (1.11x faster) |
| `utf8/mixed_len/list=64/match=0%` | 63.46 us | 49.87 us | -21.4% (1.27x faster) |
| `utf8/mixed_len/list=64/match=50%` | 154.01 us | 134.01 us | -13.0% (1.15x faster) |
| `utf8/shared_prefix/pfx=12/list=32/match=50%` | 98.73 us | 76.64 us | -22.4% (1.29x faster) |
| `utf8/short_8b/list=16/match=50%/NOT_IN` | 96.18 us | 72.15 us | -25.0% (1.33x faster) |
| `utf8/short_8b/list=256/match=0%` | 52.09 us | 30.49 us | -41.5% (1.71x faster) |
| `utf8/short_8b/list=256/match=50%` | 94.56 us | 74.39 us | -21.3% (1.27x faster) |
| `utf8/short_8b/list=4/match=0%` | 51.95 us | 32.27 us | -37.9% (1.61x faster) |
| `utf8/short_8b/list=4/match=50%` | 95.05 us | 78.47 us | -17.4% (1.21x faster) |
| `utf8/short_8b/list=64/match=0%` | 53.60 us | 33.34 us | -37.8% (1.61x faster) |
| `utf8/short_8b/list=64/match=50%` | 96.35 us | 80.95 us | -16.0% (1.19x faster) |
| `utf8view/len_12b/list=16/match=0%` | 41.43 us | 20.55 us | -50.4% (2.02x faster) |
| `utf8view/len_12b/list=16/match=50%` | 73.07 us | 50.49 us | -30.9% (1.45x faster) |
| `utf8view/len_12b/list=64/match=0%` | 41.59 us | 21.00 us | -49.5% (1.98x faster) |
| `utf8view/len_12b/list=64/match=50%` | 75.23 us | 50.25 us | -33.2% (1.50x faster) |
| `utf8view/long_24b/list=16/match=0%` | 58.48 us | 38.22 us | -34.7% (1.53x faster) |
| `utf8view/long_24b/list=16/match=50%` | 109.63 us | 87.32 us | -20.4% (1.26x faster) |
| `utf8view/long_24b/list=256/match=0%` | 61.12 us | 38.40 us | -37.2% (1.59x faster) |
| `utf8view/long_24b/list=256/match=50%` | 113.25 us | 91.61 us | -19.1% (1.24x faster) |
| `utf8view/long_24b/list=4/match=0%` | 58.43 us | 39.48 us | -32.4% (1.48x faster) |
| `utf8view/long_24b/list=4/match=50%` | 112.73 us | 90.14 us | -20.0% (1.25x faster) |
| `utf8view/long_24b/list=64/match=0%` | 62.17 us | 38.48 us | -38.1% (1.62x faster) |
| `utf8view/long_24b/list=64/match=50%` | 109.35 us | 87.64 us | -19.8% (1.25x faster) |
| `utf8view/mixed_len/list=16/match=0%` | 62.86 us | 35.25 us | -43.9% (1.78x faster) |
| `utf8view/mixed_len/list=16/match=50%` | 126.60 us | 103.97 us | -17.9% (1.22x faster) |
| `utf8view/mixed_len/list=64/match=0%` | 66.09 us | 38.00 us | -42.5% (1.74x faster) |
| `utf8view/mixed_len/list=64/match=50%` | 137.76 us | 112.23 us | -18.5% (1.23x faster) |
| `utf8view/shared_prefix/pfx=12/list=32/match=0%` | 70.61 us | 42.33 us | -40.1% (1.67x faster) |
| `utf8view/shared_prefix/pfx=12/list=32/match=50%` | 115.15 us | 94.27 us | -18.1% (1.22x faster) |
| `utf8view/shared_prefix/pfx=16/list=64/match=0%` | 63.47 us | 40.67 us | -35.9% (1.56x faster) |
| `utf8view/shared_prefix/pfx=16/list=64/match=50%` | 112.27 us | 91.32 us | -18.7% (1.23x faster) |
| `utf8view/shared_prefix/pfx=8/list=16/match=0%` | 57.54 us | 32.07 us | -44.3% (1.79x faster) |
| `utf8view/shared_prefix/pfx=8/list=16/match=50%` | 100.47 us | 82.69 us | -17.7% (1.21x faster) |
| `utf8view/short_8b/list=16/match=0%` | 44.03 us | 21.60 us | -50.9% (2.04x faster) |
| `utf8view/short_8b/list=16/match=50%` | 72.92 us | 49.10 us | -32.7% (1.49x faster) |
| `utf8view/short_8b/list=256/match=0%` | 44.34 us | 21.71 us | -51.0% (2.04x faster) |
| `utf8view/short_8b/list=256/match=50%` | 72.43 us | 51.58 us | -28.8% (1.40x faster) |
| `utf8view/short_8b/list=4/match=0%` | 41.54 us | 20.52 us | -50.6% (2.02x faster) |
| `utf8view/short_8b/list=4/match=50%` | 72.50 us | 48.46 us | -33.2% (1.50x faster) |
| `utf8view/short_8b/list=64/match=0%` | 45.55 us | 21.85 us | -52.0% (2.08x faster) |
| `utf8view/short_8b/list=64/match=50%` | 73.14 us | 50.92 us | -30.4% (1.44x faster) |

</details>
<!-- codex-benchmark-end -->
