### PR TITLE
[codex] Avoid duplicate Dev and Security audit workflow runs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,13 +22,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-
   pull_request:
     paths:
       - "**/Cargo.toml"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,9 +17,6 @@
 
 name: Dev
 on:
-  push:
-    branches-ignore:
-      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
 


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #21938.

## Rationale for this change

`Dev` and `Security audit` currently run on both `merge_group` and `push`, which means a merge-queue commit can start two runs for the same workflow and SHA. `Dependencies` exposed this race because its `merge_group` run was still active when the later `push` run started, but the same duplicate-trigger setup exists in these workflows as well.

This PR follows the existing pattern already used by `Large files PR check`:
https://github.com/apache/datafusion/blob/main/.github/workflows/large_files.yml#L24-L26

## What changes are included in this PR?

- Remove the `push` trigger from `Dev`
- Remove the `push` trigger from `Security audit`
- Keep `pull_request` and `merge_group` so PR validation and merge-queue validation still run

## Are these changes tested?

- `git diff --check`
- `actionlint` is not installed in this environment

## Are there any user-facing changes?

No.
