### PR TITLE
add `Analyze Actions`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,6 +53,7 @@ github:
         required_approving_review_count: 1
       required_status_checks:
         contexts:
+          - "Analyze Actions"
           - "Check License Header"
           - "Use prettier to check formatting of documents"
           - "Check Markdown Links"


### PR DESCRIPTION
follow up on https://github.com/apache/datafusion/pull/21940

Closes-closes: https://github.com/apache/datafusion/issues/21938

Detect unused dependencies are now gone. But we also have `CodeQL`

<img width="657" height="210" alt="Zen Browser 2026-04-29 23 26 09" src="https://github.com/user-attachments/assets/91178011-6bdf-4d32-89ca-41811d526903" />
