### PR TITLE
dependencies check are now required to merge ci

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,6 +58,8 @@ github:
           - "Check Markdown Links"
           - "Validate required_status_checks in .asf.yaml"
           - "Spell Check with Typos"
+          - "Circular Dependency Check"
+          - "Detect Unused Dependencies"
     # needs to be updated as part of the release process
     # .asf.yaml doesn't support wildcard branch protection rules, only exact branch names
     # https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#branch-protection

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,13 +25,7 @@ on:
   push:
     branches-ignore:
       - 'gh-readonly-queue/**'
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
   pull_request:
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
   merge_group:
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
@@ -42,7 +36,7 @@ permissions:
 
 jobs:
   depcheck:
-    name: circular dependency check
+    name: Circular Dependency Check
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -61,6 +55,7 @@ jobs:
           cargo run
 
   detect-unused-dependencies:
+    name: Detect Unused Dependencies
     runs-on: ubuntu-latest
     container:
       image: amd64/rust


### PR DESCRIPTION
- Closes https://github.com/apache/datafusion/issues/21938

See https://github.com/apache/datafusion/issues/21938#issuecomment-4347563789

I feel like this is quite a useful check - and it's relatively small - let's run it always? 