### PR TITLE
Add ClickBench URL pushdown benchmark

### DIFF
--- a/benchmarks/queries/clickbench/README.md
+++ b/benchmarks/queries/clickbench/README.md
@@ -241,6 +241,25 @@ These queries test the performance of the `FIRST_VALUE` aggregation function wit
 | Q12   | `WatchID`            | `Int64`     | `OS`            | `Int16`       | 91               |
 
 
+### Q13: Filter-only URL Range Match
+
+**Question**: "What is the sum of counter IDs for page views with URLs in the normal URL string range?"
+
+**Important Query Properties**: Filter-only string range match. The `URL`
+column is used only by the pushed-down filter and is not projected or
+aggregated. This makes the query useful for measuring optimizations that can
+skip RowFilter evaluation when Parquet row group statistics prove that all rows
+in a row group satisfy the string predicate. The output-side aggregation is
+intentionally lightweight so the scan-time filter evaluation cost remains
+visible. Run this query with Parquet filter pushdown enabled, for example
+`dfbench clickbench --pushdown --query 13`.
+
+```sql
+SELECT SUM("CounterID") AS counter_id_sum
+FROM hits
+WHERE "URL" < 'zzzz';
+```
+
 
 
 

--- a/benchmarks/queries/clickbench/extended/q13.sql
+++ b/benchmarks/queries/clickbench/extended/q13.sql
@@ -1,0 +1,6 @@
+-- Must set for ClickBench hits_partitioned dataset. See https://github.com/apache/datafusion/issues/16591
+-- set datafusion.execution.parquet.binary_as_string = true
+
+SELECT SUM("CounterID") AS counter_id_sum
+FROM hits
+WHERE "URL" < 'zzzz';


### PR DESCRIPTION
## Which issue does this PR close?

N/A. This is a benchmark follow-up for #21637.

## Rationale for this change

This adds a ClickBench extended query that exercises Parquet filter pushdown when row group statistics can prove a string range predicate matches every row in the row group.

This case is useful for validating the optimization in #21637: when Parquet statistics prove a row group is fully matched, DataFusion can avoid evaluating the pushed-down RowFilter for that row group.

## What changes are included in this PR?

- Add `benchmarks/queries/clickbench/extended/q13.sql`.
- Document Q13 in the ClickBench query README.

## Are these changes tested?


I ran a local synthetic-data comparison for this query. With `target_partitions=1`, the #21637 branch reduced scan processing time from about 85.82ms to 24.89ms, reduced `bytes_scanned` from 26.12M to 400.6K, and reduced `row_pushdown_eval_time` from 4.12ms to effectively zero.


## Are there any user-facing changes?

No public API changes. This adds a benchmark query and benchmark documentation.
