### PR TITLE
Fix output_rows_skew sqllogictest flake

### DIFF
--- a/datafusion/sqllogictest/test_files/explain_analyze.slt
+++ b/datafusion/sqllogictest/test_files/explain_analyze.slt
@@ -98,6 +98,7 @@ STORED AS PARQUET;
 statement ok
 CREATE EXTERNAL TABLE skew_parquet
 STORED AS PARQUET
+WITH ORDER (x)
 LOCATION 'test_files/scratch/explain_analyze/output_rows_skew';
 
 query TT


### PR DESCRIPTION
## Which issue does this PR close?

- None.

## Rationale for this change

The `output_rows_skew` sqllogictest can fail nondeterministically after [#21351](https://github.com/apache/datafusion/pull/21351) added dynamic `FileStream` work scheduling: reorderable sibling file scan streams may share one queue of unopened files. The failing case expects the four files to be attributed to output partitions as `[4, 0, 1, 0]`, producing `output_rows_skew=84.31%`; CI has observed the same scan reported as `100%` instead.

This was seen on PR #21927 and independently on `main`, so it is a pre-existing test flake.

## What changes are included in this PR?

Adds `WITH ORDER (x)` to the single `CREATE EXTERNAL TABLE skew_parquet` statement used by the four-file case in `explain_analyze.slt`. That makes the scan order-preserving, which disables shared file work stealing for this assertion and keeps the expected per-partition metric deterministic.

## Are these changes tested?

Yes: flaky test now passes consistently.

## Are there any user-facing changes?

No.