### PR TITLE
chore: fix `datafusion-spark` substring

### DIFF
--- a/datafusion/spark/src/function/string/substring.rs
+++ b/datafusion/spark/src/function/string/substring.rs
@@ -159,7 +159,10 @@ fn spark_substring(args: &[ArrayRef]) -> Result<ArrayRef> {
 /// - Zero start: treated as 1
 /// - Negative start: counts from end of string
 ///
-/// Returns the converted 1-based start position for use with `get_true_start_end`.
+/// The result may be `<= 0` when a negative start lands before the string
+/// (e.g. `start=-10` on a 3-char string gives `-6`). Such values are passed
+/// through to `get_true_start_end`, which clamps them and yields an empty
+/// slice — matching Spark's behavior for out-of-range negative positions.
 #[inline]
 fn spark_start_to_datafusion_start(start: i64, len: usize) -> i64 {
     if start >= 0 {

--- a/datafusion/spark/src/function/string/substring.rs
+++ b/datafusion/spark/src/function/string/substring.rs
@@ -166,8 +166,7 @@ fn spark_start_to_datafusion_start(start: i64, len: usize) -> i64 {
         start.max(1)
     } else {
         let len_i64 = i64::try_from(len).unwrap_or(i64::MAX);
-        let start = start.saturating_add(len_i64).saturating_add(1);
-        start.max(1)
+        start + len_i64 + 1
     }
 }
 

--- a/datafusion/sqllogictest/test_files/spark/string/substring.slt
+++ b/datafusion/sqllogictest/test_files/spark/string/substring.slt
@@ -146,7 +146,7 @@ ark SQL
 (empty)
 (empty)
 (empty)
-Spa
+(empty)
 NULL
 NULL
 NULL
@@ -197,7 +197,14 @@ ark SQL
 (empty)
 (empty)
 (empty)
-Spa
+(empty)
 NULL
 NULL
 NULL
+
+query T
+SELECT substr(column1, -10, 3)
+FROM VALUES
+('abc'::string)
+----
+(empty)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

Fix negative cases with `substring`, some tests were incorrect 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
