### PR TITLE
Decouple PR comment workflow from semver check and install protoc for cargo-semver-checks

### DIFF
--- a/.github/workflows/breaking_changes_comment.yml
+++ b/.github/workflows/breaking_changes_comment.yml
@@ -52,9 +52,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
-          PR_NUMBER=$(cat "$RUNNER_TEMP/semver-result/pr_number.txt")
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No pull request associated with workflow_run; skipping comment update"
+            exit 0
+          fi
+
           CHECK_RESULT=$(cat "$RUNNER_TEMP/semver-result/result.txt")
+          case "$CHECK_RESULT" in
+            success|failure|error) ;;
+            *)
+              echo "Unexpected semver result '$CHECK_RESULT'"
+              exit 1
+              ;;
+          esac
+
           SEMVER_LOGS=$(cat "$RUNNER_TEMP/semver-result/logs.txt")
           ci/scripts/changed_crates.sh comment \
             "$REPO" "$PR_NUMBER" "$CHECK_RESULT" "$SEMVER_LOGS"

--- a/.github/workflows/breaking_changes_comment.yml
+++ b/.github/workflows/breaking_changes_comment.yml
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: "Detect breaking changes (post comment)"
+
+on:
+  workflow_run:
+    workflows:
+      - "Detect breaking changes"
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment-on-pr:
+    name: Comment on pull request
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: ci/scripts
+
+      - name: Download semver result
+        uses: actions/download-artifact@v4
+        with:
+          name: semver-result
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/semver-result
+
+      - name: Update PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_NUMBER=$(cat "$RUNNER_TEMP/semver-result/pr_number.txt")
+          CHECK_RESULT=$(cat "$RUNNER_TEMP/semver-result/result.txt")
+          SEMVER_LOGS=$(cat "$RUNNER_TEMP/semver-result/logs.txt")
+          ci/scripts/changed_crates.sh comment \
+            "$REPO" "$PR_NUMBER" "$CHECK_RESULT" "$SEMVER_LOGS"

--- a/.github/workflows/breaking_changes_detector.yml
+++ b/.github/workflows/breaking_changes_detector.yml
@@ -105,7 +105,6 @@ jobs:
         env:
           CHANGED_PACKAGES: ${{ steps.changed_crates.outputs.packages }}
           STEP_RESULT: ${{ steps.check_semver.outputs.result }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           SEMVER_LOGS: ${{ steps.check_semver.outputs.logs }}
         run: |
           if [ -n "$STEP_RESULT" ]; then
@@ -118,7 +117,6 @@ jobs:
 
           mkdir -p "$RUNNER_TEMP/semver-result"
           printf '%s\n' "$CHECK_RESULT" > "$RUNNER_TEMP/semver-result/result.txt"
-          printf '%s\n' "$PR_NUMBER" > "$RUNNER_TEMP/semver-result/pr_number.txt"
           printf '%s' "$SEMVER_LOGS" > "$RUNNER_TEMP/semver-result/logs.txt"
 
       - name: Upload semver result artifact

--- a/.github/workflows/breaking_changes_detector.yml
+++ b/.github/workflows/breaking_changes_detector.yml
@@ -37,11 +37,6 @@ jobs:
   check-semver:
     name: Check semver
     runs-on: ubuntu-latest
-    outputs:
-      logs: ${{ steps.check_semver.outputs.logs }}
-      # Default to "success" so the comment job clears any stale comment
-      # when the check step is skipped (e.g. no published crates changed).
-      result: ${{ steps.check_semver.outputs.result || 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -65,6 +60,12 @@ jobs:
           PACKAGES=$(ci/scripts/changed_crates.sh changed-crates "origin/${BASE_REF}")
           echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
           echo "Changed crates: $PACKAGES"
+
+      - name: Install protoc
+        if: steps.changed_crates.outputs.packages != ''
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y protobuf-compiler
 
       - name: Install cargo-semver-checks
         if: steps.changed_crates.outputs.packages != ''
@@ -99,28 +100,31 @@ jobs:
             echo "result=failure" >> "$GITHUB_OUTPUT"
           fi
 
-  # Post or remove a sticky comment on the PR based on the semver check result.
-  comment-on-pr:
-    name: Comment on pull request
-    runs-on: ubuntu-latest
-    needs: check-semver
-    if: always()
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          sparse-checkout: ci/scripts
-
-      - name: Update PR comment
+      - name: Save semver result for comment workflow
+        if: always()
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
+          CHANGED_PACKAGES: ${{ steps.changed_crates.outputs.packages }}
+          STEP_RESULT: ${{ steps.check_semver.outputs.result }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          CHECK_RESULT: ${{ needs.check-semver.outputs.result }}
-          SEMVER_LOGS: ${{ needs.check-semver.outputs.logs }}
+          SEMVER_LOGS: ${{ steps.check_semver.outputs.logs }}
         run: |
-          ci/scripts/changed_crates.sh comment \
-            "$REPO" "$PR_NUMBER" "$CHECK_RESULT" "$SEMVER_LOGS"
+          if [ -n "$STEP_RESULT" ]; then
+            CHECK_RESULT="$STEP_RESULT"
+          elif [ -z "$CHANGED_PACKAGES" ]; then
+            CHECK_RESULT="success"
+          else
+            CHECK_RESULT="error"
+          fi
+
+          mkdir -p "$RUNNER_TEMP/semver-result"
+          printf '%s\n' "$CHECK_RESULT" > "$RUNNER_TEMP/semver-result/result.txt"
+          printf '%s\n' "$PR_NUMBER" > "$RUNNER_TEMP/semver-result/pr_number.txt"
+          printf '%s' "$SEMVER_LOGS" > "$RUNNER_TEMP/semver-result/logs.txt"
+
+      - name: Upload semver result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: semver-result
+          path: ${{ runner.temp }}/semver-result/
+          retention-days: 1


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

* Part of #21914.

---

## Rationale for this change

The existing PR comment step was part of the `pull_request` workflow, which caused failures for forked PRs due to restricted `GITHUB_TOKEN` permissions (read-only). This resulted in `403 Resource not accessible by integration` errors when attempting to post comments. I encountered [this](https://github.com/apache/datafusion/actions/runs/25103257734/job/73559009311) while working on #21917.

<img width="764" height="420" alt="image" src="https://github.com/user-attachments/assets/7499f6cd-0ab7-4876-bd03-d1bbe6cb2f76" />
 

Additionally, updates to Cargo metadata can trigger `cargo-semver-checks` to build with all features enabled, pulling in dependencies (e.g., Substrait) that require `protoc`. Without installing `protoc`, the semver check environment may fail to build.

This change improves both reliability and security by ensuring the workflow environment matches build requirements and by running comment updates in a context with appropriate permissions.

---

## What changes are included in this PR?

* Introduced a new `workflow_run`-based workflow to handle PR comment updates after the semver check completes.
* Removed the inline PR comment step from the main `pull_request` workflow.
* Added logic to persist semver check results and logs as an artifact.
* Downloaded and validated semver results in the follow-up workflow before posting comments.
* Derived the PR number from the trusted `workflow_run` payload instead of storing it in artifacts.
* Installed `protoc` in the semver check job when needed to support builds requiring protobuf.
* Ensured unexpected semver results fail explicitly.

---

## Are these changes tested?

No additional tests are included. These changes affect CI workflows and are validated through workflow execution.

---

## Are there any user-facing changes?

No user-facing changes. These updates only affect CI behavior and internal workflow execution.

---

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
