### PR TITLE
ci: add `auto detected api change` label on breaking change detecting in the CI

### DIFF
--- a/.github/workflows/breaking_changes_detector_comment.yml
+++ b/.github/workflows/breaking_changes_detector_comment.yml
@@ -50,6 +50,13 @@ on:
 permissions:
   contents: read
 
+# A dedicated label, separate from the existing `api change` label.
+# `api change` may be applied manually for behavioral changes that aren't
+# strictly API changes, so we can't safely auto-remove it when this check
+# passes. This auto-managed label is fully owned by the workflow.
+env:
+  BREAKING_CHANGE_LABEL: "auto detected api change"
+
 jobs:
   comment-on-pr:
     name: Comment on pull request
@@ -130,3 +137,24 @@ jobs:
           number: ${{ steps.read.outputs.pr_number }}
           body-include: '<!-- semver-check-comment -->'
           delete: true
+
+      - name: Add "auto detected api change" label
+        if: steps.read.outputs.result != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.read.outputs.pr_number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$REPO" \
+            --add-label "$BREAKING_CHANGE_LABEL"
+
+      - name: Remove "auto detected api change" label
+        if: steps.read.outputs.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.read.outputs.pr_number }}
+        run: |
+          # No-op when the label isn't currently applied.
+          gh pr edit "$PR_NUMBER" --repo "$REPO" \
+            --remove-label "$BREAKING_CHANGE_LABEL" || true

--- a/dev/release/generate-changelog.py
+++ b/dev/release/generate-changelog.py
@@ -77,7 +77,7 @@ def generate_changelog(repo, repo_name, tag1, tag2, version):
             cc_breaking = parts_tuple[2] == '!'
 
         labels = [label.name for label in pull.labels]
-        if 'api change' in labels or cc_breaking:
+        if 'api change' in labels or 'auto detected api change' in labels or cc_breaking:
             breaking.append((pull, commit))
         elif 'bug' in labels or cc_type == 'fix':
             bugs.append((pull, commit))


### PR DESCRIPTION
**before merging this PR, the label `auto detected api change` should be created**

## Which issue does this PR close?

- Closes #21952

## Rationale for this change

Without label the releaser and the people who write the change log in a new release won't find this using the regular
[`generate-changelog.py`](https://github.com/apache/datafusion/blob/main/dev/release/generate-changelog.py) script and not using the existing `api change` label as described in the issue and in the workflow comment

## What changes are included in this PR?

<img width="4122" height="1608" alt="image" src="https://github.com/user-attachments/assets/d8f5826e-2b43-43c3-9886-64ab58e86163" />


## Are these changes tested?
No

## Are there any user-facing changes?
No